### PR TITLE
[codex] Add interactive model selector

### DIFF
--- a/docs/src/content/docs/tui/slash-commands.md
+++ b/docs/src/content/docs/tui/slash-commands.md
@@ -35,11 +35,14 @@ These control the app and your session.
 | `/skills` | List available Agent Skills |
 | `/plan` | Switch to [Plan mode](../modes/) |
 | `/build` | Switch to [Build mode](../modes/) |
-| `/model` | Show or switch the active model |
+| `/model` | Choose the active model |
 | `/effort` | Choose the active model's thinking effort |
 | `/copy` | Copy the last response to the clipboard |
 | `/version` | Show the Kolega Code version |
 | `/quit` | Save the session and exit |
+
+Run `/model` to open a selectable list of supported models for the current
+provider. You can also switch directly with `/model <name>`.
 
 Run `/effort` to open a selectable list of supported effort values for the
 active model. You can also switch directly with `/effort <level>`.

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -115,8 +115,10 @@ IMPLEMENT_PLAN_PROMPT = """Implement the approved plan below. Follow it as the s
 """
 QUESTION_TOOL_NAME = "ask_user_choice"
 QUESTION_OPTION_ID_PREFIX = "question_option_"
+MODEL_OPTION_ID_PREFIX = "model_option_"
 EFFORT_OPTION_ID_PREFIX = "effort_option_"
 QUESTION_PLACEHOLDER = messages.QUESTION_PLACEHOLDER
+MODEL_PLACEHOLDER = messages.MODEL_PLACEHOLDER
 EFFORT_PLACEHOLDER = messages.EFFORT_PLACEHOLDER
 STARTUP_WORDMARK = (
     " _  __     _                    ____          _",
@@ -204,6 +206,12 @@ class PendingQuestion:
     question: str
     options: list[str]
     future: asyncio.Future[str]
+
+
+@dataclass
+class PendingModelSelection:
+    provider: str
+    options: list[tuple[str, str]]
 
 
 @dataclass
@@ -677,7 +685,7 @@ class KolegaCodeApp(App):
         opacity: 0.6;
     }
 
-    #plan_actions, #question_actions, #effort_actions {
+    #plan_actions, #question_actions, #model_actions, #effort_actions {
         display: none;
         height: auto;
         max-height: 12;
@@ -741,6 +749,7 @@ class KolegaCodeApp(App):
         self._latest_plan: Optional[str] = self.session.latest_plan_markdown or None
         self._plan_decision_active = False
         self._pending_question: Optional[PendingQuestion] = None
+        self._pending_model_selection: Optional[PendingModelSelection] = None
         self._pending_effort_selection: Optional[PendingEffortSelection] = None
         provider, model = self._startup_model()
         self._status_state = StatusDashboardState(provider=provider, model=model, mode=self.interaction_mode)
@@ -769,6 +778,7 @@ class KolegaCodeApp(App):
                 )
                 yield ActionList(id="plan_actions")
                 yield ActionList(id="question_actions")
+                yield ActionList(id="model_actions")
                 yield ActionList(id="effort_actions")
                 yield Static("", id="turn_status", markup=True)
                 yield Static("", id="composer_hint", markup=False)
@@ -824,6 +834,7 @@ class KolegaCodeApp(App):
         self._refresh_status_dashboard()
         self._restore_plan_action_visibility()
         self._set_question_actions_visible(False)
+        self._set_model_actions_visible(False)
         self._set_effort_actions_visible(False)
         self._refresh_planning_sidebar()
         self._ensure_startup_entry()
@@ -973,6 +984,14 @@ class KolegaCodeApp(App):
         if await self._handle_tui_slash_command(stripped_text, event.composer):
             return
 
+        if self._pending_model_selection is not None:
+            if not stripped_text:
+                self._set_composer_status(MODEL_PLACEHOLDER)
+                return
+            event.composer.load_text("")
+            await self._answer_model_selection(stripped_text)
+            return
+
         if self._pending_effort_selection is not None:
             if not stripped_text:
                 self._set_composer_status(EFFORT_PLACEHOLDER)
@@ -1040,6 +1059,10 @@ class KolegaCodeApp(App):
         if event.option_list.id == "question_actions":
             event.stop()
             await self._answer_question_option(event.option_index)
+            return
+        if event.option_list.id == "model_actions":
+            event.stop()
+            await self._answer_model_option(event.option_index)
             return
         if event.option_list.id == "effort_actions":
             event.stop()
@@ -1397,6 +1420,7 @@ class KolegaCodeApp(App):
         self._save_session()
         self._restore_plan_action_visibility()
         self._cancel_pending_question()
+        self._cancel_pending_model_selection()
         self._cancel_pending_effort_selection()
 
         if self.config is not None:
@@ -1489,6 +1513,29 @@ class KolegaCodeApp(App):
         except Exception:
             return
 
+    def _set_model_actions_visible(self, visible: bool) -> None:
+        try:
+            model_actions = self.query_one("#model_actions", ActionList)
+            if visible and self._pending_model_selection is not None:
+                model_actions.show_options(
+                    [
+                        Option(
+                            self._model_option_label(
+                                index,
+                                label,
+                                value,
+                                self._pending_model_selection.provider,
+                            ),
+                            id=f"{MODEL_OPTION_ID_PREFIX}{index}",
+                        )
+                        for index, (label, value) in enumerate(self._pending_model_selection.options)
+                    ]
+                )
+            else:
+                model_actions.hide()
+        except Exception:
+            return
+
     def _meta_content(self) -> str:
         return (
             f"{self.project_path} | session {self.session.session_id} | "
@@ -1564,6 +1611,8 @@ class KolegaCodeApp(App):
         handler = self._tui_command_handlers().get(command_text.lower())
         if handler is None:
             return False
+        if command_text.lower() != "/model":
+            self._cancel_pending_model_selection()
         if command_text.lower() != "/effort":
             self._cancel_pending_effort_selection()
         composer.load_text("")
@@ -1584,6 +1633,11 @@ class KolegaCodeApp(App):
         provider = self.settings.active_provider or UI_DEFAULT_PROVIDER
         model_options = ui_model_options(provider)
         if not args:
+            if self._turn_active or self.agent_worker is not None:
+                self._show_composer_hint(messages.BLOCK_STOP_BEFORE_MODEL_SWITCH)
+                self._notify_user(messages.BLOCK_STOP_BEFORE_MODEL_SWITCH, severity="warning")
+                return
+
             current_provider, current_model = self._startup_model()
             current_effort = self._startup_thinking_effort()
             active_model_line = (
@@ -1601,6 +1655,10 @@ class KolegaCodeApp(App):
                 messages.MODEL_SWITCH_HINT,
             ]
             self._add_conversation_entry(ConversationEntry(kind="system", content="\n".join(lines)))
+            self._pending_model_selection = PendingModelSelection(provider=provider, options=model_options)
+            self._cancel_pending_effort_selection()
+            self._show_model_options()
+            self._set_composer_status(MODEL_PLACEHOLDER)
             return
 
         if self._turn_active or self.agent_worker is not None:
@@ -1608,27 +1666,66 @@ class KolegaCodeApp(App):
             self._notify_user(messages.BLOCK_STOP_BEFORE_MODEL_SWITCH, severity="warning")
             return
 
-        matched = next((value for _, value in model_options if value.lower() == args.lower()), None)
+        matched = self._match_model_value(model_options, args)
         if matched is None:
             self._notify_user(messages.MODEL_UNKNOWN.format(model=args, provider=provider), severity="warning")
             return
 
+        await self._switch_model(provider, matched)
+
+    async def _answer_model_option(self, option_index: int) -> None:
+        pending = self._pending_model_selection
+        if pending is None:
+            return
+        if option_index < 0 or option_index >= len(pending.options):
+            return
+        await self._switch_model(pending.provider, pending.options[option_index][1])
+
+    async def _answer_model_selection(self, answer: str) -> None:
+        pending = self._pending_model_selection
+        if pending is None:
+            return
+
+        clean_answer = answer.strip()
+        if not clean_answer:
+            self._set_composer_status(MODEL_PLACEHOLDER)
+            return
+
+        matched = self._match_model_value(pending.options, clean_answer)
+        if matched is None:
+            self._set_composer_status(MODEL_PLACEHOLDER)
+            self._notify_user(
+                messages.MODEL_UNKNOWN.format(model=clean_answer, provider=pending.provider),
+                severity="warning",
+            )
+            return
+
+        await self._switch_model(pending.provider, matched)
+
+    async def _switch_model(self, provider: str, model: str) -> None:
+        self._cancel_pending_model_selection()
+        self._cancel_pending_effort_selection()
         self.settings.active_provider = provider
-        self.settings.active_model = matched
-        self.settings.active_thinking_effort = default_ui_thinking_effort(provider, matched)
+        self.settings.active_model = model
+        self.settings.active_thinking_effort = default_ui_thinking_effort(provider, model)
         self.settings_store.save(self.settings)
         await self._ensure_agent_from_settings(rebuild=True)
         try:
             self._populate_settings_controls()
         except Exception:
             pass
+        self._restore_composer_placeholder()
         self._notify_user(
             messages.MODEL_SWITCHED.format(
                 provider=provider,
-                model=matched,
+                model=model,
                 effort=self.settings.active_thinking_effort or "not supported",
             )
         )
+
+    def _match_model_value(self, model_options: list[tuple[str, str]], value: str) -> Optional[str]:
+        clean_value = value.strip().lower()
+        return next((model for _, model in model_options if model.lower() == clean_value), None)
 
     async def _command_effort(self, args: str) -> None:
         provider, model = self._startup_model()
@@ -1997,6 +2094,14 @@ class KolegaCodeApp(App):
         except Exception:
             return
 
+    def _show_model_options(self) -> None:
+        self._set_model_actions_visible(True)
+        try:
+            model_actions = self.query_one("#model_actions", ActionList)
+            self.screen.set_focus(model_actions)
+        except Exception:
+            return
+
     def _set_question_actions_visible(self, visible: bool) -> None:
         try:
             question_actions = self.query_one("#question_actions", ActionList)
@@ -2020,6 +2125,15 @@ class KolegaCodeApp(App):
 
     def _question_option_label(self, index: int, option: str) -> str:
         return f"{index + 1}. {option}"
+
+    def _cancel_pending_model_selection(self) -> None:
+        self._pending_model_selection = None
+        self._set_model_actions_visible(False)
+
+    def _model_option_label(self, index: int, label: str, value: str, provider: str) -> str:
+        current_provider, current_model = self._startup_model()
+        current_suffix = " current" if provider == current_provider and value == current_model else ""
+        return f"{index + 1}. {label} ({value}){current_suffix}"
 
     def _cancel_pending_effort_selection(self) -> None:
         self._pending_effort_selection = None
@@ -2047,6 +2161,7 @@ class KolegaCodeApp(App):
         self._save_session()
         self._set_plan_actions_visible(False)
         self._cancel_pending_question()
+        self._cancel_pending_model_selection()
         self._cancel_pending_effort_selection()
         self._refresh_planning_sidebar()
         self._clear_turn_status_strip()
@@ -2394,6 +2509,7 @@ class KolegaCodeApp(App):
         self._plan_decision_active = False
         self._restore_plan_action_visibility()
         self._cancel_pending_question()
+        self._cancel_pending_model_selection()
         self._cancel_pending_effort_selection()
         self._refresh_planning_sidebar()
         self._ensure_startup_entry(render=False)

--- a/kolega_code/cli/messages.py
+++ b/kolega_code/cli/messages.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 COMPOSER_PLACEHOLDER = "Ask Kolega Code..."
 PLAN_READY_PLACEHOLDER = "Plan ready. Choose Implement plan or Discuss further."
 QUESTION_PLACEHOLDER = "Choose an option below or type a custom answer..."
+MODEL_PLACEHOLDER = "Choose a model below or type a supported model name..."
 EFFORT_PLACEHOLDER = "Choose a thinking effort below or type a supported value..."
 
 # Durable transcript messages
@@ -56,7 +57,7 @@ MENTIONS_NOT_FOUND = "Not found, sent as plain text: {mentions}"
 # Slash commands
 MODEL_SWITCHED = "Switched model to {provider}/{model} with thinking effort {effort}."
 MODEL_UNKNOWN = "Unknown model {model} for provider {provider}."
-MODEL_SWITCH_HINT = "Switch with /model <name>."
+MODEL_SWITCH_HINT = "Choose below, or switch with /model <name>."
 EFFORT_SWITCHED = "Switched thinking effort to {effort} for {provider}/{model}."
 EFFORT_UNKNOWN = "Unknown thinking effort {effort} for {provider}/{model}."
 EFFORT_UNSUPPORTED = "{provider}/{model} does not support a thinking effort setting."

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -8,7 +8,12 @@ from kolega_code.llm.models import Message, TextBlock, ToolCall, ToolResult
 from kolega_code.events import AgentEvent
 from kolega_code.agent.prompt_provider import AgentMode
 from kolega_code.cli.config import build_agent_config, config_summary
-from kolega_code.cli.provider_registry import DEEPSEEK_DEFAULT_MODEL, UI_DEFAULT_MODEL, UI_DEFAULT_PROVIDER
+from kolega_code.cli.provider_registry import (
+    DEEPSEEK_DEFAULT_MODEL,
+    MOONSHOT_K26_MODEL,
+    UI_DEFAULT_MODEL,
+    UI_DEFAULT_PROVIDER,
+)
 from kolega_code.cli.session_store import SessionStore
 from kolega_code.cli.settings import CliSettings, SettingsStore
 
@@ -4261,6 +4266,11 @@ async def test_textual_app_model_slash_command_shows_and_switches_model(
         assert entry.kind == "system"
         assert UI_DEFAULT_MODEL in entry.content and "kimi-k2.6" in entry.content and "kimi-k3" in entry.content
         assert "Thinking effort: auto" in entry.content
+        model_actions = app.query_one("#model_actions", ActionList)
+        assert model_actions.display is True
+        assert app.focused is model_actions
+        assert model_actions.option_count == 3
+        assert model_actions.get_option("model_option_0").prompt.startswith(f"1. Kimi K2.7 Code ({UI_DEFAULT_MODEL})")
 
         # kimi-k3 is a fake model the real config builder rejects, so stub it for the rebuild step.
         saved_config = app.config
@@ -4271,12 +4281,213 @@ async def test_textual_app_model_slash_command_shows_and_switches_model(
         switched_settings = settings_store.load()
         assert switched_settings.active_model == "kimi-k3"
         assert switched_settings.active_thinking_effort == "high"
+        assert model_actions.display is False
         assert isinstance(app.agent, FakeCoderAgent)
         assert app.agent is not first_agent
 
         composer.load_text("/model does-not-exist")
         await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
         assert settings_store.load().active_model == "kimi-k3"
+
+
+@pytest.mark.asyncio
+async def test_textual_app_model_slash_command_selects_from_action_list(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import ActionList, ChatComposer, KolegaCodeApp
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            return None
+
+    monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    state_dir = tmp_path / "state"
+    store = SessionStore(state_dir)
+    settings_store = SettingsStore(state_dir)
+    settings = CliSettings(
+        active_provider=ModelProvider.MOONSHOT.value,
+        active_model=UI_DEFAULT_MODEL,
+        active_thinking_effort="auto",
+    )
+    settings.set_api_key(ModelProvider.MOONSHOT.value, "moonshot-key")
+    settings_store.save(settings)
+    session = store.create(project, "code", {})
+    app = KolegaCodeApp(
+        project_path=project,
+        mode="code",
+        store=store,
+        settings_store=settings_store,
+        session=session,
+    )
+
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        composer.load_text("/model")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+
+        model_actions = app.query_one("#model_actions", ActionList)
+        assert model_actions.display is True
+        assert app.focused is model_actions
+        assert model_actions.option_count == 2
+
+        await pilot.press("down", "enter")
+        await pilot.pause()
+        assert settings_store.load().active_model == MOONSHOT_K26_MODEL
+        assert model_actions.display is False
+
+        composer.load_text("/model")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+        assert app.focused is model_actions
+
+        await pilot.press("1")
+        await pilot.pause()
+        assert settings_store.load().active_model == UI_DEFAULT_MODEL
+        assert model_actions.display is False
+
+
+@pytest.mark.asyncio
+async def test_textual_app_model_slash_command_accepts_typed_selection_and_rejects_invalid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import ActionList, ChatComposer, KolegaCodeApp
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.messages = []
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            return None
+
+        async def process_message_stream(self, message):
+            self.messages.append(message)
+            yield {"type": "response", "content": "unexpected"}
+
+    monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    state_dir = tmp_path / "state"
+    store = SessionStore(state_dir)
+    settings_store = SettingsStore(state_dir)
+    settings = CliSettings(
+        active_provider=ModelProvider.MOONSHOT.value,
+        active_model=UI_DEFAULT_MODEL,
+        active_thinking_effort="auto",
+    )
+    settings.set_api_key(ModelProvider.MOONSHOT.value, "moonshot-key")
+    settings_store.save(settings)
+    session = store.create(project, "code", {})
+    app = KolegaCodeApp(
+        project_path=project,
+        mode="code",
+        store=store,
+        settings_store=settings_store,
+        session=session,
+    )
+
+    async with app.run_test():
+        composer = app.query_one("#composer", ChatComposer)
+        composer.load_text("/model")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+
+        model_actions = app.query_one("#model_actions", ActionList)
+        assert model_actions.display is True
+
+        composer.load_text("bogus-model")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+        assert settings_store.load().active_model == UI_DEFAULT_MODEL
+        assert model_actions.display is True
+        assert not any(entry.kind == "user" and entry.content == "bogus-model" for entry in app.conversation_entries)
+        assert app.agent.messages == []
+
+        composer.load_text(MOONSHOT_K26_MODEL.upper())
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+        switched_settings = settings_store.load()
+        assert switched_settings.active_model == MOONSHOT_K26_MODEL
+        assert switched_settings.active_thinking_effort == "auto"
+        assert model_actions.display is False
+
+
+@pytest.mark.asyncio
+async def test_textual_app_model_slash_command_blocks_selector_during_active_turn(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import ActionList, ChatComposer, KolegaCodeApp
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            return None
+
+    monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    state_dir = tmp_path / "state"
+    store = SessionStore(state_dir)
+    settings_store = SettingsStore(state_dir)
+    settings = CliSettings(
+        active_provider=ModelProvider.MOONSHOT.value,
+        active_model=UI_DEFAULT_MODEL,
+        active_thinking_effort="auto",
+    )
+    settings.set_api_key(ModelProvider.MOONSHOT.value, "moonshot-key")
+    settings_store.save(settings)
+    session = store.create(project, "code", {})
+    app = KolegaCodeApp(
+        project_path=project,
+        mode="code",
+        store=store,
+        settings_store=settings_store,
+        session=session,
+    )
+
+    async with app.run_test():
+        composer = app.query_one("#composer", ChatComposer)
+        app._turn_active = True
+        composer.load_text("/model")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+
+        assert app._pending_model_selection is None
+        assert app.query_one("#model_actions", ActionList).display is False
+        assert settings_store.load().active_model == UI_DEFAULT_MODEL
+        app._turn_active = False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Adds an interactive `/model` selector in the TUI using the same action-list interaction model as `/effort`.
- Keeps `/model <name>` as a direct fast path while allowing arrow, Enter, digit, and typed supported-model selection.
- Updates CLI microcopy, docs, and regression coverage for model selection behavior.

## Why

`/model` previously listed models but still required users to type the target model manually. The TUI now supports choosing from current-provider model options directly, matching the recently added `/effort` selector.

## Validation

- `uv run pytest kolega_code/cli/tests/test_app.py -k "model_slash_command or effort_slash_command"`
- `uv run ruff check kolega_code/cli/app.py kolega_code/cli/messages.py kolega_code/cli/tests/test_app.py`
- `uv run pytest kolega_code/cli/tests/test_app.py`
- `uv run pytest kolega_code/cli/tests`