### PR TITLE
chore: release v0.7.1

### DIFF
--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -148,4 +148,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.7.0"
+version = "0.7.1"
 description = "Local-first AI coding agent for the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -1098,7 +1098,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Bump `kolega-code` package metadata from `0.7.0` to `0.7.1`
- Refresh `uv.lock` local editable package record for `kolega-code`

## Validation
- `uv run pytest -ra --durations=50 --import-mode=importlib -m "not slow"`
  - 1094 passed, 50 deselected, 8 warnings
- `uv run kolega-code --version`
  - `kolega-code 0.7.1`

## Release notes
After this PR is reviewed, CI passes, and it is merged, tag `main` with `v0.7.1` to trigger the Release workflow.