### PR TITLE
Allow shell commands in plan and investigation mode

### DIFF
--- a/docs/src/content/docs/concepts/agents.md
+++ b/docs/src/content/docs/concepts/agents.md
@@ -12,10 +12,10 @@ agent can hand off to the others when a task benefits from focus.
 | Agent | Specialty | Can edit files? |
 | --- | --- | --- |
 | **Coder** | The main, general-purpose coding agent. Full toolset. | Yes |
-| **Investigation** | Read-only exploration of the codebase. | No |
+| **Investigation** | Read-only exploration of the codebase. Can run investigative commands. | No |
 | **Browser** | Web navigation and interaction via Playwright. | No (browser tools only) |
 | **General** | A flexible agent that can read and dispatch other agents. | Limited |
-| **Planning** | Drives [Plan mode](../../tui/modes/): investigates and writes a plan, read-only. | No |
+| **Planning** | Drives [Plan mode](../../tui/modes/): investigates and writes a plan. Can run commands but cannot edit files. | No |
 
 ## Dispatching sub-agents
 

--- a/docs/src/content/docs/concepts/tools.md
+++ b/docs/src/content/docs/concepts/tools.md
@@ -61,13 +61,16 @@ and `dispatch_general_agent`.
 ## Read-only vs. full access
 
 Tools are gated by mode. In a read-only context — like [Plan mode](../../tui/modes/)
-or an investigation sub-agent — only non-mutating tools are available
+or an investigation sub-agent — the agent can read and search the codebase
 (`list_directory`, `read_entire_file`, `read_file_section`, `search_codebase`,
 `find_files_by_pattern`, `web_search`, `web_fetch`, `think_hard`, and reading
-memory). Editing files and running commands require Build mode's full toolset.
+memory) **and** run shell commands to investigate. Editing files still requires
+Build mode's full toolset.
 
-This separation is what makes Plan mode safe to run against any codebase: the
-planning agent can look but not touch.
+This separation is what keeps Plan mode safe to run against any codebase: the
+planning agent can look and run investigative commands, but it has no file-edit
+tools. Shell commands are further gated by the active permission mode — in `ask`
+they prompt before running.
 
 In the Textual TUI, Build mode defaults to `ask` permission mode. Shell commands
 and file edits must be approved before they run unless you switch to `auto` or

--- a/docs/src/content/docs/tui/modes.md
+++ b/docs/src/content/docs/tui/modes.md
@@ -35,6 +35,8 @@ produces a plan.
 While planning, the agent can:
 
 - Read and search the codebase.
+- Run shell commands to investigate (e.g. `git log`, `grep`, running tests) —
+  subject to the current permission mode, so commands prompt for approval in `ask`.
 - Maintain a shared **task list** (visible in the Planning tab).
 - Write a structured plan, which appears in the **Planning** tab.
 

--- a/kolega_code/agent/investigationagent.py
+++ b/kolega_code/agent/investigationagent.py
@@ -6,7 +6,7 @@ from kolega_code.config import AgentConfig
 from kolega_code.events import AgentConnectionManager
 from kolega_code.llm.models import Message, TextBlock
 from .prompt_provider import AgentMode, AgentType, PromptExtension
-from .tools import ToolCollection
+from .tools import ToolCollection, ToolCollectionConfig
 
 
 class InvestigationAgent(BaseAgent):
@@ -106,7 +106,7 @@ class InvestigationAgent(BaseAgent):
             self.connection_manager,
             self.config,
             caller=self,
-            read_only=True,
+            tool_config=ToolCollectionConfig(read_only=True, custom_tool_groups=["command_tools"]),
             filesystem=self.filesystem,
             terminal_manager=self.terminal_manager,
             browser_manager=self.browser_manager,

--- a/kolega_code/agent/planningagent.py
+++ b/kolega_code/agent/planningagent.py
@@ -92,7 +92,9 @@ class PlanningAgent(BaseAgent):
             self.connection_manager,
             self.config,
             caller=self,
-            tool_config=ToolCollectionConfig(read_only=True, custom_tool_groups=["planning_tools"]),
+            tool_config=ToolCollectionConfig(
+                read_only=True, custom_tool_groups=["planning_tools", "command_tools"]
+            ),
             filesystem=self.filesystem,
             terminal_manager=self.terminal_manager,
             browser_manager=self.browser_manager,

--- a/kolega_code/agent/prompt_templates/system/agents/investigation.md.j2
+++ b/kolega_code/agent/prompt_templates/system/agents/investigation.md.j2
@@ -46,7 +46,7 @@ to take further action, so your last message should contain the task result.
 
 ## **Running Commands**
 
-When requesting a command to be run, you will be asked to judge if it is appropriate to run without the USER's permission. A command is unsafe if it may have some destructive side-effects. Example unsafe side-effects include: deleting files, mutating state, installing system dependencies, making external requests, etc. You must NEVER NEVER run a command automatically if it could be unsafe. You cannot allow the USER to override your judgement on this. If a command is unsafe, do not run it automatically, even if the USER wants you to.
+You may run shell commands (e.g. `git log`, `grep`, build/lint/test commands) to investigate the codebase. Never use commands to modify the project — no editing files, installing dependencies, committing, pushing, or other side effects. Prefer read-only tools when they suffice. Commands are subject to the active permission mode and may require approval.
 
 ## **Communication Guidelines**
 

--- a/kolega_code/agent/prompt_templates/system/agents/planning.md.j2
+++ b/kolega_code/agent/prompt_templates/system/agents/planning.md.j2
@@ -13,8 +13,9 @@ Here is useful information about the environment:
 
 ## Operating Mode
 
-You are in planning mode. Do not implement code changes, create files, edit files, run shell commands, start servers, or perform other mutating actions.
-Use read-only tools to inspect the repository and reduce ambiguity. If the host provides shared task-list tools, keep that list current enough that another agent could see what has been considered and what remains.
+You are in planning mode. Do not implement code changes, create files, edit files, start servers, or perform other mutating actions.
+You may run shell commands (e.g. `git log`, `grep`, build/lint/test commands) to investigate the codebase and reduce ambiguity, but never use them to modify the project — no editing files, installing dependencies, committing, pushing, or other side effects. Prefer read-only tools when they suffice, and use `exec_command` only to inspect or validate.
+Use read-only tools and investigative commands to inspect the repository and reduce ambiguity. If the host provides shared task-list tools, keep that list current enough that another agent could see what has been considered and what remains.
 
 When the plan is decision complete, call `write_plan` with the final markdown plan. Do not call `write_plan` while major product or implementation choices are still unresolved.
 

--- a/kolega_code/agent/tests/test_agent_tools_inventory.py
+++ b/kolega_code/agent/tests/test_agent_tools_inventory.py
@@ -97,6 +97,10 @@ def test_investigation_agent_tools(project_path, mock_connection_manager, agent_
     tool_names = [tool.name for tool in tools]
 
     expected_tools = [
+        "exec_command",
+        "write_stdin",
+        "kill_command",
+        "list_sessions",
         "find_files_by_pattern",
         "list_directory",
         "read_entire_file",
@@ -111,6 +115,11 @@ def test_investigation_agent_tools(project_path, mock_connection_manager, agent_
 
     assert len(tools) == len(expected_tools)
     assert set(tool_names) == set(expected_tools)
+    # File-edit tools remain unavailable to the read-only investigation agent.
+    assert "create_file" not in tool_names
+    assert "replace_entire_file" not in tool_names
+    assert "search_and_replace" not in tool_names
+    assert "replace_lines" not in tool_names
 
 
 def test_cli_coder_agent_does_not_expose_manifest_build_tools(project_path, mock_connection_manager, agent_config):
@@ -241,8 +250,13 @@ def test_planning_agent_exposes_read_only_and_planning_tools(project_path, mock_
     assert "update_task_list" not in tool_names
     assert "create_file" not in tool_names
     assert "replace_entire_file" not in tool_names
-    assert "exec_command" not in tool_names
-    assert tool_names - expected_planning_tools <= set(agent.tool_collection.read_only_tools)
+    assert "search_and_replace" not in tool_names
+    assert "replace_lines" not in tool_names
+    # Planning agent can run investigative shell commands but cannot edit files.
+    assert {"exec_command", "write_stdin", "kill_command", "list_sessions"} <= tool_names
+    assert tool_names - expected_planning_tools <= set(agent.tool_collection.read_only_tools) | set(
+        agent.tool_collection.command_tools
+    )
 
 
 def test_shared_tool_names_are_well_formed(project_path, mock_connection_manager, agent_config):

--- a/kolega_code/agent/tests/test_planning_agent.py
+++ b/kolega_code/agent/tests/test_planning_agent.py
@@ -226,3 +226,27 @@ async def test_planning_agent_does_not_print_context_token_counts(
 
     assert chunks[-1]["complete"] is True
     assert capsys.readouterr().out == ""
+
+
+def test_planning_agent_exposes_command_tools_but_not_file_edits(
+    tmp_path, mock_connection_manager, agent_config
+):
+    """PlanningAgent can run investigative shell commands but cannot edit files."""
+    agent = PlanningAgent(
+        project_path=tmp_path,
+        workspace_id="test_workspace",
+        thread_id=str(uuid.uuid4()),
+        connection_manager=mock_connection_manager,
+        config=agent_config,
+        agent_mode=AgentMode.CLI,
+    )
+
+    tool_names = {tool.name for tool in agent.tool_collection.get_tool_list()}
+
+    assert {"exec_command", "write_stdin", "kill_command", "list_sessions"} <= tool_names
+    assert "create_file" not in tool_names
+    assert "replace_entire_file" not in tool_names
+    assert "replace_lines" not in tool_names
+    assert "search_and_replace" not in tool_names
+    # read_only stays True so gigacode workflow sub-agents are still forced read-only.
+    assert agent.tool_collection.read_only is True

--- a/kolega_code/agent/tests/test_tool_registry.py
+++ b/kolega_code/agent/tests/test_tool_registry.py
@@ -82,7 +82,10 @@ class TestToolCollectionRegistry:
         assert registry.get("read_entire_file").parallel_safe
         assert registry.get("search_codebase").parallel_safe
         assert not registry.get("create_file").parallel_safe
-        assert not registry.get("exec_command").parallel_safe
+        # Command tools have side effects, so they must never be parallel-safe —
+        # even when exposed to read-only agents via the command_tools group.
+        for command_tool in ToolCollection.command_tools:
+            assert not registry.get(command_tool).parallel_safe
 
     def test_get_tool_list_matches_registry_definitions(self, tmp_path):
         from unittest.mock import Mock

--- a/kolega_code/agent/tool_backend/workflow_tool.py
+++ b/kolega_code/agent/tool_backend/workflow_tool.py
@@ -216,7 +216,9 @@ class WorkflowTool(BaseTool):
         # When the orchestrating agent is itself read-only (e.g. plan mode's
         # PlanningAgent), every workflow sub-agent is forced to a read-only
         # investigation agent so the read-only contract is preserved — the
-        # workflow can research in parallel but never write.
+        # workflow can research in parallel (including running investigative
+        # commands) but cannot edit files, since read_only agents have no
+        # file-edit tools.
         read_only = bool(getattr(getattr(self.caller, "tool_collection", None), "read_only", False))
 
         async def dispatch(spec: AgentRunSpec) -> AgentRunResult:

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -152,6 +152,17 @@ class ToolCollection(LogMixin):
         "run_workflow",
     ]
 
+    # Shell execution + session management. Exposed to the planning and
+    # investigation agents (via custom_tool_groups) so they can run investigative
+    # commands even while read_only=True. Not read-only, so deliberately excluded
+    # from the parallel-safe set in _build_tool.
+    command_tools = [
+        "exec_command",
+        "write_stdin",
+        "kill_command",
+        "list_sessions",
+    ]
+
     def __init__(
         self,
         project_path: Union[str, Path],


### PR DESCRIPTION
## Summary

The planning and investigation agents were fully read-only, which blocked investigative commands (`git log`, `grep`, running tests) and could produce suboptimal plans/reports. This exposes the exec/session tool family to both agents while keeping file-edit tools excluded.

## Changes

- **`tools.py`** — added a shared `command_tools` group (`exec_command`, `write_stdin`, `kill_command`, `list_sessions`). Since `_should_include_tool` checks `custom_tool_groups` before the `read_only` filter, this surfaces the tools even under `read_only=True`.
- **`planningagent.py`** — added `"command_tools"` to `custom_tool_groups`.
- **`investigationagent.py`** — switched from the legacy `read_only=True` flag to `ToolCollectionConfig(read_only=True, custom_tool_groups=["command_tools"])`.
- **`planning.md.j2` / `investigation.md.j2`** — prompts now permit investigative commands but forbid mutations (no editing files, installing deps, committing, etc.).
- **`workflow_tool.py`** — softened the forced-investigation-sub-agent comment to reflect that they can run commands but still can't edit files.
- **Docs** — updated `modes.md`, `tools.md`, and `agents.md`.

## Safety

- `read_only` stays `True` on both agents, preserving no-file-edit and the gigacode workflow sub-agent forcing.
- `exec_command` is in `COMMAND_PERMISSION_TOOLS`, so in the TUI's default `ask` mode commands prompt before running. Interactively-dispatched investigation sub-agents inherit the parent's permission mode.
- Command tools remain non-`parallel_safe`.
- Consistent with `GeneralAgent` (the default gigacode workflow sub-agent), which already has full command access in `auto`/auto-allow mode.

## Test plan

- [x] `ruff check` on changed files
- [x] Full agent test suite — 928 passed
- [x] Updated inventory/planning-agent tests assert command tools are present, file-edit tools absent, `read_only` stays `True`, and command tools are not parallel-safe
