### PR TITLE
chore: release v0.6.0

### DIFF
--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -148,4 +148,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.5.1"
+version = "0.6.0"
 description = "Local-first AI coding agent for the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [options]
 prerelease-mode = "allow"
-exclude-newer = "2026-06-12T10:59:47.512028Z"
+exclude-newer = "2026-06-13T03:51:52.339326Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -669,7 +669,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.5.1"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- Bump `kolega-code` package metadata from `0.5.1` to `0.6.0`.
- Refresh `uv.lock` for the release version.
- Prepare the release branch for the documented PR-then-tag flow in `RELEASING.md`.

## Release notes context

This release includes the changes merged since `v0.5.1`, including inline file edit previews, workflow card inspector improvements, external-path file tools, per-agent model selection, LLM retry/backoff fixes, GLM-5.2 context correction, CLI focus/context fixes, and refreshed docs/README.

## Validation

- `uv run pytest -ra --durations=50 --import-mode=importlib -m "not slow"`
- `uv run --with build python -m build --outdir /private/tmp/kolega-code-dist-v0.6.0`
- `uv run --with twine python -m twine check /private/tmp/kolega-code-dist-v0.6.0/kolega_code-0.6.0.tar.gz /private/tmp/kolega-code-dist-v0.6.0/kolega_code-0.6.0-py3-none-any.whl`
- `uv venv /private/tmp/kolega-code-smoke-v0.6.0-7831 --python 3.11`
- `uv pip install --python /private/tmp/kolega-code-smoke-v0.6.0-7831/bin/python /private/tmp/kolega-code-dist-v0.6.0/kolega_code-0.6.0-py3-none-any.whl`
- `/private/tmp/kolega-code-smoke-v0.6.0-7831/bin/kolega-code --version` -> `kolega-code 0.6.0`
- `npm ci` in `docs/`
- `npm run build` in `docs/`