### PR TITLE
[codex] require explicit CLI model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,20 @@ kolega-code . --resume
 kolega-code . --resume <thread-or-session-id>
 ```
 
-You can also set `MOONSHOT_API_KEY`, `DEEPSEEK_API_KEY`, or keep using env/flag based configuration for non-UI commands:
+You can also use env/flag based configuration for non-UI commands. API key
+variables provide credentials only; set a provider/model explicitly or save one
+in the Settings UI:
 
 ```bash
+export KOLEGA_CODE_PROVIDER=deepseek
+export DEEPSEEK_API_KEY=...
 kolega-code ask "summarize this repository" --project .
 kolega-code ask "summarize this repository" --project . --provider deepseek --model deepseek-v4-pro
 kolega-code sessions list --project .
 kolega-code doctor --project .
 ```
 
-The Settings UI supports Moonshot `kimi-k2.7-code`, Moonshot `kimi-k2.6`, and DeepSeek `deepseek-v4-pro`. A saved UI selection is used for all agent model roles, and switching models resets thinking effort to that model's default. API keys are stored in the local CLI settings file with restrictive permissions. Existing environment and model/provider flag overrides continue to work. Local session state is stored under the platform state directory unless `KOLEGA_CODE_STATE_DIR` is set.
+The Settings UI supports Moonshot `kimi-k2.7-code`, Moonshot `kimi-k2.6`, and DeepSeek `deepseek-v4-pro`. A saved UI selection is used for all agent model roles, and switching models resets thinking effort to that model's default. API keys are stored in the local CLI settings file with restrictive permissions. Existing environment and model/provider flag overrides continue to work, but API key variables alone never select a provider or model. Local session state is stored under the platform state directory unless `KOLEGA_CODE_STATE_DIR` is set.
 
 ## From source
 

--- a/docs/src/content/docs/cli/ask.md
+++ b/docs/src/content/docs/cli/ask.md
@@ -25,6 +25,8 @@ kolega-code ask "<prompt>" [options]
 
 All the [global model options](../overview/#global-model-options)
 (`--provider`, `--model`, `--fast-model`, …) are also accepted.
+`ask` requires a provider/model from those options, environment variables, or
+saved Settings. API key variables alone are not enough.
 
 ## Examples
 

--- a/docs/src/content/docs/configuration/environment-variables.md
+++ b/docs/src/content/docs/configuration/environment-variables.md
@@ -14,7 +14,10 @@ For any given setting, the first available source wins:
 2. **Shell environment variables**
 3. **Project `.env` file** (in the project directory)
 4. **Saved Settings** (`settings.json`)
-5. **Built-in defaults**
+
+Kolega Code requires an explicit provider/model selection from flags,
+environment variables, a project `.env` file, or saved settings. API key
+variables alone are not a model selection source.
 
 :::note
 Within the env layer, your **shell environment takes priority over the `.env`
@@ -25,6 +28,9 @@ file** — values exported in your shell override the same key in `.env`.
 
 Set the variable for each provider you use. Only the providers backing your active
 model roles are required.
+
+API key variables provide credentials only. They do not select the active
+provider or model.
 
 | Variable | Provider |
 | --- | --- |

--- a/docs/src/content/docs/configuration/providers-and-models.mdx
+++ b/docs/src/content/docs/configuration/providers-and-models.mdx
@@ -44,6 +44,10 @@ can match cost and capability to the job:
 | **Fast** | Quick, cheap utility calls | `anthropic` / `claude-haiku-4-5-20251001` |
 | **Thinking** | Extended-reasoning ("think hard") operations | `anthropic` / `claude-opus-4-7` (`medium` effort) |
 
+These built-in role defaults are used only when the corresponding provider or
+role is explicitly selected without a model. API key variables alone do not make
+these defaults active.
+
 When you pick a single provider/model in the Settings UI, that selection is applied
 to **all** roles. To assign roles individually, use environment variables or CLI
 flags.
@@ -58,12 +62,12 @@ match wins):
 2. **Environment variables** — e.g. `KOLEGA_CODE_PROVIDER`, `KOLEGA_CODE_MODEL`, the
    per-role variants, and a project-local `.env` file.
 3. **Saved Settings** — the active provider/model from the Settings tab.
-4. **Built-in defaults** — the Anthropic models listed above.
 </Steps>
 
-A configuration is only valid if every role's provider has an API key available
-(the local `llama` provider needs none). If a key is missing, the CLI reports
-exactly which environment variable is required.
+A configuration is only valid if a provider/model has been selected and every
+role's provider has an API key available (the local `llama` provider needs none).
+If a key is missing, the CLI reports exactly which environment variable is
+required.
 
 ## Set models per role
 

--- a/docs/src/content/docs/configuration/settings-and-api-keys.mdx
+++ b/docs/src/content/docs/configuration/settings-and-api-keys.mdx
@@ -24,6 +24,8 @@ When you switch models, the thinking effort resets to the new model's default.
 A saved selection is used for **all** agent model roles. Existing environment
 variables and `--provider` / `--model` flags continue to override it — see
 [Providers & Models](../providers-and-models/) for resolution order.
+API key environment variables are credentials only; they do not choose the active
+provider or model.
 
 ## Where settings live
 

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -71,7 +71,7 @@ uv tool uninstall kolega-code
 
 1. **Install** the CLI (above).
 
-2. **Add a provider and API key** — either in the in-app
+2. **Add a provider/model and API key** — either in the in-app
    [Settings tab](../../configuration/settings-and-api-keys/) or via
    [environment variables](../../configuration/environment-variables/).
 

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -31,9 +31,10 @@ This walks you from a fresh install to a working session in a few minutes.
    [Settings & API Keys](../../configuration/settings-and-api-keys/).
 
    <Aside type="tip">
-   Prefer environment variables? Set e.g. `MOONSHOT_API_KEY` (or
-   `ANTHROPIC_API_KEY`, `DEEPSEEK_API_KEY`, …) before launching and skip the
-   Settings tab. See [Environment Variables](../../configuration/environment-variables/).
+   Prefer environment variables? Set both model selection (for example
+   `KOLEGA_CODE_PROVIDER=moonshot`) and the matching API key before launching.
+   API key variables alone do not select a provider/model. See
+   [Environment Variables](../../configuration/environment-variables/).
    </Aside>
 
 3. **Ask the agent something.**

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -1238,19 +1238,17 @@ class KolegaCodeApp(App):
         self.exit()
 
     def _populate_settings_controls(self) -> None:
-        if not self.settings.active_provider:
-            self.settings.active_provider = UI_DEFAULT_PROVIDER
-        provider = self.settings.active_provider
+        provider_values = {value for _, value in ui_provider_options()}
+        provider = self.settings.active_provider if self.settings.active_provider in provider_values else UI_DEFAULT_PROVIDER
         model_options = ui_model_options(provider)
         valid_models = {value for _, value in model_options}
-        model_was_reset = False
-        if not self.settings.active_model or self.settings.active_model not in valid_models:
-            self.settings.active_model = model_options[0][1] if model_options else UI_DEFAULT_MODEL
-            model_was_reset = True
-        model = self.settings.active_model
+        model = self.settings.active_model if self.settings.active_model in valid_models else None
+        if model is None:
+            model = model_options[0][1] if model_options else UI_DEFAULT_MODEL
         effort_options = {value for _, value in ui_thinking_effort_options(provider, model)}
-        if model_was_reset or self.settings.active_thinking_effort not in effort_options:
-            self.settings.active_thinking_effort = default_ui_thinking_effort(provider, model)
+        effort = self.settings.active_thinking_effort if self.settings.active_thinking_effort in effort_options else None
+        if effort is None:
+            effort = default_ui_thinking_effort(provider, model)
         provider_select = self.query_one("#provider_select", Select)
         model_select = self.query_one("#model_select", Select)
         effort_select = self.query_one("#thinking_effort_select", Select)
@@ -1260,8 +1258,8 @@ class KolegaCodeApp(App):
         model_select.set_options(model_options)
         model_select.value = model
         effort_select.set_options(ui_thinking_effort_options(provider, model))
-        if self.settings.active_thinking_effort is not None:
-            effort_select.value = self.settings.active_thinking_effort
+        if effort is not None:
+            effort_select.value = effort
         api_key_input.placeholder = self._api_key_placeholder(provider)
         self._update_settings_status()
 
@@ -1543,8 +1541,13 @@ class KolegaCodeApp(App):
         if not args:
             current_provider, current_model = self._startup_model()
             current_effort = self._startup_thinking_effort()
+            active_model_line = (
+                messages.SETTINGS_ACTIVE_MODEL.format(provider=current_provider, model=current_model)
+                if current_model
+                else messages.SETTINGS_ACTIVE_MODEL_UNCONFIGURED
+            )
             lines = [
-                messages.SETTINGS_ACTIVE_MODEL.format(provider=current_provider, model=current_model),
+                active_model_line,
                 messages.SETTINGS_THINKING_EFFORT_LINE.format(effort=current_effort or "not supported"),
                 "",
                 "Available models:",
@@ -1565,6 +1568,7 @@ class KolegaCodeApp(App):
             self._notify_user(messages.MODEL_UNKNOWN.format(model=args, provider=provider), severity="warning")
             return
 
+        self.settings.active_provider = provider
         self.settings.active_model = matched
         self.settings.active_thinking_effort = default_ui_thinking_effort(provider, matched)
         self.settings_store.save(self.settings)
@@ -1590,8 +1594,13 @@ class KolegaCodeApp(App):
             return
 
         if not args:
+            active_model_line = (
+                messages.SETTINGS_ACTIVE_MODEL.format(provider=provider, model=model)
+                if model
+                else messages.SETTINGS_ACTIVE_MODEL_UNCONFIGURED
+            )
             lines = [
-                messages.SETTINGS_ACTIVE_MODEL.format(provider=provider, model=model),
+                active_model_line,
                 messages.SETTINGS_THINKING_EFFORT_LINE.format(effort=current_effort or "not supported"),
                 "",
                 "Available thinking efforts:",
@@ -1944,8 +1953,20 @@ class KolegaCodeApp(App):
             return
 
     def _update_settings_status(self) -> None:
-        provider = self.settings.active_provider or UI_DEFAULT_PROVIDER
-        model = self.settings.active_model or UI_DEFAULT_MODEL
+        if not (self.settings.active_provider and self.settings.active_model):
+            text = "\n".join(
+                [
+                    messages.SETTINGS_ACTIVE_MODEL_UNCONFIGURED,
+                    messages.SETTINGS_THINKING_EFFORT_LINE.format(effort="not configured"),
+                    messages.SETTINGS_API_KEY_LINE.format(status="not checked until a model is configured"),
+                ]
+            )
+            self._set_settings_status(text, "warning")
+            self._refresh_status_dashboard()
+            return
+
+        provider = self.settings.active_provider
+        model = self.settings.active_model
         effort = self.settings.active_thinking_effort or default_ui_thinking_effort(provider, model) or "not supported"
         status = key_status(provider, self.project_path, self.settings)
         tone = "warning" if "missing" in status.lower() else "ok"
@@ -1988,8 +2009,13 @@ class KolegaCodeApp(App):
     def _startup_content(self) -> str:
         session_id = str(self.session.session_id)[:8]
         provider, model = self._startup_model()
+        model_display = f"{provider}/{model}" if model else provider
         effort = self._startup_thinking_effort() or "not supported"
-        api_key = key_status(provider, self.project_path, self.settings)
+        api_key = (
+            key_status(provider, self.project_path, self.settings)
+            if model
+            else "not checked until a model is configured"
+        )
         return "\n".join(
             [
                 *STARTUP_WORDMARK,
@@ -1998,7 +2024,7 @@ class KolegaCodeApp(App):
                 f"Session: {session_id}",
                 f"Mode: {self.mode}",
                 f"Interaction: {self.interaction_mode}",
-                f"Model: {provider}/{model}",
+                f"Model: {model_display}",
                 f"Thinking effort: {effort}",
                 f"API key: {api_key}",
                 "",
@@ -2011,15 +2037,10 @@ class KolegaCodeApp(App):
         if self.config is not None:
             return self.config.long_context_config.provider.value, self.config.long_context_config.model
 
-        provider = self.settings.active_provider or UI_DEFAULT_PROVIDER
-        model = self.settings.active_model
-        if model:
-            return provider, model
+        if self.settings.active_provider and self.settings.active_model:
+            return self.settings.active_provider, self.settings.active_model
 
-        model_options = ui_model_options(provider)
-        if model_options:
-            return provider, model_options[0][1]
-        return provider, UI_DEFAULT_MODEL
+        return "not configured", ""
 
     def _startup_thinking_effort(self) -> Optional[str]:
         if self.config is not None:
@@ -2047,7 +2068,7 @@ class KolegaCodeApp(App):
 
     def _format_status_dashboard(self) -> str:
         state = self._status_state
-        provider_model = f"{state.provider}/{state.model}"
+        provider_model = f"{state.provider}/{state.model}" if state.model else state.provider
         effort = state.thinking_effort or "not supported"
         mode = state.mode.title()
         turn_style = TURN_STATE_STYLES.get(state.turn_state, Color.ACCENT)

--- a/kolega_code/cli/config.py
+++ b/kolega_code/cli/config.py
@@ -12,7 +12,7 @@ from dotenv import dotenv_values
 from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
 from kolega_code.llm.specs import get_model_specs, normalize_thinking_effort
 
-from .provider_registry import UI_DEFAULT_PROVIDER, default_model_for_provider
+from .provider_registry import default_model_for_provider
 from .settings import CliSettings
 
 DEFAULT_LONG_PROVIDER = ModelProvider.ANTHROPIC
@@ -24,6 +24,10 @@ DEFAULT_THINKING_MODEL = "claude-opus-4-7"
 DEPRECATED_THINKING_TOKENS_MESSAGE = (
     "Thinking token budgets have been replaced by model-specific named effort. "
     "Use --thinking-effort or KOLEGA_CODE_THINKING_EFFORT."
+)
+MISSING_MODEL_SELECTION_MESSAGE = (
+    "No provider/model configured. Choose a provider and model in Settings, "
+    "or set --provider/--model or KOLEGA_CODE_PROVIDER/KOLEGA_CODE_MODEL."
 )
 
 API_KEY_ENV = {
@@ -69,17 +73,6 @@ def load_cli_env(project_path: Path, env: Optional[Mapping[str, str]] = None) ->
     return {**file_env, **base_env}
 
 
-def _env_or_default(
-    env: Mapping[str, str],
-    key: str,
-    override: Optional[str],
-    default: str,
-) -> str:
-    if override:
-        return override
-    return env.get(key) or default
-
-
 def _provider(value: str) -> ModelProvider:
     try:
         return ModelProvider(value.lower())
@@ -113,9 +106,9 @@ def _active_provider_model(
         provider = _provider(provider_value or DEFAULT_LONG_PROVIDER.value)
         return provider, model_value or default_model_for_provider(provider)
 
-    if settings and (settings.active_provider or settings.active_model):
-        provider = _provider(settings.active_provider or UI_DEFAULT_PROVIDER)
-        return provider, settings.active_model or default_model_for_provider(provider)
+    if settings and settings.active_provider and settings.active_model:
+        provider = _provider(settings.active_provider)
+        return provider, settings.active_model
 
     return None, None
 
@@ -192,6 +185,8 @@ def build_agent_config(
         raise CliConfigError(DEPRECATED_THINKING_TOKENS_MESSAGE)
 
     active_provider, active_model = _active_provider_model(loaded_env, overrides, settings)
+    if active_provider is None or active_model is None:
+        raise CliConfigError(MISSING_MODEL_SELECTION_MESSAGE)
 
     long_provider, long_model = _slot_provider_model(
         loaded_env,

--- a/kolega_code/cli/messages.py
+++ b/kolega_code/cli/messages.py
@@ -74,13 +74,14 @@ BLOCK_PLAN_DECISION = "Choose Implement plan or Discuss further before sending a
 BLOCK_PLAN_DECISION_MODE_SWITCH = "Choose Implement plan or Discuss further before switching modes."
 BLOCK_PLAN_DECISION_SKILL = "Choose Implement plan or Discuss further before activating a skill."
 BLOCK_PENDING_QUESTION_SKILL = "Answer the pending planning question before activating a skill."
-SETTINGS_REQUIRED = "Save a provider, model, and API key before chatting."
-SETTINGS_REQUIRED_SKILL = "Save a provider, model, and API key before activating a skill."
+SETTINGS_REQUIRED = "Configure a provider/model and API key before chatting."
+SETTINGS_REQUIRED_SKILL = "Configure a provider/model and API key before activating a skill."
 
 # Settings tab
 SETTINGS_SAVED = "Settings saved."
 SETTINGS_INCOMPLETE = "Configuration incomplete: {error}"
 SETTINGS_ACTIVE_MODEL = "Active model: {provider}/{model}"
+SETTINGS_ACTIVE_MODEL_UNCONFIGURED = "Active model: not configured"
 SETTINGS_API_KEY_LINE = "API key: {status}"
 SETTINGS_THINKING_EFFORT_LINE = "Thinking effort: {effort}"
 

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -21,6 +21,16 @@ def extension_by_name(extensions, name: str):
     )
 
 
+def build_test_config(project: Path):
+    return build_agent_config(
+        project,
+        env={
+            "ANTHROPIC_API_KEY": "test-key",
+            "KOLEGA_CODE_PROVIDER": "anthropic",
+        },
+    )
+
+
 @pytest.mark.asyncio
 async def test_textual_app_mounts_with_fake_agent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     pytest.importorskip("textual")
@@ -49,7 +59,7 @@ async def test_textual_app_mounts_with_fake_agent(tmp_path: Path, monkeypatch: p
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
 
@@ -115,7 +125,7 @@ async def test_textual_app_status_tab_is_default_dashboard(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -162,7 +172,7 @@ async def test_textual_app_context_usage_updates_status_without_raw_json(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -225,7 +235,7 @@ async def test_textual_app_status_dashboard_tracks_interaction_mode(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -268,7 +278,7 @@ async def test_textual_app_turn_status_formats_error_duration(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -321,7 +331,7 @@ async def test_progress_entry_tone_drives_styling_not_prose(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -372,7 +382,7 @@ async def test_textual_app_keeps_command_c_for_screen_copy(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -420,7 +430,7 @@ async def test_textual_app_shift_tab_toggles_between_build_and_plan_agents(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -506,7 +516,7 @@ async def test_textual_app_restores_saved_plan_and_interaction_mode(
     saved_history = [Message(role="assistant", content=[TextBlock("saved response")]).to_dict()]
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     session.history = saved_history
@@ -557,7 +567,7 @@ async def test_textual_app_restores_saved_plan_in_build_mode_without_plan_action
     saved_plan = "# Saved plan\n\nKeep this visible."
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     session.latest_plan_markdown = saved_plan
@@ -600,7 +610,7 @@ async def test_textual_app_invalid_saved_interaction_mode_falls_back_to_build(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     session.interaction_mode = "invalid"
@@ -649,7 +659,7 @@ async def test_textual_app_passes_shared_task_list_tools_to_build_and_plan_agent
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -725,7 +735,7 @@ async def test_textual_app_passes_skill_extensions_to_build_and_plan_agents(
         "---\nname: demo-skill\ndescription: Use this demo skill.\n---\n\nFollow demo instructions.\n",
         encoding="utf-8",
     )
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -779,7 +789,7 @@ async def test_textual_app_skill_slash_commands_list_and_activate(
         "---\nname: demo-skill\ndescription: Use this demo skill.\n---\n\nFollow demo instructions.\n",
         encoding="utf-8",
     )
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -840,7 +850,7 @@ async def test_textual_app_skill_slash_command_with_prompt_starts_turn(
         "---\nname: demo-skill\ndescription: Use this demo skill.\n---\n\nFollow demo instructions.\n",
         encoding="utf-8",
     )
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -892,7 +902,7 @@ async def test_textual_app_planning_question_tool_accepts_option_list_answer(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -965,7 +975,7 @@ async def test_textual_app_planning_question_supports_arrow_and_digit_selection(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -1030,7 +1040,7 @@ async def test_textual_app_planning_question_tool_accepts_custom_text_answer(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -1089,7 +1099,7 @@ async def test_textual_app_blocks_mode_toggle_during_active_turn(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -1151,7 +1161,7 @@ async def test_textual_app_shows_plan_decision_when_planning_agent_writes_plan(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -1239,7 +1249,7 @@ async def test_textual_app_implement_plan_switches_to_build_and_sends_plan(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -1304,7 +1314,7 @@ async def test_textual_app_discuss_plan_clears_old_plan_until_new_plan_is_writte
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -1371,7 +1381,7 @@ async def test_textual_app_does_not_save_startup_entry_to_history(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -1415,7 +1425,7 @@ async def test_textual_app_composer_shift_enter_inserts_line_break_and_enter_sub
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -1465,7 +1475,7 @@ async def test_textual_app_composer_ctrl_enter_still_inserts_line_break(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -1515,7 +1525,7 @@ async def test_textual_app_composer_preserves_multiline_paste(
     pasted = "line one\n    line two\nline three"
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -1574,7 +1584,7 @@ async def test_textual_app_reset_command_clears_current_thread(
     ]
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     session.history = saved_history
@@ -1654,7 +1664,7 @@ async def test_textual_app_reset_command_waits_for_active_turn(
     saved_history = [Message(role="user", content=[TextBlock("old request")]).to_dict()]
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     session.history = saved_history
@@ -1711,11 +1721,56 @@ async def test_textual_app_mounts_settings_without_api_key(
         assert app.agent is None
         assert app.query_one("#composer", ChatComposer).disabled is True
         startup = app.conversation_entries[0].content
-        assert f"Model: {UI_DEFAULT_PROVIDER}/{UI_DEFAULT_MODEL}" in startup
-        assert "API key: missing" in startup
+        assert "Model: not configured" in startup
+        assert "API key: not checked until a model is configured" in startup
+        stored_settings = settings_store.load()
+        assert stored_settings.active_provider is None
+        assert stored_settings.active_model is None
         status = str(app.query_one("#settings_status").render())
         assert "Configuration incomplete" in status
-        assert "MOONSHOT_API_KEY" in status
+        assert "No provider/model configured" in status
+
+
+@pytest.mark.asyncio
+async def test_textual_app_does_not_select_model_from_api_key_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import ChatComposer, KolegaCodeApp
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            raise AssertionError("agent should not be built from an API key alone")
+
+    monkeypatch.setenv("MOONSHOT_API_KEY", "moonshot-key")
+    monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    state_dir = tmp_path / "state"
+    store = SessionStore(state_dir)
+    settings_store = SettingsStore(state_dir)
+    session = store.create(project, "code", {})
+
+    app = KolegaCodeApp(
+        project_path=project,
+        mode="code",
+        store=store,
+        settings_store=settings_store,
+        session=session,
+    )
+
+    async with app.run_test():
+        assert app.agent is None
+        assert app.query_one("#composer", ChatComposer).disabled is True
+        startup = app.conversation_entries[0].content
+        assert "Model: not configured" in startup
+        assert f"Model: {UI_DEFAULT_PROVIDER}/{UI_DEFAULT_MODEL}" not in startup
+        stored_settings = settings_store.load()
+        assert stored_settings.active_provider is None
+        assert stored_settings.active_model is None
 
 
 @pytest.mark.asyncio
@@ -1969,7 +2024,7 @@ async def test_textual_app_merges_streamed_response_chunks(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -2022,7 +2077,7 @@ async def test_textual_app_merges_streamed_thinking_chunks(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -2062,7 +2117,7 @@ async def test_textual_app_formats_thinking_as_italic_chat_entry(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -2104,7 +2159,7 @@ async def test_textual_app_renders_one_widget_per_chat_entry(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -2164,7 +2219,7 @@ async def test_conversation_entry_widget_extracts_plain_selected_text(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -2214,7 +2269,7 @@ async def test_conversation_entry_supports_mouse_drag_selection(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -2270,7 +2325,7 @@ async def test_command_c_copies_selected_chat_text_to_macos_clipboard(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -2318,7 +2373,7 @@ async def test_textual_app_formats_agent_and_tool_chat_entries(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -2383,7 +2438,7 @@ async def test_textual_app_ignores_empty_final_response_without_existing_entry(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -2432,7 +2487,7 @@ async def test_textual_app_shows_working_progress_during_active_turn(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -2497,7 +2552,7 @@ async def test_textual_app_renders_tool_events_in_chat(tmp_path: Path, monkeypat
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -2575,7 +2630,7 @@ async def test_textual_app_appends_append_mode_tool_streaming_events_in_chat(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -2673,7 +2728,7 @@ async def test_textual_app_replaces_default_tool_streaming_events_in_chat(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -2736,7 +2791,7 @@ async def test_textual_app_caps_long_append_mode_tool_streaming_events(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -2836,7 +2891,7 @@ async def test_textual_app_renders_queued_tool_events_during_active_turn(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -2900,7 +2955,7 @@ async def test_textual_app_late_tool_result_updates_existing_tool_row(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -2976,7 +3031,7 @@ async def test_textual_app_cancellation_is_visible_in_chat(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -3035,7 +3090,7 @@ async def test_textual_app_renders_resumed_history_in_chat(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     session.history = [
@@ -3105,7 +3160,7 @@ def _build_sub_agent_test_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     return KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -3750,7 +3805,7 @@ def _build_mention_test_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     (project / "src" / "alpha.py").write_text("print('alpha')\n", encoding="utf-8")
     (project / "src" / "alpine.txt").write_text("mountains\n", encoding="utf-8")
     (project / "README.md").write_text("# Readme\n", encoding="utf-8")
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     return KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -4093,7 +4148,7 @@ async def test_textual_app_plan_and_build_slash_commands_switch_mode(
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(project, env={"ANTHROPIC_API_KEY": "test-key"})
+    config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)

--- a/kolega_code/cli/tests/test_cli_config.py
+++ b/kolega_code/cli/tests/test_cli_config.py
@@ -4,9 +4,7 @@ import pytest
 
 from kolega_code.config import ModelProvider
 from kolega_code.cli.config import (
-    DEFAULT_FAST_MODEL,
     DEFAULT_LONG_MODEL,
-    DEFAULT_THINKING_MODEL,
     CliConfigError,
     CliConfigOverrides,
     build_agent_config,
@@ -21,13 +19,34 @@ from kolega_code.cli.provider_registry import (
 from kolega_code.cli.settings import CliSettings
 
 
-def test_build_agent_config_defaults_to_latest_anthropic_models(tmp_path: Path) -> None:
-    config = build_agent_config(tmp_path, env={"ANTHROPIC_API_KEY": "test-key"})
+@pytest.mark.parametrize(
+    ("api_key_env", "api_key"),
+    [
+        ("ANTHROPIC_API_KEY", "anthropic-key"),
+        ("MOONSHOT_API_KEY", "moonshot-key"),
+        ("DEEPSEEK_API_KEY", "deepseek-key"),
+    ],
+)
+def test_build_agent_config_requires_model_selection_even_with_api_key(
+    tmp_path: Path, api_key_env: str, api_key: str
+) -> None:
+    with pytest.raises(CliConfigError, match="No provider/model configured"):
+        build_agent_config(tmp_path, env={api_key_env: api_key})
+
+
+def test_build_agent_config_explicit_provider_uses_provider_default_model(tmp_path: Path) -> None:
+    config = build_agent_config(
+        tmp_path,
+        env={
+            "ANTHROPIC_API_KEY": "test-key",
+            "KOLEGA_CODE_PROVIDER": "anthropic",
+        },
+    )
 
     assert config.long_context_config.provider == ModelProvider.ANTHROPIC
     assert config.long_context_config.model == DEFAULT_LONG_MODEL
-    assert config.fast_config.model == DEFAULT_FAST_MODEL
-    assert config.thinking_config.model == DEFAULT_THINKING_MODEL
+    assert config.fast_config.model == DEFAULT_LONG_MODEL
+    assert config.thinking_config.model == DEFAULT_LONG_MODEL
     assert config.long_context_config.thinking_effort == "medium"
     assert config.thinking_config.thinking_effort == "medium"
 
@@ -85,7 +104,7 @@ def test_build_agent_config_rejects_invalid_thinking_effort(tmp_path: Path) -> N
 
 def test_build_agent_config_requires_api_key(tmp_path: Path) -> None:
     with pytest.raises(CliConfigError, match="ANTHROPIC_API_KEY"):
-        build_agent_config(tmp_path, env={})
+        build_agent_config(tmp_path, CliConfigOverrides(provider="anthropic"), env={})
 
 
 def test_build_agent_config_rejects_unknown_model(tmp_path: Path) -> None:
@@ -94,7 +113,13 @@ def test_build_agent_config_rejects_unknown_model(tmp_path: Path) -> None:
 
 
 def test_config_summary_excludes_api_keys(tmp_path: Path) -> None:
-    config = build_agent_config(tmp_path, env={"ANTHROPIC_API_KEY": "secret-value"})
+    config = build_agent_config(
+        tmp_path,
+        env={
+            "ANTHROPIC_API_KEY": "secret-value",
+            "KOLEGA_CODE_PROVIDER": "anthropic",
+        },
+    )
 
     summary = config_summary(config)
 

--- a/kolega_code/cli/tests/test_main.py
+++ b/kolega_code/cli/tests/test_main.py
@@ -112,6 +112,20 @@ def test_ask_skill_only_prints_activation_without_model_call(
     assert "Follow demo instructions." in output
 
 
+def test_ask_requires_model_selection_even_with_api_key(
+    tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    exit_code = main(["ask", "hello", "--project", str(project)])
+
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert "No provider/model configured" in captured.out or "No provider/model configured" in captured.err
+
+
 def test_ask_skill_with_prompt_activates_before_dispatch(
     tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
 ) -> None:
@@ -147,6 +161,7 @@ def test_ask_skill_with_prompt_activates_before_dispatch(
     project.mkdir()
     write_skill(project)
     monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("KOLEGA_CODE_PROVIDER", "anthropic")
     monkeypatch.setattr(main_module, "CoderAgent", FakeCoderAgent)
 
     exit_code = main_module.main(["ask", "/demo-skill do the task", "--project", str(project)])
@@ -176,6 +191,21 @@ def test_doctor_uses_stored_kimi_settings(tmp_path: Path, capsys, isolated_cli_e
     assert "Thinking effort: auto" in output
     assert "present in local settings" in output
     assert "moonshot-key" not in output
+
+
+def test_doctor_requires_model_selection_even_with_api_key(
+    tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    exit_code = main(["doctor", "--project", str(project)])
+
+    assert exit_code == 2
+    output = capsys.readouterr().out
+    assert "Stored active model: not configured" in output
+    assert "No provider/model configured" in output
 
 
 def test_deprecated_thinking_tokens_flag_fails(tmp_path: Path, capsys, isolated_cli_env: None) -> None:
@@ -347,6 +377,7 @@ def test_ask_json_interleaves_sub_agent_events(
     project = tmp_path / "project"
     project.mkdir()
     monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("KOLEGA_CODE_PROVIDER", "anthropic")
     monkeypatch.setattr(main_module, "CoderAgent", _SubAgentEventCoderAgent)
 
     exit_code = main_module.main(["ask", "do the task", "--project", str(project), "--json"])
@@ -370,6 +401,7 @@ def test_ask_plain_writes_sub_agent_lifecycle_to_stderr(
     project = tmp_path / "project"
     project.mkdir()
     monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("KOLEGA_CODE_PROVIDER", "anthropic")
     monkeypatch.setattr(main_module, "CoderAgent", _SubAgentEventCoderAgent)
 
     exit_code = main_module.main(["ask", "do the task", "--project", str(project)])
@@ -420,6 +452,7 @@ def test_ask_prompt_with_file_mention_attaches_content(
     project.mkdir()
     (project / "notes.md").write_text("remember the milk\n", encoding="utf-8")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("KOLEGA_CODE_PROVIDER", "anthropic")
     monkeypatch.setattr(main_module, "CoderAgent", FakeCoderAgent)
 
     exit_code = main_module.main(["ask", "summarize @notes.md", "--project", str(project)])
@@ -468,6 +501,7 @@ def test_ask_prompt_with_unresolved_mention_warns_on_stderr(
     project = tmp_path / "project"
     project.mkdir()
     monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("KOLEGA_CODE_PROVIDER", "anthropic")
     monkeypatch.setattr(main_module, "CoderAgent", FakeCoderAgent)
 
     exit_code = main_module.main(["ask", "summarize @missing.md", "--project", str(project)])


### PR DESCRIPTION
## Summary

This changes CLI model resolution so API key environment variables are treated only as credentials, not as implicit provider/model selectors.

## What changed

- Require an explicit provider/model selection from CLI flags, `KOLEGA_CODE_*` environment variables, or saved Settings before building an agent config.
- Stop the Textual settings mount path from mutating empty settings into the curated Moonshot default.
- Show an unconfigured startup/status state until the user saves a model selection.
- Update CLI tests and docs to cover and explain the new behavior.

## Why

Previously, a provider API key in the process environment could make the CLI start with a default provider/model even when the user had not selected one. That made ambient credentials act like configuration.

## Validation

- `uv run pytest kolega_code/cli/tests -q`
- `uv run ruff check kolega_code/cli/config.py kolega_code/cli/app.py kolega_code/cli/messages.py kolega_code/cli/tests/test_cli_config.py kolega_code/cli/tests/test_app.py kolega_code/cli/tests/test_main.py`