### PR TITLE
[codex] Handle LLM errors gracefully in TUI

### DIFF
--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -16,12 +16,9 @@ from .context import AgentContext, AgentServices, Telemetry, WorkspaceInfo
 from .conversation import Conversation
 from kolega_code.events import AgentEventEmitter
 from kolega_code.llm.exceptions import (
-    LLMBillingError,
-    LLMContextWindowExceededError,
     LLMError,
-    LLMInternalServerError,
     LLMRateLimitError,
-    billing_error_message,
+    llm_error_message,
     map_to_llm_error,
 )
 from kolega_code.llm.models import ImageBlock, Message, MessageHistory, TextBlock, ToolCall, ToolResult
@@ -744,7 +741,7 @@ class BaseAgent(LogMixin):
 
         This method provides centralized error handling for all LLM operations:
         - Rate limit errors: Log warning, wait 60 seconds, and allow retry
-        - Other LLM errors: Log error and re-raise
+        - Other LLM errors: Emit a user-facing status and re-raise
         - Non-LLM errors: Re-raise as-is
 
         Args:
@@ -764,33 +761,12 @@ class BaseAgent(LogMixin):
             await self.log_info("Resuming after rate limit wait period.", sender=self.agent_name)
             # Don't re-raise - allow retry
 
-        elif isinstance(error, LLMInternalServerError):
+        elif isinstance(error, LLMError):
             await self.emitter.llm_status(
                 "error",
-                "There is high traffic on our LLM provider right now. Please try again in a few seconds.",
-            )
-            raise
-
-        elif isinstance(error, LLMContextWindowExceededError):
-            await self.emitter.llm_status(
-                "error",
-                (
-                    "The conversation context became too large for the model. "
-                    "Oversized tool output is trimmed automatically; please retry the message."
-                ),
-            )
-            raise
-
-        elif isinstance(error, LLMBillingError):
-            await self.emitter.llm_status(
-                "error",
-                billing_error_message(error, model=self.config.long_context_config.model),
+                llm_error_message(error, model=self.config.long_context_config.model),
             )
             raise error
-
-        elif isinstance(error, LLMError):
-            await self.log_error(f"LLM error occurred: {error}", sender=self.agent_name)
-            raise  # Re-raise to maintain current behavior
         else:
             # Non-LLM error - just re-raise
             raise

--- a/kolega_code/agent/tests/llm/test_instrumented_client_integration.py
+++ b/kolega_code/agent/tests/llm/test_instrumented_client_integration.py
@@ -8,7 +8,7 @@ and Langfuse tracing.
 
 import asyncio
 import os
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 from dotenv import load_dotenv
@@ -17,7 +17,6 @@ from opentelemetry.sdk.trace import TracerProvider as _OtelTracerProvider
 
 from kolega_code.llm.instrumented_client import InstrumentedLLMClient
 from kolega_code.llm.models import Message, MessageHistory, TextBlock, ToolCall
-from kolega_code.llm.providers.models import GenerationParams
 
 # Load environment variables
 # Navigate up to backend directory: tests/llm -> tests -> agent -> kolega_code -> backend
@@ -41,6 +40,7 @@ TEST_MESSAGES = MessageHistory(
     [Message(role="user", content=[TextBlock(text="What is 2+2? Reply with just the number.")])]
 )
 TEST_SYSTEM = Message(role="system", content=[TextBlock(text="You are a helpful math assistant. Be concise.")])
+ANTHROPIC_CACHE_TEST_MODEL = "claude-sonnet-4-6"
 
 # Check if running in CI environment
 SKIP_IN_CI = bool(os.getenv("CI")) or bool(os.getenv("GITLAB_CI"))
@@ -290,7 +290,7 @@ class TestInstrumentedClientWithRealAPIs:
         )
 
         # Attempt API call with invalid key
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception):
             await client.generate(
                 messages=TEST_MESSAGES,
                 system=TEST_SYSTEM,
@@ -331,7 +331,7 @@ class TestInstrumentedClientWithRealAPIs:
         await client.generate(
             messages=long_messages,
             system=TEST_SYSTEM,
-            model="claude-sonnet-4-20250514",
+            model=ANTHROPIC_CACHE_TEST_MODEL,
             max_completion_tokens=100,
         )
 
@@ -339,23 +339,20 @@ class TestInstrumentedClientWithRealAPIs:
         await client.generate(
             messages=long_messages,
             system=TEST_SYSTEM,
-            model="claude-sonnet-4-5-20250929",
+            model=ANTHROPIC_CACHE_TEST_MODEL,
             max_completion_tokens=100,
         )
 
-        # Check if any call reported cache usage
+        # Cache usage is not guaranteed, but usage details should be captured for each call.
         trace = mock_langfuse_client.start_span.return_value
         generation = trace.start_generation.return_value
-        any_cache_usage = False
-        for call in generation.update.call_args_list:
-            if "usage_details" in call.kwargs and call.kwargs["usage_details"]:
-                usage = call.kwargs["usage_details"]
-                if usage.get("cache_read_input_tokens", 0) > 0:
-                    any_cache_usage = True
-                    break
-
-        # Note: Cache usage is not guaranteed, so we'll just verify the calls were made
         assert generation.update.call_count >= 2, "Should have made at least 2 calls"
+        usage_updates = [
+            call.kwargs["usage_details"]
+            for call in generation.update.call_args_list
+            if call.kwargs.get("usage_details")
+        ]
+        assert len(usage_updates) >= 2, "Should have captured usage details for both calls"
 
 
 @pytest.mark.slow
@@ -403,10 +400,10 @@ class TestRealLangfuseIntegration:
         await asyncio.sleep(1)
 
         print("✅ Real Langfuse trace sent successfully")
-        print(f"Check Langfuse dashboard for trace with:")
-        print(f"  - Workspace: integration-test")
-        print(f"  - Thread: test-thread-123")
-        print(f"  - Agent: integration-test-agent")
+        print("Check Langfuse dashboard for trace with:")
+        print("  - Workspace: integration-test")
+        print("  - Thread: test-thread-123")
+        print("  - Agent: integration-test-agent")
 
 
 @pytest.mark.slow

--- a/kolega_code/agent/tests/test_base_agent.py
+++ b/kolega_code/agent/tests/test_base_agent.py
@@ -9,7 +9,12 @@ from dotenv import load_dotenv
 from kolega_code.agent.baseagent import BaseAgent
 from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
 from kolega_code.events import AgentConnectionManager
-from kolega_code.llm.exceptions import LLMBillingError
+from kolega_code.llm.exceptions import (
+    LLMBillingError,
+    LLMAuthenticationError,
+    LLMContextWindowExceededError,
+    LLMInternalServerError,
+)
 from kolega_code.llm.models import (
     Message,
     MessageHistory,
@@ -66,20 +71,54 @@ def base_agent(tmp_path, mock_connection_manager, agent_config):
 
 class TestBaseAgent:
     @pytest.mark.asyncio
-    async def test_handle_llm_error_emits_billing_status_and_reraises(self, base_agent, mock_connection_manager):
-        base_agent.config.long_context_config.provider = ModelProvider.DEEPSEEK
-        base_agent.config.long_context_config.model = "deepseek-v4-pro"
+    @pytest.mark.parametrize(
+        "error,provider,model,expected_message",
+        [
+            (
+                LLMBillingError("DeepSeek APIError: Insufficient Balance", provider=ModelProvider.DEEPSEEK.value),
+                ModelProvider.DEEPSEEK,
+                "deepseek-v4-pro",
+                "DeepSeek/deepseek-v4-pro could not run this request",
+            ),
+            (
+                LLMContextWindowExceededError("context too large", provider=ModelProvider.ANTHROPIC.value),
+                ModelProvider.ANTHROPIC,
+                "claude-haiku-4-5-20251001",
+                "The conversation context became too large for the model",
+            ),
+            (
+                LLMInternalServerError("provider overloaded", provider=ModelProvider.ANTHROPIC.value),
+                ModelProvider.ANTHROPIC,
+                "claude-haiku-4-5-20251001",
+                "There is high traffic on our LLM provider",
+            ),
+            (
+                LLMAuthenticationError("invalid key", provider=ModelProvider.ANTHROPIC.value),
+                ModelProvider.ANTHROPIC,
+                "claude-haiku-4-5-20251001",
+                "Anthropic/claude-haiku-4-5-20251001 could not authenticate",
+            ),
+        ],
+    )
+    async def test_handle_llm_error_emits_status_and_reraises(
+        self,
+        base_agent,
+        mock_connection_manager,
+        error,
+        provider,
+        model,
+        expected_message,
+    ):
+        base_agent.config.long_context_config.provider = provider
+        base_agent.config.long_context_config.model = model
 
-        with pytest.raises(LLMBillingError):
-            await base_agent.handle_llm_error(
-                LLMBillingError("DeepSeek APIError: Insufficient Balance", provider=ModelProvider.DEEPSEEK.value)
-            )
+        with pytest.raises(type(error)):
+            await base_agent.handle_llm_error(error)
 
         event = mock_connection_manager.broadcast_event.await_args.args[0]
         assert event.event_type == "llm_status_update"
         assert event.content["status"] == "error"
-        assert "DeepSeek/deepseek-v4-pro could not run this request" in event.content["message"]
-        assert "Add credits to your DeepSeek account" in event.content["message"]
+        assert expected_message in event.content["message"]
 
     def test_build_prompt_context_loads_agents_md(self, base_agent, tmp_path):
         (tmp_path / "AGENTS.md").write_text("Use AGENTS guidance", encoding="utf-8")

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -48,7 +48,7 @@ from textual.widgets.option_list import Option
 
 from kolega_code import __version__ as kolega_code_version
 from kolega_code.agent import AgentConfig, AgentEvent, CoderAgent, PlanningAgent, PromptExtension, ToolExtension
-from kolega_code.llm.exceptions import LLMBillingError, billing_error_message
+from kolega_code.llm.exceptions import LLMError, llm_error_message
 from kolega_code.llm.models import Message, MessageHistory, TextBlock, ToolCall, ToolResult
 from kolega_code.agent.prompt_provider import AgentMode
 from kolega_code.services.browser import PlaywrightBrowserManager
@@ -1139,13 +1139,13 @@ class KolegaCodeApp(App):
             self._save_session_history()
             self._finish_turn_progress(messages.STOPPED_BY_USER, TurnState.STOPPED)
             self._log_status(messages.STOPPED_BY_USER, "warn")
-        except LLMBillingError as exc:
+        except LLMError as exc:
             self._cancel_pending_question()
             await self._drain_pending_events()
             self._finalize_sub_agent_activities()
             self._save_session_history()
             model = self.config.long_context_config.model if self.config is not None else None
-            message_text = billing_error_message(exc, model=model)
+            message_text = llm_error_message(exc, model=model)
             self._finish_turn_progress(message_text, TurnState.ERROR)
             self._log_status(message_text, "error")
         except Exception as exc:

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -4,10 +4,17 @@ import asyncio
 import pytest
 
 from kolega_code.config import ModelProvider
+from kolega_code.llm.exceptions import (
+    LLMBillingError,
+    LLMAuthenticationError,
+    LLMContextWindowExceededError,
+    LLMError,
+    LLMInternalServerError,
+)
 from kolega_code.llm.models import Message, TextBlock, ToolCall, ToolResult
 from kolega_code.events import AgentEvent
 from kolega_code.agent.prompt_provider import AgentMode
-from kolega_code.cli.config import CliConfigOverrides, build_agent_config, config_summary
+from kolega_code.cli.config import build_agent_config, config_summary
 from kolega_code.cli.provider_registry import (
     DEEPSEEK_DEFAULT_MODEL,
     MOONSHOT_K26_MODEL,
@@ -3069,8 +3076,65 @@ async def test_textual_app_cancellation_is_visible_in_chat(
 
 
 @pytest.mark.asyncio
-async def test_textual_app_handles_billing_error_without_worker_traceback(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize(
+    "error,provider,model,expected_message",
+    [
+        pytest.param(
+            LLMBillingError(
+                "DeepSeek APIError: Insufficient Balance",
+                provider=ModelProvider.DEEPSEEK.value,
+            ),
+            ModelProvider.DEEPSEEK,
+            DEEPSEEK_DEFAULT_MODEL,
+            "DeepSeek/deepseek-v4-pro could not run this request",
+            id="billing",
+        ),
+        pytest.param(
+            LLMContextWindowExceededError("context too large", provider=ModelProvider.ANTHROPIC.value),
+            ModelProvider.ANTHROPIC,
+            "claude-haiku-4-5-20251001",
+            "The conversation context became too large for the model",
+            id="context-window",
+        ),
+        pytest.param(
+            LLMInternalServerError(
+                "provider overloaded",
+                provider=ModelProvider.ANTHROPIC.value,
+            ),
+            ModelProvider.ANTHROPIC,
+            "claude-haiku-4-5-20251001",
+            "There is high traffic on our LLM provider",
+            id="internal-server",
+        ),
+        pytest.param(
+            LLMAuthenticationError(
+                "invalid key",
+                provider=ModelProvider.ANTHROPIC.value,
+            ),
+            ModelProvider.ANTHROPIC,
+            "claude-haiku-4-5-20251001",
+            "Anthropic/claude-haiku-4-5-20251001 could not authenticate",
+            id="authentication",
+        ),
+        pytest.param(
+            LLMError(
+                "unexpected provider error",
+                provider=ModelProvider.ANTHROPIC.value,
+            ),
+            ModelProvider.ANTHROPIC,
+            "claude-haiku-4-5-20251001",
+            "Anthropic/claude-haiku-4-5-20251001 returned an error",
+            id="generic-llm",
+        ),
+    ],
+)
+async def test_textual_app_handles_llm_error_without_worker_traceback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    error,
+    provider,
+    model,
+    expected_message,
 ) -> None:
     pytest.importorskip("textual")
 
@@ -3078,7 +3142,6 @@ async def test_textual_app_handles_billing_error_without_worker_traceback(
 
     from kolega_code.cli import app as app_module
     from kolega_code.cli.app import COMPOSER_PLACEHOLDER, ChatComposer, KolegaCodeApp, TurnState
-    from kolega_code.llm.exceptions import LLMBillingError
 
     class FakeCoderAgent:
         def __init__(self, **kwargs):
@@ -3094,18 +3157,16 @@ async def test_textual_app_handles_billing_error_without_worker_traceback(
             return None
 
         async def process_message_stream(self, message):
-            raise LLMBillingError("DeepSeek APIError: Insufficient Balance", provider=ModelProvider.DEEPSEEK.value)
+            raise error
             yield {"type": "response", "content": "unreachable"}
 
     monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
 
     project = tmp_path / "project"
     project.mkdir()
-    config = build_agent_config(
-        project,
-        CliConfigOverrides(provider=ModelProvider.DEEPSEEK.value, model=DEEPSEEK_DEFAULT_MODEL),
-        env={"DEEPSEEK_API_KEY": "deepseek-key"},
-    )
+    config = build_test_config(project)
+    config.long_context_config.provider = provider
+    config.long_context_config.model = model
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
@@ -3119,14 +3180,60 @@ async def test_textual_app_handles_billing_error_without_worker_traceback(
 
         progress_entries = [entry for entry in app.conversation_entries if entry.kind == "progress"]
         assert len(progress_entries) == 1
-        assert "DeepSeek/deepseek-v4-pro could not run this request" in progress_entries[0].content
-        assert "Add credits to your DeepSeek account" in progress_entries[0].content
+        assert expected_message in progress_entries[0].content
         assert progress_entries[0].tone == "error"
         assert composer.placeholder == COMPOSER_PLACEHOLDER
         assert composer.disabled is False
         assert app.agent_worker is None
         assert app._status_state.turn_state is TurnState.ERROR
         assert "Errored after" in str(turn_status.render())
+
+
+@pytest.mark.asyncio
+async def test_textual_app_reraises_non_llm_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import ChatComposer, KolegaCodeApp, TurnState
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            return None
+
+        async def process_message_stream(self, message):
+            raise RuntimeError("tool host exploded")
+            yield {"type": "response", "content": "unreachable"}
+
+    monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test():
+        composer = app.query_one("#composer", ChatComposer)
+
+        with pytest.raises(RuntimeError, match="tool host exploded"):
+            await app._process_message("hi")
+
+        progress_entries = [entry for entry in app.conversation_entries if entry.kind == "progress"]
+        assert len(progress_entries) == 1
+        assert progress_entries[0].content == "Stopped due to an error: tool host exploded"
+        assert progress_entries[0].tone == "error"
+        assert composer.disabled is False
+        assert app._status_state.turn_state is TurnState.ERROR
 
 
 @pytest.mark.asyncio

--- a/kolega_code/llm/exceptions.py
+++ b/kolega_code/llm/exceptions.py
@@ -160,6 +160,53 @@ def billing_error_message(error: LLMBillingError, model: str | None = None) -> s
     )
 
 
+def llm_error_message(error: LLMError, model: str | None = None) -> str:
+    """Return concise user-facing copy for terminal LLM failures."""
+    if isinstance(error, LLMBillingError):
+        return billing_error_message(error, model=model)
+
+    provider_name = _provider_display_name(error.provider)
+    model_label = f"/{model}" if model else ""
+    provider_model = f"{provider_name}{model_label}"
+
+    if isinstance(error, LLMContextWindowExceededError):
+        return (
+            "The conversation context became too large for the model. "
+            "Oversized tool output is trimmed automatically; please retry the message."
+        )
+
+    if isinstance(error, LLMInternalServerError):
+        return "There is high traffic on our LLM provider right now. Please try again in a few seconds."
+
+    if isinstance(error, LLMAuthenticationError):
+        return f"{provider_model} could not authenticate. Check the API key in Settings or your environment."
+
+    if isinstance(error, LLMPermissionDeniedError):
+        return f"{provider_model} rejected this request because the API key does not have access."
+
+    if isinstance(error, LLMNotFoundError):
+        return f"{provider_model} was not found. Check the selected provider/model in Settings or with /model."
+
+    if isinstance(error, LLMTimeout):
+        return f"{provider_model} timed out while processing this request. Please try again."
+
+    if isinstance(error, LLMContentPolicyViolationError):
+        return f"{provider_model} blocked this request due to the provider's content policy."
+
+    if isinstance(
+        error,
+        (
+            LLMBadRequestError,
+            LLMUnsupportedParamsError,
+            LLMInvalidRequestError,
+            LLMUnprocessableEntityError,
+        ),
+    ):
+        return f"{provider_model} could not process this request. Check the selected provider/model and try again."
+
+    return f"{provider_model} returned an error: {error}"
+
+
 def _is_billing_status(error: Exception) -> bool:
     return getattr(error, "status_code", None) == 402 or getattr(error, "status", None) == 402
 


### PR DESCRIPTION
## Summary

Handle expected LLM failures gracefully in the Textual TUI instead of allowing them to bubble into Textual worker tracebacks.

## What Changed

- Added shared user-facing copy for terminal LLM errors.
- Updated the agent error bridge so all non-rate-limit `LLMError` subclasses emit an `llm_status_update` before re-raising.
- Updated the TUI to catch `LLMError`, mark the turn as errored, save state, re-enable input, and avoid worker tracebacks.
- Kept non-LLM exceptions re-raising so real implementation bugs still surface.
- Added regression coverage for billing, context-window, provider overload, authentication, generic LLM errors, and non-LLM rethrow behavior.

## Root Cause

Only billing errors were handled at the TUI boundary. Other expected LLM errors, such as context-window exceeded and provider overload, already emitted friendly status events from the agent but were then re-raised through the generic TUI exception path, which re-raised into Textual's worker.

## Validation

- `uv run pytest kolega_code/agent/tests/test_base_agent.py -q`
- `uv run pytest kolega_code/cli/tests/test_app.py -q`
- `uv run ruff check kolega_code/llm/exceptions.py kolega_code/agent/baseagent.py kolega_code/cli/app.py kolega_code/agent/tests/test_base_agent.py kolega_code/cli/tests/test_app.py`
- `uv run python -m py_compile kolega_code/llm/exceptions.py kolega_code/agent/baseagent.py kolega_code/cli/app.py kolega_code/agent/tests/test_base_agent.py kolega_code/cli/tests/test_app.py`