### PR TITLE
chore: release v0.7.2

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,6 +20,12 @@ release branch.
 2. Update `pyproject.toml`, `uv.lock`, and package `__version__` values to the
    release version.
 
+   Running `uv lock` advances the `exclude-newer` cutoff recorded in `uv.lock`,
+   because `pyproject.toml` sets `exclude-newer = "1 week"` as a relative
+   duration. The cutoff timestamp moving forward, and any dependency versions
+   released within the new one-week window being pulled in, is expected and
+   acceptable. Do not revert these changes.
+
 3. Run the fast test suite:
 
    ```bash

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -148,4 +148,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.7.1"
+version = "0.7.2"
 description = "Local-first AI coding agent for the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [options]
 prerelease-mode = "allow"
-exclude-newer = "2026-06-13T06:35:08.454954Z"
+exclude-newer = "2026-06-14T08:36:55.231284Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1098,7 +1098,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- bump package version from 0.7.1 to 0.7.2
- regenerate uv.lock, accepting the expected exclude-newer cutoff advancement
- document the uv.lock exclude-newer release behavior in RELEASING.md

## Checks

- uv lock
- uv run pytest -ra --durations=50 --import-mode=importlib -m "not slow"

## Notes

The uv.lock diff includes the expected exclude-newer timestamp advancement because pyproject.toml sets exclude-newer = "1 week".