### PR TITLE
[codex] Handle DeepSeek billing errors

### DIFF
--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -16,10 +16,12 @@ from .context import AgentContext, AgentServices, Telemetry, WorkspaceInfo
 from .conversation import Conversation
 from kolega_code.events import AgentEventEmitter
 from kolega_code.llm.exceptions import (
+    LLMBillingError,
     LLMContextWindowExceededError,
     LLMError,
     LLMInternalServerError,
     LLMRateLimitError,
+    billing_error_message,
     map_to_llm_error,
 )
 from kolega_code.llm.models import ImageBlock, Message, MessageHistory, TextBlock, ToolCall, ToolResult
@@ -778,6 +780,13 @@ class BaseAgent(LogMixin):
                 ),
             )
             raise
+
+        elif isinstance(error, LLMBillingError):
+            await self.emitter.llm_status(
+                "error",
+                billing_error_message(error, model=self.config.long_context_config.model),
+            )
+            raise error
 
         elif isinstance(error, LLMError):
             await self.log_error(f"LLM error occurred: {error}", sender=self.agent_name)

--- a/kolega_code/agent/tests/llm/test_error_boundary.py
+++ b/kolega_code/agent/tests/llm/test_error_boundary.py
@@ -10,11 +10,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from anthropic import AnthropicError
-from google.genai.errors import APIError as GoogleAPIError
 from openai import OpenAIError
 
 from kolega_code.llm.client import LLMClient
 from kolega_code.llm.exceptions import (
+    LLMBillingError,
     LLMAuthenticationError,
     LLMContextWindowExceededError,
     LLMError,
@@ -137,6 +137,11 @@ class TestErrorMapping:
         anthropic_error = MockAnthropicError(401)
         mapped = map_to_llm_error(anthropic_error)
         assert isinstance(mapped, LLMAuthenticationError)
+
+        deepseek_error = MockAnthropicError(402)
+        mapped = map_to_llm_error(deepseek_error, provider="deepseek")
+        assert isinstance(mapped, LLMBillingError)
+        assert mapped.provider == "deepseek"
 
 
 class TestLLMClientErrorBoundary:
@@ -279,7 +284,7 @@ class TestLLMClientErrorBoundary:
                 await client.generate(messages)
             # Verify it's an LLMError subclass, not the original exception
             assert isinstance(exc_info.value, LLMError)
-            assert type(exc_info.value) != type(original_exception)
+            assert type(exc_info.value) is not type(original_exception)
 
             # Test count_tokens method
             client.provider.count_tokens = AsyncMock(side_effect=original_exception)

--- a/kolega_code/agent/tests/llm/test_exceptions.py
+++ b/kolega_code/agent/tests/llm/test_exceptions.py
@@ -4,6 +4,28 @@ Tests for the LLM exception classes and mapping functions.
 
 import pytest
 
+from kolega_code.config import ModelProvider
+from kolega_code.llm.exceptions import (
+    LLMBillingError,
+    LLMAuthenticationError,
+    LLMBadRequestError,
+    LLMContentPolicyViolationError,
+    LLMContextWindowExceededError,
+    LLMError,
+    LLMInternalServerError,
+    LLMInvalidRequestError,
+    LLMNotFoundError,
+    LLMPermissionDeniedError,
+    LLMRateLimitError,
+    LLMTimeout,
+    LLMUnprocessableEntityError,
+    LLMUnsupportedParamsError,
+    map_to_llm_error,
+    map_anthropic_errors,
+    map_google_errors,
+    map_openai_errors,
+)
+
 
 # Assuming OpenAIError, GoogleAPIError, AnthropicError can be imported or mocked
 # For simplicity, we'll mock them here.
@@ -25,27 +47,6 @@ class MockAnthropicError(Exception):
         self.status_code = status_code
 
 
-from kolega_code.config import ModelProvider
-from kolega_code.llm.exceptions import (
-    LLMAuthenticationError,
-    LLMBadRequestError,
-    LLMContentPolicyViolationError,
-    LLMContextWindowExceededError,
-    LLMError,
-    LLMInternalServerError,
-    LLMInvalidRequestError,
-    LLMNotFoundError,
-    LLMPermissionDeniedError,
-    LLMRateLimitError,
-    LLMTimeout,
-    LLMUnprocessableEntityError,
-    LLMUnsupportedParamsError,
-    map_anthropic_errors,
-    map_google_errors,
-    map_openai_errors,
-)
-
-
 # Test basic exception instantiation
 @pytest.mark.parametrize(
     "exception_class",
@@ -55,6 +56,7 @@ from kolega_code.llm.exceptions import (
         LLMUnsupportedParamsError,
         LLMContextWindowExceededError,
         LLMContentPolicyViolationError,
+        LLMBillingError,
         LLMInvalidRequestError,
         LLMAuthenticationError,
         LLMPermissionDeniedError,
@@ -164,6 +166,7 @@ def test_map_google_errors_no_status():
     [
         (400, LLMInvalidRequestError),
         (401, LLMAuthenticationError),
+        (402, LLMBillingError),
         (403, LLMPermissionDeniedError),
         (404, LLMNotFoundError),
         (413, LLMContextWindowExceededError),
@@ -192,6 +195,7 @@ def test_map_anthropic_errors_no_status_code():
         (
             LLMInvalidRequestError,
             LLMAuthenticationError,
+            LLMBillingError,
             LLMPermissionDeniedError,
             LLMNotFoundError,
             LLMContextWindowExceededError,
@@ -247,3 +251,28 @@ def test_map_anthropic_api_status_error_token_limit():
     mapped = map_anthropic_errors(err)
     assert isinstance(mapped, LLMContextWindowExceededError)
     assert mapped.provider == ModelProvider.ANTHROPIC.value
+
+
+def test_map_deepseek_anthropic_api_status_error_insufficient_balance():
+    import httpx
+    from anthropic import APIStatusError
+
+    response = httpx.Response(
+        status_code=402,
+        request=httpx.Request("POST", "https://api.deepseek.com/anthropic/v1/messages"),
+    )
+    body = {
+        "error": {
+            "message": "Insufficient Balance",
+            "type": "unknown_error",
+            "param": None,
+            "code": "invalid_request_error",
+        },
+    }
+
+    err = APIStatusError("payment required", response=response, body=body)
+
+    mapped = map_to_llm_error(err, provider=ModelProvider.DEEPSEEK.value)
+    assert isinstance(mapped, LLMBillingError)
+    assert mapped.provider == ModelProvider.DEEPSEEK.value
+    assert "AnthropicError:" in str(mapped)

--- a/kolega_code/agent/tests/test_base_agent.py
+++ b/kolega_code/agent/tests/test_base_agent.py
@@ -9,6 +9,7 @@ from dotenv import load_dotenv
 from kolega_code.agent.baseagent import BaseAgent
 from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
 from kolega_code.events import AgentConnectionManager
+from kolega_code.llm.exceptions import LLMBillingError
 from kolega_code.llm.models import (
     Message,
     MessageHistory,
@@ -64,6 +65,22 @@ def base_agent(tmp_path, mock_connection_manager, agent_config):
 
 
 class TestBaseAgent:
+    @pytest.mark.asyncio
+    async def test_handle_llm_error_emits_billing_status_and_reraises(self, base_agent, mock_connection_manager):
+        base_agent.config.long_context_config.provider = ModelProvider.DEEPSEEK
+        base_agent.config.long_context_config.model = "deepseek-v4-pro"
+
+        with pytest.raises(LLMBillingError):
+            await base_agent.handle_llm_error(
+                LLMBillingError("DeepSeek APIError: Insufficient Balance", provider=ModelProvider.DEEPSEEK.value)
+            )
+
+        event = mock_connection_manager.broadcast_event.await_args.args[0]
+        assert event.event_type == "llm_status_update"
+        assert event.content["status"] == "error"
+        assert "DeepSeek/deepseek-v4-pro could not run this request" in event.content["message"]
+        assert "Add credits to your DeepSeek account" in event.content["message"]
+
     def test_build_prompt_context_loads_agents_md(self, base_agent, tmp_path):
         (tmp_path / "AGENTS.md").write_text("Use AGENTS guidance", encoding="utf-8")
 

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -48,6 +48,7 @@ from textual.widgets.option_list import Option
 
 from kolega_code import __version__ as kolega_code_version
 from kolega_code.agent import AgentConfig, AgentEvent, CoderAgent, PlanningAgent, PromptExtension, ToolExtension
+from kolega_code.llm.exceptions import LLMBillingError, billing_error_message
 from kolega_code.llm.models import Message, MessageHistory, TextBlock, ToolCall, ToolResult
 from kolega_code.agent.prompt_provider import AgentMode
 from kolega_code.services.browser import PlaywrightBrowserManager
@@ -1138,6 +1139,15 @@ class KolegaCodeApp(App):
             self._save_session_history()
             self._finish_turn_progress(messages.STOPPED_BY_USER, TurnState.STOPPED)
             self._log_status(messages.STOPPED_BY_USER, "warn")
+        except LLMBillingError as exc:
+            self._cancel_pending_question()
+            await self._drain_pending_events()
+            self._finalize_sub_agent_activities()
+            self._save_session_history()
+            model = self.config.long_context_config.model if self.config is not None else None
+            message_text = billing_error_message(exc, model=model)
+            self._finish_turn_progress(message_text, TurnState.ERROR)
+            self._log_status(message_text, "error")
         except Exception as exc:
             self._cancel_pending_question()
             await self._drain_pending_events()

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -12,6 +12,7 @@ from typing import Iterable, Optional
 
 from kolega_code import __version__
 from kolega_code.agent import CoderAgent
+from kolega_code.llm.exceptions import LLMBillingError, billing_error_message
 from kolega_code.llm.models import TextBlock
 from kolega_code.agent.prompt_provider import AgentMode
 from kolega_code.services.browser import PlaywrightBrowserManager
@@ -413,6 +414,7 @@ async def _run_ask(args: argparse.Namespace) -> int:
         print(f"Note: @{mention} not found, sent as plain text", file=sys.stderr)
 
     response_chunks: list[dict] = []
+    exit_code = 0
     # Pump connection-manager events concurrently so sub-agent activity is
     # reported in real time instead of all at once after streaming finishes.
     pump_task = asyncio.create_task(_pump_ask_events(manager, args.json))
@@ -429,6 +431,25 @@ async def _run_ask(args: argparse.Namespace) -> int:
             session.history = agent.dump_message_history()
             session.config = summary
             store.save(session)
+    except LLMBillingError as exc:
+        exit_code = 1
+        message = billing_error_message(exc, model=config.long_context_config.model)
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "kind": "error",
+                        "data": {
+                            "type": "billing_error",
+                            "message": message,
+                            "provider": exc.provider,
+                        },
+                    },
+                    default=str,
+                )
+            )
+        else:
+            _print_styled(message, style="error", stderr=True)
     finally:
         pump_task.cancel()
         try:
@@ -439,6 +460,9 @@ async def _run_ask(args: argparse.Namespace) -> int:
             event = manager.events.get_nowait()
             _print_ask_event(event, args.json)
         await agent.cleanup()
+
+    if exit_code:
+        return exit_code
 
     if args.json:
         print(json.dumps({"kind": "summary", "chunks": len(response_chunks), "session_id": session.session_id}))

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -7,7 +7,7 @@ from kolega_code.config import ModelProvider
 from kolega_code.llm.models import Message, TextBlock, ToolCall, ToolResult
 from kolega_code.events import AgentEvent
 from kolega_code.agent.prompt_provider import AgentMode
-from kolega_code.cli.config import build_agent_config, config_summary
+from kolega_code.cli.config import CliConfigOverrides, build_agent_config, config_summary
 from kolega_code.cli.provider_registry import (
     DEEPSEEK_DEFAULT_MODEL,
     MOONSHOT_K26_MODEL,
@@ -3066,6 +3066,67 @@ async def test_textual_app_cancellation_is_visible_in_chat(
         assert progress_entries[0].complete is True
         assert composer.placeholder == COMPOSER_PLACEHOLDER
         assert "Stopped after 42s" in str(turn_status.render())
+
+
+@pytest.mark.asyncio
+async def test_textual_app_handles_billing_error_without_worker_traceback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.widgets import Static
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import COMPOSER_PLACEHOLDER, ChatComposer, KolegaCodeApp, TurnState
+    from kolega_code.llm.exceptions import LLMBillingError
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            return None
+
+        async def process_message_stream(self, message):
+            raise LLMBillingError("DeepSeek APIError: Insufficient Balance", provider=ModelProvider.DEEPSEEK.value)
+            yield {"type": "response", "content": "unreachable"}
+
+    monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_agent_config(
+        project,
+        CliConfigOverrides(provider=ModelProvider.DEEPSEEK.value, model=DEEPSEEK_DEFAULT_MODEL),
+        env={"DEEPSEEK_API_KEY": "deepseek-key"},
+    )
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+    monkeypatch.setattr(app, "_now", lambda: 10.0)
+
+    async with app.run_test():
+        composer = app.query_one("#composer", ChatComposer)
+        turn_status = app.query_one("#turn_status", Static)
+
+        await app._process_message("hi")
+
+        progress_entries = [entry for entry in app.conversation_entries if entry.kind == "progress"]
+        assert len(progress_entries) == 1
+        assert "DeepSeek/deepseek-v4-pro could not run this request" in progress_entries[0].content
+        assert "Add credits to your DeepSeek account" in progress_entries[0].content
+        assert progress_entries[0].tone == "error"
+        assert composer.placeholder == COMPOSER_PLACEHOLDER
+        assert composer.disabled is False
+        assert app.agent_worker is None
+        assert app._status_state.turn_state is TurnState.ERROR
+        assert "Errored after" in str(turn_status.render())
 
 
 @pytest.mark.asyncio

--- a/kolega_code/cli/tests/test_main.py
+++ b/kolega_code/cli/tests/test_main.py
@@ -5,10 +5,12 @@ from pathlib import Path
 import pytest
 
 from kolega_code import __version__
+from kolega_code.config import ModelProvider
 from kolega_code.cli.main import CLI_AGENT_MODE, RESUME_LATEST, _resolve_tui_session, main, parse_args
-from kolega_code.cli.provider_registry import UI_DEFAULT_MODEL, UI_DEFAULT_PROVIDER
+from kolega_code.cli.provider_registry import DEEPSEEK_DEFAULT_MODEL, UI_DEFAULT_MODEL, UI_DEFAULT_PROVIDER
 from kolega_code.cli.session_store import SessionStore, SessionStoreError
 from kolega_code.cli.settings import CliSettings, SettingsStore
+from kolega_code.llm.exceptions import LLMBillingError
 from kolega_code.llm.models import Message
 
 
@@ -173,6 +175,109 @@ def test_ask_skill_with_prompt_activates_before_dispatch(
     assert agent.messages == ["do the task"]
     assert '<skill_content name="demo-skill">' in agent.history[0].get_text_content()
     assert any(extension.name == "cli-agent-skills" for extension in agent.kwargs["tool_extensions"])
+
+
+def test_ask_plain_handles_billing_error_without_traceback(
+    tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    from kolega_code.cli import main as main_module
+
+    class FakeCoderAgent:
+        instances = []
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.cleaned = False
+            self.__class__.instances.append(self)
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_message_history(self):
+            return []
+
+        async def process_message_stream(self, message):
+            raise LLMBillingError("DeepSeek APIError: Insufficient Balance", provider=ModelProvider.DEEPSEEK.value)
+            yield {"type": "response", "content": "unreachable"}
+
+        async def cleanup(self):
+            self.cleaned = True
+
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "deepseek-key")
+    monkeypatch.setattr(main_module, "CoderAgent", FakeCoderAgent)
+
+    exit_code = main_module.main(
+        [
+            "ask",
+            "test",
+            "--project",
+            str(project),
+            "--provider",
+            ModelProvider.DEEPSEEK.value,
+            "--model",
+            DEEPSEEK_DEFAULT_MODEL,
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert captured.out == ""
+    assert "DeepSeek/deepseek-v4-pro could not run this request" in captured.err
+    assert "Add credits to your DeepSeek account" in captured.err
+    assert FakeCoderAgent.instances[0].cleaned is True
+
+
+def test_ask_json_handles_billing_error_without_traceback(
+    tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    from kolega_code.cli import main as main_module
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_message_history(self):
+            return []
+
+        async def process_message_stream(self, message):
+            raise LLMBillingError("DeepSeek APIError: Insufficient Balance", provider=ModelProvider.DEEPSEEK.value)
+            yield {"type": "response", "content": "unreachable"}
+
+        async def cleanup(self):
+            return None
+
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "deepseek-key")
+    monkeypatch.setattr(main_module, "CoderAgent", FakeCoderAgent)
+
+    exit_code = main_module.main(
+        [
+            "ask",
+            "test",
+            "--project",
+            str(project),
+            "--provider",
+            ModelProvider.DEEPSEEK.value,
+            "--model",
+            DEEPSEEK_DEFAULT_MODEL,
+            "--json",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    lines = [json.loads(line) for line in captured.out.splitlines() if line.strip()]
+    assert exit_code == 1
+    assert lines[-1]["kind"] == "error"
+    assert lines[-1]["data"]["type"] == "billing_error"
+    assert lines[-1]["data"]["provider"] == ModelProvider.DEEPSEEK.value
+    assert "DeepSeek/deepseek-v4-pro could not run this request" in lines[-1]["data"]["message"]
+    assert "Traceback" not in captured.err
 
 
 def test_doctor_uses_stored_kimi_settings(tmp_path: Path, capsys, isolated_cli_env: None) -> None:

--- a/kolega_code/llm/exceptions.py
+++ b/kolega_code/llm/exceptions.py
@@ -26,6 +26,7 @@ Error Mapping:
 | Anthropic | 401         | `LLMAuthenticationError`       |
 | Anthropic | 403         | `LLMPermissionDeniedError`     |
 | Anthropic | 404         | `LLMNotFoundError`             |
+| Anthropic | 402         | `LLMBillingError`              |
 | Anthropic | 413         | `LLMContextWindowExceededError`|
 | Anthropic | 429         | `LLMRateLimitError`            |
 | Anthropic | 500         | `LLMInternalServerError`       |
@@ -110,8 +111,72 @@ class LLMRateLimitError(LLMError):
     """Raised when the rate limit for the LLM service is exceeded."""
 
 
+class LLMBillingError(LLMError):
+    """Raised when the LLM provider rejects a request due to billing or credits."""
+
+
 class LLMInternalServerError(LLMError):
     """Raised when the LLM service encounters an internal error."""
+
+
+_BILLING_ERROR_PHRASES = (
+    "insufficient balance",
+    "insufficient credit",
+    "insufficient credits",
+    "payment required",
+    "billing",
+)
+
+
+def _provider_display_name(provider: str | None) -> str:
+    provider_names = {
+        ModelProvider.ANTHROPIC.value: "Anthropic",
+        ModelProvider.OPENAI.value: "OpenAI",
+        ModelProvider.GOOGLE.value: "Google",
+        ModelProvider.GROQ.value: "Groq",
+        ModelProvider.TOGETHER.value: "Together",
+        ModelProvider.FIREWORKS.value: "Fireworks",
+        ModelProvider.XAI.value: "xAI",
+        ModelProvider.DASHSCOPE.value: "DashScope",
+        ModelProvider.MOONSHOT.value: "Moonshot",
+        ModelProvider.DEEPSEEK.value: "DeepSeek",
+        ModelProvider.LLAMA.value: "Llama",
+    }
+    if not provider:
+        return "The selected provider"
+    return provider_names.get(provider, provider.replace("_", " ").replace("-", " ").title())
+
+
+def billing_error_message(error: LLMBillingError, model: str | None = None) -> str:
+    """Return a concise user-facing message for provider billing failures."""
+    provider = error.provider
+    provider_name = _provider_display_name(provider)
+    model_label = f"/{model}" if model else ""
+    provider_model = f"{provider_name}{model_label}"
+
+    return (
+        f"{provider_model} could not run this request because {provider_name} reported insufficient balance. "
+        f"Add credits to your {provider_name} account or switch to another provider/model in Settings or with /model."
+    )
+
+
+def _is_billing_status(error: Exception) -> bool:
+    return getattr(error, "status_code", None) == 402 or getattr(error, "status", None) == 402
+
+
+def _is_billing_message(message: str) -> bool:
+    message_lower = message.lower()
+    return any(phrase in message_lower for phrase in _BILLING_ERROR_PHRASES)
+
+
+def _anthropic_body_error_message(error: Exception) -> str:
+    body = getattr(error, "body", None)
+    if not isinstance(body, dict):
+        return ""
+    error_info = body.get("error")
+    if not isinstance(error_info, dict):
+        return ""
+    return str(error_info.get("message") or "").strip()
 
 
 def map_openai_errors(error: OpenAIError) -> LLMError:
@@ -155,7 +220,8 @@ def map_google_errors(error: GoogleAPIError) -> LLMError:
     return LLMError(message=f"Google APIError: {str(error)}", provider=ModelProvider.GOOGLE.value)
 
 
-def map_anthropic_errors(error: AnthropicError) -> LLMError:
+def map_anthropic_errors(error: AnthropicError, provider: str | None = None) -> LLMError:
+    provider = provider or ModelProvider.ANTHROPIC.value
     context_window_phrases = (
         "exceeded model token limit",
         "context window",
@@ -163,7 +229,14 @@ def map_anthropic_errors(error: AnthropicError) -> LLMError:
         "prompt is too long",
     )
 
-    if type(error) == AnthropicAPIStatusError:
+    if (
+        _is_billing_status(error)
+        or _is_billing_message(_anthropic_body_error_message(error))
+        or _is_billing_message(str(error))
+    ):
+        return LLMBillingError(message=f"AnthropicError: {str(error)}", provider=provider)
+
+    if type(error) is AnthropicAPIStatusError:
         try:
             error_data = error.body
             if isinstance(error_data, dict) and "error" in error_data:
@@ -175,12 +248,12 @@ def map_anthropic_errors(error: AnthropicError) -> LLMError:
                 # Keep internal/server overload handling by type
                 if error_type in ["overloaded_error", "api_error"]:
                     return LLMInternalServerError(
-                        message=f"AnthropicError: {str(error)}", provider=ModelProvider.ANTHROPIC.value
+                        message=f"AnthropicError: {str(error)}", provider=provider
                     )
 
                 if any(phrase in error_message_lower for phrase in context_window_phrases):
                     return LLMContextWindowExceededError(
-                        message=f"AnthropicError: {str(error)}", provider=ModelProvider.ANTHROPIC.value
+                        message=f"AnthropicError: {str(error)}", provider=provider
                     )
 
                 # Special case: content filtering block should be mapped to content policy violation
@@ -189,52 +262,51 @@ def map_anthropic_errors(error: AnthropicError) -> LLMError:
                     and error_message == "Output blocked by content filtering policy"
                 ):
                     return LLMContentPolicyViolationError(
-                        message=f"AnthropicError: {str(error)}", provider=ModelProvider.ANTHROPIC.value
+                        message=f"AnthropicError: {str(error)}", provider=provider
                     )
 
         except Exception:
             pass
 
-    if type(error) == AnthropicInternalServerError:
-        return LLMInternalServerError(message=f"AnthropicError: {str(error)}", provider=ModelProvider.ANTHROPIC.value)
+    if type(error) is AnthropicInternalServerError:
+        return LLMInternalServerError(message=f"AnthropicError: {str(error)}", provider=provider)
 
-    print("continuing Anthropic error mapping...")
     if hasattr(error, "status_code"):
         if error.status_code == 400:
             error_text = str(error).lower()
             if any(phrase in error_text for phrase in context_window_phrases):
                 return LLMContextWindowExceededError(
-                    message=f"AnthropicError: {str(error)}", provider=ModelProvider.ANTHROPIC.value
+                    message=f"AnthropicError: {str(error)}", provider=provider
                 )
             return LLMInvalidRequestError(
-                message=f"AnthropicError: {str(error)}", provider=ModelProvider.ANTHROPIC.value
+                message=f"AnthropicError: {str(error)}", provider=provider
             )
         elif error.status_code == 401:
             return LLMAuthenticationError(
-                message=f"AnthropicError: {str(error)}", provider=ModelProvider.ANTHROPIC.value
+                message=f"AnthropicError: {str(error)}", provider=provider
             )
         elif error.status_code == 403:
             return LLMPermissionDeniedError(
-                message=f"AnthropicError: {str(error)}", provider=ModelProvider.ANTHROPIC.value
+                message=f"AnthropicError: {str(error)}", provider=provider
             )
         elif error.status_code == 404:
-            return LLMNotFoundError(message=f"AnthropicError: {str(error)}", provider=ModelProvider.ANTHROPIC.value)
+            return LLMNotFoundError(message=f"AnthropicError: {str(error)}", provider=provider)
         elif error.status_code == 413:
             return LLMContextWindowExceededError(
-                message=f"AnthropicError: {str(error)}", provider=ModelProvider.ANTHROPIC.value
+                message=f"AnthropicError: {str(error)}", provider=provider
             )
         if error.status_code == 429:
-            return LLMRateLimitError(message=f"AnthropicError: {str(error)}", provider=ModelProvider.ANTHROPIC.value)
+            return LLMRateLimitError(message=f"AnthropicError: {str(error)}", provider=provider)
         if error.status_code == 500:
             return LLMInternalServerError(
-                message=f"AnthropicError: {str(error)}", provider=ModelProvider.ANTHROPIC.value
+                message=f"AnthropicError: {str(error)}", provider=provider
             )
         if error.status_code == 529:
             return LLMInternalServerError(
-                message=f"AnthropicError: {str(error)}", provider=ModelProvider.ANTHROPIC.value
+                message=f"AnthropicError: {str(error)}", provider=provider
             )
 
-    return LLMError(message=f"AnthropicError: {str(error)}", provider=ModelProvider.ANTHROPIC.value)
+    return LLMError(message=f"AnthropicError: {str(error)}", provider=provider)
 
 
 def map_to_llm_error(error: Exception, provider: str = None) -> LLMError:
@@ -261,7 +333,7 @@ def map_to_llm_error(error: Exception, provider: str = None) -> LLMError:
     elif isinstance(error, GoogleAPIError):
         return map_google_errors(error)
     elif isinstance(error, AnthropicError):
-        return map_anthropic_errors(error)
+        return map_anthropic_errors(error, provider=provider)
 
     # Map common Python exceptions
     if isinstance(error, ValueError):


### PR DESCRIPTION
## Summary

Handle DeepSeek insufficient-balance responses as expected billing failures instead of letting the CLI worker crash with a traceback.

## What Changed

- Added an `LLMBillingError` classification for Anthropic-compatible 402/payment/balance provider responses.
- Preserved the configured provider when mapping Anthropic-compatible errors so DeepSeek failures are reported as DeepSeek.
- Emitted a friendly billing message from the agent and handled it in both the Textual app and `kolega-code ask`.
- Added regression coverage for mapping, agent handling, Textual handling, and ask mode.

## Root Cause

DeepSeek’s Anthropic-compatible API returns `402 Payment Required` with an `Insufficient Balance` body. The existing mapper treated that as a generic `LLMError`, which was re-raised through the Textual worker and rendered as a traceback.

## Validation

- `uv run pytest kolega_code/agent/tests/llm/test_exceptions.py kolega_code/agent/tests/llm/test_error_boundary.py kolega_code/agent/tests/test_base_agent.py -q`
- `uv run pytest kolega_code/cli/tests/test_app.py kolega_code/cli/tests/test_main.py -q`
- `uv run ruff check kolega_code/llm/exceptions.py kolega_code/agent/baseagent.py kolega_code/cli/app.py kolega_code/cli/main.py kolega_code/agent/tests/llm/test_exceptions.py kolega_code/agent/tests/llm/test_error_boundary.py kolega_code/agent/tests/test_base_agent.py kolega_code/cli/tests/test_app.py kolega_code/cli/tests/test_main.py`
- `uv run python -m py_compile kolega_code/llm/exceptions.py kolega_code/agent/baseagent.py kolega_code/cli/app.py kolega_code/cli/main.py kolega_code/agent/tests/llm/test_exceptions.py kolega_code/agent/tests/llm/test_error_boundary.py kolega_code/agent/tests/test_base_agent.py kolega_code/cli/tests/test_app.py kolega_code/cli/tests/test_main.py`