### PR TITLE
feat(tools): let file tools read/list/write outside the project root

### DIFF
--- a/kolega_code/agent/tests/llm/test_client.py
+++ b/kolega_code/agent/tests/llm/test_client.py
@@ -170,7 +170,7 @@ async def test_anthropic_stream_tool_use_start_execution_id_matches_final_tool_c
         type = "tool_use"
         id = "toolu_create_file"
         name = "create_file"
-        input = {"relative_path": "hello.txt", "content": "hello"}
+        input = {"path": "hello.txt", "content": "hello"}
 
     class StartChunk:
         type = "content_block_start"

--- a/kolega_code/agent/tests/services/test_file_system.py
+++ b/kolega_code/agent/tests/services/test_file_system.py
@@ -229,6 +229,21 @@ class TestLocalFileSystem:
         assert "iter_test/file2.txt" in contents
         assert "iter_test/subdir" in contents
 
+    def test_iterdir_outside_root(self, filesystem):
+        """Listing a directory outside root_path yields absolute child paths, not a crash."""
+        # A sibling directory that is NOT under the filesystem's root_path.
+        with tempfile.TemporaryDirectory() as outside:
+            outside_dir = Path(outside)
+            (outside_dir / "child.txt").write_text("hello")
+            (outside_dir / "subdir").mkdir()
+
+            # Pre-fix this raised ValueError ("is not in the subpath of") while
+            # relativizing the out-of-root children to root_path.
+            contents = list(filesystem.iterdir(str(outside_dir)))
+
+            assert str(outside_dir / "child.txt") in contents
+            assert str(outside_dir / "subdir") in contents
+
     def test_glob(self, filesystem):
         """Test glob pattern matching."""
         # Create test files

--- a/kolega_code/agent/tests/test_permissions.py
+++ b/kolega_code/agent/tests/test_permissions.py
@@ -79,7 +79,7 @@ def test_allow_rule_options_for_command_include_exact_prefix_and_executable():
 
 
 def test_edit_permission_rule_can_scope_to_path():
-    request = permission_request_for_tool("create_file", {"relative_path": "src/new.py", "content": ""})
+    request = permission_request_for_tool("create_file", {"path": "src/new.py", "content": ""})
     assert request is not None
     rule = PermissionRule.create(
         kind=PermissionKind.EDIT,

--- a/kolega_code/agent/tests/test_planning_agent.py
+++ b/kolega_code/agent/tests/test_planning_agent.py
@@ -154,7 +154,7 @@ async def test_planning_agent_rejects_unavailable_file_edit_tool(
         ToolCall(
             id="tool-call-1",
             name="replace_entire_file",
-            input={"relative_path": "notes.txt", "content": "mutated\n"},
+            input={"path": "notes.txt", "content": "mutated\n"},
         )
     )
 

--- a/kolega_code/agent/tests/test_tools.py
+++ b/kolega_code/agent/tests/test_tools.py
@@ -187,23 +187,23 @@ class TestToolCollection:
         tool_collection.think_hard_tool.think_hard.assert_called_once_with(problem)
 
     async def test_search_and_replace(self, tool_collection: AsyncMock) -> None:
-        relative_path = "test.txt"
+        path = "test.txt"
         block = "<<<<<<< SEARCH\nold\n======\nnew\n>>>>>>> REPLACE"
         expected_response = "Updated content"
         tool_collection.search_and_replace_tool.search_and_replace.return_value = expected_response
 
-        result = await tool_collection.search_and_replace(relative_path, block)
+        result = await tool_collection.search_and_replace(path, block)
         assert result == expected_response
-        tool_collection.search_and_replace_tool.search_and_replace.assert_called_once_with(relative_path, block)
+        tool_collection.search_and_replace_tool.search_and_replace.assert_called_once_with(path, block)
 
     async def test_list_directory(self, tool_collection: AsyncMock) -> None:
-        relative_path = "test_dir"
+        path = "test_dir"
         expected_response = "Directory listing"
         tool_collection.list_directory_tool.list_directory.return_value = expected_response
 
-        result = await tool_collection.list_directory(relative_path)
+        result = await tool_collection.list_directory(path)
         assert result == expected_response
-        tool_collection.list_directory_tool.list_directory.assert_called_once_with(relative_path)
+        tool_collection.list_directory_tool.list_directory.assert_called_once_with(path)
 
     async def test_execute_terminal_command(self, tool_collection: AsyncMock) -> None:
         command = "ls -la"
@@ -226,57 +226,57 @@ class TestToolCollection:
         )
 
     async def test_read_entire_file(self, tool_collection: AsyncMock) -> None:
-        relative_path = "test.txt"
+        path = "test.txt"
         expected_response = "File content"
         tool_collection.read_file_tool.read_entire_file.return_value = expected_response
 
-        result = await tool_collection.read_entire_file(relative_path)
+        result = await tool_collection.read_entire_file(path)
         assert result == expected_response
-        tool_collection.read_file_tool.read_entire_file.assert_called_once_with(relative_path)
+        tool_collection.read_file_tool.read_entire_file.assert_called_once_with(path)
 
     async def test_read_file_section(self, tool_collection: AsyncMock) -> None:
-        relative_path = "test.txt"
+        path = "test.txt"
         start_line = 1
         end_line = 10
         expected_response = "File section"
         tool_collection.read_file_tool.read_file_section.return_value = expected_response
 
-        result = await tool_collection.read_file_section(relative_path, start_line, end_line)
+        result = await tool_collection.read_file_section(path, start_line, end_line)
         assert result == expected_response
-        tool_collection.read_file_tool.read_file_section.assert_called_once_with(relative_path, start_line, end_line)
+        tool_collection.read_file_tool.read_file_section.assert_called_once_with(path, start_line, end_line)
 
     async def test_create_file(self, tool_collection: AsyncMock) -> None:
-        relative_path = "test.txt"
+        path = "test.txt"
         content = "New file content"
         expected_response = "Created file content"
         tool_collection.create_file_tool.create_file.return_value = expected_response
 
-        result = await tool_collection.create_file(relative_path, content)
+        result = await tool_collection.create_file(path, content)
         assert result == expected_response
-        tool_collection.create_file_tool.create_file.assert_called_once_with(relative_path, content)
+        tool_collection.create_file_tool.create_file.assert_called_once_with(path, content)
 
     async def test_replace_entire_file(self, tool_collection: AsyncMock) -> None:
-        relative_path = "test.txt"
+        path = "test.txt"
         content = "New content"
         expected_response = "Updated content"
         tool_collection.replace_entire_file_tool.replace_entire_file.return_value = expected_response
 
-        result = await tool_collection.replace_entire_file(relative_path, content)
+        result = await tool_collection.replace_entire_file(path, content)
         assert result == expected_response
-        tool_collection.replace_entire_file_tool.replace_entire_file.assert_called_once_with(relative_path, content)
+        tool_collection.replace_entire_file_tool.replace_entire_file.assert_called_once_with(path, content)
 
     async def test_replace_lines(self, tool_collection: AsyncMock) -> None:
-        relative_path = "test.txt"
+        path = "test.txt"
         start_line = 1
         end_line = 5
         new_content = "New lines"
         expected_response = "Updated content"
         tool_collection.replace_lines_tool.replace_lines.return_value = expected_response
 
-        result = await tool_collection.replace_lines(relative_path, start_line, end_line, new_content)
+        result = await tool_collection.replace_lines(path, start_line, end_line, new_content)
         assert result == expected_response
         tool_collection.replace_lines_tool.replace_lines.assert_called_once_with(
-            relative_path, start_line, end_line, new_content
+            path, start_line, end_line, new_content
         )
 
     async def test_apply_patch(self, tool_collection: AsyncMock) -> None:

--- a/kolega_code/agent/tests/tool_backend/test_create_file_tool.py
+++ b/kolega_code/agent/tests/tool_backend/test_create_file_tool.py
@@ -74,6 +74,21 @@ class TestCreateFileTool:
         assert (project_path / "test.txt").read_text() == "Original content"
 
     @pytest.mark.asyncio
+    async def test_create_file_outside_project_root(self, create_file_tool):
+        import tempfile
+        from pathlib import Path
+
+        # Absolute path outside the project root, with a missing parent dir to create.
+        with tempfile.TemporaryDirectory() as outside:
+            target = Path(outside) / "sub" / "new.py"
+
+            result = await create_file_tool.create_file(str(target), "x = 1\n")
+
+            assert "File created successfully" in result
+            assert target.exists()
+            assert target.read_text() == "x = 1\n"
+
+    @pytest.mark.asyncio
     async def test_create_file_parent_directory_does_not_exist(self, create_file_tool, project_path):
         result = await create_file_tool.create_file("nonexistent/test.txt", "Hello World")
 

--- a/kolega_code/agent/tests/tool_backend/test_list_directory_tool.py
+++ b/kolega_code/agent/tests/tool_backend/test_list_directory_tool.py
@@ -88,6 +88,31 @@ class TestListDirectoryTool:
         assert "| 📄 | .gitignore" in result
 
     @pytest.mark.asyncio
+    async def test_list_directory_outside_root(self, test_directory, mock_agent):
+        """Listing a directory outside the project root returns a table, not a crash."""
+        filesystem = LocalFileSystem(root_path=test_directory)
+        tool = ListDirectoryTool(
+            project_path=test_directory,
+            workspace_id="test",
+            thread_id="test",
+            connection_manager=Mock(),
+            config=Mock(),
+            caller=mock_agent,
+            filesystem=filesystem,
+        )
+
+        with tempfile.TemporaryDirectory() as outside:
+            Path(os.path.join(outside, "outside_file.py")).write_text("x = 1")
+            os.makedirs(os.path.join(outside, "nested"))
+
+            # Pre-fix this raised "is not in the subpath of" from iterdir.
+            result = await tool.list_directory(outside)
+
+        assert "**Summary:**" in result
+        assert "outside_file.py" in result
+        assert "nested" in result
+
+    @pytest.mark.asyncio
     async def test_file_descriptions(self, test_directory, mock_agent):
         """Test that file descriptions are correct."""
         filesystem = LocalFileSystem(root_path=test_directory)

--- a/kolega_code/agent/tests/tool_backend/test_replace_entire_file_tool.py
+++ b/kolega_code/agent/tests/tool_backend/test_replace_entire_file_tool.py
@@ -68,6 +68,20 @@ class TestReplaceEntireFileTool:
         assert result == "# test.txt has been replaced."
         assert sample_file.read_text() == ""
 
+    async def test_replace_entire_file_outside_project_root(self, replace_entire_file_tool):
+        import tempfile
+        from pathlib import Path
+
+        # An existing file outside the project root can be edited via an absolute path.
+        with tempfile.TemporaryDirectory() as outside:
+            target = Path(outside) / "existing.txt"
+            target.write_text("old contents")
+
+            result = await replace_entire_file_tool.replace_entire_file(str(target), "new contents")
+
+            assert "has been replaced" in result
+            assert target.read_text() == "new contents"
+
     async def test_replace_entire_file_with_multiline_content(self, replace_entire_file_tool, sample_file):
         new_content = "Line 1\n\nLine 3\n\nLine 5"
         result = await replace_entire_file_tool.replace_entire_file("test.txt", new_content)

--- a/kolega_code/agent/tool_backend/apply_patch_tool.py
+++ b/kolega_code/agent/tool_backend/apply_patch_tool.py
@@ -23,7 +23,7 @@ EOF
 
 Where [YOUR_PATCH] is the actual content of your patch, specified in the following V4A diff format.
 
-*** [ACTION] File: [path/to/file] -> ACTION can be one of Add, Update, or Delete.
+*** [ACTION] File: [path/to/file] -> ACTION can be one of Add, Update, or Delete. The path may be relative to the project root (preferred) or absolute to act outside the project.
 For each snippet of code that needs to be changed, repeat the following:
 [context_before] -> See below for further instructions on context.
 - [old_code] -> Precede the old code with a minus sign.

--- a/kolega_code/agent/tool_backend/base_tool.py
+++ b/kolega_code/agent/tool_backend/base_tool.py
@@ -166,8 +166,11 @@ class BaseTool(LogMixin):
         if not hasattr(self, "_gitignore_spec") or self._gitignore_spec is None:
             return False
 
-        # Get the path relative to the project root
-        relative_path = str(file_path.relative_to(self.project_path))
+        # A file outside the project root is not governed by the project's .gitignore.
+        try:
+            relative_path = str(file_path.relative_to(self.project_path))
+        except ValueError:
+            return False
 
         # Check if the path matches any gitignore pattern
         return self._gitignore_spec.match_file(relative_path)
@@ -207,11 +210,11 @@ class BaseTool(LogMixin):
             return set(protected_files)
         return {"package.json", "tsconfig.json"}
 
-    def _enforce_vibe_edit_policy(self, relative_path: str) -> Optional[str]:
+    def _enforce_vibe_edit_policy(self, path: str) -> Optional[str]:
         """Return message if blocked; None if allowed."""
         if not self._is_vibe_mode():
             return None
 
-        if os.path.basename(relative_path) in self._get_vibe_blacklist_basenames():
-            return f"You are not allowed to edit this file: {relative_path}"
+        if os.path.basename(path) in self._get_vibe_blacklist_basenames():
+            return f"You are not allowed to edit this file: {path}"
         return None

--- a/kolega_code/agent/tool_backend/create_file_tool.py
+++ b/kolega_code/agent/tool_backend/create_file_tool.py
@@ -2,12 +2,12 @@ from .base_tool import BaseTool
 
 
 class CreateFileTool(BaseTool):
-    async def create_file(self, relative_path: str, content: str) -> str:
+    async def create_file(self, path: str, content: str) -> str:
         """
         Create a new file with the specified content.
 
         Args:
-            relative_path: Path to create the file at, relative to the project root
+            path: Path to create the file at. Relative to the project root is preferred; an absolute path is also accepted.
             content: Content to write to the file
 
         Returns:
@@ -21,29 +21,29 @@ class CreateFileTool(BaseTool):
         """
         try:
             # Enforce vibe policy for blacklisted basenames
-            blocked_msg = self._enforce_vibe_edit_policy(relative_path)
+            blocked_msg = self._enforce_vibe_edit_policy(path)
             if blocked_msg:
                 return blocked_msg
 
             # Check if file already exists
-            if self.filesystem.exists(relative_path):
-                error_msg = f"File already exists: {relative_path}"
+            if self.filesystem.exists(path):
+                error_msg = f"File already exists: {path}"
                 await self.log_error(error_msg, sender=self.caller.agent_name)
                 return error_msg
 
             # Create parent directory if it doesn't exist
-            parent_dir = self.filesystem.get_parent(relative_path)
+            parent_dir = self.filesystem.get_parent(path)
             if parent_dir and parent_dir != "." and not self.filesystem.exists(parent_dir):
                 self.filesystem.create_directory(parent_dir)
 
             # Create the file
-            self.filesystem.write_text(relative_path, content)
+            self.filesystem.write_text(path, content)
 
             # Return success message with content
             return f"File created successfully\n\n```\n{content}\n```"
 
         except PermissionError:
-            error_msg = f"Permission denied: Cannot create file {relative_path}"
+            error_msg = f"Permission denied: Cannot create file {path}"
             await self.log_error(error_msg, sender=self.caller.agent_name)
             return error_msg
         except Exception as e:

--- a/kolega_code/agent/tool_backend/list_directory_tool.py
+++ b/kolega_code/agent/tool_backend/list_directory_tool.py
@@ -5,12 +5,12 @@ from .base_tool import BaseTool
 
 
 class ListDirectoryTool(BaseTool):
-    async def list_directory(self, relative_path: str = "") -> str:
+    async def list_directory(self, path: str = "") -> str:
         """
         List files and directories at the specified path.
 
         Args:
-            relative_path: Path to list, relative to the project root
+            path: Path to list. Relative to the project root is preferred; an absolute path is also accepted.
 
         Returns:
             Markdown formatted list of files and directories with details
@@ -18,25 +18,25 @@ class ListDirectoryTool(BaseTool):
         Raises:
             NotADirectoryError: If the path is not a directory
         """
-        if not self.filesystem.exists(relative_path):
-            raise FileNotFoundError(f"Directory not found: {relative_path}")
+        if not self.filesystem.exists(path):
+            raise FileNotFoundError(f"Directory not found: {path}")
 
-        if not self.filesystem.is_directory(relative_path):
-            raise NotADirectoryError(f"Not a directory: {relative_path}")
+        if not self.filesystem.is_directory(path):
+            raise NotADirectoryError(f"Not a directory: {path}")
 
         # Use sandbox-specific implementation if available
         if hasattr(self.filesystem, "sandbox"):
-            return await self._list_directory_sandbox(relative_path)
+            return await self._list_directory_sandbox(path)
         else:
             # Use the original implementation for local filesystem
-            return await self._list_directory_local(relative_path)
+            return await self._list_directory_local(path)
 
-    async def _list_directory_sandbox(self, relative_path: str) -> str:
+    async def _list_directory_sandbox(self, path: str) -> str:
         """
         Sandbox-specific implementation using a single command for efficiency.
         """
         # Resolve the full path
-        full_path = self.filesystem._resolve_path(relative_path) if relative_path else self.filesystem.root_path
+        full_path = self.filesystem._resolve_path(path) if path else self.filesystem.root_path
 
         # Use ls with detailed format to get all info in one command
         # -la: list all files with details
@@ -94,8 +94,8 @@ class ListDirectoryTool(BaseTool):
             clean_name = name.rstrip("/")
 
             # Build relative path
-            if relative_path:
-                item_path = f"{relative_path}/{clean_name}"
+            if path:
+                item_path = f"{path}/{clean_name}"
             else:
                 item_path = clean_name
 
@@ -114,14 +114,14 @@ class ListDirectoryTool(BaseTool):
         lines_data.sort(key=lambda x: (not x["is_dir"], x["name"].lower()))
 
         # Build the markdown output
-        return self._format_directory_listing(relative_path, lines_data)
+        return self._format_directory_listing(path, lines_data)
 
-    async def _list_directory_local(self, relative_path: str) -> str:
+    async def _list_directory_local(self, path: str) -> str:
         """
         Original implementation for local filesystem.
         """
         # Get all items in the directory
-        items = self.filesystem.list_directory(relative_path)
+        items = self.filesystem.list_directory(path)
 
         # Sort items: directories first, then files, alphabetically within each group
         items.sort(key=lambda x: (not self.filesystem.is_directory(x), self.filesystem.get_name(x).lower()))
@@ -171,16 +171,16 @@ class ListDirectoryTool(BaseTool):
                 await self.log_error(f"Error processing item {item}: {e}", sender=self.caller.agent_name)
                 continue
 
-        return self._format_directory_listing(relative_path, lines_data)
+        return self._format_directory_listing(path, lines_data)
 
-    def _format_directory_listing(self, relative_path: str, items_data: list) -> str:
+    def _format_directory_listing(self, path: str, items_data: list) -> str:
         """
         Format the directory listing data into markdown.
         """
         # Prepare the header
-        if relative_path:
-            title = f"# Directory: {relative_path}"
-            parent_dir = str(Path(relative_path).parent)
+        if path:
+            title = f"# Directory: {path}"
+            parent_dir = str(Path(path).parent)
             if parent_dir and parent_dir != ".":
                 navigation = f"📁 Parent Directory: {parent_dir}"
             else:
@@ -204,7 +204,6 @@ class ListDirectoryTool(BaseTool):
 
         for item_data in items_data:
             name = item_data["name"]
-            path = item_data["path"]
             is_dir = item_data["is_dir"]
             size = item_data["size"]
             date = item_data["date"]

--- a/kolega_code/agent/tool_backend/read_file_tool.py
+++ b/kolega_code/agent/tool_backend/read_file_tool.py
@@ -7,7 +7,7 @@ class ReadFileTool(BaseTool):
 
     def _format_file_content(
         self,
-        relative_path: str,
+        path: str,
         content: str,
         *,
         line_range: str = "",
@@ -41,9 +41,9 @@ class ReadFileTool(BaseTool):
         if notice_text:
             notice_text += "\n\n"
 
-        return f"# {relative_path}{suffix}\n\n{notice_text}```\n{content}\n```"
+        return f"# {path}{suffix}\n\n{notice_text}```\n{content}\n```"
 
-    async def read_entire_file(self, relative_path: str) -> str:
+    async def read_entire_file(self, path: str) -> str:
         """
         Read the contents of a file in the project.
 
@@ -51,7 +51,7 @@ class ReadFileTool(BaseTool):
         Use read_file_section to read specific portions of large files.
 
         Args:
-            relative_path: Path to the file, relative to the project root
+            path: Path to the file. Relative to the project root is preferred; an absolute path is also accepted.
 
         Returns:
             The contents of the file as a string formatted as markdown.
@@ -60,10 +60,10 @@ class ReadFileTool(BaseTool):
         Raises:
             FileNotFoundError: If the file doesn't exist
         """
-        if not self.filesystem.exists(relative_path):
-            raise FileNotFoundError(f"File not found: {relative_path}")
+        if not self.filesystem.exists(path):
+            raise FileNotFoundError(f"File not found: {path}")
 
-        file_content = self.filesystem.read_text(relative_path)
+        file_content = self.filesystem.read_text(path)
         lines = file_content.splitlines(keepends=True)
         total_lines = len(lines)
 
@@ -73,21 +73,21 @@ class ReadFileTool(BaseTool):
             truncated_content = "".join(truncated_lines)
 
             return self._format_file_content(
-                relative_path,
+                path,
                 truncated_content,
                 line_truncation_notice=(
                     f"**⚠️ File truncated: Showing first {self.MAX_LINES_FOR_ENTIRE_FILE} of {total_lines} lines**"
                 ),
             )
 
-        return self._format_file_content(relative_path, file_content)
+        return self._format_file_content(path, file_content)
 
-    async def read_file_section(self, relative_path: str, start_line: int, end_line: int) -> str:
+    async def read_file_section(self, path: str, start_line: int, end_line: int) -> str:
         """
         Read a specific section of a file in the project from start_line to end_line (inclusive).
 
         Args:
-            relative_path: Path to the file, relative to the project root
+            path: Path to the file. Relative to the project root is preferred; an absolute path is also accepted.
             start_line: The line number to start reading from (1-indexed)
             end_line: The line number to stop reading at (1-indexed, inclusive)
 
@@ -98,8 +98,8 @@ class ReadFileTool(BaseTool):
             FileNotFoundError: If the file doesn't exist
             ValueError: If start_line or end_line are invalid
         """
-        if not self.filesystem.exists(relative_path):
-            raise FileNotFoundError(f"File not found: {relative_path}")
+        if not self.filesystem.exists(path):
+            raise FileNotFoundError(f"File not found: {path}")
 
         if start_line < 1:
             raise ValueError(f"Start line must be at least 1, got {start_line}")
@@ -107,7 +107,7 @@ class ReadFileTool(BaseTool):
         if end_line < start_line:
             raise ValueError(f"End line ({end_line}) must be greater than or equal to start line ({start_line})")
 
-        file_content = self.filesystem.read_text(relative_path)
+        file_content = self.filesystem.read_text(path)
         lines = file_content.splitlines(keepends=True)
 
         if start_line > len(lines):
@@ -116,4 +116,4 @@ class ReadFileTool(BaseTool):
         # Adjust for 0-indexed list
         section_content = "".join(lines[start_line - 1 : end_line])
         line_range = f"(lines {start_line}-{min(end_line, len(lines))})"
-        return self._format_file_content(relative_path, section_content, line_range=line_range)
+        return self._format_file_content(path, section_content, line_range=line_range)

--- a/kolega_code/agent/tool_backend/replace_entire_file_tool.py
+++ b/kolega_code/agent/tool_backend/replace_entire_file_tool.py
@@ -2,12 +2,12 @@ from .base_tool import BaseTool
 
 
 class ReplaceEntireFileTool(BaseTool):
-    async def replace_entire_file(self, relative_path: str, content: str) -> str:
+    async def replace_entire_file(self, path: str, content: str) -> str:
         """
         Replace the entire contents of a file in the project.
 
         Args:
-            relative_path: Path to the file, relative to the project root
+            path: Path to the file. Relative to the project root is preferred; an absolute path is also accepted.
             content: New content to write to the file
 
         Returns:
@@ -17,24 +17,24 @@ class ReplaceEntireFileTool(BaseTool):
             FileNotFoundError: If the file doesn't exist
             PermissionError: If the file cannot be written to
         """
-        if not self.filesystem.exists(relative_path):
-            error_msg = f"File not found: {relative_path}"
+        if not self.filesystem.exists(path):
+            error_msg = f"File not found: {path}"
             await self.log_error(error_msg, sender=self.caller.agent_name)
             raise FileNotFoundError(error_msg)
 
         try:
-            blocked_msg = self._enforce_vibe_edit_policy(relative_path)
+            blocked_msg = self._enforce_vibe_edit_policy(path)
             if blocked_msg:
                 return blocked_msg
-            self.filesystem.write_text(relative_path, content)
-            success_msg = f"Successfully replaced file: {relative_path}"
+            self.filesystem.write_text(path, content)
+            success_msg = f"Successfully replaced file: {path}"
             await self.log_info(success_msg, sender=self.caller.agent_name)
-            return f"# {relative_path} has been replaced."
+            return f"# {path} has been replaced."
         except PermissionError as e:
-            error_msg = f"Permission denied when writing to file: {relative_path}"
+            error_msg = f"Permission denied when writing to file: {path}"
             await self.log_error(error_msg, sender=self.caller.agent_name)
             raise
         except Exception as e:
-            error_msg = f"Failed to write to file {relative_path}: {str(e)}"
+            error_msg = f"Failed to write to file {path}: {str(e)}"
             await self.log_error(error_msg, sender=self.caller.agent_name)
             raise

--- a/kolega_code/agent/tool_backend/replace_lines_tool.py
+++ b/kolega_code/agent/tool_backend/replace_lines_tool.py
@@ -2,12 +2,12 @@ from .base_tool import BaseTool
 
 
 class ReplaceLinesTool(BaseTool):
-    async def replace_lines(self, relative_path: str, start_line: int, end_line: int, new_content: str) -> str:
+    async def replace_lines(self, path: str, start_line: int, end_line: int, new_content: str) -> str:
         """
         Replace a range of lines in a file with new content.
 
         Args:
-            relative_path: Path to the file, relative to the project root
+            path: Path to the file. Relative to the project root is preferred; an absolute path is also accepted.
             start_line: The starting line number (1-indexed)
             end_line: The ending line number (1-indexed, inclusive)
             new_content: The new content to replace the specified lines with
@@ -20,8 +20,8 @@ class ReplaceLinesTool(BaseTool):
             ValueError: If the line range is invalid
             PermissionError: If the file cannot be written to
         """
-        if not self.filesystem.exists(relative_path):
-            error_msg = f"File not found: {relative_path}"
+        if not self.filesystem.exists(path):
+            error_msg = f"File not found: {path}"
             await self.log_error(error_msg, sender=self.caller.agent_name)
             raise FileNotFoundError(error_msg)
 
@@ -39,7 +39,7 @@ class ReplaceLinesTool(BaseTool):
 
         try:
             # Read the original file content
-            file_content = self.filesystem.read_text(relative_path)
+            file_content = self.filesystem.read_text(path)
             lines = file_content.splitlines(keepends=True)
 
             # Check if the line range is valid
@@ -70,17 +70,17 @@ class ReplaceLinesTool(BaseTool):
             updated_content = "".join(lines[:start_idx]) + formatted_new_content + "".join(lines[end_idx:])
 
             # Write the updated content back to the file (with vibe policy enforcement)
-            blocked_msg = self._enforce_vibe_edit_policy(relative_path)
+            blocked_msg = self._enforce_vibe_edit_policy(path)
             if blocked_msg:
                 return blocked_msg
-            self.filesystem.write_text(relative_path, updated_content)
+            self.filesystem.write_text(path, updated_content)
 
-            success_msg = f"Successfully replaced lines {start_line}-{end_line} in file: {relative_path}"
+            success_msg = f"Successfully replaced lines {start_line}-{end_line} in file: {path}"
             await self.log_info(success_msg, sender=self.caller.agent_name)
 
             # Return the formatted message with both old and new content
             return (
-                f"Replaced lines {start_line}-{end_line} in file {relative_path}\n\n"
+                f"Replaced lines {start_line}-{end_line} in file {path}\n\n"
                 f"Replaced:\n"
                 f"```\n{old_content}```\n"
                 f"with:\n"
@@ -88,10 +88,10 @@ class ReplaceLinesTool(BaseTool):
             )
 
         except PermissionError:
-            error_msg = f"Permission denied when writing to file: {relative_path}"
+            error_msg = f"Permission denied when writing to file: {path}"
             await self.log_error(error_msg, sender=self.caller.agent_name)
             raise
         except Exception as e:
-            error_msg = f"Failed to replace lines in file {relative_path}: {str(e)}"
+            error_msg = f"Failed to replace lines in file {path}: {str(e)}"
             await self.log_error(error_msg, sender=self.caller.agent_name)
             raise

--- a/kolega_code/agent/tool_backend/search_and_replace_tool.py
+++ b/kolega_code/agent/tool_backend/search_and_replace_tool.py
@@ -4,7 +4,7 @@ from .base_tool import BaseTool
 
 
 class SearchAndReplaceTool(BaseTool):
-    async def search_and_replace(self, relative_path: str, blocks: str) -> str:
+    async def search_and_replace(self, path: str, blocks: str) -> str:
         """
         Edit a file using search and replace blocks.
 
@@ -22,7 +22,7 @@ class SearchAndReplaceTool(BaseTool):
         THE INDENTATION IN THE SEARCH BLOCK MUST BE IDENTICAL TO THE EXISTING FILE.
 
         Args:
-            relative_path: Path to the file to edit, relative to the project root
+            path: Path to the file to edit. Relative to the project root is preferred; an absolute path is also accepted.
             blocks: One or more search and replace blocks formatted as shown above
 
         Returns:
@@ -34,14 +34,14 @@ class SearchAndReplaceTool(BaseTool):
             ValueError: If the blocks are malformed or incorrectly formatted
             PermissionError: If the file cannot be written to
         """
-        if not self.filesystem.exists(relative_path):
-            error_msg = f"File not found: {relative_path}"
+        if not self.filesystem.exists(path):
+            error_msg = f"File not found: {path}"
             await self.log_error(error_msg, sender=self.caller.agent_name)
             raise FileNotFoundError(error_msg)
 
         try:
             # Read the original file content
-            file_content = self.filesystem.read_text(relative_path)
+            file_content = self.filesystem.read_text(path)
 
             original_content = file_content
             updated_content = file_content
@@ -109,16 +109,16 @@ class SearchAndReplaceTool(BaseTool):
             # Check if anything was changed
             if updated_content == original_content:
                 await self.log_warning(
-                    f"No changes made to {relative_path}. All replacements were identical to original text.",
+                    f"No changes made to {path}. All replacements were identical to original text.",
                     sender=self.caller.agent_name,
                 )
-                return f"# {relative_path} (No changes made)\n\n```\n{original_content}\n```"
+                return f"# {path} (No changes made)\n\n```\n{original_content}\n```"
 
             # Write the updated content back to the file (with vibe policy enforcement)
-            blocked_msg = self._enforce_vibe_edit_policy(relative_path)
+            blocked_msg = self._enforce_vibe_edit_policy(path)
             if blocked_msg:
                 return blocked_msg
-            self.filesystem.write_text(relative_path, updated_content)
+            self.filesystem.write_text(path, updated_content)
 
             # Extract search and replace text for output
             search_text = matches[0].group(1)
@@ -126,7 +126,7 @@ class SearchAndReplaceTool(BaseTool):
 
             # Return a message similar to replace_lines tool
             return (
-                f"Search and replace in file {relative_path}\n\n"
+                f"Search and replace in file {path}\n\n"
                 f"Replaced:\n"
                 f"```\n{search_text}\n```\n"
                 f"with:\n"
@@ -137,10 +137,10 @@ class SearchAndReplaceTool(BaseTool):
             # Re-raise ValueError exceptions which are used for validation errors
             raise
         except PermissionError as e:
-            error_msg = f"Permission denied when writing to file: {relative_path}"
+            error_msg = f"Permission denied when writing to file: {path}"
             await self.log_error(error_msg, sender=self.caller.agent_name)
             raise
         except Exception as e:
-            error_msg = f"Failed to apply search and replace to {relative_path}: {str(e)}"
+            error_msg = f"Failed to apply search and replace to {path}: {str(e)}"
             await self.log_error(error_msg, sender=self.caller.agent_name)
             raise

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -964,7 +964,7 @@ class ToolCollection(LogMixin):
         else:
             return f"✅ Paused execution for {seconds} seconds"
 
-    async def search_and_replace(self, relative_path: str, block: str) -> str:
+    async def search_and_replace(self, path: str, block: str) -> str:
         """
         Edit a file using a search and replace block.
 
@@ -982,7 +982,7 @@ class ToolCollection(LogMixin):
         1. Use the read_entire_file tool to understand the file's contents and context
 
         To make a file edit, provide the following:
-        1. relative_path: The absolute path to the file to modify (must be absolute, not relative)
+        1. The path to the file to modify (relative to the project root preferred; an absolute path is also accepted)
         2. block: The search and replace block, as specified above. The text to replace (must be unique within the file, and must match the file contents exactly, including all whitespace and indentation)
 
         The tool will replace ONE occurrence of old_string with new_string in the specified file.
@@ -1017,7 +1017,7 @@ class ToolCollection(LogMixin):
         THE INDENTATION IN THE SEARCH BLOCK MUST BE IDENTICAL TO THE EXISTING FILE.
 
         Args:
-            relative_path: Path to the file to edit, relative to the project root
+            path: Path to the file to edit. Relative to the project root is preferred; an absolute path is also accepted.
             block: A single search and replace blocks formatted as shown above
 
         Returns:
@@ -1030,14 +1030,14 @@ class ToolCollection(LogMixin):
             ValueError: If the block matches more than one place in the file
             PermissionError: If the file cannot be written to
         """
-        return await self.search_and_replace_tool.search_and_replace(relative_path, block)
+        return await self.search_and_replace_tool.search_and_replace(path, block)
 
-    async def list_directory(self, relative_path: str = "") -> str:
+    async def list_directory(self, path: str = "") -> str:
         """
         List files and directories at the specified path.
 
         Args:
-            relative_path: Path to list, relative to the project root
+            path: Path to list. Relative to the project root is preferred; an absolute path is also accepted.
 
         Returns:
             Markdown formatted list of files and directories with details
@@ -1045,7 +1045,7 @@ class ToolCollection(LogMixin):
         Raises:
             NotADirectoryError: If the path is not a directory
         """
-        return await self.list_directory_tool.list_directory(relative_path)
+        return await self.list_directory_tool.list_directory(path)
 
     async def execute_terminal_command(self, command: str) -> str:
         """Execute a command and display output in terminal."""
@@ -1146,7 +1146,7 @@ class ToolCollection(LogMixin):
         """
         return await self.terminal_tool.list_sessions()
 
-    async def read_entire_file(self, relative_path: str) -> str:
+    async def read_entire_file(self, path: str) -> str:
         """
         Read the contents of a file in the project.
 
@@ -1154,7 +1154,7 @@ class ToolCollection(LogMixin):
         Use read_file_section to read specific portions of large files.
 
         Args:
-            relative_path: Path to the file, relative to the project root
+            path: Path to the file. Relative to the project root is preferred; an absolute path is also accepted.
 
         Returns:
             The contents of the file as a string formatted as markdown
@@ -1162,14 +1162,14 @@ class ToolCollection(LogMixin):
         Raises:
             FileNotFoundError: If the file doesn't exist
         """
-        return await self.read_file_tool.read_entire_file(relative_path)
+        return await self.read_file_tool.read_entire_file(path)
 
-    async def read_file_section(self, relative_path: str, start_line: int, end_line: int) -> str:
+    async def read_file_section(self, path: str, start_line: int, end_line: int) -> str:
         """
         Read a specific section of a file in the project from start_line to end_line (inclusive).
 
         Args:
-            relative_path: Path to the file, relative to the project root
+            path: Path to the file. Relative to the project root is preferred; an absolute path is also accepted.
             start_line: The line number to start reading from (1-indexed)
             end_line: The line number to stop reading at (1-indexed, inclusive)
 
@@ -1180,14 +1180,14 @@ class ToolCollection(LogMixin):
             FileNotFoundError: If the file doesn't exist
             ValueError: If start_line or end_line are invalid
         """
-        return await self.read_file_tool.read_file_section(relative_path, start_line, end_line)
+        return await self.read_file_tool.read_file_section(path, start_line, end_line)
 
-    async def create_file(self, relative_path: str, content: str) -> str:
+    async def create_file(self, path: str, content: str) -> str:
         """
         Create a new file in the project with the given content.
 
         Args:
-            relative_path: Path to the file to create, relative to the project root
+            path: Path to the file to create. Relative to the project root is preferred; an absolute path is also accepted.
             content: Content to write to the new file
 
         Returns:
@@ -1198,14 +1198,14 @@ class ToolCollection(LogMixin):
             ValueError: If the parent directory doesn't exist
             PermissionError: If the file cannot be created due to permissions
         """
-        return await self.create_file_tool.create_file(relative_path, content)
+        return await self.create_file_tool.create_file(path, content)
 
-    async def replace_entire_file(self, relative_path: str, content: str) -> str:
+    async def replace_entire_file(self, path: str, content: str) -> str:
         """
         Replace the entire contents of a file in the project.
 
         Args:
-            relative_path: Path to the file, relative to the project root
+            path: Path to the file. Relative to the project root is preferred; an absolute path is also accepted.
             content: New content to write to the file
 
         Returns:
@@ -1215,14 +1215,14 @@ class ToolCollection(LogMixin):
             FileNotFoundError: If the file doesn't exist
             PermissionError: If the file cannot be written to
         """
-        return await self.replace_entire_file_tool.replace_entire_file(relative_path, content)
+        return await self.replace_entire_file_tool.replace_entire_file(path, content)
 
-    async def replace_lines(self, relative_path: str, start_line: int, end_line: int, new_content: str) -> str:
+    async def replace_lines(self, path: str, start_line: int, end_line: int, new_content: str) -> str:
         """
         Replace a range of lines in a file with new content.
 
         Args:
-            relative_path: Path to the file, relative to the project root
+            path: Path to the file. Relative to the project root is preferred; an absolute path is also accepted.
             start_line: The starting line number (1-indexed)
             end_line: The ending line number (1-indexed, inclusive)
             new_content: The new content to replace the specified lines with
@@ -1235,7 +1235,7 @@ class ToolCollection(LogMixin):
             ValueError: If the line range is invalid
             PermissionError: If the file cannot be written to
         """
-        return await self.replace_lines_tool.replace_lines(relative_path, start_line, end_line, new_content)
+        return await self.replace_lines_tool.replace_lines(path, start_line, end_line, new_content)
 
     async def apply_patch(self, input: str) -> str:
         """

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -3950,7 +3950,7 @@ async def test_textual_app_renders_resumed_history_in_chat(
             role="assistant",
             content=[
                 TextBlock("I'll inspect it."),
-                ToolCall(id="tool-1", name="read_file", input={"relative_path": "README.md"}),
+                ToolCall(id="tool-1", name="read_file", input={"path": "README.md"}),
             ],
         ).to_dict(),
         Message(

--- a/kolega_code/permissions.py
+++ b/kolega_code/permissions.py
@@ -258,7 +258,7 @@ def _matches_edit(rule: PermissionRule, request: PermissionRequest) -> bool:
 def _path_from_edit_inputs(tool_name: str, inputs: dict[str, Any]) -> str:
     if tool_name == "apply_patch":
         return ""
-    value = inputs.get("relative_path")
+    value = inputs.get("path")
     return str(value).strip() if value is not None else ""
 
 

--- a/kolega_code/services/file_system.py
+++ b/kolega_code/services/file_system.py
@@ -608,7 +608,11 @@ class LocalFileSystem(FileSystem):
         resolved_path = self._resolve_path(path)
         for item in resolved_path.iterdir():
             if self.root_path:
-                yield str(item.relative_to(self.root_path))
+                try:
+                    yield str(item.relative_to(self.root_path))
+                except ValueError:
+                    # If the child is outside root_path, yield the absolute path
+                    yield str(item)
             else:
                 yield str(item)
 


### PR DESCRIPTION
## Context

An in-workflow sub-agent called `list_directory` on a path outside its project root and got a raw, cryptic error:

> '…/agents' is not in the subpath of '/…/astro-app' OR one path is relative and the other is absolute.

That was never a deliberate sandbox guard — it was an incidental crash. `LocalFileSystem` has no boundary check: `_resolve_path` just does `root_path / path`, so out-of-root **reads already worked**. Only operations that relativize children for display broke — `iterdir` called `item.relative_to(root_path)` for every child with no handler, so `list_directory` raised pathlib's `ValueError` straight back to the agent.

The intent (per discussion): agents should be able to **read, list, and write anything outside the project path**, and the tools should **say so** rather than leave it implicit. While here, `relative_path` is now a misnomer — `path` is the conventional, model-known name.

## What changed

- **`iterdir`** falls back to the absolute path when a child is outside `root_path` (mirroring the existing `get_parent`/`get_parents` pattern), so `list_directory` works on any directory. Write/edit tools already worked out-of-root via `_resolve_path`/`get_parent`; added a guard so `_is_gitignored` returns `False` for out-of-root paths instead of raising.
- **Renamed `relative_path` → `path`** across the read/list/write/edit tools, the `permissions.py` edit-path lookup, and tests. Verified the generated tool schema: every tool's first parameter is now `path`.
- **Documented the affordance** in each tool description ("Relative to the project root is preferred; an absolute path is also accepted"); fixed the self-contradictory `search_and_replace` wording and noted it in the `apply_patch` format spec.
- **Tests**: added out-of-root regressions for `iterdir`/`list_directory`/`create_file`/`replace_entire_file`.

Left intentionally alone: `cli/skills.py`'s `relative_path` (a separate skill-resource sandbox that enforces relative-only) and the `_is_gitignored` local var (accurately named).

## Test plan

- `uv run pytest kolega_code/agent/tests/tool_backend/ kolega_code/agent/tests/services/` — green (288).
- Full touched-suite sweep including real dispatch (`test_planning_agent`, `test_permissions`) and the modified `test_app` history test — green.
- Schema introspection confirms all 7 tools expose `path` with single-line affordance descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)