### PR TITLE
Per-agent model configuration

### DIFF
--- a/docs/src/content/docs/configuration/environment-variables.md
+++ b/docs/src/content/docs/configuration/environment-variables.md
@@ -67,6 +67,19 @@ provider's default model, or set both provider and model.
 
 See [Providers & Models](../providers-and-models/) for what each role does.
 
+## Per-agent models
+
+Give an individual agent its own model. `<ROLE>` is one of `PLANNING`, `BUILDING`,
+`INVESTIGATION`, `GENERAL`, or `BROWSER`. A role with no override inherits the main
+model. These also override anything saved in the Settings tab's **Agent Models**
+section.
+
+| Variable | Purpose |
+| --- | --- |
+| `KOLEGA_CODE_<ROLE>_PROVIDER` | Provider for that agent (e.g. `KOLEGA_CODE_INVESTIGATION_PROVIDER`) |
+| `KOLEGA_CODE_<ROLE>_MODEL` | Model for that agent |
+| `KOLEGA_CODE_<ROLE>_EFFORT` | Thinking effort for that agent |
+
 ## State & environment
 
 | Variable | Purpose |

--- a/docs/src/content/docs/configuration/providers-and-models.mdx
+++ b/docs/src/content/docs/configuration/providers-and-models.mdx
@@ -121,8 +121,8 @@ Each role **inherits the active (long-context) model** unless you give it an ove
 so with nothing configured, behavior is unchanged.
 
 In the **Settings tab**, the **Agent Models** section (below the main Model section)
-has one row per role. Leave a role on **Default** to inherit; pick a provider, model,
-and thinking effort to override it.
+has a provider/model/effort group per role. Leave a role on **Default** to inherit;
+pick a provider, model, and thinking effort to override it.
 
 Or use environment variables, named `KOLEGA_CODE_<ROLE>_PROVIDER` / `_MODEL` / `_EFFORT`:
 

--- a/docs/src/content/docs/configuration/providers-and-models.mdx
+++ b/docs/src/content/docs/configuration/providers-and-models.mdx
@@ -102,6 +102,42 @@ kolega-code . \
 Or with environment variables — see
 [Environment Variables](../environment-variables/) for the complete list.
 
+## Per-agent models
+
+The three slots above describe *operational* roles (main, fast, thinking). Separately,
+you can give each **agent** its own model, so a cheap, fast model handles
+investigation while a stronger model does the building. This applies to top-level
+agents and to the sub-agents they dispatch.
+
+| Agent role | Key | Runs |
+| --- | --- | --- |
+| **Planning** | `planning` | The plan-mode agent |
+| **Building** | `building` | The main coder agent |
+| **Investigation** | `investigation` | Read-only research/exploration sub-agents |
+| **General** | `general` | General-purpose sub-agents |
+| **Browser** | `browser` | Browser/web sub-agents |
+
+Each role **inherits the active (long-context) model** unless you give it an override —
+so with nothing configured, behavior is unchanged.
+
+In the **Settings tab**, the **Agent Models** section (below the main Model section)
+has one row per role. Leave a role on **Default** to inherit; pick a provider, model,
+and thinking effort to override it.
+
+Or use environment variables, named `KOLEGA_CODE_<ROLE>_PROVIDER` / `_MODEL` / `_EFFORT`:
+
+```bash
+# Use a fast model for investigation; everything else uses the active model.
+export KOLEGA_CODE_INVESTIGATION_PROVIDER=deepseek
+export KOLEGA_CODE_INVESTIGATION_MODEL=deepseek-v4-flash
+export KOLEGA_CODE_INVESTIGATION_EFFORT=high
+```
+
+Resolution order for a role (first match wins): **env var → saved Settings → the
+active model**. Each override's provider must have an API key, exactly like the main
+roles. (Inside a `run_workflow` script, an explicit `model=`/`effort=` on an `agent()`
+call still takes precedence over these per-role defaults.)
+
 ## Thinking effort
 
 Thinking effort is model-specific. Kolega Code validates the selected value

--- a/docs/src/content/docs/configuration/settings-and-api-keys.mdx
+++ b/docs/src/content/docs/configuration/settings-and-api-keys.mdx
@@ -21,11 +21,16 @@ the TUI:
 
 When you switch models, the thinking effort resets to the new model's default.
 
-A saved selection is used for **all** agent model roles. Existing environment
+A saved selection is the default for **all** agent model roles. Existing environment
 variables and `--provider` / `--model` flags continue to override it — see
 [Providers & Models](../providers-and-models/) for resolution order.
 API key environment variables are credentials only; they do not choose the active
 provider or model.
+
+The **Agent Models** section beneath the main Model section lets you give individual
+agents (planning, building, investigation, general, browser) their own provider,
+model, and effort. Leave a role on **Default** to inherit the active model. See
+[Per-agent models](../providers-and-models/#per-agent-models).
 
 ## Where settings live
 
@@ -45,15 +50,27 @@ The file looks like this:
 
 ```json
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "active_provider": "moonshot",
   "active_model": "kimi-k2.7-code",
   "active_thinking_effort": "auto",
   "api_keys": {
-    "moonshot": "sk-..."
+    "moonshot": "sk-...",
+    "deepseek": "sk-..."
+  },
+  "agent_models": {
+    "investigation": {
+      "provider": "deepseek",
+      "model": "deepseek-v4-flash",
+      "thinking_effort": "high"
+    }
   }
 }
 ```
+
+`agent_models` holds per-agent overrides keyed by role (`planning`, `building`,
+`investigation`, `general`, `browser`); a role that is absent inherits the active
+model. The field is optional and older `schema_version` files load unchanged.
 
 <Aside type="caution" title="Keys are stored in plaintext">
 API keys are written to `settings.json` in plaintext, but the file is created with

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -212,6 +212,9 @@ class BaseAgent(LogMixin):
         self.thread_id = context.workspace.thread_id
         self.connection_manager = context.connection_manager
         self.config = context.config
+        # The model this agent runs its main loop on: the per-role override when one
+        # is configured for this agent_name, otherwise the global long-context model.
+        self.primary_model_config = self.config.model_config_for_agent(self.agent_name)
         self.filesystem = context.services.filesystem
         self.terminal_manager = context.services.terminal_manager
         self.browser_manager = context.services.browser_manager
@@ -257,7 +260,7 @@ class BaseAgent(LogMixin):
             sub_agent_info_provider=self._sub_agent_info,
         )
 
-        model_specs = get_model_specs(self.config.long_context_config.provider, self.config.long_context_config.model)
+        model_specs = get_model_specs(self.primary_model_config.provider, self.primary_model_config.model)
         self.model_context_length = model_specs["context_length"]
         self.model_completion_tokens = model_specs["max_completion_tokens"]
         self.model_default_temperature = model_specs.get("default_temperature", 1.0)
@@ -446,7 +449,7 @@ class BaseAgent(LogMixin):
             is_git_repo=is_git_repo,
             platform=platform.system(),
             date_today=datetime.now().strftime("%Y-%m-%d"),
-            model_name=self.config.long_context_config.model,
+            model_name=self.primary_model_config.model,
             available_ports=self.available_ports,
             project_guidance=project_guidance,
             project_guidance_file=project_guidance_file,
@@ -464,9 +467,9 @@ class BaseAgent(LogMixin):
 
     def _unsupported_attachment_message(self, attachments: Optional[List[Dict[str, Any]]]) -> Optional[str]:
         provider = getattr(
-            self.config.long_context_config.provider,
+            self.primary_model_config.provider,
             "value",
-            self.config.long_context_config.provider,
+            self.primary_model_config.provider,
         )
         if provider != ModelProvider.DEEPSEEK.value:
             return None
@@ -507,7 +510,7 @@ class BaseAgent(LogMixin):
         token_count = await self.llm.count_tokens(
             system=self.system_prompt,
             messages=fixed_history,
-            model=self.config.long_context_config.model,
+            model=self.primary_model_config.model,
             tools=self.tool_collection.get_tool_list(),
         )
 
@@ -554,10 +557,10 @@ class BaseAgent(LogMixin):
         await self.compressor.summarize(
             self.conversation,
             llm=self.llm,
-            model=self.config.long_context_config.model,
+            model=self.primary_model_config.model,
             max_completion_tokens=self.model_completion_tokens,
             temperature=self.model_default_temperature,
-            thinking=self.config.long_context_config.thinking_effort,
+            thinking=self.primary_model_config.thinking_effort,
             on_info=on_info,
             on_error=on_error,
         )
@@ -705,7 +708,7 @@ class BaseAgent(LogMixin):
             # Send tool_call message to indicate we're starting execution
             if not all(
                 [
-                    self.config.long_context_config.provider == ModelProvider.ANTHROPIC,
+                    self.primary_model_config.provider == ModelProvider.ANTHROPIC,
                     tool_name in self.long_content_tool_calls,
                 ]
             ):
@@ -1058,7 +1061,7 @@ class BaseAgent(LogMixin):
             LLMError: Re-raises LLM errors after logging
             Exception: Re-raises non-LLM exceptions as-is
         """
-        error = map_to_llm_error(error, provider=self.config.long_context_config.provider.value)
+        error = map_to_llm_error(error, provider=self.primary_model_config.provider.value)
 
         if isinstance(error, LLMRateLimitError):
             await self.log_warning(
@@ -1071,7 +1074,7 @@ class BaseAgent(LogMixin):
         elif isinstance(error, LLMError):
             await self.emitter.llm_status(
                 "error",
-                llm_error_message(error, model=self.config.long_context_config.model),
+                llm_error_message(error, model=self.primary_model_config.model),
             )
             raise error
         else:
@@ -1232,9 +1235,9 @@ class BaseAgent(LogMixin):
                     max_completion_tokens=self.model_completion_tokens,
                     temperature=self.model_default_temperature,
                     messages=fixed_history,
-                    model=self.config.long_context_config.model,
+                    model=self.primary_model_config.model,
                     tools=self.tool_collection.get_tool_list(),
-                    thinking=self.config.long_context_config.thinking_effort,
+                    thinking=self.primary_model_config.thinking_effort,
                 ) as stream:
                     async for event in stream:
                         if event.type == "text":

--- a/kolega_code/agent/context.py
+++ b/kolega_code/agent/context.py
@@ -90,8 +90,13 @@ class AgentContext:
     hook_dispatcher: HookDispatcher = NO_OP_DISPATCHER
 
     def create_llm_client(self, agent_name: str) -> LLMClient:
-        """Create the LLM client, instrumented when a Langfuse client is available."""
-        model_config = self.config.long_context_config
+        """Create the LLM client, instrumented when a Langfuse client is available.
+
+        The client is bound to the provider for this agent's role (which may differ
+        from the global model when a per-agent override is configured); the model id
+        itself is still passed per call.
+        """
+        model_config = self.config.model_config_for_agent(agent_name)
 
         if self.telemetry.langfuse_client:
             return InstrumentedLLMClient(

--- a/kolega_code/agent/tests/test_agent_tools_inventory.py
+++ b/kolega_code/agent/tests/test_agent_tools_inventory.py
@@ -35,6 +35,8 @@ def agent_config():
     config.openai_api_key = "test_key"
     config.anthropic_api_key = "test_key"
     config.browser_use_headless = True
+    config.agent_models = {}
+    config.model_config_for_agent.return_value = config.long_context_config
     return config
 
 

--- a/kolega_code/agent/tests/test_base_agent.py
+++ b/kolega_code/agent/tests/test_base_agent.py
@@ -2037,3 +2037,59 @@ class TestBaseAgent:
         # boundary is 2, so tail is after index 2 -> empty, but we still have summary
         assert len(eff) == 1
         assert "CONVERSATION HISTORY SUMMARY" in eff[0].content[0].text
+
+
+class _InvestigationRoleAgent(BaseAgent):
+    """Minimal BaseAgent carrying the investigation role for resolution tests."""
+
+    agent_name = "investigation-agent"
+
+
+class _BuildingRoleAgent(BaseAgent):
+    agent_name = "coder"
+
+
+def _role_config():
+    return AgentConfig(
+        anthropic_api_key="anthropic-key",
+        deepseek_api_key="deepseek-key",
+        long_context_config=ModelConfig(provider=ModelProvider.ANTHROPIC, model="claude-haiku-4-5-20251001"),
+        fast_config=ModelConfig(provider=ModelProvider.ANTHROPIC, model="claude-haiku-4-5-20251001"),
+        thinking_config=ModelConfig(provider=ModelProvider.ANTHROPIC, model="claude-haiku-4-5-20251001"),
+        agent_models={
+            "investigation": ModelConfig(
+                provider=ModelProvider.DEEPSEEK, model="deepseek-v4-flash", thinking_effort="high"
+            )
+        },
+    )
+
+
+def test_agent_uses_role_override_for_primary_model(tmp_path, mock_connection_manager):
+    agent = _InvestigationRoleAgent(
+        project_path=tmp_path,
+        workspace_id="w",
+        thread_id=str(uuid.uuid4()),
+        connection_manager=mock_connection_manager,
+        config=_role_config(),
+    )
+
+    assert agent.primary_model_config.provider == ModelProvider.DEEPSEEK
+    assert agent.primary_model_config.model == "deepseek-v4-flash"
+    assert agent.primary_model_config.thinking_effort == "high"
+    # Model specs and the LLM client both follow the resolved role model.
+    assert agent.model_context_length == 1_000_000
+    assert agent.llm.provider_name == "deepseek"
+
+
+def test_agent_without_override_inherits_long_context(tmp_path, mock_connection_manager):
+    agent = _BuildingRoleAgent(
+        project_path=tmp_path,
+        workspace_id="w",
+        thread_id=str(uuid.uuid4()),
+        connection_manager=mock_connection_manager,
+        config=_role_config(),
+    )
+
+    assert agent.primary_model_config.model == "claude-haiku-4-5-20251001"
+    assert agent.model_context_length == 200_000
+    assert agent.llm.provider_name == "anthropic"

--- a/kolega_code/agent/tests/test_coder_attachments.py
+++ b/kolega_code/agent/tests/test_coder_attachments.py
@@ -56,9 +56,7 @@ class _EmptyStream:
 
 def test_deepseek_image_attachment_is_rejected_by_provider_check():
     agent = object.__new__(BaseAgent)
-    agent.config = SimpleNamespace(
-        long_context_config=SimpleNamespace(provider=ModelProvider.DEEPSEEK.value),
-    )
+    agent.primary_model_config = SimpleNamespace(provider=ModelProvider.DEEPSEEK.value)
 
     assert (
         agent._unsupported_attachment_message([_image_attachment()])
@@ -68,13 +66,11 @@ def test_deepseek_image_attachment_is_rejected_by_provider_check():
 
 def test_deepseek_attachment_check_allows_non_images_and_other_providers():
     agent = object.__new__(BaseAgent)
-    agent.config = SimpleNamespace(
-        long_context_config=SimpleNamespace(provider=ModelProvider.DEEPSEEK),
-    )
+    agent.primary_model_config = SimpleNamespace(provider=ModelProvider.DEEPSEEK)
     assert agent._unsupported_attachment_message(None) is None
     assert agent._unsupported_attachment_message([{"type": "document", "data": "abc"}]) is None
 
-    agent.config.long_context_config.provider = ModelProvider.ANTHROPIC
+    agent.primary_model_config.provider = ModelProvider.ANTHROPIC
     assert agent._unsupported_attachment_message([_image_attachment()]) is None
 
 

--- a/kolega_code/agent/tests/test_gigacode_gating.py
+++ b/kolega_code/agent/tests/test_gigacode_gating.py
@@ -33,6 +33,8 @@ def agent_config():
     config.openai_api_key = "test_key"
     config.anthropic_api_key = "test_key"
     config.browser_use_headless = True
+    config.agent_models = {}
+    config.model_config_for_agent.return_value = config.long_context_config
     return config
 
 

--- a/kolega_code/agent/tests/test_planning_agent.py
+++ b/kolega_code/agent/tests/test_planning_agent.py
@@ -72,6 +72,8 @@ def agent_config():
     config.openai_api_key = "test_key"
     config.anthropic_api_key = "test_key"
     config.browser_use_headless = True
+    config.agent_models = {}
+    config.model_config_for_agent.return_value = config.long_context_config
     return config
 
 

--- a/kolega_code/agent/tests/tool_backend/test_workflow_tool.py
+++ b/kolega_code/agent/tests/tool_backend/test_workflow_tool.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 
 from kolega_code.agent.tool_backend.workflow_tool import WorkflowTool
-from kolega_code.config import AgentConfig
+from kolega_code.config import AgentConfig, ModelConfig, ModelProvider
 from kolega_code.events import AgentConnectionManager
 
 
@@ -173,3 +173,35 @@ async def test_invalid_meta_reports_failure(workflow_tool):
 
     with pytest.raises(WorkflowScriptError):
         await tool.run_workflow(script="return 1")
+
+
+def _config_with_investigation_override() -> AgentConfig:
+    return AgentConfig(
+        anthropic_api_key="anthropic-key",
+        deepseek_api_key="deepseek-key",
+        agent_models={
+            "investigation": ModelConfig(provider=ModelProvider.DEEPSEEK, model="deepseek-v4-flash"),
+        },
+    )
+
+
+def test_config_override_clears_agent_models_for_explicit_model(tmp_path, connection_manager, caller):
+    config = _config_with_investigation_override()
+    tool = WorkflowTool(str(tmp_path / "project"), "ws", "thread", connection_manager, config, caller, None)
+
+    overridden = tool._config_override("claude-opus-4-7", "high")
+
+    assert overridden.long_context_config.model == "claude-opus-4-7"
+    assert overridden.long_context_config.thinking_effort == "high"
+    # The workflow author's explicit model wins over the role override.
+    assert overridden.agent_models == {}
+    assert overridden.model_config_for_agent("investigation-agent").model == "claude-opus-4-7"
+
+
+def test_config_override_none_preserves_role_overrides(tmp_path, connection_manager, caller):
+    config = _config_with_investigation_override()
+    tool = WorkflowTool(str(tmp_path / "project"), "ws", "thread", connection_manager, config, caller, None)
+
+    # No explicit model/effort -> no clone, role overrides still flow to sub-agents.
+    assert tool._config_override(None, None) is None
+    assert config.model_config_for_agent("investigation-agent").model == "deepseek-v4-flash"

--- a/kolega_code/agent/tool_backend/workflow_tool.py
+++ b/kolega_code/agent/tool_backend/workflow_tool.py
@@ -274,8 +274,10 @@ class WorkflowTool(BaseTool):
             th_update["thinking_effort"] = effort
         new_long = self.config.long_context_config.model_copy(update=lc_update)
         new_thinking = self.config.thinking_config.model_copy(update=th_update)
+        # An explicit per-call model/effort is the workflow author's choice and must
+        # win over any per-agent-role override, so drop agent_models on the clone.
         return self.config.model_copy(
-            update={"long_context_config": new_long, "thinking_config": new_thinking}
+            update={"long_context_config": new_long, "thinking_config": new_thinking, "agent_models": {}}
         )
 
     def _summarize(self, meta, run_id, journal: RunJournal, budget: Budget, status, error, result) -> str:

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -1084,19 +1084,35 @@ class KolegaCodeApp(App):
         margin-top: 0;
     }
 
-    .agent-model-row {
+    .agent-model-group {
         height: auto;
         margin-top: 1;
     }
 
-    .agent-model-label {
-        width: 18;
-        margin-top: 1;
+    .agent-model-role {
+        text-style: bold;
         color: $text;
     }
 
-    .agent-model-row Select {
+    .agent-model-field {
+        height: auto;
+        margin-top: 1;
+    }
+
+    .agent-model-field-label {
+        width: 10;
+        margin-top: 1;
+        color: $text-muted;
+    }
+
+    .agent-model-field Select {
         width: 1fr;
+    }
+
+    #settings_actions {
+        height: auto;
+        padding: 0 1;
+        margin-top: 1;
     }
 
     #planning_form Markdown.empty-state {
@@ -1442,8 +1458,6 @@ class KolegaCodeApp(App):
                                 )
                                 yield Label("API key")
                                 yield Input(password=True, id="api_key_input")
-                                yield Button("Save Settings", variant="primary", id="save_settings")
-                                yield Static("", id="settings_status")
                             with Vertical(classes="settings-section", id="settings_agent_models") as agents_section:
                                 agents_section.border_title = "Agent Models"
                                 yield Static(
@@ -1452,20 +1466,22 @@ class KolegaCodeApp(App):
                                     classes="settings-hint",
                                 )
                                 for role_label, role_value in agent_role_options():
-                                    with Horizontal(classes="agent-model-row"):
-                                        yield Label(role_label, classes="agent-model-label")
-                                        yield Select(
-                                            agent_role_provider_options(),
-                                            id=f"am_provider_{role_value}",
-                                            allow_blank=False,
-                                            value=INHERIT_SENTINEL,
-                                        )
-                                        yield Select(
-                                            [], id=f"am_model_{role_value}", allow_blank=True, prompt="—"
-                                        )
-                                        yield Select(
-                                            [], id=f"am_effort_{role_value}", allow_blank=True, prompt="—"
-                                        )
+                                    with Vertical(classes="agent-model-group"):
+                                        yield Static(role_label, classes="agent-model-role")
+                                        with Horizontal(classes="agent-model-field"):
+                                            yield Label("Provider", classes="agent-model-field-label")
+                                            yield Select(
+                                                agent_role_provider_options(),
+                                                id=f"am_provider_{role_value}",
+                                                allow_blank=False,
+                                                value=INHERIT_SENTINEL,
+                                            )
+                                        with Horizontal(classes="agent-model-field"):
+                                            yield Label("Model", classes="agent-model-field-label")
+                                            yield Select([], id=f"am_model_{role_value}", allow_blank=True, prompt="—")
+                                        with Horizontal(classes="agent-model-field"):
+                                            yield Label("Effort", classes="agent-model-field-label")
+                                            yield Select([], id=f"am_effort_{role_value}", allow_blank=True, prompt="—")
                             with Vertical(classes="settings-section", id="settings_appearance") as appearance_section:
                                 appearance_section.border_title = "Appearance"
                                 yield Label("Theme")
@@ -1475,6 +1491,9 @@ class KolegaCodeApp(App):
                                     allow_blank=False,
                                     value=theme.DEFAULT_THEME_NAME,
                                 )
+                            with Vertical(id="settings_actions"):
+                                yield Button("Save Settings", variant="primary", id="save_settings")
+                                yield Static("", id="settings_status")
         yield Footer()
 
     async def on_mount(self) -> None:

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -78,8 +78,11 @@ from .connection import CliConnectionManager
 from .file_index import IndexEntry, WorkspaceFileIndex
 from .mentions import build_file_attachments
 from .provider_registry import (
+    INHERIT_SENTINEL,
     UI_DEFAULT_MODEL,
     UI_DEFAULT_PROVIDER,
+    agent_role_options,
+    agent_role_provider_options,
     default_ui_thinking_effort,
     get_ui_model,
     ui_model_options,
@@ -1076,6 +1079,26 @@ class KolegaCodeApp(App):
         margin-top: 1;
     }
 
+    .settings-hint {
+        color: $text-muted;
+        margin-top: 0;
+    }
+
+    .agent-model-row {
+        height: auto;
+        margin-top: 1;
+    }
+
+    .agent-model-label {
+        width: 18;
+        margin-top: 1;
+        color: $text;
+    }
+
+    .agent-model-row Select {
+        width: 1fr;
+    }
+
     #planning_form Markdown.empty-state {
         color: $text-muted;
     }
@@ -1323,6 +1346,11 @@ class KolegaCodeApp(App):
         self._pending_model_selection: Optional[PendingModelSelection] = None
         self._pending_effort_selection: Optional[PendingEffortSelection] = None
         self._pending_theme_selection: Optional[PendingThemeSelection] = None
+        # Saved per-agent model/effort awaiting the provider->model cascade that
+        # restores them (keyed by the row's model/effort select id). See
+        # _populate_agent_model_rows for why the cascade, not direct assignment, applies them.
+        self._pending_agent_models: dict[str, str] = {}
+        self._pending_agent_efforts: dict[str, str] = {}
         provider, model = self._startup_model()
         self._status_state = StatusDashboardState(
             provider=provider,
@@ -1416,6 +1444,28 @@ class KolegaCodeApp(App):
                                 yield Input(password=True, id="api_key_input")
                                 yield Button("Save Settings", variant="primary", id="save_settings")
                                 yield Static("", id="settings_status")
+                            with Vertical(classes="settings-section", id="settings_agent_models") as agents_section:
+                                agents_section.border_title = "Agent Models"
+                                yield Static(
+                                    "Give individual agents their own model. "
+                                    "Leave a role on “Default” to use the model above.",
+                                    classes="settings-hint",
+                                )
+                                for role_label, role_value in agent_role_options():
+                                    with Horizontal(classes="agent-model-row"):
+                                        yield Label(role_label, classes="agent-model-label")
+                                        yield Select(
+                                            agent_role_provider_options(),
+                                            id=f"am_provider_{role_value}",
+                                            allow_blank=False,
+                                            value=INHERIT_SENTINEL,
+                                        )
+                                        yield Select(
+                                            [], id=f"am_model_{role_value}", allow_blank=True, prompt="—"
+                                        )
+                                        yield Select(
+                                            [], id=f"am_effort_{role_value}", allow_blank=True, prompt="—"
+                                        )
                             with Vertical(classes="settings-section", id="settings_appearance") as appearance_section:
                                 appearance_section.border_title = "Appearance"
                                 yield Label("Theme")
@@ -1829,23 +1879,18 @@ class KolegaCodeApp(App):
             await self._save_settings_from_ui()
 
     def on_select_changed(self, event: Select.Changed) -> None:
-        if event.select.id == "provider_select":
+        select_id = event.select.id or ""
+
+        if select_id == "provider_select":
             provider = str(event.value)
+            self._repopulate_model_select(provider, "model_select", "thinking_effort_select")
             try:
-                model_select = self.query_one("#model_select", Select)
-                api_key_input = self.query_one("#api_key_input", Input)
+                self.query_one("#api_key_input", Input).placeholder = self._api_key_placeholder(provider)
             except NoMatches:
-                return
-            model_options = ui_model_options(provider)
-            model_select.set_options(model_options)
-            model = model_options[0][1] if model_options else UI_DEFAULT_MODEL
-            if model_options:
-                model_select.value = model
-            self._set_effort_select_default(provider, model)
-            api_key_input.placeholder = self._api_key_placeholder(provider)
+                pass
             return
 
-        if event.select.id == "model_select":
+        if select_id == "model_select":
             try:
                 provider = str(self.query_one("#provider_select", Select).value)
             except NoMatches:
@@ -1853,7 +1898,35 @@ class KolegaCodeApp(App):
             self._set_effort_select_default(provider, str(event.value))
             return
 
-        if event.select.id == "theme_select":
+        if select_id.startswith("am_provider_"):
+            role = select_id[len("am_provider_") :]
+            provider = str(event.value)
+            if provider == INHERIT_SENTINEL:
+                # Don't drop pending here: the selects post an initial inherit-valued
+                # Changed on mount, which would clear a restore before its real cascade
+                # runs. _populate_agent_model_rows clears stale pending per row instead.
+                self._clear_model_effort_selects(f"am_model_{role}", f"am_effort_{role}")
+            else:
+                model_value = self._pending_agent_models.pop(f"am_model_{role}", None)
+                self._repopulate_model_select(
+                    provider, f"am_model_{role}", f"am_effort_{role}", model_value=model_value
+                )
+            return
+
+        if select_id.startswith("am_model_"):
+            role = select_id[len("am_model_") :]
+            try:
+                provider = str(self.query_one(f"#am_provider_{role}", Select).value)
+            except NoMatches:
+                return
+            if provider != INHERIT_SENTINEL and event.value is not Select.NULL:
+                # A restored effort waits here for the model that hosts it; a manual
+                # model change has none pending and falls back to preserve/default.
+                preferred = self._pending_agent_efforts.pop(f"am_effort_{role}", None)
+                self._set_effort_select_default(provider, str(event.value), f"am_effort_{role}", preferred=preferred)
+            return
+
+        if select_id == "theme_select":
             name = str(event.value)
             if name != (self.settings.active_theme or theme.DEFAULT_THEME_NAME):
                 self.settings.active_theme = name
@@ -2081,18 +2154,103 @@ class KolegaCodeApp(App):
             else theme.DEFAULT_THEME_NAME
         )
         api_key_input.placeholder = self._api_key_placeholder(provider)
+        self._populate_agent_model_rows()
         self._update_settings_status()
 
-    def _set_effort_select_default(self, provider: str, model: str) -> None:
+    def _populate_agent_model_rows(self) -> None:
+        """Seed each per-agent row from saved settings (absent role -> inherit).
+
+        A model select that was just given its options can't accept a value until the
+        next refresh, and setting the provider value posts a Changed that re-runs the
+        cascade afterwards. So we stash the saved model/effort and let that cascade —
+        the last writer — apply them, rather than assigning here and being clobbered."""
+        provider_values = {value for _, value in ui_provider_options()}
+        for _, role in agent_role_options():
+            try:
+                provider_select = self.query_one(f"#am_provider_{role}", Select)
+            except NoMatches:
+                continue
+            entry = self.settings.get_agent_model(role) or {}
+            provider = entry.get("provider")
+            self._pending_agent_models.pop(f"am_model_{role}", None)
+            self._pending_agent_efforts.pop(f"am_effort_{role}", None)
+            if provider not in provider_values:
+                provider_select.value = INHERIT_SENTINEL
+                self._clear_model_effort_selects(f"am_model_{role}", f"am_effort_{role}")
+                continue
+            if entry.get("model"):
+                self._pending_agent_models[f"am_model_{role}"] = str(entry["model"])
+            if entry.get("thinking_effort"):
+                self._pending_agent_efforts[f"am_effort_{role}"] = str(entry["thinking_effort"])
+            # Triggers on_select_changed, which consumes the pending model/effort.
+            provider_select.value = provider
+
+    def _set_effort_select_default(
+        self, provider: str, model: str, effort_id: str = "thinking_effort_select", *, preferred: Optional[str] = None
+    ) -> None:
         try:
-            effort_select = self.query_one("#thinking_effort_select", Select)
+            effort_select = self.query_one(f"#{effort_id}", Select)
         except Exception:
             return
+        # Prefer an explicit value (a restored effort), else keep the current one if it
+        # is still valid for this model, else fall back to the model's default. This
+        # keeps a restore or a provider switch from clobbering the chosen effort.
+        current = effort_select.value
+        current = None if current is Select.NULL else str(current)
         effort_options = ui_thinking_effort_options(provider, model)
+        valid_efforts = {value for _, value in effort_options}
         effort_select.set_options(effort_options)
-        default_effort = default_ui_thinking_effort(provider, model)
-        if default_effort is not None:
-            effort_select.value = default_effort
+        if preferred in valid_efforts:
+            chosen = preferred
+        elif current in valid_efforts:
+            chosen = current
+        else:
+            chosen = default_ui_thinking_effort(provider, model)
+        if chosen is not None:
+            effort_select.value = chosen
+
+    def _repopulate_model_select(
+        self,
+        provider: str,
+        model_id: str,
+        effort_id: str,
+        *,
+        model_value: Optional[str] = None,
+        effort_value: Optional[str] = None,
+    ) -> None:
+        """Fill a provider→model→effort trio for a provider.
+
+        Used by the global Model section and each per-agent row. ``model_value`` /
+        ``effort_value`` pre-select a model/effort (used while restoring saved
+        settings). Otherwise the select's current model is kept when it is still valid
+        for ``provider`` (so a restore is not clobbered), falling back to the
+        provider's first model."""
+        try:
+            model_select = self.query_one(f"#{model_id}", Select)
+        except NoMatches:
+            return
+        if model_value is None:
+            current = model_select.value
+            model_value = None if current is Select.NULL else str(current)
+        model_options = ui_model_options(provider)
+        model_select.set_options(model_options)
+        valid_models = {value for _, value in model_options}
+        model = model_value if (model_value and model_value in valid_models) else None
+        if model is None:
+            model = model_options[0][1] if model_options else UI_DEFAULT_MODEL
+        if model_options:
+            model_select.value = model
+        self._set_effort_select_default(provider, model, effort_id, preferred=effort_value)
+
+    def _clear_model_effort_selects(self, model_id: str, effort_id: str) -> None:
+        """Blank a per-agent row's model+effort selects (the role inherits)."""
+        for select_id in (model_id, effort_id):
+            try:
+                select = self.query_one(f"#{select_id}", Select)
+            except NoMatches:
+                continue
+            select.set_options([])
+            select.value = Select.NULL
 
     async def _save_settings_from_ui(self) -> None:
         provider = str(self.query_one("#provider_select", Select).value)
@@ -2110,6 +2268,7 @@ class KolegaCodeApp(App):
         self.settings.active_theme = str(self.query_one("#theme_select", Select).value)
         if api_key:
             self.settings.set_api_key(provider, api_key)
+        self._collect_agent_models_from_ui()
         self.settings_store.save(self.settings)
         api_key_input.value = ""
         api_key_input.placeholder = self._api_key_placeholder(provider)
@@ -2117,6 +2276,25 @@ class KolegaCodeApp(App):
         await self._ensure_agent_from_settings(rebuild=True)
         if self.config is not None:
             self._notify_user(messages.SETTINGS_SAVED)
+
+    def _collect_agent_models_from_ui(self) -> None:
+        """Write each per-agent row into settings.agent_models (inherit rows removed)."""
+        for _, role in agent_role_options():
+            try:
+                provider = str(self.query_one(f"#am_provider_{role}", Select).value)
+                model_select = self.query_one(f"#am_model_{role}", Select)
+                effort_select = self.query_one(f"#am_effort_{role}", Select)
+            except NoMatches:
+                continue
+            if provider == INHERIT_SENTINEL or model_select.value is Select.NULL:
+                self.settings.clear_agent_model(role)
+                continue
+            model = str(model_select.value)
+            effort = "" if effort_select.value is Select.NULL else str(effort_select.value)
+            valid_efforts = {value for _, value in ui_thinking_effort_options(provider, model)}
+            if effort not in valid_efforts:
+                effort = default_ui_thinking_effort(provider, model) or ""
+            self.settings.set_agent_model(role, provider, model, effort or None)
 
     async def _ensure_agent_from_settings(self, rebuild: bool = False) -> None:
         try:

--- a/kolega_code/cli/config.py
+++ b/kolega_code/cli/config.py
@@ -9,7 +9,7 @@ from typing import Mapping, Optional
 
 from dotenv import dotenv_values
 
-from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
+from kolega_code.config import AgentConfig, AgentRole, ModelConfig, ModelProvider, RateLimitConfig
 from kolega_code.llm.specs import get_model_specs, normalize_thinking_effort
 
 from .provider_registry import default_model_for_provider
@@ -174,6 +174,52 @@ def _resolve_active_thinking_effort(
         raise CliConfigError(str(exc)) from exc
 
 
+def _agent_role_env_keys(role: AgentRole) -> tuple[str, str, str]:
+    """Env var names that override a role's provider/model/effort, e.g.
+    KOLEGA_CODE_INVESTIGATION_PROVIDER / _MODEL / _EFFORT."""
+    token = role.value.upper()
+    return (
+        f"KOLEGA_CODE_{token}_PROVIDER",
+        f"KOLEGA_CODE_{token}_MODEL",
+        f"KOLEGA_CODE_{token}_EFFORT",
+    )
+
+
+def _agent_model_overrides(
+    env: Mapping[str, str],
+    settings: Optional[CliSettings],
+    active_provider: ModelProvider,
+    active_model: str,
+) -> dict[str, ModelConfig]:
+    """Resolve per-agent-role model overrides from env vars over saved settings.
+
+    A role with neither an env nor a settings provider/model is omitted, so it
+    inherits the active model. Field-level precedence is env > settings, mirroring
+    the per-slot resolution used for long/fast/thinking.
+    """
+    saved = settings.agent_models if settings else {}
+    overrides: dict[str, ModelConfig] = {}
+    for role in AgentRole:
+        provider_key, model_key, effort_key = _agent_role_env_keys(role)
+        entry = saved.get(role.value) or {}
+        provider_value = env.get(provider_key) or entry.get("provider")
+        model_value = env.get(model_key) or entry.get("model")
+        effort_value = env.get(effort_key) or entry.get("thinking_effort")
+
+        if not provider_value and not model_value:
+            continue
+
+        provider = _provider(provider_value or active_provider.value)
+        if model_value:
+            model = model_value
+        elif active_provider == provider and active_model:
+            model = active_model
+        else:
+            model = default_model_for_provider(provider)
+        overrides[role.value] = _model_config(provider, model, thinking_effort=effort_value)
+    return overrides
+
+
 def build_agent_config(
     project_path: Path,
     overrides: Optional[CliConfigOverrides] = None,
@@ -236,7 +282,10 @@ def build_agent_config(
         else None
     )
 
+    agent_model_overrides = _agent_model_overrides(loaded_env, settings, active_provider, active_model)
+
     required_providers = {long_provider, fast_provider, thinking_provider}
+    required_providers.update(override.provider for override in agent_model_overrides.values())
     missing_keys = [
         API_KEY_ENV[provider]
         for provider in sorted(required_providers, key=lambda item: item.value)
@@ -263,6 +312,7 @@ def build_agent_config(
             long_context_config=_model_config(long_provider, long_model, thinking_effort=active_thinking_effort),
             fast_config=_model_config(fast_provider, fast_model),
             thinking_config=_model_config(thinking_provider, thinking_model, thinking_effort=think_hard_effort),
+            agent_models=agent_model_overrides,
         )
     except ValueError as exc:
         raise CliConfigError(str(exc)) from exc
@@ -280,7 +330,7 @@ def key_status(provider: str, project_path: Path, settings: Optional[CliSettings
     return "missing"
 
 
-def config_summary(config: AgentConfig) -> dict[str, str | int | None]:
+def config_summary(config: AgentConfig) -> dict[str, object]:
     """Return a session-safe summary of model configuration."""
     return {
         "environment": config.environment,
@@ -291,4 +341,8 @@ def config_summary(config: AgentConfig) -> dict[str, str | int | None]:
         "thinking_provider": config.thinking_config.provider.value,
         "thinking_model": config.thinking_config.model,
         "thinking_effort": config.long_context_config.thinking_effort,
+        "agent_models": {
+            role: f"{model_config.provider.value}/{model_config.model}"
+            for role, model_config in config.agent_models.items()
+        },
     }

--- a/kolega_code/cli/provider_registry.py
+++ b/kolega_code/cli/provider_registry.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from kolega_code.config import ModelProvider
+from kolega_code.config import AgentRole, ModelProvider
 from kolega_code.llm.specs import (
     MODEL_SPECS,
     default_thinking_effort,
@@ -204,6 +204,30 @@ def _thinking_effort_label(effort: str) -> str:
         "xhigh": "Extra high",
         "max": "Max",
     }.get(effort, effort)
+
+
+# Sentinel value used by the Settings "Agent Models" provider selects to mean
+# "no override — inherit the active model". Kept distinct from any real provider id.
+INHERIT_SENTINEL = "__inherit__"
+
+# Display labels and render order for the configurable agent roles in the UI.
+AGENT_ROLE_LABELS: dict[AgentRole, str] = {
+    AgentRole.PLANNING: "Planning",
+    AgentRole.BUILDING: "Building (Coder)",
+    AgentRole.INVESTIGATION: "Investigation",
+    AgentRole.GENERAL: "General",
+    AgentRole.BROWSER: "Browser",
+}
+
+
+def agent_role_options() -> list[tuple[str, str]]:
+    """Return (label, role-value) pairs for the configurable agent roles, in order."""
+    return [(label, role.value) for role, label in AGENT_ROLE_LABELS.items()]
+
+
+def agent_role_provider_options() -> list[tuple[str, str]]:
+    """Provider Select options for a per-agent row, with an inherit option first."""
+    return [("Default (inherit)", INHERIT_SENTINEL), *ui_provider_options()]
 
 
 def default_model_for_provider(provider: ModelProvider) -> str:

--- a/kolega_code/cli/settings.py
+++ b/kolega_code/cli/settings.py
@@ -10,11 +10,34 @@ from typing import Optional
 
 from .session_store import default_state_dir
 
-SETTINGS_SCHEMA_VERSION = 2
+SETTINGS_SCHEMA_VERSION = 3
+_SUPPORTED_SCHEMA_VERSIONS = {1, 2, 3}
+# Keys read from each saved per-agent-role model entry.
+_AGENT_MODEL_KEYS = ("provider", "model", "thinking_effort")
 
 
 class SettingsStoreError(RuntimeError):
     """Raised when CLI settings cannot be loaded or saved."""
+
+
+def _coerce_agent_models(raw: object) -> dict[str, dict]:
+    """Normalize a stored agent_models mapping (role -> {provider, model, ...}).
+
+    Tolerant of partial/legacy data: entries without a provider or model are
+    dropped so a malformed file can never crash startup."""
+    if not isinstance(raw, dict):
+        return {}
+    result: dict[str, dict] = {}
+    for role, entry in raw.items():
+        if not isinstance(entry, dict):
+            continue
+        provider = entry.get("provider")
+        model = entry.get("model")
+        if not provider or not model:
+            continue
+        normalized = {key: entry[key] for key in _AGENT_MODEL_KEYS if entry.get(key) is not None}
+        result[str(role)] = normalized
+    return result
 
 
 @dataclass
@@ -24,6 +47,10 @@ class CliSettings:
     active_thinking_effort: Optional[str] = None
     active_theme: Optional[str] = None
     api_keys: dict[str, str] = field(default_factory=dict)
+    # Per-agent-role model overrides, keyed by AgentRole value (e.g. "investigation"),
+    # each value a {provider, model, thinking_effort} dict. Empty = every role uses
+    # the active model.
+    agent_models: dict[str, dict] = field(default_factory=dict)
     # Resolved project paths whose .kolega/hooks.json the user has opted to trust.
     trusted_hook_projects: list[str] = field(default_factory=list)
     schema_version: int = SETTINGS_SCHEMA_VERSION
@@ -31,7 +58,7 @@ class CliSettings:
     @classmethod
     def from_dict(cls, data: dict) -> "CliSettings":
         schema_version = data.get("schema_version")
-        if schema_version not in {1, SETTINGS_SCHEMA_VERSION}:
+        if schema_version not in _SUPPORTED_SCHEMA_VERSIONS:
             raise SettingsStoreError(f"Unsupported settings schema version: {data.get('schema_version')}")
         api_keys = data.get("api_keys") or {}
         trusted = data.get("trusted_hook_projects") or []
@@ -39,13 +66,13 @@ class CliSettings:
             schema_version=SETTINGS_SCHEMA_VERSION,
             active_provider=data.get("active_provider"),
             active_model=data.get("active_model"),
-            active_thinking_effort=data.get("active_thinking_effort")
-            if schema_version == SETTINGS_SCHEMA_VERSION
-            else None,
+            active_thinking_effort=data.get("active_thinking_effort") if schema_version >= 2 else None,
             # Additive optional field; safe to read from any schema version
             # (absent in older files -> None -> default theme is applied).
             active_theme=data.get("active_theme"),
             api_keys={str(provider): str(key) for provider, key in api_keys.items() if key},
+            # Additive optional field; absent in pre-v3 files -> empty mapping.
+            agent_models=_coerce_agent_models(data.get("agent_models")),
             trusted_hook_projects=[str(path) for path in trusted if path],
         )
 
@@ -57,11 +84,27 @@ class CliSettings:
             "active_thinking_effort": self.active_thinking_effort,
             "active_theme": self.active_theme,
             "api_keys": self.api_keys,
+            "agent_models": self.agent_models,
             "trusted_hook_projects": self.trusted_hook_projects,
         }
 
     def get_api_key(self, provider: str) -> Optional[str]:
         return self.api_keys.get(provider)
+
+    def get_agent_model(self, role: str) -> Optional[dict]:
+        """Return the saved override for a role, or None when it inherits."""
+        return self.agent_models.get(role)
+
+    def set_agent_model(self, role: str, provider: str, model: str, thinking_effort: Optional[str] = None) -> None:
+        """Record a per-role model override (provider and model are required)."""
+        entry = {"provider": provider, "model": model}
+        if thinking_effort:
+            entry["thinking_effort"] = thinking_effort
+        self.agent_models[role] = entry
+
+    def clear_agent_model(self, role: str) -> None:
+        """Remove a per-role override so the role inherits the active model."""
+        self.agent_models.pop(role, None)
 
     def set_api_key(self, provider: str, api_key: str) -> None:
         if api_key:

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -216,8 +216,9 @@ async def test_settings_tab_grouped_into_model_and_appearance_sections(
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
 
     async with app.run_test():
-        # Two bordered, titled sections.
+        # Bordered, titled sections.
         assert app.query_one("#settings_model").border_title == "Model"
+        assert app.query_one("#settings_agent_models").border_title == "Agent Models"
         assert app.query_one("#settings_appearance").border_title == "Appearance"
         # Every control still resolves by id (wiring is unchanged).
         for control_id in (
@@ -232,9 +233,11 @@ async def test_settings_tab_grouped_into_model_and_appearance_sections(
             app.query_one(control_id)
         # Grouping: model controls in the Model card, theme in the Appearance card.
         assert app.query_one("#settings_model #provider_select")
-        assert app.query_one("#settings_model #save_settings")
         assert app.query_one("#settings_appearance #theme_select")
         assert not list(app.query("#settings_model #theme_select"))
+        # Save is a form-level action, not nested inside the Model card.
+        assert app.query_one("#settings_actions #save_settings")
+        assert not list(app.query("#settings_model #save_settings"))
 
 
 @pytest.mark.asyncio

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -6313,3 +6313,121 @@ async def test_textual_app_question_recovers_focus_but_allows_free_form_answer(
 
         app._pending_question = None
         app._set_question_actions_visible(False)
+
+
+@pytest.mark.asyncio
+async def test_agent_models_section_saves_override_and_builds_agent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.widgets import Input, Select
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import KolegaCodeApp
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            return None
+
+    monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    state_dir = tmp_path / "state"
+    store = SessionStore(state_dir)
+    settings_store = SettingsStore(state_dir)
+    session = store.create(project, "code", {})
+    app = KolegaCodeApp(
+        project_path=project,
+        mode="code",
+        store=store,
+        settings_store=settings_store,
+        session=session,
+    )
+
+    async with app.run_test() as pilot:
+        app.query_one("#api_key_input", Input).value = "moonshot-key"
+        # Give the investigation role its own model (same provider keeps one API key).
+        app.query_one("#am_provider_investigation", Select).value = UI_DEFAULT_PROVIDER
+        await pilot.pause()  # let the provider->model cascade settle
+        app.query_one("#am_model_investigation", Select).value = MOONSHOT_K26_MODEL
+        await pilot.pause()
+        await app._save_settings_from_ui()
+
+        saved = settings_store.load().get_agent_model("investigation")
+        assert saved is not None
+        assert saved["provider"] == UI_DEFAULT_PROVIDER
+        assert saved["model"] == MOONSHOT_K26_MODEL
+
+        config = app.agent.kwargs["config"]
+        assert config.model_config_for_agent("investigation-agent").model == MOONSHOT_K26_MODEL
+        # Roles left on "Default" still inherit the active model.
+        assert config.model_config_for_agent("coder").model == UI_DEFAULT_MODEL
+
+
+@pytest.mark.asyncio
+async def test_agent_models_section_populates_and_clears_to_inherit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.widgets import Select
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.cli.provider_registry import INHERIT_SENTINEL
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            return None
+
+    monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    state_dir = tmp_path / "state"
+    store = SessionStore(state_dir)
+    settings_store = SettingsStore(state_dir)
+    settings = CliSettings(active_provider=UI_DEFAULT_PROVIDER, active_model=UI_DEFAULT_MODEL)
+    settings.set_api_key(UI_DEFAULT_PROVIDER, "moonshot-key")
+    settings.set_agent_model("investigation", UI_DEFAULT_PROVIDER, MOONSHOT_K26_MODEL)
+    settings_store.save(settings)
+    session = store.create(project, "code", {})
+    app = KolegaCodeApp(
+        project_path=project,
+        mode="code",
+        store=store,
+        settings_store=settings_store,
+        session=session,
+    )
+
+    async with app.run_test() as pilot:
+        # The saved override is reflected in the row on mount.
+        assert app.query_one("#am_provider_investigation", Select).value == UI_DEFAULT_PROVIDER
+        assert app.query_one("#am_model_investigation", Select).value == MOONSHOT_K26_MODEL
+
+        # Switching the row back to "Default" clears the override on save.
+        app.query_one("#am_provider_investigation", Select).value = INHERIT_SENTINEL
+        await pilot.pause()
+        await app._save_settings_from_ui()
+
+        assert settings_store.load().get_agent_model("investigation") is None

--- a/kolega_code/cli/tests/test_cli_config.py
+++ b/kolega_code/cli/tests/test_cli_config.py
@@ -230,3 +230,84 @@ def test_stored_deepseek_settings_require_deepseek_key(tmp_path: Path) -> None:
 
     with pytest.raises(CliConfigError, match="DEEPSEEK_API_KEY"):
         build_agent_config(tmp_path, settings=settings, env={})
+
+
+def _anthropic_settings_with_deepseek_key() -> CliSettings:
+    settings = CliSettings(active_provider="anthropic", active_model=DEFAULT_LONG_MODEL)
+    settings.set_api_key("anthropic", "anthropic-key")
+    settings.set_api_key("deepseek", "deepseek-key")
+    return settings
+
+
+def test_build_agent_config_applies_settings_agent_model_override(tmp_path: Path) -> None:
+    settings = _anthropic_settings_with_deepseek_key()
+    settings.set_agent_model("investigation", "deepseek", "deepseek-v4-flash", "high")
+
+    config = build_agent_config(tmp_path, settings=settings, env={})
+
+    investigation = config.model_config_for_agent("investigation-agent")
+    assert investigation.provider == ModelProvider.DEEPSEEK
+    assert investigation.model == "deepseek-v4-flash"
+    assert investigation.thinking_effort == "high"
+    # Roles with no override inherit the active (long-context) model.
+    assert config.model_config_for_agent("coder").model == DEFAULT_LONG_MODEL
+
+
+def test_env_overrides_settings_agent_model(tmp_path: Path) -> None:
+    settings = CliSettings(active_provider="anthropic", active_model=DEFAULT_LONG_MODEL)
+    settings.set_agent_model("investigation", "deepseek", "deepseek-v4-flash")
+
+    config = build_agent_config(
+        tmp_path,
+        settings=settings,
+        env={
+            "ANTHROPIC_API_KEY": "anthropic-key",
+            "DEEPSEEK_API_KEY": "deepseek-key",
+            "KOLEGA_CODE_INVESTIGATION_MODEL": "deepseek-v4-pro",
+        },
+    )
+
+    assert config.model_config_for_agent("investigation-agent").model == "deepseek-v4-pro"
+
+
+def test_env_only_agent_model_override(tmp_path: Path) -> None:
+    config = build_agent_config(
+        tmp_path,
+        env={
+            "ANTHROPIC_API_KEY": "anthropic-key",
+            "DEEPSEEK_API_KEY": "deepseek-key",
+            "KOLEGA_CODE_PROVIDER": "anthropic",
+            "KOLEGA_CODE_INVESTIGATION_PROVIDER": "deepseek",
+            "KOLEGA_CODE_INVESTIGATION_MODEL": "deepseek-v4-flash",
+        },
+    )
+
+    assert config.model_config_for_agent("investigation-agent").provider == ModelProvider.DEEPSEEK
+    assert config.model_config_for_agent("investigation-agent").model == "deepseek-v4-flash"
+    assert config.model_config_for_agent("coder").model == DEFAULT_LONG_MODEL
+
+
+def test_agent_model_override_requires_api_key(tmp_path: Path) -> None:
+    settings = CliSettings(active_provider="anthropic", active_model=DEFAULT_LONG_MODEL)
+    settings.set_api_key("anthropic", "anthropic-key")
+    settings.set_agent_model("investigation", "deepseek", "deepseek-v4-flash")
+
+    with pytest.raises(CliConfigError, match="DEEPSEEK_API_KEY"):
+        build_agent_config(tmp_path, settings=settings, env={})
+
+
+def test_config_summary_includes_agent_models(tmp_path: Path) -> None:
+    settings = _anthropic_settings_with_deepseek_key()
+    settings.set_agent_model("investigation", "deepseek", "deepseek-v4-flash")
+
+    summary = config_summary(build_agent_config(tmp_path, settings=settings, env={}))
+
+    assert summary["agent_models"] == {"investigation": "deepseek/deepseek-v4-flash"}
+
+
+def test_build_agent_config_no_agent_model_overrides_by_default(tmp_path: Path) -> None:
+    config = build_agent_config(
+        tmp_path, env={"ANTHROPIC_API_KEY": "anthropic-key", "KOLEGA_CODE_PROVIDER": "anthropic"}
+    )
+
+    assert config.agent_models == {}

--- a/kolega_code/cli/tests/test_settings.py
+++ b/kolega_code/cli/tests/test_settings.py
@@ -15,7 +15,12 @@ from kolega_code.cli.provider_registry import (
     ui_provider_options,
     ui_thinking_effort_options,
 )
-from kolega_code.cli.settings import CliSettings, SettingsStore, SettingsStoreError
+from kolega_code.cli.settings import (
+    SETTINGS_SCHEMA_VERSION,
+    CliSettings,
+    SettingsStore,
+    SettingsStoreError,
+)
 from kolega_code.config import ModelProvider
 from kolega_code.llm.specs import MODEL_SPECS
 
@@ -48,6 +53,48 @@ def test_settings_store_missing_file_returns_empty_settings(tmp_path: Path) -> N
     assert settings.active_model is None
     assert settings.active_thinking_effort is None
     assert settings.api_keys == {}
+    assert settings.agent_models == {}
+
+
+def test_settings_store_round_trips_agent_models(tmp_path: Path) -> None:
+    store = SettingsStore(tmp_path)
+    settings = CliSettings(active_provider=UI_DEFAULT_PROVIDER, active_model=UI_DEFAULT_MODEL)
+    settings.set_agent_model("investigation", "deepseek", "deepseek-v4-flash", "high")
+    settings.set_agent_model("building", "anthropic", "claude-opus-4-8")
+
+    store.save(settings)
+    loaded = store.load()
+
+    assert loaded.get_agent_model("investigation") == {
+        "provider": "deepseek",
+        "model": "deepseek-v4-flash",
+        "thinking_effort": "high",
+    }
+    assert loaded.get_agent_model("building") == {"provider": "anthropic", "model": "claude-opus-4-8"}
+
+
+def test_clear_agent_model_makes_role_inherit() -> None:
+    settings = CliSettings()
+    settings.set_agent_model("investigation", "deepseek", "deepseek-v4-flash")
+    settings.clear_agent_model("investigation")
+
+    assert settings.get_agent_model("investigation") is None
+    assert settings.agent_models == {}
+
+
+def test_from_dict_drops_incomplete_agent_model_entries() -> None:
+    data = {
+        "schema_version": SETTINGS_SCHEMA_VERSION,
+        "agent_models": {
+            "investigation": {"provider": "deepseek", "model": "deepseek-v4-flash"},
+            "building": {"provider": "anthropic"},  # missing model -> dropped
+            "general": "not-a-dict",  # malformed -> dropped
+        },
+    }
+
+    settings = CliSettings.from_dict(data)
+
+    assert set(settings.agent_models) == {"investigation"}
 
 
 def test_settings_store_migrates_v1_settings(tmp_path: Path) -> None:
@@ -60,10 +107,11 @@ def test_settings_store_migrates_v1_settings(tmp_path: Path) -> None:
 
     settings = store.load()
 
-    assert settings.schema_version == 2
+    assert settings.schema_version == SETTINGS_SCHEMA_VERSION
     assert settings.active_provider == UI_DEFAULT_PROVIDER
     assert settings.active_model == MOONSHOT_K26_MODEL
     assert settings.active_thinking_effort is None
+    assert settings.agent_models == {}
 
 
 def test_settings_store_rejects_corrupt_json(tmp_path: Path) -> None:

--- a/kolega_code/config.py
+++ b/kolega_code/config.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional
+from typing import Dict, Optional
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -20,6 +20,31 @@ class ModelProvider(str, Enum):
     DEEPSEEK = "deepseek"
     ZAI = "zai"
     KIMI_CODING = "kimi_coding"
+
+
+class AgentRole(str, Enum):
+    """Configurable agent roles that can each run on their own model.
+
+    Keyed off each agent class's stable ``agent_name``. A role with no entry in
+    ``AgentConfig.agent_models`` inherits the global ``long_context_config``.
+    """
+
+    PLANNING = "planning"
+    BUILDING = "building"  # the coder agent
+    INVESTIGATION = "investigation"
+    GENERAL = "general"
+    BROWSER = "browser"
+
+
+# Maps a BaseAgent.agent_name to its configurable role. Agents whose name is not
+# listed (e.g. the abstract base) simply fall back to the global model.
+AGENT_ROLE_BY_NAME: Dict[str, AgentRole] = {
+    "planning-agent": AgentRole.PLANNING,
+    "coder": AgentRole.BUILDING,
+    "investigation-agent": AgentRole.INVESTIGATION,
+    "general-agent": AgentRole.GENERAL,
+    "browser-agent": AgentRole.BROWSER,
+}
 
 
 class RateLimitConfig(BaseModel):
@@ -121,6 +146,28 @@ class AgentConfig(BaseModel):
         description="Configuration for thinking operations",
     )
 
+    # Per-agent-role model overrides, keyed by AgentRole value (e.g. "investigation").
+    # A role with no entry inherits long_context_config, so an empty mapping
+    # reproduces the previous single-model behavior.
+    agent_models: Dict[str, ModelConfig] = Field(
+        default_factory=dict,
+        description="Per-agent-role model overrides keyed by AgentRole value",
+    )
+
+    def model_config_for_agent(self, agent_name: Optional[str]) -> ModelConfig:
+        """Return the model configuration an agent should use for its main loop.
+
+        Resolves the agent's role from its ``agent_name`` and returns the matching
+        override, falling back to ``long_context_config`` when the role has no
+        override configured.
+        """
+        role = AGENT_ROLE_BY_NAME.get(agent_name or "")
+        if role is not None:
+            override = self.agent_models.get(role.value)
+            if override is not None:
+                return override
+        return self.long_context_config
+
     def get_api_key(self, provider: ModelProvider) -> Optional[str]:
         """Get the API key for a specific provider."""
         api_key_map = {
@@ -148,6 +195,7 @@ class AgentConfig(BaseModel):
             (self.fast_config, "fast"),
             (self.thinking_config, "thinking"),
         ]
+        configs.extend((override, f"agent '{role}'") for role, override in self.agent_models.items())
 
         for config, config_name in configs:
             if config.provider != ModelProvider.LLAMA and self.get_api_key(config.provider) is None:


### PR DESCRIPTION
## What & why

Today every agent — the main coder, the plan-mode agent, and every dispatched sub-agent (investigation, general, browser) — runs on the **same** model (`long_context_config`). There was no way to say "use a fast/cheap model like Haiku or DeepSeek V4 Flash for investigation, but keep the strong model for building."

This PR lets users assign a **different provider/model/thinking-effort to each agent role**, edited in a new **Agent Models** section of the Settings tab (plus env vars). Roles with no override transparently inherit the active model, so default behavior is unchanged.

## How it works

Resolution happens **by role, inside the agent**, keyed off each agent's stable `agent_name`. The override map lives on the config object, so it travels to sub-agents for free — each agent self-selects its model. An investigation sub-agent automatically uses the investigation model.

Precedence (highest first):
1. gigacode explicit per-call `model`/`effort` (workflow authors)
2. per-role override: env `KOLEGA_CODE_<ROLE>_*` > saved Settings
3. global active model (`long_context_config`) — the inherited default

## Changes

- **config** (`config.py`): `AgentRole` enum + `AGENT_ROLE_BY_NAME`, `AgentConfig.agent_models`, `model_config_for_agent()`; validator requires an API key for every override provider.
- **agent** (`baseagent.py`, `context.py`): `primary_model_config` drives the main loop/specs/LLM client; `workflow_tool.py` clears `agent_models` on a gigacode clone so an explicit `model=` wins.
- **cli** (`settings.py` schema v3 + helpers, `config.py` env overrides + `config_summary`).
- **tui** (`provider_registry.py` helpers, `app.py` Agent Models section). Also fixes a latent bug where a non-default global model reset on mount, by making the provider→model cascade preserve still-valid values.
- **tests + docs** for all of the above.

## Settings example (schema v3, back-compat)

```json
{
  "schema_version": 3,
  "agent_models": {
    "investigation": { "provider": "deepseek", "model": "deepseek-v4-flash", "thinking_effort": "high" }
  }
}
```

Older settings files load unchanged (empty `agent_models`).

## Testing

`./run_tests.sh` — **989 passed, 50 deselected**. `ruff check` clean on changed files. New coverage: config resolution/validation, build-config env/settings precedence, settings round-trip + v2→v3 migration, agent role resolution (`InvestigationAgent` runs on its override), gigacode override precedence, and TUI populate/save/cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)