### PR TITLE
[codex] Release v0.3.1

### DIFF
--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -148,4 +148,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.3.0"
+version = "0.3.1"
 description = "Local-first AI coding agent for the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [options]
 prerelease-mode = "allow"
-exclude-newer = "2026-06-10T05:46:32.763695Z"
+exclude-newer = "2026-06-10T06:04:37.785255Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -666,7 +666,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Bump `kolega-code` from `0.3.0` to `0.3.1` for the next patch release.
- Align `pyproject.toml`, both package `__version__` declarations, and the `uv.lock` project package version.
- Keep `cryptography` locked at `49.0.0`; no explicit package cutoff was added.

## Why
This prepares a patch release after the merged Dependabot fixes on `main`:
- Remove unused `browser-use` and vulnerable transitive `langchain-anthropic`.
- Upgrade docs to `astro@6.4.7` / `@astrojs/starlight@0.40.0`.

## Validation
- `uv lock --check`
- `uv sync --extra dev --frozen`
- `uv run pytest -ra --durations=50 --import-mode=importlib -m "not slow"` -> 863 passed, 50 deselected, 4 warnings
- `uv run kolega-code --version` -> `kolega-code 0.3.1`

## After merge
```bash
git checkout main
git pull --ff-only
git tag v0.3.1
git push origin v0.3.1
```

Then approve/monitor the `Release` workflow through PyPI publish and GitHub Release creation.