### PR TITLE
Auto-focus prompt & approval options so arrow keys + Enter work

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -469,7 +469,11 @@ class PromptPanel(Vertical):
         self.query_one(".prompt-header", Static).update(Text.from_markup(header))
         self.actions.show_options(options)
         self.display = True
-        self.actions.focus()
+        # Focus the options synchronously (not via Widget.focus(), which defers to a
+        # later event-loop tick): in a real terminal that deferred focus races with the
+        # refresh loop and the composer being disabled, so the options never get focus
+        # and arrow/Enter keys do nothing. Matches the other selection lists in this file.
+        self.screen.set_focus(self.actions)
 
     def hide(self) -> None:
         self.display = False

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -679,6 +679,10 @@ async def test_textual_app_permission_approval_actions_show_rule_labels_without_
         app._set_approval_actions_visible(True)
 
         approval_actions = app.query_one("#approval_actions", ActionList)
+        # The options must be focused synchronously (no pilot.pause() above) so arrow
+        # keys + Enter work without a click. A deferred Widget.focus() would not have run
+        # yet here, and in a real terminal it races the refresh loop and loses focus.
+        assert app.focused is approval_actions
         prompts = [
             approval_actions.get_option(f"approval_option_{index}").prompt
             for index in range(approval_actions.option_count)


### PR DESCRIPTION
## Problem

After #38 folded the question prompt and the command-approval prompt into a shared `PromptPanel`, the selectable options stopped being focused when a prompt appeared. Arrow keys (cycle) and Enter (select) did nothing — you had to reach for the mouse and click an option.

## Root cause

`PromptPanel.prompt()` focused its inner `ActionList` via `self.actions.focus()`. Textual's `Widget.focus()` does **not** focus immediately — it schedules the focus for a later event-loop tick via `app.call_later`. In a real terminal that deferred focus races the continuously-running refresh loop (and, for approvals, the composer being disabled, which triggers Textual's disabled-watcher to `blur()` and reassign focus). The result: focus doesn't reliably land on the options.

Before the fold, command-approval prompts focused their list **synchronously** via `self.screen.set_focus(...)`, called before the composer was disabled — and that worked.

This was masked by the headless `app.run_test()` harness, which drains the event loop deterministically so the deferred focus settles there.

## Fix

Focus synchronously in `PromptPanel.prompt()` via `self.screen.set_focus(self.actions)`, matching the other selection lists in this file (effort/model/plan, and the pre-fold approval path).

## Tests

Added a regression guard to the approval test that asserts focus lands on the options **immediately** (no `pilot.pause()`). Verified it fails on the old deferred `.focus()` (focus stuck on `ChatComposer`) and passes with the fix. Full app suite: 119 passed. Confirmed working in a real terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)