### PR TITLE
Preserve same-provider reasoning for Z.AI history

### DIFF
--- a/kolega_code/agent/conversation.py
+++ b/kolega_code/agent/conversation.py
@@ -113,12 +113,11 @@ def replace_image_blocks_with_placeholders(messages: List[Message], model_name: 
     return result
 
 
+_NATIVE_REASONING_PROVIDERS = {"anthropic", "moonshot", "kimi_coding", "deepseek", "zai"}
+
+
 def _preserve_reasoning_block(block: Any, *, source_provider: str, target_provider: str) -> bool:
-    if target_provider == "anthropic":
-        return source_provider == "anthropic"
-    if target_provider in {"moonshot", "kimi_coding"}:
-        return source_provider == target_provider
-    return False
+    return target_provider in _NATIVE_REASONING_PROVIDERS and source_provider == target_provider
 
 
 def _reasoning_placeholder(block: Any, source_provider: str) -> TextBlock:
@@ -168,11 +167,11 @@ def adapt_history_for_provider(
 ) -> List[Message]:
     """Return a request-safe history for the target provider without mutating storage.
 
-    Provider-managed reasoning blocks (Anthropic/Moonshot/Kimi thinking) are not
-    portable across providers. Keep only native reasoning for the same provider;
-    convert foreign or unknown reasoning blocks to text placeholders. Image blocks
-    are preserved for vision models and replaced with placeholders for non-vision
-    models, matching the previous image compatibility behavior.
+    Provider-managed reasoning blocks are not portable across providers. Keep
+    only native reasoning for the same provider; convert foreign or unknown
+    reasoning blocks to text placeholders. Image blocks are preserved for vision
+    models and replaced with placeholders for non-vision models, matching the
+    previous image compatibility behavior.
     """
     target_provider = _provider_value(target_provider)
     result: List[Message] = []

--- a/kolega_code/agent/tests/test_image_compat.py
+++ b/kolega_code/agent/tests/test_image_compat.py
@@ -80,6 +80,36 @@ def test_adapt_preserves_anthropic_thinking_when_targeting_anthropic():
     assert out[0].content[0].signature == "anthropic-sig"
 
 
+def test_adapt_preserves_zai_thinking_when_targeting_zai():
+    history = [_assistant(ThinkingBlock(thinking="native reasoning", signature="zai-sig"), provider="zai")]
+
+    out = adapt_history_for_provider(
+        history,
+        target_provider="zai",
+        target_model="glm-5.2",
+        supports_vision=False,
+    )
+
+    assert out is history
+    assert isinstance(out[0].content[0], ThinkingBlock)
+    assert out[0].content[0].signature == "zai-sig"
+
+
+def test_adapt_preserves_deepseek_thinking_when_targeting_deepseek():
+    history = [_assistant(ThinkingBlock(thinking="native reasoning", signature="deepseek-sig"), provider="deepseek")]
+
+    out = adapt_history_for_provider(
+        history,
+        target_provider="deepseek",
+        target_model="deepseek-v4-pro",
+        supports_vision=False,
+    )
+
+    assert out is history
+    assert isinstance(out[0].content[0], ThinkingBlock)
+    assert out[0].content[0].signature == "deepseek-sig"
+
+
 def test_adapt_preserves_images_for_vision_target_while_converting_foreign_thinking():
     tr = ToolResult(tool_use_id="t1", name="read_image", content=[_image("image/jpeg")], is_error=False)
     history = [


### PR DESCRIPTION
## Summary
- preserve provider-managed reasoning blocks when the source and target provider are the same Anthropic-compatible provider
- include Z.AI and DeepSeek in the native reasoning provider set
- add regressions for Z.AI and DeepSeek same-provider history adaptation

## Tests
- uv run pytest kolega_code/agent/tests/test_image_compat.py kolega_code/agent/tests/test_base_agent.py -q