### PR TITLE
Fix transcript jump-to-bottom locking

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -374,7 +374,7 @@ class KolegaCodeApp(
         self._update_detach_button()
         if self.check_for_updates:
             self.run_worker(self._check_for_update_on_startup(), name="kolega-update-check", group="updates")
-        self._conversation.anchor()
+        self._schedule_conversation_bottom_anchor()
         self.run_worker(self._consume_events(), name="kolega-events", group="events")
         if self.config is not None:
             await self._build_agent(self.config)

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -6407,6 +6407,203 @@ async def test_conversation_scroll_position_survives_streaming(
 
 
 @pytest.mark.asyncio
+async def test_streaming_growth_stays_pinned_when_following_bottom(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.state import ConversationEntry
+    from kolega_code.cli.tui.widgets import JumpToBottomBar
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        view = app._conversation
+        for index in range(35):
+            app._add_conversation_entry(ConversationEntry(kind="user", content=f"message {index}"))
+        entry = ConversationEntry(kind="assistant", content="stream start", complete=False)
+        app._add_conversation_entry(entry)
+        app._flush_conversation_render()
+        await pilot.pause()
+        await pilot.pause()
+
+        assert view.is_at_bottom()
+        assert view.auto_follow_bottom is True
+
+        widget = app._entry_widgets[entry.entry_id]
+        for index in range(8):
+            entry.content += f"\nstreamed line {index} " + ("x" * 100)
+            app._invalidate_conversation(entry)
+            app._flush_conversation_render()
+            await pilot.pause()
+            await pilot.pause()
+            assert app._entry_widgets[entry.entry_id] is widget
+            assert view.is_at_bottom()
+            assert app.query_one("#jump_to_bottom", JumpToBottomBar).display is False
+
+
+@pytest.mark.asyncio
+async def test_jump_to_bottom_keeps_following_continued_stream(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.state import ConversationEntry
+    from kolega_code.cli.tui.widgets import JumpToBottomBar
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        view = app._conversation
+        for index in range(35):
+            app._add_conversation_entry(ConversationEntry(kind="user", content=f"message {index}"))
+        entry = ConversationEntry(kind="assistant", content="stream start", complete=False)
+        app._add_conversation_entry(entry)
+        app._flush_conversation_render()
+        await pilot.pause()
+        await pilot.pause()
+
+        view.scroll_to(y=0, animate=False)
+        await pilot.pause()
+        assert view.auto_follow_bottom is False
+
+        for index in range(6):
+            entry.content += f"\nwhile away {index} " + ("x" * 100)
+            app._invalidate_conversation(entry)
+            app._flush_conversation_render()
+            await pilot.pause()
+
+        bar = app.query_one("#jump_to_bottom", JumpToBottomBar)
+        assert view.scroll_y == 0
+        assert view.is_at_bottom() is False
+        assert bar.display is True
+
+        app.on_jump_to_bottom_bar_pressed(JumpToBottomBar.Pressed(bar))
+        await pilot.pause()
+        await pilot.pause()
+        assert view.auto_follow_bottom is True
+        assert view.is_at_bottom()
+        assert bar.display is False
+
+        for index in range(6):
+            entry.content += f"\nafter jump {index} " + ("y" * 100)
+            app._invalidate_conversation(entry)
+            app._flush_conversation_render()
+            await pilot.pause()
+            await pilot.pause()
+            assert view.is_at_bottom()
+            assert bar.display is False
+
+
+@pytest.mark.asyncio
+async def test_markdown_completion_reflow_after_jump_stays_at_bottom(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.state import ConversationEntry
+    from kolega_code.cli.tui.widgets import JumpToBottomBar
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        view = app._conversation
+        for index in range(25):
+            app._add_conversation_entry(ConversationEntry(kind="user", content=f"message {index}"))
+        markdown_lines = [f"- streamed markdown item {index} with `code`" for index in range(45)]
+        entry = ConversationEntry(kind="assistant", content="\n".join(markdown_lines), complete=False)
+        app._add_conversation_entry(entry)
+        app._flush_conversation_render()
+        await pilot.pause()
+        await pilot.pause()
+
+        view.scroll_to(y=0, animate=False)
+        await pilot.pause()
+        bar = app.query_one("#jump_to_bottom", JumpToBottomBar)
+        assert bar.display is True
+
+        app.on_jump_to_bottom_bar_pressed(JumpToBottomBar.Pressed(bar))
+        await pilot.pause()
+        await pilot.pause()
+        assert view.is_at_bottom()
+
+        entry.complete = True
+        app._invalidate_conversation(entry)
+        app._flush_conversation_render()
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+
+        assert view.auto_follow_bottom is True
+        assert view.is_at_bottom()
+        assert bar.display is False
+
+
+@pytest.mark.asyncio
+async def test_full_rebuild_preserves_manual_scroll_away(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.state import ConversationEntry
+    from kolega_code.cli.tui.widgets import JumpToBottomBar
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        view = app._conversation
+        for index in range(45):
+            app._add_conversation_entry(ConversationEntry(kind="user", content=f"message {index}"))
+        app._flush_conversation_render()
+        await pilot.pause()
+        await pilot.pause()
+        assert view.is_at_bottom()
+
+        view.scroll_to(y=0, animate=False)
+        await pilot.pause()
+        assert view.auto_follow_bottom is False
+
+        app._render_conversation()
+        await pilot.pause()
+        await pilot.pause()
+
+        assert view.scroll_y == 0
+        assert view.is_at_bottom() is False
+        assert view.auto_follow_bottom is False
+        assert app.query_one("#jump_to_bottom", JumpToBottomBar).display is True
+
+
+@pytest.mark.asyncio
+async def test_full_rebuild_keeps_following_when_already_at_bottom(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.state import ConversationEntry
+    from kolega_code.cli.tui.widgets import JumpToBottomBar
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        view = app._conversation
+        for index in range(45):
+            app._add_conversation_entry(ConversationEntry(kind="user", content=f"message {index}"))
+        app._flush_conversation_render()
+        await pilot.pause()
+        await pilot.pause()
+        assert view.is_at_bottom()
+        assert view.auto_follow_bottom is True
+
+        app._render_conversation()
+        await pilot.pause()
+        await pilot.pause()
+
+        assert view.is_at_bottom()
+        assert view.auto_follow_bottom is True
+        assert app.query_one("#jump_to_bottom", JumpToBottomBar).display is False
+
+
+@pytest.mark.asyncio
 async def test_assistant_entries_render_markdown_when_complete(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/kolega_code/cli/tui/transcript.py
+++ b/kolega_code/cli/tui/transcript.py
@@ -1068,6 +1068,8 @@ class TranscriptRenderingMixin:
             self._dirty_entry_ids.clear()
             return
 
+        should_follow = bool(getattr(view, "auto_follow_bottom", False)) or view.is_at_bottom()
+
         # Fast path for the common streaming case: the transcript shape is unchanged
         # and only already-mounted entries need their renderables refreshed.
         if (
@@ -1076,7 +1078,10 @@ class TranscriptRenderingMixin:
             and all(entry_id in self._entry_widgets for entry_id in self._dirty_entry_ids)
         ):
             self._refresh_dirty_entry_widgets()
-            self._update_jump_button()
+            if should_follow:
+                self._schedule_conversation_bottom_anchor()
+            else:
+                self._update_jump_button()
             return
 
         rendered_ids = list(self._entry_widgets)
@@ -1096,7 +1101,10 @@ class TranscriptRenderingMixin:
                 self._entry_widgets[entry.entry_id] = widget
                 widgets.append(widget)
             view.mount(*widgets)
-        self._update_jump_button()
+        if should_follow:
+            self._schedule_conversation_bottom_anchor()
+        else:
+            self._update_jump_button()
 
     def _refresh_dirty_entry_widgets(self) -> None:
         for entry_id in self._dirty_entry_ids:
@@ -1115,6 +1123,8 @@ class TranscriptRenderingMixin:
             return
         if not view.is_attached:
             return
+        had_rendered_entries = bool(self._entry_widgets)
+        should_follow = not had_rendered_entries or bool(getattr(view, "auto_follow_bottom", False)) or view.is_at_bottom()
         view.remove_children()
         self._entry_widgets = {}
         widgets = []
@@ -1124,8 +1134,11 @@ class TranscriptRenderingMixin:
             widgets.append(widget)
         if widgets:
             view.mount(*widgets)
-        view.anchor()
-        self._update_jump_button()
+        if should_follow:
+            self._schedule_conversation_bottom_anchor()
+        else:
+            view.set_auto_follow(False)
+            self._update_jump_button()
 
     def _make_entry_widget(self, entry: ConversationEntry) -> ConversationEntryWidget | ToolEntryWidget:
         if entry.kind in {"tool_call", "tool_result", "tool_error"}:
@@ -1139,21 +1152,42 @@ class TranscriptRenderingMixin:
     def _compaction_summary_title(self, entry: ConversationEntry) -> str:
         return theme.role_header(Glyph.STATUS, messages.COMPACTION_SUMMARY_TITLE, Color.ACCENT)
 
+    def _schedule_conversation_bottom_anchor(self, *, update_button: bool = True) -> None:
+        """Pin the transcript to the latest output after layout has settled."""
+        try:
+            view = self._conversation
+        except Exception:
+            return
+        if not view.is_attached:
+            return
+        view.set_auto_follow(True)
+
+        def anchor_after_refresh() -> None:
+            if not view.is_attached:
+                return
+            view.set_auto_follow(True)
+            view.anchor()
+            if update_button:
+                self.call_after_refresh(self._update_jump_button)
+
+        self.call_after_refresh(anchor_after_refresh)
+
     def _update_jump_button(self) -> None:
         try:
             view = self._conversation
             bar = self.query_one("#jump_to_bottom", JumpToBottomBar)
         except Exception:
             return
-        should_display = view.max_scroll_y > 0 and view.scroll_y < view.max_scroll_y - 1
+        should_display = (not bool(getattr(view, "auto_follow_bottom", False))) and not view.is_at_bottom()
         if bar.display != should_display:
             bar.display = should_display
+            try:
+                self.call_after_refresh(self._update_jump_button)
+            except Exception:
+                pass
 
     def on_jump_to_bottom_bar_pressed(self, message: JumpToBottomBar.Pressed) -> None:
-        view = self._conversation
-        view.scroll_end(animate=False)
-        view.anchor()
-        self._update_jump_button()
+        self._schedule_conversation_bottom_anchor()
 
     def _format_conversation_entry(self, entry: ConversationEntry) -> Text | Group:
         """Render an entry using the shared header grammar.

--- a/kolega_code/cli/tui/widgets.py
+++ b/kolega_code/cli/tui/widgets.py
@@ -273,8 +273,23 @@ class ToolEntryWidget(Vertical):
 class ConversationView(VerticalScroll):
     """Scrollable list of per-entry widgets, anchored to the bottom while streaming."""
 
+    bottom_tolerance = 1
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.auto_follow_bottom = True
+
+    def is_at_bottom(self) -> bool:
+        """Return whether the current scroll position is effectively at the end."""
+        return self.max_scroll_y <= 0 or self.scroll_y >= self.max_scroll_y - self.bottom_tolerance
+
+    def set_auto_follow(self, enabled: bool) -> None:
+        """Record whether transcript updates should keep the view pinned to the end."""
+        self.auto_follow_bottom = enabled
+
     def watch_scroll_y(self, old_value: float, new_value: float) -> None:
         super().watch_scroll_y(old_value, new_value)
+        self.auto_follow_bottom = self.is_at_bottom()
         try:
             update = getattr(self.app, "_update_jump_button", None)
         except Exception:


### PR DESCRIPTION
## Summary
- add explicit bottom-follow state to the transcript scroll view
- defer transcript bottom anchoring until after layout refreshes settle
- keep manual scroll-away stable while ensuring jump-to-latest resumes follow mode
- add regression coverage for streaming growth, jump-to-bottom during streaming, markdown reflow, and rebuild behavior

## Tests
- ruff check kolega_code/cli/app.py kolega_code/cli/tui/widgets.py kolega_code/cli/tui/transcript.py kolega_code/cli/tests/test_app.py
- pytest -q kolega_code/cli/tests/test_app.py -k 'conversation_scroll_position_survives_streaming or scroll or jump_to_bottom'
- pytest -q kolega_code/cli/tests/test_app.py
- pytest -q