### PR TITLE
[codex] Remove TUI popup notifications

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -969,13 +969,9 @@ class KolegaCodeApp(App):
         self._write_log(text, level)
 
     def _notify_user(self, message: str, *, severity: str = "information", title: Optional[str] = None) -> None:
-        """Show a transient toast and keep a copy in the Logs tab."""
+        """Record a user-facing notice in the Logs tab without showing a transient popup."""
         level = {"information": "ok", "warning": "warn", "error": "error"}.get(severity, "info")
         self._log_status(message, level)
-        try:
-            self.notify(message, severity=severity, title=title)
-        except Exception:
-            pass
 
     async def _check_for_update_on_startup(self) -> None:
         result = await asyncio.to_thread(check_for_update)

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -4034,7 +4034,7 @@ async def test_assistant_entries_render_markdown_when_complete(
 
 
 @pytest.mark.asyncio
-async def test_confirmations_surface_as_toasts_and_logs(
+async def test_confirmations_surface_as_logs_without_toasts(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     pytest.importorskip("textual")
@@ -4042,11 +4042,10 @@ async def test_confirmations_surface_as_toasts_and_logs(
     app = _build_sub_agent_test_app(tmp_path, monkeypatch)
 
     async with app.run_test():
-        notifications: list[tuple[str, str]] = []
         logged: list[tuple[str, str]] = []
 
         def fake_notify(message, *, severity="information", title=None, **kwargs):
-            notifications.append((message, severity))
+            raise AssertionError("TUI notices should not show transient popups")
 
         original_log_status = app._log_status
 
@@ -4059,13 +4058,12 @@ async def test_confirmations_surface_as_toasts_and_logs(
 
         await app._set_interaction_mode("plan")
 
-        assert ("Switched to plan mode.", "information") in notifications
         assert ("Switched to plan mode.", "ok") in logged  # diagnostic record kept
 
-        # Blockers surface as warning toasts
+        # Blockers are logged as warnings without transient popups.
         app._turn_active = True
         await app.action_toggle_interaction_mode()
-        assert ("Stop the current turn before switching modes.", "warning") in notifications
+        assert ("Stop the current turn before switching modes.", "warn") in logged
 
 
 @pytest.mark.asyncio
@@ -4222,7 +4220,7 @@ async def test_status_dashboard_context_note_uses_alert_level(
 
 
 @pytest.mark.asyncio
-async def test_save_settings_toasts_on_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_save_settings_logs_on_success_without_toast(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     pytest.importorskip("textual")
 
     from textual.widgets import Input
@@ -4230,17 +4228,24 @@ async def test_save_settings_toasts_on_success(tmp_path: Path, monkeypatch: pyte
     app = _build_sub_agent_test_app(tmp_path, monkeypatch)
 
     async with app.run_test():
-        notifications: list[tuple[str, str]] = []
+        logged: list[tuple[str, str]] = []
 
         def fake_notify(message, *, severity="information", title=None, **kwargs):
-            notifications.append((message, severity))
+            raise AssertionError("TUI notices should not show transient popups")
+
+        original_log_status = app._log_status
+
+        def spy_log_status(text, level="info"):
+            logged.append((text, level))
+            original_log_status(text, level)
 
         monkeypatch.setattr(app, "notify", fake_notify)
+        monkeypatch.setattr(app, "_log_status", spy_log_status)
 
         app.query_one("#api_key_input", Input).value = "moonshot-key"
         await app._save_settings_from_ui()
 
-        assert ("Settings saved.", "information") in notifications
+        assert ("Settings saved.", "ok") in logged
         status_text = str(app.query_one("#settings_status").render())
         assert "Active model:" in status_text
 


### PR DESCRIPTION
## Summary

Removes the bottom-right Textual popup notifications from the TUI while preserving persistent feedback in the Logs tab.

## Why

The TUI notice helper was calling Textual's transient notification API, which created popups the user explicitly does not want. The helper now centralizes notices as log entries only.

## Impact

- User-facing notices no longer show transient bottom-right popups.
- Existing confirmations and blockers still appear in the Logs tab with their severity mapping.
- Regression tests now fail if these notice paths call `app.notify` again.

## Validation

- `uv run pytest kolega_code/cli/tests/test_app.py -q` -> `117 passed`
- `rg -n "notify\\(" kolega_code/cli` -> only test fakes remain, no production calls.