### PR TITLE
fix(tui): restore chat focus after app resume and cancel

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -394,7 +394,7 @@ class KolegaCodeApp(
         if self.config is not None:
             await self._build_agent(self.config)
             self._set_chat_enabled(True)
-            self.query_one("#composer", tui_widgets.ChatComposer).focus()
+            self._schedule_primary_focus_restore()
         else:
             await self._ensure_agent_from_settings()
 
@@ -753,6 +753,12 @@ class KolegaCodeApp(
         # we run after any AUTO_FOCUS/_reset_focus the same blur triggered.
         self.call_after_refresh(self._heal_prompt_focus)
 
+    def on_app_focus(self, event: events.AppFocus) -> None:
+        # When a terminal window regains OS focus, the next likely action is typing
+        # a prompt. Defer so this runs after Textual's resume/auto-focus churn, while
+        # still respecting active prompt lists and disabled composer states.
+        self._schedule_primary_focus_restore()
+
     async def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
         if event.option_list.id == "question_actions":
             event.stop()
@@ -930,12 +936,7 @@ class KolegaCodeApp(
         except Exception:
             return
         if not visible:
-            try:
-                composer = self.query_one("#composer", tui_widgets.ChatComposer)
-                if not composer.disabled:
-                    composer.focus()
-            except Exception:
-                return
+            self._schedule_primary_focus_restore()
 
     async def _set_interaction_mode(self, interaction_mode: str) -> None:
         if interaction_mode not in {tui_constants.BUILD_INTERACTION_MODE, tui_constants.PLAN_INTERACTION_MODE}:
@@ -1042,7 +1043,7 @@ class KolegaCodeApp(
         self._set_plan_actions_visible(False)
         self._restore_composer_placeholder()
         self._set_chat_enabled(self.agent is not None)
-        self.query_one("#composer", tui_widgets.ChatComposer).focus()
+        self._schedule_primary_focus_restore()
         self._notify_user(messages.PLAN_DISCUSSION_RESUMED)
 
     def _active_prompt_actions(self) -> Optional[tui_widgets.ActionList]:
@@ -1073,6 +1074,40 @@ class KolegaCodeApp(
                 return None
             return actions if actions.display else None
         return None
+
+    def _restore_primary_focus(self) -> None:
+        """Focus the highest-priority input target for the current TUI state.
+
+        Prompt/action lists keep keyboard ownership while they are active. In the
+        normal chat state, the composer is the primary input target, but only when
+        it is enabled and the main screen is visible.
+        """
+        try:
+            if len(self.screen_stack) != 1:
+                return
+        except Exception:
+            return
+
+        if self._active_prompt_actions() is not None:
+            self._heal_prompt_focus()
+            return
+
+        try:
+            composer = self.query_one("#composer", tui_widgets.ChatComposer)
+        except Exception:
+            return
+
+        if composer.disabled or self.screen.focused is composer:
+            return
+        self.screen.set_focus(composer)
+
+    def _schedule_primary_focus_restore(self) -> None:
+        """Restore focus now and after refresh to beat Textual focus churn."""
+        self._restore_primary_focus()
+        try:
+            self.call_after_refresh(self._restore_primary_focus)
+        except Exception:
+            pass
 
     def _focus_active_prompt(self) -> None:
         """Focus the active prompt list now and re-assert after the refresh settles.

--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -17,13 +17,13 @@ from ..config import CliConfigError, build_agent_config, config_summary
 from ..skills import build_skill_prompt_extension, build_skill_tool_extension, discover_skills
 from . import constants as tui_constants
 from . import state as tui_state
-from . import widgets as tui_widgets
 
 
 class AgentRuntimeMixin:
     async def _process_message(self, message: str, attachments: list[dict] | None = None) -> None:
         if self.agent is None:
             return
+        cancelled_by_user = False
         self._begin_turn_progress()
         self._log_status(messages.GENERATING, "ok")
         try:
@@ -55,6 +55,7 @@ class AgentRuntimeMixin:
             await self._capture_completed_plan()
             self._log_status(messages.FINISHED, "ok")
         except asyncio.CancelledError:
+            cancelled_by_user = True
             self._cancel_pending_question()
             self._cancel_pending_approval()
             await self._drain_pending_events()
@@ -94,6 +95,8 @@ class AgentRuntimeMixin:
             else:
                 self._restore_composer_placeholder()
             self._set_chat_enabled(self.agent is not None and not self._plan_decision_active)
+            if cancelled_by_user:
+                self._schedule_primary_focus_restore()
 
     async def _consume_events(self) -> None:
         while True:
@@ -205,7 +208,7 @@ class AgentRuntimeMixin:
         self._set_chat_enabled(True)
         self._update_settings_status()
         self._ensure_startup_entry()
-        self.query_one("#composer", tui_widgets.ChatComposer).focus()
+        self._schedule_primary_focus_restore()
 
     async def _build_agent(
         self,

--- a/kolega_code/cli/tui/sub_agent_screen.py
+++ b/kolega_code/cli/tui/sub_agent_screen.py
@@ -332,6 +332,7 @@ class SubAgentInspectorScreen(ModalScreen):
     def action_close(self) -> None:
         self._owner._sub_agent_inspector = None
         self.dismiss()
+        self._owner._schedule_primary_focus_restore()
 
     def action_toggle_follow(self) -> None:
         self._follow = not self._follow

--- a/tests/cli/test_app_focus_behavior.py
+++ b/tests/cli/test_app_focus_behavior.py
@@ -1,0 +1,157 @@
+from pathlib import Path
+import asyncio
+
+import pytest
+
+from kolega_code.cli.config import config_summary
+from kolega_code.cli.session_store import SessionStore
+from kolega_code.permissions import PermissionDecision, allow_rule_options, permission_request_for_tool
+
+from ._app_test_utils import MinimalFakeCoderAgent, build_test_config, install_fake_agents
+
+
+def _build_focus_test_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.app import KolegaCodeApp
+
+    install_fake_agents(monkeypatch, coder_cls=MinimalFakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    return KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+
+async def _wait_for_focus(pilot, app, widget) -> None:
+    for _ in range(5):
+        await pilot.pause()
+        if app.focused is widget:
+            return
+
+
+@pytest.mark.asyncio
+async def test_app_focus_refocuses_idle_chat_composer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("textual")
+
+    from textual import events
+
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    app = _build_focus_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        conversation = app.query_one("#conversation")
+
+        app.screen.set_focus(conversation)
+        await pilot.pause()
+        assert app.focused is conversation
+
+        app.on_app_focus(events.AppFocus())
+        await _wait_for_focus(pilot, app, composer)
+
+        assert composer.disabled is False
+        assert app.focused is composer
+
+
+@pytest.mark.asyncio
+async def test_app_focus_keeps_active_approval_prompt_focused(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("textual")
+
+    from textual import events
+
+    from kolega_code.cli.tui.state import PendingApproval
+    from kolega_code.cli.tui.widgets import ActionList
+
+    app = _build_focus_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        request = permission_request_for_tool("exec_command", {"command": "npm test"})
+        assert request is not None
+        future: asyncio.Future[PermissionDecision] = asyncio.get_running_loop().create_future()
+        app._pending_approval = PendingApproval(
+            request=request,
+            future=future,
+            rule_options=allow_rule_options(request),
+        )
+        app._set_approval_actions_visible(True)
+        app._set_chat_enabled(False)
+
+        approval_actions = app.query_one("#approval_actions", ActionList)
+        assert app.focused is approval_actions
+
+        app.on_app_focus(events.AppFocus())
+        await _wait_for_focus(pilot, app, approval_actions)
+
+        assert app.focused is approval_actions
+
+        app._pending_approval = None
+        app._set_approval_actions_visible(False)
+
+
+@pytest.mark.asyncio
+async def test_app_focus_preserves_question_free_form_composer_focus(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual import events
+
+    from kolega_code.cli.tui.state import PendingQuestion
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    app = _build_focus_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+        app._pending_question = PendingQuestion(question="Choose?", options=["A", "B"], future=future)
+        app._show_question_options("Choose?", ["A", "B"])
+        app._set_chat_enabled(True)
+
+        composer = app.query_one("#composer", ChatComposer)
+        app.screen.set_focus(composer)
+        await pilot.pause()
+        assert app.focused is composer
+
+        app.on_app_focus(events.AppFocus())
+        await _wait_for_focus(pilot, app, composer)
+
+        assert composer.disabled is False
+        assert app.focused is composer
+
+        app._pending_question = None
+        app._set_question_actions_visible(False)
+
+
+@pytest.mark.asyncio
+async def test_app_focus_heals_question_drift_to_options(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("textual")
+
+    from textual import events
+
+    from kolega_code.cli.tui.state import PendingQuestion
+    from kolega_code.cli.tui.widgets import ActionList
+
+    app = _build_focus_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+        app._pending_question = PendingQuestion(question="Choose?", options=["A", "B"], future=future)
+        app._show_question_options("Choose?", ["A", "B"])
+        app._set_chat_enabled(True)
+
+        question_actions = app.query_one("#question_actions", ActionList)
+        assert app.focused is question_actions
+
+        app.screen.set_focus(app.query_one("#conversation"))
+        await pilot.pause()
+        app.on_app_focus(events.AppFocus())
+        await _wait_for_focus(pilot, app, question_actions)
+
+        assert app.focused is question_actions
+
+        app._pending_question = None
+        app._set_question_actions_visible(False)

--- a/tests/cli/test_app_rendering_errors.py
+++ b/tests/cli/test_app_rendering_errors.py
@@ -92,27 +92,32 @@ async def test_textual_app_cancellation_is_visible_in_chat(tmp_path: Path, monke
     now = 10.0
     monkeypatch.setattr(app, "_now", lambda: now)
 
-    async with app.run_test():
+    async with app.run_test() as pilot:
         composer = app.query_one("#composer", ChatComposer)
         turn_status = app.query_one("#turn_status", Static)
         task = asyncio.create_task(app._process_message("hi"))
         app.agent_worker = task
         await started.wait()
 
-        now = 52.0
-        app.action_cancel_generation()
-        progress_entries = [entry for entry in app.conversation_entries if entry.kind == "progress"]
-        assert progress_entries == []
-        assert composer.placeholder == COMPOSER_PLACEHOLDER
-        assert "Stopping…" in str(turn_status.render())
-        assert "42s" in str(turn_status.render())
+        app.screen.set_focus(app.query_one("#conversation"))
+        await pilot.pause()
+        assert composer.disabled is True
 
+        now = 52.0
+        await pilot.press("ctrl+c")
         await task
+        for _ in range(5):
+            await pilot.pause()
+            if app.focused is composer:
+                break
 
         progress_entries = [entry for entry in app.conversation_entries if entry.kind == "progress"]
         assert len(progress_entries) == 1
         assert progress_entries[0].content == "Stopped by user."
         assert progress_entries[0].complete is True
+        assert app.agent_worker is None
+        assert composer.disabled is False
+        assert app.focused is composer
         assert composer.placeholder == COMPOSER_PLACEHOLDER
         assert "Stopped after 42s" in str(turn_status.render())
 

--- a/tests/cli/test_app_sub_agents_workflows.py
+++ b/tests/cli/test_app_sub_agents_workflows.py
@@ -442,6 +442,32 @@ async def test_open_sub_agent_inspector_renders_trajectory(tmp_path: Path, monke
 
 
 @pytest.mark.asyncio
+async def test_sub_agent_inspector_close_refocuses_idle_composer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        app._render_event(_sub_agent_event(uuid="r1", text="some response"))
+        app.action_open_sub_agent()
+        await pilot.pause()
+
+        screen = app._sub_agent_inspector
+        assert screen is not None
+        screen.action_close()
+        composer = app.query_one("#composer", ChatComposer)
+        for _ in range(5):
+            await pilot.pause()
+            if app.focused is composer:
+                break
+
+        assert composer.disabled is False
+        assert app.focused is composer
+
+
+@pytest.mark.asyncio
 async def test_sub_agent_inspector_switches_agents(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     app = _build_sub_agent_test_app(tmp_path, monkeypatch)
 


### PR DESCRIPTION
## Summary
- add centralized TUI primary-focus restoration for prompts vs chat composer
- refocus the chat composer after user cancellation completes and when the terminal regains focus
- restore composer focus after closing the sub-agent inspector when chat is idle

## Tests
- pytest tests/cli/test_app_focus_behavior.py tests/cli/test_app_rendering_errors.py::test_textual_app_cancellation_is_visible_in_chat tests/cli/test_app_sub_agents_workflows.py::test_sub_agent_inspector_close_refocuses_idle_composer tests/cli/test_app_misc_commands.py::test_textual_app_prompt_list_recovers_focus_after_drift tests/cli/test_app_misc_commands.py::test_textual_app_question_recovers_focus_but_allows_free_form_answer tests/cli/test_app_permission_prompts.py::test_textual_app_permission_approval_actions_show_rule_labels_without_descriptions
- ruff check kolega_code/cli/app.py kolega_code/cli/tui/agent_runtime.py kolega_code/cli/tui/sub_agent_screen.py tests/cli/test_app_focus_behavior.py tests/cli/test_app_rendering_errors.py tests/cli/test_app_sub_agents_workflows.py