### PR TITLE
fix(tui): allow ctrl-u to clear multiline composer drafts

### DIFF
--- a/docs/src/content/docs/tui/composer.md
+++ b/docs/src/content/docs/tui/composer.md
@@ -14,6 +14,7 @@ multi-line input, and drives the option lists the agent shows you.
 | `Enter` | Send the prompt |
 | `Shift+Enter` | Insert a newline (keep typing) |
 | `Ctrl+J` | Insert a newline (alternative) |
+| `Ctrl+U` | Delete backward to the start of the line; at line start, delete the previous line |
 
 ## File mentions with `@`
 

--- a/kolega_code/cli/tui/widgets.py
+++ b/kolega_code/cli/tui/widgets.py
@@ -589,6 +589,30 @@ class ChatComposer(TextArea):
     def action_insert_newline(self) -> None:
         self.insert("\n", maintain_selection_offset=False)
 
+    def action_delete_to_start_of_line(self) -> None:
+        """Delete backward with multi-line repeat behavior for chat drafts.
+
+        Textual's default Ctrl+U deletes to the start of the current line and
+        then no-ops when the cursor is already at column 0. In the composer that
+        makes held Ctrl+U get stuck while clearing multi-line prompts, so at the
+        start of a non-first line we consume the previous line and its newline.
+        """
+        if self.read_only:
+            return
+
+        selection = self.selection
+        start, end = selection
+        if not selection.is_empty:
+            self._delete_via_keyboard(start, end)
+            return
+
+        row, col = self.cursor_location
+        if col > 0:
+            self._delete_via_keyboard((row, col), (row, 0))
+            return
+        if row > 0:
+            self._delete_via_keyboard((row - 1, 0), (row, 0))
+
     def action_mention_prev(self) -> None:
         dropdown = self.mention_dropdown()
         if dropdown is not None and dropdown.is_open:

--- a/tests/cli/test_app_composer_input.py
+++ b/tests/cli/test_app_composer_input.py
@@ -154,6 +154,82 @@ async def test_textual_app_composer_ctrl_enter_still_inserts_line_break(
 
 
 @pytest.mark.asyncio
+async def test_textual_app_composer_repeated_ctrl_u_clears_multiline_draft(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    app = _build_mention_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        composer.focus()
+        composer.load_text("one\ntwo\nthree")
+        composer.move_cursor(composer.document.end, record_width=False)
+
+        await pilot.press("ctrl+u", "ctrl+u", "ctrl+u")
+
+        assert composer.text == ""
+        assert composer.cursor_location == (0, 0)
+
+
+@pytest.mark.asyncio
+async def test_textual_app_composer_ctrl_u_preserves_within_line_behavior(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    app = _build_mention_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        composer.focus()
+
+        composer.load_text("abc def")
+        composer.move_cursor(composer.document.end, record_width=False)
+        await pilot.press("ctrl+u")
+        assert composer.text == ""
+        assert composer.cursor_location == (0, 0)
+
+        composer.load_text("one\ntwo\nthree")
+        composer.move_cursor((1, 2), record_width=False)
+        await pilot.press("ctrl+u")
+        assert composer.text == "one\no\nthree"
+        assert composer.cursor_location == (1, 0)
+
+
+@pytest.mark.asyncio
+async def test_textual_app_composer_ctrl_u_boundaries_and_selection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    app = _build_mention_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        composer.focus()
+
+        composer.load_text("abc")
+        composer.move_cursor((0, 0), record_width=False)
+        await pilot.press("ctrl+u")
+        assert composer.text == "abc"
+        assert composer.cursor_location == (0, 0)
+
+        composer.load_text("one\ntwo")
+        composer.selection = composer.selection.__class__((0, 1), (0, 3))
+        await pilot.press("ctrl+u")
+        assert composer.text == "o\ntwo"
+        assert composer.cursor_location == (0, 1)
+
+
+@pytest.mark.asyncio
 async def test_textual_app_composer_preserves_multiline_paste(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     pytest.importorskip("textual")
 


### PR DESCRIPTION
## Summary
- make composer Ctrl+U continue deleting upward through multi-line drafts
- preserve within-line and selection deletion behavior
- document Ctrl+U in the composer key reference

## Tests
- pytest tests/cli/test_app_composer_input.py