### PR TITLE
[codex] Add PR CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Install dependencies
+        run: uv sync --extra dev --frozen
+
+      - name: Run fast tests
+        run: uv run pytest -ra --durations=50 --import-mode=importlib -m "not slow"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,13 +6,15 @@ on:
     paths:
       - "docs/**"
       - ".github/workflows/docs.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yml"
   workflow_dispatch:
 
-# Allow this workflow to publish to GitHub Pages.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Allow one concurrent deployment; don't cancel an in-progress production deploy.
 concurrency:
@@ -43,13 +45,18 @@ jobs:
         run: npm run build
 
       - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3
         with:
           path: docs/dist
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/conftest.py
+++ b/conftest.py
@@ -28,7 +28,8 @@ def pytest_configure() -> None:
 
 
 @pytest.fixture
-def isolated_cli_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def isolated_cli_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Remove process CLI config so unit tests don't depend on a developer .env."""
     for key in {*API_KEY_ENV.values(), *CLI_CONFIG_ENV_KEYS}:
         monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("KOLEGA_CODE_STATE_DIR", str(tmp_path / "state"))


### PR DESCRIPTION
## Summary
- Add a dedicated CI workflow that runs on pull requests targeting `main`, pushes to `main`, and manual dispatch.
- Run the fast Python test suite on Python 3.11 and 3.12 using `uv sync --extra dev --frozen`.
- Make docs PRs build through the existing docs workflow without deploying GitHub Pages from pull requests.
- Isolate CLI test state in the shared pytest fixture so local developer settings cannot break otherwise hermetic tests.

## Root Cause
Tests were not running on PRs because the repository had no workflow with a `pull_request` trigger. The only Python test step lived in the release workflow, which runs only on `v*` tags.

## Validation
- `git diff --check`
- YAML parse check for `.github/workflows/ci.yml` and `.github/workflows/docs.yml`
- `uv run pytest kolega_code/cli/tests/test_main.py -q`
- `uv run pytest -ra --durations=50 --import-mode=importlib -m "not slow"`
- `npm --prefix docs run build`