### PR TITLE
Improve gigacode workflow transcript artifacts

### DIFF
--- a/docs/src/content/docs/gigacode.mdx
+++ b/docs/src/content/docs/gigacode.mdx
@@ -43,6 +43,15 @@ When the agent runs a workflow, the transcript shows **phase headers** and short
 [sub-agent inspector](../tui/interface/#sub-agent-inspector) — press `Ctrl+G` to
 watch every agent's live trajectory, grouped by phase.
 
+The `run_workflow` result is a compact artifact manifest. It includes paths like
+`resultPath` and `transcriptPath`; the completed workflow result is written to
+`resultPath` instead of returned inline. For normal workflow output, the agent
+should read those main files and avoid reading individual sub-agent transcripts.
+Raw and per-agent debug artifacts may exist under the run directory for explicit
+workflow debugging.
+The agent should read those paths first — not re-run the workflow just to recover
+output text.
+
 ## How it works
 
 Under the hood, the agent authors a short **Python script** and runs it with a
@@ -69,9 +78,11 @@ return findings
 
 <Aside type="note">
 Workflows are deterministic and **resumable**. Each run is saved under Kolega
-Code's state directory (`workflows/<run-id>/`) with its script, a journal, and each
-sub-agent's transcript, so an interrupted run can pick up where it left off instead
-of redoing finished work.
+Code's state directory (`workflows/<run-id>/`) with its script, full result files,
+a readable Markdown transcript, raw JSONL, a resume journal, and debug sub-agent
+transcripts, so an interrupted run can pick up where it left off instead of redoing
+finished work. Use resume when intentionally iterating on the workflow; use the
+artifact paths when you only need to inspect output.
 </Aside>
 
 ## Behavior and safety

--- a/kolega_code/agent/orchestration/guide.py
+++ b/kolega_code/agent/orchestration/guide.py
@@ -134,10 +134,26 @@ After the workflow returns, integrate the results, run the full test suite yours
 report. If the plan is small or its parts are tightly coupled, skip the workflow and just
 implement it directly — orchestration is for genuinely independent fan-out.
 
+### Artifacts and transcripts
+
+`run_workflow` returns a concise manifest, not necessarily the full workflow output.
+Every completed run persists full artifacts under the state directory and returns
+paths including `resultPath` and `transcriptPath`. If the inline tool result says output was omitted, looks incomplete,
+or would require a long transcript to understand, READ `resultPath` or `transcriptPath`
+with the file-reading tools before deciding work is missing. For normal workflow
+output, use only those main files; avoid reading individual sub-agent transcripts
+unless you are explicitly debugging workflow execution.
+
+Never re-run a completed workflow solely to recover output from an omitted/truncated
+inline result. The workflow already ran; inspect the persisted result/transcript first.
+Use `resume_from_run_id` only when you intentionally want to iterate on or change the
+workflow, not as a transcript-recovery mechanism.
+
 ### Resume
 
-Each run persists its script and a journal under the state directory and returns a
-`runId` and `scriptPath`. To iterate, edit the script and re-run with `script_path`,
-or pass `resume_from_run_id` to replay cached `agent()` results for the unchanged
-prefix and only re-run new/changed calls.
+Each run persists its script, full results, a readable transcript, raw JSONL, and a
+resume journal under the state directory and returns a `runId` plus artifact paths.
+To iterate, edit the script and re-run with `script_path`, or pass `resume_from_run_id`
+to replay cached `agent()` results for the unchanged prefix and only re-run new/changed
+calls.
 """

--- a/kolega_code/agent/orchestration/journal.py
+++ b/kolega_code/agent/orchestration/journal.py
@@ -4,9 +4,13 @@ Everything a run needs lives under::
 
     <state-dir>/workflows/<run_id>/
         script.py        the authored source (its path is returned for edit + re-run)
-        run.json         meta, args, status, timing, token totals
+        run.json         meta, args, status, timing, token totals, artifact paths
         journal.jsonl    one line per completed agent() call (drives resume)
-        agents/          per sub-agent transcripts (wired via sub_agent_recorder)
+        result.json      full JSON-rendered workflow return value
+        result.md        readable workflow return value
+        transcript.jsonl raw workflow events/call outcomes
+        transcript.md    readable workflow transcript/index
+        agents/          per sub-agent raw/readable transcripts
 
 Resume contract: scripts are deterministic (the runtime blocks ``random``/``time``
 and ``import``), so the same source + args produce ``agent()`` calls in the same
@@ -18,6 +22,7 @@ new call onward.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
@@ -32,6 +37,15 @@ def saved_workflows_dir(state_dir: Path) -> Path:
     return workflows_root(state_dir) / "_saved"
 
 
+def _slugify(value: str, *, fallback: str = "agent", max_length: int = 64) -> str:
+    """Return a filesystem-friendly slug for workflow artifact filenames."""
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "-", str(value or "").strip().lower())
+    slug = re.sub(r"-+", "-", slug).strip("-._")
+    if not slug:
+        slug = fallback
+    return slug[:max_length].rstrip("-._") or fallback
+
+
 class RunJournal:
     """Owns the on-disk artifacts for a single workflow run."""
 
@@ -40,6 +54,10 @@ class RunJournal:
         self.run_id = run_id
         self.agents_dir = self.run_dir / "agents"
         self._journal_path = self.run_dir / "journal.jsonl"
+        self._transcript_jsonl_path = self.run_dir / "transcript.jsonl"
+        self._transcript_md_path = self.run_dir / "transcript.md"
+        self._result_json_path = self.run_dir / "result.json"
+        self._result_md_path = self.run_dir / "result.md"
         self._script_path = self.run_dir / "script.py"
         self._meta_path = self.run_dir / "run.json"
 
@@ -54,6 +72,33 @@ class RunJournal:
     @property
     def script_path(self) -> Path:
         return self._script_path
+
+    @property
+    def journal_path(self) -> Path:
+        return self._journal_path
+
+    @property
+    def transcript_jsonl_path(self) -> Path:
+        return self._transcript_jsonl_path
+
+    @property
+    def transcript_md_path(self) -> Path:
+        return self._transcript_md_path
+
+    @property
+    def result_json_path(self) -> Path:
+        return self._result_json_path
+
+    @property
+    def result_md_path(self) -> Path:
+        return self._result_md_path
+
+    def agent_artifact_paths(self, call_index: int, label: Optional[str] = None) -> Dict[str, Path]:
+        """Return stable per-agent raw/readable artifact paths for a workflow call."""
+        self.ensure_dirs()
+        suffix = _slugify(label or f"call-{call_index}")
+        stem = f"agent-{call_index:03d}-{suffix}"
+        return {"markdown": self.agents_dir / f"{stem}.md", "jsonl": self.agents_dir / f"{stem}.jsonl"}
 
     def write_script(self, source: str) -> Path:
         self.ensure_dirs()
@@ -86,15 +131,40 @@ class RunJournal:
         label: Optional[str],
         value: Any,
         status: str = "completed",
+        **metadata: Any,
     ) -> None:
-        """Append one completed ``agent()`` result for resume replay."""
+        """Append one completed ``agent()`` result for resume replay.
+
+        ``journal.jsonl`` is the resume contract. Extra fields are allowed and ignored
+        by ``load_cache()`` so newer artifact metadata remains backward-compatible.
+        """
         self.ensure_dirs()
-        line = json.dumps(
-            {"index": call_index, "key": key, "label": label, "status": status, "value": value},
-            default=str,
-        )
+        payload = {"index": call_index, "key": key, "label": label, "status": status, "value": value}
+        payload.update({k: v for k, v in metadata.items() if v is not None})
+        line = json.dumps(payload, default=str)
         with self._journal_path.open("a", encoding="utf-8") as handle:
             handle.write(line + "\n")
+
+    def append_transcript_event(self, event: Dict[str, Any]) -> None:
+        """Append one raw workflow transcript event as JSONL."""
+        self.ensure_dirs()
+        with self._transcript_jsonl_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event, default=str) + "\n")
+
+    def write_result_artifacts(self, result: Any, markdown: str) -> None:
+        """Persist the full workflow return value in JSON and readable Markdown."""
+        self.ensure_dirs()
+        try:
+            rendered_json = json.dumps(result, indent=2, default=str)
+        except (TypeError, ValueError):
+            rendered_json = json.dumps(str(result), indent=2)
+        self._result_json_path.write_text(rendered_json + "\n", encoding="utf-8")
+        self._result_md_path.write_text(markdown, encoding="utf-8")
+
+    def write_transcript_markdown(self, markdown: str) -> None:
+        """Persist the readable workflow transcript."""
+        self.ensure_dirs()
+        self._transcript_md_path.write_text(markdown, encoding="utf-8")
 
     def load_cache(self) -> Dict[int, Tuple[str, Any]]:
         """Read a prior run's journal into ``{call_index: (key, value)}``.

--- a/kolega_code/agent/orchestration/runtime.py
+++ b/kolega_code/agent/orchestration/runtime.py
@@ -150,8 +150,19 @@ class WorkflowRuntime:
 
         cached = self._resume_cache.get(index)
         if cached is not None and cached[0] == key:
-            self._emit_soon("workflow_agent_cached", {"label": spec.label or prompt[:60], "phase": spec.phase})
-            return cached[1]
+            cached_value = cached[1]
+            label = spec.label or prompt[:60]
+            self._journal.append_transcript_event(
+                {
+                    "type": "agent_cached",
+                    "index": index,
+                    "label": label,
+                    "phase": spec.phase,
+                    "value": cached_value,
+                }
+            )
+            self._emit_soon("workflow_agent_cached", {"label": label, "phase": spec.phase})
+            return cached_value
 
         self._agent_count += 1
         if self._agent_count > self._agent_cap:
@@ -169,7 +180,34 @@ class WorkflowRuntime:
 
         self.budget.add(result.tokens)
         value = result.value
-        self._journal.record(index, key, spec.label, value, status=result.status)
+        self._journal.record(
+            index,
+            key,
+            spec.label,
+            value,
+            status=result.status,
+            phase=spec.phase,
+            agent_type=spec.agent_type,
+            tokens=result.tokens,
+            error=result.error,
+            transcript_path=result.transcript_path,
+            transcript_markdown_path=result.transcript_markdown_path,
+        )
+        self._journal.append_transcript_event(
+            {
+                "type": "agent_call",
+                "index": index,
+                "label": spec.label,
+                "phase": spec.phase,
+                "agent_type": spec.agent_type,
+                "status": result.status,
+                "tokens": result.tokens,
+                "error": result.error,
+                "value": value,
+                "transcript_path": result.transcript_path,
+                "transcript_markdown_path": result.transcript_markdown_path,
+            }
+        )
         return value
 
     async def parallel(self, thunks: Iterable[Callable[[], Awaitable[Any]]]) -> List[Any]:

--- a/kolega_code/agent/orchestration/types.py
+++ b/kolega_code/agent/orchestration/types.py
@@ -56,6 +56,8 @@ class AgentRunResult:
     agent_id: Optional[str] = None
     status: str = "completed"  # completed | failed | skipped
     error: Optional[str] = None
+    transcript_path: Optional[str] = None
+    transcript_markdown_path: Optional[str] = None
 
     @property
     def value(self) -> Any:

--- a/kolega_code/agent/tests/test_prompts.py
+++ b/kolega_code/agent/tests/test_prompts.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from kolega_code.agent import prompts
+from kolega_code.agent.orchestration.guide import GIGACODE_AUTHORING_GUIDE
 
 
 def test_static_prompt_templates_load() -> None:
@@ -43,6 +44,13 @@ def test_implement_plan_prompt_includes_gigacode_nudge_when_enabled() -> None:
     assert "independent" in rendered
     # The plan still renders alongside the nudge.
     assert "- [ ] update docs" in rendered
+
+
+def test_gigacode_guide_points_agents_to_artifact_transcripts() -> None:
+    assert "resultPath" in GIGACODE_AUTHORING_GUIDE
+    assert "transcriptPath" in GIGACODE_AUTHORING_GUIDE
+    assert "Never re-run a completed workflow solely" in GIGACODE_AUTHORING_GUIDE
+    assert "READ `resultPath` or `transcriptPath`" in GIGACODE_AUTHORING_GUIDE
 
 
 def test_init_agents_prompt_renders_arguments() -> None:

--- a/kolega_code/agent/tests/tool_backend/test_workflow_tool.py
+++ b/kolega_code/agent/tests/tool_backend/test_workflow_tool.py
@@ -6,7 +6,7 @@ the real run_workflow code path (state-dir resolution, journal, emit, summary).
 
 import json
 from pathlib import Path
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -29,6 +29,9 @@ def caller():
     c.sub_agent = False
     c.current_tool_execution_id = "exec-1"
     c.current_tool_call_id = "exec-1"
+    c.sub_agent_recorder = None
+    c.prompt_extensions = None
+    c.tool_extensions = None
     c.tool_collection = Mock(read_only=False)  # build-mode (writable) caller by default
     return c
 
@@ -54,8 +57,20 @@ def _stub_dispatch():
     """A dispatch_workflow_agent stub returning (recap, tokens, structured)."""
     calls = []
 
-    async def dispatch_workflow_agent(agent_class, task, *, config=None, schema=None, sub_agent_info_extra=None):
-        calls.append((task, schema, sub_agent_info_extra))
+    async def dispatch_workflow_agent(
+        agent_class,
+        task,
+        *,
+        config=None,
+        schema=None,
+        sub_agent_info_extra=None,
+        artifact_paths=None,
+        artifact_metadata=None,
+    ):
+        calls.append((task, schema, sub_agent_info_extra, artifact_paths, artifact_metadata))
+        if artifact_paths:
+            artifact_paths["jsonl"].write_text(json.dumps({"role": "assistant", "content": task}) + "\n")
+            artifact_paths["markdown"].write_text(f"# Agent artifact\n\n{task}\n")
         if schema:
             return (f"recap:{task}", 7, {"task": task})
         return (f"recap:{task}", 3, None)
@@ -85,14 +100,21 @@ async def test_run_workflow_writes_artifacts_and_summary(workflow_tool):
     assert len(calls) == 4
     assert "Workflow 'demo' completed." in summary
     assert "runId:" in summary and "scriptPath:" in summary
+    assert "resultPath:" in summary
+    assert "transcriptPath:" in summary
 
     # Artifacts under <state_dir>/workflows/<run_id>/
     run_id = next(line.split("runId:")[1].strip() for line in summary.splitlines() if "runId:" in line)
     run_dir = Path(state_dir) / "workflows" / run_id
     assert (run_dir / "script.py").read_text() == SCRIPT
+    assert (run_dir / "result.md").is_file()
+    assert (run_dir / "result.json").is_file()
+    assert (run_dir / "transcript.md").is_file()
+    assert (run_dir / "transcript.jsonl").is_file()
     meta = json.loads((run_dir / "run.json").read_text())
     assert meta["status"] == "completed"
     assert meta["name"] == "demo"
+    assert meta["artifacts"]["resultPath"] == str(run_dir / "result.md")
     # token total = 3*3 (parallel) + 7 (schema) = 16
     assert meta["total_tokens"] == 16
     journal_lines = (run_dir / "journal.jsonl").read_text().splitlines()
@@ -123,6 +145,78 @@ async def test_run_workflow_writes_artifacts_and_summary(workflow_tool):
 
 
 @pytest.mark.asyncio
+async def test_long_result_is_persisted_not_truncated_inline(workflow_tool):
+    tool, state_dir = workflow_tool
+    script = 'meta = {"name": "big", "description": "big result"}\nreturn {"blob": "x" * 5001}\n'
+
+    summary = await tool.run_workflow(script=script)
+
+    assert "resultPath:" in summary
+    assert "transcriptPath:" in summary
+    assert "result: written to resultPath" in summary
+    assert "IMPORTANT: The workflow already ran" in summary
+    assert "resultPreview:" not in summary
+    assert "… (truncated)" not in summary
+    assert len(summary) < 100_000
+
+    run_id = next(line.split("runId:")[1].strip() for line in summary.splitlines() if "runId:" in line)
+    run_dir = Path(state_dir) / "workflows" / run_id
+    result_json = json.loads((run_dir / "result.json").read_text())
+    assert result_json["blob"] == "x" * 5001
+    assert "x" * 5001 in (run_dir / "result.md").read_text()
+
+
+@pytest.mark.asyncio
+async def test_readable_transcript_indexes_agent_calls(workflow_tool):
+    tool, state_dir = workflow_tool
+    stub, calls = _stub_dispatch()
+    tool._agent_tool.dispatch_workflow_agent = stub
+    script = (
+        'meta = {"name": "transcript", "description": "d", "phases": [{"title": "Find"}]}\n'
+        'phase("Find")\n'
+        'await agent("alpha", label="alpha-label")\n'
+        'await agent("beta", label="beta-label", phase="Check")\n'
+        'return "done"\n'
+    )
+
+    summary = await tool.run_workflow(script=script)
+
+    assert len(calls) == 2
+    run_id = next(line.split("runId:")[1].strip() for line in summary.splitlines() if "runId:" in line)
+    run_dir = Path(state_dir) / "workflows" / run_id
+    transcript = (run_dir / "transcript.md").read_text()
+    assert "# Workflow transcript: transcript" in transcript
+    assert "alpha-label" in transcript
+    assert "beta-label" in transcript
+    assert "Find" in transcript
+    assert "Check" in transcript
+    # Main workflow transcript should not advertise per-agent transcript paths;
+    # agents should use the main result/transcript and avoid individual sub-agent transcripts.
+    assert "agent-000-alpha-label.md" not in transcript
+    raw_events = [json.loads(line) for line in (run_dir / "transcript.jsonl").read_text().splitlines() if line]
+    assert any(event["type"] == "agent_call" for event in raw_events)
+
+
+@pytest.mark.asyncio
+async def test_failed_agent_call_is_recorded_in_transcript(workflow_tool):
+    tool, state_dir = workflow_tool
+
+    async def failing_dispatch(*args, **kwargs):
+        raise RuntimeError("agent exploded")
+
+    tool._agent_tool.dispatch_workflow_agent = failing_dispatch
+    script = 'meta = {"name": "failure", "description": "d"}\nvalue = await agent("boom", label="boom")\nreturn {"value": value}\n'
+
+    summary = await tool.run_workflow(script=script)
+
+    assert "transcriptPath:" in summary
+    run_id = next(line.split("runId:")[1].strip() for line in summary.splitlines() if "runId:" in line)
+    transcript = (Path(state_dir) / "workflows" / run_id / "transcript.md").read_text()
+    assert "failed" in transcript
+    assert "agent exploded" in transcript
+
+
+@pytest.mark.asyncio
 async def test_run_workflow_carries_phase_and_label_to_dispatch(workflow_tool):
     tool, _ = workflow_tool
     stub, calls = _stub_dispatch()
@@ -135,10 +229,50 @@ async def test_run_workflow_carries_phase_and_label_to_dispatch(workflow_tool):
         "return 1\n"
     )
     await tool.run_workflow(script=script)
-    _task, _schema, extra = calls[0]
+    _task, _schema, extra, _artifact_paths, _artifact_metadata = calls[0]
     assert extra["phase"] == "Build"
     assert extra["label"] == "my-label"
     assert "workflow_run_id" in extra
+
+
+@pytest.mark.asyncio
+async def test_per_agent_markdown_and_jsonl_are_written(workflow_tool):
+    tool, state_dir = workflow_tool
+
+    class ArtifactAgent:
+        agent_name = "artifact-agent"
+
+        def __init__(self, **kwargs):
+            self.total_tokens_used = 11
+            self._history = [
+                {"role": "user", "content": [{"type": "text", "text": "artifact task"}]},
+                {"role": "assistant", "content": [{"type": "text", "text": "artifact answer"}]},
+            ]
+
+        async def process_message_stream(self, task):
+            yield {"type": "response", "content": "artifact answer", "complete": True, "uuid": "u1"}
+
+        def dump_message_history(self):
+            return self._history
+
+        async def recap_agent_outcome(self):
+            return "final artifact recap"
+
+    script = 'meta = {"name": "agent-artifacts", "description": "d"}\nreturn await agent("artifact task", label="artifact")\n'
+
+    with patch("kolega_code.agent.generalagent.GeneralAgent", ArtifactAgent):
+        summary = await tool.run_workflow(script=script)
+
+    run_id = next(line.split("runId:")[1].strip() for line in summary.splitlines() if "runId:" in line)
+    agents_dir = Path(state_dir) / "workflows" / run_id / "agents"
+    markdown = agents_dir / "agent-000-artifact.md"
+    raw = agents_dir / "agent-000-artifact.jsonl"
+    assert markdown.is_file()
+    assert raw.is_file()
+    markdown_text = markdown.read_text()
+    assert "artifact task" in markdown_text
+    assert "final artifact recap" in markdown_text
+    assert "artifact answer" in raw.read_text()
 
 
 @pytest.mark.asyncio
@@ -155,6 +289,10 @@ async def test_resume_replays_without_redispatch(workflow_tool):
     summary2 = await tool.run_workflow(script=SCRIPT, resume_from_run_id=run_id)
     assert len(calls) == 0  # fully replayed from journal
     assert "completed" in summary2
+    run_id2 = next(line.split("runId:")[1].strip() for line in summary2.splitlines() if "runId:" in line)
+    transcript2 = (Path(state_dir) / "workflows" / run_id2 / "transcript.md").read_text()
+    assert "Cached resume calls" in transcript2
+    assert "served from resume cache" in transcript2
 
 
 @pytest.mark.asyncio
@@ -166,7 +304,7 @@ async def test_read_only_caller_forces_investigation_agents(workflow_tool, calle
 
     seen = []
 
-    async def stub(agent_class, task, *, config=None, schema=None, sub_agent_info_extra=None):
+    async def stub(agent_class, task, *, config=None, schema=None, sub_agent_info_extra=None, **kwargs):
         seen.append(agent_class.__name__)
         return (f"recap:{task}", 1, None)
 

--- a/kolega_code/agent/tool_backend/agent_tool.py
+++ b/kolega_code/agent/tool_backend/agent_tool.py
@@ -1,7 +1,8 @@
 import uuid
 import inspect
+import json
 from pathlib import Path
-from typing import Union, Optional
+from typing import Any, Union, Optional
 from datetime import datetime, timezone
 import time
 
@@ -561,6 +562,105 @@ class AgentTool(BaseTool):
             max_iterations=getattr(self.caller, "max_iterations", None),
         )
 
+    @staticmethod
+    def _write_jsonl_message(path: Optional[Path], message: dict) -> None:
+        if path is None:
+            return
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(message, default=str) + "\n")
+
+    @staticmethod
+    def _render_workflow_message(message: dict) -> str:
+        role = str(message.get("role") or "message")
+        content = message.get("content", "")
+        lines = [f"### {role}", ""]
+        if isinstance(content, str):
+            lines.append(content)
+        elif isinstance(content, list):
+            for item in content:
+                if isinstance(item, dict):
+                    item_type = item.get("type", "content")
+                    if item_type == "text":
+                        lines.append(str(item.get("text", "")))
+                    elif item_type == "tool_use":
+                        lines.append(f"**Tool use:** `{item.get('name', '')}`")
+                        lines.append("```json")
+                        lines.append(json.dumps(item.get("input", {}), indent=2, default=str))
+                        lines.append("```")
+                    elif item_type == "tool_result":
+                        status = "Error" if item.get("is_error") else "Result"
+                        lines.append(f"**Tool {status}:** `{item.get('name', '')}`")
+                        lines.append("```")
+                        lines.append(str(item.get("content", "")))
+                        lines.append("```")
+                    else:
+                        lines.append("```json")
+                        lines.append(json.dumps(item, indent=2, default=str))
+                        lines.append("```")
+                else:
+                    rendered = item.to_markdown() if hasattr(item, "to_markdown") else str(item)
+                    lines.append(rendered)
+        else:
+            lines.append(str(content))
+        return "\n".join(lines).rstrip() + "\n"
+
+    @staticmethod
+    def _render_value_markdown(value: Any) -> str:
+        if value is None:
+            return "None"
+        if isinstance(value, str):
+            return value
+        try:
+            return "```json\n" + json.dumps(value, indent=2, default=str) + "\n```"
+        except (TypeError, ValueError):
+            return str(value)
+
+    def _write_workflow_agent_markdown(
+        self,
+        artifact_paths: Optional[dict],
+        *,
+        metadata: dict,
+        prompt: str,
+        status: str,
+        result: Optional[str] = None,
+        structured: Any = None,
+        tokens: int = 0,
+        error: Optional[str] = None,
+        history: Optional[list[dict]] = None,
+    ) -> None:
+        if not artifact_paths or not artifact_paths.get("markdown"):
+            return
+        path = Path(artifact_paths["markdown"])
+        path.parent.mkdir(parents=True, exist_ok=True)
+        lines = [
+            f"# Workflow agent {metadata.get('call_index', '')}: {metadata.get('label') or metadata.get('agent_name') or 'agent'}",
+            "",
+            "## Metadata",
+            "",
+            f"- Call index: {metadata.get('call_index', '')}",
+            f"- Label: {metadata.get('label') or ''}",
+            f"- Phase: {metadata.get('phase') or ''}",
+            f"- Agent type: {metadata.get('agent_type') or metadata.get('agent_name') or ''}",
+            f"- Status: {status}",
+            f"- Tokens: {tokens}",
+        ]
+        if error:
+            lines.append(f"- Error: {error}")
+        jsonl_path = artifact_paths.get("jsonl")
+        if jsonl_path:
+            lines.append(f"- Raw transcript: `{jsonl_path}`")
+        lines.extend(["", "## Task prompt", "", prompt.strip() or "(empty)"])
+        if structured is not None:
+            lines.extend(["", "## Structured result", "", self._render_value_markdown(structured)])
+        if result is not None:
+            lines.extend(["", "## Final recap", "", result])
+        if history:
+            lines.extend(["", "## Message history", ""])
+            for message in history:
+                lines.append(self._render_workflow_message(message))
+        path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
     async def dispatch_workflow_agent(
         self,
         agent_class,
@@ -569,6 +669,8 @@ class AgentTool(BaseTool):
         config=None,
         schema: Optional[dict] = None,
         sub_agent_info_extra: Optional[dict] = None,
+        artifact_paths: Optional[dict] = None,
+        artifact_metadata: Optional[dict] = None,
     ):
         """Dispatch one sub-agent for a gigacode workflow.
 
@@ -609,6 +711,16 @@ class AgentTool(BaseTool):
         if sub_agent_info_extra:
             sub_agent_info.update({k: v for k, v in sub_agent_info_extra.items() if v is not None})
 
+        artifact_metadata = dict(artifact_metadata or {})
+        artifact_metadata.setdefault("agent_name", agent_name)
+        if artifact_paths:
+            for key in ("markdown", "jsonl"):
+                if artifact_paths.get(key):
+                    artifact_paths[key] = Path(artifact_paths[key])
+            if artifact_paths.get("jsonl"):
+                artifact_paths["jsonl"].parent.mkdir(parents=True, exist_ok=True)
+                artifact_paths["jsonl"].write_text("", encoding="utf-8")
+
         capture: dict = {}
         extra_extensions = []
         effective_task = task
@@ -618,6 +730,7 @@ class AgentTool(BaseTool):
 
         await self._send_status_event("GENERATING", f"Starting {agent_name} task", sub_agent_info=sub_agent_info)
         conversation_finished = False
+        agent = None
 
         try:
             agent = self._construct_workflow_sub_agent(agent_class, config, extra_extensions)
@@ -627,7 +740,13 @@ class AgentTool(BaseTool):
             agent.sub_agent_context = sub_agent_info
 
             last_saved_index = await self._stream_workflow_agent(
-                agent, agent_name, sub_agent_info, conversation_id, last_saved_index=-1, task=effective_task
+                agent,
+                agent_name,
+                sub_agent_info,
+                conversation_id,
+                last_saved_index=-1,
+                task=effective_task,
+                artifact_jsonl_path=artifact_paths.get("jsonl") if artifact_paths else None,
             )
 
             # Single re-prompt if a schema was requested but submit_result wasn't called.
@@ -639,6 +758,7 @@ class AgentTool(BaseTool):
                     conversation_id,
                     last_saved_index=last_saved_index,
                     task=self._STRUCTURED_OUTPUT_NUDGE,
+                    artifact_jsonl_path=artifact_paths.get("jsonl") if artifact_paths else None,
                 )
 
             result = await agent.recap_agent_outcome()
@@ -664,6 +784,21 @@ class AgentTool(BaseTool):
             )
 
             structured = capture.get("value") if schema else None
+            final_history = agent.dump_message_history() if agent is not None else []
+            if artifact_paths and artifact_paths.get("jsonl"):
+                # Persist any history messages that completed after the last stream event.
+                for i in range(last_saved_index + 1, len(final_history)):
+                    self._write_jsonl_message(artifact_paths.get("jsonl"), final_history[i])
+            self._write_workflow_agent_markdown(
+                artifact_paths,
+                metadata=artifact_metadata,
+                prompt=task,
+                status="completed",
+                result=result,
+                structured=structured,
+                tokens=total_tokens if isinstance(total_tokens, int) else 0,
+                history=final_history,
+            )
             return result, (total_tokens if isinstance(total_tokens, int) else 0), structured
 
         except Exception as e:
@@ -678,6 +813,20 @@ class AgentTool(BaseTool):
                     },
                 )
                 conversation_finished = True
+            final_history = []
+            if agent is not None:
+                try:
+                    final_history = agent.dump_message_history()
+                except Exception:  # noqa: BLE001 - transcript capture must not mask the real failure
+                    final_history = []
+            self._write_workflow_agent_markdown(
+                artifact_paths,
+                metadata=artifact_metadata,
+                prompt=task,
+                status="failed",
+                error=str(e),
+                history=final_history,
+            )
             await self.log_error(f"Error in workflow {agent_name}: {str(e)}", sender="AgentTool")
             await self._send_status_event("ERROR", f"Error in {agent_name}: {str(e)}", sub_agent_info=sub_agent_info)
             raise
@@ -704,6 +853,7 @@ class AgentTool(BaseTool):
         *,
         last_saved_index: int,
         task: str,
+        artifact_jsonl_path: Optional[Path] = None,
     ) -> int:
         """Stream one process_message_stream pass, broadcasting events and recording
         newly-completed history messages. Returns the updated last_saved_index.
@@ -729,19 +879,21 @@ class AgentTool(BaseTool):
             )
             await self.connection_manager.broadcast_event(evt, self.workspace_id, self.thread_id)
 
-            if conversation_id and complete:
+            if complete:
                 current_history = agent.dump_message_history()
                 for i in range(last_saved_index + 1, len(current_history)):
                     hist_msg = current_history[i]
-                    await self._record_message(
-                        conversation_id,
-                        {
-                            "role": hist_msg.get("role", "assistant"),
-                            "content": hist_msg.get("content", []),
-                            "stream_uuid": None,
-                        },
-                        i + 1,
-                    )
+                    if conversation_id:
+                        await self._record_message(
+                            conversation_id,
+                            {
+                                "role": hist_msg.get("role", "assistant"),
+                                "content": hist_msg.get("content", []),
+                                "stream_uuid": None,
+                            },
+                            i + 1,
+                        )
+                    self._write_jsonl_message(artifact_jsonl_path, hist_msg)
                 last_saved_index = len(current_history) - 1
 
         return last_saved_index

--- a/kolega_code/agent/tool_backend/workflow_tool.py
+++ b/kolega_code/agent/tool_backend/workflow_tool.py
@@ -9,8 +9,10 @@ UI, and supports journal-based resume.
 
 from __future__ import annotations
 
+import json
 import time
 import uuid
+from pathlib import Path
 from typing import Any, Optional
 
 from kolega_code.events import AgentEvent
@@ -118,8 +120,11 @@ class WorkflowTool(BaseTool):
                 for the unchanged prefix and running new/changed calls live.
 
         Returns:
-            A compact summary including the runId, the persisted scriptPath, agent and
-            token counts, and the workflow's return value.
+            A compact artifact manifest including runId, scriptPath, token count,
+            resultPath, and transcriptPath. Results are persisted in the main
+            result/transcript files instead of being returned inline. Per-agent
+            artifacts are saved for debugging but are intentionally not advertised
+            to the model-facing tool result.
         """
         from kolega_code.cli.session_store import default_state_dir
 
@@ -152,7 +157,7 @@ class WorkflowTool(BaseTool):
         # Emitted (and awaited) before execute() so the workflow_start event is on
         # the broadcast queue ahead of any phase/log the runtime fires — those go
         # through fire-and-forget _emit_soon and can't run until we next await.
-        emit = self._make_emit(run_id)
+        emit = self._make_emit(run_id, journal)
         await emit(
             "workflow_start",
             {
@@ -163,7 +168,7 @@ class WorkflowTool(BaseTool):
         )
 
         runtime = WorkflowRuntime(
-            dispatch=self._make_dispatch(run_id),
+            dispatch=self._make_dispatch(run_id, journal),
             emit=emit,
             journal=journal,
             budget=budget,
@@ -183,14 +188,27 @@ class WorkflowTool(BaseTool):
             status = "failed"
             error = f"workflow failed: {exc}"
 
+        duration_seconds = round(time.time() - started, 2)
+        rendered_result = self._result_json_text(result)
+        journal.write_result_artifacts(result, self._render_result_markdown(meta, run_id, status, error, result))
+
+        await emit("workflow_end", {"status": status, "error": error})
+        journal.write_transcript_markdown(
+            self._render_workflow_transcript(meta, run_id, journal, budget, status, error, duration_seconds)
+        )
+
         journal.update_meta(
             status=status,
             error=error,
-            duration_seconds=round(time.time() - started, 2),
+            duration_seconds=duration_seconds,
             total_tokens=budget.spent(),
+            result_size_chars=len(rendered_result),
+            artifacts={
+                "scriptPath": str(journal.script_path),
+                "resultPath": str(journal.result_md_path),
+                "transcriptPath": str(journal.transcript_md_path),
+            },
         )
-
-        await emit("workflow_end", {"status": status, "error": error})
 
         return self._summarize(meta, run_id, journal, budget, status, error, result)
 
@@ -212,7 +230,7 @@ class WorkflowTool(BaseTool):
                 ) from exc
         raise WorkflowScriptError("run_workflow requires one of: script, script_path, or resume_from_run_id")
 
-    def _make_dispatch(self, run_id: str):
+    def _make_dispatch(self, run_id: str, journal: RunJournal):
         # When the orchestrating agent is itself read-only (e.g. plan mode's
         # PlanningAgent), every workflow sub-agent is forced to a read-only
         # investigation agent so the read-only contract is preserved — the
@@ -228,7 +246,21 @@ class WorkflowTool(BaseTool):
                 import_path = _AGENT_TYPE_IMPORTS.get((spec.agent_type or "").lower(), _DEFAULT_AGENT_IMPORT)
             agent_class = _import_agent_class(import_path)
             config = self._config_override(spec.model, spec.effort)
-            sub_info_extra = {"workflow_run_id": run_id, "phase": spec.phase, "label": spec.label}
+            sub_info_extra = {
+                "workflow_run_id": run_id,
+                "phase": spec.phase,
+                "label": spec.label,
+                "call_index": spec.call_index,
+            }
+            label_for_path = spec.label or spec.agent_type or agent_class.__name__
+            artifact_paths = journal.agent_artifact_paths(spec.call_index, label_for_path)
+            artifact_metadata = {
+                "call_index": spec.call_index,
+                "label": spec.label,
+                "phase": spec.phase,
+                "agent_type": spec.agent_type or agent_class.__name__,
+                "agent_name": getattr(agent_class, "agent_name", agent_class.__name__),
+            }
             try:
                 recap, tokens, structured = await self._agent_tool.dispatch_workflow_agent(
                     agent_class,
@@ -236,14 +268,28 @@ class WorkflowTool(BaseTool):
                     config=config,
                     schema=spec.schema,
                     sub_agent_info_extra=sub_info_extra,
+                    artifact_paths=artifact_paths,
+                    artifact_metadata=artifact_metadata,
                 )
             except Exception as exc:  # noqa: BLE001 - a dead agent becomes a None result, not a crash
-                return AgentRunResult(status="failed", error=str(exc))
-            return AgentRunResult(text=recap, structured=structured, tokens=tokens or 0, status="completed")
+                return AgentRunResult(
+                    status="failed",
+                    error=str(exc),
+                    transcript_path=str(artifact_paths["jsonl"]),
+                    transcript_markdown_path=str(artifact_paths["markdown"]),
+                )
+            return AgentRunResult(
+                text=recap,
+                structured=structured,
+                tokens=tokens or 0,
+                status="completed",
+                transcript_path=str(artifact_paths["jsonl"]),
+                transcript_markdown_path=str(artifact_paths["markdown"]),
+            )
 
         return dispatch
 
-    def _make_emit(self, run_id: str):
+    def _make_emit(self, run_id: str, journal: RunJournal):
         sender = getattr(self.caller, "agent_name", None) or "gigacode"
 
         async def emit(kind: str, content: dict) -> None:
@@ -271,6 +317,7 @@ class WorkflowTool(BaseTool):
                 )
             else:
                 payload.update(message_type="workflow_log", text=str(content))
+            journal.append_transcript_event({"type": kind, "content": content})
             event = AgentEvent(
                 event_type="chat_message",
                 sender=sender,
@@ -313,23 +360,147 @@ class WorkflowTool(BaseTool):
             update={"long_context_config": new_long, "thinking_config": new_thinking, "agent_models": {}}
         )
 
-    def _summarize(self, meta, run_id, journal: RunJournal, budget: Budget, status, error, result) -> str:
-        import json
+    def _result_json_text(self, result: Any) -> str:
+        try:
+            return json.dumps(result, indent=2, default=str)
+        except (TypeError, ValueError):
+            return json.dumps(str(result), indent=2)
 
+    def _render_value_markdown(self, value: Any) -> str:
+        if value is None:
+            return "None"
+        if isinstance(value, str):
+            return value
+        return "```json\n" + self._result_json_text(value) + "\n```"
+
+    def _render_result_markdown(self, meta, run_id: str, status: str, error: Optional[str], result: Any) -> str:
+        lines = [
+            f"# Workflow result: {meta.get('name') or 'workflow'}",
+            "",
+            f"- Run id: `{run_id}`",
+            f"- Status: {status}",
+        ]
+        if error:
+            lines.append(f"- Error: {error}")
+        lines.extend(["", "## Full return value", "", self._render_value_markdown(result)])
+        return "\n".join(lines).rstrip() + "\n"
+
+    def _read_jsonl(self, path: Path) -> list[dict]:
+        if not path.exists():
+            return []
+        entries: list[dict] = []
+        for raw in path.read_text(encoding="utf-8").splitlines():
+            if not raw.strip():
+                continue
+            try:
+                entries.append(json.loads(raw))
+            except json.JSONDecodeError:
+                entries.append({"type": "invalid_jsonl", "raw": raw})
+        return entries
+
+    def _render_workflow_transcript(
+        self,
+        meta,
+        run_id: str,
+        journal: RunJournal,
+        budget: Budget,
+        status: str,
+        error: Optional[str],
+        duration_seconds: float,
+    ) -> str:
+        journal_entries = self._read_jsonl(journal.journal_path)
+        raw_events = self._read_jsonl(journal.transcript_jsonl_path)
+        lines = [
+            f"# Workflow transcript: {meta.get('name') or 'workflow'}",
+            "",
+            f"- Run id: `{run_id}`",
+            f"- Status: {status}",
+            f"- Duration: {duration_seconds}s",
+            f"- Tokens: {budget.spent()}",
+            f"- Script: `{journal.script_path}`",
+            f"- Result: `{journal.result_md_path}`",
+            "",
+            (
+                "> For normal workflow output, read only this main transcript and `resultPath`. "
+                "Avoid reading individual sub-agent transcripts unless you are explicitly debugging "
+                "workflow execution."
+            ),
+        ]
+        if error:
+            lines.extend(["", f"**Error:** {error}"])
+
+        lines.extend(["", "## Agent call index", ""])
+        if journal_entries:
+            lines.append("| # | Label | Phase | Agent type | Status | Tokens |")
+            lines.append("| --- | --- | --- | --- | --- | ---: |")
+            for entry in journal_entries:
+                index = entry.get("index", "")
+                label = str(entry.get("label") or "")
+                phase = str(entry.get("phase") or "")
+                agent_type = str(entry.get("agent_type") or "")
+                status_text = str(entry.get("status") or "")
+                tokens = entry.get("tokens", "")
+                lines.append(f"| {index} | {label} | {phase} | {agent_type} | {status_text} | {tokens} |")
+        else:
+            lines.append("No agent calls were recorded.")
+
+        lines.extend(["", "## Agent results", ""])
+        if journal_entries:
+            for entry in journal_entries:
+                index = entry.get("index", "")
+                label = entry.get("label") or f"agent {index}"
+                lines.extend([f"### Call {index}: {label}", ""])
+                for key in (
+                    "phase",
+                    "agent_type",
+                    "status",
+                    "tokens",
+                    "error",
+                ):
+                    if entry.get(key) is not None:
+                        lines.append(f"- {key}: `{entry.get(key)}`")
+                value_text = self._render_value_markdown(entry.get("value"))
+                if len(value_text) <= 2000:
+                    lines.extend(["", "Returned value:", "", value_text, ""])
+                else:
+                    lines.extend(
+                        [
+                            "",
+                            (
+                                f"Returned value is {len(value_text):,} chars; "
+                                f"read `{journal.result_md_path}` for the full workflow result."
+                            ),
+                            "",
+                        ]
+                    )
+        else:
+            lines.append("No returned agent values were recorded.")
+
+        cached_events = [event for event in raw_events if event.get("type") == "agent_cached"]
+        if cached_events:
+            lines.extend(["", "## Cached resume calls", ""])
+            for event in cached_events:
+                lines.append(f"- Call {event.get('index')}: {event.get('label')} (served from resume cache)")
+
+        return "\n".join(str(line) for line in lines).rstrip() + "\n"
+
+    def _summarize(self, meta, run_id, journal: RunJournal, budget: Budget, status, error, result) -> str:
         lines = [
             f"Workflow {meta.get('name')!r} {status}.",
             f"runId: {run_id}",
             f"scriptPath: {journal.script_path}",
             f"tokens: {budget.spent()}",
+            f"resultPath: {journal.result_md_path}",
+            f"transcriptPath: {journal.transcript_md_path}",
         ]
         if error:
             lines.append(f"error: {error}")
-        if result is not None:
-            try:
-                rendered = json.dumps(result, default=str)
-            except (TypeError, ValueError):
-                rendered = str(result)
-            if len(rendered) > 4000:
-                rendered = rendered[:4000] + "… (truncated)"
-            lines.append(f"result: {rendered}")
+        lines.append(
+            "result: written to resultPath. Read resultPath for the workflow result, "
+            "or transcriptPath for execution details."
+        )
+        lines.append(
+            "IMPORTANT: The workflow already ran. Do not re-run it to recover output; "
+            "read resultPath or transcriptPath first."
+        )
         return "\n".join(lines)

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -916,8 +916,9 @@ class ToolCollection(LogMixin):
         The script's primitives are `agent()`, `parallel()`, `pipeline()`, `phase()`,
         and `log()`, plus the `args` and `budget` globals. See the gigacode authoring
         guide in your system prompt for the full API and patterns. Artifacts (script,
-        journal, per-agent transcripts) are written under the CLI state directory, and
-        a run can be resumed with `resume_from_run_id`.
+        full result and readable transcript; raw/per-agent debug artifacts are saved
+        under the run directory but are not advertised by default) are written under the CLI state directory, and a run can be resumed with
+        `resume_from_run_id`.
 
         Args:
             script: The Python orchestration script source (must define a top-level `meta` literal).
@@ -928,8 +929,11 @@ class ToolCollection(LogMixin):
                 unchanged prefix and running new/changed calls live.
 
         Returns:
-            A compact run summary: the runId, the persisted scriptPath, the token count,
-            and the workflow's return value.
+            A compact artifact manifest: the runId, persisted scriptPath, token count,
+            resultPath, and transcriptPath. The workflow result is written to
+            resultPath rather than returned inline. Read resultPath for the workflow
+            result, or transcriptPath for execution details. For normal workflow
+            output, avoid reading individual sub-agent transcripts.
         """
         return await self.workflow_tool.run_workflow(
             script=script,


### PR DESCRIPTION
## Summary
- Persist full gigacode workflow results and readable main transcripts
- Return concise resultPath/transcriptPath manifests instead of truncated inline output
- Save per-agent artifacts for debugging without advertising them to the model
- Reinforce prompt/docs guidance to read artifacts instead of re-running workflows

## Tests
- pytest -q kolega_code/agent/tests/tool_backend/test_workflow_tool.py kolega_code/agent/tests/test_prompts.py
- ruff check changed Python files
- git diff --check