### PR TITLE
Add optional agent iteration cap

### DIFF
--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -18,6 +18,7 @@ from .agent.planningagent import PlanningAgent
 from .agent.compression import HistoryCompressor
 from .agent.context import AgentContext, AgentServices, Telemetry, WorkspaceInfo
 from .agent.conversation import Conversation
+from .agent.errors import AgentError, MaxAgentIterationsExceeded
 from .events import AgentEventEmitter
 
 # Configuration
@@ -86,6 +87,8 @@ __all__ = [
     "AgentContext",
     "AgentServices",
     "Telemetry",
+    "AgentError",
+    "MaxAgentIterationsExceeded",
     "WorkspaceInfo",
     "Conversation",
     "HistoryCompressor",

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -8,6 +8,9 @@ from .browseragent import BrowserAgent
 from .generalagent import GeneralAgent
 from .planningagent import PlanningAgent
 
+# Export agent errors
+from .errors import AgentError, MaxAgentIterationsExceeded
+
 # Export agent models
 from kolega_code.events import AgentStatus, AgentEvent
 
@@ -25,6 +28,8 @@ __all__ = [
     "BrowserAgent",
     "GeneralAgent",
     "PlanningAgent",
+    "AgentError",
+    "MaxAgentIterationsExceeded",
     "AgentStatus",
     "AgentEvent",
     "AgentConfig",

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -12,6 +12,7 @@ from typing import Any, AsyncGenerator, Dict, List, Optional
 
 from .common import LogMixin
 from .compression import CompactionResult, HistoryCompressor
+from .errors import MaxAgentIterationsExceeded
 from kolega_code.config import AgentConfig, ModelProvider
 from kolega_code.events import AgentConnectionManager
 from .context import AgentContext, AgentServices, Telemetry, WorkspaceInfo
@@ -119,6 +120,7 @@ class BaseAgent(LogMixin):
         sub_agent_recorder: Optional[Any] = None,
         hook_dispatcher: Optional[HookDispatcher] = None,
         context: Optional[AgentContext] = None,
+        max_iterations: Optional[int] = None,
     ) -> None:
         """
         Initialize a new BaseAgent instance.
@@ -203,7 +205,11 @@ class BaseAgent(LogMixin):
         if hook_dispatcher is not None:
             context.hook_dispatcher = hook_dispatcher
 
+        if max_iterations is not None and max_iterations < 1:
+            raise ValueError("max_iterations must be a positive integer or None")
+
         self.context = context
+        self.max_iterations = max_iterations
 
         # Flat attributes kept for compatibility with subclasses, tools, and hosts.
         self.project_path = context.workspace.project_path
@@ -1282,7 +1288,15 @@ class BaseAgent(LogMixin):
 
         stop_reason = None
         stop_overrides = 0
+        iterations = 0
         while stop_reason not in ["end_turn", "max_tokens", "stop_sequence"]:
+            iterations += 1
+            if self.max_iterations is not None and iterations > self.max_iterations:
+                raise MaxAgentIterationsExceeded(
+                    f"Agent '{self.agent_name}' exceeded max_iterations={self.max_iterations} "
+                    "without reaching a terminal stop reason"
+                )
+
             self.mark_cache_checkpoint()
 
             try:

--- a/kolega_code/agent/browseragent.py
+++ b/kolega_code/agent/browseragent.py
@@ -45,6 +45,7 @@ class BrowserAgent(BaseAgent):
         usage_recorder: Optional[Any] = None,
         sub_agent_recorder: Optional[Any] = None,
         hook_dispatcher: Optional[Any] = None,
+        max_iterations: Optional[int] = None,
     ) -> None:
         """
         Initialize a new BrowserAgent instance.
@@ -97,6 +98,7 @@ class BrowserAgent(BaseAgent):
             usage_recorder=usage_recorder,
             sub_agent_recorder=sub_agent_recorder,
             hook_dispatcher=hook_dispatcher,
+            max_iterations=max_iterations,
         )
 
         self.tool_collection = ToolCollection(

--- a/kolega_code/agent/coder.py
+++ b/kolega_code/agent/coder.py
@@ -49,6 +49,7 @@ class CoderAgent(BaseAgent, LogMixin):
         usage_recorder: Optional[Any] = None,
         sub_agent_recorder: Optional[Any] = None,
         hook_dispatcher: Optional[Any] = None,
+        max_iterations: Optional[int] = None,
     ) -> None:
         """
         Initialize a new CoderAgent instance.
@@ -104,6 +105,7 @@ class CoderAgent(BaseAgent, LogMixin):
             usage_recorder=usage_recorder,
             sub_agent_recorder=sub_agent_recorder,
             hook_dispatcher=hook_dispatcher,
+            max_iterations=max_iterations,
         )
 
         # Configure tool collection with custom coder agent tools

--- a/kolega_code/agent/errors.py
+++ b/kolega_code/agent/errors.py
@@ -1,0 +1,9 @@
+"""Exceptions raised by agent runtime loops."""
+
+
+class AgentError(RuntimeError):
+    """Base class for catchable agent runtime errors."""
+
+
+class MaxAgentIterationsExceeded(AgentError):
+    """Raised when an opt-in agent loop iteration cap is exceeded."""

--- a/kolega_code/agent/generalagent.py
+++ b/kolega_code/agent/generalagent.py
@@ -47,6 +47,7 @@ class GeneralAgent(BaseAgent):
         usage_recorder: Optional[Any] = None,
         sub_agent_recorder: Optional[Any] = None,
         hook_dispatcher: Optional[Any] = None,
+        max_iterations: Optional[int] = None,
     ) -> None:
         """
         Initialize a new GeneralAgent instance.
@@ -99,6 +100,7 @@ class GeneralAgent(BaseAgent):
             usage_recorder=usage_recorder,
             sub_agent_recorder=sub_agent_recorder,
             hook_dispatcher=hook_dispatcher,
+            max_iterations=max_iterations,
         )
 
         # Full coder-style toolset, minus sub-agent dispatch (a dispatched agent

--- a/kolega_code/agent/investigationagent.py
+++ b/kolega_code/agent/investigationagent.py
@@ -45,6 +45,7 @@ class InvestigationAgent(BaseAgent):
         usage_recorder: Optional[Any] = None,
         sub_agent_recorder: Optional[Any] = None,
         hook_dispatcher: Optional[Any] = None,
+        max_iterations: Optional[int] = None,
     ) -> None:
         """
         Initialize a new InvestigationAgent instance.
@@ -97,6 +98,7 @@ class InvestigationAgent(BaseAgent):
             usage_recorder=usage_recorder,
             sub_agent_recorder=sub_agent_recorder,
             hook_dispatcher=hook_dispatcher,
+            max_iterations=max_iterations,
         )
 
         self.tool_collection = ToolCollection(

--- a/kolega_code/agent/planningagent.py
+++ b/kolega_code/agent/planningagent.py
@@ -44,6 +44,7 @@ class PlanningAgent(BaseAgent):
         usage_recorder: Optional[Any] = None,
         sub_agent_recorder: Optional[Any] = None,
         hook_dispatcher: Optional[Any] = None,
+        max_iterations: Optional[int] = None,
     ) -> None:
         super().__init__(
             project_path,
@@ -70,6 +71,7 @@ class PlanningAgent(BaseAgent):
             usage_recorder=usage_recorder,
             sub_agent_recorder=sub_agent_recorder,
             hook_dispatcher=hook_dispatcher,
+            max_iterations=max_iterations,
         )
 
         self._completed_plan: Optional[str] = None

--- a/kolega_code/agent/tests/test_base_agent.py
+++ b/kolega_code/agent/tests/test_base_agent.py
@@ -7,6 +7,7 @@ import pytest
 from dotenv import load_dotenv
 
 from kolega_code.agent.baseagent import BaseAgent
+from kolega_code.agent.errors import MaxAgentIterationsExceeded
 from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
 from kolega_code.events import AgentConnectionManager
 from kolega_code.llm.exceptions import (
@@ -74,6 +75,73 @@ def base_agent(tmp_path, mock_connection_manager, agent_config):
 
 
 class TestBaseAgent:
+    def test_default_max_iterations_is_uncapped(self, base_agent):
+        assert base_agent.max_iterations is None
+
+    @pytest.mark.parametrize("max_iterations", [0, -1])
+    def test_invalid_max_iterations_rejected(
+        self, tmp_path, mock_connection_manager, agent_config, max_iterations
+    ):
+        with pytest.raises(ValueError, match="max_iterations must be a positive integer or None"):
+            BaseAgent(
+                project_path=tmp_path,
+                workspace_id="test_workspace",
+                thread_id=str(uuid.uuid4()),
+                connection_manager=mock_connection_manager,
+                config=agent_config,
+                max_iterations=max_iterations,
+            )
+
+    @pytest.mark.asyncio
+    async def test_max_iterations_raises_for_runaway_tool_loop(self, tmp_path, mock_connection_manager, agent_config):
+        agent = BaseAgent(
+            project_path=tmp_path,
+            workspace_id="test_workspace",
+            thread_id=str(uuid.uuid4()),
+            connection_manager=mock_connection_manager,
+            config=agent_config,
+            max_iterations=2,
+        )
+        tool_call = ToolCall(id="tool_1", name="read_file", input={})
+        looping_message = Message(
+            role="assistant",
+            content=[tool_call],
+            stop_reason="tool_use",
+            tool_calls=[tool_call],
+        )
+        agent.system_prompt = Message(role="system", content=[TextBlock(text="sys")])
+        agent.tool_collection = MagicMock()
+        agent.tool_collection.get_tool_list = MagicMock(return_value=[])
+        agent.llm = FakeLLM(token_script=[100], final_message=looping_message)
+        agent.process_tool_calls = AsyncMock(
+            return_value=[ToolResult(tool_use_id="tool_1", name="read_file", content="ok", is_error=False)]
+        )
+        agent.log_info = AsyncMock()
+        agent.log_error = AsyncMock()
+
+        with pytest.raises(MaxAgentIterationsExceeded, match="max_iterations=2"):
+            async for _chunk in agent.process_message_stream("loop"):
+                pass
+
+        assert agent.process_tool_calls.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_terminal_turn_completes_under_max_iterations(self, base_agent):
+        base_agent.max_iterations = 1
+        base_agent.system_prompt = Message(role="system", content=[TextBlock(text="sys")])
+        base_agent.tool_collection = MagicMock()
+        base_agent.tool_collection.get_tool_list = MagicMock(return_value=[])
+        base_agent.llm = FakeLLM(
+            token_script=[100],
+            final_message=Message(role="assistant", content=[TextBlock(text="done")], stop_reason="end_turn"),
+        )
+        base_agent.log_info = AsyncMock()
+
+        chunks = [chunk async for chunk in base_agent.process_message_stream("finish")]
+
+        assert chunks[-1]["complete"] is True
+        assert base_agent.history[-1].stop_reason == "end_turn"
+
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "error,provider,model,expected_message",

--- a/kolega_code/agent/tests/tool_backend/test_agent_tool.py
+++ b/kolega_code/agent/tests/tool_backend/test_agent_tool.py
@@ -1,14 +1,12 @@
 """Tests for the unified AgentTool dispatch mechanism."""
 
 import pytest
-from pathlib import Path
 from unittest.mock import AsyncMock, Mock, MagicMock, patch
 import uuid
 import builtins
 
 from kolega_code.agent.tool_backend.agent_tool import AgentTool
 from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
-from kolega_code.events import AgentEvent
 
 
 @pytest.fixture
@@ -59,6 +57,7 @@ def mock_caller():
     caller.tool_extensions = []
     caller.usage_recorder = None
     caller.sub_agent_recorder = MockSubAgentRecorder()
+    caller.max_iterations = None
     return caller
 
 
@@ -175,6 +174,7 @@ class TestAgentTool:
 
             # Verify result
             assert result == "Mock agent completed"
+            assert MockAgent.last_instance.init_kwargs["max_iterations"] is None
 
             # Verify start status was sent
             start_event_calls = [
@@ -208,6 +208,32 @@ class TestAgentTool:
                 == mock_caller.workspace_env_var_descriptions
             )
             MockAgent.configure_streaming([])
+
+    async def test_dispatch_agent_inherits_parent_max_iterations(
+        self, agent_tool, mock_caller
+    ):
+        original_import = builtins.__import__
+        mock_caller.max_iterations = 3
+
+        with patch.object(builtins, "__import__") as mock_import:
+            mock_module = MagicMock()
+            mock_module.MockAgent = MockAgent
+
+            def mock_import_func(name, *args, **kwargs):
+                if name == "test.module":
+                    return mock_module
+                return original_import(name, *args, **kwargs)
+
+            mock_import.side_effect = mock_import_func
+            MockAgent.configure_streaming(
+                [{"content": "Done.", "complete": True, "uuid": str(uuid.uuid4()), "type": "response"}]
+            )
+            MockAgent.last_instance = None
+
+            await agent_tool._dispatch_agent(agent_class_import="test.module.MockAgent", task="Test task")
+
+        assert MockAgent.last_instance.init_kwargs["max_iterations"] == 3
+        MockAgent.configure_streaming([])
 
     async def test_dispatch_agent_uses_execution_id_for_sub_agent_conversation(
         self, agent_tool, mock_connection_manager, mock_caller
@@ -265,7 +291,7 @@ class TestAgentTool:
             with patch.object(agent_tool, "_dispatch_agent") as mock_dispatch:
                 mock_dispatch.return_value = f"{agent_type} completed"
 
-                result = await dispatch_method(task)
+                await dispatch_method(task)
 
                 # Verify the dispatch was called with the task
                 assert mock_dispatch.called

--- a/kolega_code/agent/tool_backend/agent_tool.py
+++ b/kolega_code/agent/tool_backend/agent_tool.py
@@ -241,6 +241,7 @@ class AgentTool(BaseTool):
                 usage_recorder=getattr(self.caller, "usage_recorder", None) if self.caller else None,
                 sub_agent_recorder=getattr(self.caller, "sub_agent_recorder", None) if self.caller else None,
                 hook_dispatcher=getattr(self.caller, "hook_dispatcher", None) if self.caller else None,
+                max_iterations=getattr(self.caller, "max_iterations", None),
             )
 
             # Store agent reference
@@ -557,6 +558,7 @@ class AgentTool(BaseTool):
             usage_recorder=getattr(self.caller, "usage_recorder", None) if self.caller else None,
             sub_agent_recorder=getattr(self.caller, "sub_agent_recorder", None) if self.caller else None,
             hook_dispatcher=getattr(self.caller, "hook_dispatcher", None) if self.caller else None,
+            max_iterations=getattr(self.caller, "max_iterations", None),
         )
 
     async def dispatch_workflow_agent(


### PR DESCRIPTION
## Summary
- add public AgentError / MaxAgentIterationsExceeded exceptions
- add opt-in max_iterations constructor parameter across agents
- enforce the cap in the canonical agent loop and propagate it to sub-agents

## Tests
- pytest kolega_code/agent/tests/test_base_agent.py kolega_code/agent/tests/tool_backend/test_agent_tool.py -q
- ruff check kolega_code/agent/baseagent.py kolega_code/agent/coder.py kolega_code/agent/planningagent.py kolega_code/agent/investigationagent.py kolega_code/agent/generalagent.py kolega_code/agent/browseragent.py kolega_code/agent/tool_backend/agent_tool.py kolega_code/agent/tests/test_base_agent.py kolega_code/agent/tests/tool_backend/test_agent_tool.py kolega_code/agent/errors.py kolega_code/__init__.py kolega_code/agent/__init__.py