### PR TITLE
fix: guard conversation/inspector mounts against teardown race (MountError on exit)

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -792,6 +792,8 @@ class SubAgentInspectorScreen(ModalScreen):
             roster = self.query_one("#inspector_roster", VerticalScroll)
         except Exception:
             return
+        if not roster.is_attached:
+            return
         activities = self._ordered_activities()
         keys = [a.agent_id for a in activities]
         if keys != list(self._rows):
@@ -871,6 +873,8 @@ class SubAgentInspectorScreen(ModalScreen):
         try:
             view = self.query_one("#inspector_trajectory", VerticalScroll)
         except Exception:
+            return
+        if not view.is_attached:
             return
         activity = self._owner._sub_agent_activities.get(self._selected_key)
         if activity is None:
@@ -4313,6 +4317,11 @@ class KolegaCodeApp(App):
             # A coalesced flush can fire after the widget is unmounted (e.g. on exit).
             self._dirty_entry_ids.clear()
             return
+        if not view.is_attached:
+            # During teardown the view detaches before it is flagged closing, so query_one
+            # still resolves it but mounting into it raises MountError.
+            self._dirty_entry_ids.clear()
+            return
 
         rendered_ids = list(self._entry_widgets)
         current_ids = [entry.entry_id for entry in self.conversation_entries]
@@ -4344,6 +4353,8 @@ class KolegaCodeApp(App):
         try:
             view = self._conversation
         except Exception:
+            return
+        if not view.is_attached:
             return
         view.remove_children()
         self._entry_widgets = {}

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -2638,6 +2638,69 @@ async def test_textual_app_renders_one_widget_per_chat_entry(
 
 
 @pytest.mark.asyncio
+async def test_conversation_render_skips_detached_view_during_teardown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A coalesced render timer can fire while the app is tearing down. The view is
+    detached from the DOM (is_attached is False) but query_one still resolves it, so
+    mounting into it used to raise MountError and crash the CLI on exit."""
+    pytest.importorskip("textual")
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import (
+        ConversationEntry,
+        ConversationEntryWidget,
+        ConversationView,
+        KolegaCodeApp,
+    )
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            return None
+
+    monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test() as pilot:
+        app.conversation_entries = [ConversationEntry(kind="user", content="first")]
+        app._render_conversation()
+        await pilot.pause()
+        assert len(app.query(ConversationEntryWidget)) == 1
+
+        # Queue a new entry so a flush would reach view.mount(...), then simulate the
+        # exit-time race by detaching the view (is_attached False) without removing it
+        # from the DOM, so query_one still resolves it.
+        app.conversation_entries.append(
+            ConversationEntry(kind="assistant", content="late", complete=False)
+        )
+        app._render_pending = True
+        ConversationView.is_attached = property(lambda self: False)
+        try:
+            app._flush_conversation_render()  # must not raise (pre-fix: MountError)
+            app._render_conversation()  # must not raise
+        finally:
+            del ConversationView.is_attached
+
+        # The detached render was skipped, so nothing new was mounted.
+        assert len(app.query(ConversationEntryWidget)) == 1
+
+
+@pytest.mark.asyncio
 async def test_conversation_entry_widget_extracts_plain_selected_text(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Problem

Closing the CLI could crash with:

```
MountError: Can't mount widget(s) before ConversationView(id='conversation') is mounted
```

This is a **teardown race**, not a logic bug. Hot paths coalesce re-renders behind a timer (`set_timer(..., self._flush_conversation_render)`). On exit, Textual tears down the widget tree, and there's a window where the `ConversationView` is **detached from the DOM but not yet flagged `_closing`/`_pruning`**. A pending render timer firing in that window:

- The existing guard only wrapped the *lookup* (`view = self._conversation`), but `query_one` still **resolves** the detached widget, so the `try/except` passes.
- `view.mount(*widgets)` then hits Textual's `if not self.is_attached: raise MountError` (`textual/widget.py:1454`) and crashes the CLI on close.

The original `try/except` anticipated "flush after unmount on exit" but guarded the wrong line — it assumed `query_one` would raise, which it doesn't in this state.

## Fix

Bail before mutating the view when it's detached, testing the exact condition Textual checks — `if not view.is_attached: return`, right after each lookup. Covers all **5 `.mount()` sites** in `kolega_code/cli/app.py`:

- `_flush_conversation_render` — the reported crash
- `_render_conversation` — its identical twin
- `_sync_roster` / `_sync_trajectory` — the sub-agent inspector, driven by the same `set_interval`/`set_timer` race

The early return also shields the preceding `remove_children()`/`anchor()` calls. Preferred over an app-level "exiting" flag because `is_attached` is universal — it covers app exit, inspector-screen dismissal, and any other detachment, without enumerating teardown paths.

## Testing

- New regression test `test_conversation_render_skips_detached_view_during_teardown` reproduces the **exact** `MountError` (matching the original traceback at `widget.py:1454`) without the guard, and passes with it.
- Full CLI suite: **260 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
