### PR TITLE
fix(llm): retry/backoff for rate limits + overload, tame concurrency

### DIFF
--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -2,8 +2,10 @@ import asyncio
 import contextvars
 import logging
 import os
+import random
 import re
 import uuid
+from email.utils import parsedate_to_datetime
 from datetime import datetime
 from pathlib import Path
 from typing import Any, AsyncGenerator, Dict, List, Optional
@@ -25,6 +27,7 @@ from kolega_code.hooks import (
 )
 from kolega_code.llm.exceptions import (
     LLMError,
+    LLMInternalServerError,
     LLMRateLimitError,
     llm_error_message,
     map_to_llm_error,
@@ -251,6 +254,9 @@ class BaseAgent(LogMixin):
 
         self.conversation = Conversation(max_tool_result_chars=self.max_tool_result_chars_in_history)
         self.conversation.skill_content_pattern = self.skill_content_pattern
+        # Counts consecutive transient LLM failures (rate-limit / overload) so the turn loop
+        # backs off and eventually gives up instead of retrying forever; reset on any good turn.
+        self._consecutive_llm_retries = 0
         self.compressor = HistoryCompressor(threshold=self.history_compression_threshold)
         self.emitter = AgentEventEmitter(
             connection_manager=self.connection_manager,
@@ -1045,31 +1051,74 @@ class BaseAgent(LogMixin):
             tool_call_id=tool_call_id,
         )
 
+    @staticmethod
+    def _parse_retry_after(error: Exception) -> Optional[float]:
+        """Best-effort retry-after (seconds) from a RAW provider exception.
+
+        Must be called before map_to_llm_error, which discards the response headers.
+        Handles both the integer-seconds and HTTP-date forms; returns None on any miss.
+        """
+        raw = None
+        response = getattr(error, "response", None)
+        headers = getattr(response, "headers", None)
+        if headers is not None:
+            try:
+                raw = headers.get("retry-after")
+            except Exception:
+                raw = None
+        if raw is None:
+            raw = getattr(error, "retry_after", None)
+        if raw is None:
+            return None
+        try:
+            return max(0.0, float(raw))
+        except (TypeError, ValueError):
+            pass
+        try:
+            retry_dt = parsedate_to_datetime(str(raw))
+            return max(0.0, (retry_dt - datetime.now(retry_dt.tzinfo)).total_seconds())
+        except Exception:
+            return None
+
     async def handle_llm_error(self, error: Exception) -> None:
+        """Centralized handling for LLM errors raised in the turn loop.
+
+        Transient failures (rate-limit, overload/5xx, connection drops) are retried with
+        bounded exponential backoff + jitter — honoring retry-after when present — up to
+        ``loop_max_retries`` *consecutive* attempts, then surfaced cleanly. This is the
+        fallback for failures the SDK's own retries didn't absorb (budget exhausted, or the
+        failure happened mid-stream, which the SDK does not retry). Returning (not raising)
+        lets the turn loop re-issue the identical request. Other LLM errors and non-LLM
+        errors are terminal.
         """
-        Handle LLM errors with appropriate retry logic and logging.
-
-        This method provides centralized error handling for all LLM operations:
-        - Rate limit errors: Log warning, wait 60 seconds, and allow retry
-        - Other LLM errors: Emit a user-facing status and re-raise
-        - Non-LLM errors: Re-raise as-is
-
-        Args:
-            error: The exception to handle
-
-        Raises:
-            LLMError: Re-raises LLM errors after logging
-            Exception: Re-raises non-LLM exceptions as-is
-        """
+        # Extract retry-after from the raw exception before mapping strips the headers.
+        retry_after = self._parse_retry_after(error)
         error = map_to_llm_error(error, provider=self.primary_model_config.provider.value)
 
-        if isinstance(error, LLMRateLimitError):
+        # LLMInternalServerError covers 500/529 overloaded plus connection/transport errors.
+        if isinstance(error, (LLMRateLimitError, LLMInternalServerError)):
+            cap = self.primary_model_config.rate_limits.loop_max_retries
+            self._consecutive_llm_retries += 1
+            if self._consecutive_llm_retries > cap:
+                await self.emitter.llm_status(
+                    "error",
+                    llm_error_message(error, model=self.primary_model_config.model),
+                )
+                raise error
+            if retry_after is not None:
+                delay = min(retry_after, 60.0)
+            else:
+                # Full jitter on capped exponential backoff de-correlates concurrent agents.
+                backoff = min(30.0, 2.0 * (2 ** (self._consecutive_llm_retries - 1)))
+                delay = random.uniform(0, backoff)
             await self.log_warning(
-                f"Rate limit exceeded: {error}. Waiting for 60 seconds before retrying...", sender=self.agent_name
+                f"Transient LLM error ({error}); retry "
+                f"{self._consecutive_llm_retries}/{cap} in {delay:.1f}s.",
+                sender=self.agent_name,
             )
-            await asyncio.sleep(60)
-            await self.log_info("Resuming after rate limit wait period.", sender=self.agent_name)
-            # Don't re-raise - allow retry
+            await asyncio.sleep(delay)
+            await self.log_info("Resuming after backoff.", sender=self.agent_name)
+            # Don't re-raise - the turn loop re-issues the request.
 
         elif isinstance(error, LLMError):
             await self.emitter.llm_status(
@@ -1282,6 +1331,9 @@ class BaseAgent(LogMixin):
                 stop_reason = assistant_message.stop_reason
 
                 self.append_assistant_message(assistant_message)
+                # A clean stream resets the transient-failure budget, so the cap measures
+                # only consecutive failures, not lifetime failures across the turn.
+                self._consecutive_llm_retries = 0
 
                 if thinking_started or current_thinking:
                     yield {"type": "thinking", "content": current_thinking, "complete": True, "uuid": thinking_uuid}

--- a/kolega_code/agent/orchestration/runtime.py
+++ b/kolega_code/agent/orchestration/runtime.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import os
+import random
 from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional
 
 from .budget import Budget
@@ -26,11 +27,20 @@ from .types import AgentRunSpec, DispatchFn, EmitFn, WorkflowResolver
 MAX_FANOUT = 4096
 DEFAULT_AGENT_CAP = 1000
 
+# A batch admitted through the semaphore together would otherwise fire LLM requests at the
+# same instant; a small random pre-dispatch delay de-synchronizes them so concurrent
+# sub-agents don't collectively spike the account rate limit.
+START_STAGGER_SECONDS = 0.75
+
 
 def default_concurrency() -> int:
-    """Concurrent-agent cap: a few below the core count, clamped to [1, 16]."""
+    """Concurrent-agent cap: a few below the core count, clamped to [1, 8].
+
+    Kept modest so a fan-out doesn't burst enough simultaneous LLM requests to trip
+    account-level rate limits; the jittered start-stagger further de-correlates them.
+    """
     cpus = os.cpu_count() or 4
-    return max(1, min(16, cpus - 2))
+    return max(1, min(8, cpus - 2))
 
 
 def _call_with_arity(fn: Callable[..., Any], *args: Any) -> Any:
@@ -152,6 +162,9 @@ class WorkflowRuntime:
         self.budget.check()
 
         async with self._sem:
+            # Stagger starts within the admitted batch so they don't hit the API in lockstep.
+            if START_STAGGER_SECONDS:
+                await asyncio.sleep(random.uniform(0, START_STAGGER_SECONDS))
             result = await self._dispatch(spec)
 
         self.budget.add(result.tokens)

--- a/kolega_code/agent/tests/llm/test_client.py
+++ b/kolega_code/agent/tests/llm/test_client.py
@@ -616,6 +616,12 @@ async def test_retry_on_error():
     assert isinstance(client.provider.max_retries, int)
     assert client.provider.max_retries == 3
 
+    # Regression guard: max_retries must actually reach the underlying SDK clients,
+    # whose built-in exponential backoff is the primary retry mechanism. (Previously
+    # the value was stored but never forwarded, so the SDK silently used its default.)
+    assert client.provider.async_client.max_retries == 3
+    assert client.provider.sync_client.max_retries == 3
+
     # This test passes as long as the retry mechanism is properly set up
 
 

--- a/kolega_code/agent/tests/test_base_agent.py
+++ b/kolega_code/agent/tests/test_base_agent.py
@@ -14,6 +14,7 @@ from kolega_code.llm.exceptions import (
     LLMAuthenticationError,
     LLMContextWindowExceededError,
     LLMInternalServerError,
+    LLMRateLimitError,
 )
 from kolega_code.llm.models import (
     Message,
@@ -87,12 +88,6 @@ class TestBaseAgent:
                 "The conversation context became too large for the model",
             ),
             (
-                LLMInternalServerError("provider overloaded", provider=ModelProvider.ANTHROPIC.value),
-                ModelProvider.ANTHROPIC,
-                "claude-haiku-4-5-20251001",
-                "There is high traffic on our LLM provider",
-            ),
-            (
                 LLMAuthenticationError("invalid key", provider=ModelProvider.ANTHROPIC.value),
                 ModelProvider.ANTHROPIC,
                 "claude-haiku-4-5-20251001",
@@ -119,6 +114,62 @@ class TestBaseAgent:
         assert event.event_type == "llm_status_update"
         assert event.content["status"] == "error"
         assert expected_message in event.content["message"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "make_error",
+        [
+            lambda: LLMRateLimitError("429 rate limited", provider=ModelProvider.ANTHROPIC.value),
+            lambda: LLMInternalServerError("provider overloaded", provider=ModelProvider.ANTHROPIC.value),
+        ],
+    )
+    async def test_handle_llm_error_retries_transient_then_caps(self, base_agent, make_error):
+        """Rate-limit and overload/5xx errors back off and retry up to loop_max_retries
+        consecutive attempts, then surface cleanly."""
+        cap = base_agent.primary_model_config.rate_limits.loop_max_retries
+        assert cap >= 1
+
+        sleeps: list[float] = []
+
+        async def fake_sleep(delay):
+            sleeps.append(delay)
+
+        with patch("kolega_code.agent.baseagent.asyncio.sleep", side_effect=fake_sleep):
+            # Under the cap: returns without raising (the turn loop will re-issue).
+            for attempt in range(cap):
+                await base_agent.handle_llm_error(make_error())
+                assert base_agent._consecutive_llm_retries == attempt + 1
+            # Exceeding the cap re-raises the mapped error.
+            with pytest.raises((LLMRateLimitError, LLMInternalServerError)):
+                await base_agent.handle_llm_error(make_error())
+
+        assert len(sleeps) == cap
+        assert all(s >= 0 for s in sleeps)
+
+    @pytest.mark.asyncio
+    async def test_handle_llm_error_honors_retry_after(self, base_agent):
+        """A retry-after header on the raw exception is used (capped) for the wait."""
+        raw = SimpleNamespace(response=SimpleNamespace(headers={"retry-after": "7"}))
+        # Make it look like a rate-limit so map_to_llm_error classifies it as retryable.
+        raw.status_code = 429
+
+        sleeps: list[float] = []
+
+        async def fake_sleep(delay):
+            sleeps.append(delay)
+
+        with patch("kolega_code.agent.baseagent.asyncio.sleep", side_effect=fake_sleep), patch(
+            "kolega_code.agent.baseagent.map_to_llm_error",
+            return_value=LLMRateLimitError("429", provider=ModelProvider.ANTHROPIC.value),
+        ):
+            await base_agent.handle_llm_error(raw)
+
+        assert sleeps == [7.0]
+
+    def test_parse_retry_after_forms(self):
+        seconds = SimpleNamespace(response=SimpleNamespace(headers={"retry-after": "12"}))
+        assert BaseAgent._parse_retry_after(seconds) == 12.0
+        assert BaseAgent._parse_retry_after(Exception("no header")) is None
 
     def test_build_prompt_context_loads_agents_md(self, base_agent, tmp_path):
         (tmp_path / "AGENTS.md").write_text("Use AGENTS guidance", encoding="utf-8")

--- a/kolega_code/config.py
+++ b/kolega_code/config.py
@@ -54,7 +54,17 @@ class RateLimitConfig(BaseModel):
 
     tokens_per_minute: int = Field(default=80_000, description="Maximum number of tokens allowed per minute", gt=0)
 
-    max_retries: int = Field(default=3, description="Maximum number of retries for failed requests", ge=0)
+    max_retries: int = Field(
+        default=4,
+        description="Retries the underlying SDK client performs per request (exponential backoff + jitter, honors retry-after)",
+        ge=0,
+    )
+
+    loop_max_retries: int = Field(
+        default=3,
+        description="Consecutive agent-loop retries on rate-limit/overload after the SDK's own retries are exhausted",
+        ge=0,
+    )
 
 
 class ModelConfig(BaseModel):

--- a/kolega_code/llm/providers/anthropic.py
+++ b/kolega_code/llm/providers/anthropic.py
@@ -107,8 +107,10 @@ class AnthropicProvider(BaseLLMProvider):
     ):
         super().__init__(api_key, max_retries, requests_per_minute, tokens_per_minute, base_url)
         self.provider_name = provider_name
-        self.async_client = AsyncAnthropic(api_key=api_key, base_url=base_url)
-        self.sync_client = Anthropic(api_key=api_key, base_url=base_url)
+        # Forward max_retries so the SDK's built-in exponential backoff + jitter (which
+        # honors retry-after and retries 429/5xx/529 + connection errors) is actually used.
+        self.async_client = AsyncAnthropic(api_key=api_key, base_url=base_url, max_retries=max_retries)
+        self.sync_client = Anthropic(api_key=api_key, base_url=base_url, max_retries=max_retries)
         
         # OpenAI-compatible Anthropic-shaped APIs do not expose messages/count_tokens,
         # so local counting is only a preflight context-size estimate for those models.

--- a/kolega_code/llm/providers/google.py
+++ b/kolega_code/llm/providers/google.py
@@ -82,7 +82,17 @@ class GoogleProvider(BaseLLMProvider):
         base_url: Optional[str] = None,
     ):
         super().__init__(api_key, max_retries, requests_per_minute, tokens_per_minute, base_url)
-        self.async_client = genai_client(api_key=api_key)
+        # Wire the google-genai client's built-in retry (exponential backoff) so transient
+        # 429/5xx are retried like the other providers. attempts is total tries = retries + 1.
+        self.async_client = genai_client(
+            api_key=api_key,
+            http_options=genai_types.HttpOptions(
+                retry_options=genai_types.HttpRetryOptions(
+                    attempts=max(1, max_retries + 1),
+                    http_status_codes=[408, 429, 500, 502, 503, 504],
+                )
+            ),
+        )
 
     @property
     def retry_decorator(self):

--- a/kolega_code/llm/providers/openai.py
+++ b/kolega_code/llm/providers/openai.py
@@ -138,8 +138,10 @@ class OpenAIProvider(BaseLLMProvider):
         # OpenAI-compatible providers (xai, together, fireworks, dashscope, ...) reuse this
         # provider; provider_name is used to look up the model's thinking-effort spec.
         self.provider_name = provider_name
-        self.async_client = AsyncOpenAI(api_key=api_key, base_url=base_url)
-        self.sync_client = OpenAI(api_key=api_key, base_url=base_url)
+        # Forward max_retries so the SDK's built-in exponential backoff + jitter (which
+        # honors retry-after and retries 429/5xx + connection errors) is actually used.
+        self.async_client = AsyncOpenAI(api_key=api_key, base_url=base_url, max_retries=max_retries)
+        self.sync_client = OpenAI(api_key=api_key, base_url=base_url, max_retries=max_retries)
 
     @property
     def retry_decorator(self):


### PR DESCRIPTION
## Why

When many sub-agents run concurrently (workflows fan out up to `min(16, cpu-2)` at once), users frequently hit rate-limit / overload errors that **killed** agents. Three root causes:

1. **SDK retries were silently under-configured.** `RateLimitConfig.max_retries` was plumbed to each provider but **never forwarded to the SDK client** — so the Anthropic/OpenAI SDKs fell back to their default of 2, and the configured value only fed an *unused* tenacity decorator.
2. **Overloaded (529) errors were terminal.** Anthropic 529 maps to `LLMInternalServerError`, which `handle_llm_error` re-raised → the sub-agent died. The rate-limit path itself used a crude flat `sleep(60)` with no backoff, jitter, or attempt cap.
3. **No cross-agent coordination.** `parallel`/`pipeline` admit a batch through the semaphore simultaneously → synchronized LLM bursts that collectively exceed account RPM/TPM.

## What

### Layer 1 — wire SDK retries (primary fix)
- Forward `max_retries` to `AsyncAnthropic`/`Anthropic`, `AsyncOpenAI`/`OpenAI`, and the `google-genai` client (`HttpRetryOptions`). This enables the SDKs' header-aware exponential backoff + jitter (honors `retry-after`; covers 429/5xx/529 + connection errors) for requests **and** stream-opens. Covers deepseek/moonshot/etc. (they route through `AnthropicProvider`).
- Bump `RateLimitConfig.max_retries` default 3 → 4.

### Layer 2 — recover from overload instead of dying
- `handle_llm_error` now treats `LLMInternalServerError` (529/5xx) as retryable alongside rate-limits.
- Replaced flat `sleep(60)` with bounded exponential backoff + full jitter (cap 30s), honoring `retry-after` (read from the **raw** exception before mapping strips it, via new `_parse_retry_after`).
- A per-agent consecutive-retry counter (`loop_max_retries`, default 3) resets on a clean stream and re-raises cleanly once exceeded — a stuck call terminates in seconds, not forever. The two retry layers are kept small/asymmetric because they **multiply**.

### Layer 3 — tame concurrency bursts
- Jittered start-stagger (≤0.75s) after the semaphore admits each agent, so a fanned-out batch doesn't hit the API in lockstep. Timing-only — resume determinism is preserved and cached calls skip it.
- Lower default workflow concurrency from `min(16, cpu-2)` to `min(8, cpu-2)`.

## Files
- `kolega_code/llm/providers/{anthropic,openai,google}.py` — forward `max_retries` to SDK clients.
- `kolega_code/config.py` — `max_retries` 3→4; add `loop_max_retries` (default 3).
- `kolega_code/agent/baseagent.py` — `handle_llm_error` rewrite (overload retry + bounded backoff + cap), `_parse_retry_after`, consecutive-retry counter (reset on clean stream).
- `kolega_code/agent/orchestration/runtime.py` — jittered start-stagger + lower default concurrency.

## Tests
`689 passed` (full agent suite, `-m "not slow"`). Added retry/backoff/cap + `retry-after` coverage in `test_base_agent.py` (the overloaded row moves out of the re-raises test, since it now retries), and a regression guard in `test_client.py` asserting `max_retries` actually reaches the SDK clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)