### PR TITLE
Fix invisible selected text in TUI chat area

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -399,7 +399,14 @@ def _with_selection_offsets(strip: Strip, y: int) -> Strip:
 
 
 def _with_selection_style(strip: Strip, selection: Selection | None, y: int, selection_style: Style) -> Strip:
-    """Apply screen selection styling to Rich renderables that Textual can't style natively."""
+    """Apply the screen selection highlight to Rich renderables that Textual can't style natively.
+
+    Only the selection *background* is applied; each segment keeps its own foreground
+    color. The default ``$screen-selection-foreground`` is ``"transparent"``, so adding
+    the full selection style would override every segment's foreground and render the
+    selected glyphs invisible. Applying the background alone keeps selected text readable
+    across every theme while preserving per-role colors (user/agent/code).
+    """
     if selection is None:
         return strip
 
@@ -415,6 +422,10 @@ def _with_selection_style(strip: Strip, selection: Selection | None, y: int, sel
     end = max(start, min(end, line_length))
     if start == end:
         return strip
+
+    # Background only: Style.from_color(bgcolor=None) is an empty style, so a missing
+    # selection background degrades to "no highlight" rather than blanking the text.
+    selection_background = Style.from_color(bgcolor=selection_style.bgcolor)
 
     selected_segments: list[Segment] = []
     source_x = 0
@@ -441,7 +452,7 @@ def _with_selection_style(strip: Strip, selection: Selection | None, y: int, sel
 
         selected_text = text[selected_start:selected_end]
         if selected_text:
-            style = segment.style + selection_style if segment.style is not None else selection_style
+            style = segment.style + selection_background if segment.style is not None else selection_background
             selected_segments.append(Segment(selected_text, style, segment.control))
 
         if selected_end < len(text):

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -3385,6 +3385,75 @@ async def test_conversation_entry_selection_styles_rendered_lines(
 
 
 @pytest.mark.asyncio
+async def test_conversation_entry_selection_preserves_text_foreground(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.geometry import Offset
+    from textual.selection import Selection
+
+    from kolega_code.cli import theme
+    from kolega_code.cli.app import ConversationEntry, ConversationEntryWidget
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test(size=(100, 40)) as pilot:
+        app.conversation_entries = [
+            ConversationEntry(kind="user", content="select this user text"),
+        ]
+        app._render_conversation()
+        await pilot.pause()
+
+        # Exercise every theme: the fix must keep selected text readable regardless
+        # of the active palette. Theme state is process-global, so restore it after.
+        try:
+            for theme_name in theme.available_themes():
+                app._apply_theme(theme_name)
+                await pilot.pause()
+                widget = app.query(ConversationEntryWidget).last()
+
+                # Foreground colors present on line 1 with no selection.
+                app.screen.selections = {}
+                plain_strip = widget.render_line(1)
+                plain_colors = {
+                    segment.style.color
+                    for segment in plain_strip
+                    if segment.text and segment.style is not None
+                }
+                assert plain_colors, f"expected colored content on line 1 for {theme_name}"
+
+                # Select a span on line 1 and re-render.
+                app.screen.selections = {widget: Selection(Offset(0, 1), Offset(20, 1))}
+                selected_strip = widget.render_line(1)
+                selection_style = widget.selection_style
+                selection_bg = selection_style.bgcolor
+
+                highlighted = [
+                    segment
+                    for segment in selected_strip
+                    if segment.text
+                    and segment.style is not None
+                    and segment.style.bgcolor == selection_bg
+                ]
+                assert highlighted, f"expected highlighted segments for {theme_name}"
+
+                # The selection must not blank out the text: every highlighted segment
+                # keeps its original foreground (one seen unselected) and never the
+                # transparent selection foreground.
+                for segment in highlighted:
+                    assert segment.style.color in plain_colors, (
+                        f"selection wiped the text foreground for {theme_name}"
+                    )
+                    if selection_style.color is not None:
+                        assert segment.style.color != selection_style.color, (
+                            f"selection foreground overrode text color for {theme_name}"
+                        )
+        finally:
+            theme.apply_theme(theme.DEFAULT_THEME_NAME)
+
+
+@pytest.mark.asyncio
 async def test_conversation_selection_can_start_in_blank_separator(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Problem

When drag-selecting text in the TUI conversation (chat) area, the selection highlight rendered but the selected glyphs became invisible — the text disappeared into the highlight. This affected every theme.

## Root cause

`ConversationEntryWidget.render_line` manually paints Textual's selection onto its Rich-rendered lines via `_with_selection_style` (Textual can't natively select arbitrary Rich renderables). That helper combined styles with Rich addition:

```python
style = segment.style + selection_style if segment.style is not None else selection_style
```

`selection_style` resolves to Textual's `screen--selection` component, whose foreground (`$screen-selection-foreground`) defaults to `"transparent"`. Rich's `Style.__add__` treats that non-`None` transparent foreground as an override, so every selected segment's foreground was replaced with transparent — which renders as the cell background, making the glyphs invisible. No theme overrides that token, so it affected all five themes.

## Fix

`_with_selection_style` now applies **only the selection background**, preserving each segment's original foreground:

```python
selection_background = Style.from_color(bgcolor=selection_style.bgcolor)
...
style = segment.style + selection_background if segment.style is not None else selection_background
```

This is theme-independent (it never reads `screen-selection-foreground`), keeps selected text readable, and preserves the app's per-role coloring (user/agent/code) under the highlight.

## Tests

- Added `test_conversation_entry_selection_preserves_text_foreground`, which loops over all five themes and asserts highlighted segments keep their original foreground (and never the transparent selection foreground). Verified it **fails on the old code** and **passes with the fix**.
- Existing selection tests still pass (the selection background is still applied).

## Checks

- `pytest -k selection` → 11 passed
- `pytest test_app.py test_themes.py` → 169 passed
- `ruff check` → clean