### PR TITLE
[codex] add kimi k2.7 code support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ uv tool upgrade kolega-code
 uv tool uninstall kolega-code
 ```
 
-Run the Textual UI and open the Settings tab to select Moonshot Kimi K2.6 or DeepSeek V4 Pro, choose the model's thinking effort, and save your API key:
+Run the Textual UI and open the Settings tab to select Moonshot Kimi K2.7 Code, Moonshot Kimi K2.6, or DeepSeek V4 Pro, choose the model's thinking effort, and save your API key:
 
 ```bash
 kolega-code .
@@ -56,7 +56,7 @@ kolega-code sessions list --project .
 kolega-code doctor --project .
 ```
 
-The Settings UI supports Moonshot `kimi-k2.6` and DeepSeek `deepseek-v4-pro`. A saved UI selection is used for all agent model roles, and switching models resets thinking effort to that model's default. API keys are stored in the local CLI settings file with restrictive permissions. Existing environment and model/provider flag overrides continue to work. Local session state is stored under the platform state directory unless `KOLEGA_CODE_STATE_DIR` is set.
+The Settings UI supports Moonshot `kimi-k2.7-code`, Moonshot `kimi-k2.6`, and DeepSeek `deepseek-v4-pro`. A saved UI selection is used for all agent model roles, and switching models resets thinking effort to that model's default. API keys are stored in the local CLI settings file with restrictive permissions. Existing environment and model/provider flag overrides continue to work. Local session state is stored under the platform state directory unless `KOLEGA_CODE_STATE_DIR` is set.
 
 ## From source
 

--- a/docs/src/content/docs/cli/doctor.md
+++ b/docs/src/content/docs/cli/doctor.md
@@ -40,14 +40,14 @@ you can validate a specific provider/model combination before using it.
 Project: /Users/you/code/my-app
 State dir: /Users/you/Library/Application Support/kolega-code
 Textual installed: True
-Stored active model: moonshot/kimi-k2.6
+Stored active model: moonshot/kimi-k2.7-code
 Stored thinking effort: auto
 Stored API key: present in local settings
 ✓ Configuration: valid
-Long model: moonshot/kimi-k2.6
-Fast model: moonshot/kimi-k2.6
-Edit model: moonshot/kimi-k2.6
-Thinking model: moonshot/kimi-k2.6
+Long model: moonshot/kimi-k2.7-code
+Fast model: moonshot/kimi-k2.7-code
+Edit model: moonshot/kimi-k2.7-code
+Thinking model: moonshot/kimi-k2.7-code
 Thinking effort: auto
 ```
 

--- a/docs/src/content/docs/configuration/environment-variables.md
+++ b/docs/src/content/docs/configuration/environment-variables.md
@@ -86,7 +86,7 @@ ANTHROPIC_API_KEY=
 
 # Optional: choose models per role
 KOLEGA_CODE_PROVIDER=moonshot
-KOLEGA_CODE_MODEL=kimi-k2.6
+KOLEGA_CODE_MODEL=kimi-k2.7-code
 KOLEGA_CODE_THINKING_EFFORT=auto
 
 # Optional: Langfuse tracing

--- a/docs/src/content/docs/configuration/providers-and-models.mdx
+++ b/docs/src/content/docs/configuration/providers-and-models.mdx
@@ -28,9 +28,9 @@ The agent runtime recognizes these providers:
 
 <Aside type="note">
 The **Settings tab** in the TUI currently offers a curated shortlist —
-**Moonshot (Kimi K2.6)** and **DeepSeek (DeepSeek V4 Pro)**. The full provider
-list above is available through environment variables and CLI flags. See
-[Settings & API Keys](../settings-and-api-keys/).
+**Moonshot (Kimi K2.7 Code and Kimi K2.6)** and **DeepSeek (DeepSeek V4 Pro)**.
+The full provider list above is available through environment variables and CLI
+flags. See [Settings & API Keys](../settings-and-api-keys/).
 </Aside>
 
 ## Model roles
@@ -92,6 +92,7 @@ models in the TUI.
 | --- | --- | --- |
 | Anthropic `claude-opus-4-7` | `low`, `medium`, `high`, `xhigh`, `max` | `medium` |
 | DeepSeek `deepseek-v4-pro` | `none`, `high`, `max` | `high` |
+| Moonshot `kimi-k2.7-code` | `auto` | `auto` |
 | Moonshot `kimi-k2.6` | `auto`, `none` | `auto` |
 | Google `gemini-2.5-pro` | `auto`, `low`, `medium`, `high` | `medium` |
 | OpenAI reasoning models | `low`, `medium`, `high` | `medium` |

--- a/docs/src/content/docs/configuration/settings-and-api-keys.mdx
+++ b/docs/src/content/docs/configuration/settings-and-api-keys.mdx
@@ -45,7 +45,7 @@ The file looks like this:
 {
   "schema_version": 2,
   "active_provider": "moonshot",
-  "active_model": "kimi-k2.6",
+  "active_model": "kimi-k2.7-code",
   "active_thinking_effort": "auto",
   "api_keys": {
     "moonshot": "sk-..."

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -23,7 +23,7 @@ This walks you from a fresh install to a working session in a few minutes.
 2. **Choose a model and add your API key.**
 
    Open the **Settings** tab in the side panel, pick a provider and model
-   (for example **Moonshot — Kimi K2.6** or **DeepSeek — DeepSeek V4 Pro**),
+   (for example **Moonshot — Kimi K2.7 Code** or **DeepSeek — DeepSeek V4 Pro**),
    paste your API key, and press **Save Settings**.
 
    The saved selection is used for every agent role, and your key is written to

--- a/kolega_code/agent/tests/llm/test_model_specs.py
+++ b/kolega_code/agent/tests/llm/test_model_specs.py
@@ -1,6 +1,16 @@
 from kolega_code.llm.specs import get_model_specs
 
 
+def test_kimi_k27_code_model_specs():
+    specs = get_model_specs("moonshot", "kimi-k2.7-code")
+
+    assert specs["context_length"] == 262144
+    assert specs["max_completion_tokens"] == 32768
+    assert specs["default_temperature"] == 1.0
+    assert specs["thinking_effort"].options == ("auto",)
+    assert specs["thinking_effort"].default == "auto"
+
+
 def test_kimi_k26_model_specs():
     specs = get_model_specs("moonshot", "kimi-k2.6")
 

--- a/kolega_code/agent/tests/llm/test_thinking_effort.py
+++ b/kolega_code/agent/tests/llm/test_thinking_effort.py
@@ -9,6 +9,8 @@ from kolega_code.llm.specs import default_thinking_effort, thinking_effort_optio
 
 
 def test_model_specs_expose_provider_specific_thinking_efforts() -> None:
+    assert thinking_effort_options("moonshot", "kimi-k2.7-code") == ("auto",)
+    assert default_thinking_effort("moonshot", "kimi-k2.7-code") == "auto"
     assert thinking_effort_options("moonshot", "kimi-k2.6") == ("auto", "none")
     assert default_thinking_effort("moonshot", "kimi-k2.6") == "auto"
     assert thinking_effort_options("deepseek", "deepseek-v4-pro") == ("none", "high", "max")
@@ -49,6 +51,10 @@ def test_deepseek_thinking_effort_serialization() -> None:
 def test_moonshot_kimi_thinking_toggle_serialization() -> None:
     provider = AnthropicProvider(api_key="test-key", provider_name="moonshot")
 
+    k27_params = {"model": "kimi-k2.7-code"}
+    provider._apply_thinking_params(k27_params, GenerationParams(thinking="auto"))
+    assert k27_params == {"model": "kimi-k2.7-code", "thinking": {"type": "enabled"}}
+
     auto_params = {"model": "kimi-k2.6"}
     provider._apply_thinking_params(auto_params, GenerationParams(thinking="auto"))
     assert auto_params == {"model": "kimi-k2.6", "thinking": {"type": "enabled"}}
@@ -85,3 +91,10 @@ def test_numeric_thinking_budget_is_rejected() -> None:
 
     with pytest.raises(ValueError, match="named thinking effort"):
         client._prepare_thinking_param(1024, model="kimi-k2.6")
+
+
+def test_kimi_k27_rejects_disabled_thinking_effort() -> None:
+    client = LLMClient(provider="moonshot", api_key="test-key")
+
+    with pytest.raises(ValueError, match="Unsupported thinking effort"):
+        client._prepare_thinking_param("none", model="kimi-k2.7-code")

--- a/kolega_code/cli/provider_registry.py
+++ b/kolega_code/cli/provider_registry.py
@@ -8,7 +8,8 @@ from kolega_code.config import ModelProvider
 from kolega_code.llm.specs import default_thinking_effort, get_model_specs, thinking_effort_options
 
 UI_DEFAULT_PROVIDER = ModelProvider.MOONSHOT.value
-UI_DEFAULT_MODEL = "kimi-k2.6"
+UI_DEFAULT_MODEL = "kimi-k2.7-code"
+MOONSHOT_K26_MODEL = "kimi-k2.6"
 DEEPSEEK_DEFAULT_MODEL = "deepseek-v4-pro"
 
 
@@ -51,6 +52,13 @@ UI_MODEL_OPTIONS = [
         ModelProvider.MOONSHOT,
         "Moonshot AI",
         UI_DEFAULT_MODEL,
+        "Kimi K2.7 Code",
+        "MOONSHOT_API_KEY",
+    ),
+    _model_option(
+        ModelProvider.MOONSHOT,
+        "Moonshot AI",
+        MOONSHOT_K26_MODEL,
         "Kimi K2.6",
         "MOONSHOT_API_KEY",
     ),

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -4140,17 +4140,21 @@ async def test_textual_app_model_slash_command_shows_and_switches_model(
     monkeypatch.setattr(
         app_module,
         "ui_model_options",
-        lambda provider: [("Kimi K2.6", "kimi-k2.6"), ("Kimi K3", "kimi-k3")],
+        lambda provider: [
+            ("Kimi K2.7 Code", UI_DEFAULT_MODEL),
+            ("Kimi K2.6", "kimi-k2.6"),
+            ("Kimi K3", "kimi-k3"),
+        ],
     )
     monkeypatch.setattr(
         app_module,
         "ui_thinking_effort_options",
-        lambda provider, model: [("Auto", "auto"), ("None", "none")] if model == "kimi-k2.6" else [("High", "high")],
+        lambda provider, model: [("High", "high")] if model == "kimi-k3" else [("Auto", "auto")],
     )
     monkeypatch.setattr(
         app_module,
         "default_ui_thinking_effort",
-        lambda provider, model: "auto" if model == "kimi-k2.6" else "high",
+        lambda provider, model: "high" if model == "kimi-k3" else "auto",
     )
 
     project = tmp_path / "project"
@@ -4180,11 +4184,12 @@ async def test_textual_app_model_slash_command_shows_and_switches_model(
         effort_entry = app.conversation_entries[-1]
         assert effort_entry.kind == "system"
         assert "Available thinking efforts:" in effort_entry.content
-        assert "`none`" in effort_entry.content
+        assert "`auto`" in effort_entry.content
+        assert "`none`" not in effort_entry.content
 
-        composer.load_text("/effort none")
+        composer.load_text("/effort auto")
         await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
-        assert settings_store.load().active_thinking_effort == "none"
+        assert settings_store.load().active_thinking_effort == "auto"
         first_agent = app.agent
         assert isinstance(first_agent, FakeCoderAgent)
 
@@ -4192,8 +4197,8 @@ async def test_textual_app_model_slash_command_shows_and_switches_model(
         await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
         entry = app.conversation_entries[-1]
         assert entry.kind == "system"
-        assert "kimi-k2.6" in entry.content and "kimi-k3" in entry.content
-        assert "Thinking effort: none" in entry.content
+        assert UI_DEFAULT_MODEL in entry.content and "kimi-k2.6" in entry.content and "kimi-k3" in entry.content
+        assert "Thinking effort: auto" in entry.content
 
         # kimi-k3 is a fake model the real config builder rejects, so stub it for the rebuild step.
         saved_config = app.config

--- a/kolega_code/cli/tests/test_cli_config.py
+++ b/kolega_code/cli/tests/test_cli_config.py
@@ -13,7 +13,12 @@ from kolega_code.cli.config import (
     build_agent_config,
     config_summary,
 )
-from kolega_code.cli.provider_registry import DEEPSEEK_DEFAULT_MODEL, UI_DEFAULT_MODEL, UI_DEFAULT_PROVIDER
+from kolega_code.cli.provider_registry import (
+    DEEPSEEK_DEFAULT_MODEL,
+    MOONSHOT_K26_MODEL,
+    UI_DEFAULT_MODEL,
+    UI_DEFAULT_PROVIDER,
+)
 from kolega_code.cli.settings import CliSettings
 
 
@@ -149,6 +154,18 @@ def test_build_agent_config_accepts_moonshot_cli_active_model(tmp_path: Path) ->
     assert config.fast_config.provider == ModelProvider.MOONSHOT
     assert config.edit_model_config.provider == ModelProvider.MOONSHOT
     assert config.thinking_config.provider == ModelProvider.MOONSHOT
+
+
+def test_build_agent_config_accepts_moonshot_k26_model(tmp_path: Path) -> None:
+    config = build_agent_config(
+        tmp_path,
+        CliConfigOverrides(provider=UI_DEFAULT_PROVIDER, model=MOONSHOT_K26_MODEL),
+        env={"MOONSHOT_API_KEY": "moonshot-key"},
+    )
+
+    assert config.long_context_config.provider == ModelProvider.MOONSHOT
+    assert config.long_context_config.model == MOONSHOT_K26_MODEL
+    assert config.long_context_config.thinking_effort == "auto"
 
 
 def test_build_agent_config_accepts_deepseek_cli_active_model(tmp_path: Path) -> None:

--- a/kolega_code/cli/tests/test_settings.py
+++ b/kolega_code/cli/tests/test_settings.py
@@ -6,6 +6,7 @@ import pytest
 
 from kolega_code.cli.provider_registry import (
     DEEPSEEK_DEFAULT_MODEL,
+    MOONSHOT_K26_MODEL,
     UI_DEFAULT_MODEL,
     UI_DEFAULT_PROVIDER,
     get_ui_model,
@@ -21,7 +22,7 @@ def test_settings_store_round_trip_and_file_permissions(tmp_path: Path) -> None:
     settings = CliSettings(
         active_provider=UI_DEFAULT_PROVIDER,
         active_model=UI_DEFAULT_MODEL,
-        active_thinking_effort="none",
+        active_thinking_effort="auto",
     )
     settings.set_api_key(UI_DEFAULT_PROVIDER, "secret-key")
 
@@ -30,7 +31,7 @@ def test_settings_store_round_trip_and_file_permissions(tmp_path: Path) -> None:
     loaded = store.load()
     assert loaded.active_provider == UI_DEFAULT_PROVIDER
     assert loaded.active_model == UI_DEFAULT_MODEL
-    assert loaded.active_thinking_effort == "none"
+    assert loaded.active_thinking_effort == "auto"
     assert loaded.get_api_key(UI_DEFAULT_PROVIDER) == "secret-key"
 
     if os.name != "nt":
@@ -58,7 +59,7 @@ def test_settings_store_migrates_v1_settings(tmp_path: Path) -> None:
 
     assert settings.schema_version == 2
     assert settings.active_provider == UI_DEFAULT_PROVIDER
-    assert settings.active_model == UI_DEFAULT_MODEL
+    assert settings.active_model == MOONSHOT_K26_MODEL
     assert settings.active_thinking_effort is None
 
 
@@ -73,9 +74,16 @@ def test_settings_store_rejects_corrupt_json(tmp_path: Path) -> None:
 
 def test_ui_provider_registry_supports_kimi_and_deepseek() -> None:
     assert ui_provider_options() == [("Moonshot AI", UI_DEFAULT_PROVIDER), ("DeepSeek AI", "deepseek")]
-    assert ui_model_options(UI_DEFAULT_PROVIDER) == [("Kimi K2.6", UI_DEFAULT_MODEL)]
+    assert ui_model_options(UI_DEFAULT_PROVIDER) == [
+        ("Kimi K2.7 Code", UI_DEFAULT_MODEL),
+        ("Kimi K2.6", MOONSHOT_K26_MODEL),
+    ]
     assert ui_model_options("deepseek") == [("DeepSeek V4 Pro", DEEPSEEK_DEFAULT_MODEL)]
-    assert ui_thinking_effort_options(UI_DEFAULT_PROVIDER, UI_DEFAULT_MODEL) == [("Auto", "auto"), ("None", "none")]
+    assert ui_thinking_effort_options(UI_DEFAULT_PROVIDER, UI_DEFAULT_MODEL) == [("Auto", "auto")]
+    assert ui_thinking_effort_options(UI_DEFAULT_PROVIDER, MOONSHOT_K26_MODEL) == [
+        ("Auto", "auto"),
+        ("None", "none"),
+    ]
     assert ui_thinking_effort_options("deepseek", DEEPSEEK_DEFAULT_MODEL) == [
         ("None", "none"),
         ("High", "high"),
@@ -86,6 +94,11 @@ def test_ui_provider_registry_supports_kimi_and_deepseek() -> None:
     assert model is not None
     assert model.api_key_env == "MOONSHOT_API_KEY"
     assert model.default_thinking_effort == "auto"
+
+    kimi26_model = get_ui_model(UI_DEFAULT_PROVIDER, MOONSHOT_K26_MODEL)
+    assert kimi26_model is not None
+    assert kimi26_model.api_key_env == "MOONSHOT_API_KEY"
+    assert kimi26_model.default_thinking_effort == "auto"
 
     deepseek_model = get_ui_model("deepseek", DEEPSEEK_DEFAULT_MODEL)
     assert deepseek_model is not None

--- a/kolega_code/llm/specs.py
+++ b/kolega_code/llm/specs.py
@@ -56,6 +56,16 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
             mode="moonshot_toggle",
         ),
     },
+    ("moonshot", "kimi-k2.7-code"): {
+        "context_length": 262144,
+        "max_completion_tokens": 32768,
+        "default_temperature": 1.0,
+        "thinking_effort": ThinkingEffortSpec(
+            options=("auto",),
+            default="auto",
+            mode="moonshot_toggle",
+        ),
+    },
     # DeepSeek models
     ("deepseek", "deepseek-v4-pro"): {
         "context_length": 1000000,


### PR DESCRIPTION
## Summary

- add Moonshot `kimi-k2.7-code` model specs with 256K context, 32K output, and auto-only thinking
- make Kimi K2.7 Code the Moonshot TUI default while keeping Kimi K2.6 selectable
- update CLI/TUI tests and documentation for the new default and K2.6 compatibility

## Validation

```bash
uv run pytest kolega_code/agent/tests/llm/test_model_specs.py kolega_code/agent/tests/llm/test_thinking_effort.py kolega_code/cli/tests/test_settings.py kolega_code/cli/tests/test_cli_config.py kolega_code/cli/tests/test_app.py
```

Result: `124 passed`.