### PR TITLE
chore: release v0.5.1

### DIFF
--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -148,4 +148,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.5.0"
+version = "0.5.1"
 description = "Local-first AI coding agent for the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [options]
 prerelease-mode = "allow"
-exclude-newer = "2026-06-11T15:14:38.268129Z"
+exclude-newer = "2026-06-12T10:59:47.512028Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -669,7 +669,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Bump `kolega-code` package metadata and runtime versions to `0.5.1`.
- Refresh `uv.lock` for the editable package version.

## Impact
- Prepares the next patch release after `v0.5.0`.
- No CLI or API behavior changes are introduced by this release bump.

## Validation
- `uv run pytest -ra --durations=50 --import-mode=importlib -m "not slow"`
  - 970 passed, 50 deselected, 4 pathspec deprecation warnings.