### PR TITLE
chore: release v0.8.3

### DIFF
--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -44,4 +44,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.8.2"
+version = "0.8.3"
 description = "Local-first AI coding agent for the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [options]
 prerelease-mode = "allow"
-exclude-newer = "2026-06-16T12:51:07.553149Z"
+exclude-newer = "2026-06-16T15:17:23.407988Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1098,7 +1098,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.8.2"
+version = "0.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
Prepare `kolega-code` v0.8.3.

This patch release includes changes already merged to `main` since v0.8.2:

- Fixed TUI permission mode persistence:
  - TUI permission mode changes are saved to CLI settings.
  - New TUI sessions use the saved global permission mode.
  - Resumed sessions keep their session-specific permission mode unless explicitly overridden.
- Updated locked `idna` dependency from `3.14` to patched `3.18`.
- Internal maintenance:
  - Moved tests to the top-level `tests/` directory.
  - Externalized the Textual stylesheet to `kolega_code/cli/tui/styles.tcss` and added stylesheet-loading coverage.

## Validation
- [x] `./run_tests.sh`
- [x] `uv run --with build --with twine python -m build`
- [x] `uv run --with twine python -m twine check dist/*`
- [x] `python -m zipfile -l dist/kolega_code-0.8.3-py3-none-any.whl | grep 'kolega_code/cli/tui/styles.tcss'`

## Release checklist
After this PR is reviewed, CI passes, and it is merged:

```bash
git checkout main
git pull origin main
git tag v0.8.3
git push origin v0.8.3
```

Then monitor the Release workflow and verify:

```bash
uv tool install --force kolega-code
kolega-code --version
gh release view v0.8.3 --repo kolega-ai/kolega-code
```
