### PR TITLE
[codex] fix tui conversation markup rendering

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -259,7 +259,7 @@ class ConversationEntryWidget(Static):
     """Displays one ConversationEntry and is updated in place as the entry changes."""
 
     def __init__(self, entry: ConversationEntry, format_entry: Callable[[ConversationEntry], object]) -> None:
-        super().__init__("")
+        super().__init__("", markup=False)
         self.entry = entry
         self._format_entry = format_entry
         self._kind_class = ""
@@ -3401,6 +3401,17 @@ class KolegaCodeApp(App):
             self._flush_conversation_render()
 
     def _format_sub_agent_content(self, activity: SubAgentActivity) -> str:
+        header = Text.from_markup(self._sub_agent_header(activity)).plain
+        body = "\n".join(self._sub_agent_body_lines(activity))
+        return f"{header}\n{body}" if body else header
+
+    def _format_sub_agent_renderable(self, activity: SubAgentActivity) -> Text | Group:
+        return self._entry_renderable(
+            self._sub_agent_header(activity),
+            "\n".join(self._sub_agent_body_lines(activity)),
+        )
+
+    def _sub_agent_header(self, activity: SubAgentActivity) -> str:
         if activity.finished_at is not None:
             elapsed = max(0.0, activity.finished_at - activity.started_at)
         else:
@@ -3416,13 +3427,14 @@ class KolegaCodeApp(App):
         else:
             color, state = Color.WARNING, f"stopped after {duration}"
 
-        header = theme.role_header(
+        return theme.role_header(
             Glyph.SUB_AGENT,
             escape(activity.agent_name),
             color,
             state=f"#{activity.index} {theme.g(Glyph.BULLET_SEP)} {state}",
         )
 
+    def _sub_agent_body_lines(self, activity: SubAgentActivity) -> list[str]:
         body_lines: list[str] = []
         if activity.task:
             task = activity.task
@@ -3441,8 +3453,13 @@ class KolegaCodeApp(App):
                     tail = f"…{tail[-SUB_AGENT_TAIL_CHARS:]}"
                 body_lines.append(tail)
 
-        body = self._format_inset_content("\n".join(body_lines))
-        return f"{header}\n{body}"
+        return body_lines
+
+    def _sub_agent_activity_for_entry(self, entry: ConversationEntry) -> Optional[SubAgentActivity]:
+        for activity in self._sub_agent_activities.values():
+            if activity.entry is entry:
+                return activity
+        return None
 
     def _running_sub_agents(self) -> list[SubAgentActivity]:
         return [a for a in self._sub_agent_activities.values() if a.status == "running"]
@@ -3596,7 +3613,7 @@ class KolegaCodeApp(App):
         view.anchor()
         self._update_jump_button()
 
-    def _format_conversation_entry(self, entry: ConversationEntry) -> str | Text | Group:
+    def _format_conversation_entry(self, entry: ConversationEntry) -> Text | Group:
         """Render an entry using the shared header grammar.
 
         GRAMMAR: <colored glyph> <bold label> [ · state] — body inset beneath.
@@ -3606,40 +3623,55 @@ class KolegaCodeApp(App):
         streaming = None if entry.complete else theme.g(Glyph.ELLIPSIS)
         if entry.kind == "user":
             header = theme.role_header(Glyph.USER, "You", Color.USER)
-            return f"{header}\n{self._format_inset_content(entry.content)}"
+            return self._entry_renderable(header, entry.content)
         if entry.kind == "assistant":
             header = theme.role_header(Glyph.AGENT, "Agent", Color.AGENT, state=streaming)
             if entry.complete and entry.content.strip():
                 return self._markdown_entry(header, entry.content)
-            return f"{header}\n{self._format_inset_content(entry.content)}"
+            return self._entry_renderable(header, entry.content)
         if entry.kind == "thinking":
             header = theme.role_header(
                 Glyph.STATUS, "Thinking", Color.THINKING, label_style="dim italic", state=streaming
             )
-            return f"{header}\n{self._format_inset_content(entry.content, style='italic dim')}"
+            return self._entry_renderable(header, entry.content, body_style="italic dim")
         if entry.kind == "progress":
             color = Color.ERROR if entry.tone == "error" else Color.WARNING
             header = theme.role_header(Glyph.STATUS, "Status", color, state=streaming)
-            return f"{header}\n{self._format_inset_content(entry.content)}"
+            return self._entry_renderable(header, entry.content)
         if entry.kind == "plan":
             header = theme.role_header(Glyph.PLAN, "Plan", Color.SUCCESS)
             if entry.content.strip():
                 return self._markdown_entry(header, entry.content)
-            return header
+            return Text.from_markup(header)
         if entry.kind == "question":
             header = theme.role_header(Glyph.QUESTION, "Question", Color.ACCENT)
-            return f"{header}\n{self._format_inset_content(entry.content)}"
+            return self._entry_renderable(header, entry.content)
         if entry.kind == "skill":
             header = theme.role_header(Glyph.PLAN, "Skill", Color.SUCCESS)
-            return f"{header}\n{self._format_inset_content(entry.content)}"
+            return self._entry_renderable(header, entry.content)
         if entry.kind == "sub_agent":
-            return entry.content  # pre-formatted markup, see _format_sub_agent_content
+            activity = self._sub_agent_activity_for_entry(entry)
+            if activity is not None:
+                return self._format_sub_agent_renderable(activity)
+            return Text(entry.content)
         if entry.kind in TOOL_STATE_PRESENTATION:
             state, color = TOOL_STATE_PRESENTATION[entry.kind]
             return self._format_tool_entry(entry, state=state, color=color)
         if entry.kind == "system":
-            return f"[dim]{escape(entry.content)}[/dim]"
-        return escape(entry.content)
+            return Text(entry.content, style="dim")
+        return Text(entry.content)
+
+    def _entry_renderable(
+        self,
+        header: str,
+        body: Optional[str] = None,
+        *,
+        body_style: Optional[str] = None,
+    ) -> Text | Group:
+        header_text = Text.from_markup(header)
+        if body is None:
+            return header_text
+        return Group(header_text, self._format_inset_text(body, style=body_style))
 
     def _markdown_entry(self, header: str, content: str) -> Group:
         return Group(
@@ -3671,20 +3703,26 @@ class KolegaCodeApp(App):
                 rendered.append(line, style="dim")
         return rendered
 
-    def _format_tool_entry(self, entry: ConversationEntry, *, state: str, color: str) -> str:
+    def _format_tool_entry(self, entry: ConversationEntry, *, state: str, color: str) -> Text | Group:
         tool_name = escape(entry.tool_name or "tool")
         header = theme.role_header(Glyph.TOOL, tool_name, color, state=state)
         if not entry.content:
-            return header
-        return f"{header}\n{self._format_inset_content(entry.content)}"
+            return Text.from_markup(header)
+        return self._entry_renderable(header, entry.content)
 
     def _tool_entry_title(self, entry: ConversationEntry) -> str:
         state, color = TOOL_STATE_PRESENTATION.get(entry.kind, ("running", Color.ACCENT))
         return theme.role_header(Glyph.TOOL, escape(entry.tool_name or "tool"), color, state=state)
 
-    def _format_inset_content(self, content: str, style: Optional[str] = None) -> str:
-        bar = f"[dim]  {theme.g(Glyph.INSET_BAR)}[/dim]"
+    def _format_inset_text(self, content: str, style: Optional[str] = None) -> Text:
+        bar = f"  {theme.g(Glyph.INSET_BAR)}"
         lines = content.splitlines() or [""]
-        if style:
-            return "\n".join(f"{bar} [{style}]{escape(line)}[/{style}]" if line else bar for line in lines)
-        return "\n".join(f"{bar} {escape(line)}" if line else bar for line in lines)
+        rendered = Text()
+        for index, line in enumerate(lines):
+            if index:
+                rendered.append("\n")
+            rendered.append(bar, style="dim")
+            if line:
+                rendered.append(" ")
+                rendered.append(line, style=style)
+        return rendered

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -46,6 +46,21 @@ def question_payload(question, options, *, header="Choice", multi_select=False):
     return [{"question": question, "header": header, "multiSelect": multi_select, "options": built}]
 
 
+def renderable_text(renderable) -> str:
+    from rich.console import Console
+
+    console = Console(width=240, color_system=None, force_terminal=False)
+    with console.capture() as capture:
+        console.print(renderable, soft_wrap=True, end="")
+    return capture.get()
+
+
+def first_text_styles(renderable) -> list[str]:
+    renderables = list(getattr(renderable, "renderables", [renderable]))
+    text = renderables[0]
+    return [str(span.style) for span in getattr(text, "spans", [])]
+
+
 def build_test_config(project: Path):
     return build_agent_config(
         project,
@@ -367,12 +382,12 @@ async def test_progress_entry_tone_drives_styling_not_prose(
             kind="progress", content="Stopped before the error handler ran", complete=True, tone="warning"
         )
         rendered = app._format_conversation_entry(warning_entry)
-        assert "[yellow]" in str(rendered)
-        assert "[red]" not in str(rendered)
+        assert "yellow" in first_text_styles(rendered)
+        assert "red" not in first_text_styles(rendered)
 
         error_entry = ConversationEntry(kind="progress", content="All good otherwise", complete=True, tone="error")
         rendered = app._format_conversation_entry(error_entry)
-        assert "[red]" in str(rendered)
+        assert "red" in first_text_styles(rendered)
 
         # Explicit state drives the dashboard, not content keywords
         app._turn_active = True
@@ -2496,11 +2511,12 @@ async def test_textual_app_formats_thinking_as_italic_chat_entry(
         formatted = app._format_conversation_entry(
             ConversationEntry(kind="thinking", content="inspect [red]markup[/red]", complete=False)
         )
+        rendered = renderable_text(formatted)
 
-        assert "[dim italic]Thinking[/dim italic]" in formatted
-        assert "\\[red]" in formatted
-        assert "[italic dim]" in formatted
-        assert "…" in formatted  # streaming indicator in the header
+        assert "Thinking" in rendered
+        assert "[red]markup[/red]" in rendered
+        assert "…" in rendered  # streaming indicator in the header
+        assert any("italic" in style and "dim" in style for style in first_text_styles(formatted))
 
 
 @pytest.mark.asyncio
@@ -2558,7 +2574,7 @@ async def test_textual_app_renders_one_widget_per_chat_entry(
         same_widgets = list(app.query(ConversationEntryWidget))
         assert len(same_widgets) == 3
         assert same_widgets[1] is widgets[1]
-        assert "second updated" in str(same_widgets[1]._formatted)
+        assert "second updated" in renderable_text(same_widgets[1]._formatted)
 
 
 @pytest.mark.asyncio
@@ -2766,17 +2782,21 @@ async def test_textual_app_formats_agent_and_tool_chat_entries(
         tool_error = app._format_conversation_entry(
             ConversationEntry(kind="tool_error", content="Permission denied", tool_name="write_file")
         )
+        assistant_text = renderable_text(assistant)
+        tool_call_text = renderable_text(tool_call)
+        tool_result_text = renderable_text(tool_result)
+        tool_error_text = renderable_text(tool_error)
 
-        assert "[magenta]●[/magenta] [bold]Agent[/bold]" in assistant
-        assert "Kolega" not in assistant
-        assert "[cyan]⏺[/cyan] [bold]read_file[/bold]" in tool_call
-        assert "· running" in tool_call
-        assert "[dim]  │[/dim] inspect \\[red]markup\\[/red]" in tool_call
-        assert "[dim]  │[/dim] then continue" in tool_call
-        assert "[green]⏺[/green] [bold]read_file[/bold]" in tool_result
-        assert "· done" in tool_result
-        assert "[red]⏺[/red] [bold]write_file[/bold]" in tool_error
-        assert "· failed" in tool_error
+        assert "● Agent" in assistant_text
+        assert "Kolega" not in assistant_text
+        assert "⏺ read_file" in tool_call_text
+        assert "· running" in tool_call_text
+        assert "inspect [red]markup[/red]" in tool_call_text
+        assert "then continue" in tool_call_text
+        assert "⏺ read_file" in tool_result_text
+        assert "· done" in tool_result_text
+        assert "⏺ write_file" in tool_error_text
+        assert "· failed" in tool_error_text
 
 
 @pytest.mark.asyncio
@@ -3962,6 +3982,73 @@ async def test_rapid_stream_chunks_coalesce_renders(tmp_path: Path, monkeypatch:
 
 
 @pytest.mark.asyncio
+async def test_conversation_body_renders_rich_markup_tokens_literally(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from kolega_code.cli.app import ConversationEntry
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+    literal = "I investigated [/dim]\n[bold]not bold[/bold]\npath\\"
+
+    async with app.run_test():
+        for entry in [
+            ConversationEntry(kind="user", content=literal),
+            ConversationEntry(kind="assistant", content=literal, complete=False),
+            ConversationEntry(kind="thinking", content=literal, complete=False),
+            ConversationEntry(kind="progress", content=literal, complete=True),
+            ConversationEntry(kind="question", content=literal),
+            ConversationEntry(kind="skill", content=literal),
+            ConversationEntry(kind="system", content=literal),
+            ConversationEntry(kind="message", content=literal),
+        ]:
+            rendered = app._format_conversation_entry(entry)
+            text = renderable_text(rendered)
+            assert "[/dim]" in text
+            assert "[bold]not bold[/bold]" in text
+            assert "path\\" in text
+
+        app._render_event(
+            _sub_agent_event(
+                agent_name="agent[/dim]",
+                task="inspect [red]task[/red]",
+                uuid="u1",
+                text="tail [/dim] [bold]literal[/bold]\\",
+            )
+        )
+        sub_agent_entry = _sub_agent_entries(app)[0]
+        sub_agent_text = renderable_text(app._format_conversation_entry(sub_agent_entry))
+        assert "agent[/dim]" in sub_agent_text
+        assert "[red]task[/red]" in sub_agent_text
+        assert "[bold]literal[/bold]\\" in sub_agent_text
+
+
+@pytest.mark.asyncio
+async def test_streaming_assistant_refresh_accepts_literal_markup_tokens(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from kolega_code.cli.app import ConversationEntry, ConversationEntryWidget
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        entry = ConversationEntry(kind="assistant", content="start [/dim]", complete=False)
+        app.conversation_entries = [entry]
+        app._render_conversation()
+        await pilot.pause()
+
+        widget = app.query(ConversationEntryWidget).last()
+        entry.content += "\n[bold]literal[/bold]\\"
+        app._invalidate_conversation(entry)
+        app._flush_conversation_render()
+        await pilot.pause()
+
+        assert app.query(ConversationEntryWidget).last() is widget
+        rendered = renderable_text(widget._formatted)
+        assert "[/dim]" in rendered
+        assert "[bold]literal[/bold]\\" in rendered
+
+
+@pytest.mark.asyncio
 async def test_conversation_scroll_position_survives_streaming(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -4019,8 +4106,8 @@ async def test_assistant_entries_render_markdown_when_complete(
         streaming = app._format_conversation_entry(
             ConversationEntry(kind="assistant", content="# Title\n\nsome `code`", complete=False)
         )
-        assert isinstance(streaming, str)
-        assert "…" in streaming  # header carries the streaming indicator
+        assert not isinstance(streaming, str)
+        assert "…" in renderable_text(streaming)  # header carries the streaming indicator
 
         complete = app._format_conversation_entry(
             ConversationEntry(kind="assistant", content="# Title\n\nsome `code`", complete=True)


### PR DESCRIPTION
## Summary

Fixes a TUI crash where streaming conversation entries could be parsed as malformed Rich markup, for example when assistant output contained literal tokens like `[/dim]`.

## What changed

- Render conversation entries as Rich `Text`/`Group` objects instead of mixed trusted markup plus escaped body strings.
- Keep completed assistant and plan entries rendering through Markdown.
- Store sub-agent display content as plain text while deriving the styled header renderable from live activity state.
- Add regressions for literal Rich-looking body text and the in-place streaming refresh path.

## Impact

Literal markup-like model output is now displayed as text instead of being interpreted by Textual/Rich, avoiding `MarkupError` crashes during coalesced conversation refreshes.

## Validation

- `uv run pytest kolega_code/cli/tests/test_app.py -q` -> `119 passed`
- `uv run pytest -q` -> `968 passed, 5 warnings`
- `git diff --check` -> clean
