### PR TITLE
fix(deps): update idna to patched version

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -954,11 +954,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.14"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/b1/efac073e0c297ecf2fb33c346989a529d4e19164f1759102dee5953ee17e/idna-3.14.tar.gz", hash = "sha256:466d810d7a2cc1022bea9b037c39728d51ae7dad40d480fc9b7d7ecf98ba8ee3", size = 198272, upload-time = "2026-05-10T20:32:15.935Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/3c/3f62dee257eb3d6b2c1ef2a09d36d9793c7111156a73b5654d2c2305e5ce/idna-3.14-py3-none-any.whl", hash = "sha256:e677eaf072e290f7b725f9acf0b3a2bd55f9fd6f7c70abe5f0e34823d0accf69", size = 72184, upload-time = "2026-05-10T20:32:14.295Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- update locked transitive `idna` dependency from `3.14` to `3.18`
- addresses Dependabot alert #10 / GHSA-65pc-fj4g-8rjx / CVE-2026-45409 (`idna < 3.15`)
- keep the lockfile diff limited to the `idna` package entry

## Checks
- `uv lock --check`
- `uv run python - <<'PY' ...` confirmed imported `idna.__version__ == "3.18"`
- `uv tree --package idna --invert --depth 2`
- `uv run pytest -m "not slow" tests/agent/llm/test_client.py tests/agent/tool_backend/test_web_fetch_tool.py tests/agent/tool_backend/test_web_search_tool.py tests/cli/test_cli_config.py`

## Notes
- `./run_tests.sh` was attempted and reached `1355 passed` but failed on an unrelated live Anthropic API 500 in `tests/agent/llm/test_live_providers.py::test_live_provider_generate[anthropic]`.
- A direct run of `tests/agent/llm/test_client.py` without `-m "not slow"` also hit Anthropic 500s in slow/live tests. The non-slow subset passed.
