### PR TITLE
[codex] Add interactive effort selector

### DIFF
--- a/docs/src/content/docs/tui/slash-commands.md
+++ b/docs/src/content/docs/tui/slash-commands.md
@@ -36,10 +36,13 @@ These control the app and your session.
 | `/plan` | Switch to [Plan mode](../modes/) |
 | `/build` | Switch to [Build mode](../modes/) |
 | `/model` | Show or switch the active model |
-| `/effort` | Show or set the active model's thinking effort |
+| `/effort` | Choose the active model's thinking effort |
 | `/copy` | Copy the last response to the clipboard |
 | `/version` | Show the Kolega Code version |
 | `/quit` | Save the session and exit |
+
+Run `/effort` to open a selectable list of supported effort values for the
+active model. You can also switch directly with `/effort <level>`.
 
 ## Skills
 

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -115,7 +115,9 @@ IMPLEMENT_PLAN_PROMPT = """Implement the approved plan below. Follow it as the s
 """
 QUESTION_TOOL_NAME = "ask_user_choice"
 QUESTION_OPTION_ID_PREFIX = "question_option_"
+EFFORT_OPTION_ID_PREFIX = "effort_option_"
 QUESTION_PLACEHOLDER = messages.QUESTION_PLACEHOLDER
+EFFORT_PLACEHOLDER = messages.EFFORT_PLACEHOLDER
 STARTUP_WORDMARK = (
     " _  __     _                    ____          _",
     "| |/ /___ | | ___  __ _  __ _ / ___|___   __| | ___",
@@ -202,6 +204,13 @@ class PendingQuestion:
     question: str
     options: list[str]
     future: asyncio.Future[str]
+
+
+@dataclass
+class PendingEffortSelection:
+    provider: str
+    model: str
+    options: list[tuple[str, str]]
 
 
 @dataclass
@@ -668,7 +677,7 @@ class KolegaCodeApp(App):
         opacity: 0.6;
     }
 
-    #plan_actions, #question_actions {
+    #plan_actions, #question_actions, #effort_actions {
         display: none;
         height: auto;
         max-height: 12;
@@ -732,6 +741,7 @@ class KolegaCodeApp(App):
         self._latest_plan: Optional[str] = self.session.latest_plan_markdown or None
         self._plan_decision_active = False
         self._pending_question: Optional[PendingQuestion] = None
+        self._pending_effort_selection: Optional[PendingEffortSelection] = None
         provider, model = self._startup_model()
         self._status_state = StatusDashboardState(provider=provider, model=model, mode=self.interaction_mode)
         self._turn_started_at: Optional[float] = None
@@ -759,6 +769,7 @@ class KolegaCodeApp(App):
                 )
                 yield ActionList(id="plan_actions")
                 yield ActionList(id="question_actions")
+                yield ActionList(id="effort_actions")
                 yield Static("", id="turn_status", markup=True)
                 yield Static("", id="composer_hint", markup=False)
                 yield CompletionDropdown(id="completion_dropdown")
@@ -813,6 +824,7 @@ class KolegaCodeApp(App):
         self._refresh_status_dashboard()
         self._restore_plan_action_visibility()
         self._set_question_actions_visible(False)
+        self._set_effort_actions_visible(False)
         self._refresh_planning_sidebar()
         self._ensure_startup_entry()
         self._conversation.anchor()
@@ -961,6 +973,14 @@ class KolegaCodeApp(App):
         if await self._handle_tui_slash_command(stripped_text, event.composer):
             return
 
+        if self._pending_effort_selection is not None:
+            if not stripped_text:
+                self._set_composer_status(EFFORT_PLACEHOLDER)
+                return
+            event.composer.load_text("")
+            await self._answer_effort_selection(stripped_text)
+            return
+
         if await self._handle_skill_slash_command(stripped_text, event.composer):
             return
 
@@ -1020,6 +1040,10 @@ class KolegaCodeApp(App):
         if event.option_list.id == "question_actions":
             event.stop()
             await self._answer_question_option(event.option_index)
+            return
+        if event.option_list.id == "effort_actions":
+            event.stop()
+            await self._answer_effort_option(event.option_index)
             return
         if event.option_list.id == "plan_actions":
             event.stop()
@@ -1373,6 +1397,7 @@ class KolegaCodeApp(App):
         self._save_session()
         self._restore_plan_action_visibility()
         self._cancel_pending_question()
+        self._cancel_pending_effort_selection()
 
         if self.config is not None:
             await self._build_agent(self.config, rebuild=True)
@@ -1443,6 +1468,24 @@ class KolegaCodeApp(App):
                 plan_actions.show_options(options)
             else:
                 plan_actions.hide()
+        except Exception:
+            return
+
+    def _set_effort_actions_visible(self, visible: bool) -> None:
+        try:
+            effort_actions = self.query_one("#effort_actions", ActionList)
+            if visible and self._pending_effort_selection is not None:
+                effort_actions.show_options(
+                    [
+                        Option(
+                            self._effort_option_label(index, label, value),
+                            id=f"{EFFORT_OPTION_ID_PREFIX}{index}",
+                        )
+                        for index, (label, value) in enumerate(self._pending_effort_selection.options)
+                    ]
+                )
+            else:
+                effort_actions.hide()
         except Exception:
             return
 
@@ -1521,6 +1564,8 @@ class KolegaCodeApp(App):
         handler = self._tui_command_handlers().get(command_text.lower())
         if handler is None:
             return False
+        if command_text.lower() != "/effort":
+            self._cancel_pending_effort_selection()
         composer.load_text("")
         await handler(args.strip())
         return True
@@ -1594,6 +1639,11 @@ class KolegaCodeApp(App):
             return
 
         if not args:
+            if self._turn_active or self.agent_worker is not None:
+                self._show_composer_hint(messages.BLOCK_STOP_BEFORE_EFFORT_SWITCH)
+                self._notify_user(messages.BLOCK_STOP_BEFORE_EFFORT_SWITCH, severity="warning")
+                return
+
             active_model_line = (
                 messages.SETTINGS_ACTIVE_MODEL.format(provider=provider, model=model)
                 if model
@@ -1609,6 +1659,13 @@ class KolegaCodeApp(App):
                 messages.EFFORT_SWITCH_HINT,
             ]
             self._add_conversation_entry(ConversationEntry(kind="system", content="\n".join(lines)))
+            self._pending_effort_selection = PendingEffortSelection(
+                provider=provider,
+                model=model,
+                options=effort_options,
+            )
+            self._show_effort_options()
+            self._set_composer_status(EFFORT_PLACEHOLDER)
             return
 
         if self._turn_active or self.agent_worker is not None:
@@ -1616,21 +1673,67 @@ class KolegaCodeApp(App):
             self._notify_user(messages.BLOCK_STOP_BEFORE_EFFORT_SWITCH, severity="warning")
             return
 
-        matched = next((value for _, value in effort_options if value.lower() == args.lower()), None)
+        matched = self._match_effort_value(effort_options, args)
         if matched is None:
-            self._notify_user(messages.EFFORT_UNKNOWN.format(effort=args, provider=provider, model=model), severity="warning")
+            self._notify_user(
+                messages.EFFORT_UNKNOWN.format(effort=args, provider=provider, model=model),
+                severity="warning",
+            )
             return
 
+        self._cancel_pending_effort_selection()
+        await self._switch_thinking_effort(provider, model, matched)
+
+    async def _answer_effort_option(self, option_index: int) -> None:
+        pending = self._pending_effort_selection
+        if pending is None:
+            return
+        if option_index < 0 or option_index >= len(pending.options):
+            return
+        await self._switch_thinking_effort(pending.provider, pending.model, pending.options[option_index][1])
+
+    async def _answer_effort_selection(self, answer: str) -> None:
+        pending = self._pending_effort_selection
+        if pending is None:
+            return
+
+        clean_answer = answer.strip()
+        if not clean_answer:
+            self._set_composer_status(EFFORT_PLACEHOLDER)
+            return
+
+        matched = self._match_effort_value(pending.options, clean_answer)
+        if matched is None:
+            self._set_composer_status(EFFORT_PLACEHOLDER)
+            self._notify_user(
+                messages.EFFORT_UNKNOWN.format(
+                    effort=clean_answer,
+                    provider=pending.provider,
+                    model=pending.model,
+                ),
+                severity="warning",
+            )
+            return
+
+        await self._switch_thinking_effort(pending.provider, pending.model, matched)
+
+    async def _switch_thinking_effort(self, provider: str, model: str, effort: str) -> None:
+        self._cancel_pending_effort_selection()
         self.settings.active_provider = provider
         self.settings.active_model = model
-        self.settings.active_thinking_effort = matched
+        self.settings.active_thinking_effort = effort
         self.settings_store.save(self.settings)
         await self._ensure_agent_from_settings(rebuild=True)
         try:
             self._populate_settings_controls()
         except Exception:
             pass
-        self._notify_user(messages.EFFORT_SWITCHED.format(effort=matched, provider=provider, model=model))
+        self._restore_composer_placeholder()
+        self._notify_user(messages.EFFORT_SWITCHED.format(effort=effort, provider=provider, model=model))
+
+    def _match_effort_value(self, effort_options: list[tuple[str, str]], value: str) -> Optional[str]:
+        clean_value = value.strip().lower()
+        return next((effort for _, effort in effort_options if effort.lower() == clean_value), None)
 
     async def _command_copy(self, args: str) -> None:
         entry = next(
@@ -1886,6 +1989,14 @@ class KolegaCodeApp(App):
         except Exception:
             return
 
+    def _show_effort_options(self) -> None:
+        self._set_effort_actions_visible(True)
+        try:
+            effort_actions = self.query_one("#effort_actions", ActionList)
+            self.screen.set_focus(effort_actions)
+        except Exception:
+            return
+
     def _set_question_actions_visible(self, visible: bool) -> None:
         try:
             question_actions = self.query_one("#question_actions", ActionList)
@@ -1910,6 +2021,14 @@ class KolegaCodeApp(App):
     def _question_option_label(self, index: int, option: str) -> str:
         return f"{index + 1}. {option}"
 
+    def _cancel_pending_effort_selection(self) -> None:
+        self._pending_effort_selection = None
+        self._set_effort_actions_visible(False)
+
+    def _effort_option_label(self, index: int, label: str, value: str) -> str:
+        current_suffix = " current" if value == self._startup_thinking_effort() else ""
+        return f"{index + 1}. {label} ({value}){current_suffix}"
+
     def _reset_current_thread(self) -> None:
         if self.agent is not None:
             self.agent.history = MessageHistory()
@@ -1928,6 +2047,7 @@ class KolegaCodeApp(App):
         self._save_session()
         self._set_plan_actions_visible(False)
         self._cancel_pending_question()
+        self._cancel_pending_effort_selection()
         self._refresh_planning_sidebar()
         self._clear_turn_status_strip()
         self._turn_active = False
@@ -2274,6 +2394,7 @@ class KolegaCodeApp(App):
         self._plan_decision_active = False
         self._restore_plan_action_visibility()
         self._cancel_pending_question()
+        self._cancel_pending_effort_selection()
         self._refresh_planning_sidebar()
         self._ensure_startup_entry(render=False)
         for item in history:

--- a/kolega_code/cli/messages.py
+++ b/kolega_code/cli/messages.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 COMPOSER_PLACEHOLDER = "Ask Kolega Code..."
 PLAN_READY_PLACEHOLDER = "Plan ready. Choose Implement plan or Discuss further."
 QUESTION_PLACEHOLDER = "Choose an option below or type a custom answer..."
+EFFORT_PLACEHOLDER = "Choose a thinking effort below or type a supported value..."
 
 # Durable transcript messages
 THREAD_RESET_MESSAGE = "Thread reset. Previous messages were cleared."
@@ -59,7 +60,7 @@ MODEL_SWITCH_HINT = "Switch with /model <name>."
 EFFORT_SWITCHED = "Switched thinking effort to {effort} for {provider}/{model}."
 EFFORT_UNKNOWN = "Unknown thinking effort {effort} for {provider}/{model}."
 EFFORT_UNSUPPORTED = "{provider}/{model} does not support a thinking effort setting."
-EFFORT_SWITCH_HINT = "Switch with /effort <level>."
+EFFORT_SWITCH_HINT = "Choose below, or switch with /effort <level>."
 COPY_LAST_RESPONSE = "Copied the last response to the clipboard."
 COPY_NOTHING = "No response to copy yet."
 VERSION_INFO = "Kolega Code version {version}."

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -4229,6 +4229,8 @@ async def test_textual_app_model_slash_command_shows_and_switches_model(
     async with app.run_test():
         from textual.widgets import Input
 
+        from kolega_code.cli.app import ActionList
+
         app.query_one("#api_key_input", Input).value = "moonshot-key"
         await app._save_settings_from_ui()
         assert isinstance(app.agent, FakeCoderAgent)
@@ -4241,10 +4243,15 @@ async def test_textual_app_model_slash_command_shows_and_switches_model(
         assert "Available thinking efforts:" in effort_entry.content
         assert "`auto`" in effort_entry.content
         assert "`none`" not in effort_entry.content
+        effort_actions = app.query_one("#effort_actions", ActionList)
+        assert effort_actions.display is True
+        assert app.focused is effort_actions
+        assert effort_actions.get_option("effort_option_0").prompt.startswith("1. Auto (auto)")
 
         composer.load_text("/effort auto")
         await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
         assert settings_store.load().active_thinking_effort == "auto"
+        assert effort_actions.display is False
         first_agent = app.agent
         assert isinstance(first_agent, FakeCoderAgent)
 
@@ -4270,6 +4277,204 @@ async def test_textual_app_model_slash_command_shows_and_switches_model(
         composer.load_text("/model does-not-exist")
         await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
         assert settings_store.load().active_model == "kimi-k3"
+
+
+@pytest.mark.asyncio
+async def test_textual_app_effort_slash_command_selects_from_action_list(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import ActionList, ChatComposer, KolegaCodeApp
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            return None
+
+    monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    state_dir = tmp_path / "state"
+    store = SessionStore(state_dir)
+    settings_store = SettingsStore(state_dir)
+    settings = CliSettings(
+        active_provider=ModelProvider.DEEPSEEK.value,
+        active_model=DEEPSEEK_DEFAULT_MODEL,
+        active_thinking_effort="high",
+    )
+    settings.set_api_key(ModelProvider.DEEPSEEK.value, "deepseek-key")
+    settings_store.save(settings)
+    session = store.create(project, "code", {})
+    app = KolegaCodeApp(
+        project_path=project,
+        mode="code",
+        store=store,
+        settings_store=settings_store,
+        session=session,
+    )
+
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        composer.load_text("/effort")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+
+        effort_actions = app.query_one("#effort_actions", ActionList)
+        assert effort_actions.display is True
+        assert app.focused is effort_actions
+        assert effort_actions.option_count == 3
+
+        await pilot.press("down", "down", "enter")
+        await pilot.pause()
+        assert settings_store.load().active_thinking_effort == "max"
+        assert effort_actions.display is False
+
+        composer.load_text("/effort")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+        assert app.focused is effort_actions
+
+        await pilot.press("1")
+        await pilot.pause()
+        assert settings_store.load().active_thinking_effort == "none"
+        assert effort_actions.display is False
+
+
+@pytest.mark.asyncio
+async def test_textual_app_effort_slash_command_accepts_typed_selection_and_rejects_invalid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import ActionList, ChatComposer, KolegaCodeApp
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.messages = []
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            return None
+
+        async def process_message_stream(self, message):
+            self.messages.append(message)
+            yield {"type": "response", "content": "unexpected"}
+
+    monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    state_dir = tmp_path / "state"
+    store = SessionStore(state_dir)
+    settings_store = SettingsStore(state_dir)
+    settings = CliSettings(
+        active_provider=ModelProvider.DEEPSEEK.value,
+        active_model=DEEPSEEK_DEFAULT_MODEL,
+        active_thinking_effort="high",
+    )
+    settings.set_api_key(ModelProvider.DEEPSEEK.value, "deepseek-key")
+    settings_store.save(settings)
+    session = store.create(project, "code", {})
+    app = KolegaCodeApp(
+        project_path=project,
+        mode="code",
+        store=store,
+        settings_store=settings_store,
+        session=session,
+    )
+
+    async with app.run_test():
+        composer = app.query_one("#composer", ChatComposer)
+        composer.load_text("/effort")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+
+        effort_actions = app.query_one("#effort_actions", ActionList)
+        assert effort_actions.display is True
+
+        composer.load_text("bogus")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+        assert settings_store.load().active_thinking_effort == "high"
+        assert effort_actions.display is True
+        assert not any(entry.kind == "user" and entry.content == "bogus" for entry in app.conversation_entries)
+        assert app.agent.messages == []
+
+        composer.load_text("MAX")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+        assert settings_store.load().active_thinking_effort == "max"
+        assert effort_actions.display is False
+
+
+@pytest.mark.asyncio
+async def test_textual_app_effort_slash_command_blocks_selector_during_active_turn(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import ActionList, ChatComposer, KolegaCodeApp
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            return None
+
+    monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    state_dir = tmp_path / "state"
+    store = SessionStore(state_dir)
+    settings_store = SettingsStore(state_dir)
+    settings = CliSettings(
+        active_provider=ModelProvider.DEEPSEEK.value,
+        active_model=DEEPSEEK_DEFAULT_MODEL,
+        active_thinking_effort="high",
+    )
+    settings.set_api_key(ModelProvider.DEEPSEEK.value, "deepseek-key")
+    settings_store.save(settings)
+    session = store.create(project, "code", {})
+    app = KolegaCodeApp(
+        project_path=project,
+        mode="code",
+        store=store,
+        settings_store=settings_store,
+        session=session,
+    )
+
+    async with app.run_test():
+        composer = app.query_one("#composer", ChatComposer)
+        app._turn_active = True
+        composer.load_text("/effort")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+
+        assert app._pending_effort_selection is None
+        assert app.query_one("#effort_actions", ActionList).display is False
+        assert settings_store.load().active_thinking_effort == "high"
+        app._turn_active = False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Adds an interactive `/effort` selector in the TUI using the existing action-list interaction model.
- Keeps `/effort <level>` as a direct fast path while allowing arrow, Enter, digit, and typed supported-value selection.
- Updates CLI microcopy, docs, and regression coverage for the new effort-selection behavior.

## Why

`/effort` previously expected users to type a value after the command. The TUI already has a question/answer option picker, so thinking effort should be selectable in the same style.

## Validation

- `uv run pytest kolega_code/cli/tests/test_app.py`
- `uv run ruff check kolega_code/cli/app.py kolega_code/cli/messages.py kolega_code/cli/tests/test_app.py`
- `uv run pytest kolega_code/cli/tests`