### PR TITLE
Optimize TUI streaming render updates

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -440,7 +440,10 @@ class KolegaCodeApp(
             tabs = self.query_one("#events", TabbedContent)
             if tabs.active == pane_id:
                 return
-            tabs.get_tab(pane_id).label = f"{base} {theme.g(Glyph.STATUS)}"
+            tab = tabs.get_tab(pane_id)
+            label = f"{base} {theme.g(Glyph.STATUS)}"
+            if str(tab.label) != label:
+                tab.label = label
         except Exception:
             return
 
@@ -449,7 +452,9 @@ class KolegaCodeApp(
         if base is None:
             return
         try:
-            self.query_one("#events", TabbedContent).get_tab(pane_id).label = base
+            tab = self.query_one("#events", TabbedContent).get_tab(pane_id)
+            if str(tab.label) != base:
+                tab.label = base
         except Exception:
             return
 

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -3620,6 +3620,143 @@ async def test_conversation_render_skips_detached_view_during_teardown(
 
 
 @pytest.mark.asyncio
+async def test_conversation_flush_uses_dirty_entry_fast_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.state import ConversationEntry
+    from kolega_code.cli.tui.widgets import ConversationEntryWidget
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        app.conversation_entries = [
+            ConversationEntry(kind="user", content=f"message {index}") for index in range(50)
+        ]
+        app._render_conversation()
+        await pilot.pause()
+
+        widgets = list(app.query(ConversationEntryWidget))
+        assert len(widgets) == 50
+
+        def fail_full_rebuild() -> None:
+            raise AssertionError("dirty-entry refresh should not rebuild the transcript")
+
+        monkeypatch.setattr(app, "_render_conversation", fail_full_rebuild)
+        entry = app.conversation_entries[25]
+        entry.content = "message 25 updated"
+        app._dirty_entry_ids.add(entry.entry_id)
+        app._render_pending = True
+
+        app._flush_conversation_render()
+        await pilot.pause()
+
+        refreshed = list(app.query(ConversationEntryWidget))
+        assert refreshed == widgets
+        assert "message 25 updated" in renderable_text(refreshed[25]._formatted)
+
+
+@pytest.mark.asyncio
+async def test_repeated_progress_updates_refresh_status_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.state import TurnState
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        refresh_count = 0
+
+        def refresh_status_dashboard() -> None:
+            nonlocal refresh_count
+            refresh_count += 1
+
+        monkeypatch.setattr(app, "_refresh_status_dashboard", refresh_status_dashboard)
+        app._turn_status_text = ""
+        app._status_state.turn_state = TurnState.IDLE
+        app._status_state.activity = "Ready"
+
+        app._update_progress("Reading response", complete=False, state=TurnState.GENERATING)
+        app._update_progress("Reading response", complete=False, state=TurnState.GENERATING)
+        app._update_progress("Reading response", complete=False, state=TurnState.GENERATING)
+
+        assert refresh_count == 1
+
+        app._update_progress("Reading response", complete=False, state=TurnState.THINKING)
+
+        assert refresh_count == 2
+
+
+@pytest.mark.asyncio
+async def test_tab_activity_label_changes_only_on_state_transitions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.widgets import TabbedContent
+
+    from kolega_code.cli import theme
+    from kolega_code.cli.tui.constants import TAB_BASE_LABELS
+    from kolega_code.cli.theme import Glyph
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        tabs = app.query_one("#events", TabbedContent)
+        logs_tab = tabs.get_tab("logs_pane")
+        expected_marked = f"{TAB_BASE_LABELS['logs_pane']} {theme.g(Glyph.STATUS)}"
+
+        app._mark_tab_activity("logs_pane")
+        marked_label = logs_tab.label
+        assert str(marked_label) == expected_marked
+
+        app._mark_tab_activity("logs_pane")
+        assert logs_tab.label is marked_label
+
+        app._clear_tab_activity("logs_pane")
+        cleared_label = logs_tab.label
+        assert str(cleared_label) == TAB_BASE_LABELS["logs_pane"]
+
+        app._clear_tab_activity("logs_pane")
+        assert logs_tab.label is cleared_label
+
+
+@pytest.mark.asyncio
+async def test_conversation_entry_widget_skips_unchanged_updates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.state import ConversationEntry
+    from kolega_code.cli.tui.widgets import ConversationEntryWidget
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        app.conversation_entries = [ConversationEntry(kind="assistant", content="stable")]
+        app._render_conversation()
+        await pilot.pause()
+
+        widget = app.query(ConversationEntryWidget).last()
+        updates = 0
+
+        def update(renderable) -> None:
+            nonlocal updates
+            updates += 1
+
+        monkeypatch.setattr(widget, "update", update)
+        widget.refresh_content()
+        assert updates == 0
+
+        widget.entry.content = "changed"
+        widget.refresh_content()
+        assert updates == 1
+
+
+@pytest.mark.asyncio
 async def test_conversation_entry_widget_extracts_plain_selected_text(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/kolega_code/cli/tui/status_dashboard.py
+++ b/kolega_code/cli/tui/status_dashboard.py
@@ -114,11 +114,15 @@ class StatusDashboardMixin:
         return Color.WARNING
 
     def _set_status_activity(self, content: str, *, turn_state: Optional[tui_state.TurnState] = None) -> None:
-        if content:
+        changed = False
+        if content and self._status_state.activity != content:
             self._status_state.activity = content
-        if turn_state is not None:
+            changed = True
+        if turn_state is not None and self._status_state.turn_state != turn_state:
             self._status_state.turn_state = turn_state
-        self._refresh_status_dashboard()
+            changed = True
+        if changed:
+            self._refresh_status_dashboard()
 
     def _apply_compaction_status(self, content: dict) -> None:
         """Toggle the 'compaction in progress' indicator and, on finish, drop the

--- a/kolega_code/cli/tui/transcript.py
+++ b/kolega_code/cli/tui/transcript.py
@@ -264,8 +264,14 @@ class TranscriptRenderingMixin:
                 )
             self._restore_composer_placeholder()
             return
-        self._turn_status_text = content
-        self._refresh_turn_status_strip()
+
+        text_changed = self._turn_status_text != content
+        state_changed = state is not None and self._status_state.turn_state != state
+        if not text_changed and not state_changed:
+            return
+        if text_changed:
+            self._turn_status_text = content
+            self._refresh_turn_status_strip()
         self._set_status_activity(content, turn_state=state)
 
     def _update_activity_progress(self, content: str, state: Optional[TurnState] = None) -> None:
@@ -1062,6 +1068,17 @@ class TranscriptRenderingMixin:
             self._dirty_entry_ids.clear()
             return
 
+        # Fast path for the common streaming case: the transcript shape is unchanged
+        # and only already-mounted entries need their renderables refreshed.
+        if (
+            self._dirty_entry_ids
+            and len(self._entry_widgets) == len(self.conversation_entries)
+            and all(entry_id in self._entry_widgets for entry_id in self._dirty_entry_ids)
+        ):
+            self._refresh_dirty_entry_widgets()
+            self._update_jump_button()
+            return
+
         rendered_ids = list(self._entry_widgets)
         current_ids = [entry.entry_id for entry in self.conversation_entries]
         if current_ids[: len(rendered_ids)] != rendered_ids:
@@ -1069,11 +1086,7 @@ class TranscriptRenderingMixin:
             self._render_conversation()
             return
 
-        for entry_id in self._dirty_entry_ids:
-            widget = self._entry_widgets.get(entry_id)
-            if widget is not None:
-                widget.refresh_content()
-        self._dirty_entry_ids.clear()
+        self._refresh_dirty_entry_widgets()
 
         new_entries = self.conversation_entries[len(rendered_ids) :]
         if new_entries:
@@ -1084,6 +1097,13 @@ class TranscriptRenderingMixin:
                 widgets.append(widget)
             view.mount(*widgets)
         self._update_jump_button()
+
+    def _refresh_dirty_entry_widgets(self) -> None:
+        for entry_id in self._dirty_entry_ids:
+            widget = self._entry_widgets.get(entry_id)
+            if widget is not None:
+                widget.refresh_content()
+        self._dirty_entry_ids.clear()
 
     def _render_conversation(self) -> None:
         """Full rebuild of the conversation view (restore, reset, startup changes)."""
@@ -1125,7 +1145,9 @@ class TranscriptRenderingMixin:
             bar = self.query_one("#jump_to_bottom", JumpToBottomBar)
         except Exception:
             return
-        bar.display = view.max_scroll_y > 0 and view.scroll_y < view.max_scroll_y - 1
+        should_display = view.max_scroll_y > 0 and view.scroll_y < view.max_scroll_y - 1
+        if bar.display != should_display:
+            bar.display = should_display
 
     def on_jump_to_bottom_bar_pressed(self, message: JumpToBottomBar.Pressed) -> None:
         view = self._conversation

--- a/kolega_code/cli/tui/widgets.py
+++ b/kolega_code/cli/tui/widgets.py
@@ -33,6 +33,7 @@ class ConversationEntryWidget(Static):
         self._format_entry = format_entry
         self._kind_class = ""
         self._formatted: object = None
+        self._content_snapshot: tuple[object, ...] | None = None
         self.refresh_content()
 
     def refresh_content(self) -> None:
@@ -42,8 +43,24 @@ class ConversationEntryWidget(Static):
                 self.remove_class(self._kind_class)
             self.add_class(kind_class)
             self._kind_class = kind_class
+
+        snapshot = self._entry_snapshot()
+        if snapshot == self._content_snapshot and self._formatted is not None:
+            return
+        self._content_snapshot = snapshot
         self._formatted = self._format_entry(self.entry)
         self.update(self._formatted)
+
+    def _entry_snapshot(self) -> tuple[object, ...]:
+        return (
+            self.entry.kind,
+            self.entry.content,
+            self.entry.complete,
+            self.entry.tool_name,
+            self.entry.tone,
+            self.entry.full_content,
+            repr(self.entry.edit_preview),
+        )
 
     def render_line(self, y: int) -> Strip:
         strip = _with_selection_style(super().render_line(y), self.text_selection, y, self.selection_style)
@@ -204,6 +221,10 @@ class ToolEntryWidget(Vertical):
         self._collapsible: Optional[Collapsible] = None
         self._body: Optional[Static] = None
         self._preview: Optional[Static] = None
+        self._title = ""
+        self._body_content: object = None
+        self._preview_key = ""
+        self._preview_visible = False
 
     def compose(self) -> ComposeResult:
         # Always-visible inline preview (diff/file-head) for edit tools; hidden otherwise.
@@ -220,16 +241,33 @@ class ToolEntryWidget(Vertical):
     def refresh_content(self) -> None:
         if self._collapsible is None or self._body is None:
             return
-        self._collapsible.title = self._title_factory(self.entry)
-        self._body.update(self.entry.full_content or self.entry.content)
+
+        title = self._title_factory(self.entry)
+        if title != self._title:
+            self._collapsible.title = title
+            self._title = title
+
+        body_content = self.entry.full_content or self.entry.content
+        if body_content != self._body_content:
+            self._body.update(body_content)
+            self._body_content = body_content
+
         if self._preview is not None:
+            preview_key = repr(self.entry.edit_preview)
+            if preview_key == self._preview_key:
+                return
+            self._preview_key = preview_key
             renderable = self._preview_factory(self.entry) if self._preview_factory else None
             if renderable is not None:
                 self._preview.update(renderable)
-                self._preview.display = True
+                if not self._preview_visible:
+                    self._preview.display = True
+                    self._preview_visible = True
             else:
-                self._preview.update("")
-                self._preview.display = False
+                if self._preview_visible:
+                    self._preview.update("")
+                    self._preview.display = False
+                    self._preview_visible = False
 
 
 class ConversationView(VerticalScroll):


### PR DESCRIPTION
## Summary
- make progress/status updates idempotent during streaming
- add a dirty-entry fast path for transcript refreshes
- skip redundant jump-bar, tab-label, and widget updates
- cover the new behavior with focused TUI tests

## Tests
- pytest -q kolega_code/cli/tests/test_app.py -k "conversation_flush_uses_dirty_entry_fast_path or repeated_progress_updates_refresh_status_once or tab_activity_label_changes_only_on_state_transitions or conversation_entry_widget_skips_unchanged_updates or conversation_scroll_position_survives_streaming or conversation_entry_selection"
- python -m ruff check kolega_code/cli/app.py kolega_code/cli/tui/transcript.py kolega_code/cli/tui/status_dashboard.py kolega_code/cli/tui/widgets.py kolega_code/cli/tests/test_app.py