### PR TITLE
Add Fireworks OpenAI-compatible reasoning models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ OPENAI_API_KEY=
 # (no key needed). Optional override of the OAuth client id, for testing only:
 # KOLEGA_CODE_CHATGPT_CLIENT_ID=
 GOOGLE_API_KEY=
+FIREWORKS_API_KEY=
 MOONSHOT_API_KEY=
 DEEPSEEK_API_KEY=
 ZAI_API_KEY=

--- a/docs/src/content/docs/configuration/environment-variables.md
+++ b/docs/src/content/docs/configuration/environment-variables.md
@@ -118,12 +118,17 @@ starting point:
 # Pick one provider's key (or several)
 MOONSHOT_API_KEY=
 DEEPSEEK_API_KEY=
+FIREWORKS_API_KEY=
 ANTHROPIC_API_KEY=
 
 # Optional: choose models per role
 KOLEGA_CODE_PROVIDER=moonshot
 KOLEGA_CODE_MODEL=kimi-k2.7-code
 KOLEGA_CODE_THINKING_EFFORT=auto
+
+# Fireworks example:
+# KOLEGA_CODE_PROVIDER=fireworks
+# KOLEGA_CODE_MODEL=accounts/fireworks/models/glm-5p2
 
 # Optional: web search
 KOLEGA_CODE_WEB_SEARCH_BACKEND=duckduckgo

--- a/docs/src/content/docs/configuration/providers-and-models.mdx
+++ b/docs/src/content/docs/configuration/providers-and-models.mdx
@@ -45,11 +45,21 @@ with thinking effort `auto` (enabled) requests route to **K2.7 Code**, and with 
 (disabled) they route to **K2.6**. Set `KIMI_CODING_API_KEY` to your Kimi Coding Plan key.
 </Aside>
 
+<Aside type="tip">
+**Fireworks.ai.** The `fireworks` provider targets Fireworks' OpenAI-compatible
+serverless endpoint (`https://api.fireworks.ai/inference/v1`) with `FIREWORKS_API_KEY`.
+Fireworks model IDs use resource names such as `accounts/fireworks/models/glm-5p2`.
+Kolega Code exposes GLM-5.2, GLM-5.1, Kimi K2.7 Code, DeepSeek V4 Pro/Flash,
+MiniMax M3, and Qwen 3.7 Plus through the Settings UI and CLI. Fireworks reasoning
+models return `reasoning_content`; Kolega Code exposes `none`, `low`, `medium`,
+`high`, and `max` as `reasoning_effort` values for these models.
+</Aside>
+
 <Aside type="note">
-The **Settings tab** in the TUI currently offers a curated shortlist —
-**Moonshot (Kimi K2.7 Code and Kimi K2.6)** and **DeepSeek (DeepSeek V4 Pro)**.
-The full provider list above is available through environment variables and CLI
-flags. See [Settings & API Keys](../settings-and-api-keys/).
+The **Settings tab** in the TUI is generated from Kolega Code's model registry, so
+new entries in the supported model catalog appear there automatically. You can also
+select any supported provider/model through environment variables and CLI flags.
+See [Settings & API Keys](../settings-and-api-keys/).
 </Aside>
 
 ## Model roles
@@ -153,6 +163,7 @@ models in the TUI.
 | Moonshot `kimi-k2.6` | `auto`, `none` | `auto` |
 | Z.AI `glm-5.2` | `high`, `max` | `max` |
 | Z.AI `glm-5.1` | `auto`, `none` | `auto` |
+| Fireworks serverless reasoning models | `none`, `low`, `medium`, `high`, `max` | `medium` |
 | Google `gemini-2.5-pro` | `auto`, `low`, `medium`, `high` | `medium` |
 | OpenAI reasoning models | `low`, `medium`, `high` | `medium` |
 

--- a/kolega_code/agent/tests/llm/test_client.py
+++ b/kolega_code/agent/tests/llm/test_client.py
@@ -52,6 +52,7 @@ from kolega_code.llm.models import (
     ToolResult,
 )
 from kolega_code.llm.providers.anthropic import AnthropicProvider, AnthropicStreamWrapper
+from kolega_code.llm.providers.openai import OpenAIProvider
 
 # Test data
 TEST_MESSAGES = MessageHistory([Message("user", [TextBlock("Hello, how are you?")])])
@@ -216,6 +217,148 @@ async def test_anthropic_stream_tool_use_start_execution_id_matches_final_tool_c
     assert final_message.tool_calls[0].id == "toolu_create_file"
     assert final_message.tool_calls[0].execution_id == execution_id
     assert final_message.content[0].execution_id == execution_id
+
+
+def test_fireworks_uses_openai_compatible_provider():
+    client = LLMClient("fireworks", "test-key")
+
+    assert isinstance(client.provider, OpenAIProvider)
+    assert not isinstance(client.provider, AnthropicProvider)
+    assert client.provider.provider_name == "fireworks"
+    assert client.provider.base_url == "https://api.fireworks.ai/inference/v1"
+
+
+@pytest.mark.asyncio
+async def test_fireworks_generate_maps_openai_provider_response_usage(capsys):
+    client = LLMClient("fireworks", "test-key")
+
+    class MessageObj:
+        content = "ok"
+        reasoning_content = "brief reasoning"
+        tool_calls = None
+
+    class Choice:
+        message = MessageObj()
+
+    class PromptTokenDetails:
+        cached_tokens = 76
+
+    class Usage:
+        prompt_tokens = 321
+        completion_tokens = 54
+        total_tokens = 375
+        prompt_tokens_details = PromptTokenDetails()
+
+    class OpenAIResponse:
+        choices = [Choice()]
+        usage = Usage()
+
+    create = AsyncMock(return_value=OpenAIResponse())
+    with patch.object(client.provider.async_client.chat.completions, "create", create):
+        response = await client.generate(
+            messages=TEST_MESSAGES,
+            system=TEST_SYSTEM,
+            model="accounts/fireworks/models/glm-5p2",
+            temperature=1.0,
+            max_completion_tokens=8,
+            thinking="high",
+        )
+
+    assert create.await_count == 1
+    assert create.await_args.kwargs["model"] == "accounts/fireworks/models/glm-5p2"
+    assert create.await_args.kwargs["reasoning_effort"] == "high"
+    assert response.usage_metadata == {
+        "provider": "fireworks",
+        "prompt_tokens": 321,
+        "completion_tokens": 54,
+        "total_tokens": 375,
+        "cache_read_input_tokens": 76,
+    }
+    assert response.content[0].type == "thinking"
+    assert response.content[1].text == "ok"
+    assert capsys.readouterr().out == ""
+
+
+@pytest.mark.asyncio
+async def test_fireworks_stream_final_message_maps_openai_usage():
+    client = LLMClient("fireworks", "test-key")
+
+    class Delta:
+        def __init__(self, content=None, reasoning_content=None):
+            self.content = content
+            self.reasoning_content = reasoning_content
+            self.tool_calls = []
+
+    class Choice:
+        def __init__(self, delta, finish_reason=None):
+            self.delta = delta
+            self.finish_reason = finish_reason
+
+    class PromptTokenDetails:
+        cached_tokens = 33
+
+    class Usage:
+        prompt_tokens = 11
+        completion_tokens = 22
+        total_tokens = 33
+        prompt_tokens_details = PromptTokenDetails()
+
+    class Chunk:
+        def __init__(self, delta, finish_reason=None, usage=None):
+            self.choices = [Choice(delta, finish_reason)]
+            self.usage = usage
+
+    class FakeOpenAIStream:
+        def __init__(self):
+            self._chunks = iter([
+                Chunk(Delta(reasoning_content="think ")),
+                Chunk(Delta(reasoning_content="hard")),
+                Chunk(Delta(content="ok"), finish_reason="stop", usage=Usage()),
+            ])
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            try:
+                return next(self._chunks)
+            except StopIteration:
+                raise StopAsyncIteration
+
+        async def aclose(self):
+            pass
+
+    create = AsyncMock(return_value=FakeOpenAIStream())
+    with patch.object(client.provider.async_client.chat.completions, "create", create):
+        fireworks_stream = await client.stream(
+            messages=TEST_MESSAGES,
+            system=TEST_SYSTEM,
+            model="accounts/fireworks/models/glm-5p2",
+            temperature=1.0,
+            max_completion_tokens=8,
+            thinking="low",
+        )
+
+        chunks = []
+        async with fireworks_stream as stream_ctx:
+            async for chunk in stream_ctx:
+                chunks.append(chunk)
+            final_message = await stream_ctx.get_final_message()
+
+    assert create.await_count == 1
+    assert create.await_args.kwargs["model"] == "accounts/fireworks/models/glm-5p2"
+    assert create.await_args.kwargs["reasoning_effort"] == "low"
+    assert [chunk.type for chunk in chunks] == ["thinking", "thinking", "text"]
+    assert final_message.content[0].type == "thinking"
+    assert final_message.content[0].thinking == "think hard"
+    assert final_message.content[1].text == "ok"
+    assert final_message.usage_metadata == {
+        "prompt_tokens": 11,
+        "completion_tokens": 22,
+        "total_tokens": 33,
+        "cache_read_input_tokens": 33,
+        "provider": "fireworks",
+    }
 
 
 @pytest.mark.asyncio

--- a/kolega_code/agent/tests/llm/test_langfuse_normalization.py
+++ b/kolega_code/agent/tests/llm/test_langfuse_normalization.py
@@ -37,3 +37,20 @@ def test_langfuse_normalizes_deepseek_usage():
     assert usage['cache_read_input_tokens'] == 3
     assert usage['cache_creation_input_tokens'] == 4
 
+
+def test_langfuse_normalizes_fireworks_openai_usage():
+    msg = Message(role='assistant', content='ok', usage_metadata={
+        'provider': 'fireworks',
+        'prompt_tokens': 20,
+        'completion_tokens': 5,
+        'total_tokens': 25,
+        'cache_read_input_tokens': 6,
+    })
+
+    wrapper = MinimalLangfuseStreamWrapper(stream=None, generation=None, trace=None, instrumented_client=None, model='x')
+    usage = wrapper._extract_langfuse_usage(msg)
+    assert usage['input'] == 20
+    assert usage['output'] == 5
+    assert usage['total'] == 25
+    assert usage['cache_read_input_tokens'] == 6
+

--- a/kolega_code/agent/tests/llm/test_model_specs.py
+++ b/kolega_code/agent/tests/llm/test_model_specs.py
@@ -1,4 +1,4 @@
-from kolega_code.llm.specs import get_model_specs
+from kolega_code.llm.specs import get_model_specs, thinking_effort_options
 
 
 def test_kimi_k27_code_model_specs():
@@ -29,3 +29,23 @@ def test_deepseek_v4_pro_model_specs():
     assert specs["default_temperature"] == 1.0
     assert specs["thinking_effort"].options == ("none", "high", "max")
     assert specs["thinking_effort"].default == "high"
+
+
+def test_fireworks_serverless_model_specs():
+    expected = {
+        "accounts/fireworks/models/glm-5p2": (1048576, 131072),
+        "accounts/fireworks/models/glm-5p1": (202800, 131072),
+        "accounts/fireworks/models/kimi-k2p7-code": (262144, 262144),
+        "accounts/fireworks/models/deepseek-v4-pro": (1048576, 384000),
+        "accounts/fireworks/models/deepseek-v4-flash": (1048576, 384000),
+        "accounts/fireworks/models/minimax-m3": (512000, 512000),
+        "accounts/fireworks/models/qwen3p7-plus": (262144, 65536),
+    }
+
+    for model, (context_length, max_completion_tokens) in expected.items():
+        specs = get_model_specs("fireworks", model)
+        assert specs["context_length"] == context_length
+        assert specs["max_completion_tokens"] == max_completion_tokens
+        assert specs["default_temperature"] == 1.0
+        assert thinking_effort_options("fireworks", model) == ("none", "low", "medium", "high", "max")
+        assert specs["thinking_effort"].default == "medium"

--- a/kolega_code/agent/tests/llm/test_openai_message_conversion.py
+++ b/kolega_code/agent/tests/llm/test_openai_message_conversion.py
@@ -1,6 +1,6 @@
 import pytest
 
-from kolega_code.llm.models import Message, MessageHistory, ToolCall, ToolResult, TextBlock
+from kolega_code.llm.models import Message, MessageChunk, MessageHistory, ThinkingBlock, ToolCall, ToolResult, TextBlock
 
 
 # TODO: Fix after qwen-3-coder-plus PR is merged - needs tool result filtering in Message.to_openai()
@@ -27,4 +27,48 @@ def test_mixed_content_splits_tool_result_to_separate_tool_messages():
     assert 'content' in messages[1]
 
 
+def test_openai_message_reasoning_content_maps_to_thinking_block():
+    class OpenAIMessage:
+        content = 'final answer'
+        reasoning_content = 'internal reasoning summary'
+        tool_calls = None
+
+    message = Message.from_openai(OpenAIMessage())
+
+    assert isinstance(message.content[0], ThinkingBlock)
+    assert message.content[0].thinking == 'internal reasoning summary'
+    assert isinstance(message.content[1], TextBlock)
+    assert message.content[1].text == 'final answer'
+
+
+def test_openai_stream_reasoning_content_maps_to_thinking_block():
+    message = Message.from_openai_stream(
+        role='assistant',
+        reasoning_content='streamed reasoning',
+        content='streamed answer',
+        stop_reason='stop',
+    )
+
+    assert isinstance(message.content[0], ThinkingBlock)
+    assert message.content[0].thinking == 'streamed reasoning'
+    assert isinstance(message.content[1], TextBlock)
+    assert message.content[1].text == 'streamed answer'
+    assert message.stop_reason == 'end_turn'
+
+
+def test_openai_stream_chunk_reasoning_content_delta_maps_to_thinking_chunk():
+    class Delta:
+        content = None
+        reasoning_content = 'reasoning delta'
+
+    class Choice:
+        delta = Delta()
+
+    class Chunk:
+        choices = [Choice()]
+
+    chunk = MessageChunk.from_openai(Chunk())
+
+    assert chunk.type == 'thinking'
+    assert chunk.thinking == 'reasoning delta'
 

--- a/kolega_code/agent/tests/llm/test_thinking_effort.py
+++ b/kolega_code/agent/tests/llm/test_thinking_effort.py
@@ -23,6 +23,14 @@ def test_model_specs_expose_provider_specific_thinking_efforts() -> None:
     assert default_thinking_effort("zai", "glm-5.1") == "auto"
     assert thinking_effort_options("kimi_coding", "kimi-for-coding") == ("auto", "none")
     assert default_thinking_effort("kimi_coding", "kimi-for-coding") == "auto"
+    assert thinking_effort_options("fireworks", "accounts/fireworks/models/glm-5p2") == (
+        "none", "low", "medium", "high", "max"
+    )
+    assert default_thinking_effort("fireworks", "accounts/fireworks/models/glm-5p2") == "medium"
+    assert thinking_effort_options("fireworks", "accounts/fireworks/models/deepseek-v4-pro") == (
+        "none", "low", "medium", "high", "max"
+    )
+    assert default_thinking_effort("fireworks", "accounts/fireworks/models/deepseek-v4-pro") == "medium"
 
 
 def test_anthropic_opus_effort_uses_adaptive_thinking_without_budget_tokens() -> None:
@@ -106,6 +114,24 @@ def test_kimi_coding_thinking_toggle_serialization() -> None:
     disabled = {"model": "kimi-for-coding"}
     provider._apply_thinking_params(disabled, GenerationParams(thinking="none"))
     assert disabled == {"model": "kimi-for-coding", "thinking": {"type": "disabled"}}
+
+
+def test_fireworks_openai_reasoning_effort_serialization() -> None:
+    provider = OpenAIProvider(api_key="test-key", provider_name="fireworks")
+
+    high_params = {"model": "accounts/fireworks/models/glm-5p2"}
+    provider._apply_thinking_params(high_params, GenerationParams(thinking="high"))
+    assert high_params == {
+        "model": "accounts/fireworks/models/glm-5p2",
+        "reasoning_effort": "high",
+    }
+
+    disabled_params = {"model": "accounts/fireworks/models/glm-5p2"}
+    provider._apply_thinking_params(disabled_params, GenerationParams(thinking="none"))
+    assert disabled_params == {
+        "model": "accounts/fireworks/models/glm-5p2",
+        "reasoning_effort": "none",
+    }
 
 
 def test_google_gemini_3_pro_uses_thinking_level() -> None:

--- a/kolega_code/cli/provider_registry.py
+++ b/kolega_code/cli/provider_registry.py
@@ -71,8 +71,13 @@ MODEL_LABELS: dict[str, str] = {
     "grok-4.3": "Grok 4.3",
     "grok-build-0.1": "Grok Build 0.1",
     # Fireworks
+    "accounts/fireworks/models/glm-5p2": "GLM-5.2",
     "accounts/fireworks/models/glm-5p1": "GLM-5.1",
     "accounts/fireworks/models/kimi-k2p7-code": "Kimi K2.7 Code",
+    "accounts/fireworks/models/deepseek-v4-pro": "DeepSeek V4 Pro",
+    "accounts/fireworks/models/deepseek-v4-flash": "DeepSeek V4 Flash",
+    "accounts/fireworks/models/minimax-m3": "MiniMax M3",
+    "accounts/fireworks/models/qwen3p7-plus": "Qwen 3.7 Plus",
     # Together
     "moonshotai/Kimi-K2.7-Code": "Kimi K2.7 Code",
     "zai-org/GLM-5.1": "GLM-5.1",
@@ -93,7 +98,7 @@ PROVIDER_DEFAULT_MODEL: dict[ModelProvider, str] = {
     ModelProvider.OPENAI_CHATGPT: "gpt-5.5",
     ModelProvider.GOOGLE: "gemini-3.1-pro-preview",
     ModelProvider.XAI: "grok-4.3",
-    ModelProvider.FIREWORKS: "accounts/fireworks/models/glm-5p1",
+    ModelProvider.FIREWORKS: "accounts/fireworks/models/glm-5p2",
     ModelProvider.TOGETHER: "moonshotai/Kimi-K2.7-Code",
     ModelProvider.DASHSCOPE: "qwen3-coder-plus",
 }

--- a/kolega_code/cli/tests/test_provider_registry.py
+++ b/kolega_code/cli/tests/test_provider_registry.py
@@ -1,0 +1,19 @@
+from kolega_code.cli.provider_registry import default_model_for_provider, ui_model_options
+from kolega_code.config import ModelProvider
+
+
+def test_fireworks_ui_model_options_include_serverless_catalog():
+    options = dict(ui_model_options("fireworks"))
+
+    assert options["GLM-5.2"] == "accounts/fireworks/models/glm-5p2"
+    assert options["GLM-5.1"] == "accounts/fireworks/models/glm-5p1"
+    assert options["Kimi K2.7 Code"] == "accounts/fireworks/models/kimi-k2p7-code"
+    assert options["DeepSeek V4 Pro"] == "accounts/fireworks/models/deepseek-v4-pro"
+    assert options["DeepSeek V4 Flash"] == "accounts/fireworks/models/deepseek-v4-flash"
+    assert options["MiniMax M3"] == "accounts/fireworks/models/minimax-m3"
+    assert options["Qwen 3.7 Plus"] == "accounts/fireworks/models/qwen3p7-plus"
+    assert "Gemma 4 31B IT" not in options
+
+
+def test_fireworks_default_model_is_glm_52():
+    assert default_model_for_provider(ModelProvider.FIREWORKS) == "accounts/fireworks/models/glm-5p2"

--- a/kolega_code/llm/instrumented_client.py
+++ b/kolega_code/llm/instrumented_client.py
@@ -254,7 +254,7 @@ class InstrumentedLLMClient(LLMClient):
                         "cache_read_input_tokens": usage_details.get("cache_read_input_tokens", 0),
                         "cache_creation_input_tokens": usage_details.get("cache_write_input_tokens", 0),
                     }
-                elif provider == "openai":
+                elif provider in ["openai", "fireworks"]:
                     normalized_usage = {
                         "input": usage_details.get("prompt_tokens", 0),
                         "output": usage_details.get("completion_tokens", 0),
@@ -503,7 +503,7 @@ class MinimalLangfuseStreamWrapper:
                 "cache_read_input_tokens": usage_metadata.get("cache_read_input_tokens", 0),
                 "cache_creation_input_tokens": usage_metadata.get("cache_write_input_tokens", 0),
             }
-        elif provider == "openai":
+        elif provider in ["openai", "fireworks"]:
             return {
                 "input": usage_metadata.get("prompt_tokens", 0),
                 "output": usage_metadata.get("completion_tokens", 0),

--- a/kolega_code/llm/models.py
+++ b/kolega_code/llm/models.py
@@ -769,6 +769,12 @@ class MessageChunk:
         """
         delta = chunk.choices[0].delta
 
+        # Fireworks and other OpenAI-compatible reasoning models stream their
+        # reasoning separately from answer text.
+        reasoning_content = getattr(delta, "reasoning_content", None)
+        if reasoning_content:
+            return cls(type="thinking", thinking=reasoning_content)
+
         # Handle text content
         if delta.content is not None:
             return cls(type="text", text=delta.content)
@@ -971,6 +977,12 @@ class Message:
         content_blocks = []
         tool_use_blocks = []
 
+        # OpenAI-compatible reasoning models (including Fireworks via Chat
+        # Completions) may return reasoning separately from answer text.
+        reasoning_content = getattr(message, "reasoning_content", None)
+        if reasoning_content:
+            content_blocks.append(ThinkingBlock(thinking=reasoning_content))
+
         # Handle content
         if hasattr(message, "content") and message.content:
             content_blocks.append(TextBlock(text=message.content))
@@ -1061,6 +1073,7 @@ class Message:
         cls,
         role: str,
         content: str,
+        reasoning_content: str = "",
         tool_calls: Optional[list] = None,
         stop_reason: Optional[str] = None,
         tool_execution_ids: Optional[ToolExecutionIdRegistry] = None,
@@ -1070,6 +1083,7 @@ class Message:
 
         Args:
             content: The content text from the OpenAI message
+            reasoning_content: Reasoning text from OpenAI-compatible reasoning models, if any
             tool_calls: List of tool calls from the OpenAI message, if any
             stop_reason: The reason why the generation stopped
 
@@ -1086,6 +1100,11 @@ class Message:
         tool_execution_ids = tool_execution_ids or ToolExecutionIdRegistry()
         content_blocks = []
         tool_use_blocks = []
+
+        # Handle reasoning content before answer text, matching Anthropic's
+        # thinking-then-text block order.
+        if reasoning_content:
+            content_blocks.append(ThinkingBlock(thinking=reasoning_content))
 
         # Handle content
         if content:

--- a/kolega_code/llm/providers/anthropic.py
+++ b/kolega_code/llm/providers/anthropic.py
@@ -112,7 +112,7 @@ class AnthropicProvider(BaseLLMProvider):
         self.async_client = AsyncAnthropic(api_key=api_key, base_url=base_url, max_retries=max_retries)
         self.sync_client = Anthropic(api_key=api_key, base_url=base_url, max_retries=max_retries)
         
-        # OpenAI-compatible Anthropic-shaped APIs do not expose messages/count_tokens,
+        # Anthropic-shaped compatible APIs generally do not expose messages/count_tokens,
         # so local counting is only a preflight context-size estimate for those models.
         # Billing/accounting must use provider response usage metadata instead.
         self.use_local_token_counting = (

--- a/kolega_code/llm/providers/openai.py
+++ b/kolega_code/llm/providers/openai.py
@@ -14,13 +14,15 @@ from .models import GenerationParams, TokenCount
 
 
 class OpenAIStreamWrapper:
-    def __init__(self, openai_stream, requested_include_usage: bool = False):
+    def __init__(self, openai_stream, requested_include_usage: bool = False, provider_name: str = "openai"):
         self.openai_stream = openai_stream
         self.final_content = ""
+        self.final_reasoning_content = ""
         self.final_tool_calls = {}
         self.stop_reason = None
         self.usage_data = None
         self.tool_execution_ids = ToolExecutionIdRegistry()
+        self.provider_name = provider_name
 
         self._closed = False
         self._requested_include_usage = requested_include_usage
@@ -53,6 +55,10 @@ class OpenAIStreamWrapper:
                     content = getattr(delta, "content", None) or ""
                     if content:
                         self.final_content += content
+
+                    reasoning_content = getattr(delta, "reasoning_content", None) or ""
+                    if reasoning_content:
+                        self.final_reasoning_content += reasoning_content
 
                     for tool_call in getattr(delta, "tool_calls", []) or []:
                         index = tool_call.index
@@ -99,6 +105,7 @@ class OpenAIStreamWrapper:
         message = Message.from_openai_stream(
             role="assistant",
             content=self.final_content,
+            reasoning_content=self.final_reasoning_content,
             tool_calls=self.final_tool_calls,
             stop_reason=self.stop_reason,
             tool_execution_ids=self.tool_execution_ids,
@@ -107,7 +114,8 @@ class OpenAIStreamWrapper:
         # Add usage data if available
         if self.usage_data:
             message.usage_metadata.update(self.usage_data)
-        else:
+        message.usage_metadata["provider"] = self.provider_name
+        if not self.usage_data:
             logger = logging.getLogger(__name__)
             if self._requested_include_usage:
                 logger.warning(
@@ -328,6 +336,7 @@ class OpenAIProvider(BaseLLMProvider):
         return OpenAIStreamWrapper(
             await self.async_client.chat.completions.create(messages=messages.to_openai(), **generation_params),
             requested_include_usage=True,
+            provider_name=self.provider_name,
         )
 
     async def generate(
@@ -358,6 +367,7 @@ class OpenAIProvider(BaseLLMProvider):
 
         # Extract message and add usage data
         message = Message.from_openai(response.choices[0].message)
+        message.usage_metadata["provider"] = self.provider_name
 
         # Add usage data from the response
         if hasattr(response, "usage") and response.usage:

--- a/kolega_code/llm/specs.py
+++ b/kolega_code/llm/specs.py
@@ -242,9 +242,79 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         ),
     },
     ("xai", "grok-build-0.1"): {"context_length": 256000, "max_completion_tokens": 16384, "default_temperature": 0.6},
-    # Fireworks models
-    ("fireworks", "accounts/fireworks/models/glm-5p1"): {"context_length": 202752, "max_completion_tokens": 16384, "default_temperature": 1.0},
-    ("fireworks", "accounts/fireworks/models/kimi-k2p7-code"): {"context_length": 262144, "max_completion_tokens": 16384, "default_temperature": 1.0},
+    # Fireworks models (OpenAI-compatible endpoint). Fireworks reasoning models
+    # expose reasoning_content in responses and accept flat reasoning_effort
+    # values on chat completions. "none" disables reasoning.
+    ("fireworks", "accounts/fireworks/models/glm-5p2"): {
+        "context_length": 1048576,
+        "max_completion_tokens": 131072,
+        "default_temperature": 1.0,
+        "thinking_effort": ThinkingEffortSpec(
+            options=("none", "low", "medium", "high", "max"),
+            default="medium",
+            mode="openai_reasoning_effort",
+        ),
+    },
+    ("fireworks", "accounts/fireworks/models/glm-5p1"): {
+        "context_length": 202800,
+        "max_completion_tokens": 131072,
+        "default_temperature": 1.0,
+        "thinking_effort": ThinkingEffortSpec(
+            options=("none", "low", "medium", "high", "max"),
+            default="medium",
+            mode="openai_reasoning_effort",
+        ),
+    },
+    ("fireworks", "accounts/fireworks/models/kimi-k2p7-code"): {
+        "context_length": 262144,
+        "max_completion_tokens": 262144,
+        "default_temperature": 1.0,
+        "thinking_effort": ThinkingEffortSpec(
+            options=("none", "low", "medium", "high", "max"),
+            default="medium",
+            mode="openai_reasoning_effort",
+        ),
+    },
+    ("fireworks", "accounts/fireworks/models/deepseek-v4-pro"): {
+        "context_length": 1048576,
+        "max_completion_tokens": 384000,
+        "default_temperature": 1.0,
+        "thinking_effort": ThinkingEffortSpec(
+            options=("none", "low", "medium", "high", "max"),
+            default="medium",
+            mode="openai_reasoning_effort",
+        ),
+    },
+    ("fireworks", "accounts/fireworks/models/deepseek-v4-flash"): {
+        "context_length": 1048576,
+        "max_completion_tokens": 384000,
+        "default_temperature": 1.0,
+        "thinking_effort": ThinkingEffortSpec(
+            options=("none", "low", "medium", "high", "max"),
+            default="medium",
+            mode="openai_reasoning_effort",
+        ),
+    },
+    ("fireworks", "accounts/fireworks/models/minimax-m3"): {
+        "context_length": 512000,
+        "max_completion_tokens": 512000,
+        "default_temperature": 1.0,
+        "thinking_effort": ThinkingEffortSpec(
+            options=("none", "low", "medium", "high", "max"),
+            default="medium",
+            mode="openai_reasoning_effort",
+        ),
+    },
+    ("fireworks", "accounts/fireworks/models/qwen3p7-plus"): {
+        "context_length": 262144,
+        "max_completion_tokens": 65536,
+        "default_temperature": 1.0,
+        "thinking_effort": ThinkingEffortSpec(
+            options=("none", "low", "medium", "high", "max"),
+            default="medium",
+            mode="openai_reasoning_effort",
+        ),
+    },
     # DashScope / Qwen models
     ("dashscope", "qwen3-coder-plus"): {"context_length": 1000000, "max_completion_tokens": 65536, "default_temperature": 0.7},
     ("dashscope", "qwen3-coder-flash"): {"context_length": 1000000, "max_completion_tokens": 65536, "default_temperature": 0.7},
@@ -391,6 +461,8 @@ def build_thinking_request_params(provider: str, model_name: str, effort: Option
         return {"thinking_config": {"thinking_level": normalized}}
 
     if spec.mode == "openai_reasoning_effort":
+        # OpenAI-compatible reasoning APIs use a flat reasoning_effort field.
+        # Fireworks additionally accepts "none" to disable reasoning.
         return {"reasoning_effort": normalized}
 
     if spec.mode == "openai_responses_reasoning":


### PR DESCRIPTION
## Summary
- switch Fireworks to the OpenAI-compatible inference endpoint
- add Fireworks serverless reasoning model specs, labels, defaults, and docs
- preserve OpenAI-compatible reasoning_content as thinking blocks for streaming and non-streaming responses
- normalize usage with the actual provider name for reused OpenAI-compatible providers

## Verification
- Live Fireworks API probes for GLM-5.2 reasoning_effort values: none, low, medium, high, max
- Live OpenAIProvider-backed model probes for OpenAI, Together, xAI, and DashScope models configured in MODEL_SPECS
- pytest kolega_code/agent/tests/llm/test_model_specs.py kolega_code/agent/tests/llm/test_thinking_effort.py kolega_code/agent/tests/llm/test_client.py::test_fireworks_uses_openai_compatible_provider kolega_code/agent/tests/llm/test_client.py::test_fireworks_generate_maps_openai_provider_response_usage kolega_code/agent/tests/llm/test_client.py::test_fireworks_stream_final_message_maps_openai_usage kolega_code/agent/tests/llm/test_langfuse_normalization.py kolega_code/agent/tests/llm/test_openai_message_conversion.py kolega_code/agent/tests/llm/test_openai_cached_tokens_stream.py kolega_code/cli/tests/test_provider_registry.py kolega_code/cli/tests/test_cli_config.py
