### PR TITLE
Fix TUI chrome rendering in 256-color terminals (Terminal.app)

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -665,6 +665,7 @@ class KolegaCodeApp(App):
     #composer {
         dock: bottom;
         height: 5;
+        border: round $surface;
     }
 
     #turn_status {
@@ -712,6 +713,30 @@ class KolegaCodeApp(App):
 
     .meta {
         color: $text-muted;
+    }
+
+    Footer {
+        background: $surface;
+    }
+
+    Input {
+        border: round $surface;
+    }
+
+    Input:focus {
+        border: round $surface-lighten-2;
+    }
+
+    Select > SelectCurrent {
+        border: round $surface;
+    }
+
+    Select:focus > SelectCurrent {
+        border: round $surface-lighten-2;
+    }
+
+    Select > SelectOverlay {
+        border: round $surface;
     }
     """
 


### PR DESCRIPTION
## Problem

The Textual TUI looks fine in truecolor terminals (e.g. Ghostty) but renders poorly in the default macOS **Terminal.app**, which supports only 256 colors:

- The chat input showed a **blue "broken line"** on its left/right edges.
- The bottom key-hint **Footer bar was dark blue** (grey in Ghostty).
- The sidebar **Select dropdowns** had the same blue broken edges.

**Root cause:** Terminal.app has no truecolor (`COLORTERM` unset), so Rich/Textual quantize the default *textual-dark* theme's RGB colors to the 256-color palette. The theme's blue-tinted greys (e.g. `$panel` = `surface.blend(primary, 10%)` ≈ `#1b2730`, focus `$border` = `$primary` = `#0178D4`) quantize *toward blue*, and the `tall` border style draws left/right edges with partial-block glyphs (`▊`/`▎`) that tile with vertical gaps in Terminal.app's font — the "broken line."

## Fix

CSS-only changes in `KolegaCodeApp.CSS` (`kolega_code/cli/app.py`), reusing the `round` border style and neutral `$surface` greys the app already uses everywhere else. All values are R=G=B, so they quantize to the 256-color grey ramp instead of blue.

| Element | Before | After |
|---|---|---|
| Composer | inherited `tall $border` (blue, broken glyphs) | flat `round $surface` (no focus color change) |
| Footer | `$panel` (blue-tinted) | `$surface` (neutral grey) |
| Select (`SelectCurrent`/`SelectOverlay`) | `tall $border` / `tall $border-blurred` | `round $surface`, `$surface-lighten-2` on focus |
| API-key Input | `tall $border` | `round $surface`, `$surface-lighten-2` on focus |

Ghostty's appearance is essentially unchanged (a hair more neutral on the footer).

## Verification

- CSS validated headlessly via `App.run_test()`: composer/footer/Select borders resolve to `round` with neutral greys `Color(30,30,30)` / `Color(62,62,62)` in both focus states; the blue `tall` borders are gone.
- Remaining manual step: open the TUI in a real Terminal.app window to confirm the visual result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)