### PR TITLE
Fix stray blue highlight on TUI choice lists in 256-color terminals

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -714,6 +714,16 @@ class KolegaCodeApp(App):
         background: $surface;
     }
 
+    /* Neutralize the selected-row highlight on every choice list. Textual paints
+       it with $block-cursor-background (= $primary = #0178D4, a saturated blue),
+       which clashes with the otherwise-neutral chrome and looks wrong in 256-color
+       Terminal.app. The OptionList type selector also covers its subclasses:
+       ActionList, CompletionDropdown, and the Select's SelectOverlay dropdown. */
+    OptionList > .option-list--option-highlighted {
+        background: $surface-lighten-2;
+        color: $text;
+    }
+
     .meta {
         color: $text-muted;
     }


### PR DESCRIPTION
## What

Commit `22ed850` neutralized the TUI chrome (composer, footer, `Input`, sidebar `Select` borders) so macOS Terminal.app (256-color) stops rendering it blue — but it missed the **highlighted/selected row** of the choice lists.

Textual's `OptionList` paints the highlighted option with `$block-cursor-background`, which in the `textual-dark` theme is undefined and falls back to `$primary` = `#0178D4` (a saturated blue). Nothing overrode the `option-list--option-highlighted` component class, so the currently-selected choice rendered as a blue bar that clashed with the now-neutral chrome — and looked especially wrong in Terminal.app.

(Despite the "border colours" framing, the container border was already fixed in `22ed850`; the leftover blue was the selection highlight. Confirmed via headless `run_test` that the border resolves to `round #1E1E1E` in both focused and blurred states.)

## Fix

One App-CSS rule in `KolegaCodeApp.CSS`:

```css
OptionList > .option-list--option-highlighted {
    background: $surface-lighten-2;
    color: $text;
}
```

- `$surface-lighten-2` (`#3E3E3E`, R=G=B) quantizes to the 256-color grey ramp — matches the project's TUI-color guidance.
- The `OptionList` type selector also matches its subclasses, so this fixes every choice surface in one place: question / plan / model / effort / approval action lists, the `@`/`/` completion dropdown, and the sidebar `Select` dropdown.
- A single rule (no `:focus` variant) suffices — App-CSS tier + specificity beats Textual's `&:focus > .option-list--option-highlighted` default, so it overrides both the focused (`#0178D4`) and blurred (`#0178D44C`) blue.

## Verification

- **Headless** (against the real `KolegaCodeApp.CSS`): the highlighted-row background now resolves to `Color(62,62,62)` = `#3E3E3E` with white text, instead of `Color(1,120,212)` = `#0178D4`. Border stays `round #1E1E1E`. ✅
- **Manual** (to do): launch the TUI in Terminal.app, trigger a planning question (`ask_user_choice`), confirm the highlighted choice is a neutral grey bar; spot-check the completion dropdown and sidebar `Select`. Confirm no regression in Ghostty (truecolor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)