### PR TITLE
fix(tui): persist permission mode

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -976,7 +976,9 @@ class KolegaCodeApp(
 
         self.permission_mode = mode
         self.session.permission_mode = mode.value
+        self.settings.permission_mode = mode.value
         await self._save_session_async()
+        await asyncio.to_thread(self.settings_store.save, self.settings)
         if self.agent is not None:
             self.agent.set_permission_mode(mode)
             self.agent.set_permission_callback(self._permission_callback)

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -36,7 +36,7 @@ from .config import (
 from .connection import CliConnectionManager
 from .mentions import build_file_attachments
 from .session_store import SessionRecord, SessionStore, SessionStoreError
-from .settings import SettingsStore, SettingsStoreError
+from .settings import CliSettings, SettingsStore, SettingsStoreError
 from .slash_commands import SKILLS_LIST_COMMAND, agent_command_names
 from .skills import (
     SkillCatalog,
@@ -327,6 +327,32 @@ def _resolve_tui_session(
     return store.create(project_path, CLI_AGENT_MODE, summary)
 
 
+def _safe_permission_mode_value(value: Optional[str]) -> str:
+    try:
+        return normalize_permission_mode(value, default=PermissionMode.ASK).value
+    except ValueError:
+        return PermissionMode.ASK.value
+
+
+def _resolve_tui_permission_mode(
+    session: SessionRecord,
+    settings: CliSettings,
+    requested_permission_mode: Optional[str],
+    *,
+    resumed: bool,
+) -> str:
+    """Resolve the TUI permission mode for this launch.
+
+    Precedence: explicit CLI flag, resumed session value, then global setting for
+    new sessions. Invalid legacy values fall back to ask.
+    """
+    if requested_permission_mode:
+        return normalize_permission_mode(requested_permission_mode, default=PermissionMode.ASK).value
+    if resumed:
+        return _safe_permission_mode_value(session.permission_mode)
+    return _safe_permission_mode_value(settings.permission_mode)
+
+
 def _run_version() -> int:
     result = check_for_update()
     print(f"kolega-code {result.current_version}")
@@ -374,11 +400,14 @@ def _run_tui(args: argparse.Namespace) -> int:
         args.resume,
         args.session,
     )
-    if args.permission_mode:
-        session.permission_mode = normalize_permission_mode(
-            args.permission_mode,
-            default=PermissionMode.ASK,
-        ).value
+    effective_permission_mode = _resolve_tui_permission_mode(
+        session,
+        settings,
+        args.permission_mode,
+        resumed=args.resume is not None or bool(args.session),
+    )
+    if session.permission_mode != effective_permission_mode:
+        session.permission_mode = effective_permission_mode
         store.save(session)
 
     from .app import KolegaCodeApp
@@ -391,7 +420,7 @@ def _run_tui(args: argparse.Namespace) -> int:
         settings_store=settings_store,
         overrides=_overrides_from_args(args),
         session=session,
-        permission_mode=args.permission_mode,
+        permission_mode=effective_permission_mode,
         browser_visible=args.browser_visible,
         check_for_updates=True,
         show_logs=args.show_logs,

--- a/kolega_code/cli/settings.py
+++ b/kolega_code/cli/settings.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
+from kolega_code.permissions import PermissionMode
+
 from .session_store import default_state_dir
 
 SETTINGS_SCHEMA_VERSION = 3
@@ -59,6 +61,16 @@ def _coerce_oauth_tokens(raw: object) -> dict[str, dict]:
     return result
 
 
+def _coerce_permission_mode(raw: object) -> str:
+    """Normalize a stored permission mode, falling back safely for old/bad files."""
+    if raw is None:
+        return PermissionMode.ASK.value
+    try:
+        return PermissionMode(str(raw).lower()).value
+    except ValueError:
+        return PermissionMode.ASK.value
+
+
 @dataclass
 class CliSettings:
     active_provider: Optional[str] = None
@@ -83,6 +95,9 @@ class CliSettings:
     # field — absent in older files -> empty mapping, no schema bump (same
     # convention as web_search_backend / active_theme).
     oauth_tokens: dict[str, dict] = field(default_factory=dict)
+    # Global default for new TUI sessions. Resumed sessions keep their own
+    # SessionRecord.permission_mode unless a CLI override is supplied.
+    permission_mode: str = PermissionMode.ASK.value
     schema_version: int = SETTINGS_SCHEMA_VERSION
 
     @classmethod
@@ -109,6 +124,8 @@ class CliSettings:
             web_search_base_url=data.get("web_search_base_url"),
             # Additive optional field; absent in older files -> empty mapping.
             oauth_tokens=_coerce_oauth_tokens(data.get("oauth_tokens")),
+            # Additive optional field; absent in older files -> ask.
+            permission_mode=_coerce_permission_mode(data.get("permission_mode")),
         )
 
     def to_dict(self) -> dict:
@@ -124,6 +141,7 @@ class CliSettings:
             "web_search_backend": self.web_search_backend,
             "web_search_base_url": self.web_search_base_url,
             "oauth_tokens": self.oauth_tokens,
+            "permission_mode": _coerce_permission_mode(self.permission_mode),
         }
 
     def get_api_key(self, provider: str) -> Optional[str]:

--- a/tests/cli/test_app.py
+++ b/tests/cli/test_app.py
@@ -987,8 +987,16 @@ async def test_textual_app_ctrl_p_toggles_permission_mode(
         assert app.permission_mode == PermissionMode.AUTO
         assert app.agent.permission_mode == PermissionMode.AUTO
         assert store.load(session.session_id).permission_mode == "auto"
+        assert SettingsStore(store.root).load().permission_mode == "auto"
         assert "Permissions: auto" in app.conversation_entries[0].content
         assert "Auto" in str(app.query_one("#status_dashboard", Static).render())
+
+        await app._command_permissions("ask")
+
+        assert app.permission_mode == PermissionMode.ASK
+        assert app.agent.permission_mode == PermissionMode.ASK
+        assert store.load(session.session_id).permission_mode == "ask"
+        assert SettingsStore(store.root).load().permission_mode == "ask"
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -6,7 +6,14 @@ import pytest
 
 from kolega_code import __version__
 from kolega_code.config import ModelProvider
-from kolega_code.cli.main import CLI_AGENT_MODE, RESUME_LATEST, _resolve_tui_session, main, parse_args
+from kolega_code.cli.main import (
+    CLI_AGENT_MODE,
+    RESUME_LATEST,
+    _resolve_tui_permission_mode,
+    _resolve_tui_session,
+    main,
+    parse_args,
+)
 from kolega_code.cli.provider_registry import DEEPSEEK_DEFAULT_MODEL, UI_DEFAULT_MODEL, UI_DEFAULT_PROVIDER
 from kolega_code.cli.session_store import SessionStore, SessionStoreError
 from kolega_code.cli.settings import CliSettings, SettingsStore
@@ -524,6 +531,56 @@ def test_tui_legacy_session_alias_loads_specific_session(tmp_path: Path) -> None
 
     assert session.session_id == existing.session_id
     assert session.mode == CLI_AGENT_MODE
+
+
+def test_tui_permission_mode_new_session_uses_settings(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    store = SessionStore(tmp_path / "state")
+    session = _resolve_tui_session(store, project, {}, resume=None, legacy_session_id=None)
+    settings = CliSettings(permission_mode="auto")
+
+    mode = _resolve_tui_permission_mode(session, settings, None, resumed=False)
+
+    assert mode == "auto"
+
+
+def test_tui_permission_mode_cli_overrides_settings(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    store = SessionStore(tmp_path / "state")
+    session = _resolve_tui_session(store, project, {}, resume=None, legacy_session_id=None)
+    settings = CliSettings(permission_mode="auto")
+
+    mode = _resolve_tui_permission_mode(session, settings, "ask", resumed=False)
+
+    assert mode == "ask"
+
+
+def test_tui_permission_mode_resume_uses_session_value(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", {})
+    session.permission_mode = "ask"
+    settings = CliSettings(permission_mode="auto")
+
+    mode = _resolve_tui_permission_mode(session, settings, None, resumed=True)
+
+    assert mode == "ask"
+
+
+def test_tui_permission_mode_cli_overrides_resumed_session(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", {})
+    session.permission_mode = "auto"
+    settings = CliSettings(permission_mode="auto")
+
+    mode = _resolve_tui_permission_mode(session, settings, "ask", resumed=True)
+
+    assert mode == "ask"
 
 
 def _sub_agent_test_event():

--- a/tests/cli/test_settings.py
+++ b/tests/cli/test_settings.py
@@ -31,6 +31,7 @@ def test_settings_store_round_trip_and_file_permissions(tmp_path: Path) -> None:
         active_provider=UI_DEFAULT_PROVIDER,
         active_model=UI_DEFAULT_MODEL,
         active_thinking_effort="auto",
+        permission_mode="auto",
     )
     settings.set_api_key(UI_DEFAULT_PROVIDER, "secret-key")
 
@@ -40,6 +41,7 @@ def test_settings_store_round_trip_and_file_permissions(tmp_path: Path) -> None:
     assert loaded.active_provider == UI_DEFAULT_PROVIDER
     assert loaded.active_model == UI_DEFAULT_MODEL
     assert loaded.active_thinking_effort == "auto"
+    assert loaded.permission_mode == "auto"
     assert loaded.get_api_key(UI_DEFAULT_PROVIDER) == "secret-key"
 
     if os.name != "nt":
@@ -52,6 +54,7 @@ def test_settings_store_missing_file_returns_empty_settings(tmp_path: Path) -> N
     assert settings.active_provider is None
     assert settings.active_model is None
     assert settings.active_thinking_effort is None
+    assert settings.permission_mode == "ask"
     assert settings.api_keys == {}
     assert settings.agent_models == {}
 
@@ -249,6 +252,32 @@ def test_oauth_tokens_absent_in_old_file_default_to_empty() -> None:
     )
 
     assert settings.oauth_tokens == {}
+
+
+def test_permission_mode_absent_in_old_file_defaults_to_ask() -> None:
+    settings = CliSettings.from_dict(
+        {
+            "schema_version": 3,
+            "active_provider": UI_DEFAULT_PROVIDER,
+            "active_model": UI_DEFAULT_MODEL,
+            "api_keys": {UI_DEFAULT_PROVIDER: "k"},
+        }
+    )
+
+    assert settings.permission_mode == "ask"
+
+
+def test_invalid_permission_mode_defaults_to_ask() -> None:
+    settings = CliSettings.from_dict(
+        {
+            "schema_version": 3,
+            "active_provider": UI_DEFAULT_PROVIDER,
+            "active_model": UI_DEFAULT_MODEL,
+            "permission_mode": "dangerously-yolo",
+        }
+    )
+
+    assert settings.permission_mode == "ask"
 
 
 def test_web_search_settings_absent_in_old_file_default_to_none() -> None:


### PR DESCRIPTION
## Summary
- add permission_mode to persistent CLI settings
- resolve TUI startup permission mode from CLI override, resumed session, or saved settings
- persist Ctrl+P and /permissions changes to settings and the current session

## Tests
- pytest tests/cli/test_settings.py tests/cli/test_main.py::test_tui_default_creates_new_session_even_when_latest_exists tests/cli/test_main.py::test_tui_permission_mode_new_session_uses_settings tests/cli/test_main.py::test_tui_permission_mode_cli_overrides_settings tests/cli/test_main.py::test_tui_permission_mode_resume_uses_session_value tests/cli/test_main.py::test_tui_permission_mode_cli_overrides_resumed_session tests/cli/test_app.py::test_textual_app_ctrl_p_toggles_permission_mode
- ruff check kolega_code/cli/settings.py kolega_code/cli/main.py kolega_code/cli/app.py tests/cli/test_settings.py tests/cli/test_main.py tests/cli/test_app.py
- git diff --check