### PR TITLE
feat: add image/vision support for chat input and agent tools

### DIFF
--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -509,7 +509,8 @@ class BaseAgent(LogMixin):
 
         return (
             f"{self.primary_model_config.model} does not support image input. "
-            "Remove the image or switch to a vision-capable model for this request."
+            "Your message was not sent to the model. "
+            "Remove the image attachment or switch to a vision-capable model with /model."
         )
 
     def _attachment_blocks(self, attachments: Optional[List[Dict[str, Any]]]) -> List[Any]:

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -15,7 +15,7 @@ from .compression import CompactionResult, HistoryCompressor
 from kolega_code.config import AgentConfig, ModelProvider
 from kolega_code.events import AgentConnectionManager
 from .context import AgentContext, AgentServices, Telemetry, WorkspaceInfo
-from .conversation import Conversation, replace_image_blocks_with_placeholders
+from .conversation import Conversation, adapt_history_for_provider
 from kolega_code.events import AgentEventEmitter
 from kolega_code.hooks import (
     NO_OP_DISPATCHER,
@@ -377,8 +377,13 @@ class BaseAgent(LogMixin):
         """
         effective = self.get_effective_history_for_llm()
         fixed = self.fix_incomplete_tool_calls(list(effective))
-        if not self.supports_vision:
-            fixed = replace_image_blocks_with_placeholders(fixed, self.primary_model_config.model)
+        provider = getattr(self.primary_model_config.provider, "value", self.primary_model_config.provider)
+        fixed = adapt_history_for_provider(
+            fixed,
+            target_provider=str(provider),
+            target_model=self.primary_model_config.model,
+            supports_vision=self.supports_vision,
+        )
         return MessageHistory(fixed)
 
     def mark_cache_checkpoint(self) -> None:

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -15,7 +15,7 @@ from .compression import CompactionResult, HistoryCompressor
 from kolega_code.config import AgentConfig, ModelProvider
 from kolega_code.events import AgentConnectionManager
 from .context import AgentContext, AgentServices, Telemetry, WorkspaceInfo
-from .conversation import Conversation
+from .conversation import Conversation, replace_image_blocks_with_placeholders
 from kolega_code.events import AgentEventEmitter
 from kolega_code.hooks import (
     NO_OP_DISPATCHER,
@@ -366,6 +366,21 @@ class BaseAgent(LogMixin):
         """
         return self.conversation.repaired(messages)
 
+    def _history_for_llm(self) -> MessageHistory:
+        """Build the message history to send to the LLM for this turn.
+
+        Compaction-aware and tool-call-repaired. For non-vision models, any
+        ``ImageBlock`` carried over from earlier turns (user attachments or
+        ``read_image`` tool results) is replaced with a text placeholder on this
+        request copy only — the stored history is never mutated, so switching
+        back to a vision-capable model restores the images.
+        """
+        effective = self.get_effective_history_for_llm()
+        fixed = self.fix_incomplete_tool_calls(list(effective))
+        if not self.supports_vision:
+            fixed = replace_image_blocks_with_placeholders(fixed, self.primary_model_config.model)
+        return MessageHistory(fixed)
+
     def mark_cache_checkpoint(self) -> None:
         """
         Mark the last message in history for caching and remove cache_control from all other messages.
@@ -522,9 +537,9 @@ class BaseAgent(LogMixin):
 
     async def count_current_context(self) -> TokenCount:
         self._sanitize_oversized_tool_results()
-        # Fix history before counting to get accurate count for what LLM will see
-        effective = self.get_effective_history_for_llm()
-        fixed_history = MessageHistory(self.fix_incomplete_tool_calls(list(effective)))
+        # History sent to the LLM (and to token counting): tool-call-repaired and,
+        # for non-vision models, stripped of image blocks from earlier turns.
+        fixed_history = self._history_for_llm()
         token_count = await self.llm.count_tokens(
             system=self.system_prompt,
             messages=fixed_history,
@@ -1308,9 +1323,9 @@ class BaseAgent(LogMixin):
                 response_uuid = str(uuid.uuid4())
                 thinking_uuid = str(uuid.uuid4())
 
-                # Fix history before sending to LLM to ensure valid tool call sequences
-                effective = self.get_effective_history_for_llm()
-                fixed_history = MessageHistory(self.fix_incomplete_tool_calls(list(effective)))
+                # History sent to the LLM: tool-call-repaired and, for non-vision
+                # models, stripped of image blocks carried over from earlier turns.
+                fixed_history = self._history_for_llm()
 
                 async with await self.llm.stream(
                     system=self.system_prompt,

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -34,7 +34,7 @@ from kolega_code.llm.exceptions import (
 )
 from kolega_code.llm.models import ImageBlock, Message, MessageHistory, TextBlock, ToolCall, ToolResult
 from kolega_code.llm.providers.models import TokenCount
-from kolega_code.llm.specs import get_model_specs
+from kolega_code.llm.specs import get_model_specs, supports_vision as model_supports_vision
 from kolega_code.permissions import (
     PermissionDecision,
     PermissionMode,
@@ -90,10 +90,6 @@ class BaseAgent(LogMixin):
     long_content_tool_calls = ["create_file", "replace_entire_file"]
     max_tool_result_chars_in_history = 100_000
     skill_content_pattern = re.compile(r'<skill_content name="[^"]+">')
-    deepseek_image_unsupported_message = (
-        "DeepSeek V4 Pro does not support image input via the DeepSeek API. "
-        "Remove the image or switch to a vision-capable model for this request."
-    )
 
     def __init__(
         self,
@@ -270,6 +266,11 @@ class BaseAgent(LogMixin):
         self.model_context_length = model_specs["context_length"]
         self.model_completion_tokens = model_specs["max_completion_tokens"]
         self.model_default_temperature = model_specs.get("default_temperature", 1.0)
+        # Whether this agent's primary model can accept image input. Read by the
+        # ToolCollection read_image tool gate (so non-vision models never see the
+        # tool) and used by _unsupported_attachment_message to reject image
+        # attachments for non-vision models with a clear message.
+        self.supports_vision = bool(model_specs.get("supports_vision", False))
 
         self.llm = context.create_llm_client(agent_name=self.agent_name)
 
@@ -480,18 +481,21 @@ class BaseAgent(LogMixin):
     # ------------------------------------------------------------------
 
     def _unsupported_attachment_message(self, attachments: Optional[List[Dict[str, Any]]]) -> Optional[str]:
+        if not any(attachment.get("type") == "image" for attachment in attachments or []):
+            return None
+
         provider = getattr(
             self.primary_model_config.provider,
             "value",
             self.primary_model_config.provider,
         )
-        if provider != ModelProvider.DEEPSEEK.value:
+        if model_supports_vision(provider, self.primary_model_config.model):
             return None
 
-        if any(attachment.get("type") == "image" for attachment in attachments or []):
-            return self.deepseek_image_unsupported_message
-
-        return None
+        return (
+            f"{self.primary_model_config.model} does not support image input. "
+            "Remove the image or switch to a vision-capable model for this request."
+        )
 
     def _attachment_blocks(self, attachments: Optional[List[Dict[str, Any]]]) -> List[Any]:
         """Convert attachment payloads into content blocks for a user message."""

--- a/kolega_code/agent/conversation.py
+++ b/kolega_code/agent/conversation.py
@@ -11,7 +11,16 @@ import logging
 import re
 from typing import Any, Dict, List, Optional
 
-from kolega_code.llm.models import ImageBlock, Message, MessageHistory, TextBlock, ToolCall, ToolResult
+from kolega_code.llm.models import (
+    ImageBlock,
+    Message,
+    MessageHistory,
+    RedactedThinkingBlock,
+    TextBlock,
+    ThinkingBlock,
+    ToolCall,
+    ToolResult,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +42,32 @@ def count_image_blocks(messages: List[Message]) -> int:
             elif isinstance(block, ToolResult) and isinstance(block.content, list):
                 count += sum(1 for inner in block.content if isinstance(inner, ImageBlock))
     return count
+
+
+def _provider_value(provider: Any) -> str:
+    value = getattr(provider, "value", provider)
+    return str(value or "")
+
+
+def _message_with_content(message: Message, content: List[Any]) -> Message:
+    return Message(
+        role=message.role,
+        content=content,
+        stop_reason=message.stop_reason,
+        tool_calls=message.tool_calls,
+        usage_metadata=message.usage_metadata,
+    )
+
+
+def _tool_result_with_content(tool_result: ToolResult, content: List[Any]) -> ToolResult:
+    return ToolResult(
+        tool_use_id=tool_result.tool_use_id,
+        content=content,
+        name=tool_result.name,
+        is_error=tool_result.is_error,
+        cache_checkpoint=tool_result.cache_checkpoint,
+        execution_id=tool_result.execution_id,
+    )
 
 
 def replace_image_blocks_with_placeholders(messages: List[Message], model_name: str) -> List[Message]:
@@ -65,34 +100,104 @@ def replace_image_blocks_with_placeholders(messages: List[Message], model_name: 
                     else:
                         inner_new.append(inner)
                 if inner_changed:
-                    new_blocks.append(
-                        ToolResult(
-                            tool_use_id=block.tool_use_id,
-                            content=inner_new,
-                            name=block.name,
-                            is_error=block.is_error,
-                            cache_checkpoint=block.cache_checkpoint,
-                            execution_id=block.execution_id,
-                        )
-                    )
+                    new_blocks.append(_tool_result_with_content(block, inner_new))
                     changed = True
                 else:
                     new_blocks.append(block)
             else:
                 new_blocks.append(block)
         if changed:
-            result.append(
-                Message(
-                    role=message.role,
-                    content=new_blocks,
-                    stop_reason=message.stop_reason,
-                    tool_calls=message.tool_calls,
-                    usage_metadata=message.usage_metadata,
-                )
-            )
+            result.append(_message_with_content(message, new_blocks))
         else:
             result.append(message)
     return result
+
+
+def _preserve_reasoning_block(block: Any, *, source_provider: str, target_provider: str) -> bool:
+    if target_provider == "anthropic":
+        return source_provider == "anthropic"
+    if target_provider in {"moonshot", "kimi_coding"}:
+        return source_provider == target_provider
+    return False
+
+
+def _reasoning_placeholder(block: Any, source_provider: str) -> TextBlock:
+    source = source_provider or "unknown provider"
+    if isinstance(block, RedactedThinkingBlock):
+        return TextBlock(text=f"[Prior redacted reasoning from {source} omitted for compatibility.]")
+    return TextBlock(text=f"[Prior reasoning from {source} omitted for compatibility.]")
+
+
+def _adapt_content_blocks_for_provider(
+    blocks: List[Any], *, source_provider: str, target_provider: str, target_model: str, supports_vision: bool
+) -> tuple[List[Any], bool]:
+    adapted: List[Any] = []
+    changed = False
+
+    for block in blocks:
+        if isinstance(block, ImageBlock) and not supports_vision:
+            adapted.append(TextBlock(text=_image_placeholder(block.media_type, target_model)))
+            changed = True
+        elif isinstance(block, (ThinkingBlock, RedactedThinkingBlock)):
+            if _preserve_reasoning_block(block, source_provider=source_provider, target_provider=target_provider):
+                adapted.append(block)
+            else:
+                adapted.append(_reasoning_placeholder(block, source_provider))
+                changed = True
+        elif isinstance(block, ToolResult) and isinstance(block.content, list):
+            inner, inner_changed = _adapt_content_blocks_for_provider(
+                block.content,
+                source_provider=source_provider,
+                target_provider=target_provider,
+                target_model=target_model,
+                supports_vision=supports_vision,
+            )
+            if inner_changed:
+                adapted.append(_tool_result_with_content(block, inner))
+                changed = True
+            else:
+                adapted.append(block)
+        else:
+            adapted.append(block)
+
+    return adapted, changed
+
+
+def adapt_history_for_provider(
+    messages: List[Message], *, target_provider: str, target_model: str, supports_vision: bool
+) -> List[Message]:
+    """Return a request-safe history for the target provider without mutating storage.
+
+    Provider-managed reasoning blocks (Anthropic/Moonshot/Kimi thinking) are not
+    portable across providers. Keep only native reasoning for the same provider;
+    convert foreign or unknown reasoning blocks to text placeholders. Image blocks
+    are preserved for vision models and replaced with placeholders for non-vision
+    models, matching the previous image compatibility behavior.
+    """
+    target_provider = _provider_value(target_provider)
+    result: List[Message] = []
+    changed_any = False
+
+    for message in messages:
+        if not isinstance(message.content, list):
+            result.append(message)
+            continue
+
+        source_provider = _provider_value((message.usage_metadata or {}).get("provider"))
+        adapted_content, changed = _adapt_content_blocks_for_provider(
+            message.content,
+            source_provider=source_provider,
+            target_provider=target_provider,
+            target_model=target_model,
+            supports_vision=supports_vision,
+        )
+        if changed:
+            result.append(_message_with_content(message, adapted_content))
+            changed_any = True
+        else:
+            result.append(message)
+
+    return result if changed_any else messages
 
 
 class Conversation:

--- a/kolega_code/agent/conversation.py
+++ b/kolega_code/agent/conversation.py
@@ -11,9 +11,88 @@ import logging
 import re
 from typing import Any, Dict, List, Optional
 
-from kolega_code.llm.models import Message, MessageHistory, TextBlock, ToolCall, ToolResult
+from kolega_code.llm.models import ImageBlock, Message, MessageHistory, TextBlock, ToolCall, ToolResult
 
 logger = logging.getLogger(__name__)
+
+
+def _image_placeholder(media_type: str, model_name: str) -> str:
+    """Text substituted for an image block when the active model can't see images."""
+    return f"[An image ({media_type}) was shared earlier in this thread but is not visible to {model_name}.]"
+
+
+def count_image_blocks(messages: List[Message]) -> int:
+    """Count ``ImageBlock`` instances across messages, including ones nested in tool results."""
+    count = 0
+    for message in messages:
+        if not isinstance(message.content, list):
+            continue
+        for block in message.content:
+            if isinstance(block, ImageBlock):
+                count += 1
+            elif isinstance(block, ToolResult) and isinstance(block.content, list):
+                count += sum(1 for inner in block.content if isinstance(inner, ImageBlock))
+    return count
+
+
+def replace_image_blocks_with_placeholders(messages: List[Message], model_name: str) -> List[Message]:
+    """Return a new message list with every ``ImageBlock`` replaced by a text placeholder.
+
+    Non-mutating: messages without images are returned as-is. When a replacement
+    occurs, new ``Message``/``ToolResult`` objects are built so the caller's stored
+    history is never altered — switching back to a vision-capable model restores
+    the original images. ``ImageBlock``s nested inside a ``ToolResult.content`` list
+    (e.g. from the ``read_image`` tool) are handled too.
+    """
+    result: List[Message] = []
+    for message in messages:
+        if not isinstance(message.content, list):
+            result.append(message)
+            continue
+        new_blocks: List[Any] = []
+        changed = False
+        for block in message.content:
+            if isinstance(block, ImageBlock):
+                new_blocks.append(TextBlock(text=_image_placeholder(block.media_type, model_name)))
+                changed = True
+            elif isinstance(block, ToolResult) and isinstance(block.content, list):
+                inner_new: List[Any] = []
+                inner_changed = False
+                for inner in block.content:
+                    if isinstance(inner, ImageBlock):
+                        inner_new.append(TextBlock(text=_image_placeholder(inner.media_type, model_name)))
+                        inner_changed = True
+                    else:
+                        inner_new.append(inner)
+                if inner_changed:
+                    new_blocks.append(
+                        ToolResult(
+                            tool_use_id=block.tool_use_id,
+                            content=inner_new,
+                            name=block.name,
+                            is_error=block.is_error,
+                            cache_checkpoint=block.cache_checkpoint,
+                            execution_id=block.execution_id,
+                        )
+                    )
+                    changed = True
+                else:
+                    new_blocks.append(block)
+            else:
+                new_blocks.append(block)
+        if changed:
+            result.append(
+                Message(
+                    role=message.role,
+                    content=new_blocks,
+                    stop_reason=message.stop_reason,
+                    tool_calls=message.tool_calls,
+                    usage_metadata=message.usage_metadata,
+                )
+            )
+        else:
+            result.append(message)
+    return result
 
 
 class Conversation:
@@ -74,6 +153,14 @@ class Conversation:
         self._history = MessageHistory([])
         self.summary = None
         self.compacted_through = 0
+
+    def has_image_blocks(self) -> bool:
+        """True if the effective (compaction-aware) history still carries any images.
+
+        Images folded into a compaction summary are already gone, so this reflects
+        only what would actually be sent to the model.
+        """
+        return count_image_blocks(list(self.effective_history())) > 0
 
     # ------------------------------------------------------------------
     # Appending

--- a/kolega_code/agent/tests/llm/test_chatgpt_oauth_provider.py
+++ b/kolega_code/agent/tests/llm/test_chatgpt_oauth_provider.py
@@ -89,6 +89,66 @@ def test_to_responses_input_image_and_system_skip():
     ]
 
 
+def test_to_responses_input_image_tool_result_adds_followup_user_image():
+    history = MessageHistory(
+        [
+            Message(role="assistant", content=[ToolCall(id="call_1", name="read_image", input={"path": "shot.png"})]),
+            Message(
+                role="user",
+                content=[
+                    ToolResult(
+                        tool_use_id="call_1",
+                        content=[ImageBlock(image_type="base64", media_type="image/png", data="BASE64")],
+                        name="read_image",
+                        is_error=False,
+                    )
+                ],
+            ),
+        ]
+    )
+
+    items = to_responses_input(history)
+
+    assert items[0]["type"] == "function_call"
+    assert items[1] == {
+        "type": "function_call_output",
+        "call_id": "call_1",
+        "output": "[read_image returned 1 image; attached in the following user message.]",
+    }
+    assert items[2]["role"] == "user"
+    assert items[2]["content"] == [
+        {"type": "input_text", "text": "Image returned by tool read_image for tool call call_1."},
+        {"type": "input_image", "image_url": "data:image/png;base64,BASE64"},
+    ]
+
+
+def test_to_responses_input_multiple_tool_outputs_before_image_followups():
+    history = MessageHistory(
+        [
+            Message(
+                role="user",
+                content=[
+                    ToolResult(
+                        tool_use_id="call_1",
+                        content=[ImageBlock(image_type="base64", media_type="image/png", data="BASE64")],
+                        name="read_image",
+                        is_error=False,
+                    ),
+                    ToolResult(tool_use_id="call_2", content="file contents", name="read_file", is_error=False),
+                ],
+            )
+        ]
+    )
+
+    items = to_responses_input(history)
+
+    assert [item.get("type") for item in items[:2]] == ["function_call_output", "function_call_output"]
+    assert items[0]["call_id"] == "call_1"
+    assert items[1]["call_id"] == "call_2"
+    assert items[2]["role"] == "user"
+    assert any(part.get("type") == "input_image" for part in items[2]["content"])
+
+
 def test_responses_tools_flattens_function_shape():
     tool = ToolDefinition(
         name="read_file",

--- a/kolega_code/agent/tests/llm/test_openai_message_conversion.py
+++ b/kolega_code/agent/tests/llm/test_openai_message_conversion.py
@@ -1,6 +1,9 @@
-import pytest
 
-from kolega_code.llm.models import Message, MessageChunk, MessageHistory, ThinkingBlock, ToolCall, ToolResult, TextBlock
+from kolega_code.llm.models import ImageBlock, Message, MessageChunk, MessageHistory, ThinkingBlock, ToolCall, ToolResult, TextBlock
+
+
+def _image() -> ImageBlock:
+    return ImageBlock(image_type="base64", media_type="image/png", data="BASE64")
 
 
 # TODO: Fix after qwen-3-coder-plus PR is merged - needs tool result filtering in Message.to_openai()
@@ -23,8 +26,71 @@ def test_mixed_content_splits_tool_result_to_separate_tool_messages():
 
     assert messages[1]['role'] == 'tool'
     assert messages[1]['tool_call_id'] == 'call_123'
-    # tool content can be a string or structured parts depending on our representation
-    assert 'content' in messages[1]
+    assert messages[1]['content'] == '3'
+
+
+def test_image_tool_result_serializes_as_tool_text_plus_user_image():
+    tool_call = ToolCall(id='call_img', name='read_image', input={'path': 'shot.png'})
+    assistant = Message(role='assistant', content=[tool_call])
+    result = Message(
+        role='user',
+        content=[ToolResult(tool_use_id='call_img', content=[_image()], name='read_image', is_error=False)],
+    )
+
+    messages = MessageHistory([assistant, result]).to_openai()
+
+    assert messages[0]['role'] == 'assistant'
+    assert messages[0]['tool_calls'][0]['id'] == 'call_img'
+    assert messages[1]['role'] == 'tool'
+    assert messages[1]['tool_call_id'] == 'call_img'
+    assert isinstance(messages[1]['content'], str)
+    assert 'image' in messages[1]['content']
+    assert 'image_url' not in messages[1]['content']
+    assert messages[2]['role'] == 'user'
+    assert messages[2]['content'][0]['type'] == 'text'
+    assert messages[2]['content'][1] == {
+        'type': 'image_url',
+        'image_url': {'url': 'data:image/png;base64,BASE64'},
+    }
+
+
+def test_mixed_text_and_image_tool_result_preserves_text_in_tool_output():
+    tool_call = ToolCall(id='call_img', name='read_image', input={'path': 'shot.png'})
+    result = ToolResult(
+        tool_use_id='call_img',
+        content=[TextBlock('caption text'), _image()],
+        name='read_image',
+        is_error=False,
+    )
+
+    messages = MessageHistory([
+        Message(role='assistant', content=[tool_call]),
+        Message(role='user', content=[result]),
+    ]).to_openai()
+
+    assert messages[1]['role'] == 'tool'
+    assert 'caption text' in messages[1]['content']
+    assert 'attached in the following user message' in messages[1]['content']
+    assert messages[2]['role'] == 'user'
+    assert any(part.get('type') == 'image_url' for part in messages[2]['content'])
+
+
+def test_multiple_tool_results_stay_contiguous_before_image_followup():
+    call_1 = ToolCall(id='call_1', name='read_image', input={'path': 'shot.png'})
+    call_2 = ToolCall(id='call_2', name='read_file', input={'path': 'README.md'})
+    result_1 = ToolResult(tool_use_id='call_1', content=[_image()], name='read_image', is_error=False)
+    result_2 = ToolResult(tool_use_id='call_2', content='file text', name='read_file', is_error=False)
+
+    messages = MessageHistory([
+        Message(role='assistant', content=[call_1, call_2]),
+        Message(role='user', content=[result_1, result_2]),
+    ]).to_openai()
+
+    assert [message['role'] for message in messages] == ['assistant', 'tool', 'tool', 'user']
+    assert messages[1]['tool_call_id'] == 'call_1'
+    assert messages[2]['tool_call_id'] == 'call_2'
+    assert messages[2]['content'] == 'file text'
+    assert any(part.get('type') == 'image_url' for part in messages[3]['content'])
 
 
 def test_openai_message_reasoning_content_maps_to_thinking_block():

--- a/kolega_code/agent/tests/llm/test_openai_token_counting.py
+++ b/kolega_code/agent/tests/llm/test_openai_token_counting.py
@@ -5,10 +5,7 @@ These tests verify that local tiktoken-based token counting is within reasonable
 of OpenAI's official API token counting, using real system prompts and tool definitions.
 """
 
-import json
 import os
-from pathlib import Path
-from typing import List
 from unittest.mock import Mock
 
 import pytest
@@ -16,15 +13,12 @@ from dotenv import load_dotenv
 
 from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
 from kolega_code.events import AgentConnectionManager
-from kolega_code.llm.client import LLMClient
 from kolega_code.llm.models import (
     ImageBlock,
     Message,
     MessageHistory,
     TextBlock,
     ToolCall,
-    ToolDefinition,
-    ToolParameter,
     ToolResult,
 )
 from kolega_code.llm.providers.openai import OpenAIProvider
@@ -231,6 +225,24 @@ def get_accuracy_threshold(api_count: int, has_tools: bool = False) -> float:
     return 10.0  # Moderate threshold for realistic contexts (OpenAI less predictable than Anthropic)
 
 
+@pytest.mark.asyncio
+async def test_nested_image_tool_result_contributes_image_tokens():
+    provider = OpenAIProvider(api_key="test")
+    image = ImageBlock(image_type="base64", media_type="image/png", data="A" * 100)
+    messages = MessageHistory(
+        [
+            Message(
+                "user",
+                [ToolResult(tool_use_id="call_img", name="read_image", content=[image], is_error=False)],
+            )
+        ]
+    )
+
+    result = await provider.count_tokens(messages=messages, tools=[])
+
+    assert result.input_tokens >= provider._estimate_image_tokens(len(image.data))
+
+
 @pytest.mark.slow
 @pytest.mark.integration
 @pytest.mark.asyncio
@@ -263,7 +275,7 @@ async def test_simple_message_comparison(
     diff_pct = calculate_percentage_difference(local_result.input_tokens, api_count)
     threshold = get_accuracy_threshold(api_count)
 
-    print(f"\nSimple message comparison:")
+    print("\nSimple message comparison:")
     print(f"  Local count: {local_result.input_tokens}")
     print(f"  API count: {api_count}")
     print(f"  Difference: {diff_pct:.2f}%")
@@ -307,7 +319,7 @@ async def test_with_real_system_prompt(
     diff_pct = calculate_percentage_difference(local_result.input_tokens, api_count)
     threshold = get_accuracy_threshold(api_count)
 
-    print(f"\nReal system prompt comparison:")
+    print("\nReal system prompt comparison:")
     print(f"  Local count: {local_result.input_tokens}")
     print(f"  API count: {api_count}")
     print(f"  Difference: {diff_pct:.2f}%")
@@ -353,7 +365,7 @@ async def test_with_tools(
     diff_pct = calculate_percentage_difference(local_result.input_tokens, api_count)
     threshold = get_accuracy_threshold(api_count, has_tools=True)
 
-    print(f"\nWith tools comparison:")
+    print("\nWith tools comparison:")
     print(f"  Tool count: {len(real_tools)}")
     print(f"  Local count: {local_result.input_tokens}")
     print(f"  API count: {api_count}")
@@ -398,7 +410,7 @@ async def test_with_complex_conversation(
     diff_pct = calculate_percentage_difference(local_result.input_tokens, api_count)
     threshold = get_accuracy_threshold(api_count)
 
-    print(f"\nComplex conversation comparison:")
+    print("\nComplex conversation comparison:")
     print(f"  Message count: {len(complex_messages)}")
     print(f"  Local count: {local_result.input_tokens}")
     print(f"  API count: {api_count}")
@@ -460,7 +472,7 @@ async def test_with_images(
     # Calculate percentage difference
     diff_pct = calculate_percentage_difference(local_result.input_tokens, api_count)
 
-    print(f"\nWith images comparison:")
+    print("\nWith images comparison:")
     print(f"  Image size: {len(tiny_image_base64)} chars (base64)")
     print(f"  Local count: {local_result.input_tokens}")
     print(f"  API count: {api_count}")
@@ -516,7 +528,7 @@ async def test_with_tool_calls(
     # Tool calls/results have higher variance in token counting, similar to images
     threshold = 25.0 if api_count < 200 else 15.0
 
-    print(f"\nWith tool calls comparison:")
+    print("\nWith tool calls comparison:")
     print(f"  Message count: {len(messages_with_tool_calls)}")
     print(f"  Local count: {local_result.input_tokens}")
     print(f"  API count: {api_count}")
@@ -563,7 +575,7 @@ async def test_full_agent_context(
     diff_pct = calculate_percentage_difference(local_result.input_tokens, api_count)
     threshold = get_accuracy_threshold(api_count, has_tools=True)
 
-    print(f"\nFull agent context comparison:")
+    print("\nFull agent context comparison:")
     print(f"  Message count: {len(complex_messages)}")
     print(f"  Tool count: {len(real_tools)}")
     print(f"  Local count: {local_result.input_tokens}")

--- a/kolega_code/agent/tests/llm/test_supports_vision.py
+++ b/kolega_code/agent/tests/llm/test_supports_vision.py
@@ -1,0 +1,56 @@
+"""Tests for the ``supports_vision`` capability flag and accessor."""
+
+import pytest
+
+from kolega_code.llm.specs import MODEL_SPECS, get_model_specs, supports_vision
+
+
+def test_supports_vision_flag_present_on_every_entry():
+    missing = [key for key, spec in MODEL_SPECS.items() if "supports_vision" not in spec]
+    assert not missing, f"entries missing supports_vision: {missing}"
+
+
+@pytest.mark.parametrize(
+    "provider,model,expected",
+    [
+        ("anthropic", "claude-opus-4-8", True),
+        ("anthropic", "claude-haiku-4-5-20251001", True),
+        ("openai", "gpt-5.5", True),
+        ("openai", "gpt-5.4-mini", True),
+        ("openai_chatgpt", "gpt-5.5", True),
+        ("openai_chatgpt", "gpt-5.3-codex-spark", True),
+        ("google", "gemini-3.5-flash", True),
+        ("google", "gemini-3.1-pro-preview", True),
+        ("moonshot", "kimi-k2.7-code", True),
+        ("moonshot", "kimi-k2.6", True),
+        ("kimi_coding", "kimi-for-coding", True),
+        ("xai", "grok-4.3", True),
+        ("fireworks", "accounts/fireworks/models/minimax-m3", True),
+        ("fireworks", "accounts/fireworks/models/kimi-k2p7-code", True),
+        ("together", "moonshotai/Kimi-K2.7-Code", True),
+        # Non-vision models
+        ("deepseek", "deepseek-v4-pro", False),
+        ("deepseek", "deepseek-v4-flash", False),
+        ("fireworks", "accounts/fireworks/models/deepseek-v4-pro", False),
+        ("fireworks", "accounts/fireworks/models/deepseek-v4-flash", False),
+        ("fireworks", "accounts/fireworks/models/glm-5p2", False),
+        ("fireworks", "accounts/fireworks/models/glm-5p1", False),
+        ("fireworks", "accounts/fireworks/models/qwen3p7-plus", False),
+        ("dashscope", "qwen3-coder-plus", False),
+        ("dashscope", "qwen3-coder-flash", False),
+        ("zai", "glm-5.2", False),
+        ("zai", "glm-5.1", False),
+        ("xai", "grok-build-0.1", False),
+        ("together", "zai-org/GLM-5.1", False),
+    ],
+)
+def test_supports_vision_values(provider, model, expected):
+    assert supports_vision(provider, model) is expected
+
+
+def test_supports_vision_defaults_false_when_key_absent():
+    # All real entries have the flag, but the accessor must default to False
+    # so a future entry that omits it is safely non-vision.
+    spec = get_model_specs("anthropic", "claude-opus-4-8")
+    assert spec.get("supports_vision", False) is True
+    assert {}.get("supports_vision", False) is False

--- a/kolega_code/agent/tests/test_agent_tools_inventory.py
+++ b/kolega_code/agent/tests/test_agent_tools_inventory.py
@@ -74,6 +74,7 @@ def test_browser_agent_tools(project_path, mock_connection_manager, agent_config
         "interact_with_browser",
         "launch_browser",
         "list_browsers",
+        "read_image",
         "set_browser_select_value",
         "take_browser_screenshot",
     ]
@@ -100,6 +101,7 @@ def test_investigation_agent_tools(project_path, mock_connection_manager, agent_
         "list_directory",
         "read_entire_file",
         "read_file_section",
+        "read_image",
         "search_codebase",
         "sleep",
         "think_hard",

--- a/kolega_code/agent/tests/test_base_agent.py
+++ b/kolega_code/agent/tests/test_base_agent.py
@@ -17,6 +17,7 @@ from kolega_code.llm.exceptions import (
     LLMRateLimitError,
 )
 from kolega_code.llm.models import (
+    ImageBlock,
     Message,
     MessageHistory,
     RedactedThinkingBlock,
@@ -1850,6 +1851,63 @@ class TestBaseAgent:
         assert effective[0].content[1].thinking == "signed thinking"
         assert effective[0].content[1].signature == "sig"
         assert effective[0].content[2].data == "encrypted-redacted-thinking"
+
+    def test_history_for_llm_converts_foreign_thinking_when_switching_to_anthropic(self, base_agent):
+        tool_call = ToolCall(id="tool1", name="read_file", input={"path": "README.md"})
+        base_agent.primary_model_config.provider = ModelProvider.ANTHROPIC
+        base_agent.primary_model_config.model = "claude-opus-4-8"
+        base_agent.supports_vision = True
+        base_agent.history = MessageHistory(
+            [
+                Message(
+                    role="assistant",
+                    content=[ThinkingBlock(thinking="kimi reasoning", signature="kimi-sig"), tool_call],
+                    usage_metadata={"provider": "kimi_coding"},
+                ),
+                Message(
+                    role="user",
+                    content=[ToolResult(tool_use_id="tool1", name="read_file", content="ok", is_error=False)],
+                ),
+            ]
+        )
+
+        history = base_agent._history_for_llm()
+
+        assert not any(isinstance(block, ThinkingBlock) for block in history[0].content)
+        assert isinstance(history[0].content[0], TextBlock)
+        assert "Prior reasoning from kimi_coding omitted" in history[0].content[0].text
+        assert isinstance(history[0].content[1], ToolCall)
+        assert history[1].role == "user"
+        assert isinstance(history[1].content[0], ToolResult)
+        assert history[1].content[0].tool_use_id == "tool1"
+
+    def test_history_for_llm_preserves_images_when_target_anthropic_supports_vision(self, base_agent):
+        image = ImageBlock(image_type="base64", media_type="image/png", data="BASE64")
+        nested_image = ImageBlock(image_type="base64", media_type="image/jpeg", data="BASE642")
+        base_agent.primary_model_config.provider = ModelProvider.ANTHROPIC
+        base_agent.primary_model_config.model = "claude-opus-4-8"
+        base_agent.supports_vision = True
+        base_agent.history = MessageHistory(
+            [
+                Message(role="user", content=[TextBlock(text="look"), image]),
+                Message(
+                    role="user",
+                    content=[
+                        ToolResult(
+                            tool_use_id="tool1",
+                            name="read_image",
+                            content=[nested_image],
+                            is_error=False,
+                        )
+                    ],
+                ),
+            ]
+        )
+
+        history = base_agent._history_for_llm()
+
+        assert history[0].content[1] is image
+        assert history[1].content[0].content[0] is nested_image
 
     def test_extend_history_no_fix_needed(self, base_agent):
         """Test extend_history works normally when no fix needed."""

--- a/kolega_code/agent/tests/test_coder_attachments.py
+++ b/kolega_code/agent/tests/test_coder_attachments.py
@@ -64,6 +64,7 @@ def test_non_vision_image_attachment_is_rejected_by_provider_check():
     assert message is not None
     assert "does not support image input" in message
     assert "deepseek-v4-pro" in message
+    assert "not sent to the model" in message
 
 
 def test_vision_image_attachment_is_allowed():
@@ -107,6 +108,7 @@ async def test_coder_agent_rejects_deepseek_image_without_llm_call(tmp_path):
     assert chunks[0]["type"] == "response"
     assert "does not support image input" in chunks[0]["content"]
     assert "deepseek-v4-pro" in chunks[0]["content"]
+    assert "not sent to the model" in chunks[0]["content"]
     assert chunks[0]["complete"] is True
     assert agent.history == []
     agent.llm.stream.assert_not_called()

--- a/kolega_code/agent/tests/test_coder_attachments.py
+++ b/kolega_code/agent/tests/test_coder_attachments.py
@@ -54,24 +54,34 @@ class _EmptyStream:
         return Message("assistant", [TextBlock("done")], stop_reason="end_turn")
 
 
-def test_deepseek_image_attachment_is_rejected_by_provider_check():
+def test_non_vision_image_attachment_is_rejected_by_provider_check():
     agent = object.__new__(BaseAgent)
-    agent.primary_model_config = SimpleNamespace(provider=ModelProvider.DEEPSEEK.value)
-
-    assert (
-        agent._unsupported_attachment_message([_image_attachment()])
-        == BaseAgent.deepseek_image_unsupported_message
+    agent.primary_model_config = SimpleNamespace(
+        provider=ModelProvider.DEEPSEEK.value, model="deepseek-v4-pro"
     )
 
+    message = agent._unsupported_attachment_message([_image_attachment()])
+    assert message is not None
+    assert "does not support image input" in message
+    assert "deepseek-v4-pro" in message
 
-def test_deepseek_attachment_check_allows_non_images_and_other_providers():
+
+def test_vision_image_attachment_is_allowed():
     agent = object.__new__(BaseAgent)
-    agent.primary_model_config = SimpleNamespace(provider=ModelProvider.DEEPSEEK)
+    agent.primary_model_config = SimpleNamespace(
+        provider=ModelProvider.ANTHROPIC, model="claude-opus-4-8"
+    )
+    assert agent._unsupported_attachment_message([_image_attachment()]) is None
+
+
+def test_attachment_check_allows_non_images_for_non_vision_model():
+    agent = object.__new__(BaseAgent)
+    agent.primary_model_config = SimpleNamespace(
+        provider=ModelProvider.DEEPSEEK, model="deepseek-v4-pro"
+    )
     assert agent._unsupported_attachment_message(None) is None
     assert agent._unsupported_attachment_message([{"type": "document", "data": "abc"}]) is None
-
-    agent.primary_model_config.provider = ModelProvider.ANTHROPIC
-    assert agent._unsupported_attachment_message([_image_attachment()]) is None
+    assert agent._unsupported_attachment_message([{"type": "file", "path": "a.py", "content": "x"}]) is None
 
 
 @pytest.mark.asyncio
@@ -95,7 +105,8 @@ async def test_coder_agent_rejects_deepseek_image_without_llm_call(tmp_path):
 
     assert len(chunks) == 1
     assert chunks[0]["type"] == "response"
-    assert chunks[0]["content"] == BaseAgent.deepseek_image_unsupported_message
+    assert "does not support image input" in chunks[0]["content"]
+    assert "deepseek-v4-pro" in chunks[0]["content"]
     assert chunks[0]["complete"] is True
     assert agent.history == []
     agent.llm.stream.assert_not_called()
@@ -270,12 +281,13 @@ class TestCoderAgentAttachments:
 async def test_coder_agent_process_message_imports():
     """Test that the coder agent has the necessary imports for image handling."""
     # This test verifies the imports are correct
-    from kolega_code.agent.coder import CoderAgent
+    from kolega_code.agent.coder import CoderAgent  # noqa: F401
     from kolega_code.llm.models import ImageBlock, TextBlock
 
     # Just verify the imports work
     assert ImageBlock is not None
     assert TextBlock is not None
+    assert CoderAgent is not None
 
 
 def test_attachment_blocks_mixes_images_and_files():

--- a/kolega_code/agent/tests/test_coder_attachments.py
+++ b/kolega_code/agent/tests/test_coder_attachments.py
@@ -335,3 +335,152 @@ async def test_coder_agent_file_attachment_added_to_history(tmp_path):
     texts = [block.text for block in user_message.content if isinstance(block, TextBlock)]
     assert texts[0] == "see the notes"
     assert texts[1] == '<attached-file path="notes.md">\nremember the milk\n</attached-file>'
+
+
+# ---------------------------------------------------------------------------
+# Historical image handling: non-vision model in a thread that already has images
+# ---------------------------------------------------------------------------
+
+
+def _anthropic_config() -> AgentConfig:
+    model_config = ModelConfig(
+        provider=ModelProvider.ANTHROPIC,
+        model="claude-haiku-4-5-20251001",
+        rate_limits=RateLimitConfig(),
+    )
+    return AgentConfig(
+        anthropic_api_key="test-key",
+        long_context_config=model_config,
+        fast_config=model_config,
+        thinking_config=model_config,
+    )
+
+
+def _image_history_message() -> Message:
+    """A user message carrying a text block and an image block from an earlier turn."""
+    return Message(
+        role="user",
+        content=[
+            TextBlock(text="what is in this image?"),
+            ImageBlock(image_type="base64", media_type="image/png", data="ZmFrZQ=="),
+        ],
+    )
+
+
+def _sent_messages(agent) -> list:
+    """The messages passed to llm.stream on the most recent call."""
+    return list(agent.llm.stream.call_args.kwargs["messages"])
+
+
+@pytest.mark.asyncio
+async def test_non_vision_model_strips_historical_images_before_llm_call(tmp_path):
+    from kolega_code.agent.conversation import count_image_blocks
+
+    connection_manager = Mock()
+    connection_manager.broadcast_event = AsyncMock()
+    agent = CoderAgent(
+        project_path=tmp_path,
+        workspace_id="workspace-123",
+        thread_id="thread-123",
+        connection_manager=connection_manager,
+        config=_deepseek_config(),
+        agent_mode=AgentMode.CLI,
+    )
+    assert agent.supports_vision is False
+    # Pre-populate history with an image-bearing message from an earlier turn.
+    agent.append_user_message([_image_history_message().content[0], _image_history_message().content[1]])
+    assert count_image_blocks(list(agent.history)) == 1
+
+    agent.count_current_context = AsyncMock(return_value=TokenCount(input_tokens=42))
+    agent.llm = Mock()
+    agent.llm.stream = AsyncMock(return_value=_EmptyStream())
+
+    chunks = [chunk async for chunk in agent.process_message_stream("follow up question")]
+
+    # Turn completed normally (no provider error surfaced).
+    assert chunks[-1]["complete"] is True
+    # The request sent to the LLM contains NO image blocks.
+    sent = _sent_messages(agent)
+    assert count_image_blocks(sent) == 0
+    # A text placeholder describing the image is present instead.
+    placeholders = [
+        block.text
+        for m in sent
+        for block in (m.content if isinstance(m.content, list) else [])
+        if isinstance(block, TextBlock) and "not visible" in block.text
+    ]
+    assert placeholders, "expected an image placeholder text block in the request"
+    assert "image/png" in placeholders[0]
+    assert "deepseek-v4-pro" in placeholders[0]
+    # Stored history is NOT mutated — the original image survives for a switch back.
+    assert count_image_blocks(list(agent.history)) == 1
+
+
+@pytest.mark.asyncio
+async def test_vision_model_passes_historical_images_through(tmp_path):
+    from kolega_code.agent.conversation import count_image_blocks
+
+    connection_manager = Mock()
+    connection_manager.broadcast_event = AsyncMock()
+    agent = CoderAgent(
+        project_path=tmp_path,
+        workspace_id="workspace-123",
+        thread_id="thread-123",
+        connection_manager=connection_manager,
+        config=_anthropic_config(),
+        agent_mode=AgentMode.CLI,
+    )
+    assert agent.supports_vision is True
+    agent.append_user_message([_image_history_message().content[0], _image_history_message().content[1]])
+
+    agent.count_current_context = AsyncMock(return_value=TokenCount(input_tokens=42))
+    agent.llm = Mock()
+    agent.llm.stream = AsyncMock(return_value=_EmptyStream())
+
+    chunks = [chunk async for chunk in agent.process_message_stream("follow up question")]
+    assert chunks[-1]["complete"] is True
+
+    # Vision-capable model receives the image block unchanged.
+    sent = _sent_messages(agent)
+    assert count_image_blocks(sent) == 1
+
+
+@pytest.mark.asyncio
+async def test_non_vision_model_count_context_also_strips_images(tmp_path):
+    """count_current_context must not send image blocks to a non-vision model's tokenizer."""
+    from kolega_code.agent.conversation import count_image_blocks
+
+    connection_manager = Mock()
+    connection_manager.broadcast_event = AsyncMock()
+    agent = CoderAgent(
+        project_path=tmp_path,
+        workspace_id="workspace-123",
+        thread_id="thread-123",
+        connection_manager=connection_manager,
+        config=_deepseek_config(),
+        agent_mode=AgentMode.CLI,
+    )
+    agent.append_user_message([_image_history_message().content[0], _image_history_message().content[1]])
+
+    captured = {}
+
+    async def _capture_count(*args, **kwargs):
+        captured["messages"] = list(kwargs.get("messages", []))
+        return TokenCount(input_tokens=42)
+
+    agent.llm = Mock()
+    agent.llm.count_tokens = AsyncMock(side_effect=_capture_count)
+    # Tool list needed by count_current_context.
+    agent.tool_collection = Mock()
+    agent.tool_collection.get_tool_list = Mock(return_value=[])
+
+    await agent.count_current_context()
+
+    assert count_image_blocks(captured["messages"]) == 0
+    placeholders = [
+        block.text
+        for m in captured["messages"]
+        for block in (m.content if isinstance(m.content, list) else [])
+        if isinstance(block, TextBlock) and "not visible" in block.text
+    ]
+    assert placeholders

--- a/kolega_code/agent/tests/test_image_compat.py
+++ b/kolega_code/agent/tests/test_image_compat.py
@@ -9,13 +9,16 @@ only reports images that would actually be sent.
 
 from kolega_code.agent.conversation import (
     Conversation,
+    adapt_history_for_provider,
     count_image_blocks,
     replace_image_blocks_with_placeholders,
 )
 from kolega_code.llm.models import (
     ImageBlock,
     Message,
+    RedactedThinkingBlock,
     TextBlock,
+    ThinkingBlock,
     ToolCall,
     ToolResult,
 )
@@ -29,8 +32,138 @@ def _user(*blocks) -> Message:
     return Message(role="user", content=list(blocks))
 
 
-def _assistant(*blocks) -> Message:
-    return Message(role="assistant", content=list(blocks))
+def _assistant(*blocks, provider: str | None = None) -> Message:
+    return Message(
+        role="assistant",
+        content=list(blocks),
+        usage_metadata={"provider": provider} if provider else {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# adapt_history_for_provider
+# ---------------------------------------------------------------------------
+
+
+def test_adapt_converts_kimi_thinking_when_targeting_anthropic():
+    tool_call = ToolCall(id="tool1", name="read_image", input={"path": "a.png"})
+    history = [
+        _assistant(ThinkingBlock(thinking="foreign reasoning", signature="kimi-sig"), tool_call, provider="kimi_coding")
+    ]
+
+    out = adapt_history_for_provider(
+        history,
+        target_provider="anthropic",
+        target_model="claude-opus-4-8",
+        supports_vision=True,
+    )
+
+    assert out[0] is not history[0]
+    assert not any(isinstance(block, ThinkingBlock) for block in out[0].content)
+    assert isinstance(out[0].content[0], TextBlock)
+    assert "Prior reasoning from kimi_coding omitted" in out[0].content[0].text
+    assert any(isinstance(block, ToolCall) and block.id == "tool1" for block in out[0].content)
+
+
+def test_adapt_preserves_anthropic_thinking_when_targeting_anthropic():
+    history = [_assistant(ThinkingBlock(thinking="native reasoning", signature="anthropic-sig"), provider="anthropic")]
+
+    out = adapt_history_for_provider(
+        history,
+        target_provider="anthropic",
+        target_model="claude-opus-4-8",
+        supports_vision=True,
+    )
+
+    assert out is history
+    assert isinstance(out[0].content[0], ThinkingBlock)
+    assert out[0].content[0].signature == "anthropic-sig"
+
+
+def test_adapt_preserves_images_for_vision_target_while_converting_foreign_thinking():
+    tr = ToolResult(tool_use_id="t1", name="read_image", content=[_image("image/jpeg")], is_error=False)
+    history = [
+        _user(TextBlock(text="look"), _image("image/png"), tr),
+        _assistant(ThinkingBlock(thinking="foreign", signature="kimi-sig"), provider="kimi_coding"),
+    ]
+
+    out = adapt_history_for_provider(
+        history,
+        target_provider="anthropic",
+        target_model="claude-opus-4-8",
+        supports_vision=True,
+    )
+
+    assert count_image_blocks(out) == 2
+    assert isinstance(out[0].content[1], ImageBlock)
+    assert isinstance(out[0].content[2].content[0], ImageBlock)
+    assert isinstance(out[1].content[0], TextBlock)
+
+
+def test_adapt_replaces_images_for_non_vision_target_and_converts_foreign_thinking():
+    tr = ToolResult(tool_use_id="t1", name="read_image", content=[_image("image/jpeg")], is_error=False)
+    history = [
+        _user(TextBlock(text="look"), _image("image/png"), tr),
+        _assistant(RedactedThinkingBlock(data="encrypted"), provider="kimi_coding"),
+    ]
+
+    out = adapt_history_for_provider(
+        history,
+        target_provider="deepseek",
+        target_model="deepseek-v4-pro",
+        supports_vision=False,
+    )
+
+    assert count_image_blocks(out) == 0
+    assert isinstance(out[0].content[1], TextBlock)
+    assert "not visible" in out[0].content[1].text
+    assert isinstance(out[0].content[2].content[0], TextBlock)
+    assert isinstance(out[1].content[0], TextBlock)
+    assert "redacted reasoning from kimi_coding omitted" in out[1].content[0].text
+
+
+def test_adapt_does_not_mutate_stored_history():
+    image = _image("image/png")
+    thinking = ThinkingBlock(thinking="foreign", signature="kimi-sig")
+    history = [_user(image), _assistant(thinking, provider="kimi_coding")]
+
+    out = adapt_history_for_provider(
+        history,
+        target_provider="anthropic",
+        target_model="claude-opus-4-8",
+        supports_vision=True,
+    )
+
+    assert out is not history
+    assert isinstance(history[0].content[0], ImageBlock)
+    assert history[0].content[0] is image
+    assert isinstance(history[1].content[0], ThinkingBlock)
+    assert history[1].content[0] is thinking
+    assert isinstance(out[1].content[0], TextBlock)
+
+
+def test_adapted_kimi_thinking_is_not_serialized_as_anthropic_thinking():
+    tool_call = ToolCall(id="tool1", name="read_file", input={"path": "README.md"})
+    result = ToolResult(tool_use_id="tool1", name="read_file", content="ok", is_error=False)
+    history = [
+        _assistant(ThinkingBlock(thinking="foreign", signature="kimi-sig"), tool_call, provider="kimi_coding"),
+        _user(result),
+    ]
+
+    adapted = adapt_history_for_provider(
+        history,
+        target_provider="anthropic",
+        target_model="claude-opus-4-8",
+        supports_vision=True,
+    )
+    payload = [message.to_anthropic() for message in adapted]
+
+    assert payload[0]["role"] == "assistant"
+    assert all(block.get("type") != "thinking" for block in payload[0]["content"])
+    assert payload[0]["content"][1]["type"] == "tool_use"
+    assert payload[1]["role"] == "user"
+    assert payload[1]["content"][0]["type"] == "tool_result"
+    assert payload[1]["content"][0]["tool_use_id"] == "tool1"
 
 
 # ---------------------------------------------------------------------------

--- a/kolega_code/agent/tests/test_image_compat.py
+++ b/kolega_code/agent/tests/test_image_compat.py
@@ -1,0 +1,227 @@
+"""Tests for image-block detection and placeholder replacement in conversation history.
+
+Covers the graceful-degradation path: when a non-vision model is active in a thread
+that already contains images, the images are replaced with text placeholders on the
+request copy (stored history is never mutated), and the compaction-aware detector
+only reports images that would actually be sent.
+"""
+
+
+from kolega_code.agent.conversation import (
+    Conversation,
+    count_image_blocks,
+    replace_image_blocks_with_placeholders,
+)
+from kolega_code.llm.models import (
+    ImageBlock,
+    Message,
+    TextBlock,
+    ToolCall,
+    ToolResult,
+)
+
+
+def _image(media_type: str = "image/png") -> ImageBlock:
+    return ImageBlock(image_type="base64", media_type=media_type, data="ZmFrZQ==")
+
+
+def _user(*blocks) -> Message:
+    return Message(role="user", content=list(blocks))
+
+
+def _assistant(*blocks) -> Message:
+    return Message(role="assistant", content=list(blocks))
+
+
+# ---------------------------------------------------------------------------
+# count_image_blocks
+# ---------------------------------------------------------------------------
+
+
+def test_count_image_blocks_empty_history():
+    assert count_image_blocks([]) == 0
+
+
+def test_count_image_blocks_no_images():
+    history = [_user(TextBlock(text="hi")), _assistant(TextBlock(text="hello"))]
+    assert count_image_blocks(history) == 0
+
+
+def test_count_image_blocks_user_message_image():
+    history = [_user(TextBlock(text="look"), _image())]
+    assert count_image_blocks(history) == 1
+
+
+def test_count_image_blocks_multiple_top_level():
+    history = [_user(_image("image/png"), _image("image/jpeg"))]
+    assert count_image_blocks(history) == 2
+
+
+def test_count_image_blocks_nested_in_tool_result():
+    tr = ToolResult(tool_use_id="t1", name="read_image", content=[_image()], is_error=False)
+    history = [_user(tr)]
+    assert count_image_blocks(history) == 1
+
+
+def test_count_image_blocks_nested_and_top_level():
+    tr = ToolResult(tool_use_id="t1", name="read_image", content=[_image(), TextBlock(text="ok")], is_error=False)
+    history = [_user(TextBlock(text="see"), _image()), _user(tr)]
+    assert count_image_blocks(history) == 2
+
+
+def test_count_image_blocks_ignores_string_content():
+    history = [_user("just a string")]
+    assert count_image_blocks(history) == 0
+
+
+# ---------------------------------------------------------------------------
+# Conversation.has_image_blocks (compaction-aware)
+# ---------------------------------------------------------------------------
+
+
+def test_has_image_blocks_true_for_user_image():
+    conv = Conversation([_user(TextBlock(text="hi"), _image())])
+    assert conv.has_image_blocks() is True
+
+
+def test_has_image_blocks_true_for_tool_result_image():
+    tr = ToolResult(tool_use_id="t1", name="read_image", content=[_image()], is_error=False)
+    conv = Conversation([_user(tr)])
+    assert conv.has_image_blocks() is True
+
+
+def test_has_image_blocks_false_for_text_only():
+    conv = Conversation([_user(TextBlock(text="hi")), _assistant(TextBlock(text="hello"))])
+    assert conv.has_image_blocks() is False
+
+
+def test_has_image_blocks_false_when_folded_into_summary():
+    """Images in the compacted prefix are gone from the effective history."""
+    conv = Conversation([_user(TextBlock(text="u0"), _image()), _assistant(TextBlock(text="a0"))])
+    conv.apply_compaction("SUMMARY", split_point=2)  # fold both messages into the summary
+    assert conv.has_image_blocks() is False
+
+
+def test_has_image_blocks_true_when_image_in_verbatim_tail():
+    conv = Conversation(
+        [_user(TextBlock(text="u0")), _assistant(TextBlock(text="a0")), _user(TextBlock(text="u1"), _image())]
+    )
+    conv.apply_compaction("SUMMARY", split_point=2)  # keep the image-bearing user message verbatim
+    assert conv.has_image_blocks() is True
+
+
+# ---------------------------------------------------------------------------
+# replace_image_blocks_with_placeholders
+# ---------------------------------------------------------------------------
+
+
+def test_replace_returns_same_object_for_messages_without_images():
+    m = _user(TextBlock(text="hi"))
+    out = replace_image_blocks_with_placeholders([m], "deepseek-v4-pro")
+    assert out[0] is m
+
+
+def test_replace_does_not_mutate_input():
+    original = _user(TextBlock(text="look"), _image("image/png"))
+    snapshot_content = list(original.content)
+    _ = replace_image_blocks_with_placeholders([original], "deepseek-v4-pro")
+    assert original.content == snapshot_content
+    assert isinstance(original.content[1], ImageBlock)
+
+
+def test_replace_top_level_image_with_placeholder():
+    history = [_user(TextBlock(text="look"), _image("image/png"))]
+    out = replace_image_blocks_with_placeholders(history, "deepseek-v4-pro")
+    assert out is not history
+    assert out[0] is not history[0]
+    blocks = out[0].content
+    assert isinstance(blocks[0], TextBlock)
+    assert blocks[0].text == "look"
+    assert isinstance(blocks[1], TextBlock)
+    assert "image/png" in blocks[1].text
+    assert "deepseek-v4-pro" in blocks[1].text
+    assert "not visible" in blocks[1].text
+
+
+def test_replace_preserves_message_metadata():
+    tool_call = ToolCall(id="call1", name="read_file", input={"path": "a.py"})
+    msg = Message(
+        role="assistant",
+        content=[TextBlock(text="thinking"), tool_call, _image("image/jpeg")],
+        stop_reason="end_turn",
+        tool_calls=[tool_call],
+        usage_metadata={"input_tokens": 10},
+    )
+    out = replace_image_blocks_with_placeholders([msg], "glm-5.2")
+    new_msg = out[0]
+    assert new_msg.role == "assistant"
+    assert new_msg.stop_reason == "end_turn"
+    assert new_msg.tool_calls == [tool_call]
+    assert new_msg.usage_metadata == {"input_tokens": 10}
+    # Tool call block survives if present alongside an image in the same message.
+    assert any(isinstance(b, ToolCall) for b in new_msg.content)
+
+
+def test_replace_nested_tool_result_image():
+    tr = ToolResult(
+        tool_use_id="t1",
+        name="read_image",
+        content=[_image("image/png"), TextBlock(text="caption")],
+        is_error=False,
+        execution_id="exec-1",
+    )
+    history = [_user(tr)]
+    out = replace_image_blocks_with_placeholders(history, "deepseek-v4-pro")
+    new_tr = out[0].content[0]
+    assert isinstance(new_tr, ToolResult)
+    assert new_tr is not tr  # new object, input not mutated
+    assert new_tr.tool_use_id == "t1"
+    assert new_tr.name == "read_image"
+    assert new_tr.is_error is False
+    assert new_tr.execution_id == "exec-1"
+    assert isinstance(new_tr.content[0], TextBlock)
+    assert "image/png" in new_tr.content[0].text
+    assert isinstance(new_tr.content[1], TextBlock)
+    assert new_tr.content[1].text == "caption"
+    # original untouched
+    assert isinstance(tr.content[0], ImageBlock)
+
+
+def test_replace_preserves_string_tool_result():
+    tr = ToolResult(tool_use_id="t1", name="read_file", content="plain text result", is_error=False)
+    history = [_user(tr)]
+    out = replace_image_blocks_with_placeholders(history, "deepseek-v4-pro")
+    assert out[0] is history[0]  # no images -> unchanged
+
+
+def test_replace_mixed_history_only_changes_image_messages():
+    u_img = _user(TextBlock(text="look"), _image())
+    a_text = _assistant(TextBlock(text="ok"))
+    u_text = _user(TextBlock(text="next"))
+    history = [u_img, a_text, u_text]
+    out = replace_image_blocks_with_placeholders(history, "deepseek-v4-pro")
+    assert out[0] is not u_img
+    assert out[1] is a_text  # unchanged
+    assert out[2] is u_text  # unchanged
+    assert not any(isinstance(b, ImageBlock) for b in out[0].content)
+
+
+def test_replace_eliminates_all_image_blocks():
+    tr = ToolResult(tool_use_id="t1", name="read_image", content=[_image()], is_error=False)
+    history = [_user(TextBlock(text="a"), _image()), _user(tr), _assistant(TextBlock(text="b"))]
+    out = replace_image_blocks_with_placeholders(history, "deepseek-v4-pro")
+    assert count_image_blocks(out) == 0
+
+
+def test_replace_preserves_cache_checkpoint_on_tool_result():
+    tr = ToolResult(
+        tool_use_id="t1",
+        name="read_image",
+        content=[_image()],
+        is_error=False,
+        cache_checkpoint=True,
+    )
+    history = [_user(tr)]
+    out = replace_image_blocks_with_placeholders(history, "deepseek-v4-pro")
+    new_tr = out[0].content[0]
+    assert new_tr.cache_checkpoint is True

--- a/kolega_code/agent/tests/test_planning_agent.py
+++ b/kolega_code/agent/tests/test_planning_agent.py
@@ -4,7 +4,6 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from kolega_code.agent.baseagent import BaseAgent
 from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
 from kolega_code.events import AgentConnectionManager
 from kolega_code.llm.models import Message, TextBlock, ToolCall
@@ -200,7 +199,8 @@ async def test_planning_agent_rejects_deepseek_image_without_llm_call(tmp_path, 
 
     assert len(chunks) == 1
     assert chunks[0]["type"] == "response"
-    assert chunks[0]["content"] == BaseAgent.deepseek_image_unsupported_message
+    assert "does not support image input" in chunks[0]["content"]
+    assert "deepseek-v4-pro" in chunks[0]["content"]
     assert chunks[0]["complete"] is True
     assert agent.history == []
     agent.llm.stream.assert_not_called()

--- a/kolega_code/agent/tests/test_read_image_tool.py
+++ b/kolega_code/agent/tests/test_read_image_tool.py
@@ -1,0 +1,160 @@
+import base64
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from kolega_code.agent.tool_backend.read_image_tool import ReadImageTool
+from kolega_code.agent.tools import ToolCollection
+from kolega_code.llm.models import ImageBlock
+from kolega_code.services.file_system import LocalFileSystem
+
+
+def _make_tool(tmp_path, caller=None, config=None):
+    return ReadImageTool(
+        tmp_path,
+        "ws",
+        "thread",
+        Mock(),  # connection_manager
+        config or SimpleNamespace(),
+        caller or object(),
+        LocalFileSystem(root_path=tmp_path),
+    )
+
+
+class TestReadImageToolBackend:
+    @pytest.mark.asyncio
+    async def test_read_png_returns_image_block(self, tmp_path):
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+        path = tmp_path / "shot.png"
+        path.write_bytes(png_bytes)
+
+        tool = _make_tool(tmp_path)
+        result = await tool.read_image(str(path))
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        block = result[0]
+        assert isinstance(block, ImageBlock)
+        assert block.image_type == "base64"
+        assert block.media_type == "image/png"
+        assert base64.b64decode(block.data) == png_bytes
+
+    @pytest.mark.asyncio
+    async def test_read_jpeg_returns_jpeg_media_type(self, tmp_path):
+        jpeg_bytes = b"\xff\xd8\xff\xe0" + b"\x00" * 16
+        path = tmp_path / "photo.jpg"
+        path.write_bytes(jpeg_bytes)
+
+        tool = _make_tool(tmp_path)
+        result = await tool.read_image(str(path))
+
+        assert result[0].media_type == "image/jpeg"
+        assert base64.b64decode(result[0].data) == jpeg_bytes
+
+    @pytest.mark.asyncio
+    async def test_missing_path_raises_file_not_found(self, tmp_path):
+        tool = _make_tool(tmp_path)
+        with pytest.raises(FileNotFoundError):
+            await tool.read_image(str(tmp_path / "nope.png"))
+
+    @pytest.mark.asyncio
+    async def test_directory_path_raises_value_error(self, tmp_path):
+        (tmp_path / "subdir").mkdir()
+        tool = _make_tool(tmp_path)
+        with pytest.raises(ValueError):
+            await tool.read_image(str(tmp_path / "subdir"))
+
+    @pytest.mark.asyncio
+    async def test_unsupported_extension_raises_value_error(self, tmp_path):
+        path = tmp_path / "notes.txt"
+        path.write_text("hello")
+
+        tool = _make_tool(tmp_path)
+        with pytest.raises(ValueError):
+            await tool.read_image(str(path))
+
+
+class TestReadImageWrapper:
+    @pytest.mark.asyncio
+    async def test_wrapper_delegates_to_backend(self, tmp_path):
+        collection = ToolCollection.__new__(ToolCollection)
+        expected = [ImageBlock(image_type="base64", media_type="image/png", data="")]
+        collection.read_image_tool = Mock()
+        collection.read_image_tool.read_image = AsyncMock(return_value=expected)
+        collection.caller = object()
+
+        result = await collection.read_image("x.png")
+        assert result is expected
+        collection.read_image_tool.read_image.assert_awaited_once_with("x.png")
+
+    @pytest.mark.asyncio
+    async def test_wrapper_chatgpt_provider_returns_string(self, tmp_path):
+        collection = ToolCollection.__new__(ToolCollection)
+        collection.read_image_tool = Mock()
+        collection.read_image_tool.read_image = AsyncMock()
+        collection.caller = SimpleNamespace(
+            primary_model_config=SimpleNamespace(provider="openai_chatgpt")
+        )
+
+        result = await collection.read_image("img.png")
+        assert isinstance(result, str)
+        assert "ChatGPT Responses backend" in result
+        collection.read_image_tool.read_image.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_wrapper_chatgpt_provider_enum_value(self, tmp_path):
+        from kolega_code.config import ModelProvider
+
+        collection = ToolCollection.__new__(ToolCollection)
+        collection.read_image_tool = Mock()
+        collection.read_image_tool.read_image = AsyncMock()
+        collection.caller = SimpleNamespace(
+            primary_model_config=SimpleNamespace(provider=ModelProvider.OPENAI_CHATGPT)
+        )
+
+        result = await collection.read_image("img.png")
+        assert isinstance(result, str)
+        collection.read_image_tool.read_image.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_wrapper_non_chatgpt_provider_delegates(self, tmp_path):
+        collection = ToolCollection.__new__(ToolCollection)
+        expected = [ImageBlock(image_type="base64", media_type="image/png", data="")]
+        collection.read_image_tool = Mock()
+        collection.read_image_tool.read_image = AsyncMock(return_value=expected)
+        collection.caller = SimpleNamespace(
+            primary_model_config=SimpleNamespace(provider="anthropic")
+        )
+
+        result = await collection.read_image("img.png")
+        assert result is expected
+
+
+class TestShouldIncludeReadImage:
+    def _make_collection(self):
+        collection = ToolCollection.__new__(ToolCollection)
+        collection.caller = object()
+        collection.orchestration_tools = []
+        collection.tool_config = SimpleNamespace(custom_tool_groups=None)
+        return collection
+
+    def test_vision_enabled_includes_tool(self):
+        collection = self._make_collection()
+        collection.caller = SimpleNamespace(supports_vision=True)
+        assert collection._should_include_tool("read_image") is True
+
+    def test_vision_disabled_excludes_tool(self):
+        collection = self._make_collection()
+        collection.caller = SimpleNamespace(supports_vision=False)
+        assert collection._should_include_tool("read_image") is False
+
+    def test_no_supports_vision_attr_excludes_tool(self):
+        collection = self._make_collection()
+        collection.caller = object()
+        assert collection._should_include_tool("read_image") is False
+
+
+def test_read_image_in_read_only_tools():
+    assert "read_image" in ToolCollection.read_only_tools
+    assert hasattr(ToolCollection, "read_image")

--- a/kolega_code/agent/tests/test_read_image_tool.py
+++ b/kolega_code/agent/tests/test_read_image_tool.py
@@ -89,33 +89,34 @@ class TestReadImageWrapper:
         collection.read_image_tool.read_image.assert_awaited_once_with("x.png")
 
     @pytest.mark.asyncio
-    async def test_wrapper_chatgpt_provider_returns_string(self, tmp_path):
+    async def test_wrapper_chatgpt_provider_delegates(self, tmp_path):
         collection = ToolCollection.__new__(ToolCollection)
+        expected = [ImageBlock(image_type="base64", media_type="image/png", data="")]
         collection.read_image_tool = Mock()
-        collection.read_image_tool.read_image = AsyncMock()
+        collection.read_image_tool.read_image = AsyncMock(return_value=expected)
         collection.caller = SimpleNamespace(
             primary_model_config=SimpleNamespace(provider="openai_chatgpt")
         )
 
         result = await collection.read_image("img.png")
-        assert isinstance(result, str)
-        assert "ChatGPT Responses backend" in result
-        collection.read_image_tool.read_image.assert_not_awaited()
+        assert result is expected
+        collection.read_image_tool.read_image.assert_awaited_once_with("img.png")
 
     @pytest.mark.asyncio
-    async def test_wrapper_chatgpt_provider_enum_value(self, tmp_path):
+    async def test_wrapper_chatgpt_provider_enum_value_delegates(self, tmp_path):
         from kolega_code.config import ModelProvider
 
         collection = ToolCollection.__new__(ToolCollection)
+        expected = [ImageBlock(image_type="base64", media_type="image/png", data="")]
         collection.read_image_tool = Mock()
-        collection.read_image_tool.read_image = AsyncMock()
+        collection.read_image_tool.read_image = AsyncMock(return_value=expected)
         collection.caller = SimpleNamespace(
             primary_model_config=SimpleNamespace(provider=ModelProvider.OPENAI_CHATGPT)
         )
 
         result = await collection.read_image("img.png")
-        assert isinstance(result, str)
-        collection.read_image_tool.read_image.assert_not_awaited()
+        assert result is expected
+        collection.read_image_tool.read_image.assert_awaited_once_with("img.png")
 
     @pytest.mark.asyncio
     async def test_wrapper_non_chatgpt_provider_delegates(self, tmp_path):

--- a/kolega_code/agent/tests/test_tools.py
+++ b/kolega_code/agent/tests/test_tools.py
@@ -40,6 +40,8 @@ def agent_config() -> AgentConfig:
 def mock_base_agent() -> Mock:
     mock = Mock()
     mock.agent_name = "test_agent"
+    # Default: non-vision mock so the read_image tool gate excludes it.
+    mock.supports_vision = False
     return mock
 
 
@@ -661,3 +663,8 @@ class TestToolCollection:
 
         for tool_name in tool_names_browser:
             assert tool_name in ToolCollection.browser_tools
+
+    async def test_read_image_tool_is_registered(self) -> None:
+        """read_image is in read_only_tools and has a ToolCollection wrapper."""
+        assert "read_image" in ToolCollection.read_only_tools
+        assert hasattr(ToolCollection, "read_image")

--- a/kolega_code/agent/tool_backend/read_image_tool.py
+++ b/kolega_code/agent/tool_backend/read_image_tool.py
@@ -1,0 +1,35 @@
+import base64
+from typing import List
+
+from .base_tool import BaseTool
+from kolega_code.llm.models import ContentBlock, ImageBlock
+from kolega_code.utils.images import IMAGE_MIME_TYPES
+
+
+class ReadImageTool(BaseTool):
+    async def read_image(self, path: str) -> List[ContentBlock]:
+        """
+        Read an image file from the project directory so you can see it. Use when the user references a screenshot, diagram, mockup, or other visual asset, or when visual inspection of a file in the workspace is needed. The image is returned for you to view directly.
+
+        When to use: the user asks you to look at an image/screenshot/mockup; you need to inspect a visual asset in the project; text-based reading is insufficient to understand a visual file.
+
+        Args:
+            path: Path to the image file. Relative to the project root is preferred; an absolute path is also accepted.
+
+        Returns:
+            The image, viewable directly.
+
+        Supported formats: PNG, JPEG, GIF, WebP, BMP.
+        """
+        if not self.filesystem.exists(path):
+            raise FileNotFoundError(f"Image not found: {path}")
+        if not self.filesystem.is_file(path):
+            raise ValueError(f"Not a file: {path}")
+        suffix = self.filesystem.get_suffix(path).lower()
+        media_type = IMAGE_MIME_TYPES.get(suffix)
+        if media_type is None:
+            raise ValueError(
+                f"Unsupported image format '{suffix}'. Supported: " + ", ".join(sorted(IMAGE_MIME_TYPES))
+            )
+        data = base64.b64encode(self.filesystem.read_bytes(path)).decode("ascii")
+        return [ImageBlock(image_type="base64", media_type=media_type, data=data)]

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -19,6 +19,7 @@ from .tool_backend.glob_tool import GlobTool
 from .tool_backend.list_directory_tool import ListDirectoryTool
 from .tool_backend.memory_tool import MemoryTool
 from .tool_backend.read_file_tool import ReadFileTool
+from .tool_backend.read_image_tool import ReadImageTool
 from .tool_backend.replace_entire_file_tool import (
     ReplaceEntireFileTool,
 )
@@ -107,6 +108,7 @@ class ToolCollection(LogMixin):
         "web_fetch",
         "web_search",
         "sleep",
+        "read_image",
     ]
 
     browser_tools = [
@@ -360,6 +362,15 @@ class ToolCollection(LogMixin):
             self.caller,
             self.filesystem,
         )
+        self.read_image_tool = ReadImageTool(
+            self.project_path,
+            self.workspace_id,
+            self.thread_id,
+            self.connection_manager,
+            self.config,
+            self.caller,
+            self.filesystem,
+        )
         self.create_file_tool = CreateFileTool(
             self.project_path,
             self.workspace_id,
@@ -592,6 +603,33 @@ class ToolCollection(LogMixin):
         image_block = ImageBlock(image_type="base64", media_type="image/png", data=result["screenshot"])
 
         return [image_block]
+
+    async def read_image(self, path: str) -> List[Any]:
+        """
+        Read an image file from the project directory so you can see it. Use when the user references a screenshot, diagram, mockup, or other visual asset, or when visual inspection of a file in the workspace is needed. The image is returned for you to view directly.
+
+        When to use: the user asks you to look at an image/screenshot/mockup; you need to inspect a visual asset in the project; text-based reading is insufficient to understand a visual file.
+
+        Args:
+            path: Path to the image file. Relative to the project root is preferred; an absolute path is also accepted.
+
+        Returns:
+            The image, viewable directly.
+
+        Supported formats: PNG, JPEG, GIF, WebP, BMP.
+        """
+        # ChatGPT/Responses backend drops tool-result images, so return a
+        # plain-text hint instead of an ImageBlock for that provider.
+        cfg = getattr(self.caller, "primary_model_config", None)
+        if cfg is not None:
+            provider = getattr(cfg, "provider", None)
+            provider_value = getattr(provider, "value", provider)
+            if provider_value == "openai_chatgpt":
+                return (
+                    f"Image read from {path}, but the ChatGPT Responses backend cannot receive images in tool results. "
+                    "Ask the user to attach the image directly in the chat input instead."
+                )
+        return await self.read_image_tool.read_image(path)
 
     async def interact_with_browser(
         self, browser_id: str, action: str, selector: str, text: str, scroll_px: int
@@ -1482,6 +1520,10 @@ class ToolCollection(LogMixin):
             if getattr(self.caller, "sub_agent", False):
                 return False
             return bool(getattr(self.caller, "gigacode_enabled", False))
+
+        # Vision gate: read_image is only surfaced to vision-capable models.
+        if method_name == "read_image":
+            return bool(getattr(self.caller, "supports_vision", False))
 
         # Check custom tool groups first
         if self.tool_config.custom_tool_groups:

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -618,17 +618,6 @@ class ToolCollection(LogMixin):
 
         Supported formats: PNG, JPEG, GIF, WebP, BMP.
         """
-        # ChatGPT/Responses backend drops tool-result images, so return a
-        # plain-text hint instead of an ImageBlock for that provider.
-        cfg = getattr(self.caller, "primary_model_config", None)
-        if cfg is not None:
-            provider = getattr(cfg, "provider", None)
-            provider_value = getattr(provider, "value", provider)
-            if provider_value == "openai_chatgpt":
-                return (
-                    f"Image read from {path}, but the ChatGPT Responses backend cannot receive images in tool results. "
-                    "Ask the user to attach the image directly in the chat input instead."
-                )
         return await self.read_image_tool.read_image(path)
 
     async def interact_with_browser(

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -1606,6 +1606,9 @@ class KolegaCodeApp(App):
         self._pending_question: Optional[PendingQuestion] = None
         self._pending_approval: Optional[PendingApproval] = None
         self._pending_image_attachments: list[dict] = []
+        # Dedup flag: one vision-mismatch system message per non-vision model
+        # session. Reset in _switch_model so a new model gets a fresh warning.
+        self._vision_warning_shown = False
         self._permission_lock = asyncio.Lock()
         self._pending_model_selection: Optional[PendingModelSelection] = None
         self._pending_effort_selection: Optional[PendingEffortSelection] = None
@@ -1996,6 +1999,18 @@ class KolegaCodeApp(App):
         if self._pending_image_attachments:
             attachments = (attachments or []) + self._pending_image_attachments
             self._pending_image_attachments.clear()
+        # Pre-send vision gate: block the send when the current model can't see
+        # images. This catches @file.png mentions (which bypass
+        # add_pending_image_attachment) and serves as a final gate for all
+        # attachment paths. History images are NOT blocked here — those are
+        # stripped to placeholders by _history_for_llm and the send proceeds.
+        if attachments and not self._model_supports_vision():
+            has_image = any(a.get("type") == "image" for a in attachments)
+            if has_image:
+                self._add_conversation_entry(ConversationEntry(kind="user", content=text))
+                self._add_vision_mismatch_system_message(context="attachment")
+                self._show_composer_hint(messages.MODEL_NON_VISION_IMAGE_BLOCKED, tone="warning")
+                return
         self._add_conversation_entry(ConversationEntry(kind="user", content=text))
         self.agent_worker = self.run_worker(
             self._process_message(text, attachments), name="kolega-turn", group="turns", exclusive=True
@@ -3130,11 +3145,58 @@ class KolegaCodeApp(App):
         await handler(args.strip())
         return True
 
+    def _model_supports_vision(self) -> bool:
+        """Safely check if the current agent's model supports vision input.
+
+        Returns ``False`` when no agent is loaded (conservative: images won't
+        work without a model, so a warning is the right default).
+        """
+        if self.agent is None:
+            return False
+        return getattr(self.agent, "supports_vision", False)
+
+    def _add_vision_mismatch_system_message(self, *, context: str) -> None:
+        """Add a persistent warning to the transcript when images meet a non-vision model.
+
+        ``context`` is ``"attachment"`` (new image attached) or ``"model_switch"``
+        (switched to a non-vision model with images in history). Deduplicated per
+        model session so repeated attachments don't spam the transcript — the
+        composer hint still updates with each attachment (showing all names), but
+        the transcript system message appears only once.
+        """
+        if self._vision_warning_shown:
+            return
+        model_config = getattr(self.agent, "primary_model_config", None)
+        model_name = getattr(model_config, "model", None) or "The current model"
+        if context == "attachment":
+            message = (
+                f"⚠ {model_name} does not support vision. Attached images will be omitted "
+                f"when sending. Switch to a vision-capable model with /model to include them."
+            )
+        else:  # model_switch
+            message = messages.MODEL_NON_VISION_IMAGE_HISTORY
+        self._add_conversation_entry(ConversationEntry(kind="system", content=message, tone="warning"))
+        self._vision_warning_shown = True
+
     def add_pending_image_attachment(self, attachment: dict) -> None:
-        """Stash a pending image attachment for the next submitted message."""
+        """Stash a pending image attachment for the next submitted message.
+
+        Centralized vision check: when the current model does not support vision,
+        shows a combined warning-tone hint (attachment confirmation + vision
+        mismatch) and a persistent system message in the transcript. This is the
+        single funnel for clipboard paste (both Ctrl+Shift+V and on_paste) and
+        /attach, so the warning is consistent across all three paths.
+        """
         self._pending_image_attachments.append(attachment)
         names = ", ".join(a.get("path", "image") for a in self._pending_image_attachments)
-        self._show_composer_hint(f"Attached images: {names} (press Enter to send)", tone="info")
+        if not self._model_supports_vision():
+            self._show_composer_hint(
+                f"Attached: {names}. {messages.MODEL_NON_VISION_IMAGE_ATTACHED}",
+                tone="warning",
+            )
+            self._add_vision_mismatch_system_message(context="attachment")
+        else:
+            self._show_composer_hint(f"Attached images: {names} (press Enter to send)", tone="info")
 
     async def _command_attach(self, args: str) -> None:
         arg = args.strip()
@@ -3173,13 +3235,8 @@ class KolegaCodeApp(App):
             )
             return
         data, media_type = result
-        if self.agent is not None and not getattr(self.agent, "supports_vision", False):
-            self._show_composer_hint(
-                "Pasted an image, but the current model does not support vision. "
-                "Switch with /model or attach anyway.",
-                tone="warning",
-            )
         attachment = encode_image_attachment(data, media_type, path="clipboard")
+        # Vision check is centralized in add_pending_image_attachment.
         self.add_pending_image_attachment(attachment)
 
     async def _command_plan(self, args: str) -> None:
@@ -3390,10 +3447,17 @@ class KolegaCodeApp(App):
         except Exception:
             pass
         self._restore_composer_placeholder()
-        if self.agent is not None and not getattr(self.agent, "supports_vision", False):
+        # Reset the per-session dedup flag so the new model gets a fresh warning.
+        self._vision_warning_shown = False
+        if self.agent is not None and not self._model_supports_vision():
             conversation = getattr(self.agent, "conversation", None)
             if conversation is not None and conversation.has_image_blocks():
+                # Dual-channel: persistent transcript message + ephemeral composer hint.
+                self._add_vision_mismatch_system_message(context="model_switch")
                 self._show_composer_hint(messages.MODEL_NON_VISION_IMAGE_HISTORY, tone="warning")
+        elif self.agent is not None and self._model_supports_vision():
+            # Switching to a vision-capable model: clear any stale non-vision warning.
+            self._clear_composer_hint()
         self._notify_user(
             messages.MODEL_SWITCHED.format(
                 provider=provider,

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -1381,7 +1381,8 @@ class KolegaCodeApp(App):
 
     #composer_hint {
         display: none;
-        height: 1;
+        height: auto;
+        max-height: 4;
         padding: 0 1;
         background: $surface;
     }
@@ -1994,23 +1995,28 @@ class KolegaCodeApp(App):
             if stripped_text:
                 self._set_settings_status(messages.SETTINGS_REQUIRED, tone="warning")
             return
-        event.composer.load_text("")
+        # Build attachments first (without clearing pending) so the vision gate
+        # can block before we consume the composer text and pending images.
         attachments = self._build_mention_attachments(text)
         if self._pending_image_attachments:
             attachments = (attachments or []) + self._pending_image_attachments
-            self._pending_image_attachments.clear()
-        # Pre-send vision gate: block the send when the current model can't see
-        # images. This catches @file.png mentions (which bypass
-        # add_pending_image_attachment) and serves as a final gate for all
-        # attachment paths. History images are NOT blocked here — those are
-        # stripped to placeholders by _history_for_llm and the send proceeds.
+        # Pre-send vision gate: block when the current model can't see images.
+        # Catches @file.png mentions (which bypass add_pending_image_attachment)
+        # and serves as a final gate for all attachment paths. When blocked, the
+        # composer text and pending attachments are PRESERVED so the user can
+        # remove the image (/detach or edit the @mention) or switch model and
+        # resend — nothing is added to the transcript because nothing was sent.
+        # History images are NOT blocked (stripped to placeholders by
+        # _history_for_llm, send proceeds normally).
         if attachments and not self._model_supports_vision():
             has_image = any(a.get("type") == "image" for a in attachments)
             if has_image:
-                self._add_conversation_entry(ConversationEntry(kind="user", content=text))
                 self._add_vision_mismatch_system_message(context="attachment")
                 self._show_composer_hint(messages.MODEL_NON_VISION_IMAGE_BLOCKED, tone="warning")
                 return
+        # Safe to consume — clear the composer and pending attachments now.
+        event.composer.load_text("")
+        self._pending_image_attachments.clear()
         self._add_conversation_entry(ConversationEntry(kind="user", content=text))
         self.agent_worker = self.run_worker(
             self._process_message(text, attachments), name="kolega-turn", group="turns", exclusive=True
@@ -3110,6 +3116,7 @@ class KolegaCodeApp(App):
     def _tui_command_handlers(self) -> dict[str, Callable[[str], Awaitable[None]]]:
         return {
             "/attach": self._command_attach,
+            "/detach": self._command_detach,
             "/init": self._command_init,
             "/plan": self._command_plan,
             "/build": self._command_build,
@@ -3170,8 +3177,8 @@ class KolegaCodeApp(App):
         model_name = getattr(model_config, "model", None) or "The current model"
         if context == "attachment":
             message = (
-                f"⚠ {model_name} does not support vision. Attached images will be omitted "
-                f"when sending. Switch to a vision-capable model with /model to include them."
+                f"⚠ {model_name} does not support vision. Use /detach to remove image "
+                f"attachments or /model to switch to a vision-capable model."
             )
         else:  # model_switch
             message = messages.MODEL_NON_VISION_IMAGE_HISTORY
@@ -3221,6 +3228,22 @@ class KolegaCodeApp(App):
             return
         attachment["path"] = arg
         self.add_pending_image_attachment(attachment)
+
+    async def _command_detach(self, args: str) -> None:
+        """Remove all pending image attachments (clears the attach queue).
+
+        The user has no other way to discard a pending image once attached,
+        especially on a non-vision model where the image can't be sent.
+        """
+        if not self._pending_image_attachments:
+            self._show_composer_hint("No pending image attachments to remove.", tone="info")
+            return
+        names = ", ".join(a.get("path", "image") for a in self._pending_image_attachments)
+        count = len(self._pending_image_attachments)
+        self._pending_image_attachments.clear()
+        self._show_composer_hint(
+            f"Removed {count} image attachment(s): {names}", tone="info"
+        )
 
     async def _paste_clipboard_image_worker(self) -> None:
         from kolega_code.cli.clipboard_image import read_clipboard_image

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -4768,16 +4768,12 @@ class KolegaCodeApp(App):
         if summary_entry is not None:
             through = int((self.session.compaction or {}).get("compacted_through") or 0)
             boundary = min(through, len(history))
-        for index, item in enumerate(history):
-            if summary_entry is not None and index == boundary:
-                self.conversation_entries.append(summary_entry)
-            try:
-                message = Message.from_dict(item)
-            except Exception:
-                continue
-            self.conversation_entries.extend(self._conversation_entries_from_message(message))
-        if summary_entry is not None and boundary is not None and boundary >= len(history):
+        if summary_entry is not None and boundary is not None:
+            self.conversation_entries.extend(self._conversation_entries_from_history_items(history[:boundary]))
             self.conversation_entries.append(summary_entry)
+            self.conversation_entries.extend(self._conversation_entries_from_history_items(history[boundary:]))
+        else:
+            self.conversation_entries.extend(self._conversation_entries_from_history_items(history))
         self._render_conversation()
 
     def _resume_compaction_entry(self) -> Optional[ConversationEntry]:
@@ -4792,7 +4788,51 @@ class KolegaCodeApp(App):
             return None
         return ConversationEntry(kind="compaction_summary", content=summary_text)
 
-    def _conversation_entries_from_message(self, message: Message) -> list[ConversationEntry]:
+    def _conversation_entries_from_history_items(self, history: list[dict]) -> list[ConversationEntry]:
+        """Build restored transcript entries, coalescing completed tool executions.
+
+        Live tool events render one row per execution by mutating a running
+        ``tool_call`` entry into ``tool_result``/``tool_error``. Saved history stores
+        the assistant ToolCall and the user ToolResult as separate provider messages,
+        so restore needs to rejoin them for the transcript to match the live UI.
+        """
+        entries: list[ConversationEntry] = []
+        pending_tool_entries: dict[str, ConversationEntry] = {}
+
+        def remember_tool_entry(block: ToolCall, entry: ConversationEntry) -> None:
+            for value in (getattr(block, "id", None), getattr(block, "execution_id", None)):
+                if value:
+                    pending_tool_entries[str(value)] = entry
+
+        def forget_tool_entry(entry: ConversationEntry) -> None:
+            for key, candidate in list(pending_tool_entries.items()):
+                if candidate is entry:
+                    pending_tool_entries.pop(key, None)
+
+        for item in history:
+            try:
+                message = Message.from_dict(item)
+            except Exception:
+                continue
+            entries.extend(
+                self._conversation_entries_from_message(
+                    message,
+                    pending_tool_entries=pending_tool_entries,
+                    remember_tool_entry=remember_tool_entry,
+                    forget_tool_entry=forget_tool_entry,
+                )
+            )
+
+        return entries
+
+    def _conversation_entries_from_message(
+        self,
+        message: Message,
+        *,
+        pending_tool_entries: Optional[dict[str, ConversationEntry]] = None,
+        remember_tool_entry: Optional[Callable[[ToolCall, ConversationEntry], None]] = None,
+        forget_tool_entry: Optional[Callable[[ConversationEntry], None]] = None,
+    ) -> list[ConversationEntry]:
         entries: list[ConversationEntry] = []
 
         if isinstance(message.content, str):
@@ -4814,30 +4854,57 @@ class KolegaCodeApp(App):
                 pending_text.append(block.text)
             elif isinstance(block, ToolCall):
                 flush_text()
-                entries.append(
-                    ConversationEntry(
-                        kind="tool_call",
-                        content=f"Calling {block.name}",
-                        complete=True,
-                        tool_name=block.name,
-                        tool_call_id=getattr(block, "execution_id", None),
-                    )
+                entry = ConversationEntry(
+                    kind="tool_call",
+                    content=f"Calling {block.name}",
+                    complete=False,
+                    tool_name=block.name,
+                    tool_call_id=getattr(block, "execution_id", None),
                 )
+                entries.append(entry)
+                if remember_tool_entry is not None:
+                    remember_tool_entry(block, entry)
             elif isinstance(block, ToolResult):
                 flush_text()
                 text = self._tool_content_to_text(block.content)
-                entries.append(
-                    ConversationEntry(
-                        kind="tool_error" if block.is_error else "tool_result",
-                        content=self._truncate_tool_text(text) if block.is_error else self._tool_result_preview(text),
-                        tool_name=block.name,
-                        tool_call_id=getattr(block, "execution_id", None),
-                        full_content=self._capped_tool_text(text),
+                entry = self._restored_tool_entry_for_result(block, text, pending_tool_entries)
+                if entry is None:
+                    entries.append(
+                        ConversationEntry(
+                            kind="tool_error" if block.is_error else "tool_result",
+                            content=self._truncate_tool_text(text) if block.is_error else self._tool_result_preview(text),
+                            tool_name=block.name,
+                            tool_call_id=getattr(block, "execution_id", None),
+                            full_content=self._capped_tool_text(text),
+                        )
                     )
-                )
+                else:
+                    entry.kind = "tool_error" if block.is_error else "tool_result"
+                    entry.content = self._truncate_tool_text(text) if block.is_error else self._tool_result_preview(text)
+                    entry.complete = True
+                    entry.tool_name = block.name or entry.tool_name
+                    entry.tool_call_id = getattr(block, "execution_id", None) or entry.tool_call_id
+                    entry.full_content = self._capped_tool_text(text)
+                    if forget_tool_entry is not None:
+                        forget_tool_entry(entry)
 
         flush_text()
         return entries
+
+    def _restored_tool_entry_for_result(
+        self,
+        block: ToolResult,
+        text: str,
+        pending_tool_entries: Optional[dict[str, ConversationEntry]],
+    ) -> Optional[ConversationEntry]:
+        if not pending_tool_entries:
+            return None
+        for value in (getattr(block, "tool_use_id", None), getattr(block, "execution_id", None)):
+            if value:
+                entry = pending_tool_entries.get(str(value))
+                if entry is not None:
+                    return entry
+        return None
 
     def _conversation_entry_for_text(self, role: str, text: str) -> ConversationEntry:
         names = skill_names_in_text(text)

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -715,6 +715,7 @@ class ChatComposer(TextArea):
         Binding("down", "mention_next", "Next match", show=False, priority=True),
         Binding("tab", "mention_accept", "Complete path", show=False, priority=True),
         Binding("escape", "mention_dismiss", "Dismiss matches", show=False, priority=True),
+        Binding("ctrl+shift+v", "paste_clipboard_image", "Paste image", key_display="Ctrl+Shift+V", priority=True),
     ]
 
     MENTION_QUERY_RE = re.compile(r"(?:^|(?<=\s))@(\S*)$")
@@ -827,6 +828,52 @@ class ChatComposer(TextArea):
         dropdown = self.mention_dropdown()
         if dropdown is not None:
             dropdown.close()
+
+    def action_paste_clipboard_image(self) -> None:
+        app = self.app
+        app.run_worker(app._paste_clipboard_image_worker(), name="paste-image", group="turns")
+
+    async def on_paste(self, event: events.Paste) -> None:
+        text = event.text or ""
+        import base64 as _b64
+        from pathlib import Path as _Path
+
+        from kolega_code.utils.images import (
+            encode_image_attachment,
+            encode_image_file,
+            image_media_type,
+        )
+
+        stripped = text.strip()
+        if stripped.startswith("data:image/") and ";base64," in stripped:
+            header, _, b64data = stripped.partition(";base64,")
+            media_type = header[len("data:"):]  # e.g. image/png
+            try:
+                raw = _b64.b64decode(b64data)
+            except Exception:
+                # Not a valid data-URI image — fall through to default paste.
+                return
+            self.app.add_pending_image_attachment(
+                encode_image_attachment(raw, media_type, path="pasted-data-uri")
+            )
+            event.prevent_default()
+            event.stop()
+            return
+        if (
+            stripped
+            and "\n" not in stripped
+            and _Path(stripped).exists()
+            and image_media_type(stripped) is not None
+        ):
+            att = encode_image_file(_Path(stripped))
+            if att is not None:
+                att["path"] = stripped
+                self.app.add_pending_image_attachment(att)
+                event.prevent_default()
+                event.stop()
+                return
+        # No image detected — let TextArea's default _on_paste insert the text.
+        return
 
     def on_blur(self, event) -> None:
         dropdown = self.mention_dropdown()
@@ -1558,6 +1605,7 @@ class KolegaCodeApp(App):
         self._gigacode_enabled = False
         self._pending_question: Optional[PendingQuestion] = None
         self._pending_approval: Optional[PendingApproval] = None
+        self._pending_image_attachments: list[dict] = []
         self._permission_lock = asyncio.Lock()
         self._pending_model_selection: Optional[PendingModelSelection] = None
         self._pending_effort_selection: Optional[PendingEffortSelection] = None
@@ -1945,6 +1993,9 @@ class KolegaCodeApp(App):
             return
         event.composer.load_text("")
         attachments = self._build_mention_attachments(text)
+        if self._pending_image_attachments:
+            attachments = (attachments or []) + self._pending_image_attachments
+            self._pending_image_attachments.clear()
         self._add_conversation_entry(ConversationEntry(kind="user", content=text))
         self.agent_worker = self.run_worker(
             self._process_message(text, attachments), name="kolega-turn", group="turns", exclusive=True
@@ -3043,6 +3094,7 @@ class KolegaCodeApp(App):
 
     def _tui_command_handlers(self) -> dict[str, Callable[[str], Awaitable[None]]]:
         return {
+            "/attach": self._command_attach,
             "/init": self._command_init,
             "/plan": self._command_plan,
             "/build": self._command_build,
@@ -3077,6 +3129,58 @@ class KolegaCodeApp(App):
         composer.load_text("")
         await handler(args.strip())
         return True
+
+    def add_pending_image_attachment(self, attachment: dict) -> None:
+        """Stash a pending image attachment for the next submitted message."""
+        self._pending_image_attachments.append(attachment)
+        names = ", ".join(a.get("path", "image") for a in self._pending_image_attachments)
+        self._show_composer_hint(f"Attached images: {names} (press Enter to send)", tone="info")
+
+    async def _command_attach(self, args: str) -> None:
+        arg = args.strip()
+        if not arg:
+            self._show_composer_hint(
+                "Usage: /attach <path-to-image>  (PNG, JPEG, GIF, WebP, BMP)", tone="warning"
+            )
+            return
+        from pathlib import Path as _Path
+
+        from kolega_code.utils.images import encode_image_file
+
+        candidate = _Path(arg)
+        if not candidate.is_absolute():
+            candidate = (self.project_path / arg).resolve()
+        attachment = encode_image_file(candidate)
+        if attachment is None:
+            self._show_composer_hint(
+                f"Could not attach {arg}: not a supported image, missing, or too large (>20MB). Use /attach <path>",
+                tone="warning",
+            )
+            return
+        attachment["path"] = arg
+        self.add_pending_image_attachment(attachment)
+
+    async def _paste_clipboard_image_worker(self) -> None:
+        from kolega_code.cli.clipboard_image import read_clipboard_image
+        from kolega_code.utils.images import encode_image_attachment
+
+        result = await read_clipboard_image()
+        if result is None:
+            self._show_composer_hint(
+                "No image on the clipboard, or your terminal doesn't support image paste. "
+                "Use /attach <path> or @image.png instead.",
+                tone="warning",
+            )
+            return
+        data, media_type = result
+        if self.agent is not None and not getattr(self.agent, "supports_vision", False):
+            self._show_composer_hint(
+                "Pasted an image, but the current model does not support vision. "
+                "Switch with /model or attach anyway.",
+                tone="warning",
+            )
+        attachment = encode_image_attachment(data, media_type, path="clipboard")
+        self.add_pending_image_attachment(attachment)
 
     async def _command_plan(self, args: str) -> None:
         if self._mode_switch_blocked():

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -1379,12 +1379,36 @@ class KolegaCodeApp(App):
         background: $surface;
     }
 
-    #composer_hint {
+    #composer_hint_row {
         display: none;
         height: auto;
         max-height: 4;
-        padding: 0 1;
         background: $surface;
+    }
+
+    #composer_hint_row #composer_hint {
+        width: 1fr;
+        height: auto;
+        padding: 0 1;
+    }
+
+    #composer_hint_row #detach_btn {
+        width: 3;
+        height: 1;
+        min-height: 1;
+        border: none;
+        background: transparent;
+        color: $text-muted;
+        padding: 0 1;
+    }
+
+    #composer_hint_row #detach_btn:hover {
+        color: $warning;
+    }
+
+    #composer_hint_row #detach_btn:focus {
+        color: $warning;
+        text-style: bold;
     }
 
     #completion_dropdown {
@@ -1665,7 +1689,11 @@ class KolegaCodeApp(App):
                 yield ActionList(id="effort_actions")
                 yield ActionList(id="theme_actions")
                 yield Static("", id="turn_status", markup=True)
-                yield Static("", id="composer_hint", markup=False)
+                with Horizontal(id="composer_hint_row"):
+                    yield Static("", id="composer_hint", markup=False)
+                    yield Button(
+                        theme.g(Glyph.CROSS), id="detach_btn", classes="hint-detach"
+                    )
                 yield CompletionDropdown(id="completion_dropdown")
                 yield ChatComposer(placeholder=COMPOSER_PLACEHOLDER, id="composer")
             with Vertical(id="side_panel"):
@@ -1792,6 +1820,7 @@ class KolegaCodeApp(App):
         self._set_effort_actions_visible(False)
         self._refresh_planning_sidebar()
         self._ensure_startup_entry()
+        self._update_detach_button()
         if self.check_for_updates:
             self.run_worker(self._check_for_update_on_startup(), name="kolega-update-check", group="updates")
         self._conversation.anchor()
@@ -2191,6 +2220,9 @@ class KolegaCodeApp(App):
             self._set_chat_enabled(self.agent is not None and not self._plan_decision_active)
 
     async def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "detach_btn":
+            await self._command_detach("")
+            return
         if event.button.id == "save_settings":
             await self._save_settings_from_ui()
 
@@ -3098,20 +3130,31 @@ class KolegaCodeApp(App):
     def _show_composer_hint(self, text: str, tone: str = "warning") -> None:
         try:
             hint = self.query_one("#composer_hint", Static)
+            row = self.query_one("#composer_hint_row", Horizontal)
         except Exception:
             return
         hint.set_class(tone == "warning", "hint-warning")
         hint.set_class(tone != "warning", "hint-info")
         hint.update(text)
-        hint.display = bool(text)
+        row.display = bool(text)
+        self._update_detach_button()
 
     def _clear_composer_hint(self) -> None:
         try:
+            row = self.query_one("#composer_hint_row", Horizontal)
             hint = self.query_one("#composer_hint", Static)
         except Exception:
             return
         hint.update("")
-        hint.display = False
+        row.display = False
+
+    def _update_detach_button(self) -> None:
+        """Show the detach × button only when there are pending image attachments."""
+        try:
+            btn = self.query_one("#detach_btn", Button)
+        except Exception:
+            return
+        btn.display = bool(self._pending_image_attachments)
 
     def _tui_command_handlers(self) -> dict[str, Callable[[str], Awaitable[None]]]:
         return {
@@ -3203,7 +3246,9 @@ class KolegaCodeApp(App):
             )
             self._add_vision_mismatch_system_message(context="attachment")
         else:
-            self._show_composer_hint(f"Attached images: {names} (press Enter to send)", tone="info")
+            self._show_composer_hint(
+                f"Attached images: {names} (press Enter to send, × to remove)", tone="info"
+            )
 
     async def _command_attach(self, args: str) -> None:
         arg = args.strip()

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -3390,6 +3390,10 @@ class KolegaCodeApp(App):
         except Exception:
             pass
         self._restore_composer_placeholder()
+        if self.agent is not None and not getattr(self.agent, "supports_vision", False):
+            conversation = getattr(self.agent, "conversation", None)
+            if conversation is not None and conversation.has_image_blocks():
+                self._show_composer_hint(messages.MODEL_NON_VISION_IMAGE_HISTORY, tone="warning")
         self._notify_user(
             messages.MODEL_SWITCHED.format(
                 provider=provider,

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -2043,9 +2043,11 @@ class KolegaCodeApp(App):
                 self._add_vision_mismatch_system_message(context="attachment")
                 self._show_composer_hint(messages.MODEL_NON_VISION_IMAGE_BLOCKED, tone="warning")
                 return
-        # Safe to consume — clear the composer and pending attachments now.
+        # Safe to consume — clear the composer, pending attachments, and the
+        # attach hint (which would otherwise linger during generation).
         event.composer.load_text("")
         self._pending_image_attachments.clear()
+        self._clear_composer_hint()
         self._add_conversation_entry(ConversationEntry(kind="user", content=text))
         self.agent_worker = self.run_worker(
             self._process_message(text, attachments), name="kolega-turn", group="turns", exclusive=True

--- a/kolega_code/cli/clipboard_image.py
+++ b/kolega_code/cli/clipboard_image.py
@@ -1,0 +1,152 @@
+"""Best-effort async helper to read an image from the system clipboard.
+
+This module is deliberately free of Textual imports (pure stdlib + asyncio)
+so it can be imported and unit-tested in isolation. Callers are responsible
+for surfacing failures to the user.
+
+Returns ``(image_bytes, media_type)`` or ``None`` when no image is available
+or no suitable clipboard tool exists on the platform.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from typing import Optional, Tuple
+
+# A tiny 1x1 transparent PNG used to recognize "empty"/non-image clipboard
+# results from tools that still exit 0. Anything smaller than this is treated
+# as "no image".
+_MIN_IMAGE_BYTES = 8
+
+
+async def _run_exec(*args: str) -> Tuple[bytes, bytes, int]:
+    """Run a subprocess, returning (stdout, stderr, returncode)."""
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+    return stdout or b"", stderr or b"", int(proc.returncode or 0)
+
+
+async def _run_shell(cmd: str) -> Tuple[bytes, bytes, int]:
+    """Run a shell command, returning (stdout, stderr, returncode)."""
+    proc = await asyncio.create_subprocess_shell(
+        cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+    return stdout or b"", stderr or b"", int(proc.returncode or 0)
+
+
+async def _read_macos_clipboard() -> Optional[Tuple[bytes, str]]:
+    """macOS: use osascript to write clipboard PNG to a temp file."""
+    tmp = Path(tempfile.gettempdir()) / f"kc_clip_{asyncio.get_event_loop().time()}.png"
+    try:
+        script = (
+            f'set the_file to (POSIX file "{tmp}")\n'
+            "try\n"
+            "\tset png_data to the clipboard as \u00abclass PNGf\u00bb\n"
+            "\ton error\n"
+            "\t\treturn\n"
+            "\tend try\n"
+            "\tset f to open for access the_file with write permission\n"
+            "\twrite png_data to f\n"
+            "\tclose access f"
+        )
+        _stdout, _stderr, rc = await _run_exec("osascript", "-e", script)
+        if rc == 0 and tmp.exists():
+            data = tmp.read_bytes()
+            if data and len(data) >= _MIN_IMAGE_BYTES:
+                return data, "image/png"
+        # Fallback to pngpaste if available
+        if shutil.which("pngpaste") is not None:
+            _stdout, _stderr, rc = await _run_exec("pngpaste", str(tmp))
+            if rc == 0 and tmp.exists():
+                data = tmp.read_bytes()
+                if data and len(data) >= _MIN_IMAGE_BYTES:
+                    return data, "image/png"
+        return None
+    except Exception:
+        return None
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+async def _read_linux_clipboard() -> Optional[Tuple[bytes, str]]:
+    """Linux/WSL: try xclip, wl-paste, then powershell.exe (WSL)."""
+    try:
+        if shutil.which("xclip") is not None:
+            stdout, _stderr, rc = await _run_exec(
+                "xclip", "-selection", "clipboard", "-t", "image/png", "-o"
+            )
+            if rc == 0 and stdout and len(stdout) >= _MIN_IMAGE_BYTES:
+                return stdout, "image/png"
+        if shutil.which("wl-paste") is not None:
+            stdout, _stderr, rc = await _run_exec("wl-paste", "--type", "image/png")
+            if rc == 0 and stdout and len(stdout) >= _MIN_IMAGE_BYTES:
+                return stdout, "image/png"
+        if shutil.which("powershell.exe") is not None:
+            tmp = Path(tempfile.gettempdir()) / f"kc_clip_{asyncio.get_event_loop().time()}.png"
+            try:
+                ps = (
+                    "Add-Type -AssemblyName System.Windows.Forms;"
+                    " $img = [System.Windows.Forms.Clipboard]::GetImage();"
+                    f" if ($img) {{ $img.Save('{tmp}') }}"
+                )
+                _stdout, _stderr, rc = await _run_exec("powershell.exe", "-NoProfile", "-Command", ps)
+                if rc == 0 and tmp.exists():
+                    data = tmp.read_bytes()
+                    if data and len(data) >= _MIN_IMAGE_BYTES:
+                        return data, "image/png"
+            finally:
+                tmp.unlink(missing_ok=True)
+        return None
+    except Exception:
+        return None
+
+
+async def _read_windows_clipboard() -> Optional[Tuple[bytes, str]]:
+    """Windows: use PowerShell to save the clipboard image to a temp PNG."""
+    tmp = Path(tempfile.gettempdir()) / f"kc_clip_{asyncio.get_event_loop().time()}.png"
+    try:
+        ps = (
+            "Add-Type -AssemblyName System.Windows.Forms;"
+            " $img = [System.Windows.Forms.Clipboard]::GetImage();"
+            f" if ($img) {{ $img.Save('{tmp}') }}"
+        )
+        _stdout, _stderr, rc = await _run_exec("powershell", "-NoProfile", "-Command", ps)
+        if rc == 0 and tmp.exists():
+            data = tmp.read_bytes()
+            if data and len(data) >= _MIN_IMAGE_BYTES:
+                return data, "image/png"
+        return None
+    except Exception:
+        return None
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+async def read_clipboard_image() -> Optional[Tuple[bytes, str]]:
+    """Best-effort read of an image from the system clipboard.
+
+    Returns ``(image_bytes, media_type)`` or ``None`` when no image is
+    available or no suitable clipboard tool exists on the current platform.
+    Never raises: all failures map to ``None``.
+    """
+    try:
+        if sys.platform == "darwin":
+            return await _read_macos_clipboard()
+        if sys.platform.startswith("linux"):
+            return await _read_linux_clipboard()
+        if sys.platform == "win32":
+            return await _read_windows_clipboard()
+        return None
+    except Exception:
+        return None

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -24,6 +24,7 @@ from kolega_code.permissions import (
     normalize_permission_mode,
 )
 from kolega_code.services.browser import PlaywrightBrowserManager
+from kolega_code.utils.images import encode_image_file
 
 from .config import (
     DEPRECATED_THINKING_TOKENS_MESSAGE,
@@ -193,6 +194,13 @@ def _build_subcommand_parser() -> argparse.ArgumentParser:
         "--trust-hooks",
         action="store_true",
         help="Trust and enable this project's .kolega/hooks.json (persisted for future runs).",
+    )
+    ask.add_argument(
+        "--image",
+        action="append",
+        default=[],
+        type=Path,
+        help="Attach an image file to the prompt (repeatable).",
     )
     _add_session_args(ask)
     _add_common_model_args(ask)
@@ -590,6 +598,15 @@ async def _run_ask(args: argparse.Namespace) -> int:
     attachments, unresolved_mentions = build_file_attachments(prompt, project_path)
     for mention in unresolved_mentions:
         print(f"Note: @{mention} not found, sent as plain text", file=sys.stderr)
+    for image_path in getattr(args, "image", None) or []:
+        encoded = encode_image_file(image_path)
+        if encoded is not None:
+            attachments.append(encoded)
+        else:
+            print(
+                f"Warning: --image {image_path} could not be attached (not a supported image, missing, or too large)",
+                file=sys.stderr,
+            )
 
     response_chunks: list[dict] = []
     exit_code = 0

--- a/kolega_code/cli/mentions.py
+++ b/kolega_code/cli/mentions.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
+from kolega_code.utils.images import MAX_IMAGE_BYTES, encode_image_attachment, image_media_type
+
 MENTION_RE = re.compile(r'(?:(?<=\s)|^)@(?:"([^"]+)"|(\S+))')
 
 TRAILING_PUNCTUATION = ",.;:!?)]}'\""
@@ -71,6 +73,24 @@ def build_file_attachments(text: str, project_path: Path) -> Tuple[List[Dict[str
                 }
             )
         else:
+            media_type = image_media_type(target.name)
+            if media_type is not None:
+                raw = target.read_bytes()
+                if len(raw) > MAX_IMAGE_BYTES:
+                    attachments.append(
+                        {
+                            "type": "file",
+                            "path": rel,
+                            "content": "[image too large to attach - over 20MB; ask the agent to read it directly]",
+                            "truncated": True,
+                            "is_dir": False,
+                        }
+                    )
+                else:
+                    attachment = encode_image_attachment(raw, media_type, path=rel)
+                    attachment["path"] = rel
+                    attachments.append(attachment)
+                continue
             content, truncated = _read_file_content(target)
             attachments.append(
                 {

--- a/kolega_code/cli/messages.py
+++ b/kolega_code/cli/messages.py
@@ -69,6 +69,11 @@ MENTIONS_NOT_FOUND = "Not found, sent as plain text: {mentions}"
 MODEL_SWITCHED = "Switched model to {provider}/{model} with thinking effort {effort}."
 MODEL_UNKNOWN = "Unknown model {model} for provider {provider}."
 MODEL_SWITCH_HINT = "Choose below, or switch with /model <name>."
+MODEL_NON_VISION_IMAGE_HISTORY = (
+    "This thread contains images from earlier turns. The current model does not support "
+    "vision, so those images will be replaced with text placeholders — switch back to a "
+    "vision-capable model with /model to see them again."
+)
 EFFORT_SWITCHED = "Switched thinking effort to {effort} for {provider}/{model}."
 EFFORT_UNKNOWN = "Unknown thinking effort {effort} for {provider}/{model}."
 EFFORT_UNSUPPORTED = "{provider}/{model} does not support a thinking effort setting."

--- a/kolega_code/cli/messages.py
+++ b/kolega_code/cli/messages.py
@@ -74,6 +74,14 @@ MODEL_NON_VISION_IMAGE_HISTORY = (
     "vision, so those images will be replaced with text placeholders — switch back to a "
     "vision-capable model with /model to see them again."
 )
+MODEL_NON_VISION_IMAGE_ATTACHED = (
+    "The current model does not support vision. Attached images will be omitted "
+    "when sending. Switch to a vision-capable model with /model to include them."
+)
+MODEL_NON_VISION_IMAGE_BLOCKED = (
+    "Message not sent — the current model does not support vision. "
+    "Remove the image or switch with /model."
+)
 EFFORT_SWITCHED = "Switched thinking effort to {effort} for {provider}/{model}."
 EFFORT_UNKNOWN = "Unknown thinking effort {effort} for {provider}/{model}."
 EFFORT_UNSUPPORTED = "{provider}/{model} does not support a thinking effort setting."

--- a/kolega_code/cli/messages.py
+++ b/kolega_code/cli/messages.py
@@ -75,12 +75,11 @@ MODEL_NON_VISION_IMAGE_HISTORY = (
     "vision-capable model with /model to see them again."
 )
 MODEL_NON_VISION_IMAGE_ATTACHED = (
-    "The current model does not support vision. Attached images will be omitted "
-    "when sending. Switch to a vision-capable model with /model to include them."
+    "This model can't see images — use /detach to remove or /model to switch."
 )
 MODEL_NON_VISION_IMAGE_BLOCKED = (
-    "Message not sent — the current model does not support vision. "
-    "Remove the image or switch with /model."
+    "Not sent — this model can't see images. "
+    "Use /detach to remove or /model to switch."
 )
 EFFORT_SWITCHED = "Switched thinking effort to {effort} for {provider}/{model}."
 EFFORT_UNKNOWN = "Unknown thinking effort {effort} for {provider}/{model}."

--- a/kolega_code/cli/slash_commands.py
+++ b/kolega_code/cli/slash_commands.py
@@ -41,6 +41,7 @@ SKILLS_LIST_COMMAND = "/skills"
 TUI_COMMAND_ENTRIES: tuple[SlashCommandEntry, ...] = (
     SlashCommandEntry("skills", "List available Agent Skills", CommandScope.TUI),
     SlashCommandEntry("attach", "Attach an image file to your next message", CommandScope.TUI),
+    SlashCommandEntry("detach", "Remove pending image attachments", CommandScope.TUI),
     SlashCommandEntry("init", "Create or update AGENTS.md for this repository", CommandScope.TUI),
     SlashCommandEntry("plan", "Switch to plan mode", CommandScope.TUI),
     SlashCommandEntry("build", "Switch to build mode", CommandScope.TUI),

--- a/kolega_code/cli/slash_commands.py
+++ b/kolega_code/cli/slash_commands.py
@@ -40,6 +40,7 @@ SKILLS_LIST_COMMAND = "/skills"
 
 TUI_COMMAND_ENTRIES: tuple[SlashCommandEntry, ...] = (
     SlashCommandEntry("skills", "List available Agent Skills", CommandScope.TUI),
+    SlashCommandEntry("attach", "Attach an image file to your next message", CommandScope.TUI),
     SlashCommandEntry("init", "Create or update AGENTS.md for this repository", CommandScope.TUI),
     SlashCommandEntry("plan", "Switch to plan mode", CommandScope.TUI),
     SlashCommandEntry("build", "Switch to build mode", CommandScope.TUI),

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -4731,11 +4731,188 @@ async def test_textual_app_renders_resumed_history_in_chat(
         assert [(entry.kind, entry.content, entry.tool_name) for entry in app.conversation_entries[1:]] == [
             ("user", "Please read the README", None),
             ("assistant", "I'll inspect it.", None),
-            ("tool_call", "Calling read_file", "read_file"),
             ("tool_result", "README contents", "read_file"),
             ("tool_error", "Permission denied", "write_file"),
             ("assistant", "Done.", None),
         ]
+
+
+@pytest.mark.asyncio
+async def test_textual_app_restore_tool_history_matches_legacy_and_execution_ids(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import KolegaCodeApp
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.restored_history = None
+
+        def restore_message_history(self, history):
+            self.restored_history = history
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
+        def dump_message_history(self):
+            return self.restored_history or []
+
+        async def cleanup(self):
+            return None
+
+    monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    legacy_call = {
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": "Legacy first."},
+            {
+                "type": "tool_call",
+                "id": "provider-legacy",
+                "name": "read_file",
+                "input": {"path": "legacy.md"},
+            },
+        ],
+        "stop_reason": "tool_use",
+        "usage_metadata": {},
+    }
+    legacy_result = {
+        "role": "user",
+        "content": [
+            {
+                "type": "tool_result",
+                "tool_use_id": "provider-legacy",
+                "content": "legacy contents",
+                "name": "read_file",
+                "is_error": False,
+                "cache_checkpoint": False,
+            }
+        ],
+        "stop_reason": None,
+        "usage_metadata": {},
+    }
+    execution_call = Message(
+        role="assistant",
+        content=[
+            TextBlock("Modern first."),
+            ToolCall(
+                id="provider-modern",
+                name="search_codebase",
+                input={"pattern": "needle"},
+                execution_id="tool_exec_modern",
+            ),
+        ],
+    ).to_dict()
+    execution_result = Message(
+        role="user",
+        content=[
+            ToolResult(
+                tool_use_id="provider-modern",
+                content="modern contents",
+                name="search_codebase",
+                is_error=False,
+                execution_id="tool_exec_modern",
+            ),
+            TextBlock("Thanks for the tool output."),
+        ],
+    ).to_dict()
+    pending_call = Message(
+        role="assistant",
+        content=[ToolCall(id="provider-pending", name="list_directory", input={"path": "."})],
+    ).to_dict()
+    orphan_result = Message(
+        role="user",
+        content=[
+            ToolResult(tool_use_id="provider-orphan", content="orphan failed", name="write_file", is_error=True)
+        ],
+    ).to_dict()
+    session.history = [legacy_call, legacy_result, execution_call, execution_result, pending_call, orphan_result]
+
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test():
+        restored = app.conversation_entries[1:]
+        assert [(entry.kind, entry.content, entry.tool_name) for entry in restored] == [
+            ("assistant", "Legacy first.", None),
+            ("tool_result", "legacy contents", "read_file"),
+            ("assistant", "Modern first.", None),
+            ("tool_result", "modern contents", "search_codebase"),
+            ("user", "Thanks for the tool output.", None),
+            ("tool_call", "Calling list_directory", "list_directory"),
+            ("tool_error", "orphan failed", "write_file"),
+        ]
+        modern_entry = next(entry for entry in restored if entry.tool_name == "search_codebase")
+        assert modern_entry.tool_call_id == "tool_exec_modern"
+        pending_entry = next(entry for entry in restored if entry.tool_name == "list_directory")
+        assert pending_entry.complete is False
+
+
+@pytest.mark.asyncio
+async def test_textual_app_model_rebuild_rerenders_completed_tool_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import KolegaCodeApp
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.history = []
+            self.compaction = {}
+
+        def restore_message_history(self, history):
+            self.history = history
+
+        def dump_compaction_state(self):
+            return self.compaction
+
+        def restore_compaction_state(self, data):
+            self.compaction = data or {}
+
+        def dump_message_history(self):
+            return self.history
+
+        async def cleanup(self):
+            return None
+
+    monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+    history = [
+        Message(
+            role="assistant",
+            content=[ToolCall(id="provider-1", name="list_directory", input={"path": "."})],
+        ).to_dict(),
+        Message(
+            role="user",
+            content=[ToolResult(tool_use_id="provider-1", content="files", name="list_directory", is_error=False)],
+        ).to_dict(),
+    ]
+
+    async with app.run_test():
+        app.agent.history = history
+        await app._build_agent(config, rebuild=True)
+
+        tool_entries = [entry for entry in app.conversation_entries if entry.tool_name == "list_directory"]
+        assert [(entry.kind, entry.content) for entry in tool_entries] == [("tool_result", "files")]
 
 
 # ---------------------------------------------------------------------------
@@ -6177,7 +6354,7 @@ async def test_textual_app_submitting_mention_attaches_file_and_keeps_short_text
 
 
 @pytest.mark.asyncio
-async def test_textual_app_unresolved_mention_shows_hint_and_sends_plain_text(
+async def test_textual_app_unresolved_mention_clears_hint_and_sends_plain_text(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     pytest.importorskip("textual")
@@ -6193,9 +6370,10 @@ async def test_textual_app_unresolved_mention_shows_hint_and_sends_plain_text(
         composer.load_text("look at @does/not/exist.py")
         await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
 
-        # The hint is visible while the turn runs; end-of-turn cleanup restores the placeholder.
+        # Unresolved mentions are sent as plain text; the compose-time hint must
+        # not linger after the message has been submitted.
         hint = app.query_one("#composer_hint", Static)
-        assert "does/not/exist.py" in str(hint.render())
+        assert str(hint.render()) == ""
 
         await pilot.pause()
         assert app.agent.messages == ["look at @does/not/exist.py"]

--- a/kolega_code/cli/tests/test_app_image_vision_warning.py
+++ b/kolega_code/cli/tests/test_app_image_vision_warning.py
@@ -494,3 +494,58 @@ async def test_detach_command_registered(tmp_path, monkeypatch):
         handlers = app._tui_command_handlers()
         assert "/detach" in handlers
         assert handlers["/detach"] == app._command_detach
+
+
+# ---------------------------------------------------------------------------
+# Detach × button — clickable UI element in the composer hint row
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_detach_button_visible_when_image_attached(tmp_path, monkeypatch):
+    """The × button in the hint row is visible when there are pending image attachments."""
+    from textual.widgets import Button
+
+    app = _make_app(tmp_path, monkeypatch)
+    async with app.run_test():
+        app.agent = _FakeAgent(supports_vision=True)
+        app.add_pending_image_attachment(_image_attachment("photo.png"))
+
+        btn = app.query_one("#detach_btn", Button)
+        assert btn.display, "detach button should be visible when an image is attached"
+
+
+@pytest.mark.asyncio
+async def test_detach_button_hidden_when_no_attachments(tmp_path, monkeypatch):
+    """The × button is hidden when there are no pending image attachments."""
+    from textual.widgets import Button
+
+    app = _make_app(tmp_path, monkeypatch)
+    async with app.run_test():
+        app.agent = _FakeAgent(supports_vision=True)
+
+        btn = app.query_one("#detach_btn", Button)
+        assert not btn.display, "detach button should be hidden when no image is attached"
+
+
+@pytest.mark.asyncio
+async def test_detach_button_click_clears_attachments(tmp_path, monkeypatch):
+    """Clicking the × button calls _command_detach and clears pending attachments."""
+    from textual.widgets import Button
+
+    app = _make_app(tmp_path, monkeypatch)
+    async with app.run_test():
+        app.agent = _FakeAgent(supports_vision=True)
+        app.add_pending_image_attachment(_image_attachment("photo.png"))
+        app.add_pending_image_attachment(_image_attachment("chart.png"))
+
+        assert app._pending_image_attachments, "should have pending attachments"
+
+        # Simulate clicking the detach button.
+        btn = app.query_one("#detach_btn", Button)
+        await app.on_button_pressed(Button.Pressed(btn))
+
+        assert app._pending_image_attachments == [], "clicking × should clear attachments"
+
+        # Button should now be hidden.
+        assert not btn.display, "detach button should be hidden after clearing"

--- a/kolega_code/cli/tests/test_app_image_vision_warning.py
+++ b/kolega_code/cli/tests/test_app_image_vision_warning.py
@@ -1,0 +1,424 @@
+"""Tests for vision mismatch warnings when attaching/sending images on non-vision models.
+
+Covers all four image attachment entry points:
+  1. Clipboard paste (Ctrl+Shift+V)  — _paste_clipboard_image_worker
+  2. on_paste event (data-URI / file path) — ChatComposer.on_paste -> add_pending_image_attachment
+  3. /attach <path> slash command      — _command_attach -> add_pending_image_attachment
+  4. @file.png mention + submit        — _build_mention_attachments at submit time
+
+Plus the centralised vision check in ``add_pending_image_attachment`` and the
+submit-time pre-send gate in ``on_chat_composer_submitted``.
+"""
+
+import base64
+
+import pytest
+
+from kolega_code.cli.config import build_agent_config, config_summary
+from kolega_code.cli.session_store import SessionStore
+
+
+def build_test_config(project):
+    return build_agent_config(
+        project,
+        env={
+            "ANTHROPIC_API_KEY": "test-key",
+            "KOLEGA_CODE_PROVIDER": "anthropic",
+        },
+    )
+
+
+def _image_attachment(path: str = "clipboard") -> dict:
+    return {
+        "type": "image",
+        "media_type": "image/png",
+        "data": base64.b64encode(b"fake-image").decode("ascii"),
+        "path": path,
+    }
+
+
+class _FakeConversation:
+    def __init__(self, has_images: bool = False):
+        self._has_images = has_images
+
+    def has_image_blocks(self) -> bool:
+        return self._has_images
+
+
+class _FakeAgent:
+    """Minimal agent stand-in exposing vision capability + conversation probe."""
+
+    def __init__(self, *, supports_vision: bool, has_images: bool = False, model: str = "test-model"):
+        self.supports_vision = supports_vision
+        self.conversation = _FakeConversation(has_images)
+        self.primary_model_config = type("Cfg", (), {"model": model})()
+
+
+def _make_app(tmp_path, monkeypatch):
+    """Build a KolegaCodeApp with a no-op FakeCoderAgent; agent set by the caller."""
+    pytest.importorskip("textual")
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import KolegaCodeApp
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            return None
+
+    monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+    return app
+
+
+# ---------------------------------------------------------------------------
+# add_pending_image_attachment — the centralised vision check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_add_pending_image_non_vision_shows_warning_hint(tmp_path, monkeypatch):
+    """Non-vision model: warning-tone hint + transcript system message."""
+    app = _make_app(tmp_path, monkeypatch)
+    async with app.run_test():
+        app.agent = _FakeAgent(supports_vision=False)
+        hints: list[tuple] = []
+        app._show_composer_hint = lambda text, tone="warning": hints.append((text, tone))
+        entries: list = []
+        app._add_conversation_entry = lambda entry: entries.append(entry)
+
+        app.add_pending_image_attachment(_image_attachment("clipboard"))
+
+        assert hints, "expected a composer hint"
+        text, tone = hints[0]
+        assert tone == "warning"
+        assert "clipboard" in text
+        assert "does not support vision" in text
+        # Transcript system message added.
+        system = [e for e in entries if e.kind == "system"]
+        assert system, "expected a system message in the transcript"
+        assert system[0].tone == "warning"
+
+
+@pytest.mark.asyncio
+async def test_add_pending_image_vision_shows_info_hint(tmp_path, monkeypatch):
+    """Vision model: info-tone hint, no transcript system message."""
+    app = _make_app(tmp_path, monkeypatch)
+    async with app.run_test():
+        app.agent = _FakeAgent(supports_vision=True)
+        hints: list[tuple] = []
+        app._show_composer_hint = lambda text, tone="warning": hints.append((text, tone))
+        entries: list = []
+        app._add_conversation_entry = lambda entry: entries.append(entry)
+
+        app.add_pending_image_attachment(_image_attachment("photo.png"))
+
+        assert hints, "expected a composer hint"
+        text, tone = hints[0]
+        assert tone == "info"
+        assert "photo.png" in text
+        assert entries == [], "vision model should not add a system message"
+
+
+@pytest.mark.asyncio
+async def test_multiple_attachments_non_vision_one_transcript_message(tmp_path, monkeypatch):
+    """Multiple attachments on a non-vision model: one transcript message, hint updates."""
+    app = _make_app(tmp_path, monkeypatch)
+    async with app.run_test():
+        app.agent = _FakeAgent(supports_vision=False)
+        hints: list[tuple] = []
+        app._show_composer_hint = lambda text, tone="warning": hints.append((text, tone))
+        entries: list = []
+        app._add_conversation_entry = lambda entry: entries.append(entry)
+
+        app.add_pending_image_attachment(_image_attachment("img1.png"))
+        app.add_pending_image_attachment(_image_attachment("img2.png"))
+
+        # Two hint updates (each shows all attached names).
+        assert len(hints) == 2
+        assert "img1.png" in hints[0][0]
+        assert "img2.png" in hints[1][0]
+        assert "img1.png" in hints[1][0]  # both names in the latest hint
+        # Only ONE transcript system message (deduped).
+        system = [e for e in entries if e.kind == "system"]
+        assert len(system) == 1
+
+
+# ---------------------------------------------------------------------------
+# _paste_clipboard_image_worker — warning not overwritten
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_paste_clipboard_image_non_vision_warning_not_overwritten(tmp_path, monkeypatch):
+    """The old bug: _paste_clipboard_image_worker showed a warning then add_pending_image_attachment
+    overwrote it with an info hint. Now the warning survives because the check is centralised."""
+    app = _make_app(tmp_path, monkeypatch)
+    async with app.run_test():
+        app.agent = _FakeAgent(supports_vision=False)
+
+        # Mock the clipboard reader.
+        async def _fake_read():
+            return (b"fake-image", "image/png")
+
+        monkeypatch.setattr(
+            "kolega_code.cli.clipboard_image.read_clipboard_image",
+            _fake_read,
+        )
+
+        hints: list[tuple] = []
+        app._show_composer_hint = lambda text, tone="warning": hints.append((text, tone))
+        entries: list = []
+        app._add_conversation_entry = lambda entry: entries.append(entry)
+
+        await app._paste_clipboard_image_worker()
+
+        # The final hint must be a warning (not info) and mention vision.
+        assert hints, "expected at least one hint"
+        final_text, final_tone = hints[-1]
+        assert final_tone == "warning", "warning should not be overwritten by info hint"
+        assert "does not support vision" in final_text
+        # And a transcript system message.
+        assert any(e.kind == "system" for e in entries)
+
+
+# ---------------------------------------------------------------------------
+# /attach slash command — warning on non-vision model
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_attach_command_non_vision_shows_warning(tmp_path, monkeypatch):
+    """/attach on a non-vision model shows the vision warning (centralised check)."""
+    app = _make_app(tmp_path, monkeypatch)
+    async with app.run_test():
+        app.agent = _FakeAgent(supports_vision=False)
+
+        # Create a real image file for /attach to read.
+        import struct
+        import zlib
+
+        # Minimal 1x1 PNG.
+        def _minimal_png() -> bytes:
+            sig = b"\x89PNG\r\n\x1a\n"
+            ihdr = struct.pack(
+                ">IHHBBBB", 13, 1, 1, 8, 2, 0, 0
+            )  # length=13, w=1, h=1, depth=8, color=2 (RGB)
+            ihdr_chunk = b"IHDR" + ihdr
+            ihdr_crc = struct.pack(">I", zlib.crc32(ihdr_chunk) & 0xFFFFFFFF)
+            ihdr_full = struct.pack(">I", 13) + ihdr_chunk + ihdr_crc
+            raw = b"\x00\xff\x00\x00"  # filter=none, R=0, G=0, B=0
+            idat_data = zlib.compress(raw)
+            idat_chunk = b"IDAT" + idat_data
+            idat_crc = struct.pack(">I", zlib.crc32(idat_chunk) & 0xFFFFFFFF)
+            idat_full = struct.pack(">I", len(idat_data)) + idat_chunk + idat_crc
+            iend_chunk = b"IEND"
+            iend_crc = struct.pack(">I", zlib.crc32(iend_chunk) & 0xFFFFFFFF)
+            iend_full = struct.pack(">I", 0) + iend_chunk + iend_crc
+            return sig + ihdr_full + idat_full + iend_full
+
+        img_path = tmp_path / "project" / "test.png"
+        img_path.write_bytes(_minimal_png())
+
+        hints: list[tuple] = []
+        app._show_composer_hint = lambda text, tone="warning": hints.append((text, tone))
+        entries: list = []
+        app._add_conversation_entry = lambda entry: entries.append(entry)
+
+        await app._command_attach("test.png")
+
+        # Image was attached successfully and a warning was shown.
+        assert app._pending_image_attachments, "image should be stashed"
+        assert hints, "expected a hint"
+        final_text, final_tone = hints[-1]
+        assert final_tone == "warning"
+        assert "does not support vision" in final_text
+        assert any(e.kind == "system" for e in entries)
+
+
+# ---------------------------------------------------------------------------
+# Submit-time pre-send gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_submit_with_pending_image_non_vision_blocked(tmp_path, monkeypatch):
+    """Submitting with a pending image on a non-vision model blocks the send at the CLI gate.
+    No agent worker is spawned — the user sees a transcript message, not an API failure."""
+    app = _make_app(tmp_path, monkeypatch)
+    async with app.run_test():
+        app.agent = _FakeAgent(supports_vision=False)
+        app._pending_image_attachments.append(_image_attachment("photo.png"))
+
+        hints: list[tuple] = []
+        app._show_composer_hint = lambda text, tone="warning": hints.append((text, tone))
+        entries: list = []
+        app._add_conversation_entry = lambda entry: entries.append(entry)
+        spawned: list = []
+
+        def _track_worker(coro, *a, **k):
+            spawned.append((coro, a, k))
+            coro.close()  # avoid "coroutine never awaited" warning
+            return None
+
+        app.run_worker = _track_worker
+
+        from kolega_code.cli.app import ChatComposer
+
+        composer = app.query_one("#composer", ChatComposer)
+        composer.text = "describe this"
+
+        # Simulate submit.
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, "describe this"))
+
+        # No agent worker spawned (send blocked).
+        assert spawned == [], "no agent worker should be spawned when the send is blocked"
+        # Transcript has the user message + a system warning.
+        kinds = [e.kind for e in entries]
+        assert "user" in kinds
+        assert "system" in kinds
+        system = [e for e in entries if e.kind == "system"]
+        assert "does not support vision" in system[0].content
+        # Composer hint shows the blocked message.
+        assert hints
+        assert "not sent" in hints[-1][0]
+
+
+@pytest.mark.asyncio
+async def test_submit_with_mention_image_non_vision_blocked(tmp_path, monkeypatch):
+    """@file.png mention resolved at submit time on a non-vision model: blocked at CLI gate."""
+    app = _make_app(tmp_path, monkeypatch)
+    async with app.run_test():
+        app.agent = _FakeAgent(supports_vision=False)
+
+        # Create an image file so the @mention resolves to an image attachment.
+        import struct
+        import zlib
+
+        def _minimal_png() -> bytes:
+            sig = b"\x89PNG\r\n\x1a\n"
+            ihdr = struct.pack(">IHHBBBB", 13, 1, 1, 8, 2, 0, 0)
+            ihdr_chunk = b"IHDR" + ihdr
+            ihdr_crc = struct.pack(">I", zlib.crc32(ihdr_chunk) & 0xFFFFFFFF)
+            ihdr_full = struct.pack(">I", 13) + ihdr_chunk + ihdr_crc
+            raw = b"\x00\xff\x00\x00"
+            idat_data = zlib.compress(raw)
+            idat_chunk = b"IDAT" + idat_data
+            idat_crc = struct.pack(">I", zlib.crc32(idat_chunk) & 0xFFFFFFFF)
+            idat_full = struct.pack(">I", len(idat_data)) + idat_chunk + idat_crc
+            iend_chunk = b"IEND"
+            iend_crc = struct.pack(">I", zlib.crc32(iend_chunk) & 0xFFFFFFFF)
+            iend_full = struct.pack(">I", 0) + iend_chunk + iend_crc
+            return sig + ihdr_full + idat_full + iend_full
+
+        img_path = tmp_path / "project" / "screenshot.png"
+        img_path.write_bytes(_minimal_png())
+        app.file_index.refresh()
+
+        hints: list[tuple] = []
+        app._show_composer_hint = lambda text, tone="warning": hints.append((text, tone))
+        entries: list = []
+        app._add_conversation_entry = lambda entry: entries.append(entry)
+        spawned: list = []
+
+        def _track_worker(coro, *a, **k):
+            spawned.append((coro, a, k))
+            coro.close()
+            return None
+
+        app.run_worker = _track_worker
+
+        from kolega_code.cli.app import ChatComposer
+
+        composer = app.query_one("#composer", ChatComposer)
+        text = "@screenshot.png describe this"
+        composer.text = text
+
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, text))
+
+        # Send blocked — no agent worker.
+        assert spawned == [], "no agent worker should be spawned"
+        system = [e for e in entries if e.kind == "system"]
+        assert system, "expected a system message"
+
+
+@pytest.mark.asyncio
+async def test_submit_with_image_vision_model_proceeds(tmp_path, monkeypatch):
+    """Submitting with a pending image on a vision model: send proceeds normally."""
+    app = _make_app(tmp_path, monkeypatch)
+    async with app.run_test():
+        app.agent = _FakeAgent(supports_vision=True)
+        app._pending_image_attachments.append(_image_attachment("photo.png"))
+
+        entries: list = []
+        app._add_conversation_entry = lambda entry: entries.append(entry)
+        spawned: list = []
+
+        def _track_worker(coro, *a, **k):
+            spawned.append((coro, a, k))
+            coro.close()
+            return None
+
+        app.run_worker = _track_worker
+
+        from kolega_code.cli.app import ChatComposer
+
+        composer = app.query_one("#composer", ChatComposer)
+        composer.text = "describe this"
+
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, "describe this"))
+
+        # Agent worker spawned (send proceeds).
+        assert spawned, "agent worker should be spawned for vision model"
+
+
+@pytest.mark.asyncio
+async def test_submit_text_only_non_vision_with_history_images_proceeds(tmp_path, monkeypatch):
+    """Text-only message on a non-vision model with image history: send proceeds.
+    History images are stripped by _history_for_llm, not blocked by the CLI gate."""
+    app = _make_app(tmp_path, monkeypatch)
+    async with app.run_test():
+        # Non-vision model WITH image history, but NO new image attachments.
+        app.agent = _FakeAgent(supports_vision=False, has_images=True)
+
+        entries: list = []
+        app._add_conversation_entry = lambda entry: entries.append(entry)
+        spawned: list = []
+
+        def _track_worker(coro, *a, **k):
+            spawned.append((coro, a, k))
+            coro.close()
+            return None
+
+        app.run_worker = _track_worker
+
+        from kolega_code.cli.app import ChatComposer
+
+        composer = app.query_one("#composer", ChatComposer)
+        composer.text = "follow up question"
+
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, "follow up question"))
+
+        # Agent worker spawned — the CLI gate only blocks NEW image attachments,
+        # not history images (those are handled by _history_for_llm).
+        assert spawned, "agent worker should be spawned for text-only message"

--- a/kolega_code/cli/tests/test_app_image_vision_warning.py
+++ b/kolega_code/cli/tests/test_app_image_vision_warning.py
@@ -402,6 +402,18 @@ async def test_submit_with_image_vision_model_proceeds(tmp_path, monkeypatch):
         # Agent worker spawned (send proceeds).
         assert spawned, "agent worker should be spawned for vision model"
 
+        # The composer hint must be cleared after a successful submit — it
+        # should not linger during generation.
+        from textual.containers import Horizontal
+
+        row = app.query_one("#composer_hint_row", Horizontal)
+        assert not row.display, "composer hint row should be hidden after submit"
+        # And the detach button should be hidden (no pending attachments).
+        from textual.widgets import Button
+
+        btn = app.query_one("#detach_btn", Button)
+        assert not btn.display, "detach button should be hidden after submit"
+
 
 @pytest.mark.asyncio
 async def test_submit_text_only_non_vision_with_history_images_proceeds(tmp_path, monkeypatch):

--- a/kolega_code/cli/tests/test_app_image_vision_warning.py
+++ b/kolega_code/cli/tests/test_app_image_vision_warning.py
@@ -113,11 +113,12 @@ async def test_add_pending_image_non_vision_shows_warning_hint(tmp_path, monkeyp
         text, tone = hints[0]
         assert tone == "warning"
         assert "clipboard" in text
-        assert "does not support vision" in text
+        assert "can't see images" in text
         # Transcript system message added.
         system = [e for e in entries if e.kind == "system"]
         assert system, "expected a system message in the transcript"
         assert system[0].tone == "warning"
+        assert "does not support vision" in system[0].content
 
 
 @pytest.mark.asyncio
@@ -197,7 +198,7 @@ async def test_paste_clipboard_image_non_vision_warning_not_overwritten(tmp_path
         assert hints, "expected at least one hint"
         final_text, final_tone = hints[-1]
         assert final_tone == "warning", "warning should not be overwritten by info hint"
-        assert "does not support vision" in final_text
+        assert "can't see images" in final_text
         # And a transcript system message.
         assert any(e.kind == "system" for e in entries)
 
@@ -252,7 +253,7 @@ async def test_attach_command_non_vision_shows_warning(tmp_path, monkeypatch):
         assert hints, "expected a hint"
         final_text, final_tone = hints[-1]
         assert final_tone == "warning"
-        assert "does not support vision" in final_text
+        assert "can't see images" in final_text
         assert any(e.kind == "system" for e in entries)
 
 
@@ -293,15 +294,20 @@ async def test_submit_with_pending_image_non_vision_blocked(tmp_path, monkeypatc
 
         # No agent worker spawned (send blocked).
         assert spawned == [], "no agent worker should be spawned when the send is blocked"
-        # Transcript has the user message + a system warning.
+        # The user's message must NOT appear in the transcript (it was never sent).
         kinds = [e.kind for e in entries]
-        assert "user" in kinds
+        assert "user" not in kinds, "blocked message should not appear in the transcript"
+        # A system warning IS added to the transcript.
         assert "system" in kinds
         system = [e for e in entries if e.kind == "system"]
         assert "does not support vision" in system[0].content
         # Composer hint shows the blocked message.
         assert hints
-        assert "not sent" in hints[-1][0]
+        assert "not sent" in hints[-1][0].lower() or "Not sent" in hints[-1][0]
+        # Composer text is preserved so the user can edit and resend.
+        assert composer.text == "describe this", "composer text should be preserved when blocked"
+        # Pending attachment is preserved so the user can /detach it.
+        assert app._pending_image_attachments, "pending attachment should be preserved when blocked"
 
 
 @pytest.mark.asyncio
@@ -358,8 +364,13 @@ async def test_submit_with_mention_image_non_vision_blocked(tmp_path, monkeypatc
 
         # Send blocked — no agent worker.
         assert spawned == [], "no agent worker should be spawned"
+        # The user's message must NOT appear in the transcript (it was never sent).
+        kinds = [e.kind for e in entries]
+        assert "user" not in kinds, "blocked message should not appear in the transcript"
         system = [e for e in entries if e.kind == "system"]
         assert system, "expected a system message"
+        # Composer text preserved so the user can edit the @mention and resend.
+        assert composer.text == text, "composer text should be preserved when blocked"
 
 
 @pytest.mark.asyncio
@@ -422,3 +433,64 @@ async def test_submit_text_only_non_vision_with_history_images_proceeds(tmp_path
         # Agent worker spawned — the CLI gate only blocks NEW image attachments,
         # not history images (those are handled by _history_for_llm).
         assert spawned, "agent worker should be spawned for text-only message"
+
+
+# ---------------------------------------------------------------------------
+# /detach — remove pending image attachments
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_detach_clears_pending_attachments(tmp_path, monkeypatch):
+    """/detach removes all pending image attachments and confirms via hint."""
+    app = _make_app(tmp_path, monkeypatch)
+    async with app.run_test():
+        app.agent = _FakeAgent(supports_vision=False)
+        app._pending_image_attachments.append(_image_attachment("photo.png"))
+        app._pending_image_attachments.append(_image_attachment("chart.png"))
+
+        hints: list[tuple] = []
+        app._show_composer_hint = lambda text, tone="warning": hints.append((text, tone))
+
+        await app._command_detach("")
+
+        assert app._pending_image_attachments == [], "pending attachments should be cleared"
+        assert hints, "expected a confirmation hint"
+        text, tone = hints[-1]
+        assert tone == "info"
+        assert "photo.png" in text
+        assert "chart.png" in text
+        assert "Removed" in text
+
+
+@pytest.mark.asyncio
+async def test_detach_with_no_attachments(tmp_path, monkeypatch):
+    """/detach with nothing pending shows an info hint, not an error."""
+    app = _make_app(tmp_path, monkeypatch)
+    async with app.run_test():
+        app.agent = _FakeAgent(supports_vision=False)
+
+        hints: list[tuple] = []
+        app._show_composer_hint = lambda text, tone="warning": hints.append((text, tone))
+
+        await app._command_detach("")
+
+        assert app._pending_image_attachments == []
+        assert hints, "expected an info hint"
+        text, tone = hints[-1]
+        assert tone == "info"
+        assert "No pending" in text
+
+
+@pytest.mark.asyncio
+async def test_detach_command_registered(tmp_path, monkeypatch):
+    """/detach is in the TUI command handler dict and the slash command list."""
+    from kolega_code.cli.slash_commands import TUI_COMMAND_NAMES
+
+    assert "/detach" in TUI_COMMAND_NAMES
+
+    app = _make_app(tmp_path, monkeypatch)
+    async with app.run_test():
+        handlers = app._tui_command_handlers()
+        assert "/detach" in handlers
+        assert handlers["/detach"] == app._command_detach

--- a/kolega_code/cli/tests/test_app_model_switch_vision.py
+++ b/kolega_code/cli/tests/test_app_model_switch_vision.py
@@ -1,0 +1,200 @@
+"""Tests for the model-switch warning when a non-vision model inherits image history."""
+
+import pytest
+
+from kolega_code.cli.config import build_agent_config, config_summary
+from kolega_code.cli.provider_registry import DEEPSEEK_DEFAULT_MODEL
+from kolega_code.cli.session_store import SessionStore
+from kolega_code.llm.models import ImageBlock, Message, TextBlock
+
+
+def build_test_config(project):
+    return build_agent_config(
+        project,
+        env={
+            "ANTHROPIC_API_KEY": "test-key",
+            "KOLEGA_CODE_PROVIDER": "anthropic",
+        },
+    )
+
+
+class _FakeConversation:
+    def __init__(self, has_images: bool):
+        self._has_images = has_images
+
+    def has_image_blocks(self) -> bool:
+        return self._has_images
+
+
+class _FakeAgent:
+    """Minimal agent stand-in exposing the vision capability + conversation probe."""
+
+    def __init__(self, *, supports_vision: bool, has_images: bool):
+        self.supports_vision = supports_vision
+        self.conversation = _FakeConversation(has_images)
+
+
+def _image_history() -> list:
+    return [
+        Message(
+            role="user",
+            content=[TextBlock(text="look"), ImageBlock(image_type="base64", media_type="image/png", data="ZmFrZQ==")],
+        ).to_dict()
+    ]
+
+
+@pytest.mark.asyncio
+async def test_switch_to_non_vision_model_with_image_history_warns(tmp_path, monkeypatch):
+    pytest.importorskip("textual")
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import KolegaCodeApp
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            return None
+
+    monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test():
+        # Install a non-vision agent with image history, as if the rebuild produced it.
+        async def _fake_ensure(rebuild=False):
+            app.agent = _FakeAgent(supports_vision=False, has_images=True)
+
+        app._ensure_agent_from_settings = _fake_ensure
+        app._populate_settings_controls = lambda: None
+        app._restore_composer_placeholder = lambda: None
+        app._notify_user = lambda *a, **k: None
+        hints: list[tuple] = []
+        app._show_composer_hint = lambda text, tone="warning": hints.append((text, tone))
+
+        await app._switch_model("deepseek", DEEPSEEK_DEFAULT_MODEL)
+
+        assert hints, "expected a composer hint warning for non-vision model with image history"
+        text, tone = hints[0]
+        assert "images from earlier turns" in text
+        assert tone == "warning"
+
+
+@pytest.mark.asyncio
+async def test_switch_to_vision_model_with_image_history_no_warn(tmp_path, monkeypatch):
+    pytest.importorskip("textual")
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import KolegaCodeApp
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            return None
+
+    monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test():
+        async def _fake_ensure(rebuild=False):
+            app.agent = _FakeAgent(supports_vision=True, has_images=True)
+
+        app._ensure_agent_from_settings = _fake_ensure
+        app._populate_settings_controls = lambda: None
+        app._restore_composer_placeholder = lambda: None
+        app._notify_user = lambda *a, **k: None
+        hints: list[tuple] = []
+        app._show_composer_hint = lambda text, tone="warning": hints.append((text, tone))
+
+        await app._switch_model("anthropic", "claude-opus-4-8")
+
+        assert hints == [], "vision-capable model should not trigger the image-history warning"
+
+
+@pytest.mark.asyncio
+async def test_switch_to_non_vision_model_without_image_history_no_warn(tmp_path, monkeypatch):
+    pytest.importorskip("textual")
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import KolegaCodeApp
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            return None
+
+    monkeypatch.setattr(app_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test():
+        async def _fake_ensure(rebuild=False):
+            app.agent = _FakeAgent(supports_vision=False, has_images=False)
+
+        app._ensure_agent_from_settings = _fake_ensure
+        app._populate_settings_controls = lambda: None
+        app._restore_composer_placeholder = lambda: None
+        app._notify_user = lambda *a, **k: None
+        hints: list[tuple] = []
+        app._show_composer_hint = lambda text, tone="warning": hints.append((text, tone))
+
+        await app._switch_model("deepseek", DEEPSEEK_DEFAULT_MODEL)
+
+        assert hints == [], "no image history should not trigger the warning"

--- a/kolega_code/cli/tests/test_app_model_switch_vision.py
+++ b/kolega_code/cli/tests/test_app_model_switch_vision.py
@@ -89,6 +89,8 @@ async def test_switch_to_non_vision_model_with_image_history_warns(tmp_path, mon
         app._notify_user = lambda *a, **k: None
         hints: list[tuple] = []
         app._show_composer_hint = lambda text, tone="warning": hints.append((text, tone))
+        entries: list = []
+        app._add_conversation_entry = lambda entry: entries.append(entry)
 
         await app._switch_model("deepseek", DEEPSEEK_DEFAULT_MODEL)
 
@@ -96,6 +98,12 @@ async def test_switch_to_non_vision_model_with_image_history_warns(tmp_path, mon
         text, tone = hints[0]
         assert "images from earlier turns" in text
         assert tone == "warning"
+        # A persistent system message should also be added to the transcript.
+        assert entries, "expected a system message in the transcript"
+        system_entries = [e for e in entries if e.kind == "system"]
+        assert system_entries, "expected a kind='system' entry"
+        assert "images from earlier turns" in system_entries[0].content
+        assert system_entries[0].tone == "warning"
 
 
 @pytest.mark.asyncio
@@ -143,10 +151,13 @@ async def test_switch_to_vision_model_with_image_history_no_warn(tmp_path, monke
         app._notify_user = lambda *a, **k: None
         hints: list[tuple] = []
         app._show_composer_hint = lambda text, tone="warning": hints.append((text, tone))
+        entries: list = []
+        app._add_conversation_entry = lambda entry: entries.append(entry)
 
         await app._switch_model("anthropic", "claude-opus-4-8")
 
         assert hints == [], "vision-capable model should not trigger the image-history warning"
+        assert entries == [], "vision-capable model should not add a system message"
 
 
 @pytest.mark.asyncio
@@ -194,7 +205,10 @@ async def test_switch_to_non_vision_model_without_image_history_no_warn(tmp_path
         app._notify_user = lambda *a, **k: None
         hints: list[tuple] = []
         app._show_composer_hint = lambda text, tone="warning": hints.append((text, tone))
+        entries: list = []
+        app._add_conversation_entry = lambda entry: entries.append(entry)
 
         await app._switch_model("deepseek", DEEPSEEK_DEFAULT_MODEL)
 
         assert hints == [], "no image history should not trigger the warning"
+        assert entries == [], "no image history should not add a system message"

--- a/kolega_code/cli/tests/test_clipboard_image.py
+++ b/kolega_code/cli/tests/test_clipboard_image.py
@@ -1,0 +1,185 @@
+"""Unit tests for ``kolega_code.cli.clipboard_image``.
+
+These tests mock at the subprocess boundary (``asyncio.create_subprocess_exec``
+and ``asyncio.create_subprocess_shell``) so they never touch the real system
+clipboard. They mirror the mocking pattern used in
+``kolega_code/agent/tests/tool_backend/test_terminal_tool.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+import kolega_code.cli.clipboard_image as clipboard_image
+from kolega_code.cli.clipboard_image import read_clipboard_image
+
+# A minimal valid PNG (1x1 red pixel) so the size check passes.
+_PNG_BYTES = (
+    b"\x89PNG\r\n\x1a\n"
+    b"\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde"
+    b"\x00\x00\x00\x0cIDATx\x9cc\xf8\xcf\xc0\x00\x00\x00\x03\x00\x01\x8a\xaf\x1e\x8e"
+    b"\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+def _make_proc(communicate_return=(b"", b""), returncode=0):
+    """Build an AsyncMock resembling an asyncio subprocess."""
+    proc = AsyncMock()
+    proc.communicate = AsyncMock(return_value=communicate_return)
+    proc.returncode = returncode
+    return proc
+
+
+@pytest.mark.asyncio
+async def test_macos_returns_png_when_osascript_succeeds(tmp_path, monkeypatch):
+    """On darwin, a successful osascript run writes a PNG file we read back."""
+    monkeypatch.setattr(clipboard_image.sys, "platform", "darwin")
+
+    # Make tempfile.gettempdir point at tmp_path so we control the temp file.
+    monkeypatch.setattr(clipboard_image.tempfile, "gettempdir", lambda: str(tmp_path))
+
+    # The osascript subprocess "succeeds"; the temp file must exist with PNG
+    # bytes for the helper to read it. We pre-create the file the helper will
+    # generate. Because the filename is dynamic, we intercept by writing the
+    # PNG into whatever path the helper chose *after* the exec call via a
+    # side effect.
+    written_paths: list[str] = []
+
+    async def _fake_exec(*args, **kwargs):
+        # The osascript invocation embeds the temp .png path inside the
+        # AppleScript string (as a POSIX file). Extract it and "write" the
+        # clipboard PNG there so the helper can read it back.
+        import re
+
+        from pathlib import Path
+
+        for a in args:
+            if not isinstance(a, str):
+                continue
+            m = re.search(r"(/\S*kc_clip_\S*\.png)", a)
+            if m:
+                p = m.group(1)
+                Path(p).write_bytes(_PNG_BYTES)
+                written_paths.append(p)
+                break
+        return _make_proc(communicate_return=(b"", b""), returncode=0)
+
+    monkeypatch.setattr(clipboard_image.asyncio, "create_subprocess_exec", _fake_exec)
+    # No pngpaste fallback needed.
+    monkeypatch.setattr(clipboard_image.shutil, "which", lambda _: None)
+
+    result = await read_clipboard_image()
+    assert result is not None
+    data, media_type = result
+    assert media_type == "image/png"
+    assert data == _PNG_BYTES
+    assert written_paths, "expected the helper to invoke osascript with a temp .png path"
+
+
+@pytest.mark.asyncio
+async def test_linux_no_tools_returns_none(monkeypatch):
+    """On linux with no clipboard tools installed, returns None."""
+    monkeypatch.setattr(clipboard_image.sys, "platform", "linux")
+    monkeypatch.setattr(clipboard_image.shutil, "which", lambda _: None)
+
+    result = await read_clipboard_image()
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_macos_osascript_failure_returns_none(tmp_path, monkeypatch):
+    """When osascript returns a non-zero exit and pngpaste is absent, returns None."""
+    monkeypatch.setattr(clipboard_image.sys, "platform", "darwin")
+    monkeypatch.setattr(clipboard_image.tempfile, "gettempdir", lambda: str(tmp_path))
+    monkeypatch.setattr(
+        clipboard_image.asyncio, "create_subprocess_exec", lambda *a, **k: _make_proc(returncode=1)
+    )
+    monkeypatch.setattr(clipboard_image.shutil, "which", lambda _: None)
+
+    result = await read_clipboard_image()
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_subprocess_raises_returns_none(tmp_path, monkeypatch):
+    """If subprocess creation raises, the helper swallows it and returns None."""
+    monkeypatch.setattr(clipboard_image.sys, "platform", "darwin")
+    monkeypatch.setattr(clipboard_image.tempfile, "gettempdir", lambda: str(tmp_path))
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("osascript exploded")
+
+    monkeypatch.setattr(clipboard_image.asyncio, "create_subprocess_exec", _boom)
+    monkeypatch.setattr(clipboard_image.shutil, "which", lambda _: None)
+
+    result = await read_clipboard_image()
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_unknown_platform_returns_none(monkeypatch):
+    """An unrecognized platform yields None without raising."""
+    monkeypatch.setattr(clipboard_image.sys, "platform", "freebsd9")
+
+    result = await read_clipboard_image()
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_linux_xclip_returns_png(monkeypatch):
+    """On linux with xclip, stdout PNG bytes are returned directly."""
+    monkeypatch.setattr(clipboard_image.sys, "platform", "linux")
+
+    def _which(name):
+        return "/usr/bin/xclip" if name == "xclip" else None
+
+    monkeypatch.setattr(clipboard_image.shutil, "which", _which)
+
+    async def _fake_exec(*args, **kwargs):
+        return _make_proc(communicate_return=(_PNG_BYTES, b""), returncode=0)
+
+    monkeypatch.setattr(clipboard_image.asyncio, "create_subprocess_exec", _fake_exec)
+
+    result = await read_clipboard_image()
+    assert result is not None
+    data, media_type = result
+    assert media_type == "image/png"
+    assert data == _PNG_BYTES
+
+
+@pytest.mark.asyncio
+async def test_macos_pngpaste_fallback(tmp_path, monkeypatch):
+    """If osascript fails but pngpaste is present and writes a file, it is used."""
+    monkeypatch.setattr(clipboard_image.sys, "platform", "darwin")
+    monkeypatch.setattr(clipboard_image.tempfile, "gettempdir", lambda: str(tmp_path))
+
+    call_count = {"n": 0}
+
+    async def _fake_exec(*args, **kwargs):
+        call_count["n"] += 1
+        # First call: osascript -> fails (rc=1), no file.
+        # Second call: pngpaste <path> -> succeeds, write the PNG to that path.
+        if call_count["n"] == 2:
+            for a in args:
+                if isinstance(a, str) and a.endswith(".png") and "kc_clip_" in a:
+                    from pathlib import Path
+
+                    Path(a).write_bytes(_PNG_BYTES)
+                    break
+            return _make_proc(communicate_return=(b"", b""), returncode=0)
+        return _make_proc(communicate_return=(b"", b"no image"), returncode=1)
+
+    monkeypatch.setattr(clipboard_image.asyncio, "create_subprocess_exec", _fake_exec)
+
+    def _which(name):
+        return "/usr/local/bin/pngpaste" if name == "pngpaste" else None
+
+    monkeypatch.setattr(clipboard_image.shutil, "which", _which)
+
+    result = await read_clipboard_image()
+    assert result is not None
+    data, media_type = result
+    assert media_type == "image/png"
+    assert data == _PNG_BYTES

--- a/kolega_code/cli/tests/test_mentions.py
+++ b/kolega_code/cli/tests/test_mentions.py
@@ -106,3 +106,33 @@ def test_build_file_attachments_accepts_absolute_path_inside_root(tmp_path: Path
     attachments, unresolved = build_file_attachments(f"@{tmp_path / 'inside.txt'}", tmp_path)
     assert unresolved == []
     assert attachments[0]["path"] == "inside.txt"
+
+
+def test_build_file_attachments_image_yields_image_attachment(tmp_path: Path) -> None:
+    import base64
+
+    payload = b"\x89PNG\r\n\x1a\nfake"
+    (tmp_path / "shot.png").write_bytes(payload)
+    attachments, unresolved = build_file_attachments("look at @shot.png", tmp_path)
+    assert unresolved == []
+    assert len(attachments) == 1
+    assert attachments[0]["type"] == "image"
+    assert attachments[0]["media_type"] == "image/png"
+    assert attachments[0]["path"] == "shot.png"
+    assert base64.b64decode(attachments[0]["data"]) == payload
+
+
+def test_build_file_attachments_non_image_still_file(tmp_path: Path) -> None:
+    (tmp_path / "code.py").write_text("print(1)", encoding="utf-8")
+    attachments, _ = build_file_attachments("see @code.py", tmp_path)
+    assert len(attachments) == 1
+    assert attachments[0]["type"] == "file"
+    assert attachments[0]["content"] == "print(1)"
+
+
+def test_build_file_attachments_jpeg_mention(tmp_path: Path) -> None:
+    (tmp_path / "photo.jpg").write_bytes(b"\xff\xd8\xff\xe0fake jpeg")
+    attachments, _ = build_file_attachments("@photo.jpg", tmp_path)
+    assert len(attachments) == 1
+    assert attachments[0]["type"] == "image"
+    assert attachments[0]["media_type"] == "image/jpeg"

--- a/kolega_code/llm/models.py
+++ b/kolega_code/llm/models.py
@@ -653,15 +653,15 @@ class ToolResult(ContentBlock):
         """
         Converts the tool result into the OpenAI format.
 
+        OpenAI Chat Completions tool messages only accept string content or text
+        parts. Image-bearing tool results are split by ``MessageHistory.to_openai``
+        into a text-only tool message plus a follow-up user image message. This
+        method returns only the valid text-only tool message for the result.
+
         Returns:
             Dict[str, Any]: A dictionary with the structure expected by OpenAI API
         """
-        # Handle case where content is a list
-        openai_content = self.content
-        if isinstance(self.content, list):
-            openai_content = [item.to_openai() for item in self.content]
-
-        return {"role": "tool", "content": openai_content, "tool_call_id": self.tool_use_id}
+        return _openai_tool_result_message(self)
 
     def to_google(self) -> genai_types.FunctionResponse:
         google_content = self.content
@@ -693,6 +693,91 @@ class ToolResult(ContentBlock):
             markdown_content = "\n\n".join([item.to_markdown() for item in self.content])
 
         return f"{status} from tool call (ID: {self.tool_use_id}):\n\n```\n{markdown_content}\n```"
+
+
+def _tool_result_blocks(tool_result: "ToolResult") -> List[ContentBlock]:
+    if isinstance(tool_result.content, list):
+        return tool_result.content
+    return []
+
+
+def _openai_tool_result_text(tool_result: "ToolResult") -> str:
+    """Return text-only content for an OpenAI tool message.
+
+    Chat Completions ``role=tool`` messages cannot carry image parts. If a tool
+    returned images, acknowledge them in text; ``MessageHistory.to_openai`` emits
+    the actual images in a following user message.
+    """
+    if isinstance(tool_result.content, str):
+        text = tool_result.content
+    else:
+        text_parts: List[str] = []
+        image_count = 0
+        for block in tool_result.content or []:
+            if isinstance(block, TextBlock):
+                if block.text:
+                    text_parts.append(block.text)
+            elif isinstance(block, ImageBlock):
+                image_count += 1
+            else:
+                block_text = getattr(block, "text", None)
+                if block_text:
+                    text_parts.append(str(block_text))
+        text = "\n".join(text_parts).strip()
+        if image_count:
+            marker = (
+                f"[{tool_result.name} returned {image_count} image"
+                f"{'s' if image_count != 1 else ''}; attached in the following user message.]"
+            )
+            text = f"{text}\n{marker}".strip() if text else marker
+
+    if tool_result.is_error and not text:
+        return "Tool execution error"
+    return text
+
+
+def _openai_tool_result_images(tool_result: "ToolResult") -> List[ImageBlock]:
+    return [block for block in _tool_result_blocks(tool_result) if isinstance(block, ImageBlock)]
+
+
+def _openai_tool_result_message(tool_result: "ToolResult") -> Dict[str, Any]:
+    return {
+        "role": "tool",
+        "content": _openai_tool_result_text(tool_result),
+        "tool_call_id": tool_result.tool_use_id,
+    }
+
+
+def _openai_tool_result_image_followup(tool_result: "ToolResult") -> Optional[Dict[str, Any]]:
+    images = _openai_tool_result_images(tool_result)
+    if not images:
+        return None
+    content: List[Dict[str, Any]] = [
+        {
+            "type": "text",
+            "text": f"Image returned by tool {tool_result.name} for tool call {tool_result.tool_use_id}.",
+        }
+    ]
+    content.extend(image.to_openai() for image in images)
+    return {"role": "user", "content": content}
+
+
+def _openai_messages_for_tool_results(tool_results: List["ToolResult"]) -> List[Dict[str, Any]]:
+    """Serialize tool results preserving OpenAI's required tool-message ordering.
+
+    All text-only ``role=tool`` messages are emitted first, followed by user image
+    messages for any image-bearing tool results. This keeps all required tool
+    responses contiguous immediately after the assistant tool-call message.
+    """
+    messages: List[Dict[str, Any]] = []
+    followups: List[Dict[str, Any]] = []
+    for tool_result in tool_results:
+        messages.append(_openai_tool_result_message(tool_result))
+        followup = _openai_tool_result_image_followup(tool_result)
+        if followup is not None:
+            followups.append(followup)
+    messages.extend(followups)
+    return messages
 
 
 class MessageChunk:
@@ -1298,19 +1383,45 @@ class MessageHistory(list):
     def to_openai(self) -> list:
         processed_messages = []
         consumed_tool_result_ids = set()
+        messages = list(self)
 
-        for message in self:
+        def payload_has_content(payload: Dict[str, Any]) -> bool:
+            content = payload.get("content")
+            return (isinstance(content, str) and bool(content)) or (isinstance(content, list) and bool(content))
+
+        def collect_lookahead_tool_results(start_index: int, needed_ids: set) -> List[ToolResult]:
+            found: List[ToolResult] = []
+            if not needed_ids:
+                return found
+            found_ids = set()
+            for look_ahead in messages[start_index + 1 :]:
+                if not isinstance(look_ahead.content, list):
+                    continue
+                for item in look_ahead.content:
+                    if (
+                        isinstance(item, ToolResult)
+                        and item.tool_use_id in needed_ids
+                        and item.tool_use_id not in consumed_tool_result_ids
+                        and item.tool_use_id not in found_ids
+                    ):
+                        found.append(item)
+                        found_ids.add(item.tool_use_id)
+                if needed_ids.issubset(found_ids):
+                    break
+            return found
+
+        for index, message in enumerate(messages):
             # No list content: pass through
             if not isinstance(message.content, list):
                 processed_messages.append(message.to_openai())
                 continue
 
             # Partition ToolResult blocks so they become separate 'tool' messages
-            non_tool_result_blocks = [
-                item for item in message.content if not isinstance(item, ToolResult)
-            ]
+            non_tool_result_blocks = [item for item in message.content if not isinstance(item, ToolResult)]
             tool_result_blocks = [
-                item for item in message.content if isinstance(item, ToolResult) and item.tool_use_id not in consumed_tool_result_ids
+                item
+                for item in message.content
+                if isinstance(item, ToolResult) and item.tool_use_id not in consumed_tool_result_ids
             ]
 
             if tool_result_blocks:
@@ -1325,75 +1436,62 @@ class MessageHistory(list):
                 temp_payload = temp_message.to_openai()
 
                 # Avoid emitting empty assistant/user messages with neither content nor tool_calls
-                has_content = (
-                    isinstance(temp_payload.get("content"), str) and bool(temp_payload.get("content"))
-                ) or (
-                    isinstance(temp_payload.get("content"), list) and len(temp_payload.get("content")) > 0
-                )
-                has_tool_calls = bool(temp_payload.get("tool_calls"))
-                if has_content or has_tool_calls:
+                if payload_has_content(temp_payload) or temp_payload.get("tool_calls"):
                     processed_messages.append(temp_payload)
 
-                # Emit each tool_result as a separate tool message
-                for tr in tool_result_blocks:
-                    processed_messages.append(tr.to_openai())
+                # If this same message included tool_calls, pull any missing tool
+                # results forward so all role=tool messages stay contiguous.
+                tool_call_ids = [item.id for item in message.content if isinstance(item, ToolCall)]
+                found_ids = {tr.tool_use_id for tr in tool_result_blocks}
+                lookahead_results = collect_lookahead_tool_results(index, set(tool_call_ids) - found_ids)
+                batch_tool_results = tool_result_blocks + lookahead_results
+
+                processed_messages.extend(_openai_tool_result_message(tr) for tr in batch_tool_results)
+                for tr in batch_tool_results:
                     consumed_tool_result_ids.add(tr.tool_use_id)
 
-                # If assistant included tool_calls, ensure their tool results appear immediately after
-                tool_call_ids = [item.id for item in message.content if isinstance(item, ToolCall)]
-                if tool_call_ids:
-                    found_ids = set(tr.tool_use_id for tr in tool_result_blocks)
-                    added_ids = set()
-                    # Look ahead for missing tool results and emit them now
-                    needed = set(tool_call_ids) - found_ids
-                    if needed:
-                        start_index = list(self).index(message)
-                        for look_ahead in self[start_index + 1 :]:
-                            if not isinstance(look_ahead.content, list):
-                                continue
-                            for item in look_ahead.content:
-                                if (
-                                    isinstance(item, ToolResult)
-                                    and item.tool_use_id in needed
-                                    and item.tool_use_id not in consumed_tool_result_ids
-                                ):
-                                    processed_messages.append(item.to_openai())
-                                    consumed_tool_result_ids.add(item.tool_use_id)
-                                    added_ids.add(item.tool_use_id)
-                            if needed.issubset(added_ids | found_ids):
-                                break
-
-                    # If still missing, emit placeholder tool messages to satisfy API requirements
-                    remaining = set(tool_call_ids) - (found_ids | added_ids)
-                    for missing_id in remaining:
-                        processed_messages.append({"role": "tool", "content": "", "tool_call_id": missing_id})
+                # If still missing, emit placeholder tool messages to satisfy API requirements.
+                # These must come before any image follow-up user messages so all required
+                # role=tool responses stay contiguous after the assistant tool calls.
+                added_ids = {tr.tool_use_id for tr in lookahead_results}
+                remaining = set(tool_call_ids) - (found_ids | added_ids)
+                for missing_id in remaining:
+                    processed_messages.append({"role": "tool", "content": "", "tool_call_id": missing_id})
+                for tr in batch_tool_results:
+                    followup = _openai_tool_result_image_followup(tr)
+                    if followup is not None:
+                        processed_messages.append(followup)
             else:
+                # If this message only contained tool results that were already
+                # emitted next to their assistant tool calls, skip it.
+                if not non_tool_result_blocks and any(isinstance(item, ToolResult) for item in message.content):
+                    continue
+
                 # No ToolResult in this message. If it has tool_calls, ensure immediate tool responses.
                 temp_payload = message.to_openai()
-                processed_messages.append(temp_payload)
+                if payload_has_content(temp_payload) or temp_payload.get("tool_calls"):
+                    processed_messages.append(temp_payload)
 
                 tool_calls = temp_payload.get("tool_calls") or []
                 if tool_calls:
                     tool_call_ids = [tc.get("id") for tc in tool_calls if tc.get("id")]
-                    added_ids = set()
-                    start_index = list(self).index(message)
+                    lookahead_results = collect_lookahead_tool_results(index, set(tool_call_ids))
 
-                    # Search ahead for ToolResult blocks matching these ids
-                    for look_ahead in self[start_index + 1 :]:
-                        if not isinstance(look_ahead.content, list):
-                            continue
-                        for item in look_ahead.content:
-                            if isinstance(item, ToolResult) and item.tool_use_id in tool_call_ids and item.tool_use_id not in consumed_tool_result_ids:
-                                processed_messages.append(item.to_openai())
-                                consumed_tool_result_ids.add(item.tool_use_id)
-                                added_ids.add(item.tool_use_id)
-                        if set(tool_call_ids).issubset(added_ids):
-                            break
+                    processed_messages.extend(_openai_tool_result_message(tr) for tr in lookahead_results)
+                    for tr in lookahead_results:
+                        consumed_tool_result_ids.add(tr.tool_use_id)
 
-                    # If any are still missing, emit placeholder tool messages to satisfy API ordering
+                    # If any are still missing, emit placeholder tool messages to satisfy API ordering.
+                    # Placeholders also come before image follow-up user messages to keep all role=tool
+                    # responses contiguous after the assistant tool-call message.
+                    added_ids = {tr.tool_use_id for tr in lookahead_results}
                     remaining = [tc_id for tc_id in tool_call_ids if tc_id not in added_ids]
                     for missing_id in remaining:
                         processed_messages.append({"role": "tool", "content": "", "tool_call_id": missing_id})
+                    for tr in lookahead_results:
+                        followup = _openai_tool_result_image_followup(tr)
+                        if followup is not None:
+                            processed_messages.append(followup)
 
         return processed_messages
 

--- a/kolega_code/llm/providers/chatgpt_oauth.py
+++ b/kolega_code/llm/providers/chatgpt_oauth.py
@@ -73,19 +73,51 @@ def _image_data_url(block: ImageBlock) -> str:
     return f"data:{block.media_type};base64,{block.data}"
 
 
+def _tool_result_images(block: ToolResult) -> List[ImageBlock]:
+    if not isinstance(block.content, list):
+        return []
+    return [item for item in block.content if isinstance(item, ImageBlock)]
+
+
 def _tool_result_text(block: ToolResult) -> str:
-    """Flatten a tool result to the plain text a function_call_output expects."""
+    """Flatten a tool result to the plain text a function_call_output expects.
+
+    Responses function_call_output.output is string-only. If a tool returned
+    images, ``to_responses_input`` attaches them in a following user input item.
+    """
     content = block.content
     if isinstance(content, str):
         return content
     parts: List[str] = []
+    image_count = 0
     for item in content or []:
         text = getattr(item, "text", None)
         if text:
             parts.append(text)
         elif isinstance(item, ImageBlock) or getattr(item, "media_type", None):
-            parts.append("[image omitted]")
+            image_count += 1
+    if image_count:
+        parts.append(
+            f"[{block.name} returned {image_count} image"
+            f"{'s' if image_count != 1 else ''}; attached in the following user message.]"
+        )
+    if block.is_error and not parts:
+        return "Tool execution error"
     return "\n".join(parts)
+
+
+def _tool_result_image_message(block: ToolResult) -> Optional[Dict[str, Any]]:
+    images = _tool_result_images(block)
+    if not images:
+        return None
+    content: List[Dict[str, Any]] = [
+        {
+            "type": "input_text",
+            "text": f"Image returned by tool {block.name} for tool call {block.tool_use_id}.",
+        }
+    ]
+    content.extend({"type": "input_image", "image_url": _image_data_url(image)} for image in images)
+    return {"role": "user", "content": content}
 
 
 def _role_message_item(role: str, parts: List[tuple]) -> Optional[Dict[str, Any]]:
@@ -120,6 +152,7 @@ def to_responses_input(messages: MessageHistory) -> List[Dict[str, Any]]:
             continue
 
         text_parts: List[tuple] = []
+        tool_image_messages: List[Dict[str, Any]] = []
         for block in message.content or []:
             if isinstance(block, ToolCall):
                 items.append(
@@ -138,6 +171,9 @@ def to_responses_input(messages: MessageHistory) -> List[Dict[str, Any]]:
                         "output": _tool_result_text(block),
                     }
                 )
+                image_message = _tool_result_image_message(block)
+                if image_message is not None:
+                    tool_image_messages.append(image_message)
             elif isinstance(block, TextBlock):
                 text_parts.append(("text", block.text))
             elif isinstance(block, ImageBlock):
@@ -147,6 +183,7 @@ def to_responses_input(messages: MessageHistory) -> List[Dict[str, Any]]:
             item = _role_message_item(message.role, text_parts)
             if item:
                 items.append(item)
+        items.extend(tool_image_messages)
     return items
 
 

--- a/kolega_code/llm/providers/openai.py
+++ b/kolega_code/llm/providers/openai.py
@@ -240,11 +240,19 @@ class OpenAIProvider(BaseLLMProvider):
                         elif hasattr(item, "data") and hasattr(item, "media_type"):
                             # ImageBlock - estimate tokens based on base64 data size
                             num_tokens += self._estimate_image_tokens(len(item.data))
-                        # Handle tool calls
+                        # Handle tool calls. OpenAI's prompt accounting uses a compact
+                        # internal representation for assistant tool calls rather than
+                        # charging the full Chat Completions JSON wrapper. Counting the
+                        # stable fields (id, function name, serialized arguments) tracks
+                        # the API much more closely for resumed/provider-shaped history.
                         elif isinstance(item, ToolCall):
-                            tool_call_json = json.dumps(item.to_openai())
-                            num_tokens += len(encoding.encode(tool_call_json))
-                            num_tokens += 2  # Minimal formatting overhead for tool calls
+                            tool_call_payload = item.to_openai()
+                            function_payload = tool_call_payload.get("function", {})
+                            arguments = str(function_payload.get("arguments") or "")
+                            num_tokens += len(encoding.encode(str(tool_call_payload.get("id") or "")))
+                            num_tokens += len(encoding.encode(str(function_payload.get("name") or item.name)))
+                            num_tokens += len(encoding.encode(arguments))
+                            num_tokens += 1  # Compact formatting overhead for tool calls
                         # Handle tool results
                         elif isinstance(item, ToolResult):
                             # Tool results contain content that needs to be counted.

--- a/kolega_code/llm/providers/openai.py
+++ b/kolega_code/llm/providers/openai.py
@@ -247,12 +247,19 @@ class OpenAIProvider(BaseLLMProvider):
                             num_tokens += 2  # Minimal formatting overhead for tool calls
                         # Handle tool results
                         elif isinstance(item, ToolResult):
-                            # Tool results contain content that needs to be counted
+                            # Tool results contain content that needs to be counted.
+                            # OpenAI tool messages are text-only, but image-bearing
+                            # tool results are serialized as a follow-up user image
+                            # message, so nested images contribute image tokens.
                             if isinstance(item.content, str):
                                 num_tokens += len(encoding.encode(item.content))
                             elif isinstance(item.content, list):
                                 for result_item in item.content:
-                                    if hasattr(result_item, "text") and result_item.text:
+                                    if isinstance(result_item, ImageBlock):
+                                        num_tokens += self._estimate_image_tokens(len(result_item.data))
+                                    elif hasattr(result_item, "data") and hasattr(result_item, "media_type"):
+                                        num_tokens += self._estimate_image_tokens(len(result_item.data))
+                                    elif hasattr(result_item, "text") and result_item.text:
                                         num_tokens += len(encoding.encode(result_item.text))
                             num_tokens += 2  # Minimal formatting overhead for tool results
 

--- a/kolega_code/llm/specs.py
+++ b/kolega_code/llm/specs.py
@@ -14,6 +14,13 @@ class ThinkingEffortSpec:
 # Dictionary mapping (provider, model_name) to model specifications
 # Each entry contains context_length (maximum input tokens), max_completion_tokens, default_temperature,
 # and optional model capability flags.
+#
+# ``supports_vision`` indicates whether a model accepts image input. When
+# uncertain, default to False (the safe failure mode is a clear "model doesn't
+# support images" message rather than a mid-conversation API error). The flag
+# is the single tunable knob and is consumed by ``supports_vision()`` below,
+# ``BaseAgent._unsupported_attachment_message`` (replacing the old hardcoded
+# DeepSeek guard), and the ``read_image`` tool gate.
 MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
     # Anthropic models
     ("anthropic", "claude-opus-4-8"): {
@@ -21,6 +28,7 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         "max_completion_tokens": 128000,
         "default_temperature": 1.0,
         "supports_temperature": False,
+        "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
             options=("low", "medium", "high", "xhigh", "max"),
             default="medium",
@@ -32,6 +40,7 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         "max_completion_tokens": 128000,
         "default_temperature": 1.0,
         "supports_temperature": False,
+        "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
             options=("low", "medium", "high", "xhigh", "max"),
             default="medium",
@@ -42,6 +51,7 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         "context_length": 1000000,
         "max_completion_tokens": 128000,
         "default_temperature": 1.0,
+        "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
             options=("low", "medium", "high", "max"),
             default="medium",
@@ -52,20 +62,22 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         "context_length": 1000000,
         "max_completion_tokens": 64000,
         "default_temperature": 1.0,
+        "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
             options=("low", "medium", "high", "max"),
             default="medium",
             mode="anthropic_adaptive_effort",
         ),
     },
-    ("anthropic", "claude-sonnet-4-5-20250929"): {"context_length": 200000, "max_completion_tokens": 16384, "default_temperature": 1.0},
-    ("anthropic", "claude-opus-4-5-20251101"): {"context_length": 200000, "max_completion_tokens": 16384, "default_temperature": 1.0},
-    ("anthropic", "claude-haiku-4-5-20251001"): {"context_length": 200000, "max_completion_tokens": 16384, "default_temperature": 1.0},
+    ("anthropic", "claude-sonnet-4-5-20250929"): {"context_length": 200000, "max_completion_tokens": 16384, "default_temperature": 1.0, "supports_vision": True},
+    ("anthropic", "claude-opus-4-5-20251101"): {"context_length": 200000, "max_completion_tokens": 16384, "default_temperature": 1.0, "supports_vision": True},
+    ("anthropic", "claude-haiku-4-5-20251001"): {"context_length": 200000, "max_completion_tokens": 16384, "default_temperature": 1.0, "supports_vision": True},
     # Moonshot models (recommended default first)
     ("moonshot", "kimi-k2.7-code"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
         "default_temperature": 1.0,
+        "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
             options=("auto",),
             default="auto",
@@ -76,6 +88,7 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         "context_length": 262144,
         "max_completion_tokens": 32768,
         "default_temperature": 1.0,
+        "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
             options=("auto", "none"),
             default="auto",
@@ -86,6 +99,7 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         "context_length": 262144,
         "max_completion_tokens": 32768,
         "default_temperature": 1.0,
+        "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
             options=("auto",),
             default="auto",
@@ -98,6 +112,7 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         "context_length": 262144,
         "max_completion_tokens": 32768,
         "default_temperature": 1.0,
+        "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
             options=("auto", "none"),
             default="auto",
@@ -109,6 +124,7 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         "context_length": 1000000,
         "max_completion_tokens": 384000,
         "default_temperature": 1.0,
+        "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "high", "max"),
             default="high",
@@ -119,6 +135,7 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         "context_length": 1000000,
         "max_completion_tokens": 384000,
         "default_temperature": 1.0,
+        "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "high", "max"),
             default="high",
@@ -130,6 +147,7 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         "context_length": 1050000,
         "max_completion_tokens": 128000,
         "default_temperature": 1.0,
+        "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "low", "medium", "high", "xhigh"),
             default="medium",
@@ -140,6 +158,7 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         "context_length": 400000,
         "max_completion_tokens": 128000,
         "default_temperature": 1.0,
+        "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "low", "medium", "high", "xhigh"),
             default="medium",
@@ -150,6 +169,7 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         "context_length": 400000,
         "max_completion_tokens": 128000,
         "default_temperature": 1.0,
+        "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "low", "medium", "high", "xhigh"),
             default="medium",
@@ -167,6 +187,7 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         "max_completion_tokens": 128000,
         "default_temperature": 1.0,
         "supports_temperature": False,
+        "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
             options=("minimal", "low", "medium", "high", "xhigh"),
             default="medium",
@@ -178,6 +199,7 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         "max_completion_tokens": 128000,
         "default_temperature": 1.0,
         "supports_temperature": False,
+        "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
             options=("minimal", "low", "medium", "high"),
             default="medium",
@@ -189,6 +211,7 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         "max_completion_tokens": 128000,
         "default_temperature": 1.0,
         "supports_temperature": False,
+        "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
             options=("minimal", "low", "medium", "high"),
             default="medium",
@@ -200,6 +223,7 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         "max_completion_tokens": 128000,
         "default_temperature": 1.0,
         "supports_temperature": False,
+        "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
             options=("minimal", "low", "medium"),
             default="low",
@@ -207,13 +231,14 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         ),
     },
     # Together.ai models
-    ("together", "moonshotai/Kimi-K2.7-Code"): {"context_length": 262144, "max_completion_tokens": 32768, "default_temperature": 1.0},
-    ("together", "zai-org/GLM-5.1"): {"context_length": 202752, "max_completion_tokens": 16384, "default_temperature": 1.0},
+    ("together", "moonshotai/Kimi-K2.7-Code"): {"context_length": 262144, "max_completion_tokens": 32768, "default_temperature": 1.0, "supports_vision": True},
+    ("together", "zai-org/GLM-5.1"): {"context_length": 202752, "max_completion_tokens": 16384, "default_temperature": 1.0, "supports_vision": False},
     # Google models
     ("google", "gemini-3.1-pro-preview"): {
         "context_length": 1048576,
         "max_completion_tokens": 65536,
         "default_temperature": 1.0,
+        "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
             options=("low", "medium", "high"),
             default="high",
@@ -224,6 +249,7 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         "context_length": 1048576,
         "max_completion_tokens": 65536,
         "default_temperature": 1.0,
+        "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
             options=("minimal", "low", "medium", "high"),
             default="medium",
@@ -235,13 +261,14 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         "context_length": 1000000,
         "max_completion_tokens": 16384,
         "default_temperature": 0.6,
+        "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "low", "medium", "high"),
             default="low",
             mode="openai_reasoning_effort",
         ),
     },
-    ("xai", "grok-build-0.1"): {"context_length": 256000, "max_completion_tokens": 16384, "default_temperature": 0.6},
+    ("xai", "grok-build-0.1"): {"context_length": 256000, "max_completion_tokens": 16384, "default_temperature": 0.6, "supports_vision": False},
     # Fireworks models (OpenAI-compatible endpoint). Fireworks reasoning models
     # expose reasoning_content in responses and accept flat reasoning_effort
     # values on chat completions. "none" disables reasoning.
@@ -249,6 +276,7 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         "context_length": 1048576,
         "max_completion_tokens": 131072,
         "default_temperature": 1.0,
+        "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "low", "medium", "high", "max"),
             default="medium",
@@ -259,6 +287,7 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         "context_length": 202800,
         "max_completion_tokens": 131072,
         "default_temperature": 1.0,
+        "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "low", "medium", "high", "max"),
             default="medium",
@@ -269,6 +298,7 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         "context_length": 262144,
         "max_completion_tokens": 262144,
         "default_temperature": 1.0,
+        "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "low", "medium", "high", "max"),
             default="medium",
@@ -279,6 +309,7 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         "context_length": 1048576,
         "max_completion_tokens": 384000,
         "default_temperature": 1.0,
+        "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "low", "medium", "high", "max"),
             default="medium",
@@ -289,6 +320,7 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         "context_length": 1048576,
         "max_completion_tokens": 384000,
         "default_temperature": 1.0,
+        "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "low", "medium", "high", "max"),
             default="medium",
@@ -299,6 +331,7 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         "context_length": 512000,
         "max_completion_tokens": 512000,
         "default_temperature": 1.0,
+        "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "low", "medium", "high", "max"),
             default="medium",
@@ -309,6 +342,7 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         "context_length": 262144,
         "max_completion_tokens": 65536,
         "default_temperature": 1.0,
+        "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "low", "medium", "high", "max"),
             default="medium",
@@ -316,13 +350,14 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         ),
     },
     # DashScope / Qwen models
-    ("dashscope", "qwen3-coder-plus"): {"context_length": 1000000, "max_completion_tokens": 65536, "default_temperature": 0.7},
-    ("dashscope", "qwen3-coder-flash"): {"context_length": 1000000, "max_completion_tokens": 65536, "default_temperature": 0.7},
+    ("dashscope", "qwen3-coder-plus"): {"context_length": 1000000, "max_completion_tokens": 65536, "default_temperature": 0.7, "supports_vision": False},
+    ("dashscope", "qwen3-coder-flash"): {"context_length": 1000000, "max_completion_tokens": 65536, "default_temperature": 0.7, "supports_vision": False},
     # Z.AI (GLM Coding Plan) models — Anthropic-compatible endpoint (recommended default first)
     ("zai", "glm-5.2"): {
         "context_length": 1000000,
         "max_completion_tokens": 131072,
         "default_temperature": 0.6,
+        "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(
             options=("high", "max"),
             default="max",
@@ -333,6 +368,7 @@ MODEL_SPECS: Dict[Tuple[str, str], Dict[str, Any]] = {
         "context_length": 202752,
         "max_completion_tokens": 16384,
         "default_temperature": 0.6,
+        "supports_vision": False,
         # GLM-5.1 predates GLM-5.2's named effort levels, so it's a plain
         # enable/disable toggle (no output_config.effort).
         "thinking_effort": ThinkingEffortSpec(
@@ -367,6 +403,16 @@ def get_model_specs(provider: str, model_name: str) -> Dict[str, Any]:
         raise ValueError(f"Model {model_name} from provider {provider_str} is not supported.")
 
     return MODEL_SPECS.get(key)
+
+
+def supports_vision(provider: str, model_name: str) -> bool:
+    """Whether a model accepts image input.
+
+    Defaults to ``False`` for any entry that omits the flag, so a missing key
+    is safely treated as non-vision (a clear guard message beats a mid-flight
+    provider error).
+    """
+    return get_model_specs(provider, model_name).get("supports_vision", False)
 
 
 def get_thinking_effort_spec(provider: str, model_name: str) -> Optional[ThinkingEffortSpec]:

--- a/kolega_code/utils/__init__.py
+++ b/kolega_code/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers shared across the CLI and agent layers."""

--- a/kolega_code/utils/images.py
+++ b/kolega_code/utils/images.py
@@ -1,0 +1,100 @@
+"""Shared image-encoding and MIME helpers for vision support.
+
+Used by the CLI attachment paths (@-mention detection, ``/attach`` slash
+command, clipboard paste, the ``ask --image`` flag) and by the agent
+``read_image`` tool backend. Keeping the MIME map and base64 encoding in one
+place avoids three copies of the logic and CLI<->agent import cycles.
+"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
+# Supported image extensions -> MIME types. These are the common web image
+# formats accepted by all four provider backends (Anthropic, OpenAI, Google,
+# ChatGPT/Responses).
+IMAGE_MIME_TYPES: Dict[str, str] = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".bmp": "image/bmp",
+}
+
+# Skip images larger than this to avoid blowing the context budget.
+MAX_IMAGE_BYTES = 20 * 1024 * 1024
+
+
+def image_media_type(path_or_suffix: Union[str, Path]) -> Optional[str]:
+    """Return the MIME type for an image path/suffix, or ``None`` if unsupported.
+
+    Args:
+        path_or_suffix: A file path (e.g. ``"assets/logo.png"``) or a bare
+            extension (e.g. ``".png"`` or ``"png"``). Case-insensitive.
+    """
+    text = str(path_or_suffix).lower()
+    if text.startswith("."):
+        suffix = text
+    else:
+        suffix = Path(text).suffix.lower()
+        if not suffix:  # bare extension like "png" with no dot or path sep
+            suffix = f".{text}" if "/" not in text and "\\" not in text else ""
+    return IMAGE_MIME_TYPES.get(suffix)
+
+
+def is_supported_image(path: Union[str, Path]) -> bool:
+    """True if ``path`` has a supported image extension."""
+    return image_media_type(path) is not None
+
+
+def encode_image_attachment(
+    data: bytes, media_type: str, *, path: Optional[str] = None
+) -> Dict[str, Any]:
+    """Build an image attachment dict from raw bytes.
+
+    Args:
+        data: Raw image bytes.
+        media_type: MIME type (e.g. ``"image/png"``).
+        path: Optional source path included for display/debugging.
+
+    Returns:
+        ``{"type": "image", "media_type": ..., "data": "<base64>", ...}`` —
+        the shape consumed by ``BaseAgent._attachment_blocks``.
+    """
+    attachment: Dict[str, Any] = {
+        "type": "image",
+        "media_type": media_type,
+        "data": base64.b64encode(data).decode("ascii"),
+    }
+    if path:
+        attachment["path"] = path
+    return attachment
+
+
+def encode_image_file(path: Union[str, Path]) -> Optional[Dict[str, Any]]:
+    """Read, validate, and base64-encode an image file.
+
+    Returns ``None`` if the path is not a supported image format, the file is
+    missing/unreadable, or it exceeds ``MAX_IMAGE_BYTES`` (so callers can fall
+    back to a friendly message instead of crashing).
+    """
+    path = Path(path)
+    media_type = image_media_type(path)
+    if media_type is None:
+        return None
+    try:
+        if not path.is_file():
+            return None
+        size = path.stat().st_size
+    except OSError:
+        return None
+    if size > MAX_IMAGE_BYTES:
+        return None
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return None
+    return encode_image_attachment(data, media_type, path=str(path))

--- a/kolega_code/utils/tests/test_images.py
+++ b/kolega_code/utils/tests/test_images.py
@@ -1,0 +1,90 @@
+"""Tests for the shared image-encoding helpers."""
+
+import base64
+from pathlib import Path
+
+from kolega_code.utils.images import (
+    MAX_IMAGE_BYTES,
+    encode_image_attachment,
+    encode_image_file,
+    image_media_type,
+    is_supported_image,
+)
+
+
+def test_image_media_type_maps_known_extensions() -> None:
+    assert image_media_type(".png") == "image/png"
+    assert image_media_type(".PNG") == "image/png"
+    assert image_media_type(".jpg") == "image/jpeg"
+    assert image_media_type(".jpeg") == "image/jpeg"
+    assert image_media_type(".gif") == "image/gif"
+    assert image_media_type(".webp") == "image/webp"
+    assert image_media_type(".bmp") == "image/bmp"
+
+
+def test_image_media_type_from_path() -> None:
+    assert image_media_type("assets/logo.png") == "image/png"
+    assert image_media_type(Path("/tmp/shot.JPEG")) == "image/jpeg"
+    assert image_media_type("png") == "image/png"
+
+
+def test_image_media_type_unsupported_returns_none() -> None:
+    assert image_media_type(".txt") is None
+    assert image_media_type("readme.md") is None
+    assert image_media_type("") is None
+
+
+def test_is_supported_image() -> None:
+    assert is_supported_image("logo.png") is True
+    assert is_supported_image("notes.txt") is False
+
+
+def test_encode_image_attachment_builds_dict() -> None:
+    data = b"\x89PNG\r\n\x1a\nfake"
+    att = encode_image_attachment(data, "image/png", path="x.png")
+    assert att["type"] == "image"
+    assert att["media_type"] == "image/png"
+    assert att["path"] == "x.png"
+    assert base64.b64decode(att["data"]) == data
+
+
+def test_encode_image_attachment_omits_path_when_none() -> None:
+    att = encode_image_attachment(b"x", "image/png")
+    assert "path" not in att
+    assert att["type"] == "image"
+
+
+def test_encode_image_file_reads_and_encodes(tmp_path: Path) -> None:
+    png = tmp_path / "shot.png"
+    payload = b"\x89PNG\r\n\x1a\nfake-image-bytes"
+    png.write_bytes(payload)
+
+    att = encode_image_file(png)
+    assert att is not None
+    assert att["type"] == "image"
+    assert att["media_type"] == "image/png"
+    assert base64.b64decode(att["data"]) == payload
+    assert att["path"].endswith("shot.png")
+
+
+def test_encode_image_file_non_image_returns_none(tmp_path: Path) -> None:
+    f = tmp_path / "notes.txt"
+    f.write_text("hello")
+    assert encode_image_file(f) is None
+
+
+def test_encode_image_file_missing_returns_none(tmp_path: Path) -> None:
+    assert encode_image_file(tmp_path / "nope.png") is None
+
+
+def test_encode_image_file_oversized_returns_none(tmp_path: Path, monkeypatch) -> None:
+    import kolega_code.utils.images as images_mod
+
+    monkeypatch.setattr(images_mod, "MAX_IMAGE_BYTES", 4)
+    big = tmp_path / "big.png"
+    big.write_bytes(b"\x89PNG" + b"\x00" * 100)
+    assert encode_image_file(big) is None
+
+
+def test_encode_image_file_respects_real_max(tmp_path: Path) -> None:
+    assert MAX_IMAGE_BYTES == 20 * 1024 * 1024


### PR DESCRIPTION
## Summary

Adds the ability to attach images in chat and let vision-capable models see them, plus a `read_image` tool so the agent can view images in the project directory. The core `ImageBlock` plumbing and per-provider serialization already existed; this adds the capability flag, the tool, and four CLI input paths — all sharing one encoding helper.

## Changes

### Vision capability flag (`kolega_code/llm/specs.py`)
- Added `supports_vision` to every `MODEL_SPECS` entry (37 models) + a `supports_vision()` accessor (defaults `False`).
- Values from web research: Claude/GPT/Gemini/Grok/Kimi/MiniMax = `True`; DeepSeek/GLM-text/Qwen-coder = `False` (conservative where uncertain — the safe failure mode is a clear message, not a mid-conversation API error). The flag is the single tunable knob.
- Replaced the hardcoded DeepSeek guard in `BaseAgent._unsupported_attachment_message` with the flag-based check; added `self.supports_vision`; removed the obsolete `deepseek_image_unsupported_message` constant.

### `read_image` agent tool
- New `ReadImageTool` backend (`kolega_code/agent/tool_backend/read_image_tool.py`) reading via the sandboxed filesystem, inferring MIME, base64-encoding, returning `[ImageBlock]`.
- Wired into `ToolCollection`, registered in `read_only_tools` (parallel-safe, available to read-only agents), and gated on `caller.supports_vision` in `_should_include_tool` — **non-vision models never see the tool**.
- Text fallback for the ChatGPT/Responses backend, which drops tool-result images (user-attached chat images still work there).

### CLI attach affordances (shared `kolega_code/utils/images.py`)
- **`@path` mentions**: image files now yield `type=="image"` attachments instead of `[binary file]` stubs.
- **`/attach <path>`**: slash command with a pending-attachment buffer + composer hint showing queued images.
- **Paste image**: `Ctrl+Shift+V` reads image bytes from the system clipboard via a platform-aware helper (`kolega_code/cli/clipboard_image.py`: macOS `osascript`/`pngpaste`, Linux `xclip`/`wl-paste`/WSL PowerShell, Windows PowerShell), plus `on_paste` interception for `data:image/...` URIs and image file paths.
- **`ask --image <path>`**: repeatable flag.

## How to use
- **Chat**: `@screenshot.png what's in this?` · `/attach /tmp/diagram.png` · `Ctrl+Shift+V` to paste a screenshot · paste a data-URI or image file path.
- **CLI**: `kolega-code ask --image ./mockup.png "describe this"`.
- **Agent tool**: on vision-capable models, `read_image` lets the agent view project images; non-vision models never see the tool, and image attachments produce a clear "does not support image input, switch with /model" message.

## Known limitations
- ChatGPT/Responses drops tool-result images → `read_image` returns an informative text fallback for that provider.
- Clipboard image paste is best-effort/platform-dependent; degrades to a `/attach`/`@` hint when no tool is available.
- `ImageBlock.to_google()` fails on URL-source images (not triggered here — all paths use base64); noted as a follow-up.

## Checks
- Full test suite: **1278 passed**.
- `ruff check` clean on all touched/new files.
- Import smoke checks pass for all modified modules.