### PR TITLE
fix: persist compaction summary position for correct restore placement

### DIFF
--- a/kolega_code/agent/conversation.py
+++ b/kolega_code/agent/conversation.py
@@ -214,8 +214,11 @@ class Conversation:
         # Compaction state: ``summary`` stands in for ``history[:compacted_through]``
         # in the effective view; messages from ``compacted_through`` onward are kept
         # verbatim. ``summary is None`` / ``compacted_through == 0`` means uncompacted.
+        # ``compacted_history_length`` is the history length captured when compaction
+        # ran, so the UI can place the summary after the retained tail on restore.
         self.summary: Optional[Message] = None
         self.compacted_through: int = 0
+        self.compacted_history_length: int = 0
         self.max_tool_result_chars = max_tool_result_chars
 
     # ------------------------------------------------------------------
@@ -234,6 +237,7 @@ class Conversation:
         self._history = value if isinstance(value, MessageHistory) else MessageHistory(list(value))
         self.summary = None
         self.compacted_through = 0
+        self.compacted_history_length = 0
 
     @property
     def last_compression_index(self) -> Optional[int]:
@@ -249,6 +253,7 @@ class Conversation:
         if value is None:
             self.summary = None
             self.compacted_through = 0
+            self.compacted_history_length = 0
         else:
             self.compacted_through = value + 1
 
@@ -257,6 +262,7 @@ class Conversation:
         self._history = MessageHistory([])
         self.summary = None
         self.compacted_through = 0
+        self.compacted_history_length = 0
 
     def has_image_blocks(self) -> bool:
         """True if the effective (compaction-aware) history still carries any images.
@@ -630,6 +636,7 @@ class Conversation:
             summary if isinstance(summary, Message) else Message(role="user", content=[TextBlock(text=str(summary))])
         )
         self.compacted_through = len(self._history)
+        self.compacted_history_length = len(self._history)
 
     def apply_compaction(self, summary_text: str, split_point: int) -> None:
         """Record ``summary_text`` as standing in for ``history[:split_point]``.
@@ -639,6 +646,7 @@ class Conversation:
         """
         self.summary = Message(role="user", content=[TextBlock(text=summary_text)])
         self.compacted_through = max(0, min(split_point, len(self._history)))
+        self.compacted_history_length = len(self._history)
 
     def compaction_split_point(self, *, keep_recent: int, min_prefix: int) -> Optional[int]:
         """Index where the verbatim recent tail should begin.
@@ -691,13 +699,15 @@ class Conversation:
         return {
             "summary": self.summary.get_text_content() if self.summary is not None else "",
             "compacted_through": self.compacted_through,
+            "compacted_history_length": self.compacted_history_length,
         }
 
     def restore_compaction(self, data: Optional[Dict[str, Any]]) -> None:
         """Restore a compaction boundary saved by ``dump_compaction``.
 
         Call AFTER ``restore`` (which resets compaction). Assigns the boundary
-        fields directly so it does not trip the history setter's reset.
+        fields directly so it does not trip the history setter's reset. Old
+        sessions without ``compacted_history_length`` fall back to 0.
         """
         data = data or {}
         text = (data.get("summary") or "").strip()
@@ -705,6 +715,8 @@ class Conversation:
         if text and through > 0:
             self.summary = Message(role="user", content=[TextBlock(text=text)])
             self.compacted_through = min(through, len(self._history))
+            self.compacted_history_length = int(data.get("compacted_history_length") or 0)
         else:
             self.summary = None
             self.compacted_through = 0
+            self.compacted_history_length = 0

--- a/kolega_code/agent/tests/test_compaction_persistence.py
+++ b/kolega_code/agent/tests/test_compaction_persistence.py
@@ -17,6 +17,7 @@ async def test_agent_compaction_survives_dump_restore(tmp_path):
     pre_effective = [m.get_text_content() for m in agent.get_effective_history_for_llm()]
     assert compaction_dump["summary"] == "PERSISTED SUMMARY"
     assert compaction_dump["compacted_through"] > 0
+    assert compaction_dump["compacted_history_length"] == 12  # captured at compaction time
 
     # Resume into a fresh agent: restore messages, then the compaction boundary.
     fresh, _cm2 = build_agent(tmp_path, llm=FakeLLM())
@@ -25,6 +26,7 @@ async def test_agent_compaction_survives_dump_restore(tmp_path):
 
     assert fresh.conversation.summary is not None
     assert len(fresh.history) == 12  # full history intact
+    assert fresh.conversation.compacted_history_length == 12  # round-tripped
     # The effective view the model sees is identical to before saving.
     assert [m.get_text_content() for m in fresh.get_effective_history_for_llm()] == pre_effective
 
@@ -34,7 +36,7 @@ async def test_agent_without_compaction_dumps_empty(tmp_path):
     agent, _cm = build_agent(tmp_path, llm=FakeLLM())
     agent.history = long_history(2)  # 4 messages, never compacted
     data = agent.dump_compaction_state()
-    assert data == {"summary": "", "compacted_through": 0}
+    assert data == {"summary": "", "compacted_through": 0, "compacted_history_length": 0}
 
     fresh, _cm2 = build_agent(tmp_path, llm=FakeLLM())
     fresh.restore_message_history(agent.dump_message_history())

--- a/kolega_code/agent/tests/test_conversation_compaction.py
+++ b/kolega_code/agent/tests/test_conversation_compaction.py
@@ -165,16 +165,47 @@ def test_dump_restore_compaction_round_trip():
     conv = _conv(long_history(6))  # 12 messages
     conv.apply_compaction("THE SUMMARY", 6)
     data = conv.dump_compaction()
-    assert data == {"summary": "THE SUMMARY", "compacted_through": 6}
+    assert data == {"summary": "THE SUMMARY", "compacted_through": 6, "compacted_history_length": 12}
 
     # A fresh conversation gets the full history back, then the boundary on top.
     restored = Conversation(list(conv.history))
     restored.restore_compaction(data)
     assert restored.summary is not None
     assert restored.compacted_through == 6
+    assert restored.compacted_history_length == 12
     effective = list(restored.effective_history())
     assert effective[0].get_text_content() == "THE SUMMARY"
     assert effective[1:] == list(conv.history)[6:]  # verbatim tail preserved
+
+
+def test_apply_compaction_captures_history_length():
+    conv = _conv(long_history(5))  # 10 messages
+    conv.apply_compaction("S", split_point=4)
+    assert conv.compacted_history_length == len(conv.history) == 10
+
+
+def test_restore_compaction_without_history_length_falls_back():
+    # Old sessions persisted before compacted_history_length existed.
+    conv = _conv(long_history(3))  # 6 messages
+    conv.restore_compaction({"summary": "S", "compacted_through": 3})  # no compacted_history_length
+    assert conv.summary is not None
+    assert conv.compacted_through == 3
+    assert conv.compacted_history_length == 0  # graceful default
+
+
+def test_clear_and_history_setter_reset_history_length():
+    conv = _conv(long_history(4))
+    conv.apply_compaction("S", 3)
+    assert conv.compacted_history_length == 8
+
+    conv.clear()
+    assert conv.compacted_history_length == 0
+
+    conv2 = _conv(long_history(4))
+    conv2.apply_compaction("S", 3)
+    assert conv2.compacted_history_length == 8
+    conv2.history = MessageHistory([text_msg("user", "fresh")])
+    assert conv2.compacted_history_length == 0
 
 
 def test_restore_compaction_empty_is_noop():

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -4761,17 +4761,21 @@ class KolegaCodeApp(App):
         self._cancel_pending_theme_selection()
         self._refresh_planning_sidebar()
         self._ensure_startup_entry(render=False)
-        # If the restored agent is in a compacted state, mark the boundary with a
-        # collapsible summary (between the folded prefix and the verbatim tail).
+        # If the restored agent is in a compacted state, place the collapsible
+        # summary where it sat in the live transcript: after the retained tail
+        # messages, before any newer turns. The history length captured when
+        # compaction ran tells us that position; old sessions without it fall
+        # back to the compaction boundary so the summary still renders.
         summary_entry = self._resume_compaction_entry()
-        boundary = None
         if summary_entry is not None:
-            through = int((self.session.compaction or {}).get("compacted_through") or 0)
+            compaction = self.session.compaction or {}
+            through = int(compaction.get("compacted_through") or 0)
             boundary = min(through, len(history))
-        if summary_entry is not None and boundary is not None:
-            self.conversation_entries.extend(self._conversation_entries_from_history_items(history[:boundary]))
+            summary_index = int(compaction.get("compacted_history_length") or boundary)
+            summary_index = min(summary_index, len(history))
+            self.conversation_entries.extend(self._conversation_entries_from_history_items(history[:summary_index]))
             self.conversation_entries.append(summary_entry)
-            self.conversation_entries.extend(self._conversation_entries_from_history_items(history[boundary:]))
+            self.conversation_entries.extend(self._conversation_entries_from_history_items(history[summary_index:]))
         else:
             self.conversation_entries.extend(self._conversation_entries_from_history_items(history))
         self._render_conversation()

--- a/kolega_code/cli/tests/test_app_compaction_restore.py
+++ b/kolega_code/cli/tests/test_app_compaction_restore.py
@@ -1,0 +1,166 @@
+"""Tests for compaction summary placement when restoring the conversation transcript.
+
+When the transcript is rebuilt from saved history (session resume, model switch,
+agent rebuild), the compaction summary must sit where it appeared in the live
+transcript: after the retained tail messages, before any newer turns. The history
+length captured at compaction time (``compacted_history_length``) anchors that
+position; old sessions without it fall back gracefully.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from kolega_code.cli.config import build_agent_config, config_summary
+from kolega_code.cli.session_store import SessionStore
+
+
+def _text_message(role: str, text: str) -> dict:
+    return {"role": role, "content": [{"type": "text", "text": text}]}
+
+
+def _build_history(n: int) -> list[dict]:
+    return [_text_message("user" if i % 2 == 0 else "assistant", f"msg-{i}") for i in range(n)]
+
+
+@pytest.mark.asyncio
+async def test_restore_places_summary_after_retained_tail(tmp_path: Path) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import KolegaCodeApp
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            return None
+
+    app_module.CoderAgent = FakeCoderAgent  # noqa: SLF001
+    try:
+        project = tmp_path / "project"
+        project.mkdir()
+        config = build_test_config(project)
+        store = SessionStore(tmp_path / "state")
+        session = store.create(project, "code", config_summary(config))
+
+        # 10 messages at compaction time; boundary at 4 (folded prefix).
+        # The retained tail was messages 4..9 (6 messages). After compaction,
+        # 2 more turns were added, so history is now 12 long.
+        history = _build_history(12)
+        session.history = history
+        session.compaction = {
+            "summary": "THE SUMMARY",
+            "compacted_through": 4,
+            "compacted_history_length": 10,
+        }
+        store.save(session)
+
+        app = KolegaCodeApp(
+            project_path=project,
+            config=config,
+            mode="code",
+            store=store,
+            session=session,
+        )
+
+        async with app.run_test():
+            app._restore_conversation_history(history)
+
+            kinds = [entry.kind for entry in app.conversation_entries]
+            # Startup entry is always first.
+            assert kinds[0] == "startup"
+            # The compaction_summary sits at index 1 + 10 = 11 (startup + 10 history entries).
+            summary_index = kinds.index("compaction_summary")
+            assert summary_index == 11
+            # Everything before it (besides startup) is history[:10].
+            before = app.conversation_entries[1:summary_index]
+            assert len(before) == 10
+            assert all(entry.kind in {"user", "assistant"} for entry in before)
+            # The retained tail (msg-4..msg-9) is immediately before the summary.
+            assert [entry.content for entry in before[-2:]] == ["msg-8", "msg-9"]
+            # Newer turns (msg-10, msg-11) come after the summary.
+            after = app.conversation_entries[summary_index + 1 :]
+            assert [entry.content for entry in after] == ["msg-10", "msg-11"]
+    finally:
+        del app_module.CoderAgent
+
+
+@pytest.mark.asyncio
+async def test_restore_old_session_without_history_length_falls_back(tmp_path: Path) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import KolegaCodeApp
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            return None
+
+    app_module.CoderAgent = FakeCoderAgent  # noqa: SLF001
+    try:
+        project = tmp_path / "project"
+        project.mkdir()
+        config = build_test_config(project)
+        store = SessionStore(tmp_path / "state")
+        session = store.create(project, "code", config_summary(config))
+
+        # Old session: no compacted_history_length key.
+        history = _build_history(12)
+        session.history = history
+        session.compaction = {"summary": "OLD SUMMARY", "compacted_through": 4}
+        store.save(session)
+
+        app = KolegaCodeApp(
+            project_path=project,
+            config=config,
+            mode="code",
+            store=store,
+            session=session,
+        )
+
+        async with app.run_test():
+            # Must not raise; summary still renders (at the fallback boundary position).
+            app._restore_conversation_history(history)
+            kinds = [entry.kind for entry in app.conversation_entries]
+            assert "compaction_summary" in kinds
+    finally:
+        del app_module.CoderAgent
+
+
+def build_test_config(project: Path):
+    return build_agent_config(
+        project,
+        env={
+            "ANTHROPIC_API_KEY": "test-key",
+            "KOLEGA_CODE_PROVIDER": "anthropic",
+        },
+    )

--- a/kolega_code/cli/tests/test_app_compaction_restore.py
+++ b/kolega_code/cli/tests/test_app_compaction_restore.py
@@ -23,137 +23,24 @@ def _build_history(n: int) -> list[dict]:
     return [_text_message("user" if i % 2 == 0 else "assistant", f"msg-{i}") for i in range(n)]
 
 
-@pytest.mark.asyncio
-async def test_restore_places_summary_after_retained_tail(tmp_path: Path) -> None:
-    pytest.importorskip("textual")
+class _FakeCoderAgent:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
 
-    from kolega_code.cli import app as app_module
-    from kolega_code.cli.app import KolegaCodeApp
+    def restore_message_history(self, history):
+        return None
 
-    class FakeCoderAgent:
-        def __init__(self, **kwargs):
-            self.kwargs = kwargs
+    def dump_compaction_state(self):
+        return {}
 
-        def restore_message_history(self, history):
-            return None
+    def restore_compaction_state(self, data):
+        pass
 
-        def dump_compaction_state(self):
-            return {}
+    def dump_message_history(self):
+        return []
 
-        def restore_compaction_state(self, data):
-            pass
-
-        def dump_message_history(self):
-            return []
-
-        async def cleanup(self):
-            return None
-
-    app_module.CoderAgent = FakeCoderAgent  # noqa: SLF001
-    try:
-        project = tmp_path / "project"
-        project.mkdir()
-        config = build_test_config(project)
-        store = SessionStore(tmp_path / "state")
-        session = store.create(project, "code", config_summary(config))
-
-        # 10 messages at compaction time; boundary at 4 (folded prefix).
-        # The retained tail was messages 4..9 (6 messages). After compaction,
-        # 2 more turns were added, so history is now 12 long.
-        history = _build_history(12)
-        session.history = history
-        session.compaction = {
-            "summary": "THE SUMMARY",
-            "compacted_through": 4,
-            "compacted_history_length": 10,
-        }
-        store.save(session)
-
-        app = KolegaCodeApp(
-            project_path=project,
-            config=config,
-            mode="code",
-            store=store,
-            session=session,
-        )
-
-        async with app.run_test():
-            app._restore_conversation_history(history)
-
-            kinds = [entry.kind for entry in app.conversation_entries]
-            # Startup entry is always first.
-            assert kinds[0] == "startup"
-            # The compaction_summary sits at index 1 + 10 = 11 (startup + 10 history entries).
-            summary_index = kinds.index("compaction_summary")
-            assert summary_index == 11
-            # Everything before it (besides startup) is history[:10].
-            before = app.conversation_entries[1:summary_index]
-            assert len(before) == 10
-            assert all(entry.kind in {"user", "assistant"} for entry in before)
-            # The retained tail (msg-4..msg-9) is immediately before the summary.
-            assert [entry.content for entry in before[-2:]] == ["msg-8", "msg-9"]
-            # Newer turns (msg-10, msg-11) come after the summary.
-            after = app.conversation_entries[summary_index + 1 :]
-            assert [entry.content for entry in after] == ["msg-10", "msg-11"]
-    finally:
-        del app_module.CoderAgent
-
-
-@pytest.mark.asyncio
-async def test_restore_old_session_without_history_length_falls_back(tmp_path: Path) -> None:
-    pytest.importorskip("textual")
-
-    from kolega_code.cli import app as app_module
-    from kolega_code.cli.app import KolegaCodeApp
-
-    class FakeCoderAgent:
-        def __init__(self, **kwargs):
-            self.kwargs = kwargs
-
-        def restore_message_history(self, history):
-            return None
-
-        def dump_compaction_state(self):
-            return {}
-
-        def restore_compaction_state(self, data):
-            pass
-
-        def dump_message_history(self):
-            return []
-
-        async def cleanup(self):
-            return None
-
-    app_module.CoderAgent = FakeCoderAgent  # noqa: SLF001
-    try:
-        project = tmp_path / "project"
-        project.mkdir()
-        config = build_test_config(project)
-        store = SessionStore(tmp_path / "state")
-        session = store.create(project, "code", config_summary(config))
-
-        # Old session: no compacted_history_length key.
-        history = _build_history(12)
-        session.history = history
-        session.compaction = {"summary": "OLD SUMMARY", "compacted_through": 4}
-        store.save(session)
-
-        app = KolegaCodeApp(
-            project_path=project,
-            config=config,
-            mode="code",
-            store=store,
-            session=session,
-        )
-
-        async with app.run_test():
-            # Must not raise; summary still renders (at the fallback boundary position).
-            app._restore_conversation_history(history)
-            kinds = [entry.kind for entry in app.conversation_entries]
-            assert "compaction_summary" in kinds
-    finally:
-        del app_module.CoderAgent
+    async def cleanup(self):
+        return None
 
 
 def build_test_config(project: Path):
@@ -164,3 +51,94 @@ def build_test_config(project: Path):
             "KOLEGA_CODE_PROVIDER": "anthropic",
         },
     )
+
+
+@pytest.mark.asyncio
+async def test_restore_places_summary_after_retained_tail(tmp_path: Path, monkeypatch) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import KolegaCodeApp
+
+    monkeypatch.setattr(app_module, "CoderAgent", _FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+
+    # 10 messages at compaction time; boundary at 4 (folded prefix).
+    # The retained tail was messages 4..9 (6 messages). After compaction,
+    # 2 more turns were added, so history is now 12 long.
+    history = _build_history(12)
+    session.history = history
+    session.compaction = {
+        "summary": "THE SUMMARY",
+        "compacted_through": 4,
+        "compacted_history_length": 10,
+    }
+    store.save(session)
+
+    app = KolegaCodeApp(
+        project_path=project,
+        config=config,
+        mode="code",
+        store=store,
+        session=session,
+    )
+
+    async with app.run_test():
+        app._restore_conversation_history(history)
+
+        kinds = [entry.kind for entry in app.conversation_entries]
+        # Startup entry is always first.
+        assert kinds[0] == "startup"
+        # The compaction_summary sits at index 1 + 10 = 11 (startup + 10 history entries).
+        summary_index = kinds.index("compaction_summary")
+        assert summary_index == 11
+        # Everything before it (besides startup) is history[:10].
+        before = app.conversation_entries[1:summary_index]
+        assert len(before) == 10
+        assert all(entry.kind in {"user", "assistant"} for entry in before)
+        # The retained tail (msg-4..msg-9) is immediately before the summary.
+        assert [entry.content for entry in before[-2:]] == ["msg-8", "msg-9"]
+        # Newer turns (msg-10, msg-11) come after the summary.
+        after = app.conversation_entries[summary_index + 1 :]
+        assert [entry.content for entry in after] == ["msg-10", "msg-11"]
+
+
+@pytest.mark.asyncio
+async def test_restore_old_session_without_history_length_falls_back(tmp_path: Path, monkeypatch) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli import app as app_module
+    from kolega_code.cli.app import KolegaCodeApp
+
+    monkeypatch.setattr(app_module, "CoderAgent", _FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+
+    # Old session: no compacted_history_length key.
+    history = _build_history(12)
+    session.history = history
+    session.compaction = {"summary": "OLD SUMMARY", "compacted_through": 4}
+    store.save(session)
+
+    app = KolegaCodeApp(
+        project_path=project,
+        config=config,
+        mode="code",
+        store=store,
+        session=session,
+    )
+
+    async with app.run_test():
+        # Must not raise; summary still renders (at the fallback boundary position).
+        app._restore_conversation_history(history)
+        kinds = [entry.kind for entry in app.conversation_entries]
+        assert "compaction_summary" in kinds


### PR DESCRIPTION
## Summary

The compressed message history summary (`compaction_summary`) was appearing in the wrong transcript position after resume/model-switch: it landed between the folded prefix and the retained tail, rather than after the retained tail where it sits immediately after a live compaction.

## Root cause

The restore path (`_restore_conversation_history`) only knew `compacted_through` (the prefix boundary), so it inserted the summary between the folded prefix and the retained tail. It had no way to know where the retained tail ended, because the actual retained count varies — boundary snapping moves it backward past `tool_use` groups, so it isn't always `KEEP_RECENT_MESSAGES`.

## Changes

**`kolega_code/agent/conversation.py`** — Added a `compacted_history_length` field to `Conversation`:
- Captured at compaction time in `apply_compaction` and `record_compression` (the history length *when compaction ran*)
- Reset to `0` in `clear()`, the `history` setter, and the legacy `last_compression_index` clear path
- Serialized in `dump_compaction()` / restored in `restore_compaction()` with a `0` default for old sessions

**`kolega_code/cli/app.py`** — `_restore_conversation_history` now computes the summary's insertion index from `compacted_history_length`, placing it after the retained tail. Old sessions without the field fall back to `compacted_through` (previous behavior) — graceful, no crash, summary still visible.

## Tests

- `test_conversation_compaction.py`: round-trip assertion updated; added tests for history-length capture, old-session fallback, and reset on clear/history setter
- `test_compaction_persistence.py`: assert `compacted_history_length` present and round-trips
- `test_app_compaction_restore.py` (new): restore placement with and without `compacted_history_length`

## Checks

- `test_conversation_compaction.py` — 22 passed
- `test_compaction_persistence.py` — 2 passed
- `test_app_compaction_restore.py` — 2 passed
- `test_base_agent.py` — 67 passed
- `test_app.py` — 154 passed
- Session store + vision tests — 24 passed
- Full `kolega_code/agent/tests/` — 927 passed