### PR TITLE
chore: release v0.8.1

### DIFF
--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -44,4 +44,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.8.0"
+version = "0.8.1"
 description = "Local-first AI coding agent for the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [options]
 prerelease-mode = "allow"
-exclude-newer = "2026-06-15T12:38:56.983861Z"
+exclude-newer = "2026-06-15T18:13:37.213874Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1098,7 +1098,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Release `kolega-code` v0.8.1 from current `main`
- Bump package metadata and lockfile from `0.8.0` to `0.8.1`
- Covers PRs merged since `v0.8.0`: #82, #83, #84

## Release notes draft

### Added
- Optional agent loop iteration cap via `max_iterations` on `BaseAgent` and concrete agent constructors.
- New catchable agent runtime errors: `AgentError` and `MaxAgentIterationsExceeded`, exported from `kolega_code.agent` and top-level package exports.
- Sub-agent dispatch now inherits the parent agent’s iteration cap.

### Fixed
- Preserves encrypted OpenAI Responses reasoning items across follow-up function/tool calls, improving continuity for high-effort OpenAI and ChatGPT-subscription tool loops.

### Changed
- API-key `openai` provider now uses OpenAI’s Responses API instead of Chat Completions so `gpt-5.x` models can use function tools with reasoning effort.
- OpenAI-compatible providers (`together`, `groq`, `fireworks`, `xai`, `llama`, `dashscope`) continue using the Chat Completions provider.
- OpenAI model specs now use Responses-style reasoning settings, do not send temperature where unsupported, and use `minimal` instead of `none` for the lowest reasoning effort.
- Responses provider logic is shared between API-key OpenAI and ChatGPT-subscription backends, including streaming, request building, reasoning continuity, and token counting.

## Validation
- [x] `uv lock`
- [x] `uv run pytest -ra --durations=50 --import-mode=importlib -m "not slow"`

## Post-merge release steps
After this PR is reviewed, green, and merged:

```bash
git checkout main
git pull origin main
git tag v0.8.1
git push origin v0.8.1
```

Then monitor the `Release` workflow, approve the PyPI environment deployment if prompted, and verify:

```bash
uv tool install --force kolega-code
kolega-code --version
gh release view v0.8.1 --repo kolega-ai/kolega-code
```
