### PR TITLE
Optimize sidebar terminal and logs rendering

### DIFF
--- a/docs/src/content/docs/cli/overview.md
+++ b/docs/src/content/docs/cli/overview.md
@@ -39,6 +39,7 @@ kolega-code [PROJECT_PATH]
 | `--new` | Start a new session (this is the default) |
 | `--resume [THREAD_ID]` | Resume the latest saved thread, or a specific thread/session ID |
 | `--browser-visible` | Launch visible Playwright browser windows instead of headless |
+| `--show-logs` | Show the optional diagnostic Logs side-panel tab. Hidden by default to avoid unnecessary log rendering work |
 | `--permission-mode <auto\|ask>` | Shell/edit permission mode. TUI sessions default to `ask` |
 | `--session <ID>` | Legacy alias for `--resume THREAD_ID` |
 

--- a/docs/src/content/docs/tui/interface.md
+++ b/docs/src/content/docs/tui/interface.md
@@ -14,8 +14,9 @@ The screen is split into two columns:
 - **Conversation panel** (left, larger) — your chat with the agent. Responses
   stream in live, tool calls and sub-agent activity appear inline, and detailed
   tool results are collapsed by default so you can expand only what you need.
-- **Side panel** (right) — a set of tabs for status, logs, the terminal, planning,
-  and settings. Toggle it with `Ctrl+O` or `/sidebar`.
+- **Side panel** (right) — a set of tabs for status, the terminal, planning,
+  and settings. Toggle it with `Ctrl+O` or `/sidebar`. The diagnostic Logs tab is
+  opt-in; launch with `--show-logs` when you want it.
 
 At the bottom sits the **composer** — the text box where you type prompts. See
 [Chat Composer](../composer/) for everything it can do.
@@ -25,7 +26,7 @@ At the bottom sits the **composer** — the text box where you type prompts. See
 | Tab | What it shows |
 | --- | --- |
 | **Status** | The active provider/model and thinking effort, the current interaction mode (Build/Plan), permission mode, the agent's turn state (idle, generating, thinking, running a tool, running sub-agents, waiting for input, …), token usage, and context warnings. |
-| **Logs** | A timestamped, color-coded activity log: sub-agent lifecycle, tool calls, configuration changes. An indicator flags new entries when you're on another tab. |
+| **Logs** | Optional. Launch with `--show-logs` to show a timestamped, color-coded diagnostic activity log. New entries preserve manual scrollback and an indicator flags unseen entries when you're on another tab. |
 | **Terminal** | Live output from commands the agent runs. |
 | **Planning** | The current **Plan** (markdown from the planning agent) and the shared **Task List** that both modes can edit. |
 | **Settings** | Provider, model, thinking effort, and API-key configuration. See [Settings & API Keys](../../configuration/settings-and-api-keys/). |

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -23,7 +23,6 @@ from textual.widgets import (
     Label,
     Markdown,
     OptionList,
-    RichLog,
     Select,
     Static,
     TabbedContent,
@@ -90,6 +89,10 @@ from .tui import widgets as tui_widgets
 from .tui.styles import APP_CSS
 
 CLI_AGENT_MODE = AgentMode.CLI.value
+LOG_MAX_LINES = 10_000
+TERMINAL_MAX_LINES = 10_000
+TERMINAL_FLUSH_INTERVAL = 0.04
+TERMINAL_IMMEDIATE_FLUSH_CHARS = 64 * 1024
 
 
 class KolegaCodeApp(
@@ -130,6 +133,7 @@ class KolegaCodeApp(
         permission_mode: Optional[str] = None,
         browser_visible: bool = False,
         check_for_updates: bool = False,
+        show_logs: bool = False,
     ) -> None:
         super().__init__()
         self.project_path = project_path
@@ -153,6 +157,7 @@ class KolegaCodeApp(
         self.browser_visible = browser_visible
         self.sidebar_visible = True
         self.check_for_updates = check_for_updates
+        self.show_logs = show_logs
         self.connection_manager = CliConnectionManager()
         self._hook_dispatcher: Optional[HookDispatcher] = None
         self._session_started = False
@@ -211,6 +216,9 @@ class KolegaCodeApp(
         self._last_sub_agent_tick = 0.0
         self._sub_agent_inspector: Optional[tui_sub_agents.SubAgentInspectorScreen] = None
         self._terminal_has_content = False
+        self._terminal_output_buffer: list[str] = []
+        self._terminal_output_buffer_chars = 0
+        self._terminal_flush_timer: Optional[Timer] = None
 
     def compose(self) -> ComposeResult:
         with Horizontal(id="body"):
@@ -252,10 +260,23 @@ class KolegaCodeApp(
                     with TabPane("Status", id="status_pane"):
                         with Vertical(id="status_container"):
                             yield Static("", id="status_dashboard", markup=True)
-                    with TabPane("Logs", id="logs_pane"):
-                        yield RichLog(id="logs", wrap=True, markup=True)
+                    if self.show_logs:
+                        with TabPane("Logs", id="logs_pane"):
+                            yield tui_widgets.LogOutputLog(
+                                id="logs",
+                                wrap=True,
+                                markup=True,
+                                max_lines=LOG_MAX_LINES,
+                            )
                     with TabPane("Terminal", id="terminal_pane"):
-                        yield RichLog(id="terminal", wrap=True, markup=False)
+                        # Sidebar-rendered history is bounded for UI performance;
+                        # command output returned to the agent is unaffected.
+                        yield tui_widgets.TerminalOutputLog(
+                            id="terminal",
+                            wrap=True,
+                            markup=False,
+                            max_lines=TERMINAL_MAX_LINES,
+                        )
                     with TabPane("Planning", id="planning_pane"):
                         with VerticalScroll(id="planning_form"):
                             with Collapsible(title="Plan", collapsed=False, id="planning_plan"):
@@ -388,12 +409,12 @@ class KolegaCodeApp(
         return self.query_one("#conversation", tui_widgets.ConversationView)
 
     @property
-    def _logs(self) -> RichLog:
-        return self.query_one("#logs", RichLog)
+    def _logs(self) -> tui_widgets.LogOutputLog:
+        return self.query_one("#logs", tui_widgets.LogOutputLog)
 
     @property
-    def _terminal(self) -> RichLog:
-        return self.query_one("#terminal", RichLog)
+    def _terminal(self) -> tui_widgets.TerminalOutputLog:
+        return self.query_one("#terminal", tui_widgets.TerminalOutputLog)
 
     def _format_terminal_command(self, command: str) -> Text:
         """Accent prompt glyph plus the command in bold."""
@@ -402,14 +423,58 @@ class KolegaCodeApp(
             (command, "bold"),
         )
 
+    def _queue_terminal_output(self, output: str) -> None:
+        """Buffer terminal chunks so high-volume output renders in batches."""
+        if not output:
+            return
+
+        buffer_was_empty = not self._terminal_output_buffer
+        self._terminal_output_buffer.append(output)
+        self._terminal_output_buffer_chars += len(output)
+        self._terminal_has_content = True
+
+        if buffer_was_empty:
+            self._mark_tab_activity("terminal_pane")
+
+        if self._terminal_output_buffer_chars >= TERMINAL_IMMEDIATE_FLUSH_CHARS:
+            self._flush_terminal_output()
+            return
+
+        if self._terminal_flush_timer is None:
+            self._terminal_flush_timer = self.set_timer(
+                TERMINAL_FLUSH_INTERVAL,
+                self._flush_terminal_output,
+                name="terminal-output-flush",
+            )
+
+    def _flush_terminal_output(self) -> None:
+        """Write any buffered terminal output as a single sticky-follow append."""
+        if self._terminal_flush_timer is not None:
+            self._terminal_flush_timer.stop()
+            self._terminal_flush_timer = None
+
+        if not self._terminal_output_buffer:
+            return
+
+        output = "".join(self._terminal_output_buffer)
+        self._terminal_output_buffer.clear()
+        self._terminal_output_buffer_chars = 0
+
+        try:
+            terminal = self._terminal
+        except Exception:
+            return
+        terminal.write_terminal(output)
+
     def _write_terminal_command(self, command: str) -> None:
+        self._flush_terminal_output()
         try:
             terminal = self._terminal
         except Exception:
             return
         if self._terminal_has_content:
-            terminal.write("")
-        terminal.write(self._format_terminal_command(command))
+            terminal.write_terminal("")
+        terminal.write_terminal(self._format_terminal_command(command))
         self._terminal_has_content = True
         self._mark_tab_activity("terminal_pane")
 
@@ -423,12 +488,14 @@ class KolegaCodeApp(
         )
 
     def _write_log(self, text: str, level: str = "info") -> None:
-        """Single write path into the Logs tab."""
+        """Single write path into the optional Logs tab."""
+        if not self.show_logs:
+            return
         try:
             logs = self._logs
         except Exception:
             return
-        logs.write(self._format_log_line(text, level))
+        logs.write_log(self._format_log_line(text, level))
         self._mark_tab_activity("logs_pane")
 
     def _mark_tab_activity(self, pane_id: str) -> None:

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -156,6 +156,7 @@ def _build_tui_parser() -> argparse.ArgumentParser:
         help="Resume the latest saved thread, or resume the given thread/session ID.",
     )
     parser.add_argument("--browser-visible", action="store_true", help="Launch visible Playwright browser windows.")
+    parser.add_argument("--show-logs", action="store_true", help="Show the diagnostic Logs sidebar tab.")
     parser.add_argument(
         "--permission-mode",
         choices=[mode.value for mode in PermissionMode],
@@ -393,6 +394,7 @@ def _run_tui(args: argparse.Namespace) -> int:
         permission_mode=args.permission_mode,
         browser_visible=args.browser_visible,
         check_for_updates=True,
+        show_logs=args.show_logs,
     )
     app.run()
     return 0

--- a/kolega_code/cli/tests/test_app.py
+++ b/kolega_code/cli/tests/test_app.py
@@ -193,7 +193,8 @@ async def test_textual_app_status_tab_is_default_dashboard(
         assert "Build" in dashboard
         assert "Idle" in dashboard
         assert "Waiting for first context count" in dashboard
-        assert dashboard_widget.styles.border == app.query_one("#logs").styles.border
+        assert dashboard_widget.styles.border == app.query_one("#terminal").styles.border
+        assert list(app.query("#logs")) == []
         assert list(app.query("#status")) == []
 
 
@@ -1036,7 +1037,7 @@ async def test_textual_app_ctrl_o_toggles_sidebar_and_keeps_active_tab(
 
         side_panel = app.query_one("#side_panel")
         tabs = app.query_one("#events", TabbedContent)
-        tabs.active = "logs_pane"
+        tabs.active = "terminal_pane"
         await pilot.pause()
 
         assert app.sidebar_visible is True
@@ -1046,13 +1047,13 @@ async def test_textual_app_ctrl_o_toggles_sidebar_and_keeps_active_tab(
 
         assert app.sidebar_visible is False
         assert side_panel.display is False
-        assert tabs.active == "logs_pane"
+        assert tabs.active == "terminal_pane"
 
         await pilot.press("ctrl+o")
 
         assert app.sidebar_visible is True
         assert side_panel.display is True
-        assert tabs.active == "logs_pane"
+        assert tabs.active == "terminal_pane"
 
 
 @pytest.mark.asyncio
@@ -3702,7 +3703,7 @@ async def test_tab_activity_label_changes_only_on_state_transitions(
     from kolega_code.cli.tui.constants import TAB_BASE_LABELS
     from kolega_code.cli.theme import Glyph
 
-    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch, show_logs=True)
 
     async with app.run_test():
         tabs = app.query_one("#events", TabbedContent)
@@ -5451,7 +5452,7 @@ async def test_textual_app_model_rebuild_rerenders_completed_tool_once(
 # ---------------------------------------------------------------------------
 
 
-def _build_sub_agent_test_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+def _build_sub_agent_test_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, **app_kwargs):
     pytest.importorskip("textual")
 
     from kolega_code.cli.app import KolegaCodeApp
@@ -5482,7 +5483,7 @@ def _build_sub_agent_test_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
-    return KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+    return KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session, **app_kwargs)
 
 
 def _sub_agent_event(
@@ -6749,14 +6750,14 @@ async def test_log_lines_carry_timestamp_and_level_glyph(
 
     from kolega_code.agent import AgentEvent
 
-    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch, show_logs=True)
 
     async with app.run_test():
         line = app._format_log_line("boom", "error")
         assert re.fullmatch(r"\d{2}:\d{2}:\d{2} \S+ boom", line.plain)
 
         written: list[object] = []
-        monkeypatch.setattr(app._logs, "write", written.append)
+        monkeypatch.setattr(app._logs, "write_log", written.append)
         app._render_event(
             AgentEvent(event_type="log_message", sender="coder", content={"level": "error", "message": "it [broke]"})
         )
@@ -6781,14 +6782,105 @@ async def test_terminal_commands_render_as_styled_blocks(
         assert formatted.plain == f"{theme.g(theme.Glyph.USER)} ls -la"
 
         written: list[object] = []
-        monkeypatch.setattr(app._terminal, "write", written.append)
+        monkeypatch.setattr(app._terminal, "write_terminal", written.append)
         app._render_event(AgentEvent(event_type="terminal_command", sender="coder", content={"command": "echo one"}))
         app._render_event(AgentEvent(event_type="terminal_output", sender="coder", content={"output": "one"}))
         app._render_event(AgentEvent(event_type="terminal_command", sender="coder", content={"command": "echo two"}))
 
         plains = [item.plain if hasattr(item, "plain") else item for item in written]
-        # Second command block is preceded by a blank separator line
+        # Pending output is flushed before the next command, whose block is preceded
+        # by a blank separator line.
         assert plains == [f"{theme.g(theme.Glyph.USER)} echo one", "one", "", f"{theme.g(theme.Glyph.USER)} echo two"]
+
+
+@pytest.mark.asyncio
+async def test_terminal_output_is_batched_until_flush(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.agent import AgentEvent
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        written: list[object] = []
+        monkeypatch.setattr(app._terminal, "write_terminal", written.append)
+
+        for index in range(5):
+            app._render_event(
+                AgentEvent(event_type="terminal_output", sender="coder", content={"output": f"chunk-{index}\n"})
+            )
+
+        assert written == []
+        app._flush_terminal_output()
+
+        assert written == ["chunk-0\nchunk-1\nchunk-2\nchunk-3\nchunk-4\n"]
+        assert app._terminal_output_buffer == []
+        assert app._terminal_output_buffer_chars == 0
+
+
+@pytest.mark.asyncio
+async def test_terminal_output_preserves_scrollback_when_user_scrolls_up(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.widgets import TabbedContent
+
+    from kolega_code.agent import AgentEvent
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.query_one("#events", TabbedContent).active = "terminal_pane"
+        await pilot.pause()
+
+        terminal = app._terminal
+        terminal.write_terminal("".join(f"line {index}\n" for index in range(120)))
+        await pilot.pause()
+        terminal.scroll_end(animate=False, immediate=True)
+        await pilot.pause()
+        assert terminal.max_scroll_y > 0
+
+        terminal.scroll_to(y=0, animate=False, immediate=True)
+        await pilot.pause()
+        scroll_y = terminal.scroll_y
+        assert terminal.auto_follow_bottom is False
+
+        app._render_event(AgentEvent(event_type="terminal_output", sender="coder", content={"output": "new line\n"}))
+        app._flush_terminal_output()
+        await pilot.pause()
+
+        assert terminal.scroll_y == scroll_y
+
+        terminal.scroll_end(animate=False, immediate=True)
+        await pilot.pause()
+        app._render_event(AgentEvent(event_type="terminal_output", sender="coder", content={"output": "tail line\n"}))
+        app._flush_terminal_output()
+        await pilot.pause()
+
+        assert terminal.scroll_y >= terminal.max_scroll_y - terminal.bottom_tolerance
+
+
+@pytest.mark.asyncio
+async def test_terminal_rendered_history_is_capped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("textual")
+
+    from textual.widgets import TabbedContent
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.query_one("#events", TabbedContent).active = "terminal_pane"
+        await pilot.pause()
+
+        terminal = app._terminal
+        terminal.max_lines = 5
+        terminal.write_terminal("".join(f"line {index}\n" for index in range(12)))
+        await pilot.pause()
+
+        rendered = "\n".join(strip.text for strip in terminal.lines)
+        assert len(terminal.lines) <= 5
+        assert "line 11" in rendered
 
 
 @pytest.mark.asyncio
@@ -6882,6 +6974,113 @@ async def test_planning_sidebar_marks_empty_states(tmp_path: Path, monkeypatch: 
 
 
 @pytest.mark.asyncio
+async def test_logs_tab_hidden_by_default_and_write_log_is_noop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.widgets import TabbedContent
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        tabs = app.query_one("#events", TabbedContent)
+        assert tabs.active == "status_pane"
+        assert list(app.query("#logs")) == []
+
+        def fail_format(*args, **kwargs):
+            raise AssertionError("hidden logs should not format log lines")
+
+        def fail_activity(*args, **kwargs):
+            raise AssertionError("hidden logs should not mark tab activity")
+
+        monkeypatch.setattr(app, "_format_log_line", fail_format)
+        monkeypatch.setattr(app, "_mark_tab_activity", fail_activity)
+
+        app._write_log("background activity")
+
+
+@pytest.mark.asyncio
+async def test_logs_tab_can_be_enabled_with_sticky_widget(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.widgets import TabbedContent
+
+    from kolega_code.cli.tui.widgets import LogOutputLog
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch, show_logs=True)
+
+    async with app.run_test():
+        tabs = app.query_one("#events", TabbedContent)
+
+        assert tabs.get_tab("logs_pane") is not None
+        assert isinstance(app.query_one("#logs"), LogOutputLog)
+
+
+@pytest.mark.asyncio
+async def test_logs_output_preserves_scrollback_when_user_scrolls_up(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.widgets import TabbedContent
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch, show_logs=True)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.query_one("#events", TabbedContent).active = "logs_pane"
+        await pilot.pause()
+
+        logs = app._logs
+        logs.write_log("".join(f"line {index}\n" for index in range(120)))
+        await pilot.pause()
+        logs.scroll_end(animate=False, immediate=True)
+        await pilot.pause()
+        assert logs.max_scroll_y > 0
+
+        logs.scroll_to(y=0, animate=False, immediate=True)
+        await pilot.pause()
+        scroll_y = logs.scroll_y
+        assert logs.auto_follow_bottom is False
+
+        app._write_log("new line")
+        await pilot.pause()
+
+        assert logs.scroll_y == scroll_y
+
+        logs.scroll_end(animate=False, immediate=True)
+        await pilot.pause()
+        app._write_log("tail line")
+        await pilot.pause()
+
+        assert logs.scroll_y >= logs.max_scroll_y - logs.bottom_tolerance
+
+
+@pytest.mark.asyncio
+async def test_logs_rendered_history_is_capped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("textual")
+
+    from textual.widgets import TabbedContent
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch, show_logs=True)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.query_one("#events", TabbedContent).active = "logs_pane"
+        await pilot.pause()
+
+        logs = app._logs
+        logs.max_lines = 5
+        logs.write_log("".join(f"line {index}\n" for index in range(12)))
+        await pilot.pause()
+
+        rendered = "\n".join(strip.text for strip in logs.lines)
+        assert len(logs.lines) <= 5
+        assert "line 11" in rendered
+
+
+@pytest.mark.asyncio
 async def test_logs_tab_shows_activity_dot_until_visited(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -6891,7 +7090,7 @@ async def test_logs_tab_shows_activity_dot_until_visited(
 
     from kolega_code.cli import theme
 
-    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch, show_logs=True)
 
     async with app.run_test() as pilot:
         tabs = app.query_one("#events", TabbedContent)

--- a/kolega_code/cli/tests/test_main.py
+++ b/kolega_code/cli/tests/test_main.py
@@ -37,6 +37,14 @@ def test_parse_default_command_as_tui() -> None:
     assert args.resume is None
     assert args.mode == CLI_AGENT_MODE
     assert args.permission_mode is None
+    assert args.show_logs is False
+
+
+def test_parse_tui_show_logs_flag() -> None:
+    args = parse_args(["/tmp/project", "--show-logs"])
+
+    assert args.command == "tui"
+    assert args.show_logs is True
 
 
 def test_version_flag_prints_package_version(capsys, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -43,7 +43,7 @@ class AgentRuntimeMixin:
                 if chunk.get("type") == "thinking":
                     self._update_progress(messages.THINKING, complete=False, state=tui_state.TurnState.THINKING)
                     self._apply_stream_chunk(chunk, kind="thinking")
-                    if content:
+                    if content and self.show_logs:
                         self._write_log(content, "debug")
             await self._drain_pending_events()
             self._finalize_sub_agent_activities()
@@ -103,18 +103,17 @@ class AgentRuntimeMixin:
             try:
                 event = self.connection_manager.events.get_nowait()
             except asyncio.QueueEmpty:
-                return
+                break
             self._render_event(event)
+        self._flush_terminal_output()
 
     def _render_event(self, event: AgentEvent) -> None:
-        text = self._display_text_from_event(event)
         if event.event_type == "log_message":
-            level = str(event.content.get("level", "info"))
-            self._write_log(text, level)
+            if self.show_logs:
+                level = str(event.content.get("level", "info"))
+                self._write_log(self._display_text_from_event(event), level)
         elif event.event_type == "terminal_output":
-            self._terminal.write(event.content.get("output", ""))
-            self._terminal_has_content = True
-            self._mark_tab_activity("terminal_pane")
+            self._queue_terminal_output(event.content.get("output", ""))
         elif event.event_type == "terminal_command":
             command = str(event.content.get("command") or "")
             self._write_terminal_command(command)
@@ -160,10 +159,14 @@ class AgentRuntimeMixin:
         elif event.event_type in {"llm_status_update", "status_update"}:
             if event.sub_agent_info:
                 self._note_sub_agent_status(event)
-            elif text:
-                self._write_log(text, "info")
-                self._update_activity_progress(text)
-        else:
+            else:
+                text = self._display_text_from_event(event)
+                if text:
+                    if self.show_logs:
+                        self._write_log(text, "info")
+                    self._update_activity_progress(text)
+        elif self.show_logs:
+            text = self._display_text_from_event(event)
             if text:
                 self._write_log(f"{event.event_type}: {text}", "info")
             else:

--- a/kolega_code/cli/tui/widgets.py
+++ b/kolega_code/cli/tui/widgets.py
@@ -16,7 +16,7 @@ from textual.containers import Vertical, VerticalScroll
 from textual.message import Message as TextualMessage
 from textual.selection import Selection
 from textual.strip import Strip
-from textual.widgets import Collapsible, OptionList, Static, TextArea
+from textual.widgets import Collapsible, OptionList, RichLog, Static, TextArea
 from textual.widgets._collapsible import CollapsibleTitle
 from textual.widgets.option_list import Option
 
@@ -296,6 +296,50 @@ class ConversationView(VerticalScroll):
             return
         if update is not None:
             update()
+
+
+class StickyRichLog(RichLog):
+    """RichLog with sticky bottom-follow semantics.
+
+    ``RichLog`` defaults to unconditional auto-scroll on every write. That is
+    wrong for sidebar streams because manual scrollback snaps back to the newest
+    output as soon as another line arrives. This widget keeps the view pinned
+    only while the user is already at the bottom.
+    """
+
+    bottom_tolerance = 1
+
+    def __init__(self, *args, **kwargs) -> None:
+        kwargs["auto_scroll"] = False
+        super().__init__(*args, **kwargs)
+        self.auto_follow_bottom = True
+
+    def is_at_bottom(self) -> bool:
+        """Return whether the current scroll position is effectively at the end."""
+        return self.max_scroll_y <= 0 or self.scroll_y >= self.max_scroll_y - self.bottom_tolerance
+
+    def watch_scroll_y(self, old_value: float, new_value: float) -> None:
+        super().watch_scroll_y(old_value, new_value)
+        self.auto_follow_bottom = self.is_at_bottom()
+
+    def write_sticky(self, content: object) -> None:
+        """Append content, following only if the user was at the bottom."""
+        should_follow = self.auto_follow_bottom or self.is_at_bottom()
+        self.write(content, scroll_end=should_follow)
+
+
+class TerminalOutputLog(StickyRichLog):
+    """Sticky log for terminal output."""
+
+    def write_terminal(self, content: object) -> None:
+        self.write_sticky(content)
+
+
+class LogOutputLog(StickyRichLog):
+    """Sticky log for diagnostic messages."""
+
+    def write_log(self, content: object) -> None:
+        self.write_sticky(content)
 
 
 class JumpToBottomBar(Static):


### PR DESCRIPTION
## Summary
- add sticky-follow, batched, capped rendering for terminal sidebar output
- make the Logs sidebar tab opt-in via `--show-logs`
- use sticky/capped log rendering when enabled and skip hidden log work by default

## Tests
- `pytest -v kolega_code/cli/tests/test_main.py kolega_code/cli/tests/test_app.py -k 'logs or parse_default_command_as_tui or parse'`
- `pytest -v kolega_code/cli/tests/test_app.py -k 'terminal_output_preserves_scrollback_when_user_scrolls_up or terminal_rendered_history_is_capped'`
- `pytest -v kolega_code/cli/tests/test_app.py`
- `ruff check kolega_code/cli/app.py kolega_code/cli/main.py kolega_code/cli/tui/widgets.py kolega_code/cli/tui/agent_runtime.py kolega_code/cli/tests/test_app.py kolega_code/cli/tests/test_main.py`

Note: full-repo `ruff check` still reports pre-existing unrelated lint in `kolega_code/agent` and `kolega_code/sandbox`.