### PR TITLE
fix(cli): stop re-offering "Implement plan" for an already-implemented plan

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -1314,6 +1314,7 @@ class KolegaCodeApp(App):
         self._active_progress_entry: Optional[ConversationEntry] = None
         self._turn_active = False
         self._latest_plan: Optional[str] = self.session.latest_plan_markdown or None
+        self._plan_pending: bool = bool(self.session.plan_pending)
         self._plan_decision_active = False
         self._gigacode_enabled = False
         self._pending_question: Optional[PendingQuestion] = None
@@ -1576,6 +1577,7 @@ class KolegaCodeApp(App):
         self.session.interaction_mode = self.interaction_mode
         self.session.permission_mode = self.permission_mode.value
         self.session.latest_plan_markdown = self._latest_plan or ""
+        self.session.plan_pending = self._plan_pending
 
     def _save_session(self) -> None:
         self._sync_planning_state_to_session()
@@ -1583,7 +1585,7 @@ class KolegaCodeApp(App):
 
     def _restore_plan_action_visibility(self) -> None:
         self._set_plan_actions_visible(
-            self.interaction_mode == PLAN_INTERACTION_MODE and bool(self._latest_plan),
+            self.interaction_mode == PLAN_INTERACTION_MODE and self._plan_pending,
             allow_discuss=self._plan_decision_active,
         )
 
@@ -2265,6 +2267,7 @@ class KolegaCodeApp(App):
             return
 
         self._latest_plan = plan
+        self._plan_pending = True
         self._plan_decision_active = True
         self._save_session()
         self._refresh_planning_sidebar()
@@ -2283,6 +2286,11 @@ class KolegaCodeApp(App):
         if not plan or self._turn_active or self.agent_worker is not None:
             return
 
+        # Leave self._latest_plan set so the planning sidebar keeps showing the
+        # plan as a read-only reference while it is being built; clearing
+        # _plan_pending is what hides the "Implement plan" action so it does not
+        # reappear when the user re-enters plan mode.
+        self._plan_pending = False
         self._plan_decision_active = False
         if clear_context:
             self._clear_agent_context()
@@ -2302,6 +2310,7 @@ class KolegaCodeApp(App):
             return
 
         self._latest_plan = None
+        self._plan_pending = False
         self._plan_decision_active = False
         self._save_session()
         self._refresh_planning_sidebar()
@@ -3437,6 +3446,7 @@ class KolegaCodeApp(App):
         self._sub_agent_seq = 0
         self._active_progress_entry = None
         self._latest_plan = None
+        self._plan_pending = False
         self._plan_decision_active = False
         self._save_session()
         self._set_plan_actions_visible(False)

--- a/kolega_code/cli/session_store.py
+++ b/kolega_code/cli/session_store.py
@@ -32,6 +32,7 @@ class SessionRecord:
     history: list[dict[str, Any]] = field(default_factory=list)
     task_list_markdown: str = ""
     latest_plan_markdown: str = ""
+    plan_pending: bool = False
     interaction_mode: str = "build"
     permission_mode: str = "ask"
     schema_version: int = SCHEMA_VERSION
@@ -80,6 +81,7 @@ class SessionRecord:
             history=data.get("history") or [],
             task_list_markdown=data.get("task_list_markdown") or "",
             latest_plan_markdown=data.get("latest_plan_markdown") or "",
+            plan_pending=bool(data.get("plan_pending", False)),
             interaction_mode=data.get("interaction_mode") or "build",
             permission_mode=data.get("permission_mode") or "ask",
         )
@@ -99,6 +101,7 @@ class SessionRecord:
             "history": self.history,
             "task_list_markdown": self.task_list_markdown,
             "latest_plan_markdown": self.latest_plan_markdown,
+            "plan_pending": self.plan_pending,
             "interaction_mode": self.interaction_mode,
             "permission_mode": self.permission_mode,
         }

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -801,6 +801,7 @@ async def test_textual_app_restores_saved_plan_and_interaction_mode(
     session = store.create(project, "code", config_summary(config))
     session.history = saved_history
     session.latest_plan_markdown = saved_plan
+    session.plan_pending = True
     session.interaction_mode = "plan"
     store.save(session)
 
@@ -810,6 +811,7 @@ async def test_textual_app_restores_saved_plan_and_interaction_mode(
         assert app.interaction_mode == "plan"
         assert isinstance(app.agent, FakePlanningAgent)
         assert app._latest_plan == saved_plan
+        assert app._plan_pending is True
         assert app._plan_decision_active is False
         assert app.query_one("#planning_plan_markdown", Markdown).source == saved_plan
         plan_actions = app.query_one("#plan_actions", ActionList)
@@ -851,6 +853,7 @@ async def test_textual_app_restores_saved_plan_in_build_mode_without_plan_action
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
     session.latest_plan_markdown = saved_plan
+    session.plan_pending = True
     session.interaction_mode = "build"
     store.save(session)
 
@@ -861,6 +864,7 @@ async def test_textual_app_restores_saved_plan_in_build_mode_without_plan_action
         assert isinstance(app.agent, FakeCoderAgent)
         assert app._latest_plan == saved_plan
         assert app.query_one("#planning_plan_markdown", Markdown).source == saved_plan
+        # Even with a pending plan, the action stays hidden outside plan mode.
         assert app.query_one("#plan_actions").display is False
 
 
@@ -1622,6 +1626,7 @@ async def test_textual_app_shows_plan_decision_when_planning_agent_writes_plan(
 
         initial_plan = app.agent.completed_plan or app._latest_plan
         assert app._plan_decision_active is True
+        assert app._plan_pending is True
         assert app._latest_plan == initial_plan
         assert app.query_one("#composer", ChatComposer).disabled is True
         assert app.query_one("#composer", ChatComposer).placeholder == "Plan ready. Choose Implement plan or Discuss further."
@@ -1643,6 +1648,7 @@ async def test_textual_app_shows_plan_decision_when_planning_agent_writes_plan(
         app._discuss_pending_plan()
 
         assert app._plan_decision_active is False
+        assert app._plan_pending is False
         assert app._latest_plan is None
         assert app.query_one("#composer", ChatComposer).disabled is False
         assert app.query_one("#planning_plan_markdown", Markdown).source == "No plan captured yet."
@@ -1654,6 +1660,7 @@ async def test_textual_app_shows_plan_decision_when_planning_agent_writes_plan(
         app._capture_completed_plan()
 
         assert app._plan_decision_active is True
+        assert app._plan_pending is True
         assert app._latest_plan == "# Revised plan\n\nBuild planning mode carefully."
         assert app.query_one("#composer", ChatComposer).disabled is True
         assert plan_actions.display is True
@@ -1715,6 +1722,7 @@ async def test_textual_app_implement_plan_switches_to_build_and_sends_plan(
     async with app.run_test():
         await app.action_toggle_interaction_mode()
         app._latest_plan = "# Plan\n\nBuild it."
+        app._plan_pending = True
         app._plan_decision_active = True
 
         await app._implement_pending_plan()
@@ -1726,12 +1734,85 @@ async def test_textual_app_implement_plan_switches_to_build_and_sends_plan(
         assert app.agent.messages
         assert "# Plan\n\nBuild it." in app.agent.messages[-1]
         assert app._plan_decision_active is False
+        # The plan is kept as a read-only sidebar reference, but it is no longer
+        # pending a decision so the action must not be re-offered.
+        assert app._plan_pending is False
         assert app._latest_plan == "# Plan\n\nBuild it."
         assert app.query_one("#planning_plan_markdown", Markdown).source == "# Plan\n\nBuild it."
         assert app.query_one("#plan_actions").display is False
         loaded = store.load(session.session_id)
         assert loaded.latest_plan_markdown == "# Plan\n\nBuild it."
+        assert loaded.plan_pending is False
         assert loaded.interaction_mode == "build"
+
+
+@pytest.mark.asyncio
+async def test_textual_app_implemented_plan_not_reoffered_on_reentry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.widgets import Markdown
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import PLAN_INTERACTION_MODE, ActionList, KolegaCodeApp
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.history = []
+
+        def restore_message_history(self, history):
+            self.history = list(history)
+
+        def dump_message_history(self):
+            return self.history
+
+        async def cleanup(self):
+            return None
+
+        async def process_message_stream(self, message):
+            yield {"type": "response", "content": "implemented", "complete": True, "uuid": "response-1"}
+
+    class FakePlanningAgent(FakeCoderAgent):
+        pass
+
+    monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
+    monkeypatch.setattr(app_module, "PlanningAgent", FakePlanningAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test():
+        # Enter plan mode with a freshly captured plan awaiting a decision.
+        await app.action_toggle_interaction_mode()
+        app._latest_plan = "# Plan\n\nBuild it."
+        app._plan_pending = True
+        app._plan_decision_active = True
+
+        # Implement it: switches to build and runs the plan.
+        await app._implement_pending_plan()
+        assert app.agent_worker is not None
+        await app.agent_worker.wait()
+        assert app.interaction_mode == "build"
+
+        # Re-enter plan mode. The already-implemented plan must NOT be re-offered,
+        # but it stays visible in the sidebar as a read-only reference.
+        await app._set_interaction_mode(PLAN_INTERACTION_MODE)
+
+        assert app._plan_pending is False
+        assert app._latest_plan == "# Plan\n\nBuild it."
+        plan_actions = app.query_one("#plan_actions", ActionList)
+        assert plan_actions.display is False
+        assert plan_actions.option_count == 0
+        assert app.query_one("#planning_plan_markdown", Markdown).source == "# Plan\n\nBuild it."
+
+        # A restart (reloading from the persisted session) must also not re-offer it.
+        assert store.load(session.session_id).plan_pending is False
 
 
 @pytest.mark.asyncio

--- a/kolega_code/cli/tests/test_session_store.py
+++ b/kolega_code/cli/tests/test_session_store.py
@@ -19,6 +19,7 @@ def test_session_store_create_load_list_export_delete(tmp_path: Path) -> None:
     record.history = [{"role": "user", "content": []}]
     record.task_list_markdown = "- [ ] inspect\n- [x] plan"
     record.latest_plan_markdown = "# Plan\n\nImplement it."
+    record.plan_pending = True
     record.interaction_mode = "plan"
     record.permission_mode = "auto"
     store.save(record)
@@ -28,6 +29,7 @@ def test_session_store_create_load_list_export_delete(tmp_path: Path) -> None:
     assert loaded.history == [{"role": "user", "content": []}]
     assert loaded.task_list_markdown == "- [ ] inspect\n- [x] plan"
     assert loaded.latest_plan_markdown == "# Plan\n\nImplement it."
+    assert loaded.plan_pending is True
     assert loaded.interaction_mode == "plan"
     assert loaded.permission_mode == "auto"
     assert store.latest_for_project(project).session_id == record.session_id
@@ -35,6 +37,7 @@ def test_session_store_create_load_list_export_delete(tmp_path: Path) -> None:
     assert record.session_id in exported
     assert "task_list_markdown" in exported
     assert "latest_plan_markdown" in exported
+    assert "plan_pending" in exported
     assert "interaction_mode" in exported
     assert "permission_mode" in exported
 
@@ -52,6 +55,7 @@ def test_session_store_loads_old_sessions_without_planning_state(tmp_path: Path)
     payload = record.to_dict()
     payload.pop("task_list_markdown")
     payload.pop("latest_plan_markdown")
+    payload.pop("plan_pending")
     payload.pop("interaction_mode")
     payload.pop("permission_mode")
     store.path_for(record.session_id).write_text(json.dumps(payload), encoding="utf-8")
@@ -60,6 +64,7 @@ def test_session_store_loads_old_sessions_without_planning_state(tmp_path: Path)
 
     assert loaded.task_list_markdown == ""
     assert loaded.latest_plan_markdown == ""
+    assert loaded.plan_pending is False
     assert loaded.interaction_mode == "build"
     assert loaded.permission_mode == "ask"
 


### PR DESCRIPTION
## Problem

Leaving plan mode and re-entering it sometimes showed **"Implement plan"** even when (a) no plan was made this session, or (b) the plan was already implemented.

## Root cause

`self._latest_plan` was doing two jobs at once — it was both the *planning-sidebar content* **and** the *"a plan is awaiting an implement decision"* signal. Those two meanings only stay in sync if every clearing path clears both, and one didn't:

- `_discuss_pending_plan` and `_reset_current_thread` clear `self._latest_plan = None`. ✅
- `_implement_pending_plan` only flipped `_plan_decision_active = False` and re-saved the still-set plan to the session. ❌

The visibility gate `_restore_plan_action_visibility` (which runs on **every** mode switch and at startup) decided whether to show "Implement plan" purely from `bool(self._latest_plan)`. So:

- **Already implemented:** implement → switch to build → switch back to plan → leftover `_latest_plan` is truthy → "Implement plan" reappears.
- **No plan focused:** an implemented plan was never cleared from the persisted session, so it reloaded at startup and plan mode offered to implement an old plan the user never made this session.

## Fix

Stop overloading `_latest_plan`. Add a separate, persisted `plan_pending` flag that means specifically *"a plan awaits an implement decision"*:

- Set on capture; cleared on implement / discuss / reset.
- The action-visibility gate now keys off `_plan_pending` instead of `bool(self._latest_plan)`.
- `_latest_plan` keeps driving the sidebar, so an implemented plan stays visible as a **read-only reference** while the action no longer reappears.
- Preserves the restart-restore feature: a saved, *un-implemented* plan still offers "Implement plan" after a relaunch (the flag persists).

`plan_pending` is added to `SessionRecord` as a backward-compatible field (absent key defaults to `False`; no schema bump). Legacy sessions default to `False`, which deliberately avoids resurrecting stale offers for plans that were implemented before the flag existed.

| State | `_latest_plan` | `plan_pending` | `_plan_decision_active` | Action shown |
|---|---|---|---|---|
| Fresh plan captured | set | True | True | Implement / Clear+Implement / Discuss |
| Restored un-implemented plan | set | True | False | Implement only |
| **After implement (was the bug)** | set (sidebar) | **False** | False | **none** |
| After discuss | None | False | False | none |

## Tests

- New regression test `test_textual_app_implemented_plan_not_reoffered_on_reentry`: capture → implement → re-enter plan mode → asserts the action is gone but the plan stays in the sidebar, and that a reload from the persisted session also doesn't re-offer it.
- Updated the restore / capture / implement tests to set and assert `plan_pending`.
- `session_store` round-trip + missing-key defaults cover the new field.
- **Full suite: 1022 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)