### PR TITLE
Align ask_user_choice with the structured questions format

### DIFF
--- a/kolega_code/agent/tests/test_tools.py
+++ b/kolega_code/agent/tests/test_tools.py
@@ -559,6 +559,47 @@ class TestToolCollection:
 
         assert tool_names == ["custom_status"]
 
+    async def test_tool_extension_explicit_schema_injected(
+        self,
+        project_path: Path,
+        mock_connection_manager: AgentConnectionManager,
+        agent_config: AgentConfig,
+        mock_base_agent: BaseAgent,
+    ) -> None:
+        """An explicit tool_schemas entry overrides the introspected schema on the built tool."""
+        from kolega_code.agent.tools import ToolExtension
+
+        async def ask_things(questions: list) -> str:
+            """Ask things."""
+            return "{}"
+
+        schema = {
+            "type": "object",
+            "properties": {"questions": {"type": "array", "items": {"type": "object"}}},
+            "required": ["questions"],
+        }
+        extension = ToolExtension(
+            name="schema-extension",
+            tools={"ask_things": ask_things},
+            tool_schemas={"ask_things": schema},
+            tool_groups={"host_tools": ["ask_things"]},
+        )
+        config = ToolCollectionConfig(custom_tool_groups=["host_tools"], restrict_to_tool_groups=True)
+        tool_collection = ToolCollection(
+            project_path,
+            "test_workspace",
+            str(uuid.uuid4()),
+            mock_connection_manager,
+            agent_config,
+            mock_base_agent,
+            tool_config=config,
+            tool_extensions=[extension],
+        )
+
+        definition = next(d for d in tool_collection.get_tool_list() if d.name == "ask_things")
+        assert definition.input_schema == schema
+        assert definition.to_anthropic()["input_schema"] == schema
+
     async def test_tool_collection_config_mixed_options(
         self,
         project_path: Path,

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -41,6 +41,10 @@ class ToolExtension:
     name: str
     tools: dict[str, Callable[..., Any]]
     tool_groups: dict[str, List[str]] = field(default_factory=dict)
+    # Optional explicit JSON schemas keyed by tool name. When provided, the
+    # schema is used verbatim instead of introspecting the callable signature,
+    # allowing nested input shapes the introspector cannot express.
+    tool_schemas: dict[str, dict[str, Any]] = field(default_factory=dict)
 
 
 class ToolCollectionConfig:
@@ -207,6 +211,7 @@ class ToolCollection(LogMixin):
         self.langfuse_client = langfuse_client
         self.tool_extensions = tool_extensions or []
         self.extension_callbacks = {}
+        self.extension_schemas = {}
         self._extension_group_names = set()
 
         # Set legacy attributes for backward compatibility
@@ -240,6 +245,9 @@ class ToolCollection(LogMixin):
                     raise ValueError(f"Tool extension '{extension.name}' conflicts with existing tool '{tool_name}'")
                 setattr(self, tool_name, callback)
                 self.extension_callbacks[tool_name] = callback
+
+            for tool_name, schema in extension.tool_schemas.items():
+                self.extension_schemas[tool_name] = schema
 
             for group_name, tool_names in extension.tool_groups.items():
                 existing_group = list(getattr(self, group_name, []))
@@ -1534,9 +1542,13 @@ class ToolCollection(LogMixin):
         return registry
 
     def _build_tool(self, method_name: str, method: Callable[..., Any]) -> Tool:
+        definition = self._tool_definition_from_callable(method_name, method)
+        explicit_schema = self.extension_schemas.get(method_name)
+        if explicit_schema is not None:
+            definition.input_schema = explicit_schema
         return Tool(
             name=method_name,
-            definition=self._tool_definition_from_callable(method_name, method),
+            definition=definition,
             handler=method,
             groups=self._groups_for(method_name),
             # Read-only tools have no side effects and agent dispatches operate
@@ -1651,3 +1663,4 @@ class ToolCollection(LogMixin):
             await self.log_error(f"Error during tool cleanup: {str(e)}", sender="ToolCollection")
 
         self.extension_callbacks = {}
+        self.extension_schemas = {}

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import itertools
+import json
 import re
 import subprocess
 import sys
@@ -50,6 +51,7 @@ from kolega_code import __version__ as kolega_code_version
 from kolega_code.agent import AgentConfig, AgentEvent, CoderAgent, PlanningAgent, PromptExtension, ToolExtension
 from kolega_code.llm.exceptions import LLMError, llm_error_message
 from kolega_code.llm.models import Message, MessageHistory, TextBlock, ToolCall, ToolResult
+from kolega_code.tools import ASK_USER_CHOICE_INPUT_SCHEMA, ASK_USER_CHOICE_SHAPE_HINT, ToolError
 from kolega_code.agent.prompt_provider import AgentMode
 from kolega_code.services.browser import PlaywrightBrowserManager
 
@@ -109,7 +111,7 @@ In build mode, call `get_task_list` when a shared task list exists or when imple
 After each meaningful task is completed, call `update_task_list` to check off that item by rewriting the full Markdown list.
 Do not wait until every TODO is complete to update the shared task list."""
 PLANNING_QUESTION_PROMPT = """The CLI provides `ask_user_choice` for important multiple-choice planning decisions.
-Use it only when a decision materially changes the plan. Provide concise options; the user can also type a custom answer."""
+Use it only when a decision materially changes the plan. Pass a `questions` array; each question has a short `header`, the `question` text, a `multiSelect` flag, and an `options` array of `{label, description}` choices. The user picks one option per question or types a custom answer."""
 IMPLEMENT_PLAN_PROMPT = """Implement the approved plan below. Follow it as the source of truth, but still inspect the code before editing and run appropriate checks.
 
 {plan}
@@ -205,8 +207,9 @@ class SubAgentActivity:
 @dataclass
 class PendingQuestion:
     question: str
-    options: list[str]
+    options: list[str]  # selectable option labels; the selected label is the answer
     future: asyncio.Future[str]
+    descriptions: Optional[list[str]] = None  # per-option descriptions, parallel to options
 
 
 @dataclass
@@ -1997,50 +2000,104 @@ class KolegaCodeApp(App):
         )
 
     def _planning_question_tool_extension(self) -> ToolExtension:
-        async def ask_user_choice(question: str, options: list[str]) -> str:
+        async def ask_user_choice(questions: list[dict]) -> str:
             """
-            Ask the user a multiple-choice planning question and wait for their answer.
+            Ask the user one or more multiple-choice planning questions and wait for their answers.
 
-            Use this only for planning decisions that materially affect the final plan. The user may either select
-            one of the provided options or type a custom free-text answer.
-
-            Args:
-                question: The concise question to ask the user.
-                options: Two or more concise answer options.
+            Use this only for planning decisions that materially affect the final plan. Each question has a
+            short `header`, the `question` text, a `multiSelect` flag, and an `options` array of
+            `{label, description}` choices. The user selects one option per question or types a custom
+            free-text answer. Questions are asked one at a time, in order.
 
             Returns:
-                The selected option text, or the user's custom answer text.
+                A JSON object mapping each question's header (or its text) to the chosen option label
+                or the user's custom answer.
             """
             if self.interaction_mode != PLAN_INTERACTION_MODE:
-                raise RuntimeError("ask_user_choice is only available in planning mode.")
-            if isinstance(options, str) or not isinstance(options, list):
-                raise ValueError("options must be a list of answer strings.")
+                raise ToolError("ask_user_choice is only available in planning mode.")
 
-            clean_question = str(question).strip()
-            clean_options = [str(option).strip() for option in options if str(option).strip()]
-            if not clean_question:
-                raise ValueError("question must not be empty.")
-            if len(clean_options) < 2:
-                raise ValueError("ask_user_choice requires at least two non-empty options.")
+            normalized = self._normalize_choice_questions(questions)
             if self._pending_question is not None:
-                raise RuntimeError("A planning question is already waiting for an answer.")
+                raise ToolError("A planning question is already waiting for an answer.")
 
-            return await self._ask_user_choice(clean_question, clean_options)
+            answers: dict[str, str] = {}
+            for clean_question, header, labels, descriptions in normalized:
+                answer = await self._ask_user_choice(clean_question, labels, descriptions)
+                answers[header or clean_question] = answer
+            return json.dumps(answers)
 
         return ToolExtension(
             name="cli-planning-questions",
             tools={QUESTION_TOOL_NAME: ask_user_choice},
+            tool_schemas={QUESTION_TOOL_NAME: ASK_USER_CHOICE_INPUT_SCHEMA},
             tool_groups={"planning_tools": [QUESTION_TOOL_NAME]},
         )
 
-    async def _ask_user_choice(self, question: str, options: list[str]) -> str:
+    def _normalize_choice_questions(
+        self, questions: object
+    ) -> list[tuple[str, str, list[str], list[str]]]:
+        """Validate the structured questions input and return normalized questions.
+
+        Strict: rejects malformed input with an instructive ToolError instead of coercing.
+        Each result is (question_text, header, option_labels, option_descriptions).
+        """
+        if not isinstance(questions, list) or not questions:
+            raise ToolError("'questions' must be a non-empty array of question objects. " + ASK_USER_CHOICE_SHAPE_HINT)
+
+        normalized: list[tuple[str, str, list[str], list[str]]] = []
+        for question in questions:
+            if not isinstance(question, dict):
+                raise ToolError("each item in 'questions' must be an object. " + ASK_USER_CHOICE_SHAPE_HINT)
+
+            clean_question = str(question.get("question", "")).strip()
+            if not clean_question:
+                raise ToolError("each question must include non-empty 'question' text. " + ASK_USER_CHOICE_SHAPE_HINT)
+
+            header = str(question.get("header", "")).strip()
+
+            raw_options = question.get("options")
+            if not isinstance(raw_options, list):
+                raise ToolError(
+                    "each question's 'options' must be an array of {label, description} objects. "
+                    + ASK_USER_CHOICE_SHAPE_HINT
+                )
+
+            labels: list[str] = []
+            descriptions: list[str] = []
+            for option in raw_options:
+                if not isinstance(option, dict):
+                    raise ToolError(
+                        "each option must be an object with a 'label' (and ideally a 'description'). "
+                        + ASK_USER_CHOICE_SHAPE_HINT
+                    )
+                label = str(option.get("label", "")).strip()
+                if not label:
+                    continue
+                labels.append(label)
+                descriptions.append(str(option.get("description", "")).strip())
+
+            if len(labels) < 2:
+                raise ToolError(
+                    "each question needs at least two options, each with a non-empty 'label'. "
+                    + ASK_USER_CHOICE_SHAPE_HINT
+                )
+
+            normalized.append((clean_question, header, labels, descriptions))
+
+        return normalized
+
+    async def _ask_user_choice(
+        self, question: str, options: list[str], descriptions: Optional[list[str]] = None
+    ) -> str:
         loop = asyncio.get_running_loop()
         future: asyncio.Future[str] = loop.create_future()
-        self._pending_question = PendingQuestion(question=question, options=options, future=future)
-        self._add_conversation_entry(
-            ConversationEntry(kind="question", content=self._format_question_content(question, options))
+        self._pending_question = PendingQuestion(
+            question=question, options=options, future=future, descriptions=descriptions
         )
-        self._show_question_options(options)
+        self._add_conversation_entry(
+            ConversationEntry(kind="question", content=self._format_question_content(question, options, descriptions))
+        )
+        self._show_question_options(options, descriptions)
         self._set_composer_status(QUESTION_PLACEHOLDER)
         self._set_chat_enabled(True)
         self._update_activity_progress(messages.WAITING_FOR_ANSWER, state=TurnState.WAITING_FOR_USER)
@@ -2083,12 +2140,15 @@ class KolegaCodeApp(App):
             self._restore_composer_placeholder()
             self._set_chat_enabled(self.agent is not None)
 
-    def _show_question_options(self, options: list[str]) -> None:
+    def _show_question_options(self, options: list[str], descriptions: Optional[list[str]] = None) -> None:
         try:
             question_actions = self.query_one("#question_actions", ActionList)
             question_actions.show_options(
                 [
-                    Option(self._question_option_label(index, option), id=f"{QUESTION_OPTION_ID_PREFIX}{index}")
+                    Option(
+                        self._question_option_label(index, option, self._option_description(descriptions, index)),
+                        id=f"{QUESTION_OPTION_ID_PREFIX}{index}",
+                    )
                     for index, option in enumerate(options)
                 ]
             )
@@ -2129,12 +2189,25 @@ class KolegaCodeApp(App):
         self._pending_question = None
         self._set_question_actions_visible(False)
 
-    def _format_question_content(self, question: str, options: list[str]) -> str:
-        option_lines = [f"{index + 1}. {option}" for index, option in enumerate(options)]
+    def _format_question_content(
+        self, question: str, options: list[str], descriptions: Optional[list[str]] = None
+    ) -> str:
+        option_lines = [
+            self._question_option_label(index, option, self._option_description(descriptions, index))
+            for index, option in enumerate(options)
+        ]
         return "\n".join([question, "", *option_lines])
 
-    def _question_option_label(self, index: int, option: str) -> str:
+    def _question_option_label(self, index: int, option: str, description: str = "") -> str:
+        if description:
+            return f"{index + 1}. {option} — {description}"
         return f"{index + 1}. {option}"
+
+    @staticmethod
+    def _option_description(descriptions: Optional[list[str]], index: int) -> str:
+        if descriptions is not None and 0 <= index < len(descriptions):
+            return descriptions[index]
+        return ""
 
     def _cancel_pending_model_selection(self) -> None:
         self._pending_model_selection = None

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import asyncio
+import json
 
 import pytest
 
@@ -31,6 +32,18 @@ def extension_by_name(extensions, name: str):
         for extension in extensions
         if getattr(extension, "name", None) == name or getattr(extension, "id", None) == name
     )
+
+
+def question_payload(question, options, *, header="Choice", multi_select=False):
+    """Build a structured `questions` list for a single question.
+
+    options: a list of labels, or (label, description) tuples.
+    """
+    built = []
+    for option in options:
+        label, description = option if isinstance(option, tuple) else (option, "details")
+        built.append({"label": label, "description": description})
+    return [{"question": question, "header": header, "multiSelect": multi_select, "options": built}]
 
 
 def build_test_config(project: Path):
@@ -927,7 +940,13 @@ async def test_textual_app_planning_question_tool_accepts_option_list_answer(
 
         app._turn_active = True
         answer_task = asyncio.create_task(
-            ask_user_choice("Which approach should we use?", ["Keep state local", "Persist it"])
+            ask_user_choice(
+                questions=question_payload(
+                    "Which approach should we use?",
+                    [("Keep state local", "Store in memory"), ("Persist it", "Write to disk")],
+                    header="Approach",
+                )
+            )
         )
         await pilot.pause()
 
@@ -937,13 +956,13 @@ async def test_textual_app_planning_question_tool_accepts_option_list_answer(
         assert question_actions.display is True
         assert app.focused is question_actions
         assert question_actions.highlighted == 0
-        assert question_actions.get_option("question_option_0").prompt == "1. Keep state local"
+        assert question_actions.get_option("question_option_0").prompt == "1. Keep state local — Store in memory"
         assert app.conversation_entries[-1].kind == "question"
 
         selected = question_actions.get_option("question_option_1")
         await app.on_option_list_option_selected(OptionList.OptionSelected(question_actions, selected, 1))
 
-        assert await answer_task == "Persist it"
+        assert json.loads(await answer_task) == {"Approach": "Persist it"}
         assert app._pending_question is None
         assert app.query_one("#question_actions").display is False
         assert app.query_one("#composer", ChatComposer).disabled is True
@@ -999,7 +1018,9 @@ async def test_textual_app_planning_question_supports_arrow_and_digit_selection(
         ).tools["ask_user_choice"]
 
         options = ["Alpha", "Beta", "Gamma", "Delta"]
-        answer_task = asyncio.create_task(ask_user_choice("Pick one of four?", options))
+        answer_task = asyncio.create_task(
+            ask_user_choice(questions=question_payload("Pick one of four?", options, header="Pick"))
+        )
         await pilot.pause()
 
         question_actions = app.query_one("#question_actions", ActionList)
@@ -1007,15 +1028,17 @@ async def test_textual_app_planning_question_supports_arrow_and_digit_selection(
         assert app.focused is question_actions
 
         await pilot.press("down", "down", "enter")
-        assert await answer_task == "Gamma"
+        assert json.loads(await answer_task) == {"Pick": "Gamma"}
         assert question_actions.display is False
 
-        answer_task = asyncio.create_task(ask_user_choice("Pick again?", options))
+        answer_task = asyncio.create_task(
+            ask_user_choice(questions=question_payload("Pick again?", options, header="Pick"))
+        )
         await pilot.pause()
 
         assert app.focused is app.query_one("#question_actions", ActionList)
         await pilot.press("4")
-        assert await answer_task == "Delta"
+        assert json.loads(await answer_task) == {"Pick": "Delta"}
 
 
 @pytest.mark.asyncio
@@ -1064,23 +1087,174 @@ async def test_textual_app_planning_question_tool_accepts_custom_text_answer(
         ).tools["ask_user_choice"]
 
         answer_task = asyncio.create_task(
-            ask_user_choice("Which scope?", ["Small fix", "Full workflow"])
+            ask_user_choice(
+                questions=question_payload("Which scope?", ["Small fix", "Full workflow"], header="Scope")
+            )
         )
         await pilot.pause()
 
         question_actions = app.query_one("#question_actions", ActionList)
-        assert question_actions.get_option("question_option_0").prompt == "1. Small fix"
+        assert question_actions.get_option("question_option_0").prompt == "1. Small fix — details"
 
         composer = app.query_one("#composer", ChatComposer)
         composer.load_text("Start with the small fix, but keep the API extensible.")
         await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
 
-        assert await answer_task == "Start with the small fix, but keep the API extensible."
+        assert json.loads(await answer_task) == {"Scope": "Start with the small fix, but keep the API extensible."}
         assert composer.text == ""
         assert app._pending_question is None
         assert question_actions.display is False
         assert question_actions.option_count == 0
         assert app.conversation_entries[-1].content == "Start with the small fix, but keep the API extensible."
+
+
+@pytest.mark.asyncio
+async def test_textual_app_planning_question_tool_asks_multiple_questions_sequentially(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import ActionList, KolegaCodeApp
+    from textual.widgets import OptionList
+
+    class FakeBaseAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.history = []
+
+        def restore_message_history(self, history):
+            self.history = list(history)
+
+        def dump_message_history(self):
+            return self.history
+
+        async def cleanup(self):
+            return None
+
+    class FakeCoderAgent(FakeBaseAgent):
+        pass
+
+    class FakePlanningAgent(FakeBaseAgent):
+        pass
+
+    monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
+    monkeypatch.setattr(app_module, "PlanningAgent", FakePlanningAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test() as pilot:
+        await app.action_toggle_interaction_mode()
+        ask_user_choice = extension_by_name(
+            app.agent.kwargs["tool_extensions"], "cli-planning-questions"
+        ).tools["ask_user_choice"]
+
+        questions = question_payload("First?", ["A1", "B1"], header="First") + question_payload(
+            "Second?", ["A2", "B2"], header="Second"
+        )
+        answer_task = asyncio.create_task(ask_user_choice(questions=questions))
+        await pilot.pause()
+
+        # First question is presented; answer it, then the second appears.
+        question_actions = app.query_one("#question_actions", ActionList)
+        assert question_actions.option_count == 2
+        selected = question_actions.get_option("question_option_0")
+        await app.on_option_list_option_selected(OptionList.OptionSelected(question_actions, selected, 0))
+        await pilot.pause()
+
+        assert app._pending_question is not None
+        question_actions = app.query_one("#question_actions", ActionList)
+        selected = question_actions.get_option("question_option_1")
+        await app.on_option_list_option_selected(OptionList.OptionSelected(question_actions, selected, 1))
+
+        assert json.loads(await answer_task) == {"First": "A1", "Second": "B2"}
+        assert app._pending_question is None
+
+
+@pytest.mark.asyncio
+async def test_textual_app_planning_question_tool_rejects_malformed_input(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.tools import ToolError
+
+    class FakeBaseAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.history = []
+
+        def restore_message_history(self, history):
+            self.history = list(history)
+
+        def dump_message_history(self):
+            return self.history
+
+        async def cleanup(self):
+            return None
+
+    class FakeCoderAgent(FakeBaseAgent):
+        pass
+
+    class FakePlanningAgent(FakeBaseAgent):
+        pass
+
+    monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
+    monkeypatch.setattr(app_module, "PlanningAgent", FakePlanningAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test():
+        await app.action_toggle_interaction_mode()
+        ask_user_choice = extension_by_name(
+            app.agent.kwargs["tool_extensions"], "cli-planning-questions"
+        ).tools["ask_user_choice"]
+
+        # Empty / non-list questions.
+        with pytest.raises(ToolError):
+            await ask_user_choice(questions=[])
+        with pytest.raises(ToolError):
+            await ask_user_choice(questions="Which approach?")
+
+        # Fewer than two valid options.
+        with pytest.raises(ToolError):
+            await ask_user_choice(questions=question_payload("Q?", ["only one"]))
+
+        # Options that are bare strings rather than {label, description} objects.
+        with pytest.raises(ToolError):
+            await ask_user_choice(
+                questions=[{"question": "Q?", "header": "H", "multiSelect": False, "options": ["A", "B"]}]
+            )
+
+        # Missing question text.
+        with pytest.raises(ToolError):
+            await ask_user_choice(
+                questions=[
+                    {
+                        "question": "  ",
+                        "header": "H",
+                        "multiSelect": False,
+                        "options": [
+                            {"label": "A", "description": "d"},
+                            {"label": "B", "description": "d"},
+                        ],
+                    }
+                ]
+            )
+
+        assert app._pending_question is None
 
 
 @pytest.mark.asyncio

--- a/kolega_code/llm/models.py
+++ b/kolega_code/llm/models.py
@@ -359,11 +359,52 @@ class ToolParameter:
 class ToolDefinition(ContentBlock):
     """Unified representation of a tool definition across providers"""
 
-    def __init__(self, name: str, description: str, parameters: List[ToolParameter], cache_checkpoint: bool = False):
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        parameters: List[ToolParameter],
+        cache_checkpoint: bool = False,
+        input_schema: Optional[Dict[str, Any]] = None,
+    ):
         super().__init__(type="tool_definition", cache_checkpoint=cache_checkpoint)
         self.name = name
         self.description = description
         self.parameters = parameters
+        # When set, this explicit JSON schema (an "object" schema dict) is used
+        # verbatim instead of the flat per-parameter schema. This lets a tool
+        # declare nested shapes (arrays of objects, etc.) that the callable
+        # introspection in tool_definition_from_callable cannot express.
+        self.input_schema = input_schema
+
+    def _object_schema(self) -> Dict[str, Any]:
+        """The JSON-schema object describing this tool's input."""
+        if self.input_schema is not None:
+            return self.input_schema
+
+        properties = {}
+        required = []
+        for param in self.parameters:
+            properties[param.name] = {"type": param.type, "description": param.description}
+            if param.required:
+                required.append(param.name)
+        return {"type": "object", "properties": properties, "required": required}
+
+    @classmethod
+    def _dict_to_google_schema(cls, schema: Dict[str, Any]) -> genai_types.Schema:
+        """Recursively convert a JSON-schema dict to a google.genai Schema."""
+        kwargs: Dict[str, Any] = {"type": str(schema.get("type", "string")).upper()}
+        if schema.get("description"):
+            kwargs["description"] = schema["description"]
+        if "properties" in schema:
+            kwargs["properties"] = {
+                key: cls._dict_to_google_schema(value) for key, value in schema["properties"].items()
+            }
+        if "items" in schema:
+            kwargs["items"] = cls._dict_to_google_schema(schema["items"])
+        if schema.get("required"):
+            kwargs["required"] = schema["required"]
+        return genai_types.Schema(**kwargs)
 
     def to_anthropic(self) -> Dict[str, Any]:
         """
@@ -372,19 +413,10 @@ class ToolDefinition(ContentBlock):
         Returns:
             Dict[str, Any]: A dictionary with the structure expected by Anthropic API
         """
-        properties = {}
-        required = []
-
-        for param in self.parameters:
-            properties[param.name] = {"type": param.type, "description": param.description}
-
-            if param.required:
-                required.append(param.name)
-
         result = {
             "name": self.name,
             "description": self.description,
-            "input_schema": {"type": "object", "properties": properties, "required": required},
+            "input_schema": self._object_schema(),
         }
 
         if self.cache_checkpoint:
@@ -399,40 +431,33 @@ class ToolDefinition(ContentBlock):
         Returns:
             Dict[str, Any]: A dictionary with the structure expected by OpenAI API
         """
-        properties = {}
-        required = []
-
-        for param in self.parameters:
-            properties[param.name] = {"type": param.type, "description": param.description}
-
-            if param.required:
-                required.append(param.name)
-
         return {
             "type": "function",
             "function": {
                 "name": self.name,
                 "description": self.description,
-                "parameters": {"type": "object", "properties": properties, "required": required},
+                "parameters": self._object_schema(),
             },
         }
 
     def to_google(self) -> genai_types.Tool:
-        parameters = {}
-        required = []
-
-        for parameter in self.parameters:
-            parameters[parameter.name] = genai_types.Schema(
-                type=parameter.type.upper(), description=parameter.description
-            )
-
-            if parameter.required:
-                required.append(parameter.name)
+        if self.input_schema is not None:
+            parameters = self._dict_to_google_schema(self.input_schema)
+        else:
+            properties = {}
+            required = []
+            for parameter in self.parameters:
+                properties[parameter.name] = genai_types.Schema(
+                    type=parameter.type.upper(), description=parameter.description
+                )
+                if parameter.required:
+                    required.append(parameter.name)
+            parameters = genai_types.Schema(type="OBJECT", properties=properties, required=required)
 
         function_declaration = genai_types.FunctionDeclaration(
             name=self.name,
             description=self.description,
-            parameters=genai_types.Schema(type="OBJECT", properties=parameters, required=required),
+            parameters=parameters,
         )
 
         return genai_types.Tool(function_declarations=[function_declaration])

--- a/kolega_code/tools/__init__.py
+++ b/kolega_code/tools/__init__.py
@@ -10,10 +10,16 @@ assemble an agent's tools; internally it builds a ToolRegistry.
 """
 
 from .core import Tool, ToolError
-from .definitions import tool_definition_from_callable
+from .definitions import (
+    ASK_USER_CHOICE_INPUT_SCHEMA,
+    ASK_USER_CHOICE_SHAPE_HINT,
+    tool_definition_from_callable,
+)
 from .registry import ToolPolicy, ToolRegistry
 
 __all__ = [
+    "ASK_USER_CHOICE_INPUT_SCHEMA",
+    "ASK_USER_CHOICE_SHAPE_HINT",
     "Tool",
     "ToolError",
     "ToolPolicy",

--- a/kolega_code/tools/definitions.py
+++ b/kolega_code/tools/definitions.py
@@ -79,3 +79,63 @@ def tool_definition_from_callable(
         description=description,
         parameters=tool_parameters,
     )
+
+
+# Explicit input schema for the ask_user_choice tool. It declares a `questions` array of
+# objects (header, question text, a multiSelect flag, and a list of {label, description}
+# options) — a nested shape that cannot be introspected from the handler signature, so it
+# is supplied verbatim via ToolExtension.tool_schemas.
+ASK_USER_CHOICE_INPUT_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "questions": {
+            "type": "array",
+            "description": "The questions to ask the user (1-4 questions).",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "question": {
+                        "type": "string",
+                        "description": "The complete question to ask the user.",
+                    },
+                    "header": {
+                        "type": "string",
+                        "description": "A very short label for the question (a few words).",
+                    },
+                    "multiSelect": {
+                        "type": "boolean",
+                        "description": "Whether multiple options may be selected. Currently answered single-select.",
+                    },
+                    "options": {
+                        "type": "array",
+                        "description": "Two to four distinct choices.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "label": {
+                                    "type": "string",
+                                    "description": "The concise choice text shown to the user.",
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "description": "A short explanation of what choosing this option means.",
+                                },
+                            },
+                            "required": ["label", "description"],
+                        },
+                    },
+                },
+                "required": ["question", "header", "options", "multiSelect"],
+            },
+        }
+    },
+    "required": ["questions"],
+}
+
+# Canonical correct-shape example used in ask_user_choice validation error messages so the
+# model can self-correct.
+ASK_USER_CHOICE_SHAPE_HINT = (
+    'Call it as ask_user_choice(questions=[{"question": "...", "header": "...", '
+    '"multiSelect": false, "options": [{"label": "...", "description": "..."}, '
+    '{"label": "...", "description": "..."}]}]) with at least two options per question.'
+)

--- a/kolega_code/tools/tests/test_definitions.py
+++ b/kolega_code/tools/tests/test_definitions.py
@@ -1,0 +1,114 @@
+"""Offline tests for tool-definition schema serialization.
+
+Covers the explicit `input_schema` override on ToolDefinition (used for nested
+shapes the callable introspector cannot express) across all three providers.
+No network calls.
+"""
+
+from google.genai import types as genai_types
+
+from kolega_code.llm.models import ToolDefinition, ToolParameter
+from kolega_code.tools.definitions import tool_definition_from_callable
+
+
+NESTED_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "questions": {
+            "type": "array",
+            "description": "The questions to ask.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "question": {"type": "string", "description": "The question text."},
+                    "header": {"type": "string", "description": "Short label."},
+                    "multiSelect": {"type": "boolean", "description": "Allow multiple."},
+                    "options": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "label": {"type": "string", "description": "Choice text."},
+                                "description": {"type": "string", "description": "Explanation."},
+                            },
+                            "required": ["label", "description"],
+                        },
+                    },
+                },
+                "required": ["question", "header", "options", "multiSelect"],
+            },
+        }
+    },
+    "required": ["questions"],
+}
+
+
+def _nested_definition() -> ToolDefinition:
+    return ToolDefinition(
+        name="ask_user_choice",
+        description="Ask the user.",
+        parameters=[ToolParameter(name="questions", type="array", description="", required=True)],
+        input_schema=NESTED_SCHEMA,
+    )
+
+
+def test_explicit_schema_passed_through_for_anthropic():
+    definition = _nested_definition()
+    payload = definition.to_anthropic()
+    assert payload["name"] == "ask_user_choice"
+    assert payload["input_schema"] == NESTED_SCHEMA
+
+
+def test_explicit_schema_passed_through_for_openai():
+    definition = _nested_definition()
+    payload = definition.to_openai()
+    assert payload["type"] == "function"
+    assert payload["function"]["parameters"] == NESTED_SCHEMA
+
+
+def test_explicit_schema_converted_for_google():
+    definition = _nested_definition()
+    tool = definition.to_google()
+    params = tool.function_declarations[0].parameters
+
+    assert params.type == genai_types.Type.OBJECT
+    questions = params.properties["questions"]
+    assert questions.type == genai_types.Type.ARRAY
+
+    item = questions.items
+    assert item.type == genai_types.Type.OBJECT
+    assert set(item.properties) == {"question", "header", "multiSelect", "options"}
+    assert "question" in (item.required or [])
+
+    options = item.properties["options"]
+    assert options.type == genai_types.Type.ARRAY
+    assert options.items.type == genai_types.Type.OBJECT
+    assert "label" in options.items.properties
+    assert options.items.properties["label"].type == genai_types.Type.STRING
+
+
+def test_flat_definition_still_serializes_without_input_schema():
+    """A definition built by introspection (no input_schema) keeps the flat object schema."""
+
+    async def sample(query: str, limit: int) -> str:
+        """Do a thing.
+
+        Args:
+            query: The search text.
+            limit: Max results.
+        """
+        return ""
+
+    definition = tool_definition_from_callable("sample", sample)
+    assert definition.input_schema is None
+
+    anthropic = definition.to_anthropic()["input_schema"]
+    assert anthropic["type"] == "object"
+    assert set(anthropic["properties"]) == {"query", "limit"}
+    assert anthropic["properties"]["query"]["type"] == "string"
+    assert anthropic["properties"]["limit"]["type"] == "integer"
+    assert set(anthropic["required"]) == {"query", "limit"}
+
+    google_params = definition.to_google().function_declarations[0].parameters
+    assert google_params.type == genai_types.Type.OBJECT
+    assert set(google_params.properties) == {"query", "limit"}


### PR DESCRIPTION
## Why

LLMs frequently called `ask_user_choice` with the wrong argument shape. The root cause wasn't insufficient guidance — it was that the tool's bespoke flat schema (`question: str`, `options: list[str]`) fought the model's strong prior toward a nested `questions` array of `{header, question, multiSelect, options: [{label, description}]}` objects. So models emitted a `questions` array or option objects and got rejected.

The fix conforms the tool to that prior rather than adding more validation/guidance.

## What changed

- **`ToolDefinition` can carry an explicit `input_schema`** (`kolega_code/llm/models.py`). When set, it's used verbatim for Anthropic/OpenAI and converted recursively to a `genai_types.Schema` for Google. This expresses nested array-of-object shapes the callable introspector can't. Every other tool is unaffected (none use a nested schema).
- **`ToolExtension` gained a `tool_schemas` map** (`kolega_code/agent/tools.py`); `ToolCollection` injects it onto the built definition, mirroring the existing `extension_callbacks` pattern.
- **`ask_user_choice` now takes `questions: list[dict]`** (`kolega_code/cli/app.py`): validates strictly (instructive `ToolError`, no coercion), asks each question **sequentially** via the existing single-select + free-text UI, and returns a JSON object keyed by header. Options carry `label` + `description`. `multiSelect` is accepted in the schema but answered single-select for now (true multi-pick UI deferred).
- **The schema lives with the tool-definition code**: `ASK_USER_CHOICE_INPUT_SCHEMA` / `ASK_USER_CHOICE_SHAPE_HINT` in `kolega_code/tools/definitions.py`, exported from the `tools` package — not inline in the CLI module.

## Tests

- Offline schema-serialization tests across all three providers (`kolega_code/tools/tests/test_definitions.py`).
- End-to-end `tool_schemas` injection through `ToolCollection` (`test_tools.py`).
- Rewritten + added `ask_user_choice` behavior tests: happy path, multi-question sequential, malformed-input rejection (`test_app.py`).

All affected suites pass: `pytest kolega_code/tools/tests/ kolega_code/cli/tests/test_app.py kolega_code/agent/tests/test_tools.py -k "not live and not integration"` → 144 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)