### PR TITLE
Preserve ChatGPT reasoning continuity across tool calls

### DIFF
--- a/kolega_code/agent/tests/llm/test_chatgpt_oauth_provider.py
+++ b/kolega_code/agent/tests/llm/test_chatgpt_oauth_provider.py
@@ -13,6 +13,7 @@ from kolega_code.llm.models import (
     ImageBlock,
     Message,
     MessageHistory,
+    ResponsesReasoningBlock,
     TextBlock,
     ToolCall,
     ToolDefinition,
@@ -147,6 +148,32 @@ def test_to_responses_input_multiple_tool_outputs_before_image_followups():
     assert items[1]["call_id"] == "call_2"
     assert items[2]["role"] == "user"
     assert any(part.get("type") == "input_image" for part in items[2]["content"])
+
+
+def test_to_responses_input_resends_reasoning_before_tool_call():
+    # A prior assistant turn carrying captured reasoning must resend it as a
+    # reasoning item that *precedes* the function_call it belongs to.
+    history = MessageHistory(
+        [
+            Message(
+                role="assistant",
+                content=[
+                    ResponsesReasoningBlock(encrypted_content="ENC", summary=["thinking..."], item_id="rs_1"),
+                    ToolCall(id="call_1", name="read_file", input={"path": "a.py"}),
+                ],
+            ),
+        ]
+    )
+    items = to_responses_input(history)
+    assert items[0] == {
+        "type": "reasoning",
+        "summary": [{"type": "summary_text", "text": "thinking..."}],
+        "encrypted_content": "ENC",
+    }
+    # The opaque server id is intentionally not resent (matches Codex, store=false).
+    assert "id" not in items[0]
+    assert items[1]["type"] == "function_call"
+    assert items[1]["call_id"] == "call_1"
 
 
 def test_responses_tools_flattens_function_shape():
@@ -313,6 +340,86 @@ async def test_responses_stream_wrapper_max_tokens_stop_reason():
     assert message.stop_reason == "max_tokens"
 
 
+@pytest.mark.asyncio
+async def test_responses_stream_wrapper_captures_reasoning_for_continuity():
+    # With include=["reasoning.encrypted_content"], the backend emits a completed
+    # reasoning item carrying the encrypted blob. We capture it (leading the
+    # assistant message) so it round-trips into the next request for continuity.
+    completed = _ns(output=[], usage=None, status="completed", incomplete_details=None)
+    events = [
+        _ns(
+            type="response.output_item.done",
+            item=_ns(
+                type="reasoning",
+                id="rs_1",
+                encrypted_content="ENC",
+                summary=[_ns(type="summary_text", text="planning")],
+            ),
+        ),
+        _ns(
+            type="response.output_item.done",
+            item=_ns(type="function_call", id="fc_1", call_id="call_1", name="read_file", arguments='{"path": "a.py"}'),
+        ),
+        _ns(type="response.completed", response=completed),
+    ]
+    wrapper = ResponsesStreamWrapper(_FakeStream(events))
+    async with wrapper as stream:
+        async for _chunk in stream:
+            pass
+    message = await wrapper.get_final_message()
+
+    # Reasoning leads the assistant content so it precedes the tool call on resend.
+    assert isinstance(message.content[0], ResponsesReasoningBlock)
+    assert message.content[0].encrypted_content == "ENC"
+    assert message.content[0].summary == ["planning"]
+
+    items = to_responses_input(MessageHistory([message]))
+    assert items[0]["type"] == "reasoning"
+    assert items[0]["encrypted_content"] == "ENC"
+    assert items[1]["type"] == "function_call"
+
+
+@pytest.mark.asyncio
+async def test_responses_stream_wrapper_reasoning_from_final_output_fallback():
+    # Some backends populate reasoning only on the final response output, not via
+    # output_item.done events. The fallback path must still capture it.
+    completed = _ns(
+        output=[
+            _ns(type="reasoning", id="rs_1", encrypted_content="ENC2", summary=[]),
+            _ns(type="message", content=[_ns(type="output_text", text="hi")]),
+        ],
+        usage=None,
+        status="completed",
+        incomplete_details=None,
+    )
+    wrapper = ResponsesStreamWrapper(_FakeStream([_ns(type="response.completed", response=completed)]))
+    async with wrapper as stream:
+        async for _chunk in stream:
+            pass
+    message = await wrapper.get_final_message()
+    reasoning = [b for b in message.content if isinstance(b, ResponsesReasoningBlock)]
+    assert reasoning and reasoning[0].encrypted_content == "ENC2"
+    assert reasoning[0].summary == []
+
+
+@pytest.mark.asyncio
+async def test_responses_stream_wrapper_skips_reasoning_without_encrypted_content():
+    # A reasoning item lacking encrypted_content is useless for continuity (and
+    # would be rejected on resend), so it must be dropped.
+    completed = _ns(output=[], usage=None, status="completed", incomplete_details=None)
+    events = [
+        _ns(type="response.output_item.done", item=_ns(type="reasoning", id="rs_1", encrypted_content=None, summary=[])),
+        _ns(type="response.output_text.delta", delta="ok"),
+        _ns(type="response.completed", response=completed),
+    ]
+    wrapper = ResponsesStreamWrapper(_FakeStream(events))
+    async with wrapper as stream:
+        async for _chunk in stream:
+            pass
+    message = await wrapper.get_final_message()
+    assert not [b for b in message.content if isinstance(b, ResponsesReasoningBlock)]
+
+
 # --- provider request building (no network) -------------------------------------
 
 
@@ -352,13 +459,38 @@ async def test_provider_generate_builds_codex_shaped_request():
     assert kwargs["store"] is False
     assert kwargs["stream"] is True  # backend is SSE-only; generate streams too
     assert kwargs["instructions"] == "sys"
+    # summary="auto" so the backend streams a reasoning summary for the thinking
+    # display; this is independent of continuity, which rides on `include` below.
     assert kwargs["reasoning"] == {"effort": "high", "summary": "auto"}
+    # Reasoning continuity: ask the backend for the encrypted reasoning blob so it
+    # can be resent next turn (matches Codex; the cause of the long-thinking gap).
+    assert kwargs["include"] == ["reasoning.encrypted_content"]
     assert kwargs["tool_choice"] == "auto"
     assert kwargs["parallel_tool_calls"] is False
     assert "prompt_cache_key" in kwargs
     # Codex never sends max_output_tokens; sending it triggers a 400.
     assert "max_output_tokens" not in kwargs
     assert kwargs["input"] == [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}]
+
+
+@pytest.mark.asyncio
+async def test_provider_generate_omits_reasoning_and_include_without_thinking():
+    provider = ChatGPTOAuthProvider(token_manager=ChatGPTTokenManager(_tokens()))
+    completed = _ns(
+        output=[_ns(type="message", content=[_ns(type="output_text", text="hi")])],
+        usage=None,
+        status="completed",
+        incomplete_details=None,
+    )
+    fake = _FakeResponses(_FakeStream([_ns(type="response.completed", response=completed)]))
+    provider.async_client = _ns(responses=fake)
+    await provider.generate(
+        MessageHistory([Message(role="user", content=[TextBlock(text="hello")])]),
+        params=GenerationParams(),  # no thinking effort
+        model="gpt-5.5",
+    )
+    assert "reasoning" not in fake.last_kwargs
+    assert "include" not in fake.last_kwargs
 
 
 @pytest.mark.asyncio

--- a/kolega_code/llm/models.py
+++ b/kolega_code/llm/models.py
@@ -348,6 +348,84 @@ class RedactedThinkingBlock(ContentBlock):
         return "*Redacted thinking*"
 
 
+@register_content_block
+class ResponsesReasoningBlock(ContentBlock):
+    """OpenAI Responses-API reasoning item, kept so it can be resent next turn.
+
+    The Responses API hides raw chain-of-thought, but when a request asks for
+    ``include=["reasoning.encrypted_content"]`` each reasoning item comes back
+    with an opaque ``encrypted_content`` blob. Resending that blob in the next
+    request's ``input`` lets the model *continue* its prior reasoning instead of
+    re-deriving it on every tool-call round — which is exactly what Codex does
+    and why Codex doesn't blow up its thinking time at high effort.
+
+    The block is specific to the ``openai_chatgpt`` (Responses) provider. It is
+    serialized back via :meth:`to_responses_item`; the ``to_anthropic`` /
+    ``to_openai`` / ``to_google`` conversions return a harmless placeholder so a
+    stray cross-provider conversion never sends a foreign reasoning blob.
+    """
+
+    TYPE_NAME = "responses_reasoning"
+
+    def __init__(
+        self,
+        encrypted_content: str,
+        summary: Optional[List[str]] = None,
+        item_id: Optional[str] = None,
+        cache_checkpoint: bool = False,
+    ):
+        super().__init__(type=self.TYPE_NAME, cache_checkpoint=cache_checkpoint)
+        self.encrypted_content = encrypted_content
+        self.summary = list(summary or [])
+        self.item_id = item_id
+
+    def to_dict(self) -> Dict[str, Any]:
+        result = {
+            "type": self.type,
+            "encrypted_content": self.encrypted_content,
+            "summary": list(self.summary),
+            "cache_checkpoint": self.cache_checkpoint,
+        }
+        if self.item_id:
+            result["item_id"] = self.item_id
+        return result
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ResponsesReasoningBlock":
+        return cls(
+            encrypted_content=data["encrypted_content"],
+            summary=data.get("summary") or [],
+            item_id=data.get("item_id"),
+            cache_checkpoint=data.get("cache_checkpoint", False),
+        )
+
+    def to_responses_item(self) -> Dict[str, Any]:
+        """Serialize back to a Responses API ``input`` reasoning item.
+
+        Mirrors what Codex sends to the same backend: a ``reasoning`` item with
+        its ``summary`` parts and the opaque ``encrypted_content``. The server
+        item id is intentionally omitted — with ``store=false`` it is not a valid
+        server reference and Codex clears it too.
+        """
+        return {
+            "type": "reasoning",
+            "summary": [{"type": "summary_text", "text": text} for text in self.summary],
+            "encrypted_content": self.encrypted_content,
+        }
+
+    def to_anthropic(self) -> Dict[str, Any]:
+        return {"type": "text", "text": "[Reasoning]"}
+
+    def to_openai(self) -> Dict[str, Any]:
+        return {"type": "text", "text": "[Reasoning]"}
+
+    def to_google(self) -> genai_types.Part:
+        return genai_types.Part.from_text(text="[Reasoning]")
+
+    def to_markdown(self) -> str:
+        return "*Reasoning*"
+
+
 class ToolParameter:
     """Parameter definition for a tool"""
 

--- a/kolega_code/llm/providers/chatgpt_oauth.py
+++ b/kolega_code/llm/providers/chatgpt_oauth.py
@@ -25,6 +25,7 @@ from ..models import (
     Message,
     MessageChunk,
     MessageHistory,
+    ResponsesReasoningBlock,
     TextBlock,
     ToolCall,
     ToolResult,
@@ -154,7 +155,15 @@ def to_responses_input(messages: MessageHistory) -> List[Dict[str, Any]]:
         text_parts: List[tuple] = []
         tool_image_messages: List[Dict[str, Any]] = []
         for block in message.content or []:
-            if isinstance(block, ToolCall):
+            if isinstance(block, ResponsesReasoningBlock):
+                # Resend the model's prior reasoning (opaque encrypted blob) so it
+                # continues its chain-of-thought across tool calls instead of
+                # re-deriving it every round — the key to matching Codex's
+                # thinking time. Reasoning items must precede the function_call
+                # they belong to, which holds because the stream wrapper puts the
+                # reasoning block first in the assistant message.
+                items.append(block.to_responses_item())
+            elif isinstance(block, ToolCall):
                 items.append(
                     {
                         "type": "function_call",
@@ -178,7 +187,9 @@ def to_responses_input(messages: MessageHistory) -> List[Dict[str, Any]]:
                 text_parts.append(("text", block.text))
             elif isinstance(block, ImageBlock):
                 text_parts.append(("image", _image_data_url(block)))
-            # Thinking/redacted-thinking blocks are not resent to the backend.
+            # Foreign Anthropic thinking/redacted-thinking blocks (from a prior
+            # provider) are skipped here; adapt_history_for_provider has already
+            # replaced them with text placeholders before this conversion runs.
         if text_parts:
             item = _role_message_item(message.role, text_parts)
             if item:
@@ -291,6 +302,9 @@ class ResponsesStreamWrapper:
         self._closed = False
         self._text = ""
         self._reasoning = ""
+        # Completed reasoning items (with encrypted_content), in stream order, so
+        # they can be resent next turn for chain-of-thought continuity.
+        self._reasoning_items: List[Dict[str, Any]] = []
         self._final_response: Any = None
         self._function_calls: Dict[str, Dict[str, str]] = {}
         self._tool_execution_ids = ToolExecutionIdRegistry()
@@ -358,10 +372,18 @@ class ResponsesStreamWrapper:
             if arguments is not None:
                 record["arguments"] = arguments
         elif event_type == "response.output_item.done":
-            # The completed function_call item carries the final name + arguments;
-            # capture it so tool calls survive even if argument deltas were sparse.
             item = getattr(event, "item", None)
-            if getattr(item, "type", None) == "function_call":
+            item_kind = getattr(item, "type", None)
+            if item_kind == "reasoning":
+                # Capture the completed reasoning item (carries encrypted_content)
+                # so it can be resent next turn for chain-of-thought continuity.
+                captured = self._reasoning_dict(item)
+                if captured:
+                    self._reasoning_items.append(captured)
+            elif item_kind == "function_call":
+                # The completed function_call item carries the final name +
+                # arguments; capture it so tool calls survive even if argument
+                # deltas were sparse.
                 item_id = getattr(item, "id", None) or getattr(item, "call_id", "")
                 call_id = getattr(item, "call_id", None) or item_id
                 record = self._function_calls.setdefault(item_id, {"call_id": call_id, "name": "", "arguments": ""})
@@ -399,13 +421,64 @@ class ResponsesStreamWrapper:
             stop_reason = "tool_use" if tool_use_blocks else "end_turn"
             logger.warning("ResponsesStreamWrapper: no response.completed event; billing may be skipped")
 
+        # Reasoning items lead the assistant turn (they precede the model's
+        # message/function_call output) so the backend continues the prior
+        # chain-of-thought when this message is resent next turn.
+        reasoning_blocks = self._collect_reasoning_blocks()
         return Message(
             role="assistant",
-            content=content_blocks,
+            content=reasoning_blocks + content_blocks,
             tool_calls=tool_use_blocks or None,
             stop_reason=stop_reason,
             usage_metadata=usage_metadata,
         )
+
+    def _collect_reasoning_blocks(self) -> list:
+        """Build the reasoning blocks to carry forward for continuity.
+
+        Prefers items captured from ``response.output_item.done`` events; falls
+        back to the final response output for backends that only populate
+        reasoning there.
+        """
+        items = list(self._reasoning_items)
+        if not items and self._final_response is not None:
+            for out in getattr(self._final_response, "output", None) or []:
+                if getattr(out, "type", None) == "reasoning":
+                    captured = self._reasoning_dict(out)
+                    if captured:
+                        items.append(captured)
+        return [
+            ResponsesReasoningBlock(
+                encrypted_content=item["encrypted_content"],
+                summary=item.get("summary") or [],
+                item_id=item.get("item_id"),
+            )
+            for item in items
+        ]
+
+    @staticmethod
+    def _reasoning_dict(item: Any) -> Optional[Dict[str, Any]]:
+        """Extract resend-relevant fields from a Responses reasoning item.
+
+        Only items carrying ``encrypted_content`` are useful for continuity, so
+        items without it are dropped. Summary parts (if any) are preserved so the
+        resent item matches what the backend returned.
+        """
+        encrypted = getattr(item, "encrypted_content", None)
+        if not encrypted:
+            return None
+        summary: List[str] = []
+        for part in getattr(item, "summary", None) or []:
+            text = getattr(part, "text", None)
+            if text is None and isinstance(part, dict):
+                text = part.get("text")
+            if text:
+                summary.append(text)
+        return {
+            "encrypted_content": encrypted,
+            "summary": summary,
+            "item_id": getattr(item, "id", None),
+        }
 
     def _blocks_from_accumulators(self):
         content_blocks: list = []
@@ -501,8 +574,14 @@ class ChatGPTOAuthProvider(OpenAIProvider):
         request["instructions"] = instructions_from(system, messages) or "You are a helpful coding assistant."
         if params and params.thinking:
             thinking_params = build_thinking_request_params(self.provider_name, model, params.thinking)
-            if thinking_params.get("reasoning"):
-                request["reasoning"] = thinking_params["reasoning"]
+            reasoning = thinking_params.get("reasoning")
+            if reasoning:
+                request["reasoning"] = reasoning
+                # Ask the backend to return the model's reasoning as an opaque
+                # encrypted item so we can resend it next turn for continuity
+                # (mirrors Codex). Without it the model re-reasons from scratch on
+                # every tool-call round and "thinks" far longer at high effort.
+                request["include"] = ["reasoning.encrypted_content"]
         return request
 
     async def stream(

--- a/kolega_code/llm/specs.py
+++ b/kolega_code/llm/specs.py
@@ -513,8 +513,12 @@ def build_thinking_request_params(provider: str, model_name: str, effort: Option
 
     if spec.mode == "openai_responses_reasoning":
         # The Responses API nests reasoning effort under a "reasoning" object,
-        # unlike Chat Completions' flat "reasoning_effort". Codex also sends
-        # summary=auto, which the ChatGPT backend expects.
+        # unlike Chat Completions' flat "reasoning_effort". We request
+        # summary="auto" so the backend streams a human-readable reasoning summary
+        # for the TUI thinking display. (Codex defaults these models to summary
+        # "none" and shows no reasoning text; kolega surfaces it, so we keep it
+        # on.) This is independent of reasoning continuity, which is carried by
+        # reasoning.encrypted_content (see the ChatGPT provider), not the summary.
         return {"reasoning": {"effort": normalized, "summary": "auto"}}
 
     raise ValueError(f"Unknown thinking effort mode '{spec.mode}' for {_provider_value(provider)}/{model_name}.")


### PR DESCRIPTION
## Summary
- preserve OpenAI Responses reasoning continuity for the ChatGPT OAuth provider by storing encrypted reasoning items as `ResponsesReasoningBlock`s and resending them before follow-up function calls
- request `include=["reasoning.encrypted_content"]` whenever thinking/reasoning is enabled, while keeping `summary="auto"` for TUI thinking summaries
- add provider coverage for resend ordering, stream capture + round-trip, final-output fallback, dropping unusable reasoning items, and omitting reasoning/include when thinking is disabled

## Root cause
Kolega and Codex were using the same ChatGPT backend/model/effort, but Codex round-trips the Responses API encrypted reasoning item across tool-call turns. Kolega did not request `reasoning.encrypted_content` and dropped reasoning items, so high-effort tool loops forced the model to re-establish reasoning from scratch each round.

## Testing
- `uv run pytest kolega_code/agent/tests/llm/test_chatgpt_oauth_provider.py`
- `uv run pytest kolega_code/agent/tests/llm/test_thinking_effort.py kolega_code/agent/tests/llm/test_model_specs.py kolega_code/agent/tests/llm/test_openai_message_conversion.py`
- `git diff --check`
