### PR TITLE
[codex] Adopt AGENTS.md project guidance

### DIFF
--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -28,13 +28,16 @@ from kolega_code.llm.specs import get_model_specs
 from .prompt_provider import PromptProvider, AgentMode, PromptContext, PromptExtension
 from kolega_code.services.base import TerminalManager, BrowserManager
 from kolega_code.services.file_system import FileSystem
-from .tools import ToolCollection
+from .tools import ToolCollection  # noqa: F401 - kept for tests and downstream monkeypatch compatibility
 from kolega_code.tools import ToolError
 from .utils.commands import CommandProcessor
 from langfuse import Langfuse
 
 
 logger = logging.getLogger(__name__)
+
+PROJECT_GUIDANCE_FILES = ("AGENTS.md", "KOLEGA.md")
+AGENT_MEMORY_FILE = "AGENT_MEMORY.md"
 
 
 class BaseAgent(LogMixin):
@@ -342,6 +345,26 @@ class BaseAgent(LogMixin):
     # Prompt context
     # ------------------------------------------------------------------
 
+    def _load_project_guidance(self) -> tuple[str, str]:
+        """Return the first project guidance file found and its content."""
+        for guidance_file in PROJECT_GUIDANCE_FILES:
+            if not self.filesystem.exists(guidance_file):
+                continue
+            try:
+                return guidance_file, self.filesystem.read_text(guidance_file)
+            except Exception:
+                return guidance_file, ""
+        return "", ""
+
+    def _load_agent_memory(self) -> tuple[str, str]:
+        """Return agent memory content when AGENT_MEMORY.md exists."""
+        if not self.filesystem.exists(AGENT_MEMORY_FILE):
+            return "", ""
+        try:
+            return AGENT_MEMORY_FILE, self.filesystem.read_text(AGENT_MEMORY_FILE)
+        except Exception:
+            return AGENT_MEMORY_FILE, ""
+
     def build_prompt_context(self) -> PromptContext:
         """Build PromptContext from agent state."""
         import platform
@@ -349,14 +372,8 @@ class BaseAgent(LogMixin):
         # Check if it's a git repository
         is_git_repo = self.filesystem.exists(".git") and self.filesystem.is_dir(".git")
 
-        # Load KOLEGA.md content if it exists
-        kolega_md_content = ""
-        if self.filesystem.exists("KOLEGA.md"):
-            try:
-                kolega_md_content = self.filesystem.read("KOLEGA.md")
-            except Exception:
-                # If there's an error reading the file, use empty string
-                kolega_md_content = ""
+        project_guidance_file, project_guidance = self._load_project_guidance()
+        agent_memory_file, agent_memory = self._load_agent_memory()
 
         return PromptContext(
             system_name=os.getenv("KOLEGA_CODE_SYSTEM_NAME", "Kolega Code"),
@@ -366,7 +383,11 @@ class BaseAgent(LogMixin):
             date_today=datetime.now().strftime("%Y-%m-%d"),
             model_name=self.config.long_context_config.model,
             available_ports=self.available_ports,
-            kolega_md=kolega_md_content,
+            project_guidance=project_guidance,
+            project_guidance_file=project_guidance_file,
+            agent_memory=agent_memory,
+            agent_memory_file=agent_memory_file,
+            kolega_md=project_guidance,
             workspace_id=self.workspace_id,
             workspace_environment_variables=self.workspace_env_var_descriptions,
             memories=self.workspace_memories,

--- a/kolega_code/agent/planningagent.py
+++ b/kolega_code/agent/planningagent.py
@@ -144,11 +144,19 @@ class PlanningAgent(BaseAgent):
             date_today=context.date_today,
             model_name=context.model_name,
         )
-        if context.kolega_md:
+        if context.project_guidance:
             prompt += (
                 "\n\n## Project Instructions\n\n"
-                "The project directory contains `KOLEGA.md`. Treat it as local project guidance:\n\n"
-                f"```markdown\n{context.kolega_md}\n```"
+                f"The project directory contains `{context.project_guidance_file}`. "
+                "Treat it as local project guidance:\n\n"
+                f"```markdown\n{context.project_guidance}\n```"
+            )
+        if context.agent_memory:
+            prompt += (
+                "\n\n## Agent Memory\n\n"
+                f"The project directory contains `{context.agent_memory_file}`. "
+                "Treat it as persistent agent memory:\n\n"
+                f"```markdown\n{context.agent_memory}\n```"
             )
         if self.prompt_extensions:
             prompt += "\n\n## Additional Context\n"

--- a/kolega_code/agent/prompt_provider.py
+++ b/kolega_code/agent/prompt_provider.py
@@ -50,12 +50,29 @@ class PromptContext:
     date_today: str = ""
     model_name: str = ""
     available_ports: str = "9001-9999"
+    project_guidance: str = ""
+    project_guidance_file: str = ""
+    agent_memory: str = ""
+    agent_memory_file: str = ""
     kolega_md: str = ""
     workspace_id: str = ""
     workspace_environment_variables: Dict[str, str] = field(default_factory=dict)
 
     # Workspace memories
     memories: List[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        """Keep the legacy KOLEGA.md field usable for older callers."""
+        if self.project_guidance and not self.kolega_md:
+            self.kolega_md = self.project_guidance
+            if not self.project_guidance_file:
+                self.project_guidance_file = "AGENTS.md"
+        elif self.kolega_md and not self.project_guidance:
+            self.project_guidance = self.kolega_md
+            if not self.project_guidance_file:
+                self.project_guidance_file = "KOLEGA.md"
+        if self.agent_memory and not self.agent_memory_file:
+            self.agent_memory_file = "AGENT_MEMORY.md"
 
 
 class PromptProvider:

--- a/kolega_code/agent/prompt_templates/agents/browser.j2
+++ b/kolega_code/agent/prompt_templates/agents/browser.j2
@@ -96,7 +96,22 @@ This ensures compatibility with both local and cloud sandbox environments.
 4. Before calling tools, first explain to the USER why you are calling them.
 5. WHENEVER YOU OPEN A BROWSER OR TERMINAL, ALWAYS CLOSE IT WHEN DONE.
 
-Here are the contents of KOLEGA.md:
+{% if context.project_guidance %}
+## Project Instructions
+
+The project directory contains `{{ context.project_guidance_file }}`. Treat it as local project guidance:
+
 ```
-{{ context.kolega_md }}
+{{ context.project_guidance }}
 ``` 
+{% endif %}
+
+{% if context.agent_memory %}
+## Agent Memory
+
+The project directory contains `{{ context.agent_memory_file }}`. Treat it as persistent agent memory:
+
+```
+{{ context.agent_memory }}
+```
+{% endif %}

--- a/kolega_code/agent/prompt_templates/agents/coder_cli_mode.j2
+++ b/kolega_code/agent/prompt_templates/agents/coder_cli_mode.j2
@@ -112,13 +112,23 @@ This project was created using a starter template from Kolega. Here is some info
 {% endfor %}
 {% endif %}
 
-{% if context.kolega_md %}
+{% if context.project_guidance %}
 ## Project Instructions
 
-The project directory contains `KOLEGA.md`. Treat it as local project guidance:
+The project directory contains `{{ context.project_guidance_file }}`. Treat it as local project guidance:
 
 ```markdown
-{{ context.kolega_md }}
+{{ context.project_guidance }}
+```
+{% endif %}
+
+{% if context.agent_memory %}
+## Agent Memory
+
+The project directory contains `{{ context.agent_memory_file }}`. Treat it as persistent agent memory:
+
+```markdown
+{{ context.agent_memory }}
 ```
 {% endif %}
 

--- a/kolega_code/agent/prompt_templates/agents/general.j2
+++ b/kolega_code/agent/prompt_templates/agents/general.j2
@@ -62,7 +62,22 @@ When requesting a command to be run, you will be asked to judge if it is appropr
 2. Before calling tools, briefly state why you are calling them.
 3. You must ONLY use the tools in the scope of the "Working directory". NEVER expose Kolega Code's implementation.
 
-Here are the contents of KOLEGA.md:
+{% if context.project_guidance %}
+## Project Instructions
+
+The project directory contains `{{ context.project_guidance_file }}`. Treat it as local project guidance:
+
 ```
-{{ context.kolega_md }}
+{{ context.project_guidance }}
 ```
+{% endif %}
+
+{% if context.agent_memory %}
+## Agent Memory
+
+The project directory contains `{{ context.agent_memory_file }}`. Treat it as persistent agent memory:
+
+```
+{{ context.agent_memory }}
+```
+{% endif %}

--- a/kolega_code/agent/prompt_templates/agents/investigation.j2
+++ b/kolega_code/agent/prompt_templates/agents/investigation.j2
@@ -66,7 +66,22 @@ When requesting a command to be run, you will be asked to judge if it is appropr
 4. Before calling tools, first explain to the USER why you are calling them.
 5. You must ONLY use the tools in the scope of the "Working directory". NEVER expose Kolega Code's implementation.
 
-Here are the contents of KOLEGA.md:
+{% if context.project_guidance %}
+## Project Instructions
+
+The project directory contains `{{ context.project_guidance_file }}`. Treat it as local project guidance:
+
 ```
-{{ context.kolega_md }}
+{{ context.project_guidance }}
 ``` 
+{% endif %}
+
+{% if context.agent_memory %}
+## Agent Memory
+
+The project directory contains `{{ context.agent_memory_file }}`. Treat it as persistent agent memory:
+
+```
+{{ context.agent_memory }}
+```
+{% endif %}

--- a/kolega_code/agent/prompt_templates/common/kolega_md_instructions.md
+++ b/kolega_code/agent/prompt_templates/common/kolega_md_instructions.md
@@ -1,14 +1,15 @@
-## The KOLEGA.md File
+## Project Guidance
 
-If the project directory contains a file called KOLEGA.md, it will be included below. This file serves multiple purposes:
+If the project directory contains a file called AGENTS.md, it will be included below. If AGENTS.md is absent,
+KOLEGA.md will be used as a legacy fallback. This file serves multiple purposes:
 
 1. Storing frequently used bash commands
 2. Recording code style preferences
 3. Maintaining codebase structure information
 4. Providing quick access to important information
 
-Here are the contents of KOLEGA.md:
+Here are the contents of {{ project_guidance_file }}:
 
 ```
-{{ kolega_md }}
+{{ project_guidance }}
 ```

--- a/kolega_code/agent/tests/test_base_agent.py
+++ b/kolega_code/agent/tests/test_base_agent.py
@@ -64,6 +64,47 @@ def base_agent(tmp_path, mock_connection_manager, agent_config):
 
 
 class TestBaseAgent:
+    def test_build_prompt_context_loads_agents_md(self, base_agent, tmp_path):
+        (tmp_path / "AGENTS.md").write_text("Use AGENTS guidance", encoding="utf-8")
+
+        context = base_agent.build_prompt_context()
+
+        assert context.project_guidance_file == "AGENTS.md"
+        assert context.project_guidance == "Use AGENTS guidance"
+        assert context.kolega_md == "Use AGENTS guidance"
+
+    def test_build_prompt_context_falls_back_to_kolega_md(self, base_agent, tmp_path):
+        (tmp_path / "KOLEGA.md").write_text("Use legacy guidance", encoding="utf-8")
+
+        context = base_agent.build_prompt_context()
+
+        assert context.project_guidance_file == "KOLEGA.md"
+        assert context.project_guidance == "Use legacy guidance"
+
+    def test_build_prompt_context_prefers_agents_md(self, base_agent, tmp_path):
+        (tmp_path / "AGENTS.md").write_text("Use canonical guidance", encoding="utf-8")
+        (tmp_path / "KOLEGA.md").write_text("Ignore legacy guidance", encoding="utf-8")
+
+        context = base_agent.build_prompt_context()
+
+        assert context.project_guidance_file == "AGENTS.md"
+        assert context.project_guidance == "Use canonical guidance"
+        assert "Ignore legacy guidance" not in context.project_guidance
+
+    def test_build_prompt_context_without_guidance(self, base_agent):
+        context = base_agent.build_prompt_context()
+
+        assert context.project_guidance_file == ""
+        assert context.project_guidance == ""
+
+    def test_build_prompt_context_loads_agent_memory(self, base_agent, tmp_path):
+        (tmp_path / "AGENT_MEMORY.md").write_text("Remember this detail", encoding="utf-8")
+
+        context = base_agent.build_prompt_context()
+
+        assert context.agent_memory_file == "AGENT_MEMORY.md"
+        assert context.agent_memory == "Remember this detail"
+
     @pytest.mark.asyncio
     async def test_execute_single_tool_uses_execution_id_for_app_events_and_provider_id_for_result(self, base_agent):
         class TestTools:

--- a/kolega_code/agent/tests/test_prompt_provider.py
+++ b/kolega_code/agent/tests/test_prompt_provider.py
@@ -35,7 +35,8 @@ class TestPromptProvider:
             date_today="2024-01-15",
             model_name="claude-3-5-sonnet",
             available_ports="9001-9999",
-            kolega_md="Test project documentation",
+            project_guidance="Test project documentation",
+            project_guidance_file="AGENTS.md",
             workspace_id="test-workspace-123",
         )
 
@@ -50,7 +51,26 @@ class TestPromptProvider:
         assert "Kolega Code" in prompt
         assert "/test/project" in prompt
         assert "Test project documentation" in prompt
+        assert "AGENTS.md" in prompt
         assert len(prompt) > 0
+
+    def test_prompt_includes_agent_memory(self, prompt_provider):
+        """Agent memory should render as a separate prompt section."""
+        context = PromptContext(
+            project_guidance="Project guidance",
+            project_guidance_file="AGENTS.md",
+            agent_memory="Remember the release checklist",
+            agent_memory_file="AGENT_MEMORY.md",
+        )
+
+        prompt = prompt_provider.get_system_prompt(agent_type=AgentType.CODER, mode=AgentMode.CLI, context=context)
+
+        assert "Project Instructions" in prompt
+        assert "AGENTS.md" in prompt
+        assert "Project guidance" in prompt
+        assert "Agent Memory" in prompt
+        assert "AGENT_MEMORY.md" in prompt
+        assert "Remember the release checklist" in prompt
 
     @pytest.mark.parametrize("mode", [AgentMode.CODE, AgentMode.VIBE, AgentMode.FIX])
     def test_hosted_coder_modes_require_host_template(self, prompt_provider, prompt_context, mode):

--- a/kolega_code/agent/tests/test_tools.py
+++ b/kolega_code/agent/tests/test_tools.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock
 import uuid
 
 import pytest
@@ -7,6 +7,7 @@ import pytest
 from kolega_code.agent.baseagent import BaseAgent
 from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
 from kolega_code.events import AgentConnectionManager
+from kolega_code.agent.tool_backend.memory_tool import MemoryTool
 from kolega_code.agent.tools import ToolCollection, ToolDefinition, ToolCollectionConfig
 
 
@@ -303,6 +304,99 @@ class TestToolCollection:
         result = await tool_collection.write_memory(memory_content)
         assert result == expected_response
         tool_collection.memory_tool.write_memory.assert_called_once_with(memory_content)
+
+    async def test_memory_tool_reads_agent_memory_file(
+        self,
+        project_path: Path,
+        mock_connection_manager: AgentConnectionManager,
+        agent_config: AgentConfig,
+        mock_base_agent: BaseAgent,
+    ) -> None:
+        (project_path / "AGENT_MEMORY.md").write_text("Memory content", encoding="utf-8")
+        memory_tool = MemoryTool(
+            project_path,
+            "test_workspace",
+            str(uuid.uuid4()),
+            mock_connection_manager,
+            agent_config,
+            mock_base_agent,
+        )
+        memory_tool.log_info = AsyncMock()
+
+        result = await memory_tool.read_memory()
+
+        assert result == "Memory content"
+        memory_tool.log_info.assert_called_once_with(
+            "Successfully read memory file AGENT_MEMORY.md", sender="test_agent"
+        )
+
+    async def test_memory_tool_write_creates_agent_memory_file(
+        self,
+        project_path: Path,
+        mock_connection_manager: AgentConnectionManager,
+        agent_config: AgentConfig,
+        mock_base_agent: BaseAgent,
+    ) -> None:
+        memory_tool = MemoryTool(
+            project_path,
+            "test_workspace",
+            str(uuid.uuid4()),
+            mock_connection_manager,
+            agent_config,
+            mock_base_agent,
+        )
+        memory_tool.log_info = AsyncMock()
+
+        result = await memory_tool.write_memory("New memory")
+
+        assert result == "Created memory file AGENT_MEMORY.md and added new memory"
+        assert (project_path / "AGENT_MEMORY.md").read_text(encoding="utf-8") == "# Agent Memory\n\n- New memory\n"
+
+    async def test_memory_tool_write_appends_to_agent_memory_file(
+        self,
+        project_path: Path,
+        mock_connection_manager: AgentConnectionManager,
+        agent_config: AgentConfig,
+        mock_base_agent: BaseAgent,
+    ) -> None:
+        (project_path / "AGENT_MEMORY.md").write_text("# Agent Memory\n\n- Existing memory\n", encoding="utf-8")
+        memory_tool = MemoryTool(
+            project_path,
+            "test_workspace",
+            str(uuid.uuid4()),
+            mock_connection_manager,
+            agent_config,
+            mock_base_agent,
+        )
+        memory_tool.log_info = AsyncMock()
+
+        result = await memory_tool.write_memory("New memory")
+
+        assert result == "Successfully added new memory to AGENT_MEMORY.md"
+        assert (
+            (project_path / "AGENT_MEMORY.md").read_text(encoding="utf-8")
+            == "# Agent Memory\n\n- Existing memory\n- New memory\n"
+        )
+
+    async def test_memory_tool_read_missing_agent_memory_file(
+        self,
+        project_path: Path,
+        mock_connection_manager: AgentConnectionManager,
+        agent_config: AgentConfig,
+        mock_base_agent: BaseAgent,
+    ) -> None:
+        memory_tool = MemoryTool(
+            project_path,
+            "test_workspace",
+            str(uuid.uuid4()),
+            mock_connection_manager,
+            agent_config,
+            mock_base_agent,
+        )
+        memory_tool.log_error = AsyncMock()
+
+        with pytest.raises(FileNotFoundError, match="AGENT_MEMORY.md"):
+            await memory_tool.read_memory()
 
     async def test_search_codebase(self, tool_collection: AsyncMock) -> None:
         pattern = "test"

--- a/kolega_code/agent/tool_backend/memory_tool.py
+++ b/kolega_code/agent/tool_backend/memory_tool.py
@@ -1,41 +1,43 @@
 from .base_tool import BaseTool
 
+MEMORY_FILE = "AGENT_MEMORY.md"
+
 
 class MemoryTool(BaseTool):
     async def read_memory(self) -> str:
         """
-        Read the contents of the KOLEGA.md file which serves as the agent's memory.
+        Read the contents of the AGENT_MEMORY.md file which serves as the agent's memory.
 
         Returns:
-            The contents of the KOLEGA.md file as a string
+            The contents of the AGENT_MEMORY.md file as a string
 
         Raises:
-            FileNotFoundError: If the KOLEGA.md file doesn't exist
+            FileNotFoundError: If the AGENT_MEMORY.md file doesn't exist
         """
-        memory_file = "KOLEGA.md"
+        memory_file = MEMORY_FILE
 
         if not self.filesystem.exists(memory_file):
-            error_msg = "Memory file KOLEGA.md not found in project root"
+            error_msg = f"Memory file {memory_file} not found in project root"
             await self.log_error(error_msg, sender=self.caller.agent_name)
             raise FileNotFoundError(error_msg)
 
         try:
             memory_content = self.filesystem.read_text(memory_file)
 
-            await self.log_info("Successfully read memory file KOLEGA.md", sender=self.caller.agent_name)
+            await self.log_info(f"Successfully read memory file {memory_file}", sender=self.caller.agent_name)
             return memory_content
         except PermissionError:
-            error_msg = "Permission denied when reading memory file KOLEGA.md"
+            error_msg = f"Permission denied when reading memory file {memory_file}"
             await self.log_error(error_msg, sender=self.caller.agent_name)
             raise
         except Exception as e:
-            error_msg = f"Failed to read memory file KOLEGA.md: {str(e)}"
+            error_msg = f"Failed to read memory file {memory_file}: {str(e)}"
             await self.log_error(error_msg, sender=self.caller.agent_name)
             raise
 
     async def write_memory(self, memory_content: str) -> str:
         """
-        Write a new memory to the KOLEGA.md file which serves as the agent's memory.
+        Write a new memory to the AGENT_MEMORY.md file which serves as the agent's memory.
 
         The memory is added as a markdown bullet point to the file.
 
@@ -49,13 +51,13 @@ class MemoryTool(BaseTool):
             PermissionError: If the file cannot be written to
             Exception: If any other error occurs during writing
         """
-        memory_file = "KOLEGA.md"
+        memory_file = MEMORY_FILE
 
         try:
             # Create the file if it doesn't exist
             if not self.filesystem.exists(memory_file):
-                self.filesystem.write_text(memory_file, f"# KOLEGA Memory\n\n- {memory_content}\n")
-                success_msg = "Created memory file KOLEGA.md and added new memory"
+                self.filesystem.write_text(memory_file, f"# Agent Memory\n\n- {memory_content}\n")
+                success_msg = f"Created memory file {memory_file} and added new memory"
             else:
                 # Read existing content and append the new memory
                 existing_content = self.filesystem.read_text(memory_file)
@@ -65,15 +67,15 @@ class MemoryTool(BaseTool):
 
                 # Write the updated content back to the file
                 self.filesystem.write_text(memory_file, updated_content)
-                success_msg = "Successfully added new memory to KOLEGA.md"
+                success_msg = f"Successfully added new memory to {memory_file}"
 
             await self.log_info(success_msg, sender=self.caller.agent_name)
             return success_msg
         except PermissionError:
-            error_msg = "Permission denied when writing to memory file KOLEGA.md"
+            error_msg = f"Permission denied when writing to memory file {memory_file}"
             await self.log_error(error_msg, sender=self.caller.agent_name)
             raise
         except Exception as e:
-            error_msg = f"Failed to write to memory file KOLEGA.md: {str(e)}"
+            error_msg = f"Failed to write to memory file {memory_file}: {str(e)}"
             await self.log_error(error_msg, sender=self.caller.agent_name)
             raise

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -1,13 +1,12 @@
 import asyncio
 import inspect
-import re
 from pathlib import Path
 from dataclasses import dataclass, field
 from typing import Any, Callable, List, Optional, Union
 
 from .common import LogMixin
 from kolega_code.config import AgentConfig
-from kolega_code.llm.models import ImageBlock, ToolDefinition, ToolParameter
+from kolega_code.llm.models import ImageBlock, ToolDefinition
 from kolega_code.tools import Tool, ToolRegistry, tool_definition_from_callable
 from kolega_code.services.file_system import FileSystem, LocalFileSystem
 from kolega_code.services.base import TerminalManager, BrowserManager
@@ -1360,19 +1359,19 @@ class ToolCollection(LogMixin):
 
     async def read_memory(self) -> str:
         """
-        Read the contents of the KOLEGA.md file which serves as the agent's memory.
+        Read the contents of the AGENT_MEMORY.md file which serves as the agent's memory.
 
         Returns:
-            The contents of the KOLEGA.md file as a string
+            The contents of the AGENT_MEMORY.md file as a string
 
         Raises:
-            FileNotFoundError: If the KOLEGA.md file doesn't exist
+            FileNotFoundError: If the AGENT_MEMORY.md file doesn't exist
         """
         return await self.memory_tool.read_memory()
 
     async def write_memory(self, memory_content: str) -> str:
         """
-        Write a new memory to the KOLEGA.md file which serves as the agent's memory.
+        Write a new memory to the AGENT_MEMORY.md file which serves as the agent's memory.
 
         The memory is added as a markdown bullet point to the file.
 


### PR DESCRIPTION
## Summary

- Load project guidance from `AGENTS.md` first, with `KOLEGA.md` as a legacy fallback only when `AGENTS.md` is absent.
- Add separate `AGENT_MEMORY.md` prompt interpolation for persistent agent memory.
- Retarget memory tools so `read_memory` and `write_memory` use `AGENT_MEMORY.md`.
- Update prompt templates and tests for the new guidance and memory behavior.
- Preserve `kolega_code.agent.baseagent.ToolCollection` as a compatibility import for existing monkeypatch-based tests and downstream callers.

## Validation

- `uv run ruff check kolega_code/agent/baseagent.py kolega_code/agent/planningagent.py kolega_code/agent/prompt_provider.py kolega_code/agent/tool_backend/memory_tool.py kolega_code/agent/tools.py kolega_code/agent/tests/test_base_agent.py kolega_code/agent/tests/test_prompt_provider.py kolega_code/agent/tests/test_tools.py`
- `uv run pytest kolega_code/agent/tests/test_duplicate_tool_results.py -q`
- `uv run pytest kolega_code/agent/tests/test_duplicate_tool_results.py kolega_code/agent/tests/test_base_agent.py kolega_code/agent/tests/test_prompt_provider.py kolega_code/agent/tests/test_tools.py -q`