### PR TITLE
chore: release v0.5.0

### DIFF
--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -148,4 +148,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.4.0"
+version = "0.5.0"
 description = "Local-first AI coding agent for the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [options]
 prerelease-mode = "allow"
-exclude-newer = "2026-06-11T09:14:51.248225Z"
+exclude-newer = "2026-06-11T15:14:38.268129Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -669,7 +669,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- Bump `kolega-code` package metadata and exported `__version__` values to `0.5.0`.
- Refresh `uv.lock` for the release version.
- Prepare the tag-driven release workflow without creating the release tag before merge.

## Validation

- `uv lock --check`
- `uv run kolega-code --version` -> `kolega-code 0.5.0`
- `uv run pytest -ra --durations=50 --import-mode=importlib -m "not slow"` -> 986 passed, 50 deselected, 4 warnings
- `uv run --with build python -m build --outdir /private/tmp/kolega-code-dist-v0.5.0`
- `uv run --with twine python -m twine check /private/tmp/kolega-code-dist-v0.5.0/kolega_code-0.5.0.tar.gz /private/tmp/kolega-code-dist-v0.5.0/kolega_code-0.5.0-py3-none-any.whl`

## Release Handoff

After this PR is reviewed, green, and merged, update local `main`, tag the merge commit, and push the tag:

```bash
git checkout main
git pull origin main
git tag v0.5.0
git push origin v0.5.0
```

The pushed tag will trigger the `Release` workflow to build, test, publish to PyPI, and create the GitHub Release.