### PR TITLE
fix(cli): stop sub-agents stomping the main context-window indicator

### DIFF
--- a/kolega_code/agent/tests/test_event_emitter.py
+++ b/kolega_code/agent/tests/test_event_emitter.py
@@ -1,0 +1,84 @@
+"""AgentEventEmitter tags context/status events with sub_agent_info.
+
+Regression coverage for the bug where a sub-agent's context-window updates stomped the
+main agent's context indicator in the TUI. context_update() and llm_status() must carry
+sub_agent_info (like chat() already does) so hosts can tell main- and sub-agent updates
+apart. The main agent's provider returns None; a dispatched sub-agent returns a dict.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from kolega_code.events import AgentConnectionManager, AgentEventEmitter
+
+SUB_AGENT_INFO = {"agent_id": "agent-1", "agent_name": "general-agent", "depth": 1}
+
+
+def _emitter(provider):
+    cm = AsyncMock(spec=AgentConnectionManager)
+    emitter = AgentEventEmitter(
+        connection_manager=cm,
+        workspace_id="ws",
+        thread_id="th",
+        sender="general-agent",
+        sub_agent_info_provider=provider,
+    )
+    return emitter, cm
+
+
+def _emitted(cm):
+    return cm.broadcast_event.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_context_update_carries_sub_agent_info_when_provided():
+    emitter, cm = _emitter(lambda: SUB_AGENT_INFO)
+
+    await emitter.context_update(
+        input_tokens=6000,
+        model_context_length=200000,
+        compression_threshold=0.8,
+        alert_level="normal",
+        message=None,
+    )
+
+    event = _emitted(cm)
+    assert event.event_type == "llm_context_update"
+    assert event.sub_agent_info == SUB_AGENT_INFO
+
+
+@pytest.mark.asyncio
+async def test_context_update_has_no_sub_agent_info_for_main_agent():
+    # The main agent's provider returns None (BaseAgent._sub_agent_info).
+    emitter, cm = _emitter(lambda: None)
+
+    await emitter.context_update(
+        input_tokens=123456,
+        model_context_length=200000,
+        compression_threshold=0.8,
+        alert_level="normal",
+        message=None,
+    )
+
+    assert _emitted(cm).sub_agent_info is None
+
+
+@pytest.mark.asyncio
+async def test_llm_status_carries_sub_agent_info_when_provided():
+    emitter, cm = _emitter(lambda: SUB_AGENT_INFO)
+
+    await emitter.llm_status("overloaded", "Provider overloaded, retrying")
+
+    event = _emitted(cm)
+    assert event.event_type == "llm_status_update"
+    assert event.sub_agent_info == SUB_AGENT_INFO
+
+
+@pytest.mark.asyncio
+async def test_llm_status_has_no_sub_agent_info_for_main_agent():
+    emitter, cm = _emitter(None)
+
+    await emitter.llm_status("overloaded", "Provider overloaded, retrying")
+
+    assert _emitted(cm).sub_agent_info is None

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -235,7 +235,12 @@ class SubAgentActivity:
     steps: list[ConversationEntry] = field(default_factory=list)
     tool_steps: dict[str, ConversationEntry] = field(default_factory=dict)  # tool_call_id/name -> step
     stream_steps: dict[str, ConversationEntry] = field(default_factory=dict)  # chunk uuid -> step
-    tokens: Optional[int] = None
+    tokens: Optional[int] = None  # cumulative tokens consumed, from lifecycle events
+    # Context-window occupancy (how full this sub-agent's own context is right now),
+    # from llm_context_update events. Distinct from cumulative `tokens` above.
+    context_percentage: Optional[float] = None
+    context_input_tokens: Optional[int] = None
+    context_max_tokens: Optional[int] = None
     depth: int = 1
     current_action: str = ""  # live "now:" action while running
     workflow_run_id: str = ""  # set when dispatched by a workflow, for card rollup
@@ -880,6 +885,8 @@ class SubAgentInspectorScreen(ModalScreen):
         parts = [f"#{activity.index}", activity.agent_name, self._elapsed(activity), f"{activity.tool_calls}t"]
         if activity.tokens:
             parts.append(f"{self._owner._format_token_count(activity.tokens)}tok")
+        if activity.context_percentage is not None:
+            parts.append(f"ctx {activity.context_percentage:.0f}%")
         line.append(f"  {sep}  ".join(parts), style=row_style)
         tail = activity.current_action if activity.status == "running" else activity.last_activity
         if tail:
@@ -905,6 +912,8 @@ class SubAgentInspectorScreen(ModalScreen):
         extras = [f"{activity.tool_calls} tool{'' if activity.tool_calls == 1 else 's'}"]
         if activity.tokens:
             extras.append(f"{owner._format_token_count(activity.tokens)} tok")
+        if activity.context_percentage is not None:
+            extras.append(f"ctx {activity.context_percentage:.0f}%")
         line = base + theme.styled(f" {sep} " + f" {sep} ".join(extras), "dim")
         if activity.task:
             line += "\n" + theme.styled(escape(f"Task: {activity.task}"), "dim")
@@ -2050,9 +2059,14 @@ class KolegaCodeApp(App):
             else:
                 self._apply_tool_streaming_update(event.content)
         elif event.event_type == "llm_context_update":
-            self._apply_context_status_update(event.content)
+            if event.sub_agent_info:
+                self._note_sub_agent_context(event)
+            else:
+                self._apply_context_status_update(event.content)
         elif event.event_type in {"llm_status_update", "status_update"}:
-            if text:
+            if event.sub_agent_info:
+                self._note_sub_agent_status(event)
+            elif text:
                 self._write_log(text, "info")
                 self._update_activity_progress(text)
         else:
@@ -4564,6 +4578,29 @@ class KolegaCodeApp(App):
         activity.last_activity = f"{tool_name} done" if is_complete else f"{tool_name} streaming"
         self._refresh_sub_agent_entry(activity)
 
+    def _note_sub_agent_context(self, event: AgentEvent) -> None:
+        """Record a sub-agent's context-window usage on its own card, so it never
+        overwrites the main agent's context indicator on the status dashboard."""
+        activity = self._ensure_sub_agent_activity(event)
+        content = event.content
+        activity.context_percentage = self._as_optional_float(content.get("usage_percentage"))
+        activity.context_input_tokens = self._as_optional_int(content.get("input_tokens"))
+        activity.context_max_tokens = self._as_optional_int(content.get("max_tokens"))
+        self._refresh_sub_agent_entry(activity)
+        self._invalidate_sub_agent_detail(activity)
+
+    def _note_sub_agent_status(self, event: AgentEvent) -> None:
+        """Surface a sub-agent's status notice (e.g. provider overload) on its card,
+        keeping it off the main activity line."""
+        activity = self._ensure_sub_agent_activity(event)
+        message = str(event.content.get("message") or "").strip()
+        if message:
+            activity.last_activity = message
+            if activity.status == "running":
+                activity.current_action = message
+        self._refresh_sub_agent_entry(activity)
+        self._invalidate_sub_agent_detail(activity)
+
     def _refresh_sub_agent_entry(self, activity: SubAgentActivity, *, force: bool = False) -> None:
         activity.entry.content = self._format_sub_agent_content(activity)
         self._invalidate_conversation(activity.entry)
@@ -4615,6 +4652,8 @@ class KolegaCodeApp(App):
         tools_line = f"{activity.tool_calls} tool{'' if activity.tool_calls == 1 else 's'}"
         if activity.tokens:
             tools_line += f" {sep} {self._format_token_count(activity.tokens)} tok"
+        if activity.context_percentage is not None:
+            tools_line += f" {sep} ctx {activity.context_percentage:.0f}%"
         if activity.last_activity:
             tools_line += f" {sep} last: {activity.last_activity}"
         body_lines.append(tools_line)

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -4046,6 +4046,136 @@ def _sub_agent_entries(app):
     return [entry for entry in app.conversation_entries if entry.kind == "sub_agent"]
 
 
+def _sub_agent_context_event(usage_percentage, *, input_tokens=5000, agent_id="agent-1", agent_name="general-agent"):
+    return AgentEvent(
+        event_type="llm_context_update",
+        sender=agent_name,
+        content={
+            "input_tokens": input_tokens,
+            "max_tokens": 200000,
+            "usage_percentage": usage_percentage,
+            "alert_level": "normal",
+            "message": None,
+            "compression_threshold": 80.0,
+        },
+        sub_agent_info={
+            "agent_id": agent_id,
+            "agent_name": agent_name,
+            "task": "inspect sessions",
+            "parent_tool_call_id": "tc-1",
+            "conversation_id": None,
+            "depth": 1,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_sub_agent_context_update_does_not_stomp_main_dashboard(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        # Main agent reports its context usage -> the status dashboard reflects it.
+        app._render_event(
+            AgentEvent(
+                event_type="llm_context_update",
+                sender="coder",
+                content={
+                    "input_tokens": 123456,
+                    "max_tokens": 200000,
+                    "usage_percentage": 61.7,
+                    "alert_level": "normal",
+                    "message": None,
+                    "compression_threshold": 80.0,
+                },
+            )
+        )
+        assert "61.7%" in app._format_status_dashboard()
+
+        # A sub-agent reports its much smaller context usage. It must NOT overwrite the
+        # main dashboard; it lands on the sub-agent's own card instead.
+        app._render_event(_sub_agent_context_event(3.0, input_tokens=6000))
+
+        dashboard = app._format_status_dashboard()
+        assert "61.7%" in dashboard  # main agent's value preserved
+        assert "3.0%" not in dashboard
+
+        activities = list(app._sub_agent_activities.values())
+        assert len(activities) == 1
+        assert activities[0].context_percentage == 3.0
+        assert activities[0].context_input_tokens == 6000
+        # The cumulative-token field is a different metric and stays untouched.
+        assert activities[0].tokens is None
+        # The per-agent context shows on its own card.
+        assert "ctx 3%" in activities[0].entry.content
+
+
+@pytest.mark.asyncio
+async def test_concurrent_sub_agent_context_updates_keep_main_dashboard_stable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        app._render_event(
+            AgentEvent(
+                event_type="llm_context_update",
+                sender="coder",
+                content={
+                    "input_tokens": 100000,
+                    "max_tokens": 200000,
+                    "usage_percentage": 50.0,
+                    "alert_level": "normal",
+                    "message": None,
+                    "compression_threshold": 80.0,
+                },
+            )
+        )
+
+        # Several sub-agents interleave context updates; none may move the main bar.
+        for pct, aid in [(2.0, "agent-1"), (4.0, "agent-2"), (1.5, "agent-3")]:
+            app._render_event(_sub_agent_context_event(pct, agent_id=aid, agent_name=aid))
+
+        assert "50.0%" in app._format_status_dashboard()
+        assert len(app._sub_agent_activities) == 3
+
+
+@pytest.mark.asyncio
+async def test_sub_agent_status_update_routes_to_card_not_main_activity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        # Create the sub-agent card first; this is what legitimately updates the main
+        # activity line (with the "running sub-agent" notice), before the spy is set.
+        app._render_event(_sub_agent_event(text="working"))
+
+        calls: list = []
+        monkeypatch.setattr(app, "_update_activity_progress", lambda *a, **k: calls.append(a))
+
+        app._render_event(
+            AgentEvent(
+                event_type="llm_status_update",
+                sender="general-agent",
+                content={"status": "overloaded", "message": "Provider overloaded, retrying"},
+                sub_agent_info={
+                    "agent_id": "agent-1",
+                    "agent_name": "general-agent",
+                    "task": "inspect sessions",
+                    "parent_tool_call_id": "tc-1",
+                    "conversation_id": None,
+                    "depth": 1,
+                },
+            )
+        )
+
+        assert calls == []  # the main activity line is untouched
+        activity = next(iter(app._sub_agent_activities.values()))
+        assert "Provider overloaded, retrying" in activity.last_activity
+
+
 @pytest.mark.asyncio
 async def test_sub_agent_stream_chunks_group_into_single_entry(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/kolega_code/events.py
+++ b/kolega_code/events.py
@@ -172,6 +172,7 @@ class AgentEventEmitter:
     ) -> None:
         """Send an llm_context_update event describing context-window usage."""
         usage_percentage = (input_tokens / model_context_length) * 100
+        sub_agent_info = self._sub_agent_info_provider() if self._sub_agent_info_provider else None
 
         await self.emit(
             AgentEvent(
@@ -186,11 +187,14 @@ class AgentEventEmitter:
                     "compression_threshold": compression_threshold * 100,  # Convert to percentage
                     "will_compress_at": int(model_context_length * compression_threshold),
                 },
+                sub_agent_info=sub_agent_info,
             )
         )
 
     async def llm_status(self, status: str, message: str) -> None:
         """Send an llm_status_update event (e.g. provider overload notices)."""
+        sub_agent_info = self._sub_agent_info_provider() if self._sub_agent_info_provider else None
+
         await self.emit(
             AgentEvent(
                 sender=self.sender,
@@ -198,5 +202,6 @@ class AgentEventEmitter:
                 content={"status": status, "message": message},
                 timestamp=datetime.now().isoformat(),
                 is_streaming=False,
+                sub_agent_info=sub_agent_info,
             )
         )


### PR DESCRIPTION
## Problem

In the TUI, the **context-window used %** indicator kept jumping up and down whenever multiple sub-agents were running. The dashboard is meant to show the **main agent's** context occupancy, but sub-agent updates (with much smaller token counts) overwrote it, so the bar oscillated.

## Root cause (two parts)

1. **Source — events weren't tagged.** `AgentEventEmitter.context_update()` (and `llm_status()`) in `events.py` never attached `sub_agent_info`, unlike `chat()`. So *every* `llm_context_update` event — main or sub-agent — arrived with `sub_agent_info=None` and was indistinguishable.
2. **Sink — the TUI didn't route.** `_render_event` in `cli/app.py` applied *any* `llm_context_update` to the single shared `_status_state`, with no sub-agent check — unlike the adjacent `chat_message` / `tool_streaming_update` handlers, which already branch on `if event.sub_agent_info:`.

## Changes

- **`events.py`** — `context_update()` / `llm_status()` now tag events via the existing `sub_agent_info` provider, exactly like `chat()`. The main agent's provider returns `None`; a dispatched sub-agent returns its dispatch dict.
- **`cli/app.py`** —
  - `_render_event` branches on `event.sub_agent_info` for `llm_context_update` and `llm_status_update`/`status_update`.
  - Sub-agent updates route to that sub-agent's card via new `_note_sub_agent_context` / `_note_sub_agent_status`, never the main dashboard / activity line.
  - `SubAgentActivity` gains `context_percentage` / `context_input_tokens` / `context_max_tokens` (kept distinct from the *cumulative* `tokens` field), surfaced as `ctx N%` on the inline card, inspector roster row, and inspector header.

Result: the main bar tracks only the main agent (no flicker), and each sub-agent's context usage shows on its own card. The analogous `llm_status_update` leak is fixed the same way.

## Tests

- **`agent/tests/test_event_emitter.py`** (new) — emitter tags events with `sub_agent_info` for sub-agents, leaves `None` for the main agent (for both `context_update` and `llm_status`).
- **`cli/tests/test_app.py`** (new) — main dashboard stays stable under a single sub-agent update and under 3 interleaved ones; sub-agent status notices route to the card, not the main activity line.

All pass; full `test_app.py` (144), `test_base_agent.py` + `test_agent_tool.py` (72), and the new emitter tests (4) are green — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)