### PR TITLE
[codex] add exit slash command

### DIFF
--- a/docs/src/content/docs/tui/sessions-and-resume.md
+++ b/docs/src/content/docs/tui/sessions-and-resume.md
@@ -10,7 +10,7 @@ task list. Sessions let you stop and resume work later.
 ## How sessions are created
 
 - **In the TUI**, launching `kolega-code .` starts a **fresh session by default**.
-  Your work is saved when you quit (`Ctrl+Q` or `/quit`).
+  Your work is saved when you quit (`Ctrl+Q`, `/quit`, or `/exit`).
 - **With `ask`**, a session is only persisted if you pass `--save` or `--session`.
   See [`kolega-code ask`](../../cli/ask/).
 

--- a/docs/src/content/docs/tui/slash-commands.md
+++ b/docs/src/content/docs/tui/slash-commands.md
@@ -41,6 +41,7 @@ These control the app and your session.
 | `/version` | Show the Kolega Code version |
 | `/update` | Update Kolega Code to the latest version |
 | `/quit` | Save the session and exit |
+| `/exit` | Save the session and exit |
 
 Run `/model` to open a selectable list of supported models for the current
 provider. You can also switch directly with `/model <name>`.

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -1628,6 +1628,7 @@ class KolegaCodeApp(App):
             "/version": self._command_version,
             "/update": self._command_update,
             "/quit": self._command_quit,
+            "/exit": self._command_quit,
         }
 
     async def _handle_tui_slash_command(self, stripped_text: str, composer: ChatComposer) -> bool:

--- a/kolega_code/cli/slash_commands.py
+++ b/kolega_code/cli/slash_commands.py
@@ -48,6 +48,7 @@ TUI_COMMAND_ENTRIES: tuple[SlashCommandEntry, ...] = (
     SlashCommandEntry("version", "Show the Kolega Code version", CommandScope.TUI),
     SlashCommandEntry("update", "Update Kolega Code to the latest version", CommandScope.TUI),
     SlashCommandEntry("quit", "Save the session and exit", CommandScope.TUI),
+    SlashCommandEntry("exit", "Save the session and exit", CommandScope.TUI),
 )
 
 TUI_COMMAND_NAMES: frozenset[str] = frozenset(entry.token for entry in TUI_COMMAND_ENTRIES)

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -5125,7 +5125,10 @@ async def test_textual_app_startup_update_check_notifies_when_newer(
 
 
 @pytest.mark.asyncio
-async def test_textual_app_quit_slash_command_exits(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("command", ["/quit", "/exit"])
+async def test_textual_app_quit_slash_command_exits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, command: str
+) -> None:
     pytest.importorskip("textual")
 
     from kolega_code.cli.app import ChatComposer
@@ -5134,7 +5137,7 @@ async def test_textual_app_quit_slash_command_exits(tmp_path: Path, monkeypatch:
 
     async with app.run_test():
         composer = app.query_one("#composer", ChatComposer)
-        composer.load_text("/quit")
+        composer.load_text(command)
         await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
 
     assert app.return_value is None

--- a/kolega_code/cli/tests/test_slash_commands.py
+++ b/kolega_code/cli/tests/test_slash_commands.py
@@ -32,6 +32,7 @@ def test_agent_command_names_match_command_processor():
     assert agent_command_names() == {spec.name for spec in CommandProcessor.SPECS}
     assert THREAD_RESET_COMMANDS <= agent_command_names()
     assert SKILLS_LIST_COMMAND in TUI_COMMAND_NAMES
+    assert "/exit" in TUI_COMMAND_NAMES
 
 
 def test_all_command_entries_unique_with_descriptions():
@@ -48,6 +49,7 @@ def test_all_command_entries_include_each_scope():
     assert by_name["help"].scope is CommandScope.AGENT
     assert by_name["plan"].scope is CommandScope.TUI
     assert by_name["effort"].scope is CommandScope.TUI
+    assert by_name["exit"].scope is CommandScope.TUI
     assert by_name["demo-skill"].scope is CommandScope.SKILL
 
 


### PR DESCRIPTION
## Summary

Adds `/exit` as a visible TUI slash command alias for `/quit`.

## Changes

- Registers `/exit` in the TUI slash-command metadata so it appears in autocomplete.
- Routes `/exit` through the existing quit handler, preserving current save-and-exit behavior.
- Documents `/exit` alongside `/quit` and updates tests for both command metadata and TUI behavior.

## Validation

- `uv run pytest kolega_code/cli/tests/test_slash_commands.py`
- `uv run pytest kolega_code/cli/tests/test_app.py -k "slash_command or slash_dropdown or quit"`