### PR TITLE
Move TUI persistence off event loop

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -838,7 +838,7 @@ class KolegaCodeApp(
         self._cancel_pending_theme_selection()
 
         if self.config is not None:
-            await self._build_agent(self.config, rebuild=True)
+            await self._build_agent(self.config, rebuild=True, restore_transcript=False)
 
         self._update_mode_chrome()
         self._restore_composer_placeholder()
@@ -1193,11 +1193,15 @@ class KolegaCodeApp(
         existing = next((entry for entry in self.conversation_entries if entry.kind == "startup"), None)
         if existing is None:
             self.conversation_entries.insert(0, tui_state.ConversationEntry(kind="startup", content=self._startup_content()))
+        elif self.conversation_entries[0] is existing:
+            existing.content = self._startup_content()
+            if render:
+                self._invalidate_conversation(existing)
+            return
         else:
             existing.content = self._startup_content()
-            if self.conversation_entries[0] is not existing:
-                self.conversation_entries.remove(existing)
-                self.conversation_entries.insert(0, existing)
+            self.conversation_entries.remove(existing)
+            self.conversation_entries.insert(0, existing)
         if render:
             self._render_conversation()
 

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -185,6 +185,7 @@ class KolegaCodeApp(
         # session. Reset in _switch_model so a new model gets a fresh warning.
         self._vision_warning_shown = False
         self._permission_lock = asyncio.Lock()
+        self._persistence_lock = asyncio.Lock()
         self._pending_model_selection: Optional[tui_state.PendingModelSelection] = None
         self._pending_effort_selection: Optional[tui_state.PendingEffortSelection] = None
         self._pending_theme_selection: Optional[tui_state.PendingThemeSelection] = None
@@ -491,9 +492,63 @@ class KolegaCodeApp(
         self.session.plan_pending = bool(self._latest_plan and self._plan_pending)
         self.session.plan_reofferable = bool(self._latest_plan and self._plan_reofferable)
 
-    def _save_session(self) -> None:
+    def _session_snapshot_locked(self) -> SessionRecord:
+        """Return a detached session snapshot for background persistence.
+
+        Call only while ``_persistence_lock`` is held. The snapshot gets shallow
+        copies of mutable payloads so ``SessionStore.save`` never serializes the
+        live ``self.session`` object on a worker thread.
+        """
         self._sync_planning_state_to_session()
-        self.store.save(self.session)
+        record = self.session
+        return SessionRecord(
+            schema_version=record.schema_version,
+            session_id=record.session_id,
+            project_path=record.project_path,
+            workspace_id=record.workspace_id,
+            thread_id=record.thread_id,
+            mode=record.mode,
+            title=record.title,
+            created_at=record.created_at,
+            updated_at=record.updated_at,
+            config=dict(record.config),
+            history=list(record.history),
+            compaction=dict(record.compaction),
+            task_list_markdown=record.task_list_markdown,
+            latest_plan_markdown=record.latest_plan_markdown,
+            plan_pending=record.plan_pending,
+            plan_reofferable=record.plan_reofferable,
+            interaction_mode=record.interaction_mode,
+            permission_mode=record.permission_mode,
+        )
+
+    async def _save_session_async(self) -> None:
+        """Persist lightweight session state without blocking Textual's loop."""
+        async with self._persistence_lock:
+            snapshot = self._session_snapshot_locked()
+            await asyncio.to_thread(self.store.save, snapshot)
+            self.session.updated_at = snapshot.updated_at
+
+    async def _save_session_history_async(self) -> None:
+        """Dump agent history and persist the session off the UI loop."""
+        async with self._persistence_lock:
+            agent = self.agent
+            if agent is None:
+                return
+            snapshot = self._session_snapshot_locked()
+
+            def dump_and_save() -> tuple[list[dict], dict, str]:
+                history = agent.dump_message_history()
+                compaction = agent.dump_compaction_state()
+                snapshot.history = history
+                snapshot.compaction = compaction
+                self.store.save(snapshot)
+                return history, compaction, snapshot.updated_at
+
+            history, compaction, updated_at = await asyncio.to_thread(dump_and_save)
+            self.session.history = history
+            self.session.compaction = compaction
+            self.session.updated_at = updated_at
 
     def _restore_plan_action_visibility(self) -> None:
         self._set_plan_actions_visible(
@@ -510,7 +565,7 @@ class KolegaCodeApp(
                 self._notify_user(messages.BLOCK_STOP_BEFORE_RESET, severity="warning")
                 return
             event.composer.load_text("")
-            self._reset_current_thread()
+            await self._reset_current_thread()
             return
 
         if await self._handle_tui_slash_command(stripped_text, event.composer):
@@ -662,7 +717,7 @@ class KolegaCodeApp(
             elif event.option_id == "implement_plan_clear":
                 await self._implement_pending_plan(clear_context=True)
             elif event.option_id == "discuss_plan":
-                self._discuss_pending_plan()
+                await self._discuss_pending_plan()
             return
         if event.option_list.id != "completion_dropdown":
             return
@@ -799,8 +854,7 @@ class KolegaCodeApp(
                     await fire(HookEvent.SESSION_END, {"reason": "quit"})
                 except Exception:
                     pass
-            self._persist_agent_into_session()
-            self._save_session()
+            await self._save_session_history_async()
             await self.agent.cleanup()
         self.exit()
 
@@ -829,7 +883,7 @@ class KolegaCodeApp(
 
         self.interaction_mode = interaction_mode
         self._plan_decision_active = False
-        self._save_session()
+        await self._save_session_async()
         self._restore_plan_action_visibility()
         self._cancel_pending_question()
         self._cancel_pending_approval()
@@ -852,14 +906,14 @@ class KolegaCodeApp(
 
         self.permission_mode = mode
         self.session.permission_mode = mode.value
-        self._save_session()
+        await self._save_session_async()
         if self.agent is not None:
             self.agent.set_permission_mode(mode)
             self.agent.set_permission_callback(self._permission_callback)
         self._update_mode_chrome()
         self._notify_user(messages.SWITCHED_PERMISSION_MODE.format(mode=mode.value))
 
-    def _capture_completed_plan(self) -> None:
+    async def _capture_completed_plan(self) -> None:
         if self.interaction_mode != tui_constants.PLAN_INTERACTION_MODE or self.agent is None:
             return
         consume_completed_plan = getattr(self.agent, "consume_completed_plan", None)
@@ -870,16 +924,16 @@ class KolegaCodeApp(
         if plan:
             self._latest_plan = plan
             self._plan_reofferable = True
-            self._show_plan_for_decision(plan, notification=messages.PLAN_CAPTURED)
+            await self._show_plan_for_decision(plan, notification=messages.PLAN_CAPTURED)
             return
 
         if self._latest_plan and self._plan_reofferable and not self._plan_pending:
-            self._show_plan_for_decision(self._latest_plan, notification=messages.PLAN_REOFFERED)
+            await self._show_plan_for_decision(self._latest_plan, notification=messages.PLAN_REOFFERED)
 
-    def _show_plan_for_decision(self, plan: str, *, notification: str) -> None:
+    async def _show_plan_for_decision(self, plan: str, *, notification: str) -> None:
         self._plan_pending = True
         self._plan_decision_active = True
-        self._save_session()
+        await self._save_session_async()
         self._refresh_planning_sidebar()
         self._add_conversation_entry(tui_state.ConversationEntry(kind="plan", content=plan, complete=True))
         self._set_plan_actions_visible(True, allow_discuss=True)
@@ -901,7 +955,7 @@ class KolegaCodeApp(
         self._plan_decision_active = False
         if clear_context:
             self._clear_agent_context()
-        self._save_session()
+        await self._save_session_async()
         await self._set_interaction_mode(tui_constants.BUILD_INTERACTION_MODE)
         self._refresh_planning_sidebar()
         self._set_plan_actions_visible(False)
@@ -912,14 +966,14 @@ class KolegaCodeApp(
             self._process_message(prompt), name="kolega-turn", group="turns", exclusive=True
         )
 
-    def _discuss_pending_plan(self) -> None:
+    async def _discuss_pending_plan(self) -> None:
         if not self._latest_plan:
             return
 
         self._plan_pending = False
         self._plan_reofferable = True
         self._plan_decision_active = False
-        self._save_session()
+        await self._save_session_async()
         self._refresh_planning_sidebar()
         self._set_plan_actions_visible(False)
         self._restore_composer_placeholder()
@@ -1144,7 +1198,7 @@ class KolegaCodeApp(
         self.session.history = []
         self.session.compaction = {}
 
-    def _reset_current_thread(self) -> None:
+    async def _reset_current_thread(self) -> None:
         self._close_sub_agent_inspector()
         if self.agent is not None:
             self.agent.history = MessageHistory()
@@ -1164,7 +1218,7 @@ class KolegaCodeApp(
         self._plan_pending = False
         self._plan_reofferable = False
         self._plan_decision_active = False
-        self._save_session()
+        await self._save_session_async()
         self._set_plan_actions_visible(False)
         self._cancel_pending_question()
         self._cancel_pending_approval()

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import asyncio
 import json
+import time
 
 import pytest
 
@@ -2099,7 +2100,7 @@ async def test_textual_app_shows_plan_decision_when_planning_agent_writes_plan(
         assert loaded.plan_reofferable is True
         assert loaded.interaction_mode == "plan"
 
-        app._discuss_pending_plan()
+        await app._discuss_pending_plan()
 
         assert app._plan_decision_active is False
         assert app._plan_pending is False
@@ -2133,10 +2134,10 @@ async def test_textual_app_shows_plan_decision_when_planning_agent_writes_plan(
         assert loaded.plan_pending is True
         assert loaded.plan_reofferable is True
 
-        app._discuss_pending_plan()
+        await app._discuss_pending_plan()
 
         app.agent.completed_plan = "# Revised plan\n\nBuild planning mode carefully."
-        app._capture_completed_plan()
+        await app._capture_completed_plan()
 
         assert app._plan_decision_active is True
         assert app._plan_pending is True
@@ -2459,7 +2460,7 @@ async def test_textual_app_discuss_plan_preserves_old_plan_until_new_plan_is_wri
         app._plan_reofferable = True
         app._plan_decision_active = True
 
-        app._discuss_pending_plan()
+        await app._discuss_pending_plan()
 
         assert app._latest_plan == "# Plan\n\nBuild it after discussing."
         assert app._plan_pending is False
@@ -2538,10 +2539,136 @@ async def test_textual_app_does_not_save_startup_entry_to_history(
 
     async with app.run_test():
         assert app.conversation_entries[0].kind == "startup"
-        app._save_session_history()
+        await app._save_session_history_async()
 
         assert session.history == saved_history
         assert all("Kolega Code" not in str(item) for item in session.history)
+
+
+@pytest.mark.asyncio
+async def test_textual_app_history_save_runs_off_event_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.app import KolegaCodeApp
+
+    saved_history = [Message(role="assistant", content=[TextBlock("saved response")]).to_dict()]
+
+    class FakeAgent:
+        def dump_message_history(self):
+            return saved_history
+
+        def dump_compaction_state(self):
+            return {}
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    original_save = store.save
+
+    def slow_save(record):
+        time.sleep(0.2)
+        original_save(record)
+
+    monkeypatch.setattr(store, "save", slow_save)
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+    app.agent = FakeAgent()
+
+    save_task = asyncio.create_task(app._save_session_history_async())
+    marker_task = asyncio.create_task(asyncio.sleep(0.05))
+    done, _ = await asyncio.wait({save_task, marker_task}, timeout=0.1, return_when=asyncio.FIRST_COMPLETED)
+
+    assert marker_task in done
+    assert not save_task.done()
+    await save_task
+    assert store.load(session.session_id).history == saved_history
+
+
+@pytest.mark.asyncio
+async def test_textual_app_history_save_persists_session_and_compaction(tmp_path: Path) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.app import KolegaCodeApp
+
+    saved_history = [Message(role="assistant", content=[TextBlock("persist me")]).to_dict()]
+    saved_compaction = {"summary": "older turns", "compacted_through": 3, "compacted_history_length": 5}
+
+    class FakeAgent:
+        def dump_message_history(self):
+            return saved_history
+
+        def dump_compaction_state(self):
+            return saved_compaction
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+    app.agent = FakeAgent()
+
+    await app._save_session_history_async()
+
+    assert app.session.history == saved_history
+    assert app.session.compaction == saved_compaction
+    loaded = store.load(session.session_id)
+    assert loaded.history == saved_history
+    assert loaded.compaction == saved_compaction
+
+
+@pytest.mark.asyncio
+async def test_textual_app_overlapping_saves_preserve_later_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.app import KolegaCodeApp
+
+    saved_history = [Message(role="assistant", content=[TextBlock("history from first save")]).to_dict()]
+
+    class FakeAgent:
+        def dump_message_history(self):
+            return saved_history
+
+        def dump_compaction_state(self):
+            return {}
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+    app.agent = FakeAgent()
+
+    original_save = store.save
+    saved_snapshots: list[tuple[str, list[dict]]] = []
+
+    def slow_first_save(record):
+        saved_snapshots.append((record.task_list_markdown, list(record.history)))
+        if len(saved_snapshots) == 1:
+            time.sleep(0.2)
+        original_save(record)
+
+    monkeypatch.setattr(store, "save", slow_first_save)
+
+    first_save = asyncio.create_task(app._save_session_history_async())
+    await asyncio.sleep(0.05)
+    app.session.task_list_markdown = "- [x] later state"
+    second_save = asyncio.create_task(app._save_session_async())
+
+    await asyncio.gather(first_save, second_save)
+
+    assert len(saved_snapshots) == 2
+    assert saved_snapshots[0] == ("", saved_history)
+    assert saved_snapshots[1] == ("- [x] later state", saved_history)
+    loaded = store.load(session.session_id)
+    assert loaded.task_list_markdown == "- [x] later state"
+    assert loaded.history == saved_history
 
 
 @pytest.mark.asyncio
@@ -5579,7 +5706,7 @@ async def test_thread_reset_clears_sub_agent_state(tmp_path: Path, monkeypatch: 
         app._render_event(_sub_agent_event(uuid="u1", text="some output"))
         assert app._sub_agent_activities
 
-        app._reset_current_thread()
+        await app._reset_current_thread()
 
         assert app._sub_agent_activities == {}
         assert app._sub_agent_by_tool_call == {}
@@ -5954,7 +6081,7 @@ async def test_thread_reset_closes_open_inspector(
         await pilot.pause()
         assert app._sub_agent_inspector is not None
 
-        app._reset_current_thread()
+        await app._reset_current_thread()
         await pilot.pause()
 
         assert app._sub_agent_inspector is None

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -465,6 +465,215 @@ async def test_textual_app_status_dashboard_tracks_interaction_mode(
 
 
 @pytest.mark.asyncio
+async def test_textual_app_mode_switch_rebuild_skips_transcript_restore(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.widgets import Static
+
+    from kolega_code.cli.app import KolegaCodeApp
+
+    history = [{"role": "user", "content": [{"type": "text", "text": "keep me"}]}]
+    compaction = {"summary": "summary", "compacted_through": 1, "compacted_history_length": 1}
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.restored_history = None
+            self.restored_compaction = None
+
+        def restore_message_history(self, restored):
+            self.restored_history = restored
+
+        def dump_compaction_state(self):
+            return compaction
+
+        def restore_compaction_state(self, data):
+            self.restored_compaction = data
+
+        def dump_message_history(self):
+            return history
+
+        async def cleanup(self):
+            return None
+
+    class FakePlanningAgent(FakeCoderAgent):
+        instances = []
+
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.instances.append(self)
+
+    monkeypatch.setattr(agent_runtime_module, "CoderAgent", FakeCoderAgent)
+    monkeypatch.setattr(agent_runtime_module, "PlanningAgent", FakePlanningAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test():
+        restore_calls = []
+        render_calls = []
+
+        def spy_restore(restored):
+            restore_calls.append(restored)
+
+        def spy_render():
+            render_calls.append(True)
+
+        monkeypatch.setattr(app, "_restore_conversation_history", spy_restore)
+        monkeypatch.setattr(app, "_render_conversation", spy_render)
+
+        await app._set_interaction_mode("plan")
+
+        assert restore_calls == []
+        assert render_calls == []
+        assert app.interaction_mode == "plan"
+        assert "plan" in str(app.query_one("#session_meta", Static).render())
+        assert "Plan" in str(app.query_one("#status_dashboard", Static).render())
+
+        assert FakePlanningAgent.instances
+        planning_agent = FakePlanningAgent.instances[-1]
+        assert planning_agent.restored_history == history
+        assert planning_agent.restored_compaction == compaction
+
+
+@pytest.mark.asyncio
+async def test_textual_app_startup_entry_updates_incrementally(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.app import KolegaCodeApp
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            return None
+
+    monkeypatch.setattr(agent_runtime_module, "CoderAgent", FakeAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test():
+        startup = app.conversation_entries[0]
+        original_content = startup.content
+        invalidated = []
+        rendered = []
+
+        def spy_invalidate(entry):
+            invalidated.append(entry)
+
+        def spy_render():
+            rendered.append(True)
+
+        monkeypatch.setattr(app, "_invalidate_conversation", spy_invalidate)
+        monkeypatch.setattr(app, "_render_conversation", spy_render)
+
+        app.interaction_mode = "plan"
+        app._ensure_startup_entry()
+
+        assert app.conversation_entries[0] is startup
+        assert startup.content != original_content
+        assert "Interaction: plan" in startup.content
+        assert invalidated == [startup]
+        assert rendered == []
+
+        app.conversation_entries = []
+        app._ensure_startup_entry()
+
+        assert app.conversation_entries[0].kind == "startup"
+        assert rendered == [True]
+
+
+@pytest.mark.asyncio
+async def test_textual_app_mode_switch_preserves_transcript_entries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.cli.tui.state import ConversationEntry
+
+    history = [{"role": "user", "content": [{"type": "text", "text": "persisted"}]}]
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
+        def dump_message_history(self):
+            return history
+
+        async def cleanup(self):
+            return None
+
+    monkeypatch.setattr(agent_runtime_module, "CoderAgent", FakeAgent)
+    monkeypatch.setattr(agent_runtime_module, "PlanningAgent", FakeAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test():
+        startup = app.conversation_entries[0]
+        user = ConversationEntry(kind="user", content="hello")
+        assistant = ConversationEntry(kind="assistant", content="hi", complete=True)
+        tool = ConversationEntry(
+            kind="tool_result",
+            content="done",
+            complete=True,
+            tool_name="read_file",
+            tool_call_id="tool-1",
+            full_content="done",
+        )
+        app.conversation_entries = [startup, user, assistant, tool]
+        non_startup_entries = app.conversation_entries[1:]
+
+        await app._set_interaction_mode("plan")
+
+        assert app.conversation_entries[0] is startup
+        assert app.conversation_entries[1:] == non_startup_entries
+        assert app.conversation_entries[1] is user
+        assert app.conversation_entries[2] is assistant
+        assert app.conversation_entries[3] is tool
+
+
+@pytest.mark.asyncio
 async def test_textual_app_turn_status_formats_error_duration(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -48,9 +48,9 @@ class AgentRuntimeMixin:
             await self._drain_pending_events()
             self._finalize_sub_agent_activities()
             self._finalize_workflow_activities()
-            self._save_session_history()
+            await self._save_session_history_async()
             self._finish_turn_progress(messages.FINISHED, tui_state.TurnState.IDLE)
-            self._capture_completed_plan()
+            await self._capture_completed_plan()
             self._log_status(messages.FINISHED, "ok")
         except asyncio.CancelledError:
             self._cancel_pending_question()
@@ -58,7 +58,7 @@ class AgentRuntimeMixin:
             await self._drain_pending_events()
             self._finalize_sub_agent_activities()
             self._finalize_workflow_activities()
-            self._save_session_history()
+            await self._save_session_history_async()
             self._finish_turn_progress(messages.STOPPED_BY_USER, tui_state.TurnState.STOPPED)
             self._log_status(messages.STOPPED_BY_USER, "warn")
         except LLMError as exc:
@@ -67,7 +67,7 @@ class AgentRuntimeMixin:
             await self._drain_pending_events()
             self._finalize_sub_agent_activities()
             self._finalize_workflow_activities()
-            self._save_session_history()
+            await self._save_session_history_async()
             model = self.config.long_context_config.model if self.config is not None else None
             message_text = llm_error_message(exc, model=model)
             self._finish_turn_progress(message_text, tui_state.TurnState.ERROR)
@@ -78,7 +78,7 @@ class AgentRuntimeMixin:
             await self._drain_pending_events()
             self._finalize_sub_agent_activities()
             self._finalize_workflow_activities()
-            self._save_session_history()
+            await self._save_session_history_async()
             self._finish_turn_progress(messages.STOPPED_WITH_ERROR.format(error=exc), tui_state.TurnState.ERROR)
             self._log_status(messages.STOPPED_WITH_ERROR.format(error=exc), "error")
             raise
@@ -193,7 +193,7 @@ class AgentRuntimeMixin:
 
         self.config = config
         self.session.config = config_summary(config)
-        self._save_session()
+        await self._save_session_async()
         await self._build_agent(config, rebuild=rebuild)
         self._set_chat_enabled(True)
         self._update_settings_status()
@@ -210,11 +210,9 @@ class AgentRuntimeMixin:
         history = self.session.history
         compaction = self.session.compaction
         if self.agent is not None:
-            history = self.agent.dump_message_history()
-            compaction = self.agent.dump_compaction_state()
-            self.session.history = history
-            self.session.compaction = compaction
-            self._save_session()
+            await self._save_session_history_async()
+            history = self.session.history
+            compaction = self.session.compaction
             if rebuild:
                 await self.agent.cleanup()
 

--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -200,7 +200,13 @@ class AgentRuntimeMixin:
         self._ensure_startup_entry()
         self.query_one("#composer", tui_widgets.ChatComposer).focus()
 
-    async def _build_agent(self, config: AgentConfig, rebuild: bool = False) -> None:
+    async def _build_agent(
+        self,
+        config: AgentConfig,
+        rebuild: bool = False,
+        *,
+        restore_transcript: bool = True,
+    ) -> None:
         history = self.session.history
         compaction = self.session.compaction
         if self.agent is not None:
@@ -261,7 +267,8 @@ class AgentRuntimeMixin:
         if history:
             self.agent.restore_message_history(history)
             self.agent.restore_compaction_state(compaction)
-            self._restore_conversation_history(history)
+            if restore_transcript:
+                self._restore_conversation_history(history)
         self._update_mode_chrome()
         await self._fire_session_start_once()
 

--- a/kolega_code/cli/tui/command_handlers.py
+++ b/kolega_code/cli/tui/command_handlers.py
@@ -776,7 +776,7 @@ class CommandHandlersMixin:
                 self._process_message(prompt, attachments), name="kolega-turn", group="turns", exclusive=True
             )
         else:
-            self._save_session_history()
+            await self._save_session_history_async()
             self._restore_composer_placeholder()
             self._set_chat_enabled(True)
 

--- a/kolega_code/cli/tui/prompt_flows.py
+++ b/kolega_code/cli/tui/prompt_flows.py
@@ -68,7 +68,7 @@ class PromptFlowMixin:
                 A confirmation that the shared task list was updated.
             """
             self.session.task_list_markdown = task_list_markdown.strip()
-            self._save_session()
+            await self._save_session_async()
             self._refresh_planning_sidebar()
             return "Task list updated."
 

--- a/kolega_code/cli/tui/settings_panel.py
+++ b/kolega_code/cli/tui/settings_panel.py
@@ -68,6 +68,8 @@ class SettingsPanelMixin:
         if select_id.startswith("am_provider_"):
             role = select_id[len("am_provider_") :]
             provider = str(event.value)
+            if str(event.select.value) != provider:
+                return
             if provider == INHERIT_SENTINEL:
                 # Don't drop pending here: the selects post an initial inherit-valued
                 # Changed on mount, which would clear a restore before its real cascade
@@ -95,6 +97,8 @@ class SettingsPanelMixin:
 
         if select_id == "theme_select":
             name = str(event.value)
+            if str(event.select.value) != name:
+                return
             if name != (self.settings.active_theme or theme.DEFAULT_THEME_NAME):
                 self.settings.active_theme = name
                 self.settings_store.save(self.settings)
@@ -142,10 +146,11 @@ class SettingsPanelMixin:
     def _populate_agent_model_rows(self) -> None:
         """Seed each per-agent row from saved settings (absent role -> inherit).
 
-        A model select that was just given its options can't accept a value until the
-        next refresh, and setting the provider value posts a Changed that re-runs the
-        cascade afterwards. So we stash the saved model/effort and let that cascade —
-        the last writer — apply them, rather than assigning here and being clobbered."""
+        Setting the provider value posts a Changed event that re-runs the cascade,
+        but Textual may deliver that event after other awaited startup work. Apply
+        the model/effort directly as the deterministic path, while also leaving the
+        pending values for the Changed event to consume if it arrives later.
+        """
         provider_values = {value for _, value in ui_provider_options()}
         for _, role in agent_role_options():
             try:
@@ -154,18 +159,22 @@ class SettingsPanelMixin:
                 continue
             entry = self.settings.get_agent_model(role) or {}
             provider = entry.get("provider")
-            self._pending_agent_models.pop(f"am_model_{role}", None)
-            self._pending_agent_efforts.pop(f"am_effort_{role}", None)
+            model_id = f"am_model_{role}"
+            effort_id = f"am_effort_{role}"
+            self._pending_agent_models.pop(model_id, None)
+            self._pending_agent_efforts.pop(effort_id, None)
             if provider not in provider_values:
                 provider_select.value = INHERIT_SENTINEL
-                self._clear_model_effort_selects(f"am_model_{role}", f"am_effort_{role}")
+                self._clear_model_effort_selects(model_id, effort_id)
                 continue
-            if entry.get("model"):
-                self._pending_agent_models[f"am_model_{role}"] = str(entry["model"])
-            if entry.get("thinking_effort"):
-                self._pending_agent_efforts[f"am_effort_{role}"] = str(entry["thinking_effort"])
-            # Triggers on_select_changed, which consumes the pending model/effort.
+            model_value = str(entry["model"]) if entry.get("model") else None
+            effort_value = str(entry["thinking_effort"]) if entry.get("thinking_effort") else None
+            if model_value:
+                self._pending_agent_models[model_id] = model_value
+            if effort_value:
+                self._pending_agent_efforts[effort_id] = effort_value
             provider_select.value = provider
+            self._repopulate_model_select(provider, model_id, effort_id, model_value=model_value, effort_value=effort_value)
 
     def _update_search_backend_fields(self, backend: str) -> None:
         """Show only the inputs the selected web-search backend needs.

--- a/kolega_code/cli/tui/transcript.py
+++ b/kolega_code/cli/tui/transcript.py
@@ -282,12 +282,6 @@ class TranscriptRenderingMixin:
         self.session.history = self.agent.dump_message_history()
         self.session.compaction = self.agent.dump_compaction_state()
 
-    def _save_session_history(self) -> None:
-        if self.agent is None:
-            return
-        self._persist_agent_into_session()
-        self._save_session()
-
     def _add_tool_message(self, message_type: str, content: dict) -> None:
         tool_name = str(content.get("tool_description") or content.get("tool_name") or "tool")
         tool_call_id = str(content.get("tool_call_id") or "")


### PR DESCRIPTION
## Summary
- offload TUI session/history persistence with locked async helpers and `asyncio.to_thread`
- serialize overlapping saves so later saves snapshot after earlier saves finish
- update TUI save call sites to await the async persistence path
- guard stale Textual select events during startup so restored themes and per-agent models are not clobbered
- add regression tests for off-loop persistence and overlapping save ordering

## Tests
- pytest kolega_code/cli/tests/test_app.py -k "history_save or overlapping_saves or does_not_save_startup_entry_to_history or plan_reoffer or thread_reset"
- pytest kolega_code/cli/tests/test_session_store.py kolega_code/cli/tests/test_app.py
- pytest kolega_code/cli/tests/test_themes.py::test_persisted_theme_applied_at_startup kolega_code/cli/tests/test_themes.py::test_theme_command_switches_persists_and_reskins kolega_code/cli/tests/test_app.py::test_agent_models_section_populates_and_clears_to_inherit -q
- CI=true uv run pytest -ra --durations=50 --import-mode=importlib -m "not slow"
- uv run ruff check kolega_code/cli/tui/settings_panel.py kolega_code/cli/app.py kolega_code/cli/tui/agent_runtime.py kolega_code/cli/tui/command_handlers.py kolega_code/cli/tui/prompt_flows.py kolega_code/cli/tui/transcript.py kolega_code/cli/tests/test_app.py kolega_code/cli/tests/test_themes.py