### PR TITLE
fix(llm): correct GLM-5.2 context window to 1M

### DIFF
--- a/kolega_code/llm/specs.py
+++ b/kolega_code/llm/specs.py
@@ -190,7 +190,7 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
     ("dashscope", "qwen3-coder-flash"): {"context_length": 1000000, "max_completion_tokens": 65536, "default_temperature": 0.7},
     # Z.AI (GLM Coding Plan) models — Anthropic-compatible endpoint (recommended default first)
     ("zai", "glm-5.2"): {
-        "context_length": 200000,
+        "context_length": 1000000,
         "max_completion_tokens": 131072,
         "default_temperature": 0.6,
         "thinking_effort": ThinkingEffortSpec(


### PR DESCRIPTION
## What

Corrects the `context_length` for the `("zai", "glm-5.2")` model spec from `200000` to `1000000`.

## Why

Z.AI's official docs ([docs.z.ai/guides/llm/glm-5.2](https://docs.z.ai/guides/llm/glm-5.2)) state GLM-5.2 has a **"truly usable 1M-token context"** (1,000,000 tokens). The spec understated this as 200K, so Kolega's context accounting — token budgeting, compaction triggers, and the "context remaining" UI — treated GLM-5.2 as a 200K model when it actually supports 5× that.

`1000000` matches the file's existing convention for 1M-context models (Anthropic Claude, DeepSeek, Grok, Qwen all use `1000000`).

## Scope / left unchanged

- `max_completion_tokens` stays `131072` — the power-of-two form of the docs' "128K" output limit; already correct.
- Thinking-effort config, temperature, and the GLM-5.1 entry are untouched.

## Verification

- `get_model_specs("zai", "glm-5.2")["context_length"]` returns `1000000`.
- `pytest kolega_code/agent/tests/llm/test_thinking_effort.py` — 11 passed. No test asserts the old value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)