### PR TITLE
[codex] Fix chat transcript selection copy

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -46,6 +46,7 @@ from textual.widgets import (
     TabPane,
     TextArea,
 )
+from textual.widgets._collapsible import CollapsibleTitle
 from textual.widgets.option_list import Option
 
 from kolega_code.agent import AgentConfig, AgentEvent, CoderAgent, PlanningAgent, PromptExtension, ToolExtension
@@ -364,21 +365,8 @@ class ConversationEntryWidget(Static):
         self.update(self._formatted)
 
     def render_line(self, y: int) -> Strip:
-        # Tag each segment with its rendered (x, y) offset so the compositor can
-        # map mouse positions to text offsets, enabling drag selection over any
-        # visual type, including rich renderables such as Markdown.
-        strip = super().render_line(y)
-        source_x = 0
-        selectable_segments: list[Segment] = []
-        for segment in strip:
-            if segment.control:
-                selectable_segments.append(segment)
-                continue
-            offset_style = Style.from_meta({"offset": (source_x, y)})
-            style = segment.style + offset_style if segment.style is not None else offset_style
-            selectable_segments.append(Segment(segment.text, style, segment.control))
-            source_x += len(segment.text)
-        return Strip(selectable_segments, strip.cell_length)
+        strip = _with_selection_style(super().render_line(y), self.text_selection, y, self.selection_style)
+        return _with_selection_offsets(strip, y)
 
     def get_selection(self, selection: Selection) -> tuple[str, str] | None:
         # Extract from the rendered lines so coordinates match what is on screen,
@@ -391,6 +379,121 @@ class ConversationEntryWidget(Static):
         if not text.strip():
             return None
         return selection.extract(text), "\n"
+
+
+def _with_selection_offsets(strip: Strip, y: int) -> Strip:
+    """Tag rendered segments so Textual can map mouse positions to text offsets."""
+    source_x = 0
+    selectable_segments: list[Segment] = []
+    for segment in strip:
+        if segment.control:
+            selectable_segments.append(segment)
+            continue
+        offset_style = Style.from_meta({"offset": (source_x, y)})
+        style = segment.style + offset_style if segment.style is not None else offset_style
+        selectable_segments.append(Segment(segment.text, style, segment.control))
+        source_x += len(segment.text)
+    return Strip(selectable_segments, strip.cell_length)
+
+
+def _with_selection_style(strip: Strip, selection: Selection | None, y: int, selection_style: Style) -> Strip:
+    """Apply screen selection styling to Rich renderables that Textual can't style natively."""
+    if selection is None:
+        return strip
+
+    span = selection.get_span(y)
+    if span is None:
+        return strip
+
+    start, end = span
+    line_length = sum(len(segment.text) for segment in strip if not segment.control)
+    if end == -1:
+        end = line_length
+    start = max(0, min(start, line_length))
+    end = max(start, min(end, line_length))
+    if start == end:
+        return strip
+
+    selected_segments: list[Segment] = []
+    source_x = 0
+    for segment in strip:
+        if segment.control:
+            selected_segments.append(segment)
+            continue
+
+        text = segment.text
+        segment_start = source_x
+        segment_end = source_x + len(text)
+        source_x = segment_end
+
+        if segment_end <= start or segment_start >= end:
+            selected_segments.append(segment)
+            continue
+
+        before_end = max(0, start - segment_start)
+        selected_start = before_end
+        selected_end = min(len(text), end - segment_start)
+
+        if before_end:
+            selected_segments.append(Segment(text[:before_end], segment.style, segment.control))
+
+        selected_text = text[selected_start:selected_end]
+        if selected_text:
+            style = segment.style + selection_style if segment.style is not None else selection_style
+            selected_segments.append(Segment(selected_text, style, segment.control))
+
+        if selected_end < len(text):
+            selected_segments.append(Segment(text[selected_end:], segment.style, segment.control))
+
+    return Strip(selected_segments, strip.cell_length)
+
+
+class SelectableCollapsibleTitle(CollapsibleTitle):
+    """Collapsible title that still participates in Textual text selection."""
+
+    ALLOW_SELECT = True
+
+    def render_line(self, y: int) -> Strip:
+        return _with_selection_offsets(super().render_line(y), y)
+
+
+class SelectableCollapsible(Collapsible):
+    """Collapsible with a selectable title, used for transcript tool entries."""
+
+    class Contents(Collapsible.Contents):
+        """Selectable padding/content wrapper so drags can start in the expanded tool indent."""
+
+        ALLOW_SELECT = True
+
+        def render_line(self, y: int) -> Strip:
+            return _with_selection_offsets(super().render_line(y), y)
+
+        def get_selection(self, selection: Selection) -> tuple[str, str] | None:
+            return "", ""
+
+    def __init__(
+        self,
+        *children,
+        title: str = "Toggle",
+        collapsed: bool = True,
+        collapsed_symbol: str = "▶",
+        expanded_symbol: str = "▼",
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            *children,
+            title=title,
+            collapsed=collapsed,
+            collapsed_symbol=collapsed_symbol,
+            expanded_symbol=expanded_symbol,
+            **kwargs,
+        )
+        self._title = SelectableCollapsibleTitle(
+            label=title,
+            collapsed_symbol=collapsed_symbol,
+            expanded_symbol=expanded_symbol,
+            collapsed=collapsed,
+        )
 
 
 class ToolEntryWidget(Vertical):
@@ -416,7 +519,7 @@ class ToolEntryWidget(Vertical):
         self._preview.display = False
         yield self._preview
         self._body = Static("", markup=False, classes="tool-body")
-        self._collapsible = Collapsible(self._body, title=self._title_factory(self.entry), collapsed=True)
+        self._collapsible = SelectableCollapsible(self._body, title=self._title_factory(self.entry), collapsed=True)
         yield self._collapsible
 
     def on_mount(self) -> None:
@@ -1093,12 +1196,12 @@ class KolegaCodeApp(App):
 
     ConversationEntryWidget {
         height: auto;
-        margin-bottom: 1;
+        padding-bottom: 1;
     }
 
     ToolEntryWidget {
         height: auto;
-        margin-bottom: 1;
+        padding-bottom: 1;
     }
 
     ToolEntryWidget Collapsible {
@@ -1106,6 +1209,10 @@ class KolegaCodeApp(App):
         border-top: none;
         padding-bottom: 0;
         padding-left: 0;
+    }
+
+    ToolEntryWidget Collapsible Contents {
+        padding-left: 3;
     }
 
     ToolEntryWidget .tool-body {

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -3061,6 +3061,236 @@ async def test_conversation_entry_supports_mouse_drag_selection(
 
 
 @pytest.mark.asyncio
+async def test_conversation_entry_selection_styles_rendered_lines(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.geometry import Offset
+    from textual.selection import Selection
+
+    from kolega_code.cli.app import ConversationEntry, ConversationEntryWidget
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test(size=(100, 40)) as pilot:
+        app.conversation_entries = [
+            ConversationEntry(kind="user", content="select this user text"),
+            ConversationEntry(kind="assistant", content="select this agent text"),
+            ConversationEntry(kind="assistant", content="select this streaming text", complete=False),
+        ]
+        app._render_conversation()
+        await pilot.pause()
+
+        widgets = list(app.query(ConversationEntryWidget))[-3:]
+        for widget in widgets:
+            app.screen.selections = {widget: Selection(Offset(0, 1), Offset(12, 1))}
+            strip = widget.render_line(1)
+            selection_bg = widget.selection_style.bgcolor
+
+            assert any(
+                segment.style is not None
+                and segment.style.bgcolor == selection_bg
+                and segment.style.meta.get("offset") is not None
+                for segment in strip
+            )
+
+
+@pytest.mark.asyncio
+async def test_conversation_selection_can_start_in_blank_separator(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual import events
+
+    from kolega_code.cli.app import ConversationEntry, ConversationEntryWidget
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        app.conversation_entries = [
+            ConversationEntry(kind="user", content="first"),
+            ConversationEntry(kind="assistant", content="second", complete=False),
+        ]
+        app._render_conversation()
+        await pilot.pause()
+
+        first, second = list(app.query(ConversationEntryWidget))[-2:]
+        separator_y = first.region.height - 1
+
+        await pilot.mouse_down(first, offset=(0, separator_y))
+        await pilot._post_mouse_events([events.MouseMove], second, offset=(20, 1), button=1)
+        await pilot.mouse_up(second, offset=(20, 1))
+
+        selected_text = app.screen.get_selected_text()
+        assert selected_text is not None
+        assert "second" in selected_text
+
+
+@pytest.mark.asyncio
+async def test_conversation_selection_can_start_after_line_end(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual import events
+
+    from kolega_code.cli.app import ConversationEntry, ConversationEntryWidget
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        app.conversation_entries = [
+            ConversationEntry(kind="user", content="first"),
+            ConversationEntry(kind="assistant", content="second", complete=False),
+        ]
+        app._render_conversation()
+        await pilot.pause()
+
+        first, second = list(app.query(ConversationEntryWidget))[-2:]
+
+        await pilot.mouse_down(first, offset=(30, 1))
+        await pilot._post_mouse_events([events.MouseMove], second, offset=(20, 1), button=1)
+        await pilot.mouse_up(second, offset=(20, 1))
+
+        selected_text = app.screen.get_selected_text()
+        assert selected_text is not None
+        assert "second" in selected_text
+
+
+@pytest.mark.asyncio
+async def test_conversation_selection_spans_multiple_messages(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual import events
+
+    from kolega_code.cli.app import ConversationEntry, ConversationEntryWidget
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        app.conversation_entries = [
+            ConversationEntry(kind="user", content="first message"),
+            ConversationEntry(kind="assistant", content="second message", complete=False),
+        ]
+        app._render_conversation()
+        await pilot.pause()
+
+        first, second = list(app.query(ConversationEntryWidget))[-2:]
+
+        await pilot.mouse_down(first, offset=(0, 1))
+        await pilot._post_mouse_events([events.MouseMove], second, offset=(20, 1), button=1)
+        await pilot.mouse_up(second, offset=(20, 1))
+
+        selected_text = app.screen.get_selected_text()
+        assert selected_text is not None
+        assert "first message" in selected_text
+        assert "second message" in selected_text
+        assert selected_text.index("first message") < selected_text.index("second message")
+
+
+@pytest.mark.asyncio
+async def test_collapsed_tool_title_supports_drag_selection_and_toggle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual import events
+    from textual.widgets import Collapsible
+    from textual.widgets._collapsible import CollapsibleTitle
+
+    from kolega_code.cli.app import ConversationEntry, ToolEntryWidget
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        app.conversation_entries = [
+            ConversationEntry(
+                kind="tool_result",
+                content="preview text",
+                full_content="full text",
+                tool_name="read_file",
+            )
+        ]
+        app._render_conversation()
+        await pilot.pause()
+
+        widget = app.query(ToolEntryWidget).last()
+        collapsible = widget.query_one(Collapsible)
+        title = widget.query_one(CollapsibleTitle)
+
+        await pilot.mouse_down(title, offset=(1, 0))
+        await pilot._post_mouse_events([events.MouseMove], title, offset=(20, 0), button=1)
+        await pilot.mouse_up(title, offset=(20, 0))
+
+        selected_text = app.screen.get_selected_text()
+        assert selected_text is not None
+        assert "read_file" in selected_text
+
+        await pilot.click(title, offset=(1, 0))
+        await pilot.pause()
+        assert collapsible.collapsed is False
+
+        title.focus()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert collapsible.collapsed is True
+
+
+@pytest.mark.asyncio
+async def test_expanded_tool_body_line_start_selection_copies(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual import events
+    from textual.widgets import Collapsible, Static
+    from textual.widgets._collapsible import CollapsibleTitle
+
+    from kolega_code.cli.app import ConversationEntry, ToolEntryWidget
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+    copied: list[str] = []
+    monkeypatch.setattr(app, "copy_to_clipboard", copied.append)
+
+    async with app.run_test(size=(100, 40)) as pilot:
+        app.conversation_entries = [
+            ConversationEntry(
+                kind="tool_result",
+                content="preview text",
+                full_content="alpha line\nbeta line\ngamma line",
+                tool_name="read_file",
+            )
+        ]
+        app._render_conversation()
+        await pilot.pause()
+
+        widget = app.query(ToolEntryWidget).last()
+        title = widget.query_one(CollapsibleTitle)
+        await pilot.click(title, offset=(1, 0))
+        await pilot.pause()
+
+        body = widget.query_one(".tool-body", Static)
+        assert widget.query_one(Collapsible).collapsed is False
+        assert body.region.x == widget.region.x + 3
+
+        body_y = body.region.y - widget.region.y
+        await pilot.mouse_down(widget, offset=(0, body_y))
+        await pilot._post_mouse_events([events.MouseMove], widget, offset=(11, body_y + 1), button=1)
+        await pilot.mouse_up(widget, offset=(11, body_y + 1))
+
+        selected_text = app.screen.get_selected_text()
+        assert selected_text is not None
+        assert selected_text == "alpha line\nbeta line"
+
+        await pilot.press("super+c")
+        assert copied == ["alpha line\nbeta line"]
+
+
+@pytest.mark.asyncio
 async def test_command_c_copies_selected_chat_text_to_macos_clipboard(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- Apply selection styling to Rich-rendered transcript entries so user and agent messages visibly select and copy correctly.
- Make collapsed tool titles selectable while preserving toggle behavior.
- Preserve expanded tool indentation while allowing selections that start in the indent to copy tool body text.

## Root cause

Textual applies native selection styling to simple content visuals, but completed agent Markdown and other Rich renderables need explicit styling after rendering. Expanded tool content also had a padded container that could appear selected without contributing text to `screen.get_selected_text()`.

## Validation

- `uv run pytest kolega_code/cli/tests/test_app.py -q`
