### PR TITLE
fix(tui): restore prompt focus from composer

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -1122,6 +1122,48 @@ class KolegaCodeApp(
             self.screen.set_focus(actions)
         self.call_after_refresh(self._heal_prompt_focus)
 
+    def _focus_active_prompt_from_composer(self) -> bool:
+        """Move keyboard focus from the composer back to the active option list.
+
+        Planning questions intentionally allow composer focus for custom answers.
+        When the user wants to return to the visible options, ChatComposer calls
+        this helper from its top-line Up key handling. Returns True only when the
+        handoff happened, so the composer can otherwise keep normal cursor motion.
+        """
+        actions = self._active_prompt_actions()
+        if actions is None:
+            return False
+
+        try:
+            composer = self.query_one("#composer", tui_widgets.ChatComposer)
+        except Exception:
+            return False
+
+        if composer.disabled or self.screen.focused is not composer:
+            return False
+
+        if actions.option_count:
+            actions.highlighted = actions.option_count - 1
+        self.screen.set_focus(actions)
+        return True
+
+    def _focus_composer_from_active_prompt(self, actions: tui_widgets.ActionList) -> bool:
+        """Move keyboard focus from the bottom of an active option list to composer."""
+        active_actions = self._active_prompt_actions()
+        if active_actions is None or active_actions is not actions:
+            return False
+
+        try:
+            composer = self.query_one("#composer", tui_widgets.ChatComposer)
+        except Exception:
+            return False
+
+        if composer.disabled or self.screen.focused is not actions:
+            return False
+
+        self.screen.set_focus(composer)
+        return True
+
     def _heal_prompt_focus(self) -> None:
         """Re-grab focus for the active prompt list if it has drifted. Idempotent.
 

--- a/kolega_code/cli/tui/widgets.py
+++ b/kolega_code/cli/tui/widgets.py
@@ -433,6 +433,14 @@ class ActionList(OptionList):
             if not composer.disabled:
                 composer.focus()
 
+    def action_cursor_down(self) -> None:
+        """Move down through options, or from the bottom option into composer."""
+        if self.option_count and self.highlighted == self.option_count - 1:
+            focus_composer = getattr(self.app, "_focus_composer_from_active_prompt", None)
+            if callable(focus_composer) and focus_composer(self):
+                return
+        super().action_cursor_down()
+
     def on_key(self, event: events.Key) -> None:
         if event.character and event.character.isdigit():
             index = int(event.character) - 1
@@ -614,6 +622,25 @@ class ChatComposer(TextArea):
             return
         if row > 0:
             self._delete_via_keyboard((row - 1, 0), (row, 0))
+
+    def action_cursor_up(self, select: bool = False) -> None:
+        """Move up in the draft, or from the top line back to active options."""
+        if select:
+            super().action_cursor_up(select)
+            return
+
+        dropdown = self.mention_dropdown()
+        if dropdown is not None and dropdown.is_open:
+            dropdown.action_cursor_up()
+            return
+
+        row, _ = self.cursor_location
+        if row == 0:
+            focus_prompt = getattr(self.app, "_focus_active_prompt_from_composer", None)
+            if callable(focus_prompt) and focus_prompt():
+                return
+
+        super().action_cursor_up(select)
 
     def action_mention_prev(self) -> None:
         dropdown = self.mention_dropdown()

--- a/tests/cli/test_app_focus_behavior.py
+++ b/tests/cli/test_app_focus_behavior.py
@@ -155,3 +155,144 @@ async def test_app_focus_heals_question_drift_to_options(tmp_path: Path, monkeyp
 
         app._pending_question = None
         app._set_question_actions_visible(False)
+
+
+@pytest.mark.asyncio
+async def test_question_composer_top_line_up_returns_focus_to_options(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.state import PendingQuestion
+    from kolega_code.cli.tui.widgets import ActionList, ChatComposer
+
+    app = _build_focus_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+        app._pending_question = PendingQuestion(question="Choose?", options=["A", "B"], future=future)
+        app._show_question_options("Choose?", ["A", "B"])
+        app._set_chat_enabled(True)
+
+        composer = app.query_one("#composer", ChatComposer)
+        question_actions = app.query_one("#question_actions", ActionList)
+        app.screen.set_focus(composer)
+        await pilot.pause()
+        assert app.focused is composer
+        assert composer.cursor_location[0] == 0
+
+        await pilot.press("up")
+        assert app.focused is question_actions
+        assert question_actions.highlighted == 1
+
+        await pilot.press("enter")
+        assert await future == "B"
+        assert app._pending_question is None
+
+
+@pytest.mark.asyncio
+async def test_question_composer_multiline_up_keeps_editor_focus(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.state import PendingQuestion
+    from kolega_code.cli.tui.widgets import ActionList, ChatComposer
+
+    app = _build_focus_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+        app._pending_question = PendingQuestion(question="Choose?", options=["A", "B"], future=future)
+        app._show_question_options("Choose?", ["A", "B"])
+        app._set_chat_enabled(True)
+
+        composer = app.query_one("#composer", ChatComposer)
+        question_actions = app.query_one("#question_actions", ActionList)
+        composer.load_text("one\ntwo")
+        composer.move_cursor((1, 1), record_width=False)
+        app.screen.set_focus(composer)
+        await pilot.pause()
+        assert app.focused is composer
+
+        await pilot.press("up")
+
+        assert app.focused is composer
+        assert app.focused is not question_actions
+        assert composer.cursor_location[0] == 0
+
+        app._pending_question = None
+        app._set_question_actions_visible(False)
+
+
+@pytest.mark.asyncio
+async def test_question_composer_dropdown_up_keeps_completion_navigation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.file_index import IndexEntry
+    from kolega_code.cli.tui.state import PendingQuestion
+    from kolega_code.cli.tui.widgets import ActionList, ChatComposer, CompletionDropdown, CompletionItem
+
+    app = _build_focus_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+        app._pending_question = PendingQuestion(question="Choose?", options=["A", "B"], future=future)
+        app._show_question_options("Choose?", ["A", "B"])
+        app._set_chat_enabled(True)
+
+        composer = app.query_one("#composer", ChatComposer)
+        question_actions = app.query_one("#question_actions", ActionList)
+        dropdown = app.query_one("#completion_dropdown", CompletionDropdown)
+        app.screen.set_focus(composer)
+        await pilot.pause()
+        assert app.focused is composer
+        dropdown.open_with(
+            [
+                CompletionItem(prompt="alpha.py", value=IndexEntry(path="alpha.py", is_dir=False)),
+                CompletionItem(prompt="beta.py", value=IndexEntry(path="beta.py", is_dir=False)),
+            ]
+        )
+        dropdown.highlighted = 1
+        assert dropdown.is_open is True
+
+        await pilot.press("up")
+
+        assert app.focused is composer
+        assert app.focused is not question_actions
+        assert dropdown.highlighted == 0
+
+        app._pending_question = None
+        app._set_question_actions_visible(False)
+
+
+@pytest.mark.asyncio
+async def test_question_actions_bottom_down_focuses_composer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.state import PendingQuestion
+    from kolega_code.cli.tui.widgets import ActionList, ChatComposer
+
+    app = _build_focus_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+        app._pending_question = PendingQuestion(question="Choose?", options=["A", "B", "C"], future=future)
+        app._show_question_options("Choose?", ["A", "B", "C"])
+        app._set_chat_enabled(True)
+
+        composer = app.query_one("#composer", ChatComposer)
+        question_actions = app.query_one("#question_actions", ActionList)
+        assert app.focused is question_actions
+        question_actions.highlighted = question_actions.option_count - 1
+
+        await pilot.press("down")
+
+        assert composer.disabled is False
+        assert app.focused is composer
+        assert question_actions.highlighted == question_actions.option_count - 1
+
+        app._pending_question = None
+        app._set_question_actions_visible(False)


### PR DESCRIPTION
## Summary
- let Up from the composer top line return focus to the active prompt option list
- highlight the bottom option when returning from the composer
- let Down from the bottom prompt option focus the enabled composer
- add regression coverage for prompt/composer keyboard navigation

## Tests
- pytest tests/cli/test_app_focus_behavior.py tests/cli/test_app_planning_questions.py tests/cli/test_app_composer_input.py -q
- ruff check kolega_code/cli/app.py kolega_code/cli/tui/widgets.py tests/cli/test_app_focus_behavior.py