### PR TITLE
chore: release v0.8.2

### DIFF
--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -44,4 +44,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.8.1"
+version = "0.8.2"
 description = "Local-first AI coding agent for the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [options]
 prerelease-mode = "allow"
-exclude-newer = "2026-06-15T18:13:37.213874Z"
+exclude-newer = "2026-06-16T12:51:07.553149Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1098,7 +1098,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.8.1"
+version = "0.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Bump `kolega-code` package/version exports from `0.8.1` to `0.8.2`.
- Regenerate `uv.lock` for the release bump.

## Release notes summary
This patch release packages the post-`v0.8.1` work on:
- TUI responsiveness and rendering improvements:
  - Optimized streaming render updates.
  - Optimized sidebar terminal/log rendering.
  - Avoided transcript rebuilds on mode switches.
  - Moved TUI session persistence work off the event loop.
- TUI bug fixes:
  - Fixed transcript jump-to-bottom/scroll-lock behavior.
  - Fixed layout for long approval prompts.
- Gigacode/workflow improvements:
  - Improved workflow transcript artifacts.
- Internal maintainability:
  - Split/refactored the CLI TUI package layout into focused modules/mixins.
- Documentation:
  - Documented the optional logs sidebar flag.
  - Added conventional branch/PR guidance.

## Validation
- [x] `uv lock`
- [x] `uv run pytest -ra --durations=50 --import-mode=importlib -m "not slow"`
  - `1356 passed, 50 deselected, 8 warnings in 226.20s`
- [x] `python -m build`
- [x] `python -m twine check dist/*`
- [x] Smoke install/version check with `dist/kolega_code-0.8.2-py3-none-any.whl`
  - `kolega-code 0.8.2`

Note: `dist/` already contained older local wheels (`0.1.0`, `0.7.0`), so `pip install dist/*.whl` conflicts across package versions. The release smoke check was completed against the newly built `0.8.2` wheel.
