### PR TITLE
[codex] release v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ sessions, settings, and API keys stay on your own machine.
   and applies precise edits.
 - **Runs commands.** Executes shell commands and watches their output in a dedicated terminal view.
 - **Plans before it builds.** Plan mode investigates and proposes; Build mode executes.
-- **Browses the web.** A built-in browser agent (powered by Playwright) fetches pages and
-  interacts with sites when a task needs it.
+- **Searches and browses the web.** The agent can search for relevant pages, fetch URLs
+  directly, or use the built-in browser agent (powered by Playwright) when a task needs
+  site interaction.
 - **Dispatches sub-agents.** Hands work off to specialized agents and tracks their activity live.
 - **Orchestrates workflows.** With [gigacode](https://kolega-ai.github.io/kolega-code/gigacode/),
   it fans out many sub-agents in parallel.
@@ -118,6 +119,10 @@ Settings. Local session state lives under your platform's state directory unless
 `KOLEGA_CODE_STATE_DIR` is set. See the
 [Configuration docs](https://kolega-ai.github.io/kolega-code/configuration/settings-and-api-keys/)
 for the full story.
+
+The `web_search` tool uses DuckDuckGo by default without a key. To choose another backend,
+set it in **Settings** or export `KOLEGA_CODE_WEB_SEARCH_BACKEND` as `firecrawl`, `tavily`,
+or `searxng`; use `FIRECRAWL_API_KEY`, `TAVILY_API_KEY`, or `SEARXNG_BASE_URL` as needed.
 
 ## Requirements
 

--- a/docs/src/content/docs/concepts/tools.md
+++ b/docs/src/content/docs/concepts/tools.md
@@ -38,7 +38,13 @@ the [TUI](../../cli/overview/) or [`ask`](../../cli/ask/).
 
 ### Web
 
+- `web_search` — search the web for relevant pages and return ranked results.
 - `web_fetch` — fetch and parse a web page without a full browser.
+
+Use `web_search` when you do not already know the right URL, then follow up with
+`web_fetch` to read a result in depth. The default backend is keyless DuckDuckGo;
+Firecrawl, Tavily, and self-hosted SearXNG can be selected in Settings or with
+environment variables.
 
 ### Reasoning & memory
 
@@ -57,8 +63,8 @@ and `dispatch_general_agent`.
 Tools are gated by mode. In a read-only context — like [Plan mode](../../tui/modes/)
 or an investigation sub-agent — only non-mutating tools are available
 (`list_directory`, `read_entire_file`, `read_file_section`, `search_codebase`,
-`find_files_by_pattern`, `web_fetch`, `think_hard`, and reading memory). Editing
-files and running commands require Build mode's full toolset.
+`find_files_by_pattern`, `web_search`, `web_fetch`, `think_hard`, and reading
+memory). Editing files and running commands require Build mode's full toolset.
 
 This separation is what makes Plan mode safe to run against any codebase: the
 planning agent can look but not touch.

--- a/docs/src/content/docs/configuration/environment-variables.md
+++ b/docs/src/content/docs/configuration/environment-variables.md
@@ -87,6 +87,18 @@ section.
 | `KOLEGA_CODE_STATE_DIR` | Override where settings and sessions are stored |
 | `KOLEGA_CODE_ENVIRONMENT` | Environment label attached to tracing/metadata (default `development`) |
 
+## Web search
+
+The `web_search` tool defaults to the keyless DuckDuckGo backend. Set a backend
+explicitly when you want a cloud provider or a self-hosted SearXNG instance.
+
+| Variable | Purpose |
+| --- | --- |
+| `KOLEGA_CODE_WEB_SEARCH_BACKEND` | Backend for `web_search`: `duckduckgo`, `firecrawl`, `tavily`, or `searxng` |
+| `FIRECRAWL_API_KEY` | Optional Firecrawl key for higher rate limits |
+| `TAVILY_API_KEY` | Tavily API key |
+| `SEARXNG_BASE_URL` | Base URL for a self-hosted SearXNG instance |
+
 ## Telemetry (Langfuse)
 
 Optional [Langfuse](https://langfuse.com/) tracing of LLM usage.
@@ -112,6 +124,9 @@ ANTHROPIC_API_KEY=
 KOLEGA_CODE_PROVIDER=moonshot
 KOLEGA_CODE_MODEL=kimi-k2.7-code
 KOLEGA_CODE_THINKING_EFFORT=auto
+
+# Optional: web search
+KOLEGA_CODE_WEB_SEARCH_BACKEND=duckduckgo
 
 # Optional: Langfuse tracing
 LANGFUSE_HOST=https://us.cloud.langfuse.com

--- a/docs/src/content/docs/configuration/settings-and-api-keys.mdx
+++ b/docs/src/content/docs/configuration/settings-and-api-keys.mdx
@@ -32,6 +32,13 @@ agents (planning, building, investigation, general, browser) their own provider,
 model, and effort. Leave a role on **Default** to inherit the active model. See
 [Per-agent models](../providers-and-models/#per-agent-models).
 
+The **Web Search** section configures the `web_search` tool. DuckDuckGo is the
+default and needs no key. Firecrawl can also run without a key, with an optional
+key for higher rate limits. Tavily requires a key, and SearXNG requires the base
+URL of your self-hosted instance. The same settings can be supplied with
+[`KOLEGA_CODE_WEB_SEARCH_BACKEND`, `FIRECRAWL_API_KEY`, `TAVILY_API_KEY`, and
+`SEARXNG_BASE_URL`](../environment-variables/#web-search).
+
 ## Where settings live
 
 Settings are stored as JSON in your platform's state directory, in a file named
@@ -56,7 +63,8 @@ The file looks like this:
   "active_thinking_effort": "auto",
   "api_keys": {
     "moonshot": "sk-...",
-    "deepseek": "sk-..."
+    "deepseek": "sk-...",
+    "tavily": "tvly-..."
   },
   "agent_models": {
     "investigation": {
@@ -64,13 +72,17 @@ The file looks like this:
       "model": "deepseek-v4-flash",
       "thinking_effort": "high"
     }
-  }
+  },
+  "web_search_backend": "tavily",
+  "web_search_base_url": null
 }
 ```
 
 `agent_models` holds per-agent overrides keyed by role (`planning`, `building`,
 `investigation`, `general`, `browser`); a role that is absent inherits the active
 model. The field is optional and older `schema_version` files load unchanged.
+Cloud web-search keys are stored in `api_keys` under their backend names
+(`firecrawl` or `tavily`); `web_search_base_url` is used by SearXNG.
 
 <Aside type="caution" title="Keys are stored in plaintext">
 API keys are written to `settings.json` in plaintext, but the file is created with
@@ -83,7 +95,7 @@ store keys on disk at all, supply them via
 
 <FileTree>
 - kolega-code/
-  - settings.json   Provider, model, thinking effort, and API keys (0600)
+  - settings.json   Provider, model, web search, thinking effort, and API keys (0600)
   - sessions/
     - &lt;session-id&gt;.json   One file per saved session
 </FileTree>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -19,8 +19,9 @@ and your sessions, settings, and API keys are stored on your own machine.
   dedicated terminal view in the UI.
 - **Plans before it builds.** A read-only **Plan mode** produces a reviewable plan
   and a shared task list; **Build mode** implements it.
-- **Browses the web.** A built-in browser agent (powered by Playwright) can fetch
-  pages and interact with sites when a task needs it.
+- **Searches and browses the web.** The agent can search for relevant pages,
+  fetch URLs directly, or use the built-in browser agent (powered by Playwright)
+  when a task needs site interaction.
 - **Dispatches sub-agents.** For larger tasks, the main agent can hand off to
   specialized agents (investigation, browser, coding, general) and track their
   activity live.

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -148,4 +148,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.6.0"
+version = "0.7.0"
 description = "Local-first AI coding agent for the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -34,6 +34,7 @@ dependencies = [
     "httpx==0.28.1",
     "jinja2==3.1.6",
     "langfuse==3.14.5",
+    "lxml-html-clean==0.4.4",
     "nest-asyncio==1.6.0",
     "openai==1.109.1",
     "packaging==25.0",

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [options]
 prerelease-mode = "allow"
-exclude-newer = "2026-06-13T05:12:39.17404Z"
+exclude-newer = "2026-06-13T06:35:08.454954Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1098,7 +1098,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -1109,6 +1109,7 @@ dependencies = [
     { name = "httpx" },
     { name = "jinja2" },
     { name = "langfuse" },
+    { name = "lxml-html-clean" },
     { name = "nest-asyncio" },
     { name = "openai" },
     { name = "packaging" },
@@ -1142,6 +1143,7 @@ requires-dist = [
     { name = "httpx", specifier = "==0.28.1" },
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "langfuse", specifier = "==3.14.5" },
+    { name = "lxml-html-clean", specifier = "==0.4.4" },
     { name = "nest-asyncio", specifier = "==1.6.0" },
     { name = "openai", specifier = "==1.109.1" },
     { name = "packaging", specifier = "==25.0" },


### PR DESCRIPTION
## Summary

Prepare the `v0.7.0` release for the merged `web_search` feature.

This bumps the package version to `0.7.0`, documents the new web search tool and backend configuration, and updates package metadata for the release.

## Changes

- Bump Kolega Code package/version metadata from `0.6.0` to `0.7.0`.
- Document `web_search` in the README and docs site, including the Settings UI and environment variables.
- Add explicit runtime dependency `lxml-html-clean==0.4.4`.

## Why

The clean wheel smoke test exposed a startup failure in a fresh pip install: `trafilatura` imports `justext`, which imports `lxml.html.clean`; with current `lxml`, that module is supplied by the separate `lxml_html_clean` package. The project lock already resolved it through uv, but the built wheel did not require it directly for pip installs, so this PR makes the dependency explicit.

## Validation

- `uv run pytest -ra --durations=50 --import-mode=importlib -m "not slow"` (`1053 passed`, `50 deselected`)
- `npm ci` in `docs/`
- `npm run build` in `docs/`
- `uv run --with build python -m build`
- `uv run --with twine python -m twine check dist/kolega_code-0.7.0.tar.gz dist/kolega_code-0.7.0-py3-none-any.whl`
- Clean venv wheel install from `dist/kolega_code-0.7.0-py3-none-any.whl`
- `/private/tmp/kolega-code-smoke-0.7.0-codex-2/bin/kolega-code --version` -> `kolega-code 0.7.0`

## Release Notes

After merge, tag `v0.7.0` from `main` to trigger the release workflow and publish to PyPI.