### PR TITLE
[codex] toggle TUI sidebar

### DIFF
--- a/docs/src/content/docs/tui/interface.md
+++ b/docs/src/content/docs/tui/interface.md
@@ -15,7 +15,7 @@ The screen is split into two columns:
   stream in live, tool calls and sub-agent activity appear inline, and detailed
   tool results are collapsed by default so you can expand only what you need.
 - **Side panel** (right) — a set of tabs for status, logs, the terminal, planning,
-  and settings.
+  and settings. Toggle it with `Ctrl+O` or `/sidebar`.
 
 At the bottom sits the **composer** — the text box where you type prompts. See
 [Chat Composer](../composer/) for everything it can do.
@@ -51,6 +51,7 @@ At the bottom sits the **composer** — the text box where you type prompts. See
 | --- | --- |
 | `Shift+Tab` | Toggle Build ⇄ Plan mode |
 | `Ctrl+P` | Toggle shell/edit permissions between Ask ⇄ Auto |
+| `Ctrl+O` | Show or hide the side panel |
 | `Enter` | Send the prompt |
 | `Shift+Enter` / `Ctrl+J` | Insert a newline |
 | `Ctrl+C` / `Escape` | Cancel the current generation |

--- a/docs/src/content/docs/tui/slash-commands.md
+++ b/docs/src/content/docs/tui/slash-commands.md
@@ -36,6 +36,7 @@ These control the app and your session.
 | `/init` | Create or update `AGENTS.md` for this repository |
 | `/plan` | Switch to [Plan mode](../modes/) |
 | `/build` | Switch to [Build mode](../modes/) |
+| `/sidebar` | Show or hide the side panel |
 | `/permissions` | Show or switch the shell/edit permission mode |
 | `/model` | Choose the active model |
 | `/effort` | Choose the active model's thinking effort |

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -718,6 +718,7 @@ class KolegaCodeApp(App):
     BINDINGS = [
         Binding("shift+tab", "toggle_interaction_mode", "Plan/Build", show=True, key_display="Shift+Tab", priority=True),
         Binding("ctrl+p", "toggle_permission_mode", "Permissions", show=True, key_display="Ctrl+P", priority=True),
+        Binding("ctrl+o", "toggle_sidebar", "Sidebar", show=True, key_display="Ctrl+O", priority=True),
         Binding("ctrl+c", "cancel_generation", "Cancel", show=True),
         Binding("escape", "cancel_generation", "Cancel", show=False),
         Binding("ctrl+q", "quit", "Quit", show=True),
@@ -756,6 +757,7 @@ class KolegaCodeApp(App):
         self.skill_catalog: SkillCatalog = discover_skills(self.project_path)
         self.file_index = WorkspaceFileIndex(self.project_path)
         self.browser_visible = browser_visible
+        self.sidebar_visible = True
         self.check_for_updates = check_for_updates
         self.connection_manager = CliConnectionManager()
         self.agent: Optional[CoderAgent | PlanningAgent] = None
@@ -1362,12 +1364,32 @@ class KolegaCodeApp(App):
         target = PermissionMode.AUTO if self.permission_mode == PermissionMode.ASK else PermissionMode.ASK
         await self._set_permission_mode(target)
 
+    async def action_toggle_sidebar(self) -> None:
+        self._set_sidebar_visible(not self.sidebar_visible)
+        message = messages.SIDEBAR_SHOWN if self.sidebar_visible else messages.SIDEBAR_HIDDEN
+        self._notify_user(message)
+
     async def action_quit(self) -> None:
         if self.agent is not None:
             self.session.history = self.agent.dump_message_history()
             self._save_session()
             await self.agent.cleanup()
         self.exit()
+
+    def _set_sidebar_visible(self, visible: bool) -> None:
+        self.sidebar_visible = visible
+        try:
+            side_panel = self.query_one("#side_panel")
+            side_panel.display = visible
+        except Exception:
+            return
+        if not visible:
+            try:
+                composer = self.query_one("#composer", ChatComposer)
+                if not composer.disabled:
+                    composer.focus()
+            except Exception:
+                return
 
     def _populate_settings_controls(self) -> None:
         provider_values = {value for _, value in ui_provider_options()}
@@ -1700,6 +1722,7 @@ class KolegaCodeApp(App):
             "/init": self._command_init,
             "/plan": self._command_plan,
             "/build": self._command_build,
+            "/sidebar": self._command_sidebar,
             "/permissions": self._command_permissions,
             "/model": self._command_model,
             "/effort": self._command_effort,
@@ -1734,6 +1757,9 @@ class KolegaCodeApp(App):
         if self._mode_switch_blocked():
             return
         await self._set_interaction_mode(BUILD_INTERACTION_MODE)
+
+    async def _command_sidebar(self, args: str) -> None:
+        await self.action_toggle_sidebar()
 
     async def _command_init(self, args: str) -> None:
         if self._pending_question is not None:
@@ -2673,7 +2699,7 @@ class KolegaCodeApp(App):
                 f"Thinking effort: {effort}",
                 f"API key: {api_key}",
                 "",
-                f"Enter send {theme.g(Glyph.BULLET_SEP)} Shift+Enter newline {theme.g(Glyph.BULLET_SEP)} Shift+Tab plan/build {theme.g(Glyph.BULLET_SEP)} Ctrl+P permissions",
+                f"Enter send {theme.g(Glyph.BULLET_SEP)} Shift+Enter newline {theme.g(Glyph.BULLET_SEP)} Shift+Tab plan/build {theme.g(Glyph.BULLET_SEP)} Ctrl+P permissions {theme.g(Glyph.BULLET_SEP)} Ctrl+O sidebar",
                 f"Ctrl+C stop turn {theme.g(Glyph.BULLET_SEP)} Cmd+C copy selection {theme.g(Glyph.BULLET_SEP)} / commands",
             ]
         )

--- a/kolega_code/cli/messages.py
+++ b/kolega_code/cli/messages.py
@@ -49,6 +49,8 @@ RUNNING_SUB_AGENTS = "Running {count} sub-agents…"
 # Confirmations
 SWITCHED_MODE = "Switched to {mode} mode."
 SWITCHED_PERMISSION_MODE = "Switched permissions to {mode} mode."
+SIDEBAR_HIDDEN = "Sidebar hidden."
+SIDEBAR_SHOWN = "Sidebar shown."
 PLAN_CAPTURED = "Plan captured. Choose Implement plan or Discuss further."
 PLAN_DISCUSSION_RESUMED = "Planning discussion resumed."
 SKILL_ACTIVATED = "Activated skill {name}."

--- a/kolega_code/cli/slash_commands.py
+++ b/kolega_code/cli/slash_commands.py
@@ -43,6 +43,7 @@ TUI_COMMAND_ENTRIES: tuple[SlashCommandEntry, ...] = (
     SlashCommandEntry("init", "Create or update AGENTS.md for this repository", CommandScope.TUI),
     SlashCommandEntry("plan", "Switch to plan mode", CommandScope.TUI),
     SlashCommandEntry("build", "Switch to build mode", CommandScope.TUI),
+    SlashCommandEntry("sidebar", "Show or hide the side panel", CommandScope.TUI),
     SlashCommandEntry("permissions", "Show or switch shell/edit permission mode", CommandScope.TUI),
     SlashCommandEntry("model", "Show or switch the active model", CommandScope.TUI),
     SlashCommandEntry("effort", "Show or set the active thinking effort", CommandScope.TUI),

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -560,6 +560,66 @@ async def test_textual_app_ctrl_p_toggles_permission_mode(
 
 
 @pytest.mark.asyncio
+async def test_textual_app_ctrl_o_toggles_sidebar_and_keeps_active_tab(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.widgets import TabbedContent
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import KolegaCodeApp
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            return None
+
+    monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test() as pilot:
+        toggle_binding = next(binding for binding in app.BINDINGS if binding.action == "toggle_sidebar")
+        assert toggle_binding.key == "ctrl+o"
+        assert toggle_binding.key_display == "Ctrl+O"
+        assert toggle_binding.priority is True
+
+        side_panel = app.query_one("#side_panel")
+        tabs = app.query_one("#events", TabbedContent)
+        tabs.active = "logs_pane"
+        await pilot.pause()
+
+        assert app.sidebar_visible is True
+        assert side_panel.display is True
+
+        await pilot.press("ctrl+o")
+
+        assert app.sidebar_visible is False
+        assert side_panel.display is False
+        assert tabs.active == "logs_pane"
+
+        await pilot.press("ctrl+o")
+
+        assert app.sidebar_visible is True
+        assert side_panel.display is True
+        assert tabs.active == "logs_pane"
+
+
+@pytest.mark.asyncio
 async def test_textual_app_permission_approval_actions_show_rule_labels_without_descriptions(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -4634,6 +4694,35 @@ async def test_textual_app_plan_and_build_slash_commands_switch_mode(
         await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
         assert app.interaction_mode == "build"
         assert isinstance(app.agent, FakeCoderAgent)
+
+
+@pytest.mark.asyncio
+async def test_textual_app_sidebar_slash_command_toggles_sidebar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.app import ChatComposer
+
+    app = _build_mention_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        composer = app.query_one("#composer", ChatComposer)
+        side_panel = app.query_one("#side_panel")
+
+        composer.load_text("/sidebar")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+
+        assert composer.text == ""
+        assert app.sidebar_visible is False
+        assert side_panel.display is False
+
+        composer.load_text("/sidebar")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+
+        assert composer.text == ""
+        assert app.sidebar_visible is True
+        assert side_panel.display is True
 
 
 @pytest.mark.asyncio

--- a/kolega_code/cli/tests/test_slash_commands.py
+++ b/kolega_code/cli/tests/test_slash_commands.py
@@ -33,6 +33,7 @@ def test_agent_command_names_match_command_processor():
     assert THREAD_RESET_COMMANDS <= agent_command_names()
     assert SKILLS_LIST_COMMAND in TUI_COMMAND_NAMES
     assert "/init" in TUI_COMMAND_NAMES
+    assert "/sidebar" in TUI_COMMAND_NAMES
     assert "/exit" in TUI_COMMAND_NAMES
 
 
@@ -51,6 +52,7 @@ def test_all_command_entries_include_each_scope():
     assert by_name["init"].scope is CommandScope.TUI
     assert by_name["plan"].scope is CommandScope.TUI
     assert by_name["effort"].scope is CommandScope.TUI
+    assert by_name["sidebar"].scope is CommandScope.TUI
     assert by_name["exit"].scope is CommandScope.TUI
     assert by_name["demo-skill"].scope is CommandScope.SKILL
 


### PR DESCRIPTION
## Summary

Adds a session-local toggle for the TUI side panel so users can show or hide the sidebar without leaving the composer flow.

## Changes

- Adds `Ctrl+O` as a TUI key binding for toggling the sidebar.
- Adds `/sidebar` as a TUI slash command using the same toggle action.
- Keeps the sidebar mounted while hidden so the active tab and tab state are preserved.
- Updates TUI docs and command autocomplete metadata.

## Validation

- `uv run pytest kolega_code/cli/tests/test_app.py kolega_code/cli/tests/test_slash_commands.py`
- `uv run ruff check kolega_code/cli/app.py kolega_code/cli/messages.py kolega_code/cli/slash_commands.py kolega_code/cli/tests/test_app.py kolega_code/cli/tests/test_slash_commands.py`