### PR TITLE
Fix chat compaction: stream summary, keep recent turns, show in TUI

### DIFF
--- a/docs/src/content/docs/hooks.md
+++ b/docs/src/content/docs/hooks.md
@@ -63,6 +63,7 @@ Both files use the same shape:
 | `PreToolUse` | Before a tool runs (after the permission gate) | Denies the tool; the reason is returned to the agent as a tool error, so it can adjust |
 | `PostToolUse` | After a tool succeeds (and on failure) | Ends the turn; the reason is shown as a warning |
 | `PreCompact` | Before the conversation is compacted | Advisory |
+| `PostCompact` | After the conversation is compacted | Advisory; payload reports before/after token counts |
 | `Stop` | The agent is about to finish its turn | Keeps the agent working; the reason becomes its next instruction |
 | `SubagentStop` | A dispatched sub-agent finished | Advisory; can annotate the result the parent sees |
 | `Notification` | A permission prompt is about to be shown | Advisory (desktop notifications, sounds) |

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
 from .common import LogMixin
-from .compression import HistoryCompressor
+from .compression import CompactionResult, HistoryCompressor
 from kolega_code.config import AgentConfig, ModelProvider
 from kolega_code.events import AgentConnectionManager
 from .context import AgentContext, AgentServices, Telemetry, WorkspaceInfo
@@ -549,9 +549,12 @@ class BaseAgent(LogMixin):
             message=message,
         )
 
-    async def compress_history(self) -> None:
+    async def compress_history(self) -> CompactionResult:
         """
-        Non-destructively summarize the current history and mark a compression boundary.
+        Non-destructively summarize the current history, keeping recent turns
+        verbatim. Emits a compaction_status event around the work so the UI can
+        show progress, then recounts + emits a context_update so the gauge
+        refreshes. Returns the structured outcome.
         """
 
         async def on_info(message: str) -> None:
@@ -560,16 +563,34 @@ class BaseAgent(LogMixin):
         async def on_error(message: str) -> None:
             await self.log_error(message, sender=self.agent_name)
 
-        await self.compressor.summarize(
-            self.conversation,
-            llm=self.llm,
-            model=self.primary_model_config.model,
-            max_completion_tokens=self.model_completion_tokens,
-            temperature=self.model_default_temperature,
-            thinking=self.primary_model_config.thinking_effort,
-            on_info=on_info,
-            on_error=on_error,
+        await self.emitter.compaction_status("started", "Compacting conversation…")
+        try:
+            result = await self.compressor.summarize(
+                self.conversation,
+                llm=self.llm,
+                model=self.primary_model_config.model,
+                temperature=self.model_default_temperature,
+                # No extended thinking: a bounded summary doesn't need it, and the
+                # thinking budget could otherwise exceed the small summary max_tokens.
+                thinking=None,
+                on_info=on_info,
+                on_error=on_error,
+            )
+        finally:
+            # Recount + emit so the context gauge reflects post-compaction reality
+            # (even on a no-op the UI may have been stale).
+            await self.count_current_context()
+
+        phase = "finished" if result.ok else "error"
+        summary_text = (
+            self.conversation.summary.get_text_content() if result.ok and self.conversation.summary else ""
         )
+        await self.emitter.compaction_status(phase, result.message, summary=summary_text)
+        return result
+
+    def clear_history(self) -> None:
+        """Drop all history and reset compaction state."""
+        self.conversation.clear()
 
     # ------------------------------------------------------------------
     # Tool execution
@@ -1136,9 +1157,8 @@ class BaseAgent(LogMixin):
     #
     # process_message_stream is the single canonical loop shared by every
     # agent. Subclasses customize behavior through the hook methods below
-    # (build_user_content, apply_compression_fallback, on_tool_use_start,
-    # should_stop_after_tools, recap_agent_outcome) rather than overriding
-    # the loop itself.
+    # (build_user_content, on_tool_use_start, should_stop_after_tools,
+    # recap_agent_outcome) rather than overriding the loop itself.
     # ------------------------------------------------------------------
 
     completion_log_message = "Processing complete"
@@ -1165,21 +1185,6 @@ class BaseAgent(LogMixin):
                 )
 
         return content_blocks
-
-    def apply_compression_fallback(self) -> None:
-        """
-        Hard-truncate history when compression alone could not get under budget.
-
-        Default: keep the first message (the original task) plus any protected
-        skill-content messages.
-        """
-        first_message = self.history[0]
-        protected = [
-            message
-            for message in self.history
-            if message is not first_message and self._is_protected_skill_content(message)
-        ]
-        self.history = MessageHistory(protected + [first_message])
 
     async def on_tool_use_start(self, tool_call_delta: Dict[str, Any]) -> None:
         """
@@ -1252,20 +1257,35 @@ class BaseAgent(LogMixin):
                 logger.debug("Input token count: %s", token_count)
 
                 if self.compressor.over_budget(token_count.input_tokens, self.model_context_length):
+                    before_tokens = token_count.input_tokens
                     # PreCompact hooks (advisory): observe before history is compacted.
                     await self.fire_hook(
                         HookEvent.PRE_COMPACT,
                         {
                             "trigger": "auto",
-                            "input_tokens": token_count.input_tokens,
+                            "input_tokens": before_tokens,
                             "model_context_length": self.model_context_length,
                         },
                     )
-                    await self.compress_history()
+                    result = await self.compress_history()
                     token_count = await self.count_current_context()
 
-                    if self.compressor.over_budget(token_count.input_tokens, self.model_context_length):
-                        self.apply_compression_fallback()
+                    # PostCompact hooks (advisory): observe the outcome. There is no
+                    # destructive fallback — a bounded summary plus capped tool results
+                    # and a small verbatim tail keep us under budget; if somehow not, we
+                    # send as-is rather than wipe history.
+                    await self.fire_hook(
+                        HookEvent.POST_COMPACT,
+                        {
+                            "trigger": "auto",
+                            "ok": result.ok,
+                            "reason": result.reason,
+                            "summarized_messages": result.summarized_messages,
+                            "input_tokens_before": before_tokens,
+                            "input_tokens_after": token_count.input_tokens,
+                            "model_context_length": self.model_context_length,
+                        },
+                    )
 
                     self.mark_cache_checkpoint()
 

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -398,6 +398,14 @@ class BaseAgent(LogMixin):
         """Restores the message history from a list of dictionaries using custom methods."""
         self.conversation.restore(serialized_history)
 
+    def dump_compaction_state(self) -> Dict[str, Any]:
+        """Serialize the compaction boundary (summary + how many leading messages it folds)."""
+        return self.conversation.dump_compaction()
+
+    def restore_compaction_state(self, data: Optional[Dict[str, Any]]) -> None:
+        """Restore the compaction boundary; must be called after restore_message_history."""
+        self.conversation.restore_compaction(data)
+
     def _sanitize_oversized_tool_results(self) -> int:
         return self.conversation.sanitize_oversized_tool_results()
 

--- a/kolega_code/agent/compression.py
+++ b/kolega_code/agent/compression.py
@@ -1,6 +1,7 @@
 """History compression: summarize a conversation when it outgrows the context window."""
 
 import logging
+from dataclasses import dataclass
 from typing import Awaitable, Callable, Optional
 
 from .conversation import Conversation
@@ -15,10 +16,31 @@ logger = logging.getLogger(__name__)
 LogCallback = Callable[[str], Awaitable[None]]
 
 
+@dataclass(frozen=True)
+class CompactionResult:
+    """Outcome of a compaction attempt, surfaced to callers and the UI.
+
+    ``reason`` is a machine tag: "ok" | "too_few" | "nothing_to_summarize" | "llm_error".
+    ``message`` is a human-readable line for the command output / logs.
+    """
+
+    ok: bool
+    reason: str
+    summarized_messages: int = 0
+    message: str = ""
+
+
 class HistoryCompressor:
     """Summarizes a conversation non-destructively when it crosses the budget threshold."""
 
     MIN_MESSAGES_TO_COMPRESS = 5
+    # How many of the most recent messages to keep verbatim after the summary.
+    KEEP_RECENT_MESSAGES = 6
+    # Don't bother summarizing a trivially short prefix.
+    MIN_PREFIX_TO_SUMMARIZE = 3
+    # Cap the summary length: the prompt targets ~600 words (~900 tokens), so a
+    # small ceiling keeps it tight and avoids the model's full completion budget.
+    SUMMARY_MAX_TOKENS = 2048
 
     def __init__(self, threshold: float = 0.8) -> None:
         # Fraction of the model context window above which compression kicks in
@@ -33,49 +55,92 @@ class HistoryCompressor:
         *,
         llm,
         model: str,
-        max_completion_tokens: int,
         temperature: float,
         thinking,
         on_info: Optional[LogCallback] = None,
         on_error: Optional[LogCallback] = None,
-    ) -> bool:
+    ) -> CompactionResult:
         """
-        Non-destructively summarize the conversation and mark a compression boundary.
+        Non-destructively summarize the aged-out prefix while keeping the most
+        recent turns verbatim, and move the compaction boundary.
 
-        Returns True if a summary was recorded.
+        Incremental: only the messages that have aged out since the previous
+        boundary are summarized, with the prior summary folded in for continuity.
+        Returns a CompactionResult describing what happened — never a silent no-op.
         """
-        if not conversation.history or len(conversation.history) < self.MIN_MESSAGES_TO_COMPRESS:
-            return False
+        history = conversation.history
+        if not history or len(history) < self.MIN_MESSAGES_TO_COMPRESS:
+            return CompactionResult(
+                ok=False,
+                reason="too_few",
+                message=(
+                    f"Nothing to compress yet ({len(history)} message(s); "
+                    f"need at least {self.MIN_MESSAGES_TO_COMPRESS})."
+                ),
+            )
+
+        split = conversation.compaction_split_point(
+            keep_recent=self.KEEP_RECENT_MESSAGES, min_prefix=self.MIN_PREFIX_TO_SUMMARIZE
+        )
+        prior_through = conversation.compacted_through if conversation.summary is not None else 0
+        if split is None or split <= prior_through:
+            return CompactionResult(
+                ok=False,
+                reason="nothing_to_summarize",
+                message="Already compact — no older messages to summarize.",
+            )
 
         if on_info:
             await on_info("Compressing message history...")
 
         try:
-            conversation_markdown = conversation.history.get_markdown_conversation()
-            user_prompt_filled = build_compression_summary_user_prompt(conversation_markdown)
+            prefix = MessageHistory(list(history[prior_through:split]))
+            prefix_markdown = prefix.get_markdown_conversation()
+            previous_summary = conversation.summary.get_text_content() if conversation.summary is not None else None
+            user_prompt_filled = build_compression_summary_user_prompt(
+                prefix_markdown, previous_summary=previous_summary
+            )
 
             messages = MessageHistory([Message(role="user", content=[TextBlock(text=user_prompt_filled)])])
             system_message = Message(role="system", content=[TextBlock(text=COMPRESSION_SUMMARY_SYSTEM_PROMPT)])
 
-            response = await llm.generate(
+            # Stream and drain rather than calling generate(): the Anthropic SDK
+            # rejects non-streaming requests whose max_tokens is large enough to risk
+            # a >10-minute response, which the model's full completion budget triggers.
+            async with await llm.stream(
                 messages=messages,
                 system=system_message,
                 temperature=temperature,
                 model=model,
-                max_completion_tokens=max_completion_tokens,
+                max_completion_tokens=self.SUMMARY_MAX_TOKENS,
                 thinking=thinking,
-            )
+            ) as stream:
+                async for _event in stream:
+                    pass
+            response = await stream.get_final_message()
 
-            summary = response.get_text_content()
-            conversation.record_compression(Message(role="user", content=[TextBlock(text=summary)]))
+            summary_text = response.get_text_content()
+            if not summary_text or not summary_text.strip():
+                msg = "Compression produced an empty summary; history left unchanged."
+                if on_error:
+                    await on_error(msg)
+                else:
+                    logger.error(msg)
+                return CompactionResult(ok=False, reason="llm_error", message=msg)
 
+            folded = split - prior_through
+            conversation.apply_compaction(summary_text, split)
+
+            done = f"Compressed {folded} older message(s) into a summary; kept the latest turns verbatim."
             if on_info:
-                await on_info("Message history compressed (non-destructive).")
-            return True
+                await on_info(done)
+            return CompactionResult(ok=True, reason="ok", summarized_messages=folded, message=done)
 
         except Exception as e:
+            # Never swallow into a fake success: log the full traceback and surface
+            # the real error to the caller.
+            logger.exception("Failed to compress message history")
+            msg = f"Failed to compress message history: {type(e).__name__}: {e}"
             if on_error:
-                await on_error(f"Failed to compress message history: {str(e)}")
-            else:
-                logger.error("Failed to compress message history: %s", e)
-            return False
+                await on_error(msg)
+            return CompactionResult(ok=False, reason="llm_error", message=msg)

--- a/kolega_code/agent/conversation.py
+++ b/kolega_code/agent/conversation.py
@@ -27,10 +27,53 @@ class Conversation:
         *,
         max_tool_result_chars: int = 100_000,
     ) -> None:
-        self.history = MessageHistory(list(messages) if messages else [])
-        # Compression marker: index of the last message before a summary was appended
-        self.last_compression_index: Optional[int] = None
+        self._history = MessageHistory(list(messages) if messages else [])
+        # Compaction state: ``summary`` stands in for ``history[:compacted_through]``
+        # in the effective view; messages from ``compacted_through`` onward are kept
+        # verbatim. ``summary is None`` / ``compacted_through == 0`` means uncompacted.
+        self.summary: Optional[Message] = None
+        self.compacted_through: int = 0
         self.max_tool_result_chars = max_tool_result_chars
+
+    # ------------------------------------------------------------------
+    # History access (compaction-aware)
+    # ------------------------------------------------------------------
+
+    @property
+    def history(self) -> MessageHistory:
+        return self._history
+
+    @history.setter
+    def history(self, value) -> None:
+        # Wholesale replacement of the log invalidates any compaction boundary.
+        # Internal mutators that must preserve an active summary assign to
+        # ``self._history`` directly instead of going through this setter.
+        self._history = value if isinstance(value, MessageHistory) else MessageHistory(list(value))
+        self.summary = None
+        self.compacted_through = 0
+
+    @property
+    def last_compression_index(self) -> Optional[int]:
+        """Back-compat: index of the last message folded into the summary, or None."""
+        if self.summary is not None and self.compacted_through > 0:
+            return self.compacted_through - 1
+        return None
+
+    @last_compression_index.setter
+    def last_compression_index(self, value: Optional[int]) -> None:
+        # Legacy setter. The only meaningful operation is clearing the boundary;
+        # a real summary is recorded through ``apply_compaction``/``record_compression``.
+        if value is None:
+            self.summary = None
+            self.compacted_through = 0
+        else:
+            self.compacted_through = value + 1
+
+    def clear(self) -> None:
+        """Drop all history and reset compaction state."""
+        self._history = MessageHistory([])
+        self.summary = None
+        self.compacted_through = 0
 
     # ------------------------------------------------------------------
     # Appending
@@ -125,7 +168,9 @@ class Conversation:
     def extend(self, messages: List[Message]) -> None:
         """Extend history with multiple messages, repairing incomplete tool calls in the result."""
         all_messages = list(self.history) + messages
-        self.history = MessageHistory(self.repaired(all_messages))
+        # Assign to _history (not the public setter) so an active compaction survives
+        # appending live turns.
+        self._history = MessageHistory(self.repaired(all_messages))
 
     # ------------------------------------------------------------------
     # Views and validity
@@ -134,20 +179,17 @@ class Conversation:
     def effective_history(self) -> MessageHistory:
         """
         Return the subset of history to send to the LLM:
-        - If compressed: protected skill content + summary + all messages after the summary
-        - Else: the full history
+        - If compacted: protected skill content from the folded prefix, then the
+          summary, then the most-recent turns kept verbatim.
+        - Else: the full history.
         """
-        if self.last_compression_index is not None and self.history:
-            # Summary is the message immediately after the boundary
-            summary_idx = self.last_compression_index + 1
-            if summary_idx < len(self.history):
-                summary_msg = self.history[summary_idx]
-                protected = [message for message in self.history[:summary_idx] if self.is_protected(message)]
-                # Tail starts after the summary
-                tail = list(self.history[summary_idx + 1 :]) if summary_idx + 1 < len(self.history) else []
-                return MessageHistory(protected + [summary_msg] + tail)
+        if self.summary is not None and self.compacted_through > 0 and self._history:
+            cut = min(self.compacted_through, len(self._history))
+            protected = [message for message in self._history[:cut] if self.is_protected(message)]
+            tail = list(self._history[cut:])
+            return MessageHistory(protected + [self.summary] + tail)
 
-        return MessageHistory(list(self.history))
+        return MessageHistory(list(self._history))
 
     def is_protected(self, message: Message) -> bool:
         """True for user messages carrying skill content that must survive compression."""
@@ -388,9 +430,55 @@ class Conversation:
         return sanitized_count
 
     def record_compression(self, summary: Message) -> None:
-        """Append a compression summary and mark the boundary before it."""
-        self.history.append(summary)
-        self.last_compression_index = len(self.history) - 2
+        """Back-compat shim: fold the entire current history into ``summary``.
+
+        Newer callers use ``apply_compaction`` with an explicit split point so the
+        most recent turns are kept verbatim.
+        """
+        self.summary = (
+            summary if isinstance(summary, Message) else Message(role="user", content=[TextBlock(text=str(summary))])
+        )
+        self.compacted_through = len(self._history)
+
+    def apply_compaction(self, summary_text: str, split_point: int) -> None:
+        """Record ``summary_text`` as standing in for ``history[:split_point]``.
+
+        Non-destructive: the full history is untouched; only the compaction
+        boundary moves. Messages from ``split_point`` onward stay verbatim.
+        """
+        self.summary = Message(role="user", content=[TextBlock(text=summary_text)])
+        self.compacted_through = max(0, min(split_point, len(self._history)))
+
+    def compaction_split_point(self, *, keep_recent: int, min_prefix: int) -> Optional[int]:
+        """Index where the verbatim recent tail should begin.
+
+        Keeps the last ``keep_recent`` messages verbatim, then snaps the cut
+        backward so it never lands between an assistant tool_use and its
+        tool_result. Returns None when the prefix to summarize would be smaller
+        than ``min_prefix``.
+        """
+        n = len(self._history)
+        if n <= min_prefix:
+            return None
+        candidate = self._snap_to_safe_boundary(max(0, n - keep_recent))
+        if candidate < min_prefix:
+            return None
+        return candidate
+
+    def _snap_to_safe_boundary(self, idx: int) -> int:
+        """Move ``idx`` backward past any assistant tool_use so a tool_use/tool_result
+        group is never split across the compaction boundary."""
+        while idx > 0:
+            prev = self._history[idx - 1]
+            if (
+                prev.role == "assistant"
+                and isinstance(prev.content, list)
+                and any(isinstance(block, ToolCall) for block in prev.content)
+            ):
+                idx -= 1
+                continue
+            break
+        return idx
 
     # ------------------------------------------------------------------
     # Serialization

--- a/kolega_code/agent/conversation.py
+++ b/kolega_code/agent/conversation.py
@@ -494,3 +494,26 @@ class Conversation:
         # Keep history authentic - no fixing here
         self.history = MessageHistory(parsed_messages)
         self.sanitize_oversized_tool_results()
+
+    def dump_compaction(self) -> Dict[str, Any]:
+        """Serialize the compaction boundary so it survives save/restore."""
+        return {
+            "summary": self.summary.get_text_content() if self.summary is not None else "",
+            "compacted_through": self.compacted_through,
+        }
+
+    def restore_compaction(self, data: Optional[Dict[str, Any]]) -> None:
+        """Restore a compaction boundary saved by ``dump_compaction``.
+
+        Call AFTER ``restore`` (which resets compaction). Assigns the boundary
+        fields directly so it does not trip the history setter's reset.
+        """
+        data = data or {}
+        text = (data.get("summary") or "").strip()
+        through = int(data.get("compacted_through") or 0)
+        if text and through > 0:
+            self.summary = Message(role="user", content=[TextBlock(text=text)])
+            self.compacted_through = min(through, len(self._history))
+        else:
+            self.summary = None
+            self.compacted_through = 0

--- a/kolega_code/agent/prompt_templates/auxiliary/compression/summary.system.md
+++ b/kolega_code/agent/prompt_templates/auxiliary/compression/summary.system.md
@@ -1,59 +1,28 @@
-You are an expert at analyzing and summarizing technical coding conversations. Your task is to create comprehensive, structured summaries of conversations between users and coding assistants.
+You are compacting an in-progress coding session so the work can continue seamlessly in a smaller context window. Produce a TIGHT continuity briefing — not a transcript.
 
-Your summaries must follow this exact structure:
+Hard rules:
+- Respond with the summary text ONLY. Do NOT call tools. Do NOT ask questions.
+- Be bounded: aim for under ~600 words. Omit anything not needed to keep working.
+- Quote identifiers EXACTLY: file paths, function/class names, variable names, error strings, commands, and config keys. Do not paraphrase code or paths.
+- Do not invent facts. If something is unknown or unfinished, say so briefly.
+- Preserve any `<skill_content name="...">` instructions referenced earlier — note them by name so they are not lost.
 
-## Analysis Section
-Provide a chronological, detailed walkthrough of the entire conversation. Number each major interaction and describe:
-- What the user requested
-- How the assistant approached the problem
-- What files were read/modified/created
-- Key decisions and discoveries made
-- Any iterations or corrections
+Write these sections, each terse. Use `##` headers and keep them in this order:
 
-## Summary Section
-Create a detailed summary with these exact subsections:
+## Goal
+The user's overall objective and any explicit constraints, in 1-3 sentences.
 
-### 1. Primary Request and Intent
-List all explicit user requests in order. Be clear and specific about what the user wanted to accomplish.
+## State
+What is true RIGHT NOW: what has been built or changed, what works, what has been verified.
 
-### 2. Key Technical Concepts
-List all relevant technologies, frameworks, libraries, architectural patterns, and technical concepts used or discussed.
+## Files Touched
+A bullet list of exact paths read/created/modified, each with a 3-8 word note on what changed or why it matters. No code blocks unless a snippet is load-bearing.
 
-### 3. Files and Code Sections
-For EACH file that was modified or created:
-- **Full file path** (in bold)
-- **(Created)** or **(Modified)** indicator
-- **Why**: Brief explanation of why this file was changed
-- **Changes**: Detailed description with actual code snippets showing the key changes
-- Include line numbers when relevant
-- Show enough code context to understand the change
+## Decisions
+Key technical decisions and their one-line rationale. Note approaches already tried and rejected.
 
-### 4. Errors and Fixes
-Document any errors encountered, incorrect approaches, or debugging that occurred. If none, explicitly state "No explicit errors occurred."
+## Open Problems
+Exact open errors (quote them), failing tests, or unresolved questions. Write "None" if there are none.
 
-### 5. Problem Solving
-Describe:
-- **Problems Solved**: What issues were addressed and how
-- **Key Architectural Decisions**: Important technical choices and their rationale
-
-### 6. All User Messages
-List every user message verbatim (excluding the current summary request).
-
-### 7. Pending Tasks
-List any incomplete work, explicitly mentioned future tasks, or known issues. If none, state "No pending tasks."
-
-### 8. Current Work
-Describe the most recent work completed in detail, including the specific file(s) and changes made.
-
-### 9. Optional Next Step
-Suggest a logical next step if appropriate, or state that no next step is needed.
-
-## Formatting Requirements
-- Use markdown headers (##, ###)
-- Use **bold** for file paths and important labels
-- Use `code blocks` for all code snippets
-- Use bullet points and numbered lists for clarity
-- Be precise with technical terminology
-- Include actual code snippets, not just descriptions
-- Maintain chronological order in the Analysis section
-- Be comprehensive but concise
+## Next Steps
+The concrete next actions to take, in order. Write "None" if the task appears complete.

--- a/kolega_code/agent/prompt_templates/auxiliary/compression/summary.user.md.j2
+++ b/kolega_code/agent/prompt_templates/auxiliary/compression/summary.user.md.j2
@@ -1,18 +1,17 @@
-Please create a comprehensive summary of the following coding conversation. Follow the structured format exactly as specified in your instructions.
+{% if previous_summary %}
+A prior summary already covers the earliest part of this session. Treat it as established context and fold its facts into your new summary (do not drop anything important from it):
+
+<previous_summary>
+{{ previous_summary }}
+</previous_summary>
+
+Below are the messages that have happened SINCE that summary and now need to be folded in as well:
+{% else %}
+Summarize the following coding session so far:
+{% endif %}
 
 <conversation_history>
 {{ history }}
 </conversation_history>
 
-Create a detailed summary that captures:
-1. The complete chronological flow of the conversation
-2. All technical decisions and implementations
-3. Every file that was modified or created with code snippets
-4. Any problems encountered and how they were solved
-5. The current state and any pending work
-
-Format your response as:
-- An Analysis section with chronological walkthrough
-- A Summary section with all 9 required subsections
-
-Be thorough and include actual code snippets from the conversation.
+Produce the continuity briefing exactly as specified in your instructions. Summary text only — do not call tools.

--- a/kolega_code/agent/prompts.py
+++ b/kolega_code/agent/prompts.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from functools import lru_cache
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 import jinja2
 
@@ -56,8 +56,12 @@ SKILL_CATALOG_PROMPT_TEMPLATE = prompt_template_source("extensions/skills/catalo
 PLANNING_AGENT_SYSTEM_PROMPT_TEMPLATE = prompt_template_source("system/agents/planning.md.j2")
 
 
-def build_compression_summary_user_prompt(history: str) -> str:
-    return render_prompt_template("auxiliary/compression/summary.user.md.j2", history=history)
+def build_compression_summary_user_prompt(history: str, previous_summary: Optional[str] = None) -> str:
+    return render_prompt_template(
+        "auxiliary/compression/summary.user.md.j2",
+        history=history,
+        previous_summary=previous_summary,
+    )
 
 
 def build_implement_plan_prompt(plan: str, gigacode_enabled: bool = False) -> str:

--- a/kolega_code/agent/tests/compaction_helpers.py
+++ b/kolega_code/agent/tests/compaction_helpers.py
@@ -1,0 +1,189 @@
+"""Reusable, hermetic fakes for conversation-compaction tests.
+
+No network and no API keys: every test installs a ``FakeLLM`` on the agent so
+``count_tokens``/``generate``/``stream`` are fully scripted.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+from kolega_code.events import AgentConnectionManager
+from kolega_code.llm.models import Message, MessageHistory, TextBlock, ToolCall, ToolResult
+from kolega_code.llm.providers.models import TokenCount
+
+
+class FakeStream:
+    """Minimal end_turn stream: yields no events, returns one assistant message."""
+
+    def __init__(self, final_message=None):
+        self._final = final_message or Message(role="assistant", content=[TextBlock(text="ok")], stop_reason="end_turn")
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+    async def get_final_message(self):
+        return self._final
+
+
+class FakeLLM:
+    """Drop-in replacement for ``agent.llm`` (the LLMClient surface BaseAgent uses).
+
+    - ``count_tokens`` returns a scripted sequence of ``TokenCount``s (pops per call
+      and repeats the final value), so a single over-budget turn — which counts
+      tokens more than once — is fully deterministic. With ``proxy=True`` it instead
+      counts a chars/4 proxy of the messages, which lets a test prove that the
+      effective token count drops after compaction.
+    - ``generate`` returns a scripted summary message.
+    - ``stream`` returns a ``FakeStream`` that ends the agent loop after one pass.
+    """
+
+    def __init__(
+        self, token_script=None, *, summary_text="SUMMARY: condensed older turns.", proxy=False, final_message=None
+    ):
+        self._token_script = list(token_script) if token_script else None
+        self._summary_text = summary_text
+        self._proxy = proxy
+        self._final_message = final_message
+        self.count_tokens = AsyncMock(side_effect=self._count_tokens)
+        self.generate = AsyncMock(side_effect=self._generate)
+        self.stream = AsyncMock(side_effect=self._stream)
+
+    async def _count_tokens(self, *args, **kwargs):
+        if self._proxy:
+            messages = kwargs.get("messages")
+            if messages is None and args:
+                messages = args[0]
+            total = sum(len(m.get_text_content()) for m in (messages or []))
+            return TokenCount(input_tokens=total // 4)
+        if self._token_script:
+            value = self._token_script.pop(0) if len(self._token_script) > 1 else self._token_script[0]
+            return TokenCount(input_tokens=value)
+        return TokenCount(input_tokens=0)
+
+    async def _generate(self, *args, **kwargs):
+        return Message(role="assistant", content=[TextBlock(text=self._summary_text)], stop_reason="end_turn")
+
+    async def _stream(self, *args, **kwargs):
+        # The summary is produced by streaming (compaction) and the turn loop also
+        # streams; a single end_turn message carrying the summary text serves both.
+        final = self._final_message or Message(
+            role="assistant", content=[TextBlock(text=self._summary_text)], stop_reason="end_turn"
+        )
+        return FakeStream(final)
+
+
+# ---------------------------------------------------------------------------
+# Message builders
+# ---------------------------------------------------------------------------
+
+
+def text_msg(role: str, text: str) -> Message:
+    return Message(role=role, content=[TextBlock(text=text)])
+
+
+def skill_msg(name: str = "kolega-skill", body: str = "protected body") -> Message:
+    """A user message carrying skill content (protected from compaction)."""
+    return Message(role="user", content=[TextBlock(text=f'<skill_content name="{name}">{body}</skill_content>')])
+
+
+def tool_pair(call_id: str = "t1", name: str = "read_file"):
+    """Return (assistant-with-toolcall, user-with-toolresult) — a valid atomic pair."""
+    return (
+        Message(role="assistant", content=[ToolCall(id=call_id, name=name, input={})]),
+        Message(role="user", content=[ToolResult(tool_use_id=call_id, name=name, content="ok", is_error=False)]),
+    )
+
+
+def long_history(n_pairs: int = 6) -> MessageHistory:
+    """``n_pairs`` user/assistant exchanges (>= MIN_MESSAGES_TO_COMPRESS for n_pairs>=3)."""
+    messages = []
+    for i in range(n_pairs):
+        messages.append(text_msg("user", f"user turn {i} " + "x" * 40))
+        messages.append(text_msg("assistant", f"assistant turn {i} " + "y" * 40))
+    return MessageHistory(messages)
+
+
+# ---------------------------------------------------------------------------
+# Agent builders
+# ---------------------------------------------------------------------------
+
+
+def make_agent_config():
+    from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
+
+    def cfg(**extra):
+        return ModelConfig(
+            provider=ModelProvider.ANTHROPIC,
+            model="claude-haiku-4-5-20251001",
+            rate_limits=RateLimitConfig(),
+            **extra,
+        )
+
+    return AgentConfig(
+        anthropic_api_key="test_key",
+        openai_api_key="test_key",
+        long_context_config=cfg(),
+        fast_config=cfg(),
+        thinking_config=cfg(thinking_effort="medium"),
+    )
+
+
+def build_agent(
+    tmp_path, *, connection_manager=None, agent_cls=None, sub_agent=False, llm=None, model_context_length=1000
+):
+    """Construct an agent wired for hermetic compaction tests.
+
+    Returns ``(agent, connection_manager)``. The agent has a FakeLLM (if provided),
+    a stub tool collection + system prompt, and AsyncMock log/chat sinks.
+    """
+    from kolega_code.agent.baseagent import BaseAgent
+
+    cm = connection_manager or AsyncMock(spec=AgentConnectionManager)
+    cls = agent_cls or BaseAgent
+    agent = cls(
+        project_path=tmp_path,
+        workspace_id="test_ws",
+        thread_id=str(uuid.uuid4()),
+        connection_manager=cm,
+        config=make_agent_config(),
+        sub_agent=sub_agent,
+    )
+    agent.send_chat_message = AsyncMock()
+    agent.log_info = AsyncMock()
+    agent.log_error = AsyncMock()
+    agent.system_prompt = Message(role="system", content=[TextBlock(text="test agent")])
+    agent.tool_collection = MagicMock()
+    agent.tool_collection.get_tool_list = MagicMock(return_value=[])
+    if llm is not None:
+        agent.llm = llm
+    agent.model_context_length = model_context_length
+    return agent, cm
+
+
+def context_update_events(connection_manager):
+    """All llm_context_update events broadcast through ``connection_manager``."""
+    events = []
+    for call in connection_manager.broadcast_event.call_args_list:
+        event = call.args[0] if call.args else call.kwargs.get("event")
+        if event is not None and getattr(event, "event_type", None) == "llm_context_update":
+            events.append(event)
+    return events
+
+
+def compaction_status_events(connection_manager):
+    """All compaction_status events broadcast through ``connection_manager``."""
+    events = []
+    for call in connection_manager.broadcast_event.call_args_list:
+        event = call.args[0] if call.args else call.kwargs.get("event")
+        if event is not None and getattr(event, "event_type", None) == "compaction_status":
+            events.append(event)
+    return events

--- a/kolega_code/agent/tests/test_base_agent.py
+++ b/kolega_code/agent/tests/test_base_agent.py
@@ -1,7 +1,7 @@
 import os
 import uuid
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from dotenv import load_dotenv
@@ -25,6 +25,8 @@ from kolega_code.llm.models import (
     ToolCall,
     ToolResult,
 )
+
+from .compaction_helpers import FakeLLM
 
 # Load environment variables
 load_dotenv()
@@ -278,33 +280,31 @@ class TestBaseAgent:
         base_agent.history = MessageHistory(
             [Message(role=role, content=[TextBlock(text=text)]) for role, text in conversation]
         )
+        base_agent.system_prompt = Message(role="system", content=[TextBlock(text="sys")])
+        base_agent.tool_collection = MagicMock()
+        base_agent.tool_collection.get_tool_list = MagicMock(return_value=[])
+        base_agent.model_context_length = 1000
 
-        # Mock the LLM response
-        mock_response = Message(
-            role="assistant", content=[TextBlock(text="This is a compressed summary of the conversation")]
-        )
+        fake = FakeLLM(token_script=[300], summary_text="This is a compressed summary of the conversation")
+        base_agent.llm = fake
 
-        # Mock the LLM client's generate method
-        with patch.object(base_agent.llm, "generate", new_callable=AsyncMock) as mock_generate:
-            mock_generate.return_value = mock_response
+        result = await base_agent.compress_history()
 
-            # Call the method (non-destructive)
-            await base_agent.compress_history()
+        assert result.ok is True
+        # Non-destructive: full history retained; the summary is stored out-of-band.
+        assert len(base_agent.history) == len(conversation)
+        assert base_agent.conversation.summary is not None
+        assert base_agent.last_compression_index is not None
+        # Effective history keeps recent turns verbatim after the summary (fewer than the full log).
+        effective = base_agent.get_effective_history_for_llm()
+        assert len(effective) < len(conversation)
+        assert base_agent.history[-1] in list(effective)  # most recent turn kept verbatim
 
-            # Verify full history retained plus appended summary
-            assert len(base_agent.history) == len(conversation) + 1
-            # Verify markers set and effective history contains summary only (single-message effective)
-            assert base_agent.last_compression_index == len(conversation) - 1
-            effective = base_agent.get_effective_history_for_llm()
-            assert len(effective) == 1  # only the summary is used for LLM
-
-            # Verify the LLM was called with correct parameters
-            mock_generate.assert_called_once()
-            call_args = mock_generate.call_args[1]
-            assert call_args["model"] == base_agent.config.long_context_config.model
-            assert (
-                call_args["max_completion_tokens"] == base_agent.model_completion_tokens
-            )  # Use the model's actual limit
+        fake.stream.assert_awaited_once()
+        call_args = fake.stream.await_args.kwargs
+        assert call_args["model"] == base_agent.primary_model_config.model
+        # Summary budget is capped small (we are not aiming for a gigantic summary).
+        assert call_args["max_completion_tokens"] <= 2048
 
     @pytest.mark.asyncio
     async def testcompress_history_insufficient_history(self, base_agent):
@@ -319,17 +319,22 @@ class TestBaseAgent:
         base_agent.history = MessageHistory(
             [Message(role=role, content=[TextBlock(text=text)]) for role, text in conversation]
         )
+        base_agent.system_prompt = Message(role="system", content=[TextBlock(text="sys")])
+        base_agent.tool_collection = MagicMock()
+        base_agent.tool_collection.get_tool_list = MagicMock(return_value=[])
+        base_agent.model_context_length = 1000
 
-        # Mock the LLM client's generate method
-        with patch.object(base_agent.llm, "generate", new_callable=AsyncMock) as mock_generate:
-            # Call the method
-            await base_agent.compress_history()
+        fake = FakeLLM(token_script=[100])
+        base_agent.llm = fake
 
-            # Verify the history was not compressed
-            assert len(base_agent.history) == 4
-            assert all(isinstance(msg, Message) for msg in base_agent.history)
-            assert base_agent.history == base_agent.history  # History unchanged
-            mock_generate.assert_not_called()
+        result = await base_agent.compress_history()
+
+        # Too few messages to compress: nothing recorded, generate never called.
+        assert result.ok is False
+        assert result.reason == "too_few"
+        assert len(base_agent.history) == 4
+        assert base_agent.conversation.summary is None
+        fake.stream.assert_not_called()
 
     @pytest.mark.asyncio
     async def testcompress_history_error_handling(self, base_agent):
@@ -350,18 +355,22 @@ class TestBaseAgent:
         base_agent.history = MessageHistory(
             [Message(role=role, content=[TextBlock(text=text)]) for role, text in conversation]
         )
+        base_agent.system_prompt = Message(role="system", content=[TextBlock(text="sys")])
+        base_agent.tool_collection = MagicMock()
+        base_agent.tool_collection.get_tool_list = MagicMock(return_value=[])
+        base_agent.model_context_length = 1000
 
-        # Mock the LLM client's generate method to raise an exception
-        with patch.object(base_agent.llm, "generate", new_callable=AsyncMock) as mock_generate:
-            mock_generate.side_effect = Exception("Test error")
+        fake = FakeLLM(token_script=[100])
+        fake.stream = AsyncMock(side_effect=Exception("Test error"))
+        base_agent.llm = fake
 
-            # Call the method
-            await base_agent.compress_history()
+        result = await base_agent.compress_history()
 
-            # Verify the history was not modified
-            assert len(base_agent.history) == 10
-            assert all(isinstance(msg, Message) for msg in base_agent.history)
-            assert base_agent.history == base_agent.history  # History unchanged
+        # The failure is surfaced (not swallowed as success) and history is untouched.
+        assert result.ok is False
+        assert result.reason == "llm_error"
+        assert len(base_agent.history) == 10
+        assert base_agent.conversation.summary is None
 
     @pytest.mark.slow
     @pytest.mark.integration
@@ -407,25 +416,26 @@ class TestBaseAgent:
             [Message(role=role, content=[TextBlock(text=text)]) for role, text in conversation]
         )
 
-        # Store the last two messages for comparison
-        last_two_messages = base_agent.history[-2:]
+        base_agent.system_prompt = Message(role="system", content=[TextBlock(text="You are a helpful coding agent.")])
+        base_agent.tool_collection = MagicMock()
+        base_agent.tool_collection.get_tool_list = MagicMock(return_value=[])
+
+        # The most recent original message should survive compaction verbatim.
+        last_message = base_agent.history[-1]
 
         try:
-            # Call the method with real LLM
-            await base_agent.compress_history()
+            result = await base_agent.compress_history()
 
-            # Verify the summary was appended (allowing for environments where real LLM may be skipped)
-            assert len(base_agent.history) >= len(conversation)
+            assert result.ok is True
+            # Non-destructive: the full log is retained and the summary is recorded out-of-band.
+            assert len(base_agent.history) == len(conversation)
+            summary = base_agent.conversation.summary
+            assert summary is not None
+            assert summary.get_text_content().strip()
 
-            # Verify the summary message was appended at the end
-            summary_message = base_agent.history[-1]
-            assert isinstance(summary_message, Message)
-            assert summary_message.role == "user"
-            summary_text = summary_message.content[0].text
-            assert ("CONVERSATION HISTORY SUMMARY" in summary_text) or ("## Analysis Section" in summary_text)
-
-            # Verify the last two messages are still present just before the summary
-            assert base_agent.history[-3:-1] == last_two_messages
+            # The recent tail is kept verbatim in the effective view.
+            effective = list(base_agent.get_effective_history_for_llm())
+            assert last_message in effective
         except Exception as e:
             pytest.fail(f"Test failed with error: {str(e)}")
 
@@ -2079,13 +2089,10 @@ class TestBaseAgent:
                 Message(role="user", content=[TextBlock(text="c")]),
             ]
         )
-        base_agent.last_compression_index = 2
-        # Append a summary message as it would be after compression
-        base_agent.history.append(
-            Message(role="user", content=[TextBlock(text="CONVERSATION HISTORY SUMMARY (compressed at ...)")])
-        )
+        # Compact all three messages into a summary (empty verbatim tail).
+        base_agent.conversation.apply_compaction("CONVERSATION HISTORY SUMMARY (compressed at ...)", split_point=3)
         eff = base_agent.get_effective_history_for_llm()
-        # boundary is 2, so tail is after index 2 -> empty, but we still have summary
+        # everything folded, tail empty -> just the summary
         assert len(eff) == 1
         assert "CONVERSATION HISTORY SUMMARY" in eff[0].content[0].text
 

--- a/kolega_code/agent/tests/test_commands.py
+++ b/kolega_code/agent/tests/test_commands.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock, MagicMock, create_autospec
 
 import pytest
 
+from kolega_code.agent.compression import CompactionResult
 from kolega_code.llm.models import Message, MessageHistory
 from ..utils.commands import CommandProcessor
 
@@ -14,6 +15,10 @@ class MockAgent:
         self.command_processor = CommandProcessor(self)
         self.compress_history = AsyncMock()
         self.count_current_context = AsyncMock()
+        self.model_context_length = 1000
+
+    def clear_history(self):
+        self.history = MessageHistory()
 
 
 @pytest.fixture
@@ -55,13 +60,33 @@ async def test_handle_help(command_processor):
 
 
 @pytest.mark.asyncio
-async def test_handle_compress(command_processor, mock_agent):
-    """Test the /compress command handler"""
+async def test_handle_compress(command_processor, mock_agent, mock_message):
+    """The /compress handler reports the real compaction outcome."""
+    mock_agent.history.append(mock_message)
+    token = MagicMock()
+    token.input_tokens = 500
+    mock_agent.count_current_context = AsyncMock(return_value=token)
+    mock_agent.compress_history = AsyncMock(
+        return_value=CompactionResult(ok=True, reason="ok", summarized_messages=3, message="done")
+    )
+
     result = await command_processor._handle_compress()
 
-    # Verify compress was called and returned expected message
-    mock_agent.compress_history.assert_called_once()
-    assert result == "Message history compressed."
+    mock_agent.compress_history.assert_awaited_once()
+    assert "Compressed history" in result
+    assert "3 older message" in result
+
+
+@pytest.mark.asyncio
+async def test_handle_compress_nothing_to_compress(command_processor, mock_agent):
+    """A no-op compaction is reported honestly, not as a success."""
+    mock_agent.compress_history = AsyncMock(
+        return_value=CompactionResult(ok=False, reason="too_few", message="Nothing to compress yet (0 message(s)).")
+    )
+
+    result = await command_processor._handle_compress()
+
+    assert "Nothing to compress" in result
 
 
 @pytest.mark.asyncio
@@ -151,6 +176,27 @@ async def test_process_commands_decorator():
     assert responses[0]["type"] == "response"
     assert responses[0]["content"] == "Normal processing"
     assert responses[0]["complete"] is True
+
+
+@pytest.mark.asyncio
+async def test_command_response_includes_uuid():
+    """Command responses carry a uuid like every other process_message_stream chunk."""
+
+    @CommandProcessor.process_commands
+    class TestAgent:
+        def __init__(self):
+            self.history = MessageHistory()
+            self.command_processor = CommandProcessor(self)
+
+        async def process_message_stream(self, message, attachments=None):
+            yield {"type": "response", "content": "Normal", "complete": True, "uuid": "orig"}
+
+    agent = TestAgent()
+    chunks = [chunk async for chunk in agent.process_message_stream("/help")]
+
+    assert len(chunks) == 1
+    assert isinstance(chunks[0].get("uuid"), str)
+    assert chunks[0]["uuid"]
 
 
 @pytest.mark.asyncio

--- a/kolega_code/agent/tests/test_compaction_integration.py
+++ b/kolega_code/agent/tests/test_compaction_integration.py
@@ -1,0 +1,66 @@
+"""Full agent-loop integration for compaction (hermetic, no network)."""
+
+import pytest
+
+from kolega_code.hooks.events import HookEvent
+
+from .compaction_helpers import FakeLLM, build_agent, context_update_events, long_history
+
+
+def _hook_spy(agent):
+    fired = []
+    original = agent.fire_hook
+
+    async def spy(name, payload, **kwargs):
+        fired.append(name)
+        return await original(name, payload, **kwargs)
+
+    agent.fire_hook = spy
+    return fired
+
+
+@pytest.mark.asyncio
+async def test_full_loop_compacts_then_terminates(tmp_path):
+    agent, cm = build_agent(tmp_path, llm=FakeLLM(token_script=[900, 300]))
+    agent.history = long_history(6)
+    fired = _hook_spy(agent)
+
+    async for _chunk in agent.process_message_stream("hello"):
+        pass
+
+    assert HookEvent.PRE_COMPACT in fired
+    assert HookEvent.POST_COMPACT in fired
+    assert fired.index(HookEvent.PRE_COMPACT) < fired.index(HookEvent.POST_COMPACT)
+    assert agent.conversation.summary is not None
+    assert agent.last_compression_index is not None
+    # A context_update carrying the lower post-compaction count was emitted.
+    counts = [e.content["input_tokens"] for e in context_update_events(cm)]
+    assert 300 in counts
+
+
+@pytest.mark.asyncio
+async def test_full_loop_no_fallback_preserves_summary_when_still_over_budget(tmp_path):
+    # Even if still over budget after compaction, there is no destructive fallback:
+    # the summary survives and history is never wiped.
+    agent, _cm = build_agent(tmp_path, llm=FakeLLM(token_script=[900, 900]))
+    agent.history = long_history(6)
+
+    async for _chunk in agent.process_message_stream("hello"):
+        pass
+
+    assert agent.conversation.summary is not None
+    assert not hasattr(agent, "apply_compression_fallback")
+
+
+@pytest.mark.asyncio
+async def test_full_loop_no_compaction_under_budget(tmp_path):
+    agent, _cm = build_agent(tmp_path, llm=FakeLLM(token_script=[100]))
+    agent.history = long_history(6)
+    fired = _hook_spy(agent)
+
+    async for _chunk in agent.process_message_stream("hello"):
+        pass
+
+    assert HookEvent.PRE_COMPACT not in fired
+    assert HookEvent.POST_COMPACT not in fired
+    assert agent.conversation.summary is None

--- a/kolega_code/agent/tests/test_compaction_persistence.py
+++ b/kolega_code/agent/tests/test_compaction_persistence.py
@@ -1,0 +1,43 @@
+"""Compaction state survives a dump/restore round-trip (save + resume)."""
+
+import pytest
+
+from .compaction_helpers import FakeLLM, build_agent, long_history
+
+
+@pytest.mark.asyncio
+async def test_agent_compaction_survives_dump_restore(tmp_path):
+    agent, _cm = build_agent(tmp_path, llm=FakeLLM(summary_text="PERSISTED SUMMARY"))
+    agent.history = long_history(6)  # 12 messages
+    result = await agent.compress_history()
+    assert result.ok
+
+    history_dump = agent.dump_message_history()
+    compaction_dump = agent.dump_compaction_state()
+    pre_effective = [m.get_text_content() for m in agent.get_effective_history_for_llm()]
+    assert compaction_dump["summary"] == "PERSISTED SUMMARY"
+    assert compaction_dump["compacted_through"] > 0
+
+    # Resume into a fresh agent: restore messages, then the compaction boundary.
+    fresh, _cm2 = build_agent(tmp_path, llm=FakeLLM())
+    fresh.restore_message_history(history_dump)
+    fresh.restore_compaction_state(compaction_dump)
+
+    assert fresh.conversation.summary is not None
+    assert len(fresh.history) == 12  # full history intact
+    # The effective view the model sees is identical to before saving.
+    assert [m.get_text_content() for m in fresh.get_effective_history_for_llm()] == pre_effective
+
+
+@pytest.mark.asyncio
+async def test_agent_without_compaction_dumps_empty(tmp_path):
+    agent, _cm = build_agent(tmp_path, llm=FakeLLM())
+    agent.history = long_history(2)  # 4 messages, never compacted
+    data = agent.dump_compaction_state()
+    assert data == {"summary": "", "compacted_through": 0}
+
+    fresh, _cm2 = build_agent(tmp_path, llm=FakeLLM())
+    fresh.restore_message_history(agent.dump_message_history())
+    fresh.restore_compaction_state(data)
+    assert fresh.conversation.summary is None
+    assert fresh.conversation.compacted_through == 0

--- a/kolega_code/agent/tests/test_compaction_subagent.py
+++ b/kolega_code/agent/tests/test_compaction_subagent.py
@@ -1,0 +1,26 @@
+"""Auto-compaction must work for sub-agent types too (shared BaseAgent loop)."""
+
+import pytest
+
+from .compaction_helpers import FakeLLM, build_agent, long_history
+
+
+@pytest.mark.asyncio
+async def test_general_agent_auto_compacts(tmp_path):
+    from kolega_code.agent.generalagent import GeneralAgent
+
+    agent, _cm = build_agent(
+        tmp_path,
+        agent_cls=GeneralAgent,
+        sub_agent=True,
+        llm=FakeLLM(token_script=[900, 300]),  # over budget, then under after compaction
+    )
+    agent.history = long_history(6)
+
+    # Drain the shared loop; the sub-agent should compact before generating.
+    async for _chunk in agent.process_message_stream("do the task"):
+        pass
+
+    # The summarization ran inside the sub-agent (shared BaseAgent loop).
+    assert agent.conversation.summary is not None
+    assert agent.last_compression_index is not None

--- a/kolega_code/agent/tests/test_compaction_tui_events.py
+++ b/kolega_code/agent/tests/test_compaction_tui_events.py
@@ -1,0 +1,79 @@
+"""Tests that compaction emits status events and the TUI toggles its indicator."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from .compaction_helpers import FakeLLM, build_agent, compaction_status_events, long_history
+
+
+@pytest.mark.asyncio
+async def test_compress_history_emits_started_then_finished(tmp_path):
+    agent, cm = build_agent(tmp_path, llm=FakeLLM(token_script=[100]))
+    agent.history = long_history(6)
+
+    await agent.compress_history()
+
+    events = compaction_status_events(cm)
+    phases = [e.content["phase"] for e in events]
+    assert phases[0] == "started"
+    assert phases[-1] == "finished"
+    # The finished event carries the summary text so the UI can show it.
+    assert events[-1].content["summary"].strip()
+
+
+@pytest.mark.asyncio
+async def test_compress_history_emits_error_phase_on_failure(tmp_path):
+    llm = FakeLLM(token_script=[100])
+    llm.stream = AsyncMock(side_effect=RuntimeError("boom"))
+    agent, cm = build_agent(tmp_path, llm=llm)
+    agent.history = long_history(6)
+
+    await agent.compress_history()
+
+    phases = [e.content["phase"] for e in compaction_status_events(cm)]
+    assert "started" in phases
+    assert "error" in phases
+
+
+def test_app_apply_compaction_status_toggles_indicator():
+    # Exercise the dashboard toggle without constructing the full Textual app.
+    from kolega_code.cli.app import KolegaCodeApp, StatusDashboardState
+
+    refreshed = []
+    fake = SimpleNamespace(
+        _status_state=StatusDashboardState(),
+        _refresh_status_dashboard=lambda: refreshed.append(True),
+    )
+
+    KolegaCodeApp._apply_compaction_status(fake, {"phase": "started", "message": "Compacting…"})
+    assert fake._status_state.is_compacting is True
+    assert fake._status_state.compaction_message == "Compacting…"
+
+    KolegaCodeApp._apply_compaction_status(fake, {"phase": "finished", "message": ""})
+    assert fake._status_state.is_compacting is False
+    assert fake._status_state.compaction_message == ""
+
+    assert refreshed  # the dashboard was refreshed on each phase
+
+
+def test_app_apply_compaction_status_adds_summary_collapsible():
+    # On finish with a summary, a collapsible transcript entry is created.
+    from kolega_code.cli.app import ConversationEntry, KolegaCodeApp, StatusDashboardState
+
+    added = []
+    fake = SimpleNamespace(
+        _status_state=StatusDashboardState(),
+        _refresh_status_dashboard=lambda: None,
+        _add_conversation_entry=lambda entry: added.append(entry),
+    )
+
+    KolegaCodeApp._apply_compaction_status(
+        fake, {"phase": "finished", "message": "done", "summary": "## Goal\nDo the thing"}
+    )
+
+    assert len(added) == 1
+    assert isinstance(added[0], ConversationEntry)
+    assert added[0].kind == "compaction_summary"
+    assert "Do the thing" in added[0].content

--- a/kolega_code/agent/tests/test_compaction_tui_events.py
+++ b/kolega_code/agent/tests/test_compaction_tui_events.py
@@ -77,3 +77,22 @@ def test_app_apply_compaction_status_adds_summary_collapsible():
     assert isinstance(added[0], ConversationEntry)
     assert added[0].kind == "compaction_summary"
     assert "Do the thing" in added[0].content
+
+
+def test_app_resume_compaction_entry():
+    # The resume helper builds a collapsible summary entry from session.compaction.
+    from kolega_code.cli.app import KolegaCodeApp
+
+    def app_with(compaction):
+        return SimpleNamespace(session=SimpleNamespace(compaction=compaction))
+
+    assert KolegaCodeApp._resume_compaction_entry(app_with({})) is None
+    assert KolegaCodeApp._resume_compaction_entry(app_with({"summary": "", "compacted_through": 3})) is None
+    assert KolegaCodeApp._resume_compaction_entry(app_with({"summary": "S", "compacted_through": 0})) is None
+
+    entry = KolegaCodeApp._resume_compaction_entry(
+        app_with({"summary": "RESTORED SUMMARY", "compacted_through": 5})
+    )
+    assert entry is not None
+    assert entry.kind == "compaction_summary"
+    assert "RESTORED SUMMARY" in entry.content

--- a/kolega_code/agent/tests/test_compress_command.py
+++ b/kolega_code/agent/tests/test_compress_command.py
@@ -1,0 +1,41 @@
+"""Tests for the /compress command: real outcome reporting + context update."""
+
+import pytest
+
+from .compaction_helpers import FakeLLM, build_agent, context_update_events, long_history
+
+
+@pytest.mark.asyncio
+async def test_compress_command_reports_real_outcome(tmp_path):
+    agent, _cm = build_agent(tmp_path, llm=FakeLLM(token_script=[900, 300]))
+    agent.history = long_history(6)  # 12 messages, >= MIN_MESSAGES_TO_COMPRESS
+
+    result = await agent.command_processor._handle_compress()
+
+    assert "Compressed history" in result
+    assert "→" in result and "%" in result  # before -> after percentages
+    assert agent.conversation.summary is not None
+
+
+@pytest.mark.asyncio
+async def test_compress_command_nothing_to_compress_under_five(tmp_path):
+    agent, _cm = build_agent(tmp_path, llm=FakeLLM(token_script=[100]))
+    agent.history = long_history(2)  # 4 messages < MIN_MESSAGES_TO_COMPRESS
+
+    result = await agent.command_processor._handle_compress()
+
+    assert "Nothing to compress" in result
+    assert agent.conversation.summary is None
+    agent.llm.stream.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_compress_command_emits_context_update(tmp_path):
+    agent, cm = build_agent(tmp_path, llm=FakeLLM(token_script=[900, 300]))
+    agent.history = long_history(6)
+
+    await agent.command_processor._handle_compress()
+
+    counts = [e.content["input_tokens"] for e in context_update_events(cm)]
+    assert counts  # the gauge was refreshed
+    assert 300 in counts  # reflects the post-compaction (lower) count

--- a/kolega_code/agent/tests/test_compression.py
+++ b/kolega_code/agent/tests/test_compression.py
@@ -1,0 +1,143 @@
+"""Unit tests for HistoryCompressor (recency-aware, structured-outcome compaction)."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from kolega_code.agent.compression import CompactionResult, HistoryCompressor
+from kolega_code.agent.conversation import Conversation
+
+from .compaction_helpers import FakeLLM, long_history, tool_pair, text_msg
+from kolega_code.llm.models import MessageHistory
+
+
+SUMMARIZE_KW = dict(model="claude-haiku-4-5-20251001", temperature=1.0, thinking=None)
+
+
+def proxy_tokens(messages) -> int:
+    return sum(len(m.get_text_content()) for m in messages) // 4
+
+
+@pytest.mark.parametrize(
+    "input_tokens,expected",
+    [(799, False), (800, False), (801, True), (0, False)],  # strict ">" at 80% of 1000
+)
+def test_over_budget_boundary(input_tokens, expected):
+    compressor = HistoryCompressor(threshold=0.8)
+    assert compressor.over_budget(input_tokens, 1000) is expected
+
+
+@pytest.mark.asyncio
+async def test_summarize_too_few_records_nothing():
+    conv = Conversation(list(long_history(2)))  # 4 messages < MIN_MESSAGES_TO_COMPRESS
+    llm = FakeLLM()
+    result = await HistoryCompressor().summarize(conv, llm=llm, **SUMMARIZE_KW)
+
+    assert isinstance(result, CompactionResult)
+    assert result.ok is False
+    assert result.reason == "too_few"
+    assert conv.summary is None
+    assert len(conv.history) == 4
+    llm.stream.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_summarize_happy_path_records_summary():
+    conv = Conversation(list(long_history(6)))  # 12 messages
+    llm = FakeLLM(summary_text="SUMMARY: earlier turns")
+    result = await HistoryCompressor().summarize(conv, llm=llm, **SUMMARIZE_KW)
+
+    assert result.ok is True
+    assert result.reason == "ok"
+    assert result.summarized_messages > 0
+    assert conv.summary is not None
+    assert conv.summary.get_text_content() == "SUMMARY: earlier turns"
+    assert conv.last_compression_index is not None
+    llm.stream.assert_awaited_once()
+    # the summary was streamed with the model/params we passed (capped to a small budget).
+    kwargs = llm.stream.await_args.kwargs
+    assert kwargs["model"] == SUMMARIZE_KW["model"]
+    assert kwargs["max_completion_tokens"] <= HistoryCompressor.SUMMARY_MAX_TOKENS
+
+
+@pytest.mark.asyncio
+async def test_summarize_keeps_recent_messages_verbatim():
+    history = long_history(6)  # 12 messages
+    conv = Conversation(list(history))
+    await HistoryCompressor().summarize(conv, llm=FakeLLM(), **SUMMARIZE_KW)
+
+    effective = list(conv.effective_history())
+    # The most recent KEEP_RECENT_MESSAGES survive verbatim after the summary.
+    assert list(history)[-1] in effective
+    assert list(history)[-HistoryCompressor.KEEP_RECENT_MESSAGES] in effective
+
+
+@pytest.mark.asyncio
+async def test_summarize_reduces_effective_tokens():
+    conv = Conversation(list(long_history(6)))
+    pre = proxy_tokens(conv.effective_history())
+    result = await HistoryCompressor().summarize(conv, llm=FakeLLM(), **SUMMARIZE_KW)
+    post = proxy_tokens(conv.effective_history())
+
+    assert result.ok is True
+    assert post < pre  # compaction must reduce what the LLM sees
+
+
+@pytest.mark.asyncio
+async def test_summarize_llm_error_is_nondestructive():
+    history = long_history(6)
+    conv = Conversation(list(history))
+    llm = FakeLLM()
+    llm.stream = AsyncMock(side_effect=RuntimeError("boom"))
+    on_error = AsyncMock()
+
+    result = await HistoryCompressor().summarize(conv, llm=llm, on_error=on_error, **SUMMARIZE_KW)
+
+    assert result.ok is False
+    assert result.reason == "llm_error"
+    assert "boom" in result.message
+    assert conv.summary is None  # state untouched
+    assert list(conv.history) == list(history)
+    on_error.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_summarize_empty_output_is_error():
+    conv = Conversation(list(long_history(6)))
+    result = await HistoryCompressor().summarize(conv, llm=FakeLLM(summary_text="   "), **SUMMARIZE_KW)
+    assert result.ok is False
+    assert result.reason == "llm_error"
+    assert conv.summary is None
+
+
+@pytest.mark.asyncio
+async def test_summarize_nothing_new_after_compaction():
+    conv = Conversation(list(long_history(6)))
+    first = await HistoryCompressor().summarize(conv, llm=FakeLLM(), **SUMMARIZE_KW)
+    assert first.ok is True
+    # No new messages added → nothing further to summarize.
+    second = await HistoryCompressor().summarize(conv, llm=FakeLLM(), **SUMMARIZE_KW)
+    assert second.ok is False
+    assert second.reason == "nothing_to_summarize"
+
+
+@pytest.mark.asyncio
+async def test_summarize_snaps_split_out_of_tool_pair():
+    a_tc, u_tr = tool_pair("tool_z")
+    history = MessageHistory(
+        [
+            text_msg("user", "u0"),
+            text_msg("assistant", "a0"),
+            text_msg("user", "u1"),
+            text_msg("assistant", "a1"),
+            text_msg("user", "u2"),
+            text_msg("assistant", "a2"),
+            a_tc,
+            u_tr,
+        ]  # tool pair at the boundary for KEEP_RECENT default math (8 -> split ~ 0..)
+    )
+    conv = Conversation(list(history))
+    result = await HistoryCompressor(threshold=0.8).summarize(conv, llm=FakeLLM(), **SUMMARIZE_KW)
+    # Whether or not it summarized, the effective view is always valid.
+    assert conv.is_valid_for_anthropic(list(conv.effective_history())) is True
+    assert isinstance(result, CompactionResult)

--- a/kolega_code/agent/tests/test_conversation_compaction.py
+++ b/kolega_code/agent/tests/test_conversation_compaction.py
@@ -159,3 +159,34 @@ def test_dump_restore_resets_compaction():
     assert restored.summary is None
     assert restored.compacted_through == 0
     assert len(restored.history) == 8
+
+
+def test_dump_restore_compaction_round_trip():
+    conv = _conv(long_history(6))  # 12 messages
+    conv.apply_compaction("THE SUMMARY", 6)
+    data = conv.dump_compaction()
+    assert data == {"summary": "THE SUMMARY", "compacted_through": 6}
+
+    # A fresh conversation gets the full history back, then the boundary on top.
+    restored = Conversation(list(conv.history))
+    restored.restore_compaction(data)
+    assert restored.summary is not None
+    assert restored.compacted_through == 6
+    effective = list(restored.effective_history())
+    assert effective[0].get_text_content() == "THE SUMMARY"
+    assert effective[1:] == list(conv.history)[6:]  # verbatim tail preserved
+
+
+def test_restore_compaction_empty_is_noop():
+    conv = _conv(long_history(3))
+    for data in ({}, None, {"summary": "", "compacted_through": 5}, {"summary": "S", "compacted_through": 0}):
+        conv.restore_compaction(data)
+        assert conv.summary is None
+        assert conv.compacted_through == 0
+
+
+def test_restore_compaction_clamps_boundary():
+    conv = _conv(long_history(2))  # 4 messages
+    conv.restore_compaction({"summary": "S", "compacted_through": 999})
+    assert conv.compacted_through == 4  # clamped to len(history)
+    assert conv.summary is not None

--- a/kolega_code/agent/tests/test_conversation_compaction.py
+++ b/kolega_code/agent/tests/test_conversation_compaction.py
@@ -1,0 +1,161 @@
+"""Unit tests for the recency-preserving compaction model on Conversation."""
+
+import pytest
+
+from kolega_code.agent.conversation import Conversation
+from kolega_code.llm.models import Message, MessageHistory, TextBlock
+
+from .compaction_helpers import long_history, skill_msg, text_msg, tool_pair
+
+
+def _conv(messages):
+    return Conversation(list(messages))
+
+
+def test_effective_history_no_compaction_returns_full():
+    conv = _conv(long_history(3))  # 6 messages, uncompacted
+    effective = conv.effective_history()
+    assert list(effective) == list(conv.history)
+    assert conv.last_compression_index is None
+
+
+def test_effective_history_after_compaction_order():
+    skill = skill_msg()
+    u0, a0 = text_msg("user", "u0"), text_msg("assistant", "a0")
+    u1, a1 = text_msg("user", "u1"), text_msg("assistant", "a1")
+    u2, a2 = text_msg("user", "u2"), text_msg("assistant", "a2")
+    conv = _conv([skill, u0, a0, u1, a1, u2, a2])  # 7 messages
+
+    conv.apply_compaction("SUMMARY TEXT", split_point=5)  # fold [skill,u0,a0,u1,a1]; keep [u2,a2]
+    effective = list(conv.effective_history())
+
+    assert effective[0] is skill  # protected skill content survives from the folded prefix
+    assert effective[1].get_text_content() == "SUMMARY TEXT"  # the summary
+    assert effective[2:] == [u2, a2]  # recent turns kept verbatim, in order
+
+
+def test_effective_history_preserves_only_protected_prefix():
+    skill = skill_msg()
+    u0, a0, u1, a1 = (
+        text_msg("user", "u0"),
+        text_msg("assistant", "a0"),
+        text_msg("user", "u1"),
+        text_msg("assistant", "a1"),
+    )
+    conv = _conv([u0, skill, a0, u1, a1])
+    conv.apply_compaction("S", split_point=4)  # fold first 4; keep [a1]
+    effective = list(conv.effective_history())
+    # Only the protected skill message survives verbatim from the folded prefix.
+    assert effective[0] is skill
+    assert effective[1].get_text_content() == "S"
+    assert effective[2:] == [a1]
+    assert u0 not in effective and a0 not in effective and u1 not in effective
+
+
+def test_recent_tail_is_verbatim_identity():
+    history = long_history(5)  # 10 messages
+    conv = _conv(history)
+    conv.apply_compaction("S", split_point=4)
+    effective = list(conv.effective_history())
+    assert effective[0].get_text_content() == "S"  # no protected prefix here -> summary first
+    tail = effective[1:]
+    # Every tail message is the *same object* as in history (not re-summarized).
+    for original, shown in zip(list(history)[4:], tail):
+        assert original is shown
+
+
+@pytest.mark.parametrize("keep_recent", [1, 2, 3, 4, 5])
+def test_compaction_never_splits_tool_pair(keep_recent):
+    a_tc, u_tr = tool_pair("tool_x")
+    history = MessageHistory(
+        [
+            text_msg("user", "u0"),
+            text_msg("assistant", "a0"),
+            text_msg("user", "u1"),
+            text_msg("assistant", "a1"),
+            a_tc,
+            u_tr,
+            text_msg("user", "u2"),
+            text_msg("assistant", "a2"),
+        ]
+    )
+    conv = _conv(history)
+    split = conv.compaction_split_point(keep_recent=keep_recent, min_prefix=1)
+    if split is None:
+        pytest.skip("prefix too small for this keep_recent")
+    conv.apply_compaction("S", split)
+    # No tool_use is orphaned across the boundary.
+    assert conv.is_valid_for_anthropic(list(conv.effective_history())) is True
+
+
+def test_stale_compacted_through_is_clamped():
+    conv = _conv(long_history(3))  # 6 messages
+    conv.summary = Message(role="user", content=[TextBlock(text="S")])
+    conv.compacted_through = 999  # beyond len(history)
+    # min(compacted_through, len) keeps it safe; no IndexError.
+    effective = list(conv.effective_history())
+    assert effective[-1].get_text_content() == "S"  # everything folded, tail empty
+
+
+def test_clear_resets_compaction_state():
+    conv = _conv(long_history(4))
+    conv.apply_compaction("S", 3)
+    conv.clear()
+    assert list(conv.history) == []
+    assert conv.summary is None
+    assert conv.compacted_through == 0
+    assert conv.last_compression_index is None
+    assert list(conv.effective_history()) == []
+
+
+def test_history_setter_resets_compaction_state():
+    conv = _conv(long_history(4))
+    conv.apply_compaction("S", 3)
+    conv.history = MessageHistory([text_msg("user", "fresh")])
+    assert conv.summary is None
+    assert conv.compacted_through == 0
+    assert conv.last_compression_index is None
+
+
+def test_compaction_survives_extend():
+    conv = _conv(long_history(4))  # 8 messages
+    conv.apply_compaction("S", 4)
+    conv.extend([text_msg("user", "a live follow-up turn")])
+    # Appending live turns must NOT wipe the active summary.
+    assert conv.summary is not None
+    assert conv.compacted_through == 4
+    effective = list(conv.effective_history())
+    assert effective[0].get_text_content() == "S"
+    assert effective[-1].get_text_content() == "a live follow-up turn"
+
+
+def test_record_compression_shim_folds_everything():
+    history = long_history(3)  # 6 messages
+    conv = _conv(history)
+    conv.record_compression(Message(role="user", content=[TextBlock(text="WHOLE")]))
+    assert conv.compacted_through == len(history)
+    effective = list(conv.effective_history())
+    assert len(effective) == 1  # only the summary (no protected prefix, empty tail)
+    assert effective[0].get_text_content() == "WHOLE"
+
+
+def test_last_compression_index_back_compat():
+    conv = _conv(long_history(3))
+    conv.apply_compaction("S", split_point=3)
+    assert conv.last_compression_index == 2  # compacted_through - 1
+    conv.last_compression_index = None  # legacy clear
+    assert conv.summary is None
+    assert conv.compacted_through == 0
+
+
+def test_dump_restore_resets_compaction():
+    conv = _conv(long_history(4))
+    conv.apply_compaction("S", 4)
+    dumped = conv.dump()
+    restored = Conversation()
+    restored.restore(dumped)
+    # restore() treats the dumped log as authentic + uncompacted; it re-compacts
+    # on the next over-budget turn.
+    assert restored.summary is None
+    assert restored.compacted_through == 0
+    assert len(restored.history) == 8

--- a/kolega_code/agent/tests/test_prompts.py
+++ b/kolega_code/agent/tests/test_prompts.py
@@ -5,7 +5,7 @@ from kolega_code.agent import prompts
 
 def test_static_prompt_templates_load() -> None:
     assert "software architect" in prompts.THINK_HARD_PROMPT
-    assert "summarizing technical coding conversations" in prompts.COMPRESSION_SUMMARY_SYSTEM_PROMPT
+    assert "continuity briefing" in prompts.COMPRESSION_SUMMARY_SYSTEM_PROMPT
     assert "evaluating shell commands for safety" in prompts.SHELL_SAFETY_SYSTEM_PROMPT
     assert "analyzing shell command output" in prompts.SHELL_COMPRESSION_SYSTEM_PROMPT
     assert "get_task_list" in prompts.SHARED_TASK_LIST_PROMPT

--- a/kolega_code/agent/utils/commands.py
+++ b/kolega_code/agent/utils/commands.py
@@ -1,8 +1,7 @@
+import uuid
 from dataclasses import dataclass
 from functools import wraps
 from typing import Any, AsyncGenerator, Dict, List, Optional, Type
-
-from kolega_code.llm.models import MessageHistory
 
 
 @dataclass(frozen=True)
@@ -44,12 +43,28 @@ class CommandProcessor:
 
     async def _handle_compress(self) -> str:
         """Handle the /compress command."""
-        await self.agent.compress_history()
-        return "Message history compressed."
+        agent = self.agent
+        has_history = len(agent.history) > 0
+        before = (await agent.count_current_context()).input_tokens if has_history else 0
+        result = await agent.compress_history()
+        after = (await agent.count_current_context()).input_tokens if has_history else 0
+        ctx = agent.model_context_length
+
+        def pct(tokens: int) -> int:
+            return int(tokens * 100 / ctx) if ctx else 0
+
+        if result.ok:
+            return (
+                f"Compressed history: {result.summarized_messages} older message(s) summarized. "
+                f"Context {pct(before)}% → {pct(after)}% of the window."
+            )
+        if result.reason == "llm_error":
+            return f"Compression failed: {result.message}"
+        return f"Nothing to compress. {result.message} (context {pct(before)}% of the window)."
 
     async def _handle_clear(self) -> str:
         """Handle the /clear command."""
-        self.agent.history = MessageHistory()
+        self.agent.clear_history()
         return "Message history cleared."
 
     async def _handle_context(self) -> str:
@@ -82,7 +97,12 @@ class CommandProcessor:
             if stripped_message in self.command_processor.commands:
                 command_result = await self.command_processor.commands[stripped_message]()
 
-                yield {"type": "response", "content": command_result, "complete": True}
+                yield {
+                    "type": "response",
+                    "content": command_result,
+                    "complete": True,
+                    "uuid": str(uuid.uuid4()),
+                }
 
                 return
 

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -341,6 +341,8 @@ class StatusDashboardState:
     compression_threshold: Optional[float] = None
     alert_level: str = "normal"
     context_note: str = ""
+    is_compacting: bool = False
+    compaction_message: str = ""
 
 
 class ConversationEntryWidget(Static):
@@ -2230,6 +2232,11 @@ class KolegaCodeApp(App):
                 self._note_sub_agent_context(event)
             else:
                 self._apply_context_status_update(event.content)
+        elif event.event_type == "compaction_status":
+            # Only the main agent's compaction drives the status dashboard; a
+            # sub-agent's compaction must not stomp the main indicator.
+            if not event.sub_agent_info:
+                self._apply_compaction_status(event.content)
         elif event.event_type in {"llm_status_update", "status_update"}:
             if event.sub_agent_info:
                 self._note_sub_agent_status(event)
@@ -4279,6 +4286,10 @@ class KolegaCodeApp(App):
                 note_style = self._context_note_style(state.alert_level)
                 context_lines += f"\n[{note_style}]{escape(state.context_note)}[/{note_style}]"
 
+        if state.is_compacting:
+            indicator = escape(state.compaction_message or messages.COMPACTING)
+            context_lines += f"\n[{Color.ACCENT}]{theme.g(Glyph.RUNNING)} {indicator}[/{Color.ACCENT}]"
+
         title = theme.role_header(Glyph.STATUS, "Status", Color.ACCENT)
         turn_line = (
             f"{label('Turn')} [{turn_style}]{theme.g(Glyph.STATUS)}[/{turn_style}] "
@@ -4329,6 +4340,27 @@ class KolegaCodeApp(App):
             self._status_state.activity = content
         if turn_state is not None:
             self._status_state.turn_state = turn_state
+        self._refresh_status_dashboard()
+
+    def _apply_compaction_status(self, content: dict) -> None:
+        """Toggle the 'compaction in progress' indicator and, on finish, drop the
+        summary into the transcript as a collapsible the user can expand."""
+        phase = str(content.get("phase") or "")
+        if phase == "started":
+            self._status_state.is_compacting = True
+            message = content.get("message")
+            self._status_state.compaction_message = (
+                message if isinstance(message, str) and message else messages.COMPACTING
+            )
+        else:  # "finished" | "error"
+            self._status_state.is_compacting = False
+            self._status_state.compaction_message = ""
+            if phase == "finished":
+                summary = content.get("summary")
+                if isinstance(summary, str) and summary.strip():
+                    self._add_conversation_entry(
+                        ConversationEntry(kind="compaction_summary", content=summary.strip())
+                    )
         self._refresh_status_dashboard()
 
     def _apply_context_status_update(self, content: dict) -> None:
@@ -5436,9 +5468,14 @@ class KolegaCodeApp(App):
     def _make_entry_widget(self, entry: ConversationEntry) -> ConversationEntryWidget | ToolEntryWidget:
         if entry.kind in {"tool_call", "tool_result", "tool_error"}:
             return ToolEntryWidget(entry, self._tool_entry_title, self._tool_preview_renderable)
+        if entry.kind == "compaction_summary":
+            return ToolEntryWidget(entry, self._compaction_summary_title)
         if entry.kind == "sub_agent":
             return SubAgentEntryWidget(entry, self._format_conversation_entry)
         return ConversationEntryWidget(entry, self._format_conversation_entry)
+
+    def _compaction_summary_title(self, entry: ConversationEntry) -> str:
+        return theme.role_header(Glyph.STATUS, messages.COMPACTION_SUMMARY_TITLE, Color.ACCENT)
 
     def _update_jump_button(self) -> None:
         try:

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -2355,7 +2355,7 @@ class KolegaCodeApp(App):
                     await fire(HookEvent.SESSION_END, {"reason": "quit"})
                 except Exception:
                     pass
-            self.session.history = self.agent.dump_message_history()
+            self._persist_agent_into_session()
             self._save_session()
             await self.agent.cleanup()
         self.exit()
@@ -2644,9 +2644,12 @@ class KolegaCodeApp(App):
 
     async def _build_agent(self, config: AgentConfig, rebuild: bool = False) -> None:
         history = self.session.history
+        compaction = self.session.compaction
         if self.agent is not None:
             history = self.agent.dump_message_history()
+            compaction = self.agent.dump_compaction_state()
             self.session.history = history
+            self.session.compaction = compaction
             self._save_session()
             if rebuild:
                 await self.agent.cleanup()
@@ -2699,6 +2702,7 @@ class KolegaCodeApp(App):
         self.agent.gigacode_enabled = gigacode_active
         if history:
             self.agent.restore_message_history(history)
+            self.agent.restore_compaction_state(compaction)
             self._restore_conversation_history(history)
         self._update_mode_chrome()
         await self._fire_session_start_once()
@@ -4087,12 +4091,14 @@ class KolegaCodeApp(App):
             self.agent.history = MessageHistory()
             self.agent.last_compression_index = None
         self.session.history = []
+        self.session.compaction = {}
 
     def _reset_current_thread(self) -> None:
         self._close_sub_agent_inspector()
         if self.agent is not None:
             self.agent.history = MessageHistory()
         self.session.history = []
+        self.session.compaction = {}
         self.session.task_list_markdown = ""
         self.conversation_entries = []
         self._stream_entries = {}
@@ -4502,13 +4508,36 @@ class KolegaCodeApp(App):
         self._cancel_pending_theme_selection()
         self._refresh_planning_sidebar()
         self._ensure_startup_entry(render=False)
-        for item in history:
+        # If the restored agent is in a compacted state, mark the boundary with a
+        # collapsible summary (between the folded prefix and the verbatim tail).
+        summary_entry = self._resume_compaction_entry()
+        boundary = None
+        if summary_entry is not None:
+            through = int((self.session.compaction or {}).get("compacted_through") or 0)
+            boundary = min(through, len(history))
+        for index, item in enumerate(history):
+            if summary_entry is not None and index == boundary:
+                self.conversation_entries.append(summary_entry)
             try:
                 message = Message.from_dict(item)
             except Exception:
                 continue
             self.conversation_entries.extend(self._conversation_entries_from_message(message))
+        if summary_entry is not None and boundary is not None and boundary >= len(history):
+            self.conversation_entries.append(summary_entry)
         self._render_conversation()
+
+    def _resume_compaction_entry(self) -> Optional[ConversationEntry]:
+        """A collapsible summary entry for the restored compaction boundary, or None.
+
+        Built from the session's persisted compaction metadata (the same data the
+        agent was restored from), so it does not depend on agent internals.
+        """
+        data = self.session.compaction or {}
+        summary_text = (data.get("summary") or "").strip()
+        if not summary_text or int(data.get("compacted_through") or 0) <= 0:
+            return None
+        return ConversationEntry(kind="compaction_summary", content=summary_text)
 
     def _conversation_entries_from_message(self, message: Message) -> list[ConversationEntry]:
         entries: list[ConversationEntry] = []
@@ -4634,10 +4663,17 @@ class KolegaCodeApp(App):
     def _finish_turn_progress(self, content: str, state: TurnState = TurnState.IDLE) -> None:
         self._update_progress(content, complete=True, state=state)
 
-    def _save_session_history(self) -> None:
+    def _persist_agent_into_session(self) -> None:
+        """Capture the agent's message history and compaction boundary into the session."""
         if self.agent is None:
             return
         self.session.history = self.agent.dump_message_history()
+        self.session.compaction = self.agent.dump_compaction_state()
+
+    def _save_session_history(self) -> None:
+        if self.agent is None:
+            return
+        self._persist_agent_into_session()
         self._save_session()
 
     def _add_tool_message(self, message_type: str, content: dict) -> None:

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -545,6 +545,7 @@ async def _run_ask(args: argparse.Namespace) -> int:
     agent_ref["agent"] = agent
     if session.history:
         agent.restore_message_history(session.history)
+        agent.restore_compaction_state(session.compaction)
 
     fire_hook = getattr(agent, "fire_hook", None)
     if fire_hook is not None:
@@ -580,6 +581,7 @@ async def _run_ask(args: argparse.Namespace) -> int:
                 print(activation_content)
             if args.save or args.session:
                 session.history = agent.dump_message_history()
+                session.compaction = agent.dump_compaction_state()
                 session.config = summary
                 store.save(session)
             await agent.cleanup()
@@ -607,6 +609,7 @@ async def _run_ask(args: argparse.Namespace) -> int:
 
         if args.save or args.session:
             session.history = agent.dump_message_history()
+            session.compaction = agent.dump_compaction_state()
             session.config = summary
             store.save(session)
     except LLMBillingError as exc:

--- a/kolega_code/cli/messages.py
+++ b/kolega_code/cli/messages.py
@@ -115,6 +115,8 @@ SETTINGS_ACTIVE_THEME = "Active theme: {theme}"
 
 # Status dashboard
 STATUS_TOKENS_UNKNOWN = "Token counts unavailable."
+COMPACTING = "Compacting conversation…"
+COMPACTION_SUMMARY_TITLE = "Conversation compacted — summary"
 
 # Logs
 LOG_IGNORED_EVENT = "Ignored non-display event: {event_type}"

--- a/kolega_code/cli/session_store.py
+++ b/kolega_code/cli/session_store.py
@@ -30,6 +30,7 @@ class SessionRecord:
     updated_at: str
     config: dict[str, Any] = field(default_factory=dict)
     history: list[dict[str, Any]] = field(default_factory=list)
+    compaction: dict[str, Any] = field(default_factory=dict)
     task_list_markdown: str = ""
     latest_plan_markdown: str = ""
     plan_pending: bool = False
@@ -79,6 +80,7 @@ class SessionRecord:
             updated_at=data["updated_at"],
             config=data.get("config") or {},
             history=data.get("history") or [],
+            compaction=data.get("compaction") or {},
             task_list_markdown=data.get("task_list_markdown") or "",
             latest_plan_markdown=data.get("latest_plan_markdown") or "",
             plan_pending=bool(data.get("plan_pending", False)),
@@ -99,6 +101,7 @@ class SessionRecord:
             "updated_at": self.updated_at,
             "config": self.config,
             "history": self.history,
+            "compaction": self.compaction,
             "task_list_markdown": self.task_list_markdown,
             "latest_plan_markdown": self.latest_plan_markdown,
             "plan_pending": self.plan_pending,

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -89,6 +89,12 @@ async def test_textual_app_mounts_with_fake_agent(tmp_path: Path, monkeypatch: p
         def restore_message_history(self, history):
             self.history_restored = bool(history)
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -155,6 +161,12 @@ async def test_textual_app_status_tab_is_default_dashboard(
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -199,6 +211,12 @@ async def test_settings_tab_grouped_into_model_and_appearance_sections(
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return []
@@ -257,6 +275,12 @@ async def test_web_search_settings_section_reveal_and_save(
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return []
@@ -342,6 +366,12 @@ async def test_textual_app_context_usage_updates_status_without_raw_json(
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -404,6 +434,12 @@ async def test_textual_app_status_dashboard_tracks_interaction_mode(
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -447,6 +483,12 @@ async def test_textual_app_turn_status_formats_error_duration(
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return []
@@ -504,6 +546,12 @@ async def test_progress_entry_tone_drives_styling_not_prose(
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -555,6 +603,12 @@ async def test_textual_app_keeps_command_c_for_screen_copy(
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -595,6 +649,12 @@ async def test_textual_app_shift_tab_toggles_between_build_and_plan_agents(
 
         def restore_message_history(self, history):
             self.history = list(history)
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return self.history
@@ -681,6 +741,12 @@ async def test_textual_app_ctrl_p_toggles_permission_mode(
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -734,6 +800,12 @@ async def test_textual_app_ctrl_o_toggles_sidebar_and_keeps_active_tab(
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return []
@@ -793,6 +865,12 @@ async def test_textual_app_permission_approval_actions_show_rule_labels_without_
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return []
@@ -864,6 +942,12 @@ async def test_textual_app_restores_saved_plan_and_interaction_mode(
         def restore_message_history(self, history):
             self.history = list(history)
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return self.history
 
@@ -925,6 +1009,12 @@ async def test_textual_app_restores_saved_plan_in_build_mode_without_plan_action
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -971,6 +1061,12 @@ async def test_textual_app_invalid_saved_interaction_mode_falls_back_to_build(
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -1012,6 +1108,12 @@ async def test_textual_app_passes_shared_task_list_tools_to_build_agent_only(
 
         def restore_message_history(self, history):
             self.history = list(history)
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return self.history
@@ -1089,6 +1191,12 @@ async def test_textual_app_passes_skill_extensions_to_build_and_plan_agents(
         def restore_message_history(self, history):
             self.history = list(history)
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return self.history
 
@@ -1150,6 +1258,12 @@ async def test_textual_app_skill_slash_commands_list_and_activate(
         def restore_message_history(self, history):
             self.history = [Message.from_dict(item) for item in history]
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return [message.to_dict() for message in self.history]
 
@@ -1207,6 +1321,12 @@ async def test_textual_app_skill_slash_command_with_prompt_starts_turn(
         def restore_message_history(self, history):
             self.history = [Message.from_dict(item) for item in history]
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return [message.to_dict() for message in self.history]
 
@@ -1260,6 +1380,12 @@ async def test_textual_app_planning_question_tool_accepts_option_list_answer(
 
         def restore_message_history(self, history):
             self.history = list(history)
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return self.history
@@ -1344,6 +1470,12 @@ async def test_textual_app_planning_question_supports_arrow_and_digit_selection(
         def restore_message_history(self, history):
             self.history = list(history)
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return self.history
 
@@ -1413,6 +1545,12 @@ async def test_textual_app_planning_question_tool_accepts_custom_text_answer(
         def restore_message_history(self, history):
             self.history = list(history)
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return self.history
 
@@ -1481,6 +1619,12 @@ async def test_textual_app_planning_question_tool_asks_multiple_questions_sequen
         def restore_message_history(self, history):
             self.history = list(history)
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return self.history
 
@@ -1548,6 +1692,12 @@ async def test_textual_app_planning_question_tool_rejects_malformed_input(
 
         def restore_message_history(self, history):
             self.history = list(history)
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return self.history
@@ -1630,6 +1780,12 @@ async def test_textual_app_blocks_mode_toggle_during_active_turn(
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -1674,6 +1830,12 @@ async def test_textual_app_shows_plan_decision_when_planning_agent_writes_plan(
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return []
@@ -1783,6 +1945,12 @@ async def test_textual_app_implement_plan_switches_to_build_and_sends_plan(
         def restore_message_history(self, history):
             self.history = list(history)
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return self.history
 
@@ -1851,6 +2019,12 @@ async def test_textual_app_implemented_plan_not_reoffered_on_reentry(
 
         def restore_message_history(self, history):
             self.history = list(history)
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return self.history
@@ -1922,6 +2096,12 @@ async def test_textual_app_clear_context_and_implement_plan_starts_build_agent_f
 
         def restore_message_history(self, history):
             self.history = list(history)
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return self.history
@@ -2002,6 +2182,12 @@ async def test_textual_app_discuss_plan_clears_old_plan_until_new_plan_is_writte
         def restore_message_history(self, history):
             self.history = list(history)
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return self.history
 
@@ -2077,6 +2263,12 @@ async def test_textual_app_does_not_save_startup_entry_to_history(
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return saved_history
 
@@ -2116,6 +2308,12 @@ async def test_textual_app_composer_shift_enter_inserts_line_break_and_enter_sub
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return []
@@ -2171,6 +2369,12 @@ async def test_textual_app_composer_ctrl_enter_still_inserts_line_break(
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -2215,6 +2419,12 @@ async def test_textual_app_composer_preserves_multiline_paste(
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return []
@@ -2272,6 +2482,12 @@ async def test_textual_app_reset_command_clears_current_thread(
 
         def restore_message_history(self, history):
             self.history = list(history)
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return self.history
@@ -2358,6 +2574,12 @@ async def test_textual_app_reset_command_waits_for_active_turn(
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return self.history
@@ -2495,6 +2717,12 @@ async def test_textual_app_mounts_with_stored_kimi_settings(
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -2544,6 +2772,12 @@ async def test_textual_app_mounts_with_stored_deepseek_settings(
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return []
@@ -2596,6 +2830,12 @@ async def test_textual_app_saves_settings_and_builds_agent(
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return []
@@ -2653,6 +2893,12 @@ async def test_textual_app_saves_deepseek_settings_and_builds_agent(
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return []
@@ -2716,6 +2962,12 @@ async def test_textual_app_merges_streamed_response_chunks(
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -2769,6 +3021,12 @@ async def test_textual_app_merges_streamed_thinking_chunks(
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -2813,6 +3071,12 @@ async def test_textual_app_formats_thinking_as_italic_chat_entry(
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -2855,6 +3119,12 @@ async def test_textual_app_renders_one_widget_per_chat_entry(
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return []
@@ -2922,6 +3192,12 @@ async def test_conversation_render_skips_detached_view_during_teardown(
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -2979,6 +3255,12 @@ async def test_conversation_entry_widget_extracts_plain_selected_text(
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -3028,6 +3310,12 @@ async def test_conversation_entry_supports_mouse_drag_selection(
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return []
@@ -3308,6 +3596,12 @@ async def test_command_c_copies_selected_chat_text_to_macos_clipboard(
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -3362,6 +3656,12 @@ async def test_textual_app_formats_agent_and_tool_chat_entries(
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return []
@@ -3429,6 +3729,12 @@ async def test_textual_app_ignores_empty_final_response_without_existing_entry(
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -3475,6 +3781,12 @@ async def test_textual_app_shows_working_progress_during_active_turn(
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return []
@@ -3545,6 +3857,12 @@ async def test_textual_app_renders_tool_events_in_chat(tmp_path: Path, monkeypat
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return []
@@ -3623,6 +3941,12 @@ async def test_textual_app_appends_append_mode_tool_streaming_events_in_chat(
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return []
@@ -3722,6 +4046,12 @@ async def test_textual_app_replaces_default_tool_streaming_events_in_chat(
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -3785,6 +4115,12 @@ async def test_textual_app_caps_long_append_mode_tool_streaming_events(
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -3844,6 +4180,12 @@ async def test_textual_app_renders_queued_tool_events_during_active_turn(
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return []
@@ -3949,6 +4291,12 @@ async def test_textual_app_late_tool_result_updates_existing_tool_row(
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -4018,6 +4366,12 @@ async def test_textual_app_cancellation_is_visible_in_chat(
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return []
@@ -4142,6 +4496,12 @@ async def test_textual_app_handles_llm_error_without_worker_traceback(
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -4195,6 +4555,12 @@ async def test_textual_app_reraises_non_llm_error(tmp_path: Path, monkeypatch: p
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -4244,6 +4610,12 @@ async def test_textual_app_renders_resumed_history_in_chat(
 
         def restore_message_history(self, history):
             self.restored_history = history
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return self.restored_history or []
@@ -4314,6 +4686,12 @@ def _build_sub_agent_test_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return []
@@ -5573,6 +5951,12 @@ def _build_mention_test_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         def restore_message_history(self, history):
             self.history = [Message.from_dict(item) for item in history]
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return [message.to_dict() for message in self.history]
 
@@ -5918,6 +6302,12 @@ async def test_textual_app_plan_and_build_slash_commands_switch_mode(
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -6028,6 +6418,12 @@ async def test_textual_app_init_slash_command_switches_from_plan_to_build(
         def restore_message_history(self, history):
             self.history = list(history)
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return self.history
 
@@ -6109,6 +6505,12 @@ async def test_textual_app_model_slash_command_shows_and_switches_model(
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return []
@@ -6226,6 +6628,12 @@ async def test_textual_app_model_slash_command_selects_from_action_list(
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -6296,6 +6704,12 @@ async def test_textual_app_model_slash_command_accepts_typed_selection_and_rejec
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return []
@@ -6369,6 +6783,12 @@ async def test_textual_app_model_slash_command_blocks_selector_during_active_tur
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -6425,6 +6845,12 @@ async def test_textual_app_effort_slash_command_selects_from_action_list(
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return []
@@ -6497,6 +6923,12 @@ async def test_textual_app_effort_slash_command_accepts_typed_selection_and_reje
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -6566,6 +6998,12 @@ async def test_textual_app_effort_slash_command_blocks_selector_during_active_tu
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return []
@@ -6765,6 +7203,12 @@ async def test_textual_app_prompt_list_recovers_focus_after_drift(
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -6826,6 +7270,12 @@ async def test_textual_app_question_recovers_focus_but_allows_free_form_answer(
         def restore_message_history(self, history):
             return None
 
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
         def dump_message_history(self):
             return []
 
@@ -6883,6 +7333,12 @@ async def test_agent_models_section_saves_override_and_builds_agent(
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return []
@@ -6944,6 +7400,12 @@ async def test_agent_models_section_populates_and_clears_to_inherit(
 
         def restore_message_history(self, history):
             return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
 
         def dump_message_history(self):
             return []

--- a/kolega_code/cli/tests/test_session_store.py
+++ b/kolega_code/cli/tests/test_session_store.py
@@ -69,6 +69,33 @@ def test_session_store_loads_old_sessions_without_planning_state(tmp_path: Path)
     assert loaded.permission_mode == "ask"
 
 
+def test_session_store_round_trips_compaction(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    store = SessionStore(tmp_path / "state")
+
+    record = store.create(project, "code", {})
+    record.compaction = {"summary": "## Goal\nShip it", "compacted_through": 7}
+    store.save(record)
+
+    loaded = store.load(record.session_id)
+    assert loaded.compaction == {"summary": "## Goal\nShip it", "compacted_through": 7}
+
+
+def test_session_store_loads_old_sessions_without_compaction(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    store = SessionStore(tmp_path / "state")
+
+    record = store.create(project, "code", {})
+    payload = record.to_dict()
+    payload.pop("compaction")
+    store.path_for(record.session_id).write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = store.load(record.session_id)
+    assert loaded.compaction == {}
+
+
 def test_session_store_ignores_corrupt_files_when_listing(tmp_path: Path) -> None:
     store = SessionStore(tmp_path / "state")
     store.ensure_dirs()

--- a/kolega_code/events.py
+++ b/kolega_code/events.py
@@ -31,6 +31,7 @@ class AgentEvent(BaseModel):
         "llm_status_update",
         "credit_alert",
         "llm_context_update",
+        "compaction_status",
         "tool_streaming_update",
         "file_edit_preview",
         "memory_suggestions",
@@ -188,6 +189,25 @@ class AgentEventEmitter:
                     "compression_threshold": compression_threshold * 100,  # Convert to percentage
                     "will_compress_at": int(model_context_length * compression_threshold),
                 },
+                sub_agent_info=sub_agent_info,
+            )
+        )
+
+    async def compaction_status(self, phase: str, message: str = "", summary: str = "") -> None:
+        """Send a compaction_status event so the UI can show compaction progress.
+
+        ``phase`` is one of "started" | "finished" | "error". On "finished",
+        ``summary`` carries the summary text so the UI can show it in the transcript.
+        """
+        sub_agent_info = self._sub_agent_info_provider() if self._sub_agent_info_provider else None
+
+        await self.emit(
+            AgentEvent(
+                sender=self.sender,
+                event_type="compaction_status",
+                content={"phase": phase, "message": message, "summary": summary},
+                timestamp=datetime.now().isoformat(),
+                is_streaming=False,
                 sub_agent_info=sub_agent_info,
             )
         )

--- a/kolega_code/hooks/events.py
+++ b/kolega_code/hooks/events.py
@@ -26,6 +26,7 @@ class HookEvent(str, Enum):
     STOP = "Stop"
     SUBAGENT_STOP = "SubagentStop"
     PRE_COMPACT = "PreCompact"
+    POST_COMPACT = "PostCompact"
     NOTIFICATION = "Notification"
 
 


### PR DESCRIPTION
## Context

Two reported symptoms:
- **`/compress` did nothing** — it returned "Message history compressed." instantly, with no effect.
- **Auto-compaction at the threshold wiped the agent's memory.**

## Root cause

`/compress` returning instantly meant `HistoryCompressor.summarize()` never reached the LLM — and a broad `except Exception` swallowed the real error into a fake "success." The actual error (surfaced once the swallow was removed): the **Anthropic SDK requires streaming** for requests with a large `max_tokens`, but compaction used the non-streaming `generate()` with the model's full completion budget.

Auto-compaction wiped memory because `apply_compression_fallback()` hard-truncated history, **discarded the just-built summary**, and left a stale boundary — triggered by a verbose 9-section summary prompt that kept the summary nearly as large as the original.

## Changes

- **Stream the summary** (drain `llm.stream(...)` like the turn loop) and cap it to a small bounded budget (`SUMMARY_MAX_TOKENS = 2048`, no extended thinking) — not the full completion budget.
- **Recency-preserving model**: effective history = protected skill content → one concise summary → the last few turns verbatim; the boundary is snapped so a `tool_use`/`tool_result` pair is never split.
- **Removed the destructive fallback entirely** — the summary is never wiped; a bounded summary + already-capped tool results keep us under budget.
- **No more silent failures**: `summarize()` returns a structured `CompactionResult`, logs exceptions with traceback, and surfaces the real outcome.
- **Concise continuity-focused summary prompt** (Goal/State/Files/Decisions/Open Problems/Next Steps) replacing the 9-section verbatim dump.
- `/compress` reports `Context X% → Y%` (or the real error / "nothing to compress"); `/clear` resets compaction state; command responses carry a `uuid`.
- New `compaction_status` event + `PostCompact` hook.

### TUI
- A **"Compacting conversation…" spinner** on the status dashboard while compaction runs (auto + manual).
- The **summary itself as a collapsed-by-default collapsible in the chat transcript** so it can be expanded to read exactly what was summarized.

## Verification

- New hermetic compaction test suite (`FakeLLM`, no network): the model, compressor, `/compress`, full agent loop, sub-agent compaction, and the TUI events/collapsible — plus updated existing tests.
- Full fast suite green (1140 passed locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)