### PR TITLE
chore: remove unused imports flagged by ruff F401

### DIFF
--- a/kolega_code/agent/tool_backend/list_directory_tool.py
+++ b/kolega_code/agent/tool_backend/list_directory_tool.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from pathlib import Path
 
 from .base_tool import BaseTool

--- a/kolega_code/agent/tool_backend/search_codebase_tool.py
+++ b/kolega_code/agent/tool_backend/search_codebase_tool.py
@@ -1,7 +1,6 @@
 import re
-import os
 from pathlib import Path
-from typing import List, Tuple, Optional, Dict, Any
+from typing import List, Tuple
 
 from .base_tool import BaseTool
 

--- a/kolega_code/models/sandbox_terminal_state.py
+++ b/kolega_code/models/sandbox_terminal_state.py
@@ -1,7 +1,7 @@
 """Sandbox terminal state model for persisting terminal sessions."""
 
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 import uuid
 
 from pydantic import BaseModel, ConfigDict, Field

--- a/kolega_code/sandbox/async_filesystem.py
+++ b/kolega_code/sandbox/async_filesystem.py
@@ -3,9 +3,7 @@
 import os
 import base64
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional, Union, BinaryIO
-from contextlib import contextmanager
-from datetime import datetime
+from typing import Any, Dict, Iterator, List, Optional
 import asyncio
 import nest_asyncio
 
@@ -64,7 +62,6 @@ class AsyncSandboxFileSystem(FileSystem):
             # If we couldn't apply nest_asyncio (e.g., uvloop),
             # we need to use a different approach
             import concurrent.futures
-            import threading
 
             # Create a new event loop in a separate thread
             def run_in_new_loop():

--- a/kolega_code/sandbox/filesystem.py
+++ b/kolega_code/sandbox/filesystem.py
@@ -3,9 +3,7 @@
 import os
 import base64
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional, Union, BinaryIO
-from contextlib import contextmanager
-from datetime import datetime
+from typing import Any, Dict, Iterator, List, Optional
 
 from ..services.file_system import FileSystem
 

--- a/kolega_code/sandbox/serializer.py
+++ b/kolega_code/sandbox/serializer.py
@@ -1,6 +1,6 @@
 """Terminal manager state serialization utilities."""
 
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, List
 from datetime import datetime, timezone
 from kolega_code.models.sandbox_terminal_state import SandboxTerminalState, TerminalInfo, TerminalOutput
 

--- a/kolega_code/sandbox/utils.py
+++ b/kolega_code/sandbox/utils.py
@@ -2,7 +2,7 @@
 
 import logging
 import shlex
-from typing import List, Optional, Dict, Any
+from typing import List, Optional
 from .base import SandboxManager, ProjectManifest
 import yaml
 

--- a/tests/agent/llm/test_anthropic_token_counting.py
+++ b/tests/agent/llm/test_anthropic_token_counting.py
@@ -7,7 +7,6 @@ of Anthropic's official API token counting, using real system prompts and tool d
 
 import os
 from pathlib import Path
-from typing import List
 from unittest.mock import Mock, patch
 
 import pytest
@@ -15,8 +14,7 @@ from dotenv import load_dotenv
 
 from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
 from kolega_code.events import AgentConnectionManager
-from kolega_code.llm.client import LLMClient
-from kolega_code.llm.models import Message, MessageHistory, TextBlock, ImageBlock, ToolDefinition, ToolParameter
+from kolega_code.llm.models import Message, MessageHistory, TextBlock, ImageBlock
 from kolega_code.llm.providers.anthropic import AnthropicProvider
 from kolega_code.agent.prompt_provider import AgentMode, AgentType, PromptContext, PromptProvider
 from kolega_code.agent.tools import ToolCollection, ToolCollectionConfig

--- a/tests/agent/services/test_browser.py
+++ b/tests/agent/services/test_browser.py
@@ -1,7 +1,7 @@
 import datetime
 import os
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock
 from kolega_code.services.browser import PlaywrightBrowserManager
 
 # Check if running in CI environment

--- a/tests/agent/services/test_browser_parity.py
+++ b/tests/agent/services/test_browser_parity.py
@@ -3,7 +3,7 @@
 import datetime
 import os
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from dotenv import load_dotenv
 
 from kolega_code.services.browser import PlaywrightBrowserManager

--- a/tests/agent/services/test_file_system.py
+++ b/tests/agent/services/test_file_system.py
@@ -2,8 +2,6 @@ import os
 import tempfile
 import pytest
 from pathlib import Path
-from unittest.mock import patch, mock_open
-from datetime import datetime
 
 from kolega_code.services.file_system import LocalFileSystem, FileSystemPath
 

--- a/tests/agent/services/test_terminal_state_serializer.py
+++ b/tests/agent/services/test_terminal_state_serializer.py
@@ -1,8 +1,7 @@
 """Unit tests for terminal state serialization."""
 
-import pytest
 from datetime import datetime
-from unittest.mock import Mock, MagicMock
+from unittest.mock import Mock
 from kolega_code.sandbox.serializer import TerminalStateSerializer
 from kolega_code.models.sandbox_terminal_state import SandboxTerminalState, TerminalInfo, TerminalOutput
 

--- a/tests/agent/test_duplicate_tool_results.py
+++ b/tests/agent/test_duplicate_tool_results.py
@@ -4,11 +4,10 @@ Test duplicate tool result prevention logic.
 """
 
 import pytest
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 from kolega_code.agent.baseagent import BaseAgent
 from kolega_code.llm.models import Message, TextBlock, ToolCall, ToolResult
 from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
-from kolega_code.services.file_system import LocalFileSystem
 
 
 class TestDuplicateToolResultPrevention:

--- a/tests/agent/tool_backend/test_browser_tool.py
+++ b/tests/agent/tool_backend/test_browser_tool.py
@@ -1,7 +1,7 @@
 import datetime
 import pytest
 import uuid
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 from kolega_code.agent.tool_backend.browser_tool import BrowserTool
 from kolega_code.config import AgentConfig
 

--- a/tests/agent/tool_backend/test_build_tool.py
+++ b/tests/agent/tool_backend/test_build_tool.py
@@ -1,10 +1,8 @@
-import asyncio
 from pathlib import Path
 
 import pytest
 
 from kolega_code.agent.tool_backend.build_tool import BuildTool
-from kolega_code.agent.tool_backend.base_tool import BaseTool
 
 
 class DummyFS:

--- a/tests/agent/tool_backend/test_glob_tool_sandbox_parity.py
+++ b/tests/agent/tool_backend/test_glob_tool_sandbox_parity.py
@@ -1,5 +1,3 @@
-import os
-import time
 from pathlib import Path
 from typing import Any, List
 


### PR DESCRIPTION
## Summary

Removes 37 unused imports (ruff rule **F401**) across 16 files — 7 source, 9 test. These are dead imports that ruff already detects (F401 is part of ruff's default `F` ruleset) but accumulated because CI does not currently gate on `ruff check`.

Applied via ruff's built-in autofix, which trims only the unused names from multi-name import lines and drops now-empty statements.

## Verification

- `ruff check --select F401 .` → `All checks passed!` (clean)
- `ruff check .` (full default set) → no new errors introduced (default error count dropped 71 → 34, exactly the 37 F401s removed)
- `./run_tests.sh` (fast suite) → **1364 passed, 50 deselected**

## Files

**Source (`kolega_code/`):** `list_directory_tool.py`, `search_codebase_tool.py`, `sandbox_terminal_state.py`, `sandbox/async_filesystem.py`, `sandbox/filesystem.py`, `sandbox/serializer.py`, `sandbox/utils.py`

**Tests (`tests/`):** `test_anthropic_token_counting.py`, `test_browser.py`, `test_browser_parity.py`, `test_file_system.py`, `test_terminal_state_serializer.py`, `test_duplicate_tool_results.py`, `test_browser_tool.py`, `test_build_tool.py`, `test_glob_tool_sandbox_parity.py`

## Out of scope

F401 is already enforced by ruff's defaults, but `.github/workflows/ci.yml` only runs `./run_tests.sh` and does not gate on `ruff check` — which is how these accumulated. Adding a lint step to CI would prevent regression; left out of this PR unless desired.