### PR TITLE
[codex] Preserve same-provider reasoning

### DIFF
--- a/kolega_code/agent/conversation.py
+++ b/kolega_code/agent/conversation.py
@@ -113,11 +113,8 @@ def replace_image_blocks_with_placeholders(messages: List[Message], model_name: 
     return result
 
 
-_NATIVE_REASONING_PROVIDERS = {"anthropic", "moonshot", "kimi_coding", "deepseek", "zai"}
-
-
 def _preserve_reasoning_block(block: Any, *, source_provider: str, target_provider: str) -> bool:
-    return target_provider in _NATIVE_REASONING_PROVIDERS and source_provider == target_provider
+    return bool(source_provider) and source_provider == target_provider
 
 
 def _reasoning_placeholder(block: Any, source_provider: str) -> TextBlock:
@@ -167,11 +164,12 @@ def adapt_history_for_provider(
 ) -> List[Message]:
     """Return a request-safe history for the target provider without mutating storage.
 
-    Provider-managed reasoning blocks are not portable across providers. Keep
-    only native reasoning for the same provider; convert foreign or unknown
-    reasoning blocks to text placeholders. Image blocks are preserved for vision
-    models and replaced with placeholders for non-vision models, matching the
-    previous image compatibility behavior.
+    Provider-managed reasoning blocks are not portable across providers, but
+    reasoning produced by a provider is safe to send back to the same provider.
+    Preserve same-provider reasoning; convert foreign or unknown reasoning
+    blocks to text placeholders. Image blocks are preserved for vision models
+    and replaced with placeholders for non-vision models, matching the previous
+    image compatibility behavior.
     """
     target_provider = _provider_value(target_provider)
     result: List[Message] = []

--- a/kolega_code/agent/tests/test_base_agent.py
+++ b/kolega_code/agent/tests/test_base_agent.py
@@ -1881,6 +1881,30 @@ class TestBaseAgent:
         assert isinstance(history[1].content[0], ToolResult)
         assert history[1].content[0].tool_use_id == "tool1"
 
+    def test_history_for_llm_preserves_fireworks_thinking_when_targeting_fireworks(self, base_agent):
+        base_agent.primary_model_config.provider = ModelProvider.FIREWORKS
+        base_agent.primary_model_config.model = "accounts/fireworks/models/glm-5p2"
+        base_agent.supports_vision = False
+        base_agent.history = MessageHistory(
+            [
+                Message(
+                    role="assistant",
+                    content=[
+                        ThinkingBlock(thinking="fireworks reasoning"),
+                        TextBlock(text="final answer"),
+                    ],
+                    usage_metadata={"provider": "fireworks"},
+                )
+            ]
+        )
+
+        history = base_agent._history_for_llm()
+
+        assert isinstance(history[0].content[0], ThinkingBlock)
+        assert history[0].content[0].thinking == "fireworks reasoning"
+        assert isinstance(history[0].content[1], TextBlock)
+        assert history[0].content[1].text == "final answer"
+
     def test_history_for_llm_preserves_images_when_target_anthropic_supports_vision(self, base_agent):
         image = ImageBlock(image_type="base64", media_type="image/png", data="BASE64")
         nested_image = ImageBlock(image_type="base64", media_type="image/jpeg", data="BASE642")

--- a/kolega_code/agent/tests/test_image_compat.py
+++ b/kolega_code/agent/tests/test_image_compat.py
@@ -110,6 +110,36 @@ def test_adapt_preserves_deepseek_thinking_when_targeting_deepseek():
     assert out[0].content[0].signature == "deepseek-sig"
 
 
+def test_adapt_preserves_fireworks_thinking_when_targeting_fireworks():
+    history = [_assistant(ThinkingBlock(thinking="native reasoning"), provider="fireworks")]
+
+    out = adapt_history_for_provider(
+        history,
+        target_provider="fireworks",
+        target_model="accounts/fireworks/models/glm-5p2",
+        supports_vision=False,
+    )
+
+    assert out is history
+    assert isinstance(out[0].content[0], ThinkingBlock)
+    assert out[0].content[0].thinking == "native reasoning"
+
+
+def test_adapt_converts_thinking_without_source_provider():
+    history = [_assistant(ThinkingBlock(thinking="unknown-source reasoning"))]
+
+    out = adapt_history_for_provider(
+        history,
+        target_provider="fireworks",
+        target_model="accounts/fireworks/models/glm-5p2",
+        supports_vision=False,
+    )
+
+    assert out[0] is not history[0]
+    assert isinstance(out[0].content[0], TextBlock)
+    assert "Prior reasoning from unknown provider omitted" in out[0].content[0].text
+
+
 def test_adapt_preserves_images_for_vision_target_while_converting_foreign_thinking():
     tr = ToolResult(tool_use_id="t1", name="read_image", content=[_image("image/jpeg")], is_error=False)
     history = [


### PR DESCRIPTION
## Summary
- Preserve reasoning blocks whenever the stored source provider matches the target provider.
- Keep foreign or unknown-source reasoning redacted with compatibility placeholders.
- Add Fireworks GLM-5.2 regression coverage for the adapter and BaseAgent request-history path.

## Root Cause
Fireworks reasoning was captured as a ThinkingBlock and tagged with usage_metadata provider=fireworks, but the request adapter only preserved reasoning for a hard-coded allowlist that omitted Fireworks.

## Validation
- uv run pytest kolega_code/agent/tests/test_image_compat.py -q
- uv run pytest kolega_code/agent/tests/test_base_agent.py -q