### PR TITLE
[codex] add shell and edit permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 .env
 .env.*
 !.env.example
+.kolega/permissions.json
 dist/
 build/
 *.egg-info/

--- a/docs/src/content/docs/cli/ask.md
+++ b/docs/src/content/docs/cli/ask.md
@@ -20,6 +20,7 @@ kolega-code ask "<prompt>" [options]
 | `--save` | Persist the session after the prompt completes |
 | `--json` | Emit response chunks and events as JSON |
 | `--browser-visible` | Launch visible Playwright browser windows |
+| `--permission-mode <auto\|ask>` | Shell/edit permission mode (default `auto`) |
 | `--session <ID>` | Resume or create a specific session |
 | `--state-dir <PATH>` | Directory for CLI session state |
 
@@ -97,3 +98,10 @@ The stream includes:
 In plain (non-JSON) mode, the answer is written to **stdout** while sub-agent and
 tool activity is reported on **stderr** — so piping stdout gives you just the
 answer.
+
+## Permissions
+
+`ask` defaults to `--permission-mode auto` so scripts do not stop for
+confirmations. If you pass `--permission-mode ask`, shell commands and file edits
+prompt on stderr when stdin is interactive. Persisted allow rules are stored in
+the project at `.kolega/permissions.json`.

--- a/docs/src/content/docs/cli/overview.md
+++ b/docs/src/content/docs/cli/overview.md
@@ -39,6 +39,7 @@ kolega-code [PROJECT_PATH]
 | `--new` | Start a new session (this is the default) |
 | `--resume [THREAD_ID]` | Resume the latest saved thread, or a specific thread/session ID |
 | `--browser-visible` | Launch visible Playwright browser windows instead of headless |
+| `--permission-mode <auto\|ask>` | Shell/edit permission mode. TUI sessions default to `ask` |
 | `--session <ID>` | Legacy alias for `--resume THREAD_ID` |
 
 See [Sessions & Resuming](../../tui/sessions-and-resume/) for the full session

--- a/docs/src/content/docs/concepts/tools.md
+++ b/docs/src/content/docs/concepts/tools.md
@@ -62,3 +62,7 @@ files and running commands require Build mode's full toolset.
 
 This separation is what makes Plan mode safe to run against any codebase: the
 planning agent can look but not touch.
+
+In the Textual TUI, Build mode defaults to `ask` permission mode. Shell commands
+and file edits must be approved before they run unless you switch to `auto` or
+save a matching allow rule in `.kolega/permissions.json`.

--- a/docs/src/content/docs/tui/interface.md
+++ b/docs/src/content/docs/tui/interface.md
@@ -24,7 +24,7 @@ At the bottom sits the **composer** — the text box where you type prompts. See
 
 | Tab | What it shows |
 | --- | --- |
-| **Status** | The active provider/model and thinking effort, the current interaction mode (Build/Plan), the agent's turn state (idle, generating, thinking, running a tool, running sub-agents, waiting for input, …), token usage, and context warnings. |
+| **Status** | The active provider/model and thinking effort, the current interaction mode (Build/Plan), permission mode, the agent's turn state (idle, generating, thinking, running a tool, running sub-agents, waiting for input, …), token usage, and context warnings. |
 | **Logs** | A timestamped, color-coded activity log: sub-agent lifecycle, tool calls, configuration changes. An indicator flags new entries when you're on another tab. |
 | **Terminal** | Live output from commands the agent runs. |
 | **Planning** | The current **Plan** (markdown from the planning agent) and the shared **Task List** that both modes can edit. |
@@ -40,7 +40,8 @@ At the bottom sits the **composer** — the text box where you type prompts. See
 - **Sub-agents** — when the main agent dispatches a sub-agent, its activity is
   tracked live with status updates.
 - **Option lists** — when the agent asks you to choose between options (including
-  plan decisions), they render as a **vertical, arrow-key-selectable list**.
+  plan decisions and tool approvals), they render as a **vertical,
+  arrow-key-selectable list**.
   Use the arrow keys to highlight, number keys (`1`–`9`) to jump, and `Enter` to
   confirm.
 
@@ -49,6 +50,7 @@ At the bottom sits the **composer** — the text box where you type prompts. See
 | Keys | Action |
 | --- | --- |
 | `Shift+Tab` | Toggle Build ⇄ Plan mode |
+| `Ctrl+P` | Toggle shell/edit permissions between Ask ⇄ Auto |
 | `Enter` | Send the prompt |
 | `Shift+Enter` / `Ctrl+J` | Insert a newline |
 | `Ctrl+C` / `Escape` | Cancel the current generation |

--- a/docs/src/content/docs/tui/modes.md
+++ b/docs/src/content/docs/tui/modes.md
@@ -14,6 +14,14 @@ implementing whatever you ask.
 
 Use Build mode for hands-on work: making changes, running tests, fixing bugs.
 
+Build mode is still subject to the current **permission mode**. TUI sessions
+default to `ask`, so shell commands and file edits prompt before they run. Press
+`Ctrl+P` to toggle between `ask` and `auto`, or use `/permissions ask`,
+`/permissions auto`, and `/permissions toggle`.
+
+When you choose an “always allow” approval, Kolega Code stores the local rule in
+`.kolega/permissions.json` for that project.
+
 ## Plan mode
 
 A **read-only** planning pass. Plan mode uses a standalone planning agent that does

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -24,6 +24,13 @@ from kolega_code.llm.exceptions import (
 from kolega_code.llm.models import ImageBlock, Message, MessageHistory, TextBlock, ToolCall, ToolResult
 from kolega_code.llm.providers.models import TokenCount
 from kolega_code.llm.specs import get_model_specs
+from kolega_code.permissions import (
+    PermissionDecision,
+    PermissionMode,
+    auto_allow_permission_callback,
+    normalize_permission_mode,
+    permission_request_for_tool,
+)
 from .prompt_provider import PromptProvider, AgentMode, PromptContext, PromptExtension
 from kolega_code.services.base import TerminalManager, BrowserManager
 from kolega_code.services.file_system import FileSystem
@@ -86,6 +93,8 @@ class BaseAgent(LogMixin):
         prompt_provider: Optional[PromptProvider] = None,
         prompt_extensions: Optional[List[PromptExtension]] = None,
         tool_extensions: Optional[List[Any]] = None,
+        permission_mode: Optional[PermissionMode | str] = None,
+        permission_callback: Optional[Any] = None,
         usage_recorder: Optional[Any] = None,
         sub_agent_recorder: Optional[Any] = None,
         context: Optional[AgentContext] = None,
@@ -160,9 +169,15 @@ class BaseAgent(LogMixin):
                 prompt_provider=prompt_provider,
                 prompt_extensions=prompt_extensions or [],
                 tool_extensions=tool_extensions or [],
+                permission_mode=normalize_permission_mode(permission_mode, default=PermissionMode.AUTO),
+                permission_callback=permission_callback or auto_allow_permission_callback,
             )
         elif prompt_provider is not None:
             context.prompt_provider = prompt_provider
+            if permission_mode is not None:
+                context.permission_mode = normalize_permission_mode(permission_mode, default=context.permission_mode)
+            if permission_callback is not None:
+                context.permission_callback = permission_callback
 
         self.context = context
 
@@ -185,6 +200,8 @@ class BaseAgent(LogMixin):
         self.workspace_memories = context.workspace.memories
         self.prompt_extensions = context.prompt_extensions
         self.tool_extensions = context.tool_extensions
+        self.permission_mode = context.permission_mode
+        self.permission_callback = context.permission_callback or auto_allow_permission_callback
         self.usage_recorder = context.telemetry.usage_recorder
         self.sub_agent_recorder = context.telemetry.sub_agent_recorder
 
@@ -500,6 +517,16 @@ class BaseAgent(LogMixin):
     # Tool execution
     # ------------------------------------------------------------------
 
+    def set_permission_mode(self, permission_mode: PermissionMode | str) -> None:
+        """Update the active permission mode without rebuilding the agent."""
+        self.permission_mode = normalize_permission_mode(permission_mode, default=self.permission_mode)
+        self.context.permission_mode = self.permission_mode
+
+    def set_permission_callback(self, permission_callback: Any) -> None:
+        """Update the host callback used when permission mode is ask."""
+        self.permission_callback = permission_callback or auto_allow_permission_callback
+        self.context.permission_callback = self.permission_callback
+
     @property
     def current_tool_call_id(self):
         """Internal execution ID for UI and sub-agent records (task-local)."""
@@ -561,6 +588,49 @@ class BaseAgent(LogMixin):
 
             # Log the tool being called
             await self.log_info(f"Executing tool: {tool_name}", sender=self.agent_name)
+
+            permission_request = permission_request_for_tool(tool_name, inputs)
+            if permission_request is not None and self.permission_mode == PermissionMode.ASK:
+                try:
+                    decision = await self.permission_callback(permission_request)
+                    if not isinstance(decision, PermissionDecision):
+                        raise TypeError("permission callback must return PermissionDecision")
+                except Exception as ex:
+                    error_message = f"Permission check failed for {tool_name}: {ex}"
+                    await self.log_error(error_message, sender=self.agent_name)
+                    await self.send_chat_message(
+                        message_type="tool_error",
+                        content=error_message,
+                        is_streaming=False,
+                        tool_description=tool_name,
+                        tool_call_id=tool_execution_id,
+                    )
+                    return ToolResult(
+                        tool_use_id=provider_tool_call_id,
+                        content=error_message,
+                        name=tool_name,
+                        is_error=True,
+                        execution_id=tool_execution_id,
+                    )
+
+                if not decision.allowed:
+                    reason = decision.reason or "The user denied permission for this action."
+                    error_message = f"Permission denied for {tool_name}: {reason}"
+                    await self.log_warning(error_message, sender=self.agent_name)
+                    await self.send_chat_message(
+                        message_type="tool_error",
+                        content=error_message,
+                        is_streaming=False,
+                        tool_description=tool_name,
+                        tool_call_id=tool_execution_id,
+                    )
+                    return ToolResult(
+                        tool_use_id=provider_tool_call_id,
+                        content=error_message,
+                        name=tool_name,
+                        is_error=True,
+                        execution_id=tool_execution_id,
+                    )
 
             # Send tool_call message to indicate we're starting execution
             if not all(

--- a/kolega_code/agent/browseragent.py
+++ b/kolega_code/agent/browseragent.py
@@ -5,7 +5,7 @@ from .baseagent import BaseAgent
 from kolega_code.config import AgentConfig
 from kolega_code.events import AgentConnectionManager
 from kolega_code.llm.models import Message, TextBlock
-from .prompt_provider import AgentType, PromptExtension
+from .prompt_provider import AgentMode, AgentType, PromptExtension
 from .tools import ToolCollection
 
 
@@ -40,6 +40,8 @@ class BrowserAgent(BaseAgent):
         workspace_memories: Optional[List[str]] = None,
         prompt_extensions: Optional[List[PromptExtension]] = None,
         tool_extensions: Optional[List[Any]] = None,
+        permission_mode: Optional[Any] = None,
+        permission_callback: Optional[Any] = None,
         usage_recorder: Optional[Any] = None,
         sub_agent_recorder: Optional[Any] = None,
     ) -> None:
@@ -89,6 +91,8 @@ class BrowserAgent(BaseAgent):
             workspace_memories=workspace_memories,
             prompt_extensions=prompt_extensions,
             tool_extensions=tool_extensions,
+            permission_mode=permission_mode,
+            permission_callback=permission_callback,
             usage_recorder=usage_recorder,
             sub_agent_recorder=sub_agent_recorder,
         )

--- a/kolega_code/agent/coder.py
+++ b/kolega_code/agent/coder.py
@@ -44,6 +44,8 @@ class CoderAgent(BaseAgent, LogMixin):
         prompt_provider: Optional[PromptProvider] = None,
         prompt_extensions: Optional[List[PromptExtension]] = None,
         tool_extensions: Optional[List[Any]] = None,
+        permission_mode: Optional[Any] = None,
+        permission_callback: Optional[Any] = None,
         usage_recorder: Optional[Any] = None,
         sub_agent_recorder: Optional[Any] = None,
     ) -> None:
@@ -96,6 +98,8 @@ class CoderAgent(BaseAgent, LogMixin):
             prompt_provider=prompt_provider,
             prompt_extensions=prompt_extensions,
             tool_extensions=tool_extensions,
+            permission_mode=permission_mode,
+            permission_callback=permission_callback,
             usage_recorder=usage_recorder,
             sub_agent_recorder=sub_agent_recorder,
         )

--- a/kolega_code/agent/context.py
+++ b/kolega_code/agent/context.py
@@ -15,6 +15,7 @@ from kolega_code.config import AgentConfig
 from kolega_code.events import AgentConnectionManager
 from kolega_code.llm.client import LLMClient
 from kolega_code.llm.instrumented_client import InstrumentedLLMClient
+from kolega_code.permissions import PermissionMode, auto_allow_permission_callback
 from .prompt_provider import AgentMode, PromptExtension, PromptProvider
 from kolega_code.services.base import BrowserManager, TerminalManager
 from kolega_code.services.browser import PlaywrightBrowserManager
@@ -81,6 +82,8 @@ class AgentContext:
     prompt_provider: Optional[PromptProvider] = None
     prompt_extensions: List[PromptExtension] = field(default_factory=list)
     tool_extensions: List[Any] = field(default_factory=list)
+    permission_mode: PermissionMode = PermissionMode.AUTO
+    permission_callback: Any = auto_allow_permission_callback
 
     def create_llm_client(self, agent_name: str) -> LLMClient:
         """Create the LLM client, instrumented when a Langfuse client is available."""

--- a/kolega_code/agent/generalagent.py
+++ b/kolega_code/agent/generalagent.py
@@ -42,6 +42,8 @@ class GeneralAgent(BaseAgent):
         workspace_memories: Optional[List[str]] = None,
         prompt_extensions: Optional[List[PromptExtension]] = None,
         tool_extensions: Optional[List[Any]] = None,
+        permission_mode: Optional[Any] = None,
+        permission_callback: Optional[Any] = None,
         usage_recorder: Optional[Any] = None,
         sub_agent_recorder: Optional[Any] = None,
     ) -> None:
@@ -91,6 +93,8 @@ class GeneralAgent(BaseAgent):
             workspace_memories=workspace_memories,
             prompt_extensions=prompt_extensions,
             tool_extensions=tool_extensions,
+            permission_mode=permission_mode,
+            permission_callback=permission_callback,
             usage_recorder=usage_recorder,
             sub_agent_recorder=sub_agent_recorder,
         )

--- a/kolega_code/agent/investigationagent.py
+++ b/kolega_code/agent/investigationagent.py
@@ -5,7 +5,7 @@ from .baseagent import BaseAgent
 from kolega_code.config import AgentConfig
 from kolega_code.events import AgentConnectionManager
 from kolega_code.llm.models import Message, TextBlock
-from .prompt_provider import AgentType, PromptExtension
+from .prompt_provider import AgentMode, AgentType, PromptExtension
 from .tools import ToolCollection
 
 
@@ -40,6 +40,8 @@ class InvestigationAgent(BaseAgent):
         workspace_memories: Optional[List[str]] = None,
         prompt_extensions: Optional[List[PromptExtension]] = None,
         tool_extensions: Optional[List[Any]] = None,
+        permission_mode: Optional[Any] = None,
+        permission_callback: Optional[Any] = None,
         usage_recorder: Optional[Any] = None,
         sub_agent_recorder: Optional[Any] = None,
     ) -> None:
@@ -89,6 +91,8 @@ class InvestigationAgent(BaseAgent):
             workspace_memories=workspace_memories,
             prompt_extensions=prompt_extensions,
             tool_extensions=tool_extensions,
+            permission_mode=permission_mode,
+            permission_callback=permission_callback,
             usage_recorder=usage_recorder,
             sub_agent_recorder=sub_agent_recorder,
         )

--- a/kolega_code/agent/planningagent.py
+++ b/kolega_code/agent/planningagent.py
@@ -80,6 +80,8 @@ class PlanningAgent(BaseAgent):
         workspace_memories: Optional[List[str]] = None,
         prompt_extensions: Optional[List[PromptExtension]] = None,
         tool_extensions: Optional[List[Any]] = None,
+        permission_mode: Optional[Any] = None,
+        permission_callback: Optional[Any] = None,
         usage_recorder: Optional[Any] = None,
         sub_agent_recorder: Optional[Any] = None,
     ) -> None:
@@ -103,6 +105,8 @@ class PlanningAgent(BaseAgent):
             workspace_memories=workspace_memories,
             prompt_extensions=prompt_extensions,
             tool_extensions=tool_extensions,
+            permission_mode=permission_mode,
+            permission_callback=permission_callback,
             usage_recorder=usage_recorder,
             sub_agent_recorder=sub_agent_recorder,
         )

--- a/kolega_code/agent/tests/test_permissions.py
+++ b/kolega_code/agent/tests/test_permissions.py
@@ -1,0 +1,138 @@
+import os
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from kolega_code.agent.baseagent import BaseAgent
+from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
+from kolega_code.events import AgentConnectionManager
+from kolega_code.llm.models import ToolCall
+from kolega_code.llm.models import ToolDefinition
+from kolega_code.permissions import (
+    PermissionDecision,
+    PermissionKind,
+    PermissionMode,
+    PermissionRule,
+    ProjectPermissionStore,
+    allow_rule_options,
+    permission_request_for_tool,
+)
+from kolega_code.tools import Tool, ToolRegistry
+
+
+@pytest.fixture
+def agent_config():
+    return AgentConfig(
+        anthropic_api_key=os.getenv("ANTHROPIC_API_KEY", "test_key"),
+        long_context_config=ModelConfig(
+            provider=ModelProvider.ANTHROPIC,
+            model="claude-haiku-4-5-20251001",
+            rate_limits=RateLimitConfig(),
+        ),
+        fast_config=ModelConfig(
+            provider=ModelProvider.ANTHROPIC,
+            model="claude-haiku-4-5-20251001",
+            rate_limits=RateLimitConfig(),
+        ),
+        thinking_config=ModelConfig(
+            provider=ModelProvider.ANTHROPIC,
+            model="claude-haiku-4-5-20251001",
+            rate_limits=RateLimitConfig(),
+            thinking_effort="medium",
+        ),
+    )
+
+
+def test_permission_store_matches_command_rules(tmp_path):
+    request = permission_request_for_tool(
+        "run_command_tracked",
+        {"command": "npm run test -- --watch=false"},
+    )
+    assert request is not None
+    store = ProjectPermissionStore(tmp_path)
+    store.save(
+        [
+            PermissionRule.create(
+                kind=PermissionKind.COMMAND,
+                tool="*",
+                match_type="prefix",
+                pattern="npm run",
+            )
+        ]
+    )
+
+    assert store.first_match(request) is not None
+    assert (tmp_path / ".kolega" / "permissions.json").exists()
+
+
+def test_allow_rule_options_for_command_include_exact_prefix_and_executable():
+    request = permission_request_for_tool("run_command_tracked", {"command": "npm run test"})
+    assert request is not None
+
+    options = allow_rule_options(request)
+    rules = {(option.rule.match_type, option.rule.pattern) for option in options}
+
+    assert ("exact", "npm run test") in rules
+    assert ("prefix", "npm run") in rules
+    assert ("executable", "npm") in rules
+
+
+def test_edit_permission_rule_can_scope_to_path():
+    request = permission_request_for_tool("create_file", {"relative_path": "src/new.py", "content": ""})
+    assert request is not None
+    rule = PermissionRule.create(
+        kind=PermissionKind.EDIT,
+        tool="create_file",
+        match_type="path",
+        pattern="src/new.py",
+    )
+
+    assert rule.matches(request)
+
+
+@pytest.mark.asyncio
+async def test_execute_single_tool_denies_gated_tool_before_dispatch(tmp_path, agent_config):
+    handler = AsyncMock(return_value="command ran")
+
+    class TestTools:
+        def registry(self):
+            return ToolRegistry(
+                [
+                    Tool(
+                        name="run_command_tracked",
+                        definition=ToolDefinition(name="run_command_tracked", description="", parameters=[]),
+                        handler=handler,
+                    )
+                ]
+            )
+
+    async def deny(_request):
+        return PermissionDecision(allowed=False, reason="No.")
+
+    agent = BaseAgent(
+        project_path=tmp_path,
+        workspace_id="test_workspace",
+        thread_id=str(uuid.uuid4()),
+        connection_manager=AsyncMock(spec=AgentConnectionManager),
+        config=agent_config,
+        permission_mode=PermissionMode.ASK,
+        permission_callback=deny,
+    )
+    agent.tool_collection = TestTools()
+    agent.send_chat_message = AsyncMock()
+    agent.log_info = AsyncMock()
+    agent.log_warning = AsyncMock()
+
+    result = await agent.execute_single_tool(
+        ToolCall(
+            id="tool_1",
+            name="run_command_tracked",
+            input={"terminal_id": "term", "command": "npm run test", "purpose": "test"},
+            execution_id="exec_1",
+        )
+    )
+
+    assert result.is_error is True
+    assert "Permission denied" in result.content
+    handler.assert_not_awaited()

--- a/kolega_code/agent/tool_backend/agent_tool.py
+++ b/kolega_code/agent/tool_backend/agent_tool.py
@@ -192,6 +192,8 @@ class AgentTool(BaseTool):
                 workspace_memories=getattr(self.caller, "workspace_memories", None) if self.caller else None,
                 prompt_extensions=getattr(self.caller, "prompt_extensions", None) if self.caller else None,
                 tool_extensions=getattr(self.caller, "tool_extensions", None) if self.caller else None,
+                permission_mode=getattr(self.caller, "permission_mode", None) if self.caller else None,
+                permission_callback=getattr(self.caller, "permission_callback", None) if self.caller else None,
                 usage_recorder=getattr(self.caller, "usage_recorder", None) if self.caller else None,
                 sub_agent_recorder=getattr(self.caller, "sub_agent_recorder", None) if self.caller else None,
             )

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -50,6 +50,16 @@ from textual.widgets.option_list import Option
 from kolega_code.agent import AgentConfig, AgentEvent, CoderAgent, PlanningAgent, PromptExtension, ToolExtension
 from kolega_code.llm.exceptions import LLMError, llm_error_message
 from kolega_code.llm.models import Message, MessageHistory, TextBlock, ToolCall, ToolResult
+from kolega_code.permissions import (
+    PermissionDecision,
+    PermissionMode,
+    PermissionRequest,
+    PermissionRuleOption,
+    PermissionStoreError,
+    ProjectPermissionStore,
+    allow_rule_options,
+    normalize_permission_mode,
+)
 from kolega_code.tools import ASK_USER_CHOICE_INPUT_SCHEMA, ASK_USER_CHOICE_SHAPE_HINT, ToolError
 from kolega_code.agent.prompt_provider import AgentMode
 from kolega_code.services.browser import PlaywrightBrowserManager
@@ -118,9 +128,11 @@ IMPLEMENT_PLAN_PROMPT = """Implement the approved plan below. Follow it as the s
 """
 QUESTION_TOOL_NAME = "ask_user_choice"
 QUESTION_OPTION_ID_PREFIX = "question_option_"
+APPROVAL_OPTION_ID_PREFIX = "approval_option_"
 MODEL_OPTION_ID_PREFIX = "model_option_"
 EFFORT_OPTION_ID_PREFIX = "effort_option_"
 QUESTION_PLACEHOLDER = messages.QUESTION_PLACEHOLDER
+APPROVAL_PLACEHOLDER = messages.APPROVAL_PLACEHOLDER
 MODEL_PLACEHOLDER = messages.MODEL_PLACEHOLDER
 EFFORT_PLACEHOLDER = messages.EFFORT_PLACEHOLDER
 STARTUP_WORDMARK = (
@@ -213,6 +225,13 @@ class PendingQuestion:
 
 
 @dataclass
+class PendingApproval:
+    request: PermissionRequest
+    future: asyncio.Future[PermissionDecision]
+    rule_options: list[PermissionRuleOption]
+
+
+@dataclass
 class PendingModelSelection:
     provider: str
     options: list[tuple[str, str]]
@@ -231,6 +250,7 @@ class StatusDashboardState:
     model: str = UI_DEFAULT_MODEL
     thinking_effort: Optional[str] = None
     mode: str = BUILD_INTERACTION_MODE
+    permission_mode: str = PermissionMode.ASK.value
     turn_state: TurnState = TurnState.IDLE
     activity: str = "Ready"
     input_tokens: Optional[int] = None
@@ -704,6 +724,7 @@ class KolegaCodeApp(App):
 
     BINDINGS = [
         Binding("shift+tab", "toggle_interaction_mode", "Plan/Build", show=True, key_display="Shift+Tab", priority=True),
+        Binding("ctrl+p", "toggle_permission_mode", "Permissions", show=True, key_display="Ctrl+P", priority=True),
         Binding("ctrl+c", "cancel_generation", "Cancel", show=True),
         Binding("escape", "cancel_generation", "Cancel", show=False),
         Binding("ctrl+q", "quit", "Quit", show=True),
@@ -718,6 +739,7 @@ class KolegaCodeApp(App):
         config: Optional[AgentConfig] = None,
         settings_store: Optional[SettingsStore] = None,
         overrides: Optional[CliConfigOverrides] = None,
+        permission_mode: Optional[str] = None,
         browser_visible: bool = False,
         check_for_updates: bool = False,
     ) -> None:
@@ -730,6 +752,11 @@ class KolegaCodeApp(App):
         self.session.mode = CLI_AGENT_MODE
         self.interaction_mode = self._validated_interaction_mode(self.session.interaction_mode)
         self.session.interaction_mode = self.interaction_mode
+        self.permission_mode = normalize_permission_mode(
+            permission_mode or self.session.permission_mode,
+            default=PermissionMode.ASK,
+        )
+        self.session.permission_mode = self.permission_mode.value
         self.settings_store = settings_store or SettingsStore(store.root)
         self.overrides = overrides or CliConfigOverrides()
         self.settings: CliSettings = CliSettings()
@@ -755,10 +782,17 @@ class KolegaCodeApp(App):
         self._latest_plan: Optional[str] = self.session.latest_plan_markdown or None
         self._plan_decision_active = False
         self._pending_question: Optional[PendingQuestion] = None
+        self._pending_approval: Optional[PendingApproval] = None
+        self._permission_lock = asyncio.Lock()
         self._pending_model_selection: Optional[PendingModelSelection] = None
         self._pending_effort_selection: Optional[PendingEffortSelection] = None
         provider, model = self._startup_model()
-        self._status_state = StatusDashboardState(provider=provider, model=model, mode=self.interaction_mode)
+        self._status_state = StatusDashboardState(
+            provider=provider,
+            model=model,
+            mode=self.interaction_mode,
+            permission_mode=self.permission_mode.value,
+        )
         self._turn_started_at: Optional[float] = None
         self._turn_finished_duration: Optional[float] = None
         self._turn_timer: Optional[Timer] = None
@@ -784,6 +818,7 @@ class KolegaCodeApp(App):
                 )
                 yield ActionList(id="plan_actions")
                 yield ActionList(id="question_actions")
+                yield ActionList(id="approval_actions")
                 yield ActionList(id="model_actions")
                 yield ActionList(id="effort_actions")
                 yield Static("", id="turn_status", markup=True)
@@ -840,6 +875,7 @@ class KolegaCodeApp(App):
         self._refresh_status_dashboard()
         self._restore_plan_action_visibility()
         self._set_question_actions_visible(False)
+        self._set_approval_actions_visible(False)
         self._set_model_actions_visible(False)
         self._set_effort_actions_visible(False)
         self._refresh_planning_sidebar()
@@ -973,6 +1009,7 @@ class KolegaCodeApp(App):
 
     def _sync_planning_state_to_session(self) -> None:
         self.session.interaction_mode = self.interaction_mode
+        self.session.permission_mode = self.permission_mode.value
         self.session.latest_plan_markdown = self._latest_plan or ""
 
     def _save_session(self) -> None:
@@ -1027,6 +1064,11 @@ class KolegaCodeApp(App):
             await self._answer_pending_question(stripped_text)
             return
 
+        if self._pending_approval is not None:
+            self._set_composer_status(APPROVAL_PLACEHOLDER)
+            self._notify_user(messages.BLOCK_PENDING_APPROVAL, severity="warning")
+            return
+
         if self._plan_decision_active:
             self._set_composer_status(PLAN_READY_PLACEHOLDER)
             self._notify_user(messages.BLOCK_PLAN_DECISION, severity="warning")
@@ -1075,6 +1117,10 @@ class KolegaCodeApp(App):
         if event.option_list.id == "question_actions":
             event.stop()
             await self._answer_question_option(event.option_index)
+            return
+        if event.option_list.id == "approval_actions":
+            event.stop()
+            await self._answer_approval_option(event.option_index)
             return
         if event.option_list.id == "model_actions":
             event.stop()
@@ -1149,6 +1195,7 @@ class KolegaCodeApp(App):
             self._log_status(messages.FINISHED, "ok")
         except asyncio.CancelledError:
             self._cancel_pending_question()
+            self._cancel_pending_approval()
             await self._drain_pending_events()
             self._finalize_sub_agent_activities()
             self._save_session_history()
@@ -1156,6 +1203,7 @@ class KolegaCodeApp(App):
             self._log_status(messages.STOPPED_BY_USER, "warn")
         except LLMError as exc:
             self._cancel_pending_question()
+            self._cancel_pending_approval()
             await self._drain_pending_events()
             self._finalize_sub_agent_activities()
             self._save_session_history()
@@ -1165,6 +1213,7 @@ class KolegaCodeApp(App):
             self._log_status(message_text, "error")
         except Exception as exc:
             self._cancel_pending_question()
+            self._cancel_pending_approval()
             await self._drain_pending_events()
             self._finalize_sub_agent_activities()
             self._save_session_history()
@@ -1281,10 +1330,15 @@ class KolegaCodeApp(App):
         if self.agent_worker is not None:
             self._update_progress(messages.STOP_REQUESTED, complete=False, state=TurnState.STOPPING)
             self._cancel_pending_question()
+            self._cancel_pending_approval()
             self.agent_worker.cancel()
             self._notify_user(messages.CANCEL_REQUESTED, severity="warning")
 
     def _mode_switch_blocked(self) -> bool:
+        if self._pending_approval is not None:
+            self._set_composer_status(APPROVAL_PLACEHOLDER)
+            self._notify_user(messages.BLOCK_PENDING_APPROVAL, severity="warning")
+            return True
         if self._turn_active or self.agent_worker is not None:
             self._show_composer_hint(messages.BLOCK_STOP_BEFORE_MODE_SWITCH)
             self._notify_user(messages.BLOCK_STOP_BEFORE_MODE_SWITCH, severity="warning")
@@ -1295,12 +1349,25 @@ class KolegaCodeApp(App):
             return True
         return False
 
+    def _permission_mode_switch_blocked(self) -> bool:
+        if self._pending_approval is not None:
+            self._set_composer_status(APPROVAL_PLACEHOLDER)
+            self._notify_user(messages.BLOCK_PENDING_APPROVAL_MODE_SWITCH, severity="warning")
+            return True
+        return False
+
     async def action_toggle_interaction_mode(self) -> None:
         if self._mode_switch_blocked():
             return
 
         target = PLAN_INTERACTION_MODE if self.interaction_mode == BUILD_INTERACTION_MODE else BUILD_INTERACTION_MODE
         await self._set_interaction_mode(target)
+
+    async def action_toggle_permission_mode(self) -> None:
+        if self._permission_mode_switch_blocked():
+            return
+        target = PermissionMode.AUTO if self.permission_mode == PermissionMode.ASK else PermissionMode.ASK
+        await self._set_permission_mode(target)
 
     async def action_quit(self) -> None:
         if self.agent is not None:
@@ -1428,6 +1495,8 @@ class KolegaCodeApp(App):
             agent_mode=AgentMode(self.mode),
             prompt_extensions=prompt_extensions,
             tool_extensions=tool_extensions,
+            permission_mode=self.permission_mode,
+            permission_callback=self._permission_callback,
         )
         if history:
             self.agent.restore_message_history(history)
@@ -1445,6 +1514,7 @@ class KolegaCodeApp(App):
         self._save_session()
         self._restore_plan_action_visibility()
         self._cancel_pending_question()
+        self._cancel_pending_approval()
         self._cancel_pending_model_selection()
         self._cancel_pending_effort_selection()
 
@@ -1455,6 +1525,20 @@ class KolegaCodeApp(App):
         self._restore_composer_placeholder()
         self._set_chat_enabled(self.agent is not None)
         self._notify_user(messages.SWITCHED_MODE.format(mode=self.interaction_mode))
+
+    async def _set_permission_mode(self, permission_mode: PermissionMode | str) -> None:
+        mode = normalize_permission_mode(permission_mode, default=self.permission_mode)
+        if self.permission_mode == mode:
+            return
+
+        self.permission_mode = mode
+        self.session.permission_mode = mode.value
+        self._save_session()
+        if self.agent is not None:
+            self.agent.set_permission_mode(mode)
+            self.agent.set_permission_callback(self._permission_callback)
+        self._update_mode_chrome()
+        self._notify_user(messages.SWITCHED_PERMISSION_MODE.format(mode=mode.value))
 
     def _capture_completed_plan(self) -> None:
         if self.interaction_mode != PLAN_INTERACTION_MODE or not isinstance(self.agent, PlanningAgent):
@@ -1564,7 +1648,7 @@ class KolegaCodeApp(App):
     def _meta_content(self) -> str:
         return (
             f"{self.project_path} | session {self.session.session_id} | "
-            f"agent {self.mode} | {self.interaction_mode}"
+            f"agent {self.mode} | {self.interaction_mode} | permissions {self.permission_mode.value}"
         )
 
     def _update_mode_chrome(self) -> None:
@@ -1591,7 +1675,7 @@ class KolegaCodeApp(App):
 
     def _set_chat_enabled(self, enabled: bool) -> None:
         composer = self.query_one("#composer", ChatComposer)
-        composer.disabled = not enabled or self._plan_decision_active
+        composer.disabled = not enabled or self._plan_decision_active or self._pending_approval is not None
 
     def _set_composer_status(self, status: str) -> None:
         self.query_one("#composer", ChatComposer).placeholder = status
@@ -1622,6 +1706,7 @@ class KolegaCodeApp(App):
         return {
             "/plan": self._command_plan,
             "/build": self._command_build,
+            "/permissions": self._command_permissions,
             "/model": self._command_model,
             "/effort": self._command_effort,
             "/copy": self._command_copy,
@@ -1655,6 +1740,31 @@ class KolegaCodeApp(App):
         if self._mode_switch_blocked():
             return
         await self._set_interaction_mode(BUILD_INTERACTION_MODE)
+
+    async def _command_permissions(self, args: str) -> None:
+        if self._permission_mode_switch_blocked():
+            return
+
+        clean_args = args.strip().lower()
+        if not clean_args:
+            lines = [
+                messages.PERMISSIONS_STATUS.format(mode=self.permission_mode.value),
+                messages.PERMISSIONS_SWITCH_HINT,
+            ]
+            self._add_conversation_entry(ConversationEntry(kind="system", content="\n".join(lines)))
+            return
+
+        if clean_args == "toggle":
+            await self.action_toggle_permission_mode()
+            return
+
+        try:
+            mode = normalize_permission_mode(clean_args, default=self.permission_mode)
+        except ValueError as exc:
+            self._notify_user(str(exc), severity="warning")
+            return
+
+        await self._set_permission_mode(mode)
 
     async def _command_model(self, args: str) -> None:
         provider = self.settings.active_provider or UI_DEFAULT_PROVIDER
@@ -1925,6 +2035,11 @@ class KolegaCodeApp(App):
         if self._pending_question is not None:
             self._set_composer_status(QUESTION_PLACEHOLDER)
             self._notify_user(messages.BLOCK_PENDING_QUESTION_SKILL, severity="warning")
+            return True
+
+        if self._pending_approval is not None:
+            self._set_composer_status(APPROVAL_PLACEHOLDER)
+            self._notify_user(messages.BLOCK_PENDING_APPROVAL, severity="warning")
             return True
 
         if self._plan_decision_active:
@@ -2201,6 +2316,108 @@ class KolegaCodeApp(App):
         except Exception:
             return
 
+    async def _permission_callback(self, request: PermissionRequest) -> PermissionDecision:
+        if self.permission_mode != PermissionMode.ASK:
+            return PermissionDecision(allowed=True)
+
+        async with self._permission_lock:
+            store = ProjectPermissionStore(self.project_path)
+            try:
+                matched_rule = store.first_match(request)
+            except PermissionStoreError as exc:
+                matched_rule = None
+                self._notify_user(str(exc), severity="warning")
+
+            if matched_rule is not None:
+                return PermissionDecision(allowed=True, reason=f"Allowed by saved rule {matched_rule.id}.")
+
+            return await self._ask_permission(request)
+
+    async def _ask_permission(self, request: PermissionRequest) -> PermissionDecision:
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[PermissionDecision] = loop.create_future()
+        rule_options = allow_rule_options(request)
+        self._pending_approval = PendingApproval(request=request, future=future, rule_options=rule_options)
+        self._add_conversation_entry(
+            ConversationEntry(kind="question", content=self._format_permission_content(request, rule_options))
+        )
+        self._show_approval_options(rule_options)
+        self._set_composer_status(APPROVAL_PLACEHOLDER)
+        self._set_chat_enabled(False)
+        self._update_activity_progress(messages.WAITING_FOR_PERMISSION, state=TurnState.WAITING_FOR_USER)
+
+        try:
+            return await future
+        finally:
+            if self._pending_approval is not None and self._pending_approval.future is future:
+                self._pending_approval = None
+                self._set_approval_actions_visible(False)
+
+    def _show_approval_options(self, rule_options: list[PermissionRuleOption]) -> None:
+        self._set_approval_actions_visible(True)
+        try:
+            approval_actions = self.query_one("#approval_actions", ActionList)
+            self.screen.set_focus(approval_actions)
+        except Exception:
+            return
+
+    async def _answer_approval_option(self, option_index: int) -> None:
+        pending = self._pending_approval
+        if pending is None:
+            return
+
+        decision: PermissionDecision
+        if option_index == 0:
+            decision = PermissionDecision(allowed=True, reason="Allowed once by the user.")
+        elif option_index == 1:
+            decision = PermissionDecision(allowed=False, reason="Denied by the user.")
+        else:
+            rule_index = option_index - 2
+            if rule_index < 0 or rule_index >= len(pending.rule_options):
+                return
+            rule = pending.rule_options[rule_index].rule
+            try:
+                ProjectPermissionStore(self.project_path).add_rule(rule)
+            except PermissionStoreError as exc:
+                self._notify_user(str(exc), severity="warning")
+                decision = PermissionDecision(allowed=True, reason="Allowed once because the rule could not be saved.")
+            else:
+                decision = PermissionDecision(allowed=True, reason="Allowed by a saved rule.", rule=rule)
+
+        self._pending_approval = None
+        self._set_approval_actions_visible(False)
+        if not pending.future.done():
+            pending.future.set_result(decision)
+
+        if self._turn_active:
+            self._restore_composer_placeholder()
+            self._set_chat_enabled(False)
+            self._update_progress(messages.WORKING, complete=False, state=TurnState.GENERATING)
+        else:
+            self._restore_composer_placeholder()
+            self._set_chat_enabled(self.agent is not None)
+
+    def _format_permission_content(
+        self, request: PermissionRequest, rule_options: list[PermissionRuleOption]
+    ) -> str:
+        if request.kind.value == "command":
+            lines = [
+                "Allow the agent to run this command?",
+                "",
+                "```bash",
+                request.command,
+                "```",
+            ]
+        else:
+            target = f" on `{request.path}`" if request.path else ""
+            lines = [
+                f"Allow the agent to run `{request.tool_name}`{target}?",
+            ]
+
+        options = ["Allow once", "Deny", *(option.label for option in rule_options)]
+        option_lines = [self._question_option_label(index, option) for index, option in enumerate(options)]
+        return "\n".join([*lines, "", *option_lines])
+
     def _show_effort_options(self) -> None:
         self._set_effort_actions_visible(True)
         try:
@@ -2227,12 +2444,42 @@ class KolegaCodeApp(App):
         except Exception:
             return
 
+    def _set_approval_actions_visible(self, visible: bool) -> None:
+        try:
+            approval_actions = self.query_one("#approval_actions", ActionList)
+            if visible and self._pending_approval is not None:
+                labels = [
+                    "1. Allow once",
+                    "2. Deny",
+                    *[
+                        self._question_option_label(index + 2, option.label, option.description)
+                        for index, option in enumerate(self._pending_approval.rule_options)
+                    ],
+                ]
+                approval_actions.show_options(
+                    [
+                        Option(label, id=f"{APPROVAL_OPTION_ID_PREFIX}{index}")
+                        for index, label in enumerate(labels)
+                    ]
+                )
+            else:
+                approval_actions.hide()
+        except Exception:
+            return
+
     def _cancel_pending_question(self) -> None:
         pending_question = self._pending_question
         if pending_question is not None and not pending_question.future.done():
             pending_question.future.cancel()
         self._pending_question = None
         self._set_question_actions_visible(False)
+
+    def _cancel_pending_approval(self) -> None:
+        pending_approval = self._pending_approval
+        if pending_approval is not None and not pending_approval.future.done():
+            pending_approval.future.cancel()
+        self._pending_approval = None
+        self._set_approval_actions_visible(False)
 
     def _format_question_content(
         self, question: str, options: list[str], descriptions: Optional[list[str]] = None
@@ -2289,6 +2536,7 @@ class KolegaCodeApp(App):
         self._save_session()
         self._set_plan_actions_visible(False)
         self._cancel_pending_question()
+        self._cancel_pending_approval()
         self._cancel_pending_model_selection()
         self._cancel_pending_effort_selection()
         self._refresh_planning_sidebar()
@@ -2387,11 +2635,12 @@ class KolegaCodeApp(App):
                 f"Session: {session_id}",
                 f"Mode: {self.mode}",
                 f"Interaction: {self.interaction_mode}",
+                f"Permissions: {self.permission_mode.value}",
                 f"Model: {model_display}",
                 f"Thinking effort: {effort}",
                 f"API key: {api_key}",
                 "",
-                f"Enter send {theme.g(Glyph.BULLET_SEP)} Shift+Enter newline {theme.g(Glyph.BULLET_SEP)} Shift+Tab plan/build",
+                f"Enter send {theme.g(Glyph.BULLET_SEP)} Shift+Enter newline {theme.g(Glyph.BULLET_SEP)} Shift+Tab plan/build {theme.g(Glyph.BULLET_SEP)} Ctrl+P permissions",
                 f"Ctrl+C stop turn {theme.g(Glyph.BULLET_SEP)} Cmd+C copy selection {theme.g(Glyph.BULLET_SEP)} / commands",
             ]
         )
@@ -2424,6 +2673,7 @@ class KolegaCodeApp(App):
         self._status_state.model = model
         self._status_state.thinking_effort = self._startup_thinking_effort()
         self._status_state.mode = self.interaction_mode
+        self._status_state.permission_mode = self.permission_mode.value
         try:
             self._status_dashboard.update(self._format_status_dashboard())
         except Exception:
@@ -2434,6 +2684,7 @@ class KolegaCodeApp(App):
         provider_model = f"{state.provider}/{state.model}" if state.model else state.provider
         effort = state.thinking_effort or "not supported"
         mode = state.mode.title()
+        permission_mode = state.permission_mode.title()
         turn_style = TURN_STATE_STYLES.get(state.turn_state, Color.ACCENT)
         context_style = self._context_style(state.usage_percentage, state.compression_threshold)
 
@@ -2466,6 +2717,7 @@ class KolegaCodeApp(App):
             f"{label('Model')}\n[bold]{escape(provider_model)}[/bold]\n\n"
             f"{label('Thinking effort')} [bold]{escape(effort)}[/bold]\n"
             f"{label('Mode')} [bold]{mode}[/bold]\n"
+            f"{label('Permissions')} [bold]{permission_mode}[/bold]\n"
             f"{turn_line}\n\n"
             f"{label('Context')}\n"
             f"{context_lines}\n\n"

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -14,6 +14,14 @@ from kolega_code.agent import CoderAgent
 from kolega_code.llm.exceptions import LLMBillingError, billing_error_message
 from kolega_code.llm.models import TextBlock
 from kolega_code.agent.prompt_provider import AgentMode
+from kolega_code.permissions import (
+    PermissionDecision,
+    PermissionMode,
+    PermissionStoreError,
+    ProjectPermissionStore,
+    allow_rule_options,
+    normalize_permission_mode,
+)
 from kolega_code.services.browser import PlaywrightBrowserManager
 
 from .config import (
@@ -41,6 +49,7 @@ from .updater import check_for_update, run_self_update, update_status_message
 SUBCOMMANDS = {"ask", "sessions", "doctor", "update"}
 RESUME_LATEST = "__latest__"
 CLI_AGENT_MODE = AgentMode.CLI.value
+ASK_DEFAULT_PERMISSION_MODE = PermissionMode.AUTO.value
 
 
 def main(argv: Optional[Iterable[str]] = None) -> int:
@@ -126,6 +135,11 @@ def _build_tui_parser() -> argparse.ArgumentParser:
         help="Resume the latest saved thread, or resume the given thread/session ID.",
     )
     parser.add_argument("--browser-visible", action="store_true", help="Launch visible Playwright browser windows.")
+    parser.add_argument(
+        "--permission-mode",
+        choices=[mode.value for mode in PermissionMode],
+        help="How to handle shell command and file edit permissions.",
+    )
     _add_session_args(parser, session_help="Legacy alias for --resume THREAD_ID.")
     _add_common_model_args(parser)
     return parser
@@ -142,6 +156,12 @@ def _build_subcommand_parser() -> argparse.ArgumentParser:
     ask.add_argument("--save", action="store_true", help="Persist the session after the prompt completes.")
     ask.add_argument("--json", action="store_true", help="Emit response chunks and events as JSON.")
     ask.add_argument("--browser-visible", action="store_true", help="Launch visible Playwright browser windows.")
+    ask.add_argument(
+        "--permission-mode",
+        choices=[mode.value for mode in PermissionMode],
+        default=ASK_DEFAULT_PERMISSION_MODE,
+        help="How to handle shell command and file edit permissions.",
+    )
     _add_session_args(ask)
     _add_common_model_args(ask)
 
@@ -310,6 +330,12 @@ def _run_tui(args: argparse.Namespace) -> int:
         args.resume,
         args.session,
     )
+    if args.permission_mode:
+        session.permission_mode = normalize_permission_mode(
+            args.permission_mode,
+            default=PermissionMode.ASK,
+        ).value
+        store.save(session)
 
     from .app import KolegaCodeApp
 
@@ -321,11 +347,73 @@ def _run_tui(args: argparse.Namespace) -> int:
         settings_store=settings_store,
         overrides=_overrides_from_args(args),
         session=session,
+        permission_mode=args.permission_mode,
         browser_visible=args.browser_visible,
         check_for_updates=True,
     )
     app.run()
     return 0
+
+
+def _permission_callback_for_ask(project_path: Path):
+    async def permission_callback(request) -> PermissionDecision:
+        store = ProjectPermissionStore(project_path)
+        try:
+            matched_rule = store.first_match(request)
+        except PermissionStoreError as exc:
+            print(f"Warning: {exc}", file=sys.stderr)
+            matched_rule = None
+
+        if matched_rule is not None:
+            return PermissionDecision(allowed=True, reason=f"Allowed by saved rule {matched_rule.id}.")
+
+        if not sys.stdin.isatty():
+            return PermissionDecision(
+                allowed=False,
+                reason="Permission required, but stdin is not interactive.",
+            )
+
+        rule_options = allow_rule_options(request)
+        print("", file=sys.stderr)
+        if request.kind.value == "command":
+            print("Allow the agent to run this command?", file=sys.stderr)
+            print(f"  {request.command}", file=sys.stderr)
+        else:
+            target = f" on {request.path}" if request.path else ""
+            print(f"Allow the agent to run {request.tool_name}{target}?", file=sys.stderr)
+
+        labels = ["Allow once", "Deny", *(option.label for option in rule_options)]
+        for index, label in enumerate(labels, start=1):
+            print(f"  {index}. {label}", file=sys.stderr)
+
+        while True:
+            print("Choose an option: ", end="", file=sys.stderr, flush=True)
+            choice = (await asyncio.to_thread(sys.stdin.readline)).strip()
+            if not choice:
+                continue
+            if not choice.isdigit():
+                print("Enter a number from the list.", file=sys.stderr)
+                continue
+            option_index = int(choice) - 1
+            if option_index < 0 or option_index >= len(labels):
+                print("Enter a number from the list.", file=sys.stderr)
+                continue
+            break
+
+        if option_index == 0:
+            return PermissionDecision(allowed=True, reason="Allowed once by the user.")
+        if option_index == 1:
+            return PermissionDecision(allowed=False, reason="Denied by the user.")
+
+        rule = rule_options[option_index - 2].rule
+        try:
+            store.add_rule(rule)
+        except PermissionStoreError as exc:
+            print(f"Warning: {exc}", file=sys.stderr)
+            return PermissionDecision(allowed=True, reason="Allowed once because the rule could not be saved.")
+        return PermissionDecision(allowed=True, reason="Allowed by a saved rule.", rule=rule)
+
+    return permission_callback
 
 
 async def _run_ask(args: argparse.Namespace) -> int:
@@ -388,6 +476,10 @@ async def _run_ask(args: argparse.Namespace) -> int:
         prompt_extensions.append(skill_prompt_extension)
     if skill_tool_extension is not None:
         tool_extensions.append(skill_tool_extension)
+    permission_mode = normalize_permission_mode(
+        getattr(args, "permission_mode", ASK_DEFAULT_PERMISSION_MODE),
+        default=PermissionMode.AUTO,
+    )
     agent = CoderAgent(
         project_path=project_path,
         workspace_id=session.workspace_id,
@@ -398,6 +490,10 @@ async def _run_ask(args: argparse.Namespace) -> int:
         agent_mode=AgentMode.CLI,
         prompt_extensions=prompt_extensions,
         tool_extensions=tool_extensions,
+        permission_mode=permission_mode,
+        permission_callback=_permission_callback_for_ask(project_path)
+        if permission_mode == PermissionMode.ASK
+        else None,
     )
     agent_ref["agent"] = agent
     if session.history:

--- a/kolega_code/cli/messages.py
+++ b/kolega_code/cli/messages.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 COMPOSER_PLACEHOLDER = "Ask Kolega Code..."
 PLAN_READY_PLACEHOLDER = "Plan ready. Choose Implement plan or Discuss further."
 QUESTION_PLACEHOLDER = "Choose an option below or type a custom answer..."
+APPROVAL_PLACEHOLDER = "Choose whether to allow this action..."
 MODEL_PLACEHOLDER = "Choose a model below or type a supported model name..."
 EFFORT_PLACEHOLDER = "Choose a thinking effort below or type a supported value..."
 
@@ -30,6 +31,7 @@ STOPPED_BY_USER = "Stopped by user."
 STOPPED_WITH_ERROR = "Stopped due to an error: {error}"
 CANCEL_REQUESTED = "Cancellation requested."
 WAITING_FOR_ANSWER = "Waiting for your answer…"
+WAITING_FOR_PERMISSION = "Waiting for permission…"
 
 # Turn status strip finals
 DONE_IN = "Done in {duration}"
@@ -46,6 +48,7 @@ RUNNING_SUB_AGENTS = "Running {count} sub-agents…"
 
 # Confirmations
 SWITCHED_MODE = "Switched to {mode} mode."
+SWITCHED_PERMISSION_MODE = "Switched permissions to {mode} mode."
 PLAN_CAPTURED = "Plan captured. Choose Implement plan or Discuss further."
 PLAN_DISCUSSION_RESUMED = "Planning discussion resumed."
 SKILL_ACTIVATED = "Activated skill {name}."
@@ -62,6 +65,8 @@ EFFORT_SWITCHED = "Switched thinking effort to {effort} for {provider}/{model}."
 EFFORT_UNKNOWN = "Unknown thinking effort {effort} for {provider}/{model}."
 EFFORT_UNSUPPORTED = "{provider}/{model} does not support a thinking effort setting."
 EFFORT_SWITCH_HINT = "Choose below, or switch with /effort <level>."
+PERMISSIONS_STATUS = "Permissions are in {mode} mode."
+PERMISSIONS_SWITCH_HINT = "Switch with /permissions auto, /permissions ask, /permissions toggle, or Ctrl+P."
 COPY_LAST_RESPONSE = "Copied the last response to the clipboard."
 COPY_NOTHING = "No response to copy yet."
 VERSION_INFO = "Kolega Code version {version}."
@@ -80,6 +85,8 @@ BLOCK_PLAN_DECISION = "Choose Implement plan or Discuss further before sending a
 BLOCK_PLAN_DECISION_MODE_SWITCH = "Choose Implement plan or Discuss further before switching modes."
 BLOCK_PLAN_DECISION_SKILL = "Choose Implement plan or Discuss further before activating a skill."
 BLOCK_PENDING_QUESTION_SKILL = "Answer the pending planning question before activating a skill."
+BLOCK_PENDING_APPROVAL = "Choose whether to allow the pending action before continuing."
+BLOCK_PENDING_APPROVAL_MODE_SWITCH = "Choose whether to allow the pending action before switching permission modes."
 SETTINGS_REQUIRED = "Configure a provider/model and API key before chatting."
 SETTINGS_REQUIRED_SKILL = "Configure a provider/model and API key before activating a skill."
 

--- a/kolega_code/cli/session_store.py
+++ b/kolega_code/cli/session_store.py
@@ -33,6 +33,7 @@ class SessionRecord:
     task_list_markdown: str = ""
     latest_plan_markdown: str = ""
     interaction_mode: str = "build"
+    permission_mode: str = "ask"
     schema_version: int = SCHEMA_VERSION
 
     @classmethod
@@ -80,6 +81,7 @@ class SessionRecord:
             task_list_markdown=data.get("task_list_markdown") or "",
             latest_plan_markdown=data.get("latest_plan_markdown") or "",
             interaction_mode=data.get("interaction_mode") or "build",
+            permission_mode=data.get("permission_mode") or "ask",
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -98,6 +100,7 @@ class SessionRecord:
             "task_list_markdown": self.task_list_markdown,
             "latest_plan_markdown": self.latest_plan_markdown,
             "interaction_mode": self.interaction_mode,
+            "permission_mode": self.permission_mode,
         }
 
 

--- a/kolega_code/cli/slash_commands.py
+++ b/kolega_code/cli/slash_commands.py
@@ -42,6 +42,7 @@ TUI_COMMAND_ENTRIES: tuple[SlashCommandEntry, ...] = (
     SlashCommandEntry("skills", "List available Agent Skills", CommandScope.TUI),
     SlashCommandEntry("plan", "Switch to plan mode", CommandScope.TUI),
     SlashCommandEntry("build", "Switch to build mode", CommandScope.TUI),
+    SlashCommandEntry("permissions", "Show or switch shell/edit permission mode", CommandScope.TUI),
     SlashCommandEntry("model", "Show or switch the active model", CommandScope.TUI),
     SlashCommandEntry("effort", "Show or set the active thinking effort", CommandScope.TUI),
     SlashCommandEntry("copy", "Copy the last response to the clipboard", CommandScope.TUI),

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -504,6 +504,62 @@ async def test_textual_app_shift_tab_toggles_between_build_and_plan_agents(
 
 
 @pytest.mark.asyncio
+async def test_textual_app_ctrl_p_toggles_permission_mode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.widgets import Static
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.permissions import PermissionMode
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.permission_mode = kwargs["permission_mode"]
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_message_history(self):
+            return []
+
+        def set_permission_mode(self, permission_mode):
+            self.permission_mode = permission_mode
+
+        def set_permission_callback(self, permission_callback):
+            self.permission_callback = permission_callback
+
+        async def cleanup(self):
+            return None
+
+    monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test() as pilot:
+        toggle_binding = next(binding for binding in app.BINDINGS if binding.action == "toggle_permission_mode")
+        assert toggle_binding.key == "ctrl+p"
+        assert app.permission_mode == PermissionMode.ASK
+        assert app.agent.kwargs["permission_mode"] == PermissionMode.ASK
+
+        await pilot.press("ctrl+p")
+
+        assert app.permission_mode == PermissionMode.AUTO
+        assert app.agent.permission_mode == PermissionMode.AUTO
+        assert store.load(session.session_id).permission_mode == "auto"
+        assert "Permissions: auto" in app.conversation_entries[0].content
+        assert "Auto" in str(app.query_one("#status_dashboard", Static).render())
+
+
+@pytest.mark.asyncio
 async def test_textual_app_restores_saved_plan_and_interaction_mode(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/kolega_code/cli/tests/test_main.py
+++ b/kolega_code/cli/tests/test_main.py
@@ -36,6 +36,7 @@ def test_parse_default_command_as_tui() -> None:
     assert args.new is True
     assert args.resume is None
     assert args.mode == CLI_AGENT_MODE
+    assert args.permission_mode is None
 
 
 def test_version_flag_prints_package_version(capsys, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -99,6 +100,15 @@ def test_parse_ask_subcommand() -> None:
     assert args.json is True
     assert args.mode == CLI_AGENT_MODE
     assert args.thinking_effort == "high"
+    assert args.permission_mode == "auto"
+
+
+def test_parse_permission_mode_flags() -> None:
+    tui_args = parse_args(["/tmp/project", "--permission-mode", "ask"])
+    ask_args = parse_args(["ask", "hello", "--project", "/tmp/project", "--permission-mode", "ask"])
+
+    assert tui_args.permission_mode == "ask"
+    assert ask_args.permission_mode == "ask"
 
 
 def test_parse_sessions_list_subcommand() -> None:

--- a/kolega_code/cli/tests/test_session_store.py
+++ b/kolega_code/cli/tests/test_session_store.py
@@ -20,6 +20,7 @@ def test_session_store_create_load_list_export_delete(tmp_path: Path) -> None:
     record.task_list_markdown = "- [ ] inspect\n- [x] plan"
     record.latest_plan_markdown = "# Plan\n\nImplement it."
     record.interaction_mode = "plan"
+    record.permission_mode = "auto"
     store.save(record)
 
     loaded = store.load(record.session_id)
@@ -28,12 +29,14 @@ def test_session_store_create_load_list_export_delete(tmp_path: Path) -> None:
     assert loaded.task_list_markdown == "- [ ] inspect\n- [x] plan"
     assert loaded.latest_plan_markdown == "# Plan\n\nImplement it."
     assert loaded.interaction_mode == "plan"
+    assert loaded.permission_mode == "auto"
     assert store.latest_for_project(project).session_id == record.session_id
     exported = store.export(record.session_id)
     assert record.session_id in exported
     assert "task_list_markdown" in exported
     assert "latest_plan_markdown" in exported
     assert "interaction_mode" in exported
+    assert "permission_mode" in exported
 
     store.delete(record.session_id)
     with pytest.raises(SessionStoreError):
@@ -50,6 +53,7 @@ def test_session_store_loads_old_sessions_without_planning_state(tmp_path: Path)
     payload.pop("task_list_markdown")
     payload.pop("latest_plan_markdown")
     payload.pop("interaction_mode")
+    payload.pop("permission_mode")
     store.path_for(record.session_id).write_text(json.dumps(payload), encoding="utf-8")
 
     loaded = store.load(record.session_id)
@@ -57,6 +61,7 @@ def test_session_store_loads_old_sessions_without_planning_state(tmp_path: Path)
     assert loaded.task_list_markdown == ""
     assert loaded.latest_plan_markdown == ""
     assert loaded.interaction_mode == "build"
+    assert loaded.permission_mode == "ask"
 
 
 def test_session_store_ignores_corrupt_files_when_listing(tmp_path: Path) -> None:

--- a/kolega_code/permissions.py
+++ b/kolega_code/permissions.py
@@ -1,0 +1,378 @@
+"""Project-local permission rules for agent tool execution."""
+
+from __future__ import annotations
+
+import json
+import shlex
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+
+class PermissionMode(str, Enum):
+    AUTO = "auto"
+    ASK = "ask"
+
+
+class PermissionKind(str, Enum):
+    COMMAND = "command"
+    EDIT = "edit"
+
+
+class PermissionStoreError(RuntimeError):
+    """Raised when project-local permission rules cannot be loaded."""
+
+
+COMMAND_PERMISSION_TOOLS = frozenset(
+    {
+        "execute_terminal_command",
+        "run_command",
+        "run_command_tracked",
+    }
+)
+EDIT_PERMISSION_TOOLS = frozenset(
+    {
+        "apply_patch",
+        "create_file",
+        "replace_entire_file",
+        "replace_lines",
+        "search_and_replace",
+    }
+)
+
+PERMISSIONS_SCHEMA_VERSION = 1
+PERMISSIONS_RELATIVE_PATH = Path(".kolega") / "permissions.json"
+
+
+@dataclass(frozen=True)
+class PermissionRequest:
+    """A host approval request for a gated tool call."""
+
+    kind: PermissionKind
+    tool_name: str
+    inputs: dict[str, Any]
+    command: str = ""
+    path: str = ""
+
+    @property
+    def summary(self) -> str:
+        if self.kind == PermissionKind.COMMAND:
+            return self.command
+        if self.path:
+            return f"{self.tool_name} {self.path}"
+        return self.tool_name
+
+
+@dataclass(frozen=True)
+class PermissionRule:
+    """A persisted allow rule."""
+
+    id: str
+    kind: PermissionKind
+    tool: str
+    match_type: str
+    pattern: str
+    created_at: str
+
+    @classmethod
+    def create(cls, *, kind: PermissionKind, tool: str, match_type: str, pattern: str) -> "PermissionRule":
+        return cls(
+            id=uuid.uuid4().hex,
+            kind=kind,
+            tool=tool,
+            match_type=match_type,
+            pattern=pattern,
+            created_at=datetime.now(timezone.utc).isoformat(),
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "PermissionRule":
+        try:
+            return cls(
+                id=str(data["id"]),
+                kind=PermissionKind(str(data["kind"])),
+                tool=str(data.get("tool") or ""),
+                match_type=str(data["match_type"]),
+                pattern=str(data["pattern"]),
+                created_at=str(data["created_at"]),
+            )
+        except (KeyError, ValueError, TypeError) as exc:
+            raise PermissionStoreError("Permission rule is malformed.") from exc
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "id": self.id,
+            "kind": self.kind.value,
+            "tool": self.tool,
+            "match_type": self.match_type,
+            "pattern": self.pattern,
+            "created_at": self.created_at,
+        }
+
+    def matches(self, request: PermissionRequest) -> bool:
+        if self.kind != request.kind:
+            return False
+        if self.tool and self.tool != "*" and self.tool != request.tool_name:
+            return False
+
+        if self.kind == PermissionKind.COMMAND:
+            return _matches_command(self.match_type, self.pattern, request.command)
+
+        return _matches_edit(self, request)
+
+
+@dataclass(frozen=True)
+class PermissionDecision:
+    """The host's decision for a permission request."""
+
+    allowed: bool
+    reason: str = ""
+    rule: Optional[PermissionRule] = None
+
+
+@dataclass(frozen=True)
+class PermissionRuleOption:
+    """A rule the UI can offer for an always-allow decision."""
+
+    label: str
+    description: str
+    rule: PermissionRule
+
+
+class ProjectPermissionStore:
+    """Filesystem-backed permission rule store rooted at a project directory."""
+
+    def __init__(self, project_path: Path) -> None:
+        self.project_path = project_path
+        self.path = project_path / PERMISSIONS_RELATIVE_PATH
+
+    def load(self) -> list[PermissionRule]:
+        if not self.path.exists():
+            return []
+
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+        except OSError as exc:
+            raise PermissionStoreError(f"Could not read permissions file: {self.path}") from exc
+        except json.JSONDecodeError as exc:
+            raise PermissionStoreError(f"Permissions file is not valid JSON: {self.path}") from exc
+
+        if data.get("schema_version") != PERMISSIONS_SCHEMA_VERSION:
+            raise PermissionStoreError(f"Unsupported permissions schema version: {data.get('schema_version')}")
+
+        raw_rules = data.get("rules")
+        if not isinstance(raw_rules, list):
+            raise PermissionStoreError("Permissions file must contain a rules array.")
+        return [PermissionRule.from_dict(rule) for rule in raw_rules]
+
+    def save(self, rules: Iterable[PermissionRule]) -> None:
+        payload = {
+            "schema_version": PERMISSIONS_SCHEMA_VERSION,
+            "rules": [rule.to_dict() for rule in rules],
+        }
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            temp = self.path.with_suffix(".json.tmp")
+            temp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            temp.replace(self.path)
+        except OSError as exc:
+            raise PermissionStoreError(f"Could not write permissions file: {self.path}") from exc
+
+    def add_rule(self, rule: PermissionRule) -> None:
+        rules = self.load()
+        if not any(_same_rule(existing, rule) for existing in rules):
+            rules.append(rule)
+        self.save(rules)
+
+    def first_match(self, request: PermissionRequest) -> Optional[PermissionRule]:
+        for rule in self.load():
+            if rule.matches(request):
+                return rule
+        return None
+
+
+def permission_request_for_tool(tool_name: str, inputs: dict[str, Any]) -> Optional[PermissionRequest]:
+    if tool_name in COMMAND_PERMISSION_TOOLS:
+        command = str(inputs.get("command") or "").strip()
+        return PermissionRequest(
+            kind=PermissionKind.COMMAND,
+            tool_name=tool_name,
+            inputs=inputs,
+            command=command,
+        )
+
+    if tool_name in EDIT_PERMISSION_TOOLS:
+        path = _path_from_edit_inputs(tool_name, inputs)
+        return PermissionRequest(
+            kind=PermissionKind.EDIT,
+            tool_name=tool_name,
+            inputs=inputs,
+            path=path,
+        )
+
+    return None
+
+
+def allow_rule_options(request: PermissionRequest) -> list[PermissionRuleOption]:
+    if request.kind == PermissionKind.COMMAND:
+        return _command_rule_options(request)
+    return _edit_rule_options(request)
+
+
+def normalize_permission_mode(value: str | PermissionMode | None, *, default: PermissionMode) -> PermissionMode:
+    if isinstance(value, PermissionMode):
+        return value
+    if value is None:
+        return default
+    try:
+        return PermissionMode(str(value).lower())
+    except ValueError as exc:
+        valid = ", ".join(mode.value for mode in PermissionMode)
+        raise ValueError(f"Unsupported permission mode '{value}'. Valid modes: {valid}") from exc
+
+
+async def auto_allow_permission_callback(request: PermissionRequest) -> PermissionDecision:
+    return PermissionDecision(allowed=True)
+
+
+def _matches_command(match_type: str, pattern: str, command: str) -> bool:
+    if match_type == "exact":
+        return command == pattern
+    if match_type == "prefix":
+        return command == pattern or command.startswith(pattern + " ")
+    if match_type == "executable":
+        return _first_shell_token(command) == pattern
+    return False
+
+
+def _matches_edit(rule: PermissionRule, request: PermissionRequest) -> bool:
+    if rule.match_type == "tool":
+        return rule.pattern in {"*", request.tool_name}
+    if rule.match_type == "path":
+        return bool(request.path) and request.path == rule.pattern
+    return False
+
+
+def _path_from_edit_inputs(tool_name: str, inputs: dict[str, Any]) -> str:
+    if tool_name == "apply_patch":
+        return ""
+    value = inputs.get("relative_path")
+    return str(value).strip() if value is not None else ""
+
+
+def _command_rule_options(request: PermissionRequest) -> list[PermissionRuleOption]:
+    command = request.command
+    if not command:
+        return []
+
+    options = [
+        PermissionRuleOption(
+            label="Always allow this exact command",
+            description=f"Allow `{command}`.",
+            rule=PermissionRule.create(
+                kind=PermissionKind.COMMAND,
+                tool="*",
+                match_type="exact",
+                pattern=command,
+            ),
+        )
+    ]
+
+    tokens = _shell_tokens(command)
+    if len(tokens) >= 2:
+        prefix = " ".join(tokens[:2])
+        options.append(
+            PermissionRuleOption(
+                label=f"Always allow commands starting with `{prefix}`",
+                description=f"Allow commands whose first words are `{prefix}`.",
+                rule=PermissionRule.create(
+                    kind=PermissionKind.COMMAND,
+                    tool="*",
+                    match_type="prefix",
+                    pattern=prefix,
+                ),
+            )
+        )
+
+    executable = tokens[0] if tokens else ""
+    if executable and executable != command:
+        options.append(
+            PermissionRuleOption(
+                label=f"Always allow `{executable}` commands",
+                description=f"Allow commands whose executable is `{executable}`.",
+                rule=PermissionRule.create(
+                    kind=PermissionKind.COMMAND,
+                    tool="*",
+                    match_type="executable",
+                    pattern=executable,
+                ),
+            )
+        )
+
+    return _dedupe_options(options)
+
+
+def _edit_rule_options(request: PermissionRequest) -> list[PermissionRuleOption]:
+    options: list[PermissionRuleOption] = []
+    if request.path:
+        options.append(
+            PermissionRuleOption(
+                label=f"Always allow `{request.tool_name}` on `{request.path}`",
+                description="Allow this edit tool for this path.",
+                rule=PermissionRule.create(
+                    kind=PermissionKind.EDIT,
+                    tool=request.tool_name,
+                    match_type="path",
+                    pattern=request.path,
+                ),
+            )
+        )
+    options.append(
+        PermissionRuleOption(
+            label=f"Always allow `{request.tool_name}` edits",
+            description="Allow this edit tool for any path.",
+            rule=PermissionRule.create(
+                kind=PermissionKind.EDIT,
+                tool=request.tool_name,
+                match_type="tool",
+                pattern=request.tool_name,
+            ),
+        )
+    )
+    return options
+
+
+def _shell_tokens(command: str) -> list[str]:
+    try:
+        return shlex.split(command)
+    except ValueError:
+        return command.split()
+
+
+def _first_shell_token(command: str) -> str:
+    tokens = _shell_tokens(command)
+    return tokens[0] if tokens else ""
+
+
+def _same_rule(left: PermissionRule, right: PermissionRule) -> bool:
+    return (
+        left.kind == right.kind
+        and left.tool == right.tool
+        and left.match_type == right.match_type
+        and left.pattern == right.pattern
+    )
+
+
+def _dedupe_options(options: list[PermissionRuleOption]) -> list[PermissionRuleOption]:
+    deduped: list[PermissionRuleOption] = []
+    seen: set[tuple[PermissionKind, str, str, str]] = set()
+    for option in options:
+        key = (option.rule.kind, option.rule.tool, option.rule.match_type, option.rule.pattern)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(option)
+    return deduped


### PR DESCRIPTION
## Summary

Adds a host-enforced permission layer for shell commands and file edits.

- introduces `auto` and `ask` permission modes with agent-level enforcement before gated tool dispatch
- defaults the Textual TUI to `ask`, with `Ctrl+P` and `/permissions auto|ask|toggle` controls
- persists per-session TUI permission mode and project-local always-allow rules in `.kolega/permissions.json`
- keeps `kolega-code ask` defaulting to `auto`, with optional interactive `--permission-mode ask`
- updates docs and focused tests for permission matching, parser defaults, session persistence, and TUI toggling

## Validation

- `.venv/bin/python -m ruff check ...` on touched Python files
- `.venv/bin/python -m pytest kolega_code/agent/tests/test_permissions.py kolega_code/cli/tests -q` (`225 passed`)

## Notes

A broader local agent test run excluding slow/integration had one environment-specific failure: `test_local_terminal_manager_can_answer_python_prompt` expects `python` on PATH, while this environment exposes `.venv/bin/python`. Full live/API/browser agent tests also fail under restricted network.