### PR TITLE
fix(sandbox): forward exec_command env to e2b commands.run

### DIFF
--- a/kolega_code/agent/tests/services/test_sandbox_terminal_input.py
+++ b/kolega_code/agent/tests/services/test_sandbox_terminal_input.py
@@ -71,6 +71,18 @@ async def test_exec_command_runs_background_with_stdin():
 
 
 @pytest.mark.asyncio
+async def test_exec_command_forwards_env_to_sandbox():
+    sandbox = FakeSandbox()
+    manager = SandboxTerminalManager(sandbox, "workspace", "thread")
+
+    await manager.exec_command("echo $FOO", env={"FOO": "bar"}, yield_time_ms=200)
+
+    assert sandbox.commands.run_calls
+    _, kwargs = sandbox.commands.run_calls[0]
+    assert kwargs.get("envs") == {"FOO": "bar"}
+
+
+@pytest.mark.asyncio
 async def test_write_stdin_sends_raw_input_and_reports_exit():
     sandbox = FakeSandbox()
     manager = SandboxTerminalManager(sandbox, "workspace", "thread")

--- a/kolega_code/sandbox/terminal.py
+++ b/kolega_code/sandbox/terminal.py
@@ -455,6 +455,9 @@ class SandboxTerminalManager(TerminalManager):
         if hasattr(working_dir, "__fspath__"):  # Check if it's a Path-like object
             working_dir = str(working_dir)
 
+        # Forward the terminal's environment to the sandbox command.
+        env = terminal_info.get("env") or {}
+
         # Store command in output
         self.outputs[terminal_id].append(
             {"type": "command", "data": command, "timestamp": datetime.now(timezone.utc), "purpose": purpose}
@@ -481,6 +484,7 @@ class SandboxTerminalManager(TerminalManager):
                 result = await self.sandbox.commands.run(
                     command,
                     cwd=working_dir,
+                    envs=env,
                     on_stdout=stdout_handler,
                     on_stderr=stderr_handler,
                     timeout=0,  # No timeout for sandbox
@@ -491,6 +495,7 @@ class SandboxTerminalManager(TerminalManager):
                     self.sandbox.commands.run(
                         command,
                         cwd=working_dir,
+                        envs=env,
                         on_stdout=stdout_handler,
                         on_stderr=stderr_handler,
                         timeout=sandbox_timeout,
@@ -697,6 +702,9 @@ class SandboxTerminalManager(TerminalManager):
             if hasattr(working_dir, "__fspath__"):  # Check if it's a Path-like object
                 working_dir = str(working_dir)
 
+            # Forward the terminal's environment to the sandbox command.
+            env = self.terminals.get(terminal_id, {}).get("env") or {}
+
             # Create streaming output handlers
             stdout_handler = await self._create_output_handler(terminal_id, "stdout")
             stderr_handler = await self._create_output_handler(terminal_id, "stderr")
@@ -711,6 +719,7 @@ class SandboxTerminalManager(TerminalManager):
                         command,
                         background=True,
                         cwd=working_dir,
+                        envs=env,
                         on_stdout=stdout_handler,
                         on_stderr=stderr_handler,
                         stdin=True,
@@ -724,6 +733,7 @@ class SandboxTerminalManager(TerminalManager):
                         command,
                         background=True,
                         cwd=working_dir,
+                        envs=env,
                         on_stdout=stdout_handler,
                         on_stderr=stderr_handler,
                         stdin=True,


### PR DESCRIPTION
## Problem

`SandboxTerminalManager.exec_command(..., env=...)` merges the env onto the terminal record (`info["env"]`) but never forwards it to the actual sandbox command. Execution runs through `send_command_tracked` → `_execute_command_async` → `sandbox.commands.run(...)`, which had **no `envs=` argument** — so env vars passed to `exec_command` had **no effect on the e2b backend**.

This is a pre-existing gap (the old code never forwarded env either) that the new `env=` parameter made visible. The local PTY backend already applies env; this was e2b-only.

## Fix

Thread the terminal's stored env to `sandbox.commands.run(..., envs=…)` (the e2b SDK's env kwarg) in both:
- `_execute_command_async` (the tracked path that `exec_command`/`write_stdin` use), and
- `send_command` (non-tracked path), for parity.

`run_command` (the convenience helper) takes no env and is unchanged.

## Test

Adds a fake-sandbox unit test asserting the env is forwarded:

```python
await manager.exec_command("echo $FOO", env={"FOO": "bar"})
_, kwargs = sandbox.commands.run_calls[0]
assert kwargs.get("envs") == {"FOO": "bar"}
```

`pytest kolega_code/agent/tests/services/test_sandbox_terminal_input.py test_terminal.py test_terminal_state_serializer.py` → **30 passed**.

## Follow-up

Once this ships (e.g. **0.5.2**), kolega-code-e2b can add a live env assertion (`exec_command("echo $FOO", env={"FOO":"bar"})` → output contains `bar`), which was deliberately omitted from its current PR because it would fail against 0.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)