### PR TITLE
feat: add "Clear context and implement plan" option to plan prompt

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -1711,6 +1711,8 @@ class KolegaCodeApp(App):
             event.stop()
             if event.option_id == "implement_plan":
                 await self._implement_pending_plan()
+            elif event.option_id == "implement_plan_clear":
+                await self._implement_pending_plan(clear_context=True)
             elif event.option_id == "discuss_plan":
                 self._discuss_pending_plan()
             return
@@ -2276,12 +2278,14 @@ class KolegaCodeApp(App):
             pass
         self._notify_user(messages.PLAN_CAPTURED)
 
-    async def _implement_pending_plan(self) -> None:
+    async def _implement_pending_plan(self, *, clear_context: bool = False) -> None:
         plan = self._latest_plan
         if not plan or self._turn_active or self.agent_worker is not None:
             return
 
         self._plan_decision_active = False
+        if clear_context:
+            self._clear_agent_context()
         self._save_session()
         await self._set_interaction_mode(BUILD_INTERACTION_MODE)
         self._refresh_planning_sidebar()
@@ -2313,6 +2317,7 @@ class KolegaCodeApp(App):
             if visible:
                 options = [Option("Implement plan", id="implement_plan")]
                 if allow_discuss:
+                    options.append(Option("Clear context and implement plan", id="implement_plan_clear"))
                     options.append(Option("Discuss further", id="discuss_plan"))
                 plan_actions.show_options(options)
             else:
@@ -3408,6 +3413,14 @@ class KolegaCodeApp(App):
         current = self.settings.active_theme or theme.DEFAULT_THEME_NAME
         current_suffix = " current" if name == current else ""
         return f"{index + 1}. {name}{current_suffix}"
+
+    def _clear_agent_context(self) -> None:
+        """Wipe the agent's LLM history so the build agent starts fresh, while leaving
+        the visible transcript and the captured plan intact."""
+        if self.agent is not None:
+            self.agent.history = MessageHistory()
+            self.agent.last_compression_index = None
+        self.session.history = []
 
     def _reset_current_thread(self) -> None:
         self._close_sub_agent_inspector()

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -1627,7 +1627,11 @@ async def test_textual_app_shows_plan_decision_when_planning_agent_writes_plan(
         assert app.query_one("#composer", ChatComposer).placeholder == "Plan ready. Choose Implement plan or Discuss further."
         plan_actions = app.query_one("#plan_actions", ActionList)
         assert plan_actions.display is True
-        assert [option.id for option in plan_actions.options] == ["implement_plan", "discuss_plan"]
+        assert [option.id for option in plan_actions.options] == [
+            "implement_plan",
+            "implement_plan_clear",
+            "discuss_plan",
+        ]
         assert app.focused is plan_actions
         assert app.query_one("#planning_plan_markdown", Markdown).source == initial_plan
         assert "Step 25" in app.query_one("#planning_plan_markdown", Markdown).source
@@ -1653,7 +1657,11 @@ async def test_textual_app_shows_plan_decision_when_planning_agent_writes_plan(
         assert app._latest_plan == "# Revised plan\n\nBuild planning mode carefully."
         assert app.query_one("#composer", ChatComposer).disabled is True
         assert plan_actions.display is True
-        assert [option.id for option in plan_actions.options] == ["implement_plan", "discuss_plan"]
+        assert [option.id for option in plan_actions.options] == [
+            "implement_plan",
+            "implement_plan_clear",
+            "discuss_plan",
+        ]
         assert (
             app.query_one("#planning_plan_markdown", Markdown).source
             == "# Revised plan\n\nBuild planning mode carefully."
@@ -1724,6 +1732,86 @@ async def test_textual_app_implement_plan_switches_to_build_and_sends_plan(
         loaded = store.load(session.session_id)
         assert loaded.latest_plan_markdown == "# Plan\n\nBuild it."
         assert loaded.interaction_mode == "build"
+
+
+@pytest.mark.asyncio
+async def test_textual_app_clear_context_and_implement_plan_starts_build_agent_fresh(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.widgets import Markdown
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import KolegaCodeApp
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.messages: list[str] = []
+            self.history = []
+            self.last_compression_index = None
+
+        def restore_message_history(self, history):
+            self.history = list(history)
+
+        def dump_message_history(self):
+            return self.history
+
+        async def cleanup(self):
+            return None
+
+        async def process_message_stream(self, message):
+            self.messages.append(message)
+            yield {"type": "response", "content": "implemented", "complete": True, "uuid": "response-1"}
+
+    class FakePlanningAgent(FakeCoderAgent):
+        pass
+
+    monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
+    monkeypatch.setattr(app_module, "PlanningAgent", FakePlanningAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test():
+        await app.action_toggle_interaction_mode()
+        # Seed the planning agent with prior conversation that the normal implement flow
+        # would carry forward into the build agent.
+        app.agent.history = ["planning message 1", "planning message 2"]
+        prior_entry_count = len(app.conversation_entries)
+        app._latest_plan = "# Plan\n\nBuild it."
+        app._plan_decision_active = True
+
+        await app._implement_pending_plan(clear_context=True)
+        assert app.agent_worker is not None
+        await app.agent_worker.wait()
+
+        assert app.interaction_mode == "build"
+        assert isinstance(app.agent, FakeCoderAgent)
+        # The build agent starts fresh: the planning conversation was wiped before the
+        # mode switch, so it never reached the new agent.
+        assert app.agent.history == []
+        assert app.session.history == []
+        # The plan is still delivered to the build agent via the implement prompt.
+        assert app.agent.messages
+        assert "# Plan\n\nBuild it." in app.agent.messages[-1]
+        # The plan itself is preserved (sidebar keeps showing it).
+        assert app._plan_decision_active is False
+        assert app._latest_plan == "# Plan\n\nBuild it."
+        assert app.query_one("#planning_plan_markdown", Markdown).source == "# Plan\n\nBuild it."
+        assert app.query_one("#plan_actions").display is False
+        # LLM-context-only clear: the visible transcript is preserved, plus the new
+        # "Implement the approved plan." entry.
+        assert len(app.conversation_entries) > prior_entry_count
+        assert any(
+            entry.kind == "user" and entry.content == "Implement the approved plan."
+            for entry in app.conversation_entries
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds a third action to the plan decision prompt, placed in the middle:

1. Implement plan
2. **Clear context and implement plan** ← new
3. Discuss further

Like **Implement plan**, the new option switches to build mode and implements the approved plan — but it first wipes the agent's **LLM context** so the build agent starts fresh, seeing only the plan (the implement prompt already embeds the full plan).

### Why

The plan→build switch (`_set_interaction_mode` → `_build_agent`) normally carries the entire planning conversation forward: it dumps the `PlanningAgent`'s history into `session.history` and restores it into the new `CoderAgent`. That's useful sometimes, but often it just bloats the context the implementation runs in. This option lets the user start implementation on a clean LLM context.

Per the chosen behavior, only the **LLM context** is cleared — the visible conversation transcript stays on screen as scrollback, and the plan stays in the sidebar.

## Changes (`kolega_code/cli/app.py`)

- `_set_plan_actions_visible` — renders `Option("Clear context and implement plan", id="implement_plan_clear")` between the existing two options.
- Option-selected handler — routes the new id to `_implement_pending_plan(clear_context=True)`.
- `_implement_pending_plan(*, clear_context=False)` — wipes history **before** the mode switch (otherwise the planning conversation carries into the new `CoderAgent`).
- New `_clear_agent_context()` helper — resets `agent.history`, `agent.last_compression_index`, and `session.history`; leaves the transcript, UI state, and `_latest_plan` untouched.

## Tests

- New `test_textual_app_clear_context_and_implement_plan_starts_build_agent_fresh`: seeds planning history, asserts the build agent starts empty while the plan, sidebar, and transcript are preserved.
- Updated the capture/discuss test's option-id assertions to expect the three options.

All 134 tests in `test_app.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)