### PR TITLE
fix(tui): add composer select all shortcut

### DIFF
--- a/docs/src/content/docs/tui/composer.md
+++ b/docs/src/content/docs/tui/composer.md
@@ -14,7 +14,15 @@ multi-line input, and drives the option lists the agent shows you.
 | `Enter` | Send the prompt |
 | `Shift+Enter` | Insert a newline (keep typing) |
 | `Ctrl+J` | Insert a newline (alternative) |
+| `Ctrl+L` | Select all composer text |
+| `Cmd+A` / `⌘A` | Select all composer text on macOS, when forwarded by the terminal |
+| `Ctrl+A` | Move to the start of the current line (intentionally not select-all) |
 | `Ctrl+U` | Delete backward to the start of the line; at line start, delete the previous line |
+
+`Ctrl+L` is the portable select-all shortcut because `Ctrl+A` is preserved for
+terminal-style line navigation. Some macOS terminal emulators reserve `Cmd+A` for
+terminal scrollback selection before the TUI can see it; `Ctrl+L` still works in
+the composer.
 
 ## File mentions with `@`
 

--- a/docs/src/content/docs/tui/composer.md
+++ b/docs/src/content/docs/tui/composer.md
@@ -24,15 +24,6 @@ terminal-style line navigation. Some macOS terminal emulators reserve `Cmd+A` fo
 terminal scrollback selection before the TUI can see it; `Ctrl+L` still works in
 the composer.
 
-Ghostty on macOS binds `Cmd+A` to terminal scrollback selection by default. To
-forward it to Kolega Code instead, add this to your Ghostty config:
-
-```ini
-keybind = cmd+a=csi:97;9u
-```
-
-That emits the enhanced keyboard sequence Textual reads as `super+a`.
-
 ## File mentions with `@`
 
 Type `@` to reference a file. A fuzzy-searchable dropdown of project files appears

--- a/docs/src/content/docs/tui/composer.md
+++ b/docs/src/content/docs/tui/composer.md
@@ -24,6 +24,15 @@ terminal-style line navigation. Some macOS terminal emulators reserve `Cmd+A` fo
 terminal scrollback selection before the TUI can see it; `Ctrl+L` still works in
 the composer.
 
+Ghostty on macOS binds `Cmd+A` to terminal scrollback selection by default. To
+forward it to Kolega Code instead, add this to your Ghostty config:
+
+```ini
+keybind = cmd+a=csi:97;9u
+```
+
+That emits the enhanced keyboard sequence Textual reads as `super+a`.
+
 ## File mentions with `@`
 
 Type `@` to reference a file. A fuzzy-searchable dropdown of project files appears

--- a/kolega_code/cli/tui/widgets.py
+++ b/kolega_code/cli/tui/widgets.py
@@ -489,6 +489,8 @@ class ChatComposer(TextArea):
         Binding(
             "shift+enter,ctrl+enter,ctrl+j", "insert_newline", "New line", key_display="Shift+Enter", priority=True
         ),
+        Binding("ctrl+l", "select_all", "Select all", key_display="Ctrl+L", priority=True),
+        Binding("super+a", "select_all", "Select all", show=False, key_display="Cmd+A", priority=True),
         Binding("up", "mention_prev", "Previous match", show=False, priority=True),
         Binding("down", "mention_next", "Next match", show=False, priority=True),
         Binding("tab", "mention_accept", "Complete path", show=False, priority=True),

--- a/tests/cli/test_app_composer_input.py
+++ b/tests/cli/test_app_composer_input.py
@@ -230,6 +230,87 @@ async def test_textual_app_composer_ctrl_u_boundaries_and_selection(
 
 
 @pytest.mark.asyncio
+async def test_textual_app_composer_ctrl_l_selects_all_and_backspace_clears_draft(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    app = _build_mention_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        composer.focus()
+        draft = "one\ntwo\nthree"
+        composer.load_text(draft)
+        composer.move_cursor(composer.document.end, record_width=False)
+
+        await pilot.press("ctrl+l")
+
+        assert composer.selected_text == draft
+        assert composer.selection.start == (0, 0)
+        assert composer.selection.end == composer.document.end
+
+        await pilot.press("backspace")
+
+        assert composer.text == ""
+        assert composer.cursor_location == (0, 0)
+
+
+@pytest.mark.asyncio
+async def test_textual_app_composer_cmd_a_selects_all_and_backspace_clears_draft(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    app = _build_mention_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        composer.focus()
+        draft = "one\ntwo\nthree"
+        composer.load_text(draft)
+        composer.move_cursor(composer.document.end, record_width=False)
+
+        await pilot.press("super+a")
+
+        assert composer.selected_text == draft
+        assert composer.selection.start == (0, 0)
+        assert composer.selection.end == composer.document.end
+
+        await pilot.press("backspace")
+
+        assert composer.text == ""
+        assert composer.cursor_location == (0, 0)
+
+
+@pytest.mark.asyncio
+async def test_textual_app_composer_ctrl_a_still_moves_to_start_of_line(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    app = _build_mention_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        composer.focus()
+        composer.load_text("one\ntwo\nthree")
+        composer.move_cursor((1, 2), record_width=False)
+
+        await pilot.press("ctrl+a")
+
+        assert composer.cursor_location == (1, 0)
+        assert composer.selected_text == ""
+        assert composer.text == "one\ntwo\nthree"
+
+
+@pytest.mark.asyncio
 async def test_textual_app_composer_preserves_multiline_paste(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     pytest.importorskip("textual")
 


### PR DESCRIPTION
## Summary
- add composer select-all bindings for Ctrl+L and macOS Cmd+A/super+a
- preserve Ctrl+A as line-start behavior
- document the cross-platform shortcut and macOS terminal caveat

## Tests
- pytest tests/cli/test_app_composer_input.py