### PR TITLE
fix(cli): keep keyboard focus on prompt option lists

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -1688,6 +1688,18 @@ class KolegaCodeApp(App):
             return
         dropdown.open_with([file_completion_item(entry) for entry in entries])
 
+    def on_descendant_focus(self, event: events.DescendantFocus) -> None:
+        # Fires after screen.focused settles. Catches AUTO_FOCUS landing on the
+        # conversation transcript (resume/resize) and any other stray focus while a
+        # prompt is shown, pulling focus back to the active option list.
+        self._heal_prompt_focus()
+
+    def on_descendant_blur(self, event: events.DescendantBlur) -> None:
+        # A background click does set_focus(None) and emits no DescendantFocus, so
+        # the focus hook alone would miss it. Re-assert after the refresh settles, so
+        # we run after any AUTO_FOCUS/_reset_focus the same blur triggered.
+        self.call_after_refresh(self._heal_prompt_focus)
+
     async def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
         if event.option_list.id == "question_actions":
             event.stop()
@@ -2275,10 +2287,6 @@ class KolegaCodeApp(App):
         self._set_plan_actions_visible(True, allow_discuss=True)
         self._set_composer_status(PLAN_READY_PLACEHOLDER)
         self._set_chat_enabled(False)
-        try:
-            self.screen.set_focus(self.query_one("#plan_actions", ActionList))
-        except Exception:
-            pass
         self._notify_user(messages.PLAN_CAPTURED)
 
     async def _implement_pending_plan(self, *, clear_context: bool = False) -> None:
@@ -2320,6 +2328,70 @@ class KolegaCodeApp(App):
         self.query_one("#composer", ChatComposer).focus()
         self._notify_user(messages.PLAN_DISCUSSION_RESUMED)
 
+    def _active_prompt_actions(self) -> Optional[ActionList]:
+        """The option list that must own keyboard focus while a prompt is shown.
+
+        Returns None when no prompt is active (free typing). Keys off the same
+        _pending_* / plan flags that gate visibility, plus a .display check, so
+        "displayed" and "should be focused" cannot drift. Only one of these is ever
+        active at a time; the order is a safety net.
+        """
+        candidates = [
+            (self._pending_approval is not None, "#approval_actions"),
+            (self._pending_question is not None, "#question_actions"),
+            (self._pending_model_selection is not None, "#model_actions"),
+            (self._pending_effort_selection is not None, "#effort_actions"),
+            (self._pending_theme_selection is not None, "#theme_actions"),
+            (
+                self.interaction_mode == PLAN_INTERACTION_MODE and self._plan_pending,
+                "#plan_actions",
+            ),
+        ]
+        for active, selector in candidates:
+            if not active:
+                continue
+            try:
+                actions = self.query_one(selector, ActionList)
+            except Exception:
+                return None
+            return actions if actions.display else None
+        return None
+
+    def _focus_active_prompt(self) -> None:
+        """Focus the active prompt list now and re-assert after the refresh settles.
+
+        The synchronous set_focus handles the common fast path; the deferred
+        re-assert defeats the documented race where compose/resume/disable churn
+        resets focus right after we set it (see PromptPanel.prompt)."""
+        actions = self._active_prompt_actions()
+        if actions is None:
+            return
+        if self.screen.focused is not actions:
+            self.screen.set_focus(actions)
+        self.call_after_refresh(self._heal_prompt_focus)
+
+    def _heal_prompt_focus(self) -> None:
+        """Re-grab focus for the active prompt list if it has drifted. Idempotent.
+
+        Restores keyboard navigation after focus is lost to nothing (background
+        click), to the conversation transcript (AUTO_FOCUS on resume/resize), or to
+        any other stray widget. No-op when no prompt is active or the list is already
+        focused."""
+        actions = self._active_prompt_actions()
+        if actions is None or self.screen.focused is actions:
+            return
+        # Legitimate exception: during a QUESTION the composer is enabled so the user
+        # can type a free-form answer; don't fight a deliberate move there. For
+        # approvals/plan the composer is disabled and thus never focusable here.
+        focused = self.screen.focused
+        if (
+            self._pending_question is not None
+            and isinstance(focused, ChatComposer)
+            and not focused.disabled
+        ):
+            return
+        self.screen.set_focus(actions)
+
     def _set_plan_actions_visible(self, visible: bool, *, allow_discuss: bool = False) -> None:
         try:
             plan_actions = self.query_one("#plan_actions", ActionList)
@@ -2329,6 +2401,7 @@ class KolegaCodeApp(App):
                     options.append(Option("Clear context and implement plan", id="implement_plan_clear"))
                     options.append(Option("Discuss further", id="discuss_plan"))
                 plan_actions.show_options(options)
+                self._focus_active_prompt()
             else:
                 plan_actions.hide()
         except Exception:
@@ -3235,6 +3308,7 @@ class KolegaCodeApp(App):
             for index, option in enumerate(options)
         ]
         panel.prompt(escape(question), option_widgets)
+        self._focus_active_prompt()
 
     async def _permission_callback(self, request: PermissionRequest) -> PermissionDecision:
         if self.permission_mode != PermissionMode.ASK:
@@ -3324,27 +3398,15 @@ class KolegaCodeApp(App):
 
     def _show_effort_options(self) -> None:
         self._set_effort_actions_visible(True)
-        try:
-            effort_actions = self.query_one("#effort_actions", ActionList)
-            self.screen.set_focus(effort_actions)
-        except Exception:
-            return
+        self._focus_active_prompt()
 
     def _show_model_options(self) -> None:
         self._set_model_actions_visible(True)
-        try:
-            model_actions = self.query_one("#model_actions", ActionList)
-            self.screen.set_focus(model_actions)
-        except Exception:
-            return
+        self._focus_active_prompt()
 
     def _show_theme_options(self) -> None:
         self._set_theme_actions_visible(True)
-        try:
-            theme_actions = self.query_one("#theme_actions", ActionList)
-            self.screen.set_focus(theme_actions)
-        except Exception:
-            return
+        self._focus_active_prompt()
 
     def _set_question_actions_visible(self, visible: bool) -> None:
         try:
@@ -3354,6 +3416,7 @@ class KolegaCodeApp(App):
         if visible:
             panel.display = True
             panel.actions.display = True
+            self._focus_active_prompt()
         else:
             panel.hide()
 
@@ -3369,6 +3432,7 @@ class KolegaCodeApp(App):
                 for index, label in enumerate(labels)
             ]
             panel.prompt(escape(self._format_permission_content(self._pending_approval.request)), options)
+            self._focus_active_prompt()
         else:
             panel.hide()
 

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -6188,3 +6188,128 @@ async def test_textual_app_unknown_slash_command_falls_through_to_agent(
         await pilot.pause()
 
         assert app.agent.messages == ["/help"]
+
+
+@pytest.mark.asyncio
+async def test_textual_app_prompt_list_recovers_focus_after_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A shown prompt list must regain keyboard focus if focus drifts away.
+
+    Regression for: after a prompt appears, a background click or a resize could
+    leave the option list without focus and the user had no keyboard way back
+    (arrow keys / Enter dead). The composer is disabled during an approval, so the
+    list is always the only valid focus target here.
+    """
+    pytest.importorskip("textual")
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import ActionList, KolegaCodeApp, PendingApproval
+    from kolega_code.permissions import PermissionDecision, allow_rule_options, permission_request_for_tool
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            pass
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            return None
+
+    monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test() as pilot:
+        request = permission_request_for_tool("exec_command", {"command": "npm run test"})
+        assert request is not None
+        future: asyncio.Future[PermissionDecision] = asyncio.get_running_loop().create_future()
+        app._pending_approval = PendingApproval(
+            request=request, future=future, rule_options=allow_rule_options(request)
+        )
+        app._set_approval_actions_visible(True)
+        app._set_chat_enabled(False)
+
+        approval_actions = app.query_one("#approval_actions", ActionList)
+        assert app.focused is approval_actions
+
+        # Focus drifts to the conversation transcript (the AUTO_FOCUS magnet that
+        # would otherwise win on resize/resume). The focus hook pulls it back.
+        app.screen.set_focus(app.query_one("#conversation"))
+        await pilot.pause()
+        assert app.focused is approval_actions
+
+        # A background (NoWidget) click does set_focus(None); the blur hook restores.
+        app.screen.set_focus(None)
+        await pilot.pause()
+        assert app.focused is approval_actions
+
+        app._pending_approval = None
+        app._set_approval_actions_visible(False)
+
+
+@pytest.mark.asyncio
+async def test_textual_app_question_recovers_focus_but_allows_free_form_answer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """During a question the option list self-heals, but a deliberate move to the
+    enabled composer (to type a free-form answer) must NOT be fought."""
+    pytest.importorskip("textual")
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import ActionList, ChatComposer, KolegaCodeApp, PendingQuestion
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            pass
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            return None
+
+    monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test() as pilot:
+        future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+        app._pending_question = PendingQuestion(question="Choose?", options=["A", "B"], future=future)
+        app._show_question_options("Choose?", ["A", "B"])
+        app._set_chat_enabled(True)
+
+        question_actions = app.query_one("#question_actions", ActionList)
+        assert app.focused is question_actions
+
+        # Drift to the transcript is pulled back to the option list.
+        app.screen.set_focus(app.query_one("#conversation"))
+        await pilot.pause()
+        assert app.focused is question_actions
+
+        # A deliberate move to the ENABLED composer is preserved (free-form answer).
+        composer = app.query_one("#composer", ChatComposer)
+        assert composer.disabled is False
+        app.screen.set_focus(composer)
+        await pilot.pause()
+        assert app.focused is composer
+
+        app._pending_question = None
+        app._set_question_actions_visible(False)


### PR DESCRIPTION
## Problem

When the agent shows an interactive prompt (an `ask_user_choice` question, a permission/approval request, a plan decision, or the `/model` `/effort` `/theme` pickers), the selectable option list could lose keyboard focus. When that happened, arrow keys and Enter stopped navigating/selecting and **there was no keyboard way to get focus back** — clicking the chat input didn't help; only clicking an option directly worked.

## Root cause (Textual 8.x)

Each prompt list was focused **once, synchronously, at show time** and never recovered:

- `Screen.set_focus(w)` is a **no-op if `w` isn't focusable** at that instant (it doesn't blur otherwise); `set_focus(None)` blurs to nothing.
- `ConversationView` is focusable (`ScrollableContainer`) and **first in DOM order**, and `App.AUTO_FOCUS="*"` re-grabs the first focusable widget whenever `screen.focused is None`.
- A background (NoWidget) click calls `set_focus(None)`, a resize/resume re-runs auto-focus, and a disabled composer can't be focused.

So any of those left the option list without focus, AUTO_FOCUS preferred the transcript, and nothing routed focus back.

## Fix

- `_active_prompt_actions()` — single source of truth for which list should own focus (keyed off the existing `_pending_*` / plan flags + `.display`).
- `_focus_active_prompt()` — focuses it now **and** re-asserts via `call_after_refresh` (closes the documented refresh-loop race).
- `on_descendant_focus` / `on_descendant_blur` handlers (both events bubble to the App) → `_heal_prompt_focus()` self-heals focus when it drifts to `None`, the transcript, or any stray widget. A deliberate move to the **enabled** composer during a question (free-form answer) is preserved.
- Every show / re-show / restore path now routes through the focus helper.

`ConversationView` is intentionally left focusable — the hooks fix the bug with **zero behavior change** (keyboard transcript scrolling preserved).

## Tests

Added two regression tests in `test_app.py`:
- prompt list regains focus after drift to the transcript and after a background `set_focus(None)` (approval prompt, composer disabled);
- during a question, focus self-heals from drift **but** a deliberate move to the enabled composer is not fought.

Full suite green; `test_app.py` passes 137 tests (135 existing + 2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)