### PR TITLE
Add lifecycle events and a hooks system

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -90,6 +90,10 @@ export default defineConfig({
           items: [{ label: "Agent Skills", slug: "skills" }],
         },
         {
+          label: "Hooks",
+          items: [{ label: "Lifecycle Hooks", slug: "hooks" }],
+        },
+        {
           label: "How It Works",
           items: [
             { label: "Architecture", slug: "concepts/how-it-works" },

--- a/docs/src/content/docs/hooks.md
+++ b/docs/src/content/docs/hooks.md
@@ -1,0 +1,240 @@
+---
+title: Hooks
+description: Run shell commands, Python callables, or LLM checks on agent lifecycle events to observe, block, or modify what the agent does.
+---
+
+**Hooks** let you attach handlers to the agent's **lifecycle events** — points like
+"before a tool runs", "a prompt was submitted", or "the agent is about to stop". A hook
+can **observe** (log, notify), **block** (deny a tool, end a turn, keep the agent
+working), or **modify** (rewrite a tool's input or output, inject context).
+
+This is how you add guardrails ("never run `rm -rf`"), automation ("format files after
+every edit"), and quality gates ("don't stop until the tests pass") without changing the
+agent itself.
+
+## Where hooks live
+
+Hooks are declared in JSON, in two places that are **merged** (global first, project last):
+
+- **Global / user:** `~/.kolega-state/hooks.json` — always active.
+- **Project:** `<project>/.kolega/hooks.json` — alongside `permissions.json`. Because a
+  project file can run arbitrary commands from a cloned repo, project hooks are
+  **disabled until you trust the project** (see [Trust](#trusting-project-hooks)).
+
+Both files use the same shape:
+
+```json
+{
+  "schema_version": 1,
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "execute_terminal_command|run_command_tracked",
+        "hooks": [
+          { "type": "command", "command": "./.kolega/guard-bash.sh", "timeout": 30 }
+        ]
+      }
+    ]
+  }
+}
+```
+
+- The `hooks` map is keyed by **event name**.
+- Each entry has a **`matcher`** and a list of **hook handlers**.
+- `matcher` is tested against the tool name for tool events (or a source string for other
+  events): `""` or `"*"` matches everything; `"Edit|Write"` is an exact-name OR list;
+  anything else is a regular expression (e.g. `"mcp__.*"`).
+- Handler lists from the global and project files are concatenated, so the global handler
+  sees the action first and the project handler last.
+
+## Lifecycle events
+
+| Event | When it fires | What a "block" does |
+|---|---|---|
+| `SessionStart` | The agent session begins | Advisory; can inject starting context |
+| `UserPromptSubmit` | You submit a prompt, before the agent sees it | Ends the turn; the reason is shown as a warning |
+| `PreToolUse` | Before a tool runs (after the permission gate) | Denies the tool; the reason is returned to the agent as a tool error, so it can adjust |
+| `PostToolUse` | After a tool succeeds (and on failure) | Ends the turn; the reason is shown as a warning |
+| `PreCompact` | Before the conversation is compacted | Advisory |
+| `Stop` | The agent is about to finish its turn | Keeps the agent working; the reason becomes its next instruction |
+| `SubagentStop` | A dispatched sub-agent finished | Advisory; can annotate the result the parent sees |
+| `Notification` | A permission prompt is about to be shown | Advisory (desktop notifications, sounds) |
+| `SessionEnd` | The session ends | Advisory (cleanup, final logging) |
+
+Hooks can also **modify** rather than block:
+
+- `PreToolUse` can return `updatedInput` to rewrite the tool's arguments.
+- `PostToolUse` can return `updatedToolOutput` to replace what the model sees, or
+  `additionalContext` to append to it.
+- `SessionStart` / `UserPromptSubmit` can return `additionalContext` to inject text.
+
+## Hook types
+
+### `command` — run a shell program
+
+The event is sent as JSON on **stdin**. The hook communicates back through its exit code:
+
+- **exit 0** — success. Optional JSON on stdout controls behavior:
+  ```json
+  {
+    "hookSpecificOutput": {
+      "permissionDecision": "deny",
+      "permissionDecisionReason": "rm -rf is not allowed here",
+      "updatedInput": { "command": "ls" },
+      "updatedToolOutput": "…",
+      "additionalContext": "…"
+    },
+    "systemMessage": "shown to the user",
+    "continue": false
+  }
+  ```
+- **exit 2** — block. Whatever the hook wrote to **stderr** becomes the reason.
+- **any other code** — a non-blocking error: it is logged and the action proceeds.
+
+```json
+{ "type": "command", "command": "./.kolega/format.sh", "timeout": 30 }
+```
+
+Commands run with the project directory as the working directory and are split like a
+shell argument list (no shell features such as pipes — call a script if you need them).
+
+### `python` — run an in-process callable
+
+Point at an importable `module.path:function`. It receives a `LifecycleEvent` and returns
+a `HookOutcome` (or a dict with the same fields). Runs in the agent's process — best for
+first-party checks.
+
+```json
+{ "type": "python", "callable": "myproject.hooks:block_secrets", "timeout": 15 }
+```
+
+```python
+from kolega_code.hooks import HookOutcome
+
+def block_secrets(event):
+    inputs = event.payload.get("tool_input", {})
+    if "AWS_SECRET" in str(inputs):
+        return HookOutcome.deny("Refusing to write a secret to disk.")
+    return HookOutcome.empty()
+```
+
+### `prompt` and `agent` — let an LLM decide
+
+For judgment calls rather than deterministic rules. Both return a yes/no decision as
+`{"ok": true}` (allow) or `{"ok": false, "reason": "…"}` (block); the per-event meaning of
+a block is the same as the table above.
+
+- **`prompt`** sends your prompt plus the event data to a model (the fast model by
+  default; `"model"` may be `"fast"`, `"long"`, or `"thinking"`). Use `$EVENT` in the
+  prompt to interpolate the event JSON.
+
+  ```json
+  {
+    "type": "prompt",
+    "prompt": "Have all of the user's requested tasks been completed? $EVENT",
+    "model": "fast",
+    "timeout": 30
+  }
+  ```
+
+- **`agent`** spawns a full sub-agent that can read files, search the code, and run
+  commands to verify a condition before answering. Heavier, with a longer default timeout.
+  Because an agent hook uses tools, it is **not allowed on `PreToolUse`/`PostToolUse`**
+  (that would recurse); use it on `Stop`, `SubagentStop`, `UserPromptSubmit`, or the
+  session events.
+
+  ```json
+  {
+    "type": "agent",
+    "prompt": "Run the test suite. Only report ok:true if every test passes.",
+    "timeout": 120
+  }
+  ```
+
+  Tool calls made by an agent hook do **not** re-trigger tool hooks, so there is no
+  infinite loop.
+
+## Examples
+
+**Block dangerous shell commands (project, command hook):**
+
+```json
+{
+  "schema_version": 1,
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "execute_terminal_command|run_command|run_command_tracked",
+        "hooks": [{ "type": "command", "command": "./.kolega/deny-rm.sh" }]
+      }
+    ]
+  }
+}
+```
+
+**Don't stop until the tests pass (prompt hook):**
+
+```json
+{
+  "schema_version": 1,
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [{
+          "type": "prompt",
+          "prompt": "Based on the conversation, did the agent finish ALL requested work AND leave the tests passing? $EVENT"
+        }]
+      }
+    ]
+  }
+}
+```
+
+**Verify tests actually pass before stopping (agent hook):**
+
+```json
+{
+  "schema_version": 1,
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [{
+          "type": "agent",
+          "prompt": "Run the project's test command and confirm it exits cleanly.",
+          "timeout": 120
+        }]
+      }
+    ]
+  }
+}
+```
+
+## Trusting project hooks
+
+A project's `.kolega/hooks.json` can run arbitrary commands, so it is **ignored until you
+explicitly trust the project**. Global/user hooks are always trusted.
+
+When an untrusted project defines hooks, Kolega Code tells you and runs only the global
+hooks. To enable the project's hooks, launch with:
+
+```bash
+kolega-code --trust-hooks          # TUI
+kolega-code ask "…" --trust-hooks  # non-interactive
+```
+
+Trust is recorded once (per resolved project path) in your user settings, so future runs
+in that project enable its hooks automatically.
+
+## Safety and behavior notes
+
+- **Failure is isolated.** A hook that crashes, times out, or prints garbage is logged and
+  the action proceeds — a broken hook never wedges the agent. Only a clean `exit 2`,
+  `permissionDecision: "deny"`, or `ok: false` blocks.
+- **Each handler has a `timeout`** (seconds). On timeout the process is killed and treated
+  as a non-blocking error.
+- **Tool hooks apply to sub-agents too**, so a `PreToolUse` guard also covers tools used by
+  dispatched sub-agents.
+- A `Stop` hook can force the agent to keep working only a bounded number of times per
+  turn, so a misbehaving "don't stop" hook cannot loop forever.

--- a/docs/src/content/docs/hooks.md
+++ b/docs/src/content/docs/hooks.md
@@ -16,7 +16,14 @@ agent itself.
 
 Hooks are declared in JSON, in two places that are **merged** (global first, project last):
 
-- **Global / user:** `~/.kolega-state/hooks.json` — always active.
+- **Global / user:** `hooks.json` in the Kolega Code state directory — always active. The
+  state directory is platform-specific:
+  - macOS: `~/Library/Application Support/kolega-code/hooks.json`
+  - Linux: `$XDG_STATE_HOME/kolega-code/hooks.json` (defaults to `~/.local/state/kolega-code/hooks.json`)
+  - Windows: `%LOCALAPPDATA%\kolega-code\hooks.json`
+
+  Override the location with the `KOLEGA_CODE_STATE_DIR` environment variable or the
+  `--state-dir <dir>` flag (the file is then `<dir>/hooks.json`).
 - **Project:** `<project>/.kolega/hooks.json` — alongside `permissions.json`. Because a
   project file can run arbitrary commands from a cloned repo, project hooks are
   **disabled until you trust the project** (see [Trust](#trusting-project-hooks)).

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -15,6 +15,14 @@ from kolega_code.events import AgentConnectionManager
 from .context import AgentContext, AgentServices, Telemetry, WorkspaceInfo
 from .conversation import Conversation
 from kolega_code.events import AgentEventEmitter
+from kolega_code.hooks import (
+    NO_OP_DISPATCHER,
+    HookCapabilities,
+    HookDispatcher,
+    HookEvent,
+    HookOutcome,
+    LifecycleEvent,
+)
 from kolega_code.llm.exceptions import (
     LLMError,
     LLMRateLimitError,
@@ -45,6 +53,16 @@ logger = logging.getLogger(__name__)
 PROJECT_GUIDANCE_FILES = ("AGENTS.md", "KOLEGA.md")
 AGENT_MEMORY_FILE = "AGENT_MEMORY.md"
 
+# System prompt for `prompt`/`agent` lifecycle hooks: the model's only job is a
+# yes/no decision returned as a compact JSON object.
+HOOK_DECISION_SYSTEM_PROMPT = (
+    "You are a lifecycle hook that makes a single yes/no decision about an AI coding "
+    "agent's action. You are given the event data and a question or condition to evaluate. "
+    'Respond with ONLY a JSON object: {"ok": true} to allow the action to proceed, or '
+    '{"ok": false, "reason": "<short explanation>"} to block it. The reason is shown to the '
+    "agent. Output nothing other than the JSON object."
+)
+
 
 class BaseAgent(LogMixin):
     """
@@ -63,6 +81,9 @@ class BaseAgent(LogMixin):
     # sub-agent runs its own multi-turn LLM loop, so an unbounded fan-out would
     # multiply token spend and shared-resource pressure).
     PARALLEL_TOOL_LIMIT = 8
+    # Cap on how many times a Stop hook may force the agent to keep working in one
+    # turn, so a misbehaving "don't stop until X" hook cannot loop forever.
+    MAX_STOP_HOOK_OVERRIDES = 5
     long_content_tool_calls = ["create_file", "replace_entire_file"]
     max_tool_result_chars_in_history = 100_000
     skill_content_pattern = re.compile(r'<skill_content name="[^"]+">')
@@ -97,6 +118,7 @@ class BaseAgent(LogMixin):
         permission_callback: Optional[Any] = None,
         usage_recorder: Optional[Any] = None,
         sub_agent_recorder: Optional[Any] = None,
+        hook_dispatcher: Optional[HookDispatcher] = None,
         context: Optional[AgentContext] = None,
     ) -> None:
         """
@@ -132,9 +154,7 @@ class BaseAgent(LogMixin):
         """
         if context is None:
             if project_path is None or workspace_id is None or thread_id is None:
-                raise TypeError(
-                    "BaseAgent requires either an AgentContext or project_path/workspace_id/thread_id"
-                )
+                raise TypeError("BaseAgent requires either an AgentContext or project_path/workspace_id/thread_id")
 
             workspace = WorkspaceInfo(
                 project_path=Path(project_path) if isinstance(project_path, str) else project_path,
@@ -179,6 +199,11 @@ class BaseAgent(LogMixin):
             if permission_callback is not None:
                 context.permission_callback = permission_callback
 
+        # Apply an explicitly-passed hook dispatcher regardless of how the context
+        # was built; otherwise the context's default (NO_OP_DISPATCHER) is used.
+        if hook_dispatcher is not None:
+            context.hook_dispatcher = hook_dispatcher
+
         self.context = context
 
         # Flat attributes kept for compatibility with subclasses, tools, and hosts.
@@ -202,6 +227,7 @@ class BaseAgent(LogMixin):
         self.tool_extensions = context.tool_extensions
         self.permission_mode = context.permission_mode
         self.permission_callback = context.permission_callback or auto_allow_permission_callback
+        self.hook_dispatcher = context.hook_dispatcher or NO_OP_DISPATCHER
         self.usage_recorder = context.telemetry.usage_recorder
         self.sub_agent_recorder = context.telemetry.sub_agent_recorder
 
@@ -251,6 +277,8 @@ class BaseAgent(LogMixin):
         self.parent_tool_call_id = None  # Parent tool call ID when running as sub-agent
         self.conversation_id = None  # Sub-agent conversation ID
         self.sub_agent_context = None  # Dispatch metadata (agent_id, task) set by AgentTool
+        # Set by a blocking PostToolUse hook to end the turn after the current tool batch.
+        self._hook_end_turn = False
 
     # ------------------------------------------------------------------
     # Conversation delegation
@@ -480,7 +508,7 @@ class BaseAgent(LogMixin):
             message = (
                 "Longer threads consume more credits. "
                 f"Contents will be compressed automatically at {self.history_compression_threshold * 100:.0f}%. "
-                "You can start fresh by clicking \"New Thread\" in the sidebar."
+                'You can start fresh by clicking "New Thread" in the sidebar.'
             )
 
         await self.emitter.context_update(
@@ -591,6 +619,15 @@ class BaseAgent(LogMixin):
 
             permission_request = permission_request_for_tool(tool_name, inputs)
             if permission_request is not None and self.permission_mode == PermissionMode.ASK:
+                await self.fire_hook(
+                    HookEvent.NOTIFICATION,
+                    {
+                        "notification_type": "permission_prompt",
+                        "message": f"Permission requested for {tool_name}",
+                        "tool_name": tool_name,
+                    },
+                    target="permission_prompt",
+                )
                 try:
                     decision = await self.permission_callback(permission_request)
                     if not isinstance(decision, PermissionDecision):
@@ -632,6 +669,18 @@ class BaseAgent(LogMixin):
                         execution_id=tool_execution_id,
                     )
 
+            # PreToolUse hooks: may deny the call (returned to the model as a tool
+            # error, like a permission denial) or rewrite the tool inputs.
+            pre = await self.fire_hook(
+                HookEvent.PRE_TOOL_USE,
+                {"tool_name": tool_name, "tool_input": inputs, "tool_use_id": tool_execution_id},
+                target=tool_name,
+            )
+            if pre.blocked:
+                return await self._blocked_tool_result(tool_name, provider_tool_call_id, tool_execution_id, pre.reason)
+            if pre.updated_input is not None:
+                inputs = pre.updated_input
+
             # Send tool_call message to indicate we're starting execution
             if not all(
                 [
@@ -648,6 +697,19 @@ class BaseAgent(LogMixin):
                 )
 
             output = await registry.call(tool_name, **inputs)
+
+            # PostToolUse hooks: may replace the output or append context the model sees.
+            post = await self.fire_hook(
+                HookEvent.POST_TOOL_USE,
+                {
+                    "tool_name": tool_name,
+                    "tool_input": inputs,
+                    "tool_output": self._hook_text(output),
+                    "is_error": False,
+                },
+                target=tool_name,
+            )
+            output = self._apply_post_tool_hook(output, post)
 
             # Handle the case where the output is a list of ContentBlock objects
             chat_message_content = output
@@ -678,6 +740,7 @@ class BaseAgent(LogMixin):
             # internal-error log.
             error_message = str(ex)
             await self.log_warning(f"Tool {tool_name} failed: {error_message}", sender=self.agent_name)
+            error_message = await self._post_tool_error_hook(tool_name, inputs, error_message)
 
             await self.send_chat_message(
                 message_type="tool_error",
@@ -697,6 +760,7 @@ class BaseAgent(LogMixin):
         except Exception as ex:
             error_message = str(ex)
             await self.log_error(f"Error executing tool {tool_name}: {error_message}", sender=self.agent_name)
+            error_message = await self._post_tool_error_hook(tool_name, inputs, error_message)
 
             # Send tool_error message for failed execution
             await self.send_chat_message(
@@ -785,6 +849,158 @@ class BaseAgent(LogMixin):
                 "parent_tool_call_id": self.parent_tool_call_id,
                 "depth": 1,  # Can be enhanced to track nested depth
             }
+        return None
+
+    # ------------------------------------------------------------------
+    # Lifecycle hooks
+    # ------------------------------------------------------------------
+
+    async def fire_hook(self, name: HookEvent, payload: Dict[str, Any], *, target: str = "") -> HookOutcome:
+        """Build a LifecycleEvent and dispatch it. Returns an empty outcome when no
+        hooks are configured (the common case) or when already inside a hook."""
+        # Hot path: skip building the event/capabilities when no hooks exist.
+        if not self.hook_dispatcher.is_active:
+            return HookOutcome.empty()
+        event = LifecycleEvent(
+            name=name,
+            payload=payload,
+            session_id=self.thread_id,
+            cwd=str(self.project_path),
+            permission_mode=self.permission_mode.value if self.permission_mode else None,
+        )
+        return await self.hook_dispatcher.dispatch(event, target=target, caps=self._hook_capabilities())
+
+    def _hook_capabilities(self) -> HookCapabilities:
+        """Capabilities passed to hook backends: project cwd, an LLM prompt runner,
+        a sub-agent runner (for `agent` hooks), and a log sink."""
+        return HookCapabilities(
+            project_path=self.project_path,
+            prompt_runner=self._run_hook_prompt,
+            agent_runner=self._run_hook_agent,
+            log=self._log_hook_message,
+        )
+
+    async def _log_hook_message(self, message: str) -> None:
+        await self.log_warning(message, sender=self.agent_name)
+
+    async def _run_hook_prompt(self, prompt_text: str, model_hint: Optional[str]) -> str:
+        """Run a `prompt` hook: a single completion on a chosen model slot.
+
+        ``model_hint`` selects a configured slot ("fast" (default), "long", or
+        "thinking"); arbitrary model ids are not used here to keep provider/API-key
+        pairing correct across kolega's multi-provider setup.
+        """
+        slot = (model_hint or "fast").lower()
+        if slot in ("long", "main", "long_context"):
+            model_config = self.config.long_context_config
+        elif slot == "thinking":
+            model_config = self.config.thinking_config
+        else:
+            model_config = self.config.fast_config
+
+        from kolega_code.llm.client import LLMClient
+
+        client = LLMClient(
+            provider=model_config.provider.value,
+            api_key=self.config.get_api_key(model_config.provider),
+            max_retries=model_config.rate_limits.max_retries,
+            requests_per_minute=model_config.rate_limits.requests_per_minute,
+            tokens_per_minute=model_config.rate_limits.tokens_per_minute,
+        )
+        response = await client.generate(
+            model=model_config.model,
+            max_completion_tokens=512,
+            system=Message(role="system", content=[TextBlock(text=HOOK_DECISION_SYSTEM_PROMPT)]),
+            messages=MessageHistory([Message(role="user", content=[TextBlock(text=prompt_text)])]),
+            temperature=0.0,
+        )
+        return response.get_text_content() or ""
+
+    async def _run_hook_agent(self, task: str) -> str:
+        """Run an `agent` hook: dispatch a full-tool sub-agent to verify a condition.
+
+        Runs under the dispatcher's re-entrancy guard, so the sub-agent's own tool
+        calls do not re-fire tool hooks.
+        """
+        if self.tool_collection is None or not hasattr(self.tool_collection, "agent_tool"):
+            raise RuntimeError("agent hooks require a tool collection with sub-agent dispatch")
+        instruction = (
+            f"{task}\n\nWhen finished, end your reply with a single JSON object on its own line: "
+            '{"ok": true} if the condition holds, or {"ok": false, "reason": "<why>"} if it does not.'
+        )
+        return await self.tool_collection.agent_tool.dispatch_general_agent(instruction)
+
+    @staticmethod
+    def _hook_text(output: Any) -> str:
+        """Stringify a tool output (which may be a list of content blocks) for hook input."""
+        if isinstance(output, list):
+            return "\n\n".join(getattr(item, "to_markdown", lambda: str(item))() for item in output)
+        return output if isinstance(output, str) else str(output)
+
+    async def _blocked_tool_result(
+        self, tool_name: str, provider_tool_call_id: str, tool_execution_id: str, reason: str
+    ) -> ToolResult:
+        """Build the is_error ToolResult a blocked tool produces — identical to the
+        permission-deny path so the model and UI handle a hook block the same way."""
+        error_message = (
+            f"Permission denied for {tool_name}: {reason}" if reason else f"Permission denied for {tool_name}."
+        )
+        await self.log_warning(error_message, sender=self.agent_name)
+        await self.send_chat_message(
+            message_type="tool_error",
+            content=error_message,
+            is_streaming=False,
+            tool_description=tool_name,
+            tool_call_id=tool_execution_id,
+        )
+        return ToolResult(
+            tool_use_id=provider_tool_call_id,
+            content=error_message,
+            name=tool_name,
+            is_error=True,
+            execution_id=tool_execution_id,
+        )
+
+    def _apply_post_tool_hook(self, output: Any, outcome: HookOutcome) -> Any:
+        """Fold a PostToolUse outcome into the tool output the model will see."""
+        if outcome.is_empty:
+            return output
+        if outcome.updated_output is not None:
+            output = outcome.updated_output
+        if outcome.additional_context:
+            output = f"{self._hook_text(output)}\n\n{outcome.additional_context}"
+        if outcome.blocked or outcome.end_turn:
+            # End the turn after this tool batch; surface the reason as a warning line.
+            self._hook_end_turn = True
+            if outcome.reason:
+                output = f"{self._hook_text(output)}\n\n[hook] {outcome.reason}"
+        return output
+
+    async def _post_tool_error_hook(self, tool_name: str, inputs: dict, error_message: str) -> str:
+        """Fire PostToolUse for a failed tool. On error the hook may only append
+        context (it must not mask or rewrite a genuine tool failure)."""
+        post = await self.fire_hook(
+            HookEvent.POST_TOOL_USE,
+            {"tool_name": tool_name, "tool_input": inputs, "tool_output": error_message, "is_error": True},
+            target=tool_name,
+        )
+        if post.additional_context:
+            return f"{error_message}\n\n{post.additional_context}"
+        return error_message
+
+    async def _fire_stop_hook(self, stop_reason: Optional[str]) -> Optional[str]:
+        """Fire the Stop event. Returns a 'keep working' instruction when a hook
+        blocks the stop (ok:false), otherwise None."""
+        try:
+            last_message = await self.recap_agent_outcome()
+        except Exception:  # noqa: BLE001 - recap is best-effort context for the hook
+            last_message = ""
+        outcome = await self.fire_hook(
+            HookEvent.STOP,
+            {"stop_reason": stop_reason, "last_message": last_message},
+        )
+        if outcome.blocked:
+            return outcome.reason or "Continue working; the stop condition is not yet satisfied."
         return None
 
     async def send_chat_message(
@@ -937,9 +1153,23 @@ class BaseAgent(LogMixin):
             }
             return
 
-        self.append_user_message(await self.build_user_content(message, attachments))
+        content_blocks = await self.build_user_content(message, attachments)
+
+        # UserPromptSubmit hooks (skipped for sub-agents, whose task is machine-
+        # generated, not a user prompt). May end the turn or inject extra context.
+        if not self.sub_agent:
+            submit = await self.fire_hook(HookEvent.USER_PROMPT_SUBMIT, {"user_message": message})
+            if submit.blocked or submit.end_turn:
+                reason = submit.reason or "A hook blocked this prompt."
+                yield {"type": "response", "content": reason, "complete": True, "uuid": str(uuid.uuid4())}
+                return
+            if submit.additional_context:
+                content_blocks.append(TextBlock(text=submit.additional_context))
+
+        self.append_user_message(content_blocks)
 
         stop_reason = None
+        stop_overrides = 0
         while stop_reason not in ["end_turn", "max_tokens", "stop_sequence"]:
             self.mark_cache_checkpoint()
 
@@ -948,6 +1178,15 @@ class BaseAgent(LogMixin):
                 logger.debug("Input token count: %s", token_count)
 
                 if self.compressor.over_budget(token_count.input_tokens, self.model_context_length):
+                    # PreCompact hooks (advisory): observe before history is compacted.
+                    await self.fire_hook(
+                        HookEvent.PRE_COMPACT,
+                        {
+                            "trigger": "auto",
+                            "input_tokens": token_count.input_tokens,
+                            "model_context_length": self.model_context_length,
+                        },
+                    )
                     await self.compress_history()
                     token_count = await self.count_current_context()
 
@@ -1037,6 +1276,10 @@ class BaseAgent(LogMixin):
 
                         if self.should_stop_after_tools():
                             break
+                        if self._hook_end_turn:
+                            # A blocking PostToolUse hook asked to end the turn.
+                            self._hook_end_turn = False
+                            break
                     except Exception as ex:
                         error_message = f"Error processing tool calls: {str(ex)}"
                         await self.log_error(error_message, sender=self.agent_name)
@@ -1051,6 +1294,15 @@ class BaseAgent(LogMixin):
                             for tool_call in assistant_message.tool_calls
                         ]
                         self.append_user_message(error_responses)
+
+                # Stop hooks (main agent only). On a natural turn end, a hook may
+                # keep the agent working by blocking the stop and returning a reason.
+                if stop_reason in ["end_turn", "max_tokens", "stop_sequence"] and not self.sub_agent:
+                    keep_working = await self._fire_stop_hook(stop_reason)
+                    if keep_working is not None and stop_overrides < self.MAX_STOP_HOOK_OVERRIDES:
+                        stop_overrides += 1
+                        self.append_user_message([TextBlock(text=keep_working)])
+                        stop_reason = None
 
             except Exception as ex:
                 await self.handle_llm_error(ex)

--- a/kolega_code/agent/browseragent.py
+++ b/kolega_code/agent/browseragent.py
@@ -44,6 +44,7 @@ class BrowserAgent(BaseAgent):
         permission_callback: Optional[Any] = None,
         usage_recorder: Optional[Any] = None,
         sub_agent_recorder: Optional[Any] = None,
+        hook_dispatcher: Optional[Any] = None,
     ) -> None:
         """
         Initialize a new BrowserAgent instance.
@@ -95,6 +96,7 @@ class BrowserAgent(BaseAgent):
             permission_callback=permission_callback,
             usage_recorder=usage_recorder,
             sub_agent_recorder=sub_agent_recorder,
+            hook_dispatcher=hook_dispatcher,
         )
 
         self.tool_collection = ToolCollection(

--- a/kolega_code/agent/coder.py
+++ b/kolega_code/agent/coder.py
@@ -48,6 +48,7 @@ class CoderAgent(BaseAgent, LogMixin):
         permission_callback: Optional[Any] = None,
         usage_recorder: Optional[Any] = None,
         sub_agent_recorder: Optional[Any] = None,
+        hook_dispatcher: Optional[Any] = None,
     ) -> None:
         """
         Initialize a new CoderAgent instance.
@@ -102,6 +103,7 @@ class CoderAgent(BaseAgent, LogMixin):
             permission_callback=permission_callback,
             usage_recorder=usage_recorder,
             sub_agent_recorder=sub_agent_recorder,
+            hook_dispatcher=hook_dispatcher,
         )
 
         # Configure tool collection with custom coder agent tools

--- a/kolega_code/agent/context.py
+++ b/kolega_code/agent/context.py
@@ -13,6 +13,7 @@ from langfuse import Langfuse
 
 from kolega_code.config import AgentConfig
 from kolega_code.events import AgentConnectionManager
+from kolega_code.hooks import NO_OP_DISPATCHER, HookDispatcher
 from kolega_code.llm.client import LLMClient
 from kolega_code.llm.instrumented_client import InstrumentedLLMClient
 from kolega_code.permissions import PermissionMode, auto_allow_permission_callback
@@ -84,6 +85,9 @@ class AgentContext:
     tool_extensions: List[Any] = field(default_factory=list)
     permission_mode: PermissionMode = PermissionMode.AUTO
     permission_callback: Any = auto_allow_permission_callback
+    # Lifecycle-hook dispatcher. Defaults to a stateless no-op so hosts that do
+    # not configure hooks (and every existing caller/test) are unaffected.
+    hook_dispatcher: HookDispatcher = NO_OP_DISPATCHER
 
     def create_llm_client(self, agent_name: str) -> LLMClient:
         """Create the LLM client, instrumented when a Langfuse client is available."""

--- a/kolega_code/agent/generalagent.py
+++ b/kolega_code/agent/generalagent.py
@@ -46,6 +46,7 @@ class GeneralAgent(BaseAgent):
         permission_callback: Optional[Any] = None,
         usage_recorder: Optional[Any] = None,
         sub_agent_recorder: Optional[Any] = None,
+        hook_dispatcher: Optional[Any] = None,
     ) -> None:
         """
         Initialize a new GeneralAgent instance.
@@ -97,6 +98,7 @@ class GeneralAgent(BaseAgent):
             permission_callback=permission_callback,
             usage_recorder=usage_recorder,
             sub_agent_recorder=sub_agent_recorder,
+            hook_dispatcher=hook_dispatcher,
         )
 
         # Full coder-style toolset, minus sub-agent dispatch (a dispatched agent

--- a/kolega_code/agent/investigationagent.py
+++ b/kolega_code/agent/investigationagent.py
@@ -44,6 +44,7 @@ class InvestigationAgent(BaseAgent):
         permission_callback: Optional[Any] = None,
         usage_recorder: Optional[Any] = None,
         sub_agent_recorder: Optional[Any] = None,
+        hook_dispatcher: Optional[Any] = None,
     ) -> None:
         """
         Initialize a new InvestigationAgent instance.
@@ -95,6 +96,7 @@ class InvestigationAgent(BaseAgent):
             permission_callback=permission_callback,
             usage_recorder=usage_recorder,
             sub_agent_recorder=sub_agent_recorder,
+            hook_dispatcher=hook_dispatcher,
         )
 
         self.tool_collection = ToolCollection(

--- a/kolega_code/agent/planningagent.py
+++ b/kolega_code/agent/planningagent.py
@@ -43,6 +43,7 @@ class PlanningAgent(BaseAgent):
         permission_callback: Optional[Any] = None,
         usage_recorder: Optional[Any] = None,
         sub_agent_recorder: Optional[Any] = None,
+        hook_dispatcher: Optional[Any] = None,
     ) -> None:
         super().__init__(
             project_path,
@@ -68,6 +69,7 @@ class PlanningAgent(BaseAgent):
             permission_callback=permission_callback,
             usage_recorder=usage_recorder,
             sub_agent_recorder=sub_agent_recorder,
+            hook_dispatcher=hook_dispatcher,
         )
 
         self._completed_plan: Optional[str] = None

--- a/kolega_code/agent/tests/test_hooks_integration.py
+++ b/kolega_code/agent/tests/test_hooks_integration.py
@@ -1,0 +1,231 @@
+"""Integration tests: lifecycle hooks fired through BaseAgent's real loop and tool path."""
+
+import os
+import uuid
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from kolega_code.agent.baseagent import BaseAgent
+from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
+from kolega_code.events import AgentConnectionManager
+from kolega_code.hooks import HookConfig, HookDispatcher, HookEvent, HookMatcher, HookOutcome, HookSpec
+from kolega_code.llm.models import Message, TextBlock, ToolCall, ToolDefinition
+from kolega_code.llm.providers.models import TokenCount
+from kolega_code.tools import Tool, ToolRegistry
+
+
+@pytest.fixture
+def agent_config():
+    return AgentConfig(
+        anthropic_api_key=os.getenv("ANTHROPIC_API_KEY", "test_key"),
+        long_context_config=ModelConfig(
+            provider=ModelProvider.ANTHROPIC, model="claude-haiku-4-5-20251001", rate_limits=RateLimitConfig()
+        ),
+        fast_config=ModelConfig(
+            provider=ModelProvider.ANTHROPIC, model="claude-haiku-4-5-20251001", rate_limits=RateLimitConfig()
+        ),
+        thinking_config=ModelConfig(
+            provider=ModelProvider.ANTHROPIC,
+            model="claude-haiku-4-5-20251001",
+            rate_limits=RateLimitConfig(),
+            thinking_effort="medium",
+        ),
+    )
+
+
+# --- module-level python hooks referenced from configs ---------------------- #
+
+_STOP_BLOCKS_REMAINING = [0]
+
+
+def deny_hook(event):
+    return HookOutcome.deny("blocked by test")
+
+
+def modify_input_hook(event):
+    return HookOutcome(updated_input={"command": "echo safe"})
+
+
+def modify_output_hook(event):
+    return HookOutcome(updated_output="REDACTED")
+
+
+def deny_boom_hook(event):
+    if event.payload.get("tool_input", {}).get("task") == "boom":
+        return HookOutcome.deny("boom is not allowed")
+    return HookOutcome.empty()
+
+
+def deny_prompt_hook(event):
+    return HookOutcome.deny("prompt rejected")
+
+
+def stop_until_flag_hook(event):
+    if _STOP_BLOCKS_REMAINING[0] > 0:
+        _STOP_BLOCKS_REMAINING[0] -= 1
+        return HookOutcome.deny("keep going")
+    return HookOutcome.empty()
+
+
+def _dispatcher(event: HookEvent, func: str, matcher: str = "*") -> HookDispatcher:
+    spec = HookSpec(type="python", timeout=5, scope="global", callable=f"{__name__}:{func}")
+    return HookDispatcher(HookConfig(entries={event: [(HookMatcher(matcher), [spec])]}))
+
+
+def _make_agent(tmp_path, agent_config, dispatcher):
+    agent = BaseAgent(
+        project_path=tmp_path,
+        workspace_id="test_workspace",
+        thread_id=str(uuid.uuid4()),
+        connection_manager=AsyncMock(spec=AgentConnectionManager),
+        config=agent_config,
+        hook_dispatcher=dispatcher,
+    )
+    agent.send_chat_message = AsyncMock()
+    agent.log_info = AsyncMock()
+    agent.log_warning = AsyncMock()
+    agent.log_error = AsyncMock()
+    return agent
+
+
+def _tools(handler, name="do_thing", parallel_safe=False):
+    class Tools:
+        def registry(self):
+            return ToolRegistry(
+                [
+                    Tool(
+                        name=name,
+                        definition=ToolDefinition(name=name, description="", parameters=[]),
+                        handler=handler,
+                        parallel_safe=parallel_safe,
+                    )
+                ]
+            )
+
+    return Tools()
+
+
+def _call(name="do_thing", index=1, **inputs):
+    return ToolCall(id=f"{name}_{index}", name=name, input=inputs, execution_id=f"exec_{index}")
+
+
+# --- PreToolUse -------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_pre_tool_use_deny_blocks_and_skips_handler(tmp_path, agent_config):
+    handler = AsyncMock(return_value="ran")
+    agent = _make_agent(tmp_path, agent_config, _dispatcher(HookEvent.PRE_TOOL_USE, "deny_hook"))
+    agent.tool_collection = _tools(handler)
+
+    result = await agent.execute_single_tool(_call(command="rm -rf /"))
+
+    assert result.is_error is True
+    assert "Permission denied for do_thing" in result.content
+    assert "blocked by test" in result.content
+    handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pre_tool_use_updated_input_is_applied(tmp_path, agent_config):
+    handler = AsyncMock(return_value="ran")
+    agent = _make_agent(tmp_path, agent_config, _dispatcher(HookEvent.PRE_TOOL_USE, "modify_input_hook"))
+    agent.tool_collection = _tools(handler)
+
+    result = await agent.execute_single_tool(_call(command="rm -rf /"))
+
+    assert result.is_error is False
+    handler.assert_awaited_once_with(command="echo safe")
+
+
+# --- PostToolUse ------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_post_tool_use_updated_output_replaces_content(tmp_path, agent_config):
+    handler = AsyncMock(return_value="secret value")
+    agent = _make_agent(tmp_path, agent_config, _dispatcher(HookEvent.POST_TOOL_USE, "modify_output_hook"))
+    agent.tool_collection = _tools(handler)
+
+    result = await agent.execute_single_tool(_call())
+
+    assert result.is_error is False
+    assert result.content == "REDACTED"
+
+
+# --- concurrency: deny exactly one tool in a parallel batch ------------------ #
+
+
+@pytest.mark.asyncio
+async def test_parallel_batch_denies_only_matching_tool(tmp_path, agent_config):
+    handler = AsyncMock(return_value="ran")
+    agent = _make_agent(tmp_path, agent_config, _dispatcher(HookEvent.PRE_TOOL_USE, "deny_boom_hook"))
+    # search_codebase is parallel-safe, so the batch runs via asyncio.gather.
+    agent.tool_collection = _tools(handler, name="search_codebase", parallel_safe=True)
+
+    results = await agent.process_tool_calls(
+        [_call(name="search_codebase", index=1, task="boom"), _call(name="search_codebase", index=2, task="ok")]
+    )
+
+    assert results[0].is_error is True and "boom is not allowed" in results[0].content
+    assert results[1].is_error is False
+    # The non-denied call still reached the handler exactly once.
+    handler.assert_awaited_once_with(task="ok")
+
+
+# --- UserPromptSubmit -------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_user_prompt_submit_block_ends_turn_without_llm_call(tmp_path, agent_config):
+    agent = _make_agent(tmp_path, agent_config, _dispatcher(HookEvent.USER_PROMPT_SUBMIT, "deny_prompt_hook"))
+    agent.llm = Mock()
+
+    chunks = [chunk async for chunk in agent.process_message_stream("do the thing")]
+
+    assert len(chunks) == 1
+    assert chunks[0]["content"] == "prompt rejected"
+    assert chunks[0]["complete"] is True
+    assert agent.history == []
+    agent.llm.stream.assert_not_called()
+
+
+# --- Stop keep-working ------------------------------------------------------- #
+
+
+class _EndTurnStream:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+    async def get_final_message(self):
+        return Message("assistant", [TextBlock("done")], stop_reason="end_turn")
+
+
+@pytest.mark.asyncio
+async def test_stop_hook_keeps_working_then_completes(tmp_path, agent_config):
+    _STOP_BLOCKS_REMAINING[0] = 1  # block the first stop, allow the second
+    agent = _make_agent(tmp_path, agent_config, _dispatcher(HookEvent.STOP, "stop_until_flag_hook"))
+    agent.system_prompt = Message("system", [TextBlock("test agent")])  # set by subclasses in real use
+    agent.tool_collection = Mock()
+    agent.tool_collection.get_tool_list = Mock(return_value=[])
+    agent.count_current_context = AsyncMock(return_value=TokenCount(input_tokens=10))
+    agent.llm = Mock()
+    agent.llm.stream = AsyncMock(return_value=_EndTurnStream())
+
+    chunks = [chunk async for chunk in agent.process_message_stream("hello")]
+
+    # The Stop hook forced one extra loop, so the LLM was streamed twice.
+    assert agent.llm.stream.await_count == 2
+    assert chunks[-1]["complete"] is True
+    # The keep-working reason was appended to history as a user message.
+    assert any("keep going" in m.get_text_content() for m in agent.history if m.role == "user")

--- a/kolega_code/agent/tool_backend/agent_tool.py
+++ b/kolega_code/agent/tool_backend/agent_tool.py
@@ -7,6 +7,7 @@ import time
 
 from kolega_code.config import AgentConfig
 from kolega_code.events import AgentEvent
+from kolega_code.hooks import HookDispatcher, HookEvent
 from .base_tool import BaseTool
 
 
@@ -105,6 +106,23 @@ class AgentTool(BaseTool):
         )
         await self.connection_manager.broadcast_event(event, self.workspace_id, self.thread_id)
 
+    async def _apply_subagent_stop_hooks(self, agent_name: str, result: str, sub_agent_info: Optional[dict]) -> str:
+        """Fire SubagentStop on the parent agent and fold any augmentation into the result."""
+        dispatcher = getattr(self.caller, "hook_dispatcher", None)
+        fire = getattr(self.caller, "fire_hook", None)
+        if not isinstance(dispatcher, HookDispatcher) or not dispatcher.is_active or not callable(fire):
+            return result
+        outcome = await fire(
+            HookEvent.SUBAGENT_STOP,
+            {"agent_name": agent_name, "result": result, "sub_agent_info": sub_agent_info},
+            target=agent_name,
+        )
+        if outcome.additional_context:
+            result = f"{result}\n\n{outcome.additional_context}"
+        if outcome.blocked and outcome.reason:
+            result = f"{result}\n\n[hook] {outcome.reason}"
+        return result
+
     async def _dispatch_agent(self, agent_class_import: str, task: str) -> str:
         """
         Generic method to dispatch any agent type.
@@ -196,6 +214,7 @@ class AgentTool(BaseTool):
                 permission_callback=getattr(self.caller, "permission_callback", None) if self.caller else None,
                 usage_recorder=getattr(self.caller, "usage_recorder", None) if self.caller else None,
                 sub_agent_recorder=getattr(self.caller, "sub_agent_recorder", None) if self.caller else None,
+                hook_dispatcher=getattr(self.caller, "hook_dispatcher", None) if self.caller else None,
             )
 
             # Store agent reference
@@ -292,6 +311,11 @@ class AgentTool(BaseTool):
             # Get agent recap
             result = await agent.recap_agent_outcome()
 
+            # SubagentStop hooks: let the parent observe completion and augment the
+            # result the parent sees. (Forcing the sub-agent to resume on a blocked
+            # SubagentStop is deferred; the per-agent Stop hook covers keep-working.)
+            result = await self._apply_subagent_stop_hooks(agent_name, result, sub_agent_info)
+
             # Update conversation with completion status
             if conversation_id:
                 execution_time = time.time() - start_time
@@ -312,9 +336,7 @@ class AgentTool(BaseTool):
                 conversation_finished = True
 
             # Send completion status
-            await self._send_status_event(
-                "STOPPED", f"Completed {agent_name} task", sub_agent_info=sub_agent_info
-            )
+            await self._send_status_event("STOPPED", f"Completed {agent_name} task", sub_agent_info=sub_agent_info)
 
             return result
 

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -86,6 +86,7 @@ from .provider_registry import (
     ui_provider_options,
     ui_thinking_effort_options,
 )
+from kolega_code.hooks import HookDispatcher, HookEvent, load_hook_config, project_hooks_present
 from .session_store import SessionRecord, SessionStore
 from .settings import CliSettings, SettingsStore
 from .slash_commands import (
@@ -448,7 +449,9 @@ class ChatComposer(TextArea):
     BINDINGS = [
         *TextArea.BINDINGS,
         Binding("enter", "submit", "Send", priority=True),
-        Binding("shift+enter,ctrl+enter,ctrl+j", "insert_newline", "New line", key_display="Shift+Enter", priority=True),
+        Binding(
+            "shift+enter,ctrl+enter,ctrl+j", "insert_newline", "New line", key_display="Shift+Enter", priority=True
+        ),
         Binding("up", "mention_prev", "Previous match", show=False, priority=True),
         Binding("down", "mention_next", "Next match", show=False, priority=True),
         Binding("tab", "mention_accept", "Complete path", show=False, priority=True),
@@ -741,7 +744,9 @@ class KolegaCodeApp(App):
     """
 
     BINDINGS = [
-        Binding("shift+tab", "toggle_interaction_mode", "Plan/Build", show=True, key_display="Shift+Tab", priority=True),
+        Binding(
+            "shift+tab", "toggle_interaction_mode", "Plan/Build", show=True, key_display="Shift+Tab", priority=True
+        ),
         Binding("ctrl+p", "toggle_permission_mode", "Permissions", show=True, key_display="Ctrl+P", priority=True),
         Binding("ctrl+o", "toggle_sidebar", "Sidebar", show=True, key_display="Ctrl+O", priority=True),
         Binding("ctrl+c", "cancel_generation", "Cancel", show=True),
@@ -785,6 +790,8 @@ class KolegaCodeApp(App):
         self.sidebar_visible = True
         self.check_for_updates = check_for_updates
         self.connection_manager = CliConnectionManager()
+        self._hook_dispatcher: Optional[HookDispatcher] = None
+        self._session_started = False
         self.agent: Optional[CoderAgent | PlanningAgent] = None
         self.agent_worker = None
         self.conversation_entries: list[ConversationEntry] = []
@@ -1392,6 +1399,12 @@ class KolegaCodeApp(App):
 
     async def action_quit(self) -> None:
         if self.agent is not None:
+            fire = getattr(self.agent, "fire_hook", None)
+            if fire is not None:
+                try:
+                    await fire(HookEvent.SESSION_END, {"reason": "quit"})
+                except Exception:
+                    pass
             self.session.history = self.agent.dump_message_history()
             self._save_session()
             await self.agent.cleanup()
@@ -1414,14 +1427,18 @@ class KolegaCodeApp(App):
 
     def _populate_settings_controls(self) -> None:
         provider_values = {value for _, value in ui_provider_options()}
-        provider = self.settings.active_provider if self.settings.active_provider in provider_values else UI_DEFAULT_PROVIDER
+        provider = (
+            self.settings.active_provider if self.settings.active_provider in provider_values else UI_DEFAULT_PROVIDER
+        )
         model_options = ui_model_options(provider)
         valid_models = {value for _, value in model_options}
         model = self.settings.active_model if self.settings.active_model in valid_models else None
         if model is None:
             model = model_options[0][1] if model_options else UI_DEFAULT_MODEL
         effort_options = {value for _, value in ui_thinking_effort_options(provider, model)}
-        effort = self.settings.active_thinking_effort if self.settings.active_thinking_effort in effort_options else None
+        effort = (
+            self.settings.active_thinking_effort if self.settings.active_thinking_effort in effort_options else None
+        )
         if effort is None:
             effort = default_ui_thinking_effort(provider, model)
         provider_select = self.query_one("#provider_select", Select)
@@ -1533,11 +1550,45 @@ class KolegaCodeApp(App):
             tool_extensions=tool_extensions,
             permission_mode=self.permission_mode,
             permission_callback=self._permission_callback,
+            hook_dispatcher=self._session_hook_dispatcher(),
         )
         if history:
             self.agent.restore_message_history(history)
             self._restore_conversation_history(history)
         self._update_mode_chrome()
+        await self._fire_session_start_once()
+
+    def _session_hook_dispatcher(self) -> HookDispatcher:
+        """Build (once) the hook dispatcher for this session from global + project config."""
+        if self._hook_dispatcher is None:
+            trusted = self.settings.is_hook_project_trusted(self.project_path)
+            config = load_hook_config(self.project_path, self.settings_store.root, project_trusted=trusted)
+            self._hook_dispatcher = HookDispatcher(config)
+            self._announce_hook_status(config)
+        return self._hook_dispatcher
+
+    def _announce_hook_status(self, config) -> None:
+        """Surface hook diagnostics and an untrusted-project notice once at startup."""
+        for diagnostic in config.diagnostics:
+            self._log_status(f"hooks: {diagnostic}", level="warn")
+        if project_hooks_present(self.project_path) and not self.settings.is_hook_project_trusted(self.project_path):
+            self._notify_user(
+                "This project defines hooks in .kolega/hooks.json, but they are not trusted, so they "
+                "are disabled. Global hooks still run. Re-launch with `--trust-hooks` to enable them.",
+                severity="warning",
+                title="Untrusted project hooks",
+            )
+
+    async def _fire_session_start_once(self) -> None:
+        if self._session_started or self.agent is None:
+            return
+        fire = getattr(self.agent, "fire_hook", None)
+        if fire is None:
+            return
+        self._session_started = True
+        outcome = await fire(HookEvent.SESSION_START, {"source": "startup"})
+        if outcome.additional_context:
+            self._add_conversation_entry(ConversationEntry(kind="system", content=outcome.additional_context))
 
     async def _set_interaction_mode(self, interaction_mode: str) -> None:
         if interaction_mode not in {BUILD_INTERACTION_MODE, PLAN_INTERACTION_MODE}:
@@ -1611,7 +1662,9 @@ class KolegaCodeApp(App):
 
         prompt = build_implement_plan_prompt(plan)
         self._add_conversation_entry(ConversationEntry(kind="user", content="Implement the approved plan."))
-        self.agent_worker = self.run_worker(self._process_message(prompt), name="kolega-turn", group="turns", exclusive=True)
+        self.agent_worker = self.run_worker(
+            self._process_message(prompt), name="kolega-turn", group="turns", exclusive=True
+        )
 
     def _discuss_pending_plan(self) -> None:
         if not self._latest_plan:
@@ -2066,9 +2119,7 @@ class KolegaCodeApp(App):
         update_message = update_status_message(result, include_up_to_date=True, include_errors=True)
         if update_message:
             lines.append(update_message)
-        self._add_conversation_entry(
-            ConversationEntry(kind="system", content="\n".join(lines))
-        )
+        self._add_conversation_entry(ConversationEntry(kind="system", content="\n".join(lines)))
 
     async def _command_update(self, args: str) -> None:
         if self._turn_active or self.agent_worker is not None:
@@ -2273,9 +2324,7 @@ class KolegaCodeApp(App):
             tool_groups={"planning_tools": [QUESTION_TOOL_NAME]},
         )
 
-    def _normalize_choice_questions(
-        self, questions: object
-    ) -> list[tuple[str, str, list[str], list[str]]]:
+    def _normalize_choice_questions(self, questions: object) -> list[tuple[str, str, list[str], list[str]]]:
         """Validate the structured questions input and return normalized questions.
 
         Strict: rejects malformed input with an instructive ToolError instead of coercing.
@@ -2477,9 +2526,7 @@ class KolegaCodeApp(App):
             self._restore_composer_placeholder()
             self._set_chat_enabled(self.agent is not None)
 
-    def _format_permission_content(
-        self, request: PermissionRequest, rule_options: list[PermissionRuleOption]
-    ) -> str:
+    def _format_permission_content(self, request: PermissionRequest, rule_options: list[PermissionRuleOption]) -> str:
         if request.kind.value == "command":
             lines = [
                 "Allow the agent to run this command?",
@@ -2537,10 +2584,7 @@ class KolegaCodeApp(App):
                     ],
                 ]
                 approval_actions.show_options(
-                    [
-                        Option(label, id=f"{APPROVAL_OPTION_ID_PREFIX}{index}")
-                        for index, label in enumerate(labels)
-                    ]
+                    [Option(label, id=f"{APPROVAL_OPTION_ID_PREFIX}{index}") for index, label in enumerate(labels)]
                 )
             else:
                 approval_actions.hide()
@@ -2880,7 +2924,9 @@ class KolegaCodeApp(App):
         self._turn_final_text = ""
         self._turn_final_state = TurnState.IDLE
         self._spinner_frame = 0
-        self._turn_timer = self.set_interval(theme.SPINNER_INTERVAL, self._refresh_turn_status_strip, name="turn-status")
+        self._turn_timer = self.set_interval(
+            theme.SPINNER_INTERVAL, self._refresh_turn_status_strip, name="turn-status"
+        )
         self._refresh_turn_status_strip()
 
     def _complete_turn_timer(self, content: str, state: TurnState = TurnState.IDLE) -> None:
@@ -3046,9 +3092,7 @@ class KolegaCodeApp(App):
         if isinstance(content, str):
             return content
         if isinstance(content, list):
-            return "\n\n".join(
-                item.to_markdown() if hasattr(item, "to_markdown") else str(item) for item in content
-            )
+            return "\n\n".join(item.to_markdown() if hasattr(item, "to_markdown") else str(item) for item in content)
         return str(content)
 
     def _apply_stream_chunk(self, chunk: dict, *, kind: str) -> None:
@@ -3234,12 +3278,7 @@ class KolegaCodeApp(App):
 
     def _sub_agent_key(self, event: AgentEvent) -> str:
         info = event.sub_agent_info or {}
-        return str(
-            info.get("agent_id")
-            or info.get("parent_tool_call_id")
-            or info.get("agent_name")
-            or event.sender
-        )
+        return str(info.get("agent_id") or info.get("parent_tool_call_id") or info.get("agent_name") or event.sender)
 
     def _ensure_sub_agent_activity(self, event: AgentEvent) -> SubAgentActivity:
         key = self._sub_agent_key(event)
@@ -3404,7 +3443,7 @@ class KolegaCodeApp(App):
     def _capped_tool_text(self, text: str) -> str:
         if len(text) <= theme.TOOL_FULL_CONTENT_CAP_CHARS:
             return text
-        return f"{text[:theme.TOOL_FULL_CONTENT_CAP_CHARS]}{theme.g(Glyph.ELLIPSIS)}"
+        return f"{text[: theme.TOOL_FULL_CONTENT_CAP_CHARS]}{theme.g(Glyph.ELLIPSIS)}"
 
     def _tool_stream_preview(self, text: str) -> str:
         if len(text) <= TOOL_STREAM_PREVIEW_CHARS:
@@ -3459,7 +3498,7 @@ class KolegaCodeApp(App):
                 widget.refresh_content()
         self._dirty_entry_ids.clear()
 
-        new_entries = self.conversation_entries[len(rendered_ids):]
+        new_entries = self.conversation_entries[len(rendered_ids) :]
         if new_entries:
             widgets = []
             for entry in new_entries:
@@ -3525,7 +3564,9 @@ class KolegaCodeApp(App):
                 return self._markdown_entry(header, entry.content)
             return f"{header}\n{self._format_inset_content(entry.content)}"
         if entry.kind == "thinking":
-            header = theme.role_header(Glyph.STATUS, "Thinking", Color.THINKING, label_style="dim italic", state=streaming)
+            header = theme.role_header(
+                Glyph.STATUS, "Thinking", Color.THINKING, label_style="dim italic", state=streaming
+            )
             return f"{header}\n{self._format_inset_content(entry.content, style='italic dim')}"
         if entry.kind == "progress":
             color = Color.ERROR if entry.tone == "error" else Color.WARNING

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Iterable, Optional
 
 from kolega_code.agent import CoderAgent
+from kolega_code.hooks import HookDispatcher, HookEvent, load_hook_config
 from kolega_code.llm.exceptions import LLMBillingError, billing_error_message
 from kolega_code.llm.models import TextBlock
 from kolega_code.agent.prompt_provider import AgentMode
@@ -135,7 +136,9 @@ def _build_tui_parser() -> argparse.ArgumentParser:
     parser.set_defaults(command="tui")
     parser.add_argument("--version", action="store_true", help="Show the Kolega Code version.")
     parser.add_argument("project_path", nargs="?", default=".", type=Path, help="Project directory to work in.")
-    parser.add_argument("--mode", choices=[mode.value for mode in AgentMode], default=CLI_AGENT_MODE, help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--mode", choices=[mode.value for mode in AgentMode], default=CLI_AGENT_MODE, help=argparse.SUPPRESS
+    )
     parser.add_argument("--new", action="store_true", help="Start a new session. This is now the default.")
     parser.add_argument(
         "--resume",
@@ -150,6 +153,11 @@ def _build_tui_parser() -> argparse.ArgumentParser:
         choices=[mode.value for mode in PermissionMode],
         help="How to handle shell command and file edit permissions.",
     )
+    parser.add_argument(
+        "--trust-hooks",
+        action="store_true",
+        help="Trust and enable this project's .kolega/hooks.json (persisted for future runs).",
+    )
     _add_session_args(parser, session_help="Legacy alias for --resume THREAD_ID.")
     _add_common_model_args(parser)
     return parser
@@ -162,7 +170,9 @@ def _build_subcommand_parser() -> argparse.ArgumentParser:
     ask = subparsers.add_parser("ask", help="Run a single prompt and print the answer.")
     ask.add_argument("prompt", help="Prompt to send to Kolega Code.")
     ask.add_argument("--project", default=".", type=Path, help="Project directory to work in.")
-    ask.add_argument("--mode", choices=[mode.value for mode in AgentMode], default=CLI_AGENT_MODE, help=argparse.SUPPRESS)
+    ask.add_argument(
+        "--mode", choices=[mode.value for mode in AgentMode], default=CLI_AGENT_MODE, help=argparse.SUPPRESS
+    )
     ask.add_argument("--save", action="store_true", help="Persist the session after the prompt completes.")
     ask.add_argument("--json", action="store_true", help="Emit response chunks and events as JSON.")
     ask.add_argument("--browser-visible", action="store_true", help="Launch visible Playwright browser windows.")
@@ -171,6 +181,11 @@ def _build_subcommand_parser() -> argparse.ArgumentParser:
         choices=[mode.value for mode in PermissionMode],
         default=ASK_DEFAULT_PERMISSION_MODE,
         help="How to handle shell command and file edit permissions.",
+    )
+    ask.add_argument(
+        "--trust-hooks",
+        action="store_true",
+        help="Trust and enable this project's .kolega/hooks.json (persisted for future runs).",
     )
     _add_session_args(ask)
     _add_common_model_args(ask)
@@ -325,6 +340,9 @@ def _run_tui(args: argparse.Namespace) -> int:
     store = _store_from_args(args)
     settings_store = _settings_store_from_args(args)
     settings = settings_store.load()
+    if getattr(args, "trust_hooks", False):
+        settings.trust_hook_project(project_path)
+        settings_store.save(settings)
     summary = {}
     try:
         config = build_agent_config(project_path, _overrides_from_args(args), settings=settings)
@@ -460,8 +478,19 @@ async def _run_ask(args: argparse.Namespace) -> int:
     store = _store_from_args(args)
     settings_store = _settings_store_from_args(args)
     settings = settings_store.load()
+    if getattr(args, "trust_hooks", False):
+        settings.trust_hook_project(project_path)
+        settings_store.save(settings)
     config = build_agent_config(project_path, _overrides_from_args(args), settings=settings)
     summary = config_summary(config)
+
+    hook_config = load_hook_config(
+        project_path, settings_store.root, project_trusted=settings.is_hook_project_trusted(project_path)
+    )
+    hook_dispatcher = HookDispatcher(hook_config)
+    if not args.json:
+        for diagnostic in hook_config.diagnostics:
+            print(f"hooks: {diagnostic}", file=sys.stderr)
 
     if args.session:
         session = _get_or_create_session(store, project_path, CLI_AGENT_MODE, summary, args.session, force_new=False)
@@ -504,10 +533,17 @@ async def _run_ask(args: argparse.Namespace) -> int:
         permission_callback=_permission_callback_for_ask(project_path)
         if permission_mode == PermissionMode.ASK
         else None,
+        hook_dispatcher=hook_dispatcher,
     )
     agent_ref["agent"] = agent
     if session.history:
         agent.restore_message_history(session.history)
+
+    fire_hook = getattr(agent, "fire_hook", None)
+    if fire_hook is not None:
+        session_start = await fire_hook(HookEvent.SESSION_START, {"source": "startup"})
+        if session_start.additional_context:
+            agent.append_user_message([TextBlock(text=session_start.additional_context)])
 
     prompt = args.prompt
     if skill_command:
@@ -552,7 +588,9 @@ async def _run_ask(args: argparse.Namespace) -> int:
     # reported in real time instead of all at once after streaming finishes.
     pump_task = asyncio.create_task(_pump_ask_events(manager, args.json))
     try:
-        stream = agent.process_message_stream(prompt, attachments) if attachments else agent.process_message_stream(prompt)
+        stream = (
+            agent.process_message_stream(prompt, attachments) if attachments else agent.process_message_stream(prompt)
+        )
         async for chunk in stream:
             response_chunks.append(chunk)
             if args.json:
@@ -581,6 +619,12 @@ async def _run_ask(args: argparse.Namespace) -> int:
         while not manager.events.empty():
             event = manager.events.get_nowait()
             _print_ask_event(event, args.json)
+        end_fire_hook = getattr(agent, "fire_hook", None)
+        if end_fire_hook is not None:
+            try:
+                await end_fire_hook(HookEvent.SESSION_END, {"reason": "ask_complete"})
+            except Exception:
+                pass
         await agent.cleanup()
 
     if exit_code:

--- a/kolega_code/cli/settings.py
+++ b/kolega_code/cli/settings.py
@@ -23,6 +23,8 @@ class CliSettings:
     active_model: Optional[str] = None
     active_thinking_effort: Optional[str] = None
     api_keys: dict[str, str] = field(default_factory=dict)
+    # Resolved project paths whose .kolega/hooks.json the user has opted to trust.
+    trusted_hook_projects: list[str] = field(default_factory=list)
     schema_version: int = SETTINGS_SCHEMA_VERSION
 
     @classmethod
@@ -31,12 +33,16 @@ class CliSettings:
         if schema_version not in {1, SETTINGS_SCHEMA_VERSION}:
             raise SettingsStoreError(f"Unsupported settings schema version: {data.get('schema_version')}")
         api_keys = data.get("api_keys") or {}
+        trusted = data.get("trusted_hook_projects") or []
         return cls(
             schema_version=SETTINGS_SCHEMA_VERSION,
             active_provider=data.get("active_provider"),
             active_model=data.get("active_model"),
-            active_thinking_effort=data.get("active_thinking_effort") if schema_version == SETTINGS_SCHEMA_VERSION else None,
+            active_thinking_effort=data.get("active_thinking_effort")
+            if schema_version == SETTINGS_SCHEMA_VERSION
+            else None,
             api_keys={str(provider): str(key) for provider, key in api_keys.items() if key},
+            trusted_hook_projects=[str(path) for path in trusted if path],
         )
 
     def to_dict(self) -> dict:
@@ -46,6 +52,7 @@ class CliSettings:
             "active_model": self.active_model,
             "active_thinking_effort": self.active_thinking_effort,
             "api_keys": self.api_keys,
+            "trusted_hook_projects": self.trusted_hook_projects,
         }
 
     def get_api_key(self, provider: str) -> Optional[str]:
@@ -57,6 +64,14 @@ class CliSettings:
 
     def has_api_key(self, provider: str) -> bool:
         return bool(self.get_api_key(provider))
+
+    def is_hook_project_trusted(self, project_path) -> bool:
+        return str(Path(project_path).resolve()) in self.trusted_hook_projects
+
+    def trust_hook_project(self, project_path) -> None:
+        resolved = str(Path(project_path).resolve())
+        if resolved not in self.trusted_hook_projects:
+            self.trusted_hook_projects.append(resolved)
 
 
 class SettingsStore:

--- a/kolega_code/hooks/__init__.py
+++ b/kolega_code/hooks/__init__.py
@@ -1,0 +1,60 @@
+"""Lifecycle events and hooks for kolega-code.
+
+A hook runs a user-configured handler (shell command, in-process Python callable,
+or an LLM prompt/agent) when a lifecycle event fires — to observe, block, or
+modify the agent's behavior. See ``kolega_code/hooks/config.py`` for the on-disk
+schema and ``dispatcher.py`` for how events are fired.
+
+This is separate from ``kolega_code.events`` (the UI broadcast bus); the two never
+share types.
+"""
+
+from __future__ import annotations
+
+from .backends import AgentRunner, HookCapabilities, HookExecutionError, PromptRunner, run_hook
+from .config import (
+    GLOBAL_HOOKS_FILENAME,
+    HOOKS_RELATIVE_PATH,
+    HOOKS_SCHEMA_VERSION,
+    HookConfig,
+    HookConfigError,
+    HookSpec,
+    load_hook_config,
+    project_hooks_present,
+)
+from .dispatcher import NO_OP_DISPATCHER, HookDispatcher
+from .events import (
+    BLOCKING_EVENTS,
+    TOOL_EVENTS,
+    HookEvent,
+    LifecycleEvent,
+    in_hook,
+)
+from .matcher import HookMatcher
+from .outcome import HookOutcome, merge
+
+__all__ = [
+    "AgentRunner",
+    "BLOCKING_EVENTS",
+    "GLOBAL_HOOKS_FILENAME",
+    "HOOKS_RELATIVE_PATH",
+    "HOOKS_SCHEMA_VERSION",
+    "HookCapabilities",
+    "HookConfig",
+    "HookConfigError",
+    "HookDispatcher",
+    "HookEvent",
+    "HookExecutionError",
+    "HookMatcher",
+    "HookOutcome",
+    "HookSpec",
+    "LifecycleEvent",
+    "NO_OP_DISPATCHER",
+    "PromptRunner",
+    "TOOL_EVENTS",
+    "in_hook",
+    "load_hook_config",
+    "merge",
+    "project_hooks_present",
+    "run_hook",
+]

--- a/kolega_code/hooks/backends.py
+++ b/kolega_code/hooks/backends.py
@@ -1,0 +1,218 @@
+"""Hook execution backends: command (subprocess), python (in-process), and LLM.
+
+Each backend takes a ``LifecycleEvent``, a ``HookSpec`` and a ``HookCapabilities``
+bundle and returns a ``HookOutcome``. Backends raise ``HookExecutionError`` for
+operational failures (timeout, bad exit code, unparseable LLM reply); the
+dispatcher logs those and treats them as non-blocking (fail-open).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import inspect
+import json
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Optional
+
+from .config import HookSpec
+from .events import LifecycleEvent
+from .outcome import HookOutcome
+
+# (prompt_text, model_hint) -> model response text
+PromptRunner = Callable[[str, Optional[str]], Awaitable[str]]
+# (task_text) -> sub-agent final report text
+AgentRunner = Callable[[str], Awaitable[str]]
+# (message) -> None, for surfacing hook errors/diagnostics to the user/logs
+LogFn = Callable[[str], Awaitable[None]]
+
+
+class HookExecutionError(RuntimeError):
+    """A hook failed to run (non-blocking; the action proceeds)."""
+
+
+@dataclass
+class HookCapabilities:
+    """Host-provided capabilities a hook backend may need.
+
+    ``command``/``python`` hooks need none of these. ``prompt`` needs
+    ``prompt_runner``; ``agent`` needs ``agent_runner``. When a required
+    capability is absent the LLM hook fails open with a logged error.
+    """
+
+    project_path: Optional[Path] = None
+    prompt_runner: Optional[PromptRunner] = None
+    agent_runner: Optional[AgentRunner] = None
+    log: Optional[LogFn] = None
+
+
+async def run_hook(event: LifecycleEvent, spec: HookSpec, caps: HookCapabilities) -> HookOutcome:
+    """Dispatch to the backend for ``spec.type`` and return its outcome."""
+    if spec.type == "command":
+        return await _run_command(event, spec, caps)
+    if spec.type == "python":
+        return await _run_python(event, spec, caps)
+    return await _run_llm(event, spec, caps)
+
+
+# --------------------------------------------------------------------------- #
+# command
+# --------------------------------------------------------------------------- #
+
+
+async def _run_command(event: LifecycleEvent, spec: HookSpec, caps: HookCapabilities) -> HookOutcome:
+    if not spec.command:
+        raise HookExecutionError("command hook has no command")
+
+    payload = json.dumps(event.to_hook_input()).encode("utf-8")
+    proc = await asyncio.create_subprocess_exec(
+        *shlex.split(spec.command),
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=str(caps.project_path) if caps.project_path else None,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(payload), timeout=spec.timeout)
+    except asyncio.TimeoutError as exc:
+        proc.kill()
+        await proc.wait()
+        raise HookExecutionError(f"command hook timed out after {spec.timeout}s") from exc
+
+    code = proc.returncode
+    if code == 0:
+        return _parse_command_stdout(stdout.decode("utf-8", "replace"))
+    if code == 2:
+        reason = stderr.decode("utf-8", "replace").strip() or "Hook blocked the action."
+        return HookOutcome.deny(reason)
+    detail = stderr.decode("utf-8", "replace").strip()
+    raise HookExecutionError(f"command hook exited {code}: {detail}")
+
+
+def _parse_command_stdout(text: str) -> HookOutcome:
+    text = text.strip()
+    if not text:
+        return HookOutcome.empty()
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return HookOutcome.empty()
+    if not isinstance(data, dict):
+        return HookOutcome.empty()
+
+    hso = data.get("hookSpecificOutput") or {}
+    if not isinstance(hso, dict):
+        hso = {}
+    decision = str(hso.get("permissionDecision") or "").lower()
+    updated_input = hso.get("updatedInput")
+    blocked = decision == "deny"
+    return HookOutcome(
+        blocked=blocked,
+        reason=str(hso.get("permissionDecisionReason") or data.get("systemMessage") or "") if blocked else "",
+        updated_input=updated_input if isinstance(updated_input, dict) else None,
+        updated_output=_as_text(hso.get("updatedToolOutput")),
+        additional_context=_as_text(hso.get("additionalContext")),
+        end_turn=data.get("continue") is False or blocked,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# python
+# --------------------------------------------------------------------------- #
+
+
+async def _run_python(event: LifecycleEvent, spec: HookSpec, caps: HookCapabilities) -> HookOutcome:
+    target = spec.callable or ""
+    module_name, sep, attr = target.partition(":")
+    if not module_name or not sep or not attr:
+        raise HookExecutionError(f"invalid python callable {target!r} (expected 'module.path:function')")
+
+    try:
+        module = importlib.import_module(module_name)
+        func = getattr(module, attr)
+    except (ImportError, AttributeError) as exc:
+        raise HookExecutionError(f"could not import python hook {target!r}: {exc}") from exc
+
+    result = func(event)
+    if inspect.isawaitable(result):
+        result = await asyncio.wait_for(result, timeout=spec.timeout)
+    return _coerce_outcome(result)
+
+
+def _coerce_outcome(result: Any) -> HookOutcome:
+    if isinstance(result, HookOutcome):
+        return result
+    if result is None:
+        return HookOutcome.empty()
+    if isinstance(result, dict):
+        return HookOutcome(
+            blocked=bool(result.get("blocked")),
+            reason=str(result.get("reason") or ""),
+            updated_input=result.get("updated_input") if isinstance(result.get("updated_input"), dict) else None,
+            updated_output=_as_text(result.get("updated_output")),
+            additional_context=_as_text(result.get("additional_context")),
+            end_turn=bool(result.get("end_turn")) or bool(result.get("blocked")),
+        )
+    raise HookExecutionError(f"python hook returned unsupported type {type(result).__name__}")
+
+
+# --------------------------------------------------------------------------- #
+# LLM (prompt + agent), using the {"ok": bool, "reason": str} protocol
+# --------------------------------------------------------------------------- #
+
+
+async def _run_llm(event: LifecycleEvent, spec: HookSpec, caps: HookCapabilities) -> HookOutcome:
+    rendered = _render_prompt(spec.prompt or "", event)
+    if spec.type == "prompt":
+        if caps.prompt_runner is None:
+            raise HookExecutionError("prompt hook unavailable: no LLM runner in this host")
+        text = await asyncio.wait_for(caps.prompt_runner(rendered, spec.model), timeout=spec.timeout)
+    else:  # agent
+        if caps.agent_runner is None:
+            raise HookExecutionError("agent hook unavailable: no agent runner in this host")
+        text = await asyncio.wait_for(caps.agent_runner(rendered), timeout=spec.timeout)
+    return _parse_ok_reason(text)
+
+
+def _render_prompt(template: str, event: LifecycleEvent) -> str:
+    payload = json.dumps(event.to_hook_input(), indent=2)
+    if "$EVENT" in template or "$ARGUMENTS" in template:
+        return template.replace("$EVENT", payload).replace("$ARGUMENTS", payload)
+    return f"{template}\n\nEvent data:\n{payload}"
+
+
+def _parse_ok_reason(text: str) -> HookOutcome:
+    data = _extract_json_object(text)
+    if not isinstance(data, dict) or "ok" not in data:
+        raise HookExecutionError(f"LLM hook did not return an {{ok, reason}} object: {text[:200]!r}")
+    if data.get("ok"):
+        return HookOutcome.empty()
+    return HookOutcome.deny(str(data.get("reason") or "Hook blocked the action."))
+
+
+def _extract_json_object(text: str) -> Any:
+    text = (text or "").strip()
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+    # Tolerate prose around the JSON: grab the first balanced {...} block.
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end > start:
+        try:
+            return json.loads(text[start : end + 1])
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+def _as_text(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value)
+    return text or None

--- a/kolega_code/hooks/config.py
+++ b/kolega_code/hooks/config.py
@@ -1,0 +1,203 @@
+"""Hook configuration: the on-disk schema, parsing, scope merging, and trust gate.
+
+Config lives in two JSON files, both ``{"schema_version": 1, "hooks": {...}}``:
+- global / user scope: ``<state_dir>/hooks.json`` (always trusted)
+- project scope: ``<project>/.kolega/hooks.json`` (loaded only when the project is trusted)
+
+The ``hooks`` map is ``{EventName: [{"matcher": "...", "hooks": [<spec>, ...]}]}``.
+Lists concatenate across scopes (global first, project last), matching Claude Code.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+from .events import TOOL_EVENTS, HookEvent
+from .matcher import HookMatcher
+
+HOOKS_SCHEMA_VERSION = 1
+HOOKS_RELATIVE_PATH = Path(".kolega") / "hooks.json"
+GLOBAL_HOOKS_FILENAME = "hooks.json"
+
+VALID_TYPES = frozenset({"command", "python", "prompt", "agent"})
+DEFAULT_TIMEOUTS = {"command": 60, "python": 30, "prompt": 30, "agent": 60}
+# Required field for each hook type.
+REQUIRED_FIELD = {"command": "command", "python": "callable", "prompt": "prompt", "agent": "prompt"}
+
+
+class HookConfigError(RuntimeError):
+    """Raised when a hooks file cannot be loaded or is malformed."""
+
+
+def _opt_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+@dataclass(frozen=True)
+class HookSpec:
+    """One configured hook handler."""
+
+    type: str
+    timeout: int
+    scope: str
+    command: Optional[str] = None
+    callable: Optional[str] = None
+    prompt: Optional[str] = None
+    model: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Any, *, scope: str) -> "HookSpec":
+        if not isinstance(data, dict):
+            raise HookConfigError("hook entry must be an object")
+
+        htype = str(data.get("type") or "").strip()
+        if htype not in VALID_TYPES:
+            raise HookConfigError(f"unknown hook type {data.get('type')!r} (expected one of {sorted(VALID_TYPES)})")
+
+        spec = cls(
+            type=htype,
+            timeout=int(data.get("timeout") or DEFAULT_TIMEOUTS[htype]),
+            scope=scope,
+            command=_opt_str(data.get("command")),
+            callable=_opt_str(data.get("callable")),
+            prompt=_opt_str(data.get("prompt")),
+            model=_opt_str(data.get("model")),
+        )
+
+        required = REQUIRED_FIELD[htype]
+        if getattr(spec, required) is None:
+            raise HookConfigError(f"{htype} hook requires a '{required}' field")
+        return spec
+
+
+@dataclass
+class HookConfig:
+    """Parsed, merged hook configuration plus any load-time diagnostics."""
+
+    entries: dict[HookEvent, list[tuple[HookMatcher, list[HookSpec]]]] = field(default_factory=dict)
+    diagnostics: list[str] = field(default_factory=list)
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.entries
+
+    def specs_for(self, event: HookEvent, target: str = "") -> list[HookSpec]:
+        """All hook specs whose matcher applies to ``target`` for ``event``."""
+        matched: list[HookSpec] = []
+        for matcher, specs in self.entries.get(event, []):
+            if matcher.matches(target):
+                matched.extend(specs)
+        return matched
+
+
+def project_hooks_present(project_path: Path | str) -> bool:
+    """True when the project defines a hooks file (used to decide whether to prompt for trust)."""
+    return (Path(project_path) / HOOKS_RELATIVE_PATH).exists()
+
+
+def _read_hooks_file(path: Path) -> Optional[dict[str, Any]]:
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise HookConfigError(f"could not read hooks file: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise HookConfigError(f"hooks file is not valid JSON: {path}") from exc
+
+    if not isinstance(data, dict):
+        raise HookConfigError(f"hooks file must be a JSON object: {path}")
+    version = data.get("schema_version")
+    if version != HOOKS_SCHEMA_VERSION:
+        raise HookConfigError(f"unsupported hooks schema version {version!r} in {path}")
+    return data
+
+
+def _parse_scope(
+    blob: dict[str, Any],
+    *,
+    scope: str,
+    diagnostics: list[str],
+) -> dict[HookEvent, list[tuple[HookMatcher, list[HookSpec]]]]:
+    parsed: dict[HookEvent, list[tuple[HookMatcher, list[HookSpec]]]] = {}
+    hooks_map = blob.get("hooks") or {}
+    if not isinstance(hooks_map, dict):
+        diagnostics.append(f"[{scope}] 'hooks' must be an object — ignored")
+        return parsed
+
+    for event_name, raw_entries in hooks_map.items():
+        try:
+            event = HookEvent(event_name)
+        except ValueError:
+            diagnostics.append(f"[{scope}] unknown event '{event_name}' — ignored")
+            continue
+
+        for entry in raw_entries or []:
+            if not isinstance(entry, dict):
+                diagnostics.append(f"[{scope}] {event_name}: entry must be an object — ignored")
+                continue
+            matcher = HookMatcher(entry.get("matcher"))
+            specs: list[HookSpec] = []
+            for raw_spec in entry.get("hooks") or []:
+                try:
+                    spec = HookSpec.from_dict(raw_spec, scope=scope)
+                except HookConfigError as exc:
+                    diagnostics.append(f"[{scope}] {event_name}: {exc} — skipped")
+                    continue
+                if spec.type == "agent" and event in TOOL_EVENTS:
+                    diagnostics.append(
+                        f"[{scope}] {event_name}: 'agent' hooks are not allowed on tool events "
+                        "(recursion risk) — skipped"
+                    )
+                    continue
+                specs.append(spec)
+            if specs:
+                parsed.setdefault(event, []).append((matcher, specs))
+    return parsed
+
+
+def load_hook_config(
+    project_path: Path | str,
+    state_dir: Path | str | None,
+    *,
+    project_trusted: bool = False,
+) -> HookConfig:
+    """Load and merge global + project hook configuration.
+
+    Global/user hooks are always loaded. Project hooks are loaded only when
+    ``project_trusted`` is True; otherwise their presence is reported as a
+    diagnostic so the host can offer to trust the project.
+    """
+    diagnostics: list[str] = []
+    merged: dict[HookEvent, list[tuple[HookMatcher, list[HookSpec]]]] = {}
+
+    def absorb(blob: Optional[dict[str, Any]], scope: str) -> None:
+        if not blob:
+            return
+        for event, entries in _parse_scope(blob, scope=scope, diagnostics=diagnostics).items():
+            merged.setdefault(event, []).extend(entries)
+
+    if state_dir is not None:
+        global_path = Path(state_dir).expanduser() / GLOBAL_HOOKS_FILENAME
+        try:
+            absorb(_read_hooks_file(global_path), "global")
+        except HookConfigError as exc:
+            diagnostics.append(str(exc))
+
+    project_file = Path(project_path) / HOOKS_RELATIVE_PATH
+    if project_file.exists():
+        if not project_trusted:
+            diagnostics.append(f"project hooks at {project_file} are disabled until this project is trusted")
+        else:
+            try:
+                absorb(_read_hooks_file(project_file), "project")
+            except HookConfigError as exc:
+                diagnostics.append(str(exc))
+
+    return HookConfig(entries=merged, diagnostics=diagnostics)

--- a/kolega_code/hooks/dispatcher.py
+++ b/kolega_code/hooks/dispatcher.py
@@ -1,0 +1,82 @@
+"""HookDispatcher: select matching hooks for an event, run them, merge outcomes.
+
+The dispatcher is stateless: every call is a pure function of its arguments and
+returns a fresh ``HookOutcome``. This is required for correctness — tool events
+fire concurrently for parallel-safe batches and recursively inside sub-agents, so
+the dispatcher must never stash per-call state on itself.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Optional
+
+from .backends import HookCapabilities, run_hook
+from .config import HookConfig
+from .events import TOOL_EVENTS, LifecycleEvent, enter_hook, exit_hook, in_hook
+from .outcome import HookOutcome, merge
+
+
+class HookDispatcher:
+    """Runs the hooks configured for a lifecycle event and folds their outcomes."""
+
+    def __init__(self, config: HookConfig) -> None:
+        self.config = config
+
+    @property
+    def is_active(self) -> bool:
+        return not self.config.is_empty
+
+    async def dispatch(
+        self,
+        event: LifecycleEvent,
+        *,
+        target: str = "",
+        caps: Optional[HookCapabilities] = None,
+    ) -> HookOutcome:
+        # Suppress re-entrant dispatch: a hook (e.g. an ``agent`` hook) may itself
+        # drive the agent / spawn a sub-agent, whose fire points must not recurse.
+        if in_hook():
+            return HookOutcome.empty()
+
+        specs = self.config.specs_for(event.name, target)
+        if not specs:
+            return HookOutcome.empty()
+
+        caps = caps or HookCapabilities()
+        token = enter_hook()
+        try:
+            current_input = event.payload.get("tool_input")
+            outcomes: list[HookOutcome] = []
+            for spec in specs:
+                fired = event
+                if event.name in TOOL_EVENTS and current_input is not None:
+                    fired = replace(event, payload={**event.payload, "tool_input": current_input})
+                try:
+                    outcome = await run_hook(fired, spec, caps)
+                except Exception as exc:  # noqa: BLE001 - hooks must never crash the turn
+                    await self._log(caps, f"hook error [{event.name.value}/{spec.type}]: {exc}")
+                    outcome = HookOutcome.empty()
+
+                outcomes.append(outcome)
+                if outcome.updated_input is not None:
+                    current_input = outcome.updated_input
+                if outcome.blocked:
+                    break  # first block wins; skip remaining hooks
+
+            return merge(outcomes)
+        finally:
+            exit_hook(token)
+
+    @staticmethod
+    async def _log(caps: HookCapabilities, message: str) -> None:
+        if caps.log is not None:
+            try:
+                await caps.log(message)
+            except Exception:  # noqa: BLE001 - logging must never crash the turn
+                pass
+
+
+# Default dispatcher used everywhere a host has not configured hooks. Its empty
+# config makes dispatch() return immediately, so existing callers/tests are unaffected.
+NO_OP_DISPATCHER = HookDispatcher(HookConfig())

--- a/kolega_code/hooks/events.py
+++ b/kolega_code/hooks/events.py
@@ -1,0 +1,90 @@
+"""Lifecycle events and the re-entrancy guard for the hooks system.
+
+This module is deliberately free of any dependency on the rest of kolega_code so
+the hooks package stays a self-contained, importable unit. The event model here
+(``LifecycleEvent``) is distinct from ``kolega_code.events.AgentEvent`` — the
+latter is the WebSocket/queue broadcast bus for UI messages, this is the
+agent-control hook system.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+
+class HookEvent(str, Enum):
+    """The lifecycle events a hook can be attached to (Claude-Code wire names)."""
+
+    SESSION_START = "SessionStart"
+    SESSION_END = "SessionEnd"
+    USER_PROMPT_SUBMIT = "UserPromptSubmit"
+    PRE_TOOL_USE = "PreToolUse"
+    POST_TOOL_USE = "PostToolUse"
+    STOP = "Stop"
+    SUBAGENT_STOP = "SubagentStop"
+    PRE_COMPACT = "PreCompact"
+    NOTIFICATION = "Notification"
+
+
+# Tool-scoped events: a tool-spawning ``agent`` hook is forbidden here because the
+# sub-agent it spawns would itself trigger these events (recursion + latency).
+TOOL_EVENTS = frozenset({HookEvent.PRE_TOOL_USE, HookEvent.POST_TOOL_USE})
+
+# Events whose hooks may alter control flow (deny/end-turn/keep-working) rather
+# than being purely advisory.
+BLOCKING_EVENTS = frozenset(
+    {
+        HookEvent.USER_PROMPT_SUBMIT,
+        HookEvent.PRE_TOOL_USE,
+        HookEvent.POST_TOOL_USE,
+        HookEvent.STOP,
+        HookEvent.SUBAGENT_STOP,
+    }
+)
+
+
+# Re-entrancy guard. While a hook runs (an ``agent`` hook can drive the agent and
+# spawn a sub-agent in the same asyncio task), nested fire points must NOT dispatch
+# again, or a tool-using hook would recurse forever. ContextVars propagate to
+# awaited sub-agents and to child tasks, so this suppresses the whole subtree.
+_in_hook: contextvars.ContextVar[bool] = contextvars.ContextVar("kolega_in_hook", default=False)
+
+
+def in_hook() -> bool:
+    """True when the current execution is already inside a hook dispatch."""
+    return _in_hook.get()
+
+
+def enter_hook() -> contextvars.Token:
+    """Mark the current context as inside a hook; returns a token for ``exit_hook``."""
+    return _in_hook.set(True)
+
+
+def exit_hook(token: contextvars.Token) -> None:
+    """Restore the re-entrancy flag set by ``enter_hook``."""
+    _in_hook.reset(token)
+
+
+@dataclass(frozen=True)
+class LifecycleEvent:
+    """A fired lifecycle event with its payload and ambient context."""
+
+    name: HookEvent
+    payload: dict[str, Any] = field(default_factory=dict)
+    session_id: Optional[str] = None
+    cwd: Optional[str] = None
+    permission_mode: Optional[str] = None
+
+    def to_hook_input(self) -> dict[str, Any]:
+        """The JSON document handed to a hook (stdin for command hooks, $EVENT for LLM hooks)."""
+        document: dict[str, Any] = {
+            "hook_event_name": self.name.value,
+            "session_id": self.session_id,
+            "cwd": self.cwd,
+            "permission_mode": self.permission_mode,
+        }
+        document.update(self.payload)
+        return document

--- a/kolega_code/hooks/matcher.py
+++ b/kolega_code/hooks/matcher.py
@@ -1,0 +1,37 @@
+"""HookMatcher: decide whether a hook entry applies to a tool name / source string.
+
+Mirrors the matching conventions used by permission rules and Claude Code:
+- ``""`` or ``"*"`` matches everything.
+- A pipe list of plain identifiers (``"Edit|Write"``) is an exact-name OR.
+- Anything else is treated as a regular expression (full match).
+"""
+
+from __future__ import annotations
+
+import re
+
+_SIMPLE_OR = re.compile(r"[A-Za-z0-9_|]+")
+
+
+class HookMatcher:
+    """Matches a hook entry's ``matcher`` against a target string."""
+
+    def __init__(self, pattern: str | None) -> None:
+        self.pattern = (pattern or "").strip()
+
+    def matches(self, target: str) -> bool:
+        pattern = self.pattern
+        if pattern in ("", "*"):
+            return True
+
+        target = target or ""
+        if _SIMPLE_OR.fullmatch(pattern):
+            return target in pattern.split("|")
+
+        try:
+            return re.fullmatch(pattern, target) is not None
+        except re.error:
+            return False
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"HookMatcher({self.pattern!r})"

--- a/kolega_code/hooks/outcome.py
+++ b/kolega_code/hooks/outcome.py
@@ -1,0 +1,81 @@
+"""HookOutcome: the normalized result every hook backend returns, plus merge()."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Optional
+
+
+@dataclass(frozen=True)
+class HookOutcome:
+    """What a hook decided. The same shape for command, python, and LLM backends.
+
+    - ``blocked``: the hook denied/stopped the action; ``reason`` explains why.
+    - ``updated_input``: replacement tool input (PreToolUse) applied before the call.
+    - ``updated_output``: replacement tool output (PostToolUse) fed to the model.
+    - ``additional_context``: extra text appended to the prompt / tool result.
+    - ``end_turn``: end the current turn after this event (set implicitly when blocked).
+    """
+
+    blocked: bool = False
+    reason: str = ""
+    updated_input: Optional[dict[str, Any]] = None
+    updated_output: Optional[str] = None
+    additional_context: Optional[str] = None
+    end_turn: bool = False
+
+    @classmethod
+    def empty(cls) -> "HookOutcome":
+        return cls()
+
+    @classmethod
+    def deny(cls, reason: str) -> "HookOutcome":
+        return cls(blocked=True, reason=reason or "Hook blocked the action.", end_turn=True)
+
+    @property
+    def is_empty(self) -> bool:
+        return not (
+            self.blocked
+            or self.updated_input is not None
+            or self.updated_output is not None
+            or self.additional_context
+            or self.end_turn
+        )
+
+
+def merge(outcomes: Iterable[HookOutcome]) -> HookOutcome:
+    """Fold sequential hook outcomes into one.
+
+    First block wins (and the dispatcher short-circuits remaining hooks). Input
+    and output replacements take the last value (the dispatcher threads each
+    hook's ``updated_input`` into the next, so last-writer-wins is the cumulative
+    result). ``additional_context`` is concatenated in order.
+    """
+    blocked = False
+    reason = ""
+    updated_input: Optional[dict[str, Any]] = None
+    updated_output: Optional[str] = None
+    contexts: list[str] = []
+    end_turn = False
+
+    for outcome in outcomes:
+        if outcome.updated_input is not None:
+            updated_input = outcome.updated_input
+        if outcome.updated_output is not None:
+            updated_output = outcome.updated_output
+        if outcome.additional_context:
+            contexts.append(outcome.additional_context)
+        if outcome.end_turn:
+            end_turn = True
+        if outcome.blocked and not blocked:
+            blocked = True
+            reason = outcome.reason
+
+    return HookOutcome(
+        blocked=blocked,
+        reason=reason,
+        updated_input=updated_input,
+        updated_output=updated_output,
+        additional_context="\n".join(contexts) if contexts else None,
+        end_turn=end_turn or blocked,
+    )

--- a/kolega_code/hooks/tests/test_hooks.py
+++ b/kolega_code/hooks/tests/test_hooks.py
@@ -1,0 +1,410 @@
+import json
+import sys
+
+import pytest
+
+from kolega_code.hooks import (
+    HookCapabilities,
+    HookConfig,
+    HookConfigError,
+    HookDispatcher,
+    HookEvent,
+    HookMatcher,
+    HookOutcome,
+    HookSpec,
+    LifecycleEvent,
+    load_hook_config,
+    merge,
+)
+from kolega_code.hooks.events import enter_hook, exit_hook
+
+
+# --------------------------------------------------------------------------- #
+# matcher
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "pattern,target,expected",
+    [
+        ("", "Bash", True),
+        ("*", "Bash", True),
+        ("Edit|Write", "Edit", True),
+        ("Edit|Write", "Read", False),
+        (r"mcp__.*", "mcp__memory__read", True),
+        (r"mcp__.*", "execute_terminal_command", False),
+        ("execute_terminal_command", "execute_terminal_command", True),
+    ],
+)
+def test_matcher(pattern, target, expected):
+    assert HookMatcher(pattern).matches(target) is expected
+
+
+# --------------------------------------------------------------------------- #
+# outcome / merge
+# --------------------------------------------------------------------------- #
+
+
+def test_merge_first_block_wins_and_chains_input():
+    merged = merge(
+        [
+            HookOutcome(updated_input={"command": "a"}),
+            HookOutcome(updated_input={"command": "b"}),
+            HookOutcome(blocked=True, reason="nope"),
+        ]
+    )
+    assert merged.blocked is True
+    assert merged.reason == "nope"
+    assert merged.updated_input == {"command": "b"}
+    assert merged.end_turn is True  # a block always ends the turn
+
+
+def test_merge_concatenates_context():
+    merged = merge([HookOutcome(additional_context="one"), HookOutcome(additional_context="two")])
+    assert merged.additional_context == "one\ntwo"
+    assert merged.blocked is False
+
+
+# --------------------------------------------------------------------------- #
+# config loading / trust / validation
+# --------------------------------------------------------------------------- #
+
+
+def _write(path, payload):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_load_merges_global_then_project_when_trusted(tmp_path):
+    state_dir = tmp_path / "state"
+    project = tmp_path / "project"
+    _write(
+        state_dir / "hooks.json",
+        {
+            "schema_version": 1,
+            "hooks": {"PreToolUse": [{"matcher": "*", "hooks": [{"type": "command", "command": "g"}]}]},
+        },
+    )
+    _write(
+        project / ".kolega" / "hooks.json",
+        {
+            "schema_version": 1,
+            "hooks": {"PreToolUse": [{"matcher": "*", "hooks": [{"type": "command", "command": "p"}]}]},
+        },
+    )
+
+    config = load_hook_config(project, state_dir, project_trusted=True)
+    specs = config.specs_for(HookEvent.PRE_TOOL_USE, "execute_terminal_command")
+    assert [s.command for s in specs] == ["g", "p"]  # global first, project last
+    assert [s.scope for s in specs] == ["global", "project"]
+
+
+def test_project_hooks_skipped_when_untrusted(tmp_path):
+    state_dir = tmp_path / "state"
+    project = tmp_path / "project"
+    _write(
+        project / ".kolega" / "hooks.json",
+        {
+            "schema_version": 1,
+            "hooks": {"PreToolUse": [{"matcher": "*", "hooks": [{"type": "command", "command": "p"}]}]},
+        },
+    )
+    config = load_hook_config(project, state_dir, project_trusted=False)
+    assert config.is_empty
+    assert any("trusted" in d for d in config.diagnostics)
+
+
+def test_unsupported_schema_version_is_diagnostic(tmp_path):
+    state_dir = tmp_path / "state"
+    _write(state_dir / "hooks.json", {"schema_version": 99, "hooks": {}})
+    config = load_hook_config(tmp_path / "project", state_dir, project_trusted=True)
+    assert config.is_empty
+    assert any("schema version" in d for d in config.diagnostics)
+
+
+def test_malformed_json_is_diagnostic(tmp_path):
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    (state_dir / "hooks.json").write_text("{not json", encoding="utf-8")
+    config = load_hook_config(tmp_path / "project", state_dir, project_trusted=True)
+    assert config.is_empty
+    assert any("valid JSON" in d for d in config.diagnostics)
+
+
+def test_agent_hook_rejected_on_tool_event(tmp_path):
+    state_dir = tmp_path / "state"
+    _write(
+        state_dir / "hooks.json",
+        {"schema_version": 1, "hooks": {"PreToolUse": [{"matcher": "*", "hooks": [{"type": "agent", "prompt": "x"}]}]}},
+    )
+    config = load_hook_config(tmp_path / "project", state_dir, project_trusted=True)
+    assert config.is_empty
+    assert any("not allowed on tool events" in d for d in config.diagnostics)
+
+
+def test_agent_hook_allowed_on_stop(tmp_path):
+    state_dir = tmp_path / "state"
+    _write(
+        state_dir / "hooks.json",
+        {"schema_version": 1, "hooks": {"Stop": [{"matcher": "*", "hooks": [{"type": "agent", "prompt": "x"}]}]}},
+    )
+    config = load_hook_config(tmp_path / "project", state_dir, project_trusted=True)
+    assert config.specs_for(HookEvent.STOP)
+
+
+def test_hookspec_requires_type_field():
+    with pytest.raises(HookConfigError):
+        HookSpec.from_dict({"type": "command"}, scope="global")  # missing command
+    with pytest.raises(HookConfigError):
+        HookSpec.from_dict({"type": "bogus", "command": "x"}, scope="global")
+
+
+# --------------------------------------------------------------------------- #
+# command backend
+# --------------------------------------------------------------------------- #
+
+
+def _command_dispatcher(command: str, event: HookEvent = HookEvent.PRE_TOOL_USE, timeout: int = 10) -> HookDispatcher:
+    config = HookConfig(
+        entries={
+            event: [(HookMatcher("*"), [HookSpec(type="command", timeout=timeout, scope="global", command=command)])]
+        }
+    )
+    return HookDispatcher(config)
+
+
+def _script(tmp_path, body: str) -> str:
+    path = tmp_path / "hook.py"
+    path.write_text("import sys, json\nevent = json.load(sys.stdin)\n" + body, encoding="utf-8")
+    return f"{sys.executable} {path}"
+
+
+@pytest.mark.asyncio
+async def test_command_block_via_exit_2(tmp_path):
+    command = _script(tmp_path, "sys.stderr.write('denied by policy')\nsys.exit(2)\n")
+    disp = _command_dispatcher(command)
+    event = LifecycleEvent(name=HookEvent.PRE_TOOL_USE, payload={"tool_name": "x", "tool_input": {}})
+    outcome = await disp.dispatch(event, target="x", caps=HookCapabilities(project_path=tmp_path))
+    assert outcome.blocked and "denied by policy" in outcome.reason
+
+
+@pytest.mark.asyncio
+async def test_command_modifies_input_via_stdout_json(tmp_path):
+    command = _script(
+        tmp_path,
+        "print(json.dumps({'hookSpecificOutput': {'updatedInput': {'command': 'echo safe'}}}))\n",
+    )
+    disp = _command_dispatcher(command)
+    event = LifecycleEvent(
+        name=HookEvent.PRE_TOOL_USE, payload={"tool_name": "x", "tool_input": {"command": "rm -rf /"}}
+    )
+    outcome = await disp.dispatch(event, target="x", caps=HookCapabilities(project_path=tmp_path))
+    assert not outcome.blocked
+    assert outcome.updated_input == {"command": "echo safe"}
+
+
+@pytest.mark.asyncio
+async def test_command_nonzero_is_nonblocking(tmp_path):
+    logs = []
+    command = _script(tmp_path, "sys.exit(1)\n")
+    disp = _command_dispatcher(command)
+    event = LifecycleEvent(name=HookEvent.PRE_TOOL_USE, payload={"tool_name": "x", "tool_input": {}})
+
+    async def log(msg):
+        logs.append(msg)
+
+    outcome = await disp.dispatch(event, target="x", caps=HookCapabilities(project_path=tmp_path, log=log))
+    assert outcome.is_empty
+    assert any("exited 1" in m for m in logs)
+
+
+@pytest.mark.asyncio
+async def test_command_timeout_is_nonblocking(tmp_path):
+    logs = []
+    command = _script(tmp_path, "import time\ntime.sleep(5)\n")
+    disp = _command_dispatcher(command, timeout=1)
+    event = LifecycleEvent(name=HookEvent.PRE_TOOL_USE, payload={"tool_name": "x", "tool_input": {}})
+
+    async def log(msg):
+        logs.append(msg)
+
+    outcome = await disp.dispatch(event, target="x", caps=HookCapabilities(project_path=tmp_path, log=log))
+    assert outcome.is_empty
+    assert any("timed out" in m for m in logs)
+
+
+# --------------------------------------------------------------------------- #
+# python backend
+# --------------------------------------------------------------------------- #
+
+
+def deny_python_hook(event: LifecycleEvent) -> HookOutcome:
+    return HookOutcome.deny("python says no")
+
+
+async def modify_python_hook(event: LifecycleEvent) -> HookOutcome:
+    return HookOutcome(updated_input={"command": "ls"})
+
+
+@pytest.mark.asyncio
+async def test_python_backend_block():
+    config = HookConfig(
+        entries={
+            HookEvent.PRE_TOOL_USE: [
+                (
+                    HookMatcher("*"),
+                    [HookSpec(type="python", timeout=5, scope="global", callable=f"{__name__}:deny_python_hook")],
+                )
+            ]
+        }
+    )
+    event = LifecycleEvent(name=HookEvent.PRE_TOOL_USE, payload={"tool_name": "x", "tool_input": {}})
+    outcome = await HookDispatcher(config).dispatch(event, target="x")
+    assert outcome.blocked and outcome.reason == "python says no"
+
+
+@pytest.mark.asyncio
+async def test_python_backend_async_modify():
+    config = HookConfig(
+        entries={
+            HookEvent.PRE_TOOL_USE: [
+                (
+                    HookMatcher("*"),
+                    [HookSpec(type="python", timeout=5, scope="global", callable=f"{__name__}:modify_python_hook")],
+                )
+            ]
+        }
+    )
+    event = LifecycleEvent(name=HookEvent.PRE_TOOL_USE, payload={"tool_name": "x", "tool_input": {"command": "boom"}})
+    outcome = await HookDispatcher(config).dispatch(event, target="x")
+    assert outcome.updated_input == {"command": "ls"}
+
+
+# --------------------------------------------------------------------------- #
+# LLM backends (prompt / agent) via stub runners
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_prompt_backend_ok_reason():
+    config = HookConfig(
+        entries={
+            HookEvent.STOP: [
+                (HookMatcher("*"), [HookSpec(type="prompt", timeout=5, scope="global", prompt="done? $EVENT")])
+            ]
+        }
+    )
+    seen = {}
+
+    async def prompt_runner(text, model):
+        seen["text"] = text
+        return 'The tasks are not finished. {"ok": false, "reason": "tests still failing"}'
+
+    outcome = await HookDispatcher(config).dispatch(
+        LifecycleEvent(name=HookEvent.STOP, payload={"stop_reason": "end_turn"}),
+        caps=HookCapabilities(prompt_runner=prompt_runner),
+    )
+    assert "hook_event_name" in seen["text"]  # $EVENT was rendered
+    assert outcome.blocked and outcome.reason == "tests still failing"
+
+
+@pytest.mark.asyncio
+async def test_prompt_backend_missing_runner_fails_open():
+    logs = []
+    config = HookConfig(
+        entries={HookEvent.STOP: [(HookMatcher("*"), [HookSpec(type="prompt", timeout=5, scope="global", prompt="x")])]}
+    )
+
+    async def log(msg):
+        logs.append(msg)
+
+    outcome = await HookDispatcher(config).dispatch(
+        LifecycleEvent(name=HookEvent.STOP, payload={}), caps=HookCapabilities(log=log)
+    )
+    assert outcome.is_empty
+    assert any("no LLM runner" in m for m in logs)
+
+
+@pytest.mark.asyncio
+async def test_agent_backend_runs_under_reentrancy_guard():
+    from kolega_code.hooks.events import in_hook
+
+    config = HookConfig(
+        entries={
+            HookEvent.STOP: [(HookMatcher("*"), [HookSpec(type="agent", timeout=5, scope="global", prompt="verify")])]
+        }
+    )
+    flags = {}
+
+    async def agent_runner(task):
+        flags["in_hook"] = in_hook()
+        return '{"ok": true}'
+
+    outcome = await HookDispatcher(config).dispatch(
+        LifecycleEvent(name=HookEvent.STOP, payload={}), caps=HookCapabilities(agent_runner=agent_runner)
+    )
+    assert flags["in_hook"] is True  # guard active while the agent hook runs
+    assert outcome.is_empty
+
+
+# --------------------------------------------------------------------------- #
+# dispatcher behavior
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_dispatch_is_suppressed_when_already_in_hook():
+    config = HookConfig(
+        entries={
+            HookEvent.PRE_TOOL_USE: [
+                (
+                    HookMatcher("*"),
+                    [HookSpec(type="python", timeout=5, scope="global", callable=f"{__name__}:deny_python_hook")],
+                )
+            ]
+        }
+    )
+    event = LifecycleEvent(name=HookEvent.PRE_TOOL_USE, payload={"tool_name": "x", "tool_input": {}})
+    token = enter_hook()
+    try:
+        outcome = await HookDispatcher(config).dispatch(event, target="x")
+    finally:
+        exit_hook(token)
+    assert outcome.is_empty
+
+
+@pytest.mark.asyncio
+async def test_no_op_dispatcher_returns_empty():
+    from kolega_code.hooks import NO_OP_DISPATCHER
+
+    event = LifecycleEvent(name=HookEvent.PRE_TOOL_USE, payload={"tool_name": "x", "tool_input": {}})
+    assert (await NO_OP_DISPATCHER.dispatch(event, target="x")).is_empty
+
+
+@pytest.mark.asyncio
+async def test_matcher_scopes_specs_to_target():
+    config = HookConfig(
+        entries={
+            HookEvent.PRE_TOOL_USE: [
+                (
+                    HookMatcher("execute_terminal_command"),
+                    [HookSpec(type="python", timeout=5, scope="global", callable=f"{__name__}:deny_python_hook")],
+                )
+            ]
+        }
+    )
+    disp = HookDispatcher(config)
+    # Non-matching tool -> no hooks run.
+    other = await disp.dispatch(
+        LifecycleEvent(name=HookEvent.PRE_TOOL_USE, payload={"tool_name": "read_file", "tool_input": {}}),
+        target="read_file",
+    )
+    assert other.is_empty
+    # Matching tool -> blocked.
+    match = await disp.dispatch(
+        LifecycleEvent(
+            name=HookEvent.PRE_TOOL_USE, payload={"tool_name": "execute_terminal_command", "tool_input": {}}
+        ),
+        target="execute_terminal_command",
+    )
+    assert match.blocked


### PR DESCRIPTION
## What

Adds **lifecycle events** to the agent and a **hooks system** that runs user-configured handlers when those events fire — to **observe**, **block**, or **modify** the agent's behavior, mirroring the model used by Claude Code / opencode.

This lands as a new, self-contained `kolega_code/hooks/` package wired in through `AgentContext`. The dispatcher defaults to a stateless no-op, so the change is **purely additive** — every existing caller and test is unaffected.

## Lifecycle events (v1)

Fired at verified chokepoints in the agent loop and tool path:

| Event | Block behavior |
|---|---|
| `UserPromptSubmit` | end the turn |
| `PreToolUse` | deny the tool (reason returned as a tool error, so the agent can adjust) |
| `PostToolUse` | end the turn; can also rewrite the output |
| `Stop` | keep working (reason becomes the next instruction; bounded re-entry) |
| `SubagentStop` | annotate the result the parent sees |
| `SessionStart` / `SessionEnd` / `PreCompact` / `Notification` | advisory |

`PreToolUse` can also rewrite tool inputs; `PostToolUse` can replace output or append context.

## Hook backends

- **`command`** — JSON on stdin; exit `2` blocks; stdout JSON drives `permissionDecision` / `updatedInput` / `updatedToolOutput` / `additionalContext`.
- **`python`** — in-process `module:func` returning a `HookOutcome`.
- **`prompt` / `agent`** — LLM judgment via the `{"ok", "reason"}` protocol. `prompt` is a single fast-model call; `agent` spawns a full-tool sub-agent to verify a condition.

## Configuration & trust

- Global/user: `~/.kolega-state/hooks.json` (always active).
- Project: `<project>/.kolega/hooks.json` — **trust-gated**: ignored until the project is trusted once via `--trust-hooks` (persisted in user settings). Global hooks still run.

## Safety (red-teamed)

- `PreToolUse` deny reuses the **exact** permission-deny `ToolResult` shape, so the model/UI need no new handling.
- A `_in_hook` contextvar guard stops an `agent` hook's sub-agent from re-firing tool hooks; `agent` hooks are config-rejected on tool events.
- The dispatcher is **stateless** — safe under parallel tool batches and recursive sub-agents.
- Blocking events **fail open**: a crashed/timed-out/garbage hook is logged and the action proceeds. Only a clean `exit 2` / `deny` / `ok:false` blocks.

## Testing

- 28 unit tests (`kolega_code/hooks/tests/`): matcher, config loading + trust gate + agent-on-tool rejection, command/python/LLM backends, merge, dispatcher re-entrancy.
- 6 integration tests driving the real loop: PreToolUse deny/modify, PostToolUse modify, parallel-batch deny-one, UserPromptSubmit block, Stop keep-working.
- Full suite: **965 passed** (1 pre-existing flaky terminal-timing test deselected, unrelated to this change).

## Docs

New **Hooks** page in the docs site (config shape, the 9 events, the `ok/reason` and command exit-code protocols, the trust model, and examples for each backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)