### PR TITLE
fix(tui): optimize planning sidebar markdown

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -21,7 +21,6 @@ from textual.widgets import (
     Footer,
     Input,
     Label,
-    Markdown,
     OptionList,
     Select,
     Static,
@@ -274,9 +273,17 @@ class KolegaCodeApp(
                     with TabPane("Planning", id="planning_pane"):
                         with VerticalScroll(id="planning_form"):
                             with Collapsible(title="Plan", collapsed=False, id="planning_plan"):
-                                yield Markdown(messages.PLAN_EMPTY_MESSAGE, id="planning_plan_markdown")
+                                yield tui_widgets.PlanningMarkdown(
+                                    messages.PLAN_EMPTY_MESSAGE,
+                                    id="planning_plan_markdown",
+                                    empty_source=messages.PLAN_EMPTY_MESSAGE,
+                                )
                             with Collapsible(title="Task List", collapsed=False, id="planning_task_list"):
-                                yield Markdown(messages.TASK_LIST_EMPTY_MESSAGE, id="planning_task_list_markdown")
+                                yield tui_widgets.PlanningMarkdown(
+                                    messages.TASK_LIST_EMPTY_MESSAGE,
+                                    id="planning_task_list_markdown",
+                                    empty_source=messages.TASK_LIST_EMPTY_MESSAGE,
+                                )
                     with TabPane("Settings", id="settings_pane"):
                         with VerticalScroll(id="settings_form"):
                             with Vertical(classes="settings-section", id="settings_model") as model_section:
@@ -1102,10 +1109,28 @@ class KolegaCodeApp(
         self.screen.set_focus(composer)
 
     def _schedule_primary_focus_restore(self) -> None:
-        """Restore focus now and after refresh to beat Textual focus churn."""
+        """Restore focus now and after refresh to beat Textual focus churn.
+
+        The deferred restore is only a re-assertion of the focus we just set. If
+        focus moves before the next refresh (for example, a user clicks or a test
+        deliberately focuses the transcript), do not yank it back to the composer.
+        """
         self._restore_primary_focus()
         try:
-            self.call_after_refresh(self._restore_primary_focus)
+            scheduled_focus = self.screen.focused
+        except Exception:
+            scheduled_focus = None
+
+        def restore_if_unchanged() -> None:
+            try:
+                current_focus = self.screen.focused
+            except Exception:
+                return
+            if current_focus is None or current_focus is scheduled_focus:
+                self._restore_primary_focus()
+
+        try:
+            self.call_after_refresh(restore_if_unchanged)
         except Exception:
             pass
 
@@ -1279,8 +1304,8 @@ class KolegaCodeApp(
         plan_content = self._latest_plan or messages.PLAN_EMPTY_MESSAGE
         task_list_content = self.session.task_list_markdown or messages.TASK_LIST_EMPTY_MESSAGE
         try:
-            plan_markdown = self.query_one("#planning_plan_markdown", Markdown)
-            task_list_markdown = self.query_one("#planning_task_list_markdown", Markdown)
+            plan_markdown = self.query_one("#planning_plan_markdown", tui_widgets.PlanningMarkdown)
+            task_list_markdown = self.query_one("#planning_task_list_markdown", tui_widgets.PlanningMarkdown)
             plan_markdown.update(plan_content)
             task_list_markdown.update(task_list_content)
             plan_markdown.set_class(plan_content == messages.PLAN_EMPTY_MESSAGE, "empty-state")

--- a/kolega_code/cli/tui/styles.tcss
+++ b/kolega_code/cli/tui/styles.tcss
@@ -129,7 +129,11 @@ ToolEntryWidget .tool-body {
     margin-top: 1;
 }
 
-#planning_form Markdown.empty-state {
+#planning_form PlanningMarkdown {
+    height: auto;
+}
+
+#planning_form PlanningMarkdown.empty-state {
     color: $text-muted;
 }
 

--- a/kolega_code/cli/tui/widgets.py
+++ b/kolega_code/cli/tui/widgets.py
@@ -6,6 +6,7 @@ import re
 from dataclasses import dataclass
 from typing import Callable, Optional
 
+from rich.markdown import Markdown as RichMarkdown
 from rich.segment import Segment
 from rich.style import Style
 from rich.text import Text
@@ -20,6 +21,7 @@ from textual.widgets import Collapsible, OptionList, RichLog, Static, TextArea
 from textual.widgets._collapsible import CollapsibleTitle
 from textual.widgets.option_list import Option
 
+from .. import theme as cli_theme
 from ..file_index import IndexEntry
 from ..slash_commands import SlashCommandEntry
 from .state import ConversationEntry
@@ -156,6 +158,53 @@ def _with_selection_style(strip: Strip, selection: Selection | None, y: int, sel
             selected_segments.append(Segment(text[selected_end:], segment.style, segment.control))
 
     return Strip(selected_segments, strip.cell_length)
+
+
+class PlanningMarkdown(Static):
+    """Single-widget Markdown renderer for the Planning sidebar.
+
+    Textual's ``Markdown`` widget parses a document into many child widgets. That is
+    useful for rich document navigation, but expensive for the sidebar's long,
+    read-only plan/task-list reference. This widget keeps the public ``source``
+    property expected by tests and callers while rendering the document as one Rich
+    renderable and skipping identical updates entirely.
+    """
+
+    def __init__(
+        self,
+        markdown: str = "",
+        *,
+        empty_source: str | None = None,
+        **kwargs,
+    ) -> None:
+        classes = kwargs.pop("classes", None)
+        combined_classes = "planning-markdown" if not classes else f"planning-markdown {classes}"
+        self.source = ""
+        self._empty_sources = {empty_source} if empty_source is not None else set()
+        super().__init__("", markup=False, classes=combined_classes, **kwargs)
+        self.update(markdown)
+
+    def update(self, markdown: str = "", *, layout: bool = True, force: bool = False) -> None:
+        """Render ``markdown`` unless it is unchanged.
+
+        Args:
+            markdown: New source text for the sidebar section.
+            layout: Passed through to ``Static.update`` when content changes.
+            force: Re-render even if the source text is unchanged.
+        """
+        if not force and markdown == self.source:
+            return
+        self.source = markdown
+        renderable: object
+        if markdown in self._empty_sources or not markdown.strip():
+            renderable = Text(markdown)
+        else:
+            renderable = RichMarkdown(markdown, code_theme=cli_theme.markdown_code_theme())
+        super().update(renderable, layout=layout)
+
+    def render_line(self, y: int) -> Strip:
+        strip = _with_selection_style(super().render_line(y), self.text_selection, y, self.selection_style)
+        return _with_selection_offsets(strip, y)
 
 
 class SelectableCollapsibleTitle(CollapsibleTitle):

--- a/tests/cli/test_app_agent_wiring.py
+++ b/tests/cli/test_app_agent_wiring.py
@@ -50,7 +50,7 @@ async def test_textual_app_passes_shared_task_list_tools_to_build_agent_only(
 ) -> None:
     pytest.importorskip("textual")
 
-    from textual.widgets import Markdown
+    from kolega_code.cli.tui.widgets import PlanningMarkdown
 
     from kolega_code.cli.app import KolegaCodeApp
 
@@ -108,7 +108,7 @@ async def test_textual_app_passes_shared_task_list_tools_to_build_agent_only(
         assert await build_tools["get_task_list"]() == "No task list has been set."
         assert await build_tools["update_task_list"]("- [ ] inspect\n- [x] plan") == "Task list updated."
         assert app.session.task_list_markdown == "- [ ] inspect\n- [x] plan"
-        assert app.query_one("#planning_task_list_markdown", Markdown).source == "- [ ] inspect\n- [x] plan"
+        assert app.query_one("#planning_task_list_markdown", PlanningMarkdown).source == "- [ ] inspect\n- [x] plan"
         assert store.load(session.session_id).task_list_markdown == "- [ ] inspect\n- [x] plan"
 
         await pilot.press("shift+tab")

--- a/tests/cli/test_app_bootstrap_settings.py
+++ b/tests/cli/test_app_bootstrap_settings.py
@@ -49,9 +49,10 @@ async def test_textual_app_mounts_with_fake_agent(tmp_path: Path, monkeypatch: p
     pytest.importorskip("textual")
 
     from textual.containers import VerticalScroll
-    from textual.widgets import Collapsible, Header, Markdown
+    from textual.widgets import Collapsible, Header
 
     from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.cli.tui.widgets import PlanningMarkdown
 
     class FakeCoderAgent:
         def __init__(self, **kwargs):
@@ -102,8 +103,8 @@ async def test_textual_app_mounts_with_fake_agent(tmp_path: Path, monkeypatch: p
         assert app.query_one("#planning_form", VerticalScroll) is not None
         assert app.query_one("#planning_plan", Collapsible).collapsed is False
         assert app.query_one("#planning_task_list", Collapsible).collapsed is False
-        assert app.query_one("#planning_plan_markdown", Markdown).source == "No plan captured yet."
-        assert app.query_one("#planning_task_list_markdown", Markdown).source == "No task list has been set."
+        assert app.query_one("#planning_plan_markdown", PlanningMarkdown).source == "No plan captured yet."
+        assert app.query_one("#planning_task_list_markdown", PlanningMarkdown).source == "No task list has been set."
         assert app.conversation_entries[0].kind == "startup"
         startup = app.conversation_entries[0].content
         assert "____          _" in startup

--- a/tests/cli/test_app_persistence_history.py
+++ b/tests/cli/test_app_persistence_history.py
@@ -286,7 +286,7 @@ async def test_textual_app_reset_command_clears_current_thread(
 ) -> None:
     pytest.importorskip("textual")
 
-    from textual.widgets import Markdown
+    from kolega_code.cli.tui.widgets import PlanningMarkdown
 
     from kolega_code.cli.app import KolegaCodeApp
     from kolega_code.cli.tui.state import PendingQuestion
@@ -365,8 +365,8 @@ async def test_textual_app_reset_command_clears_current_thread(
         assert question_future.cancelled()
         assert app.query_one("#plan_actions").display is False
         assert app.query_one("#question_actions").display is False
-        assert app.query_one("#planning_plan_markdown", Markdown).source == "No plan captured yet."
-        assert app.query_one("#planning_task_list_markdown", Markdown).source == "No task list has been set."
+        assert app.query_one("#planning_plan_markdown", PlanningMarkdown).source == "No plan captured yet."
+        assert app.query_one("#planning_task_list_markdown", PlanningMarkdown).source == "No task list has been set."
         assert store.load(session.session_id).history == []
         assert store.load(session.session_id).task_list_markdown == ""
         assert store.load(session.session_id).latest_plan_markdown == ""

--- a/tests/cli/test_app_plan_lifecycle.py
+++ b/tests/cli/test_app_plan_lifecycle.py
@@ -50,7 +50,7 @@ async def test_textual_app_shows_plan_decision_when_planning_agent_writes_plan(
 ) -> None:
     pytest.importorskip("textual")
 
-    from textual.widgets import Markdown
+    from kolega_code.cli.tui.widgets import PlanningMarkdown
 
     from kolega_code.cli.app import KolegaCodeApp
     from kolega_code.cli.tui.widgets import ActionList, ChatComposer
@@ -120,8 +120,8 @@ async def test_textual_app_shows_plan_decision_when_planning_agent_writes_plan(
             "discuss_plan",
         ]
         assert app.focused is plan_actions
-        assert app.query_one("#planning_plan_markdown", Markdown).source == initial_plan
-        assert "Step 25" in app.query_one("#planning_plan_markdown", Markdown).source
+        assert app.query_one("#planning_plan_markdown", PlanningMarkdown).source == initial_plan
+        assert "Step 25" in app.query_one("#planning_plan_markdown", PlanningMarkdown).source
         assert app.conversation_entries[-1].kind == "plan"
         loaded = store.load(session.session_id)
         assert loaded.latest_plan_markdown == initial_plan
@@ -135,7 +135,7 @@ async def test_textual_app_shows_plan_decision_when_planning_agent_writes_plan(
         assert app._plan_reofferable is True
         assert app._latest_plan == initial_plan
         assert app.query_one("#composer", ChatComposer).disabled is False
-        assert app.query_one("#planning_plan_markdown", Markdown).source == initial_plan
+        assert app.query_one("#planning_plan_markdown", PlanningMarkdown).source == initial_plan
         assert plan_actions.display is False
         assert plan_actions.option_count == 0
         loaded = store.load(session.session_id)
@@ -178,7 +178,7 @@ async def test_textual_app_shows_plan_decision_when_planning_agent_writes_plan(
             "discuss_plan",
         ]
         assert (
-            app.query_one("#planning_plan_markdown", Markdown).source
+            app.query_one("#planning_plan_markdown", PlanningMarkdown).source
             == "# Revised plan\n\nBuild planning mode carefully."
         )
         loaded = store.load(session.session_id)
@@ -192,7 +192,7 @@ async def test_textual_app_implement_plan_switches_to_build_and_sends_plan(
 ) -> None:
     pytest.importorskip("textual")
 
-    from textual.widgets import Markdown
+    from kolega_code.cli.tui.widgets import PlanningMarkdown
 
     from kolega_code.cli.app import KolegaCodeApp
 
@@ -255,7 +255,7 @@ async def test_textual_app_implement_plan_switches_to_build_and_sends_plan(
         assert app._plan_pending is False
         assert app._plan_reofferable is False
         assert app._latest_plan == "# Plan\n\nBuild it."
-        assert app.query_one("#planning_plan_markdown", Markdown).source == "# Plan\n\nBuild it."
+        assert app.query_one("#planning_plan_markdown", PlanningMarkdown).source == "# Plan\n\nBuild it."
         assert app.query_one("#plan_actions").display is False
         loaded = store.load(session.session_id)
         assert loaded.latest_plan_markdown == "# Plan\n\nBuild it."
@@ -270,7 +270,7 @@ async def test_textual_app_implemented_plan_not_reoffered_on_reentry(
 ) -> None:
     pytest.importorskip("textual")
 
-    from textual.widgets import Markdown
+    from kolega_code.cli.tui.widgets import PlanningMarkdown
 
     from kolega_code.cli.app import KolegaCodeApp
     from kolega_code.cli.tui.constants import PLAN_INTERACTION_MODE
@@ -336,7 +336,7 @@ async def test_textual_app_implemented_plan_not_reoffered_on_reentry(
         plan_actions = app.query_one("#plan_actions", ActionList)
         assert plan_actions.display is False
         assert plan_actions.option_count == 0
-        assert app.query_one("#planning_plan_markdown", Markdown).source == "# Plan\n\nBuild it."
+        assert app.query_one("#planning_plan_markdown", PlanningMarkdown).source == "# Plan\n\nBuild it."
 
         # A restart (reloading from the persisted session) must also not re-offer it.
         loaded = store.load(session.session_id)
@@ -350,7 +350,7 @@ async def test_textual_app_clear_context_and_implement_plan_starts_build_agent_f
 ) -> None:
     pytest.importorskip("textual")
 
-    from textual.widgets import Markdown
+    from kolega_code.cli.tui.widgets import PlanningMarkdown
 
     from kolega_code.cli.app import KolegaCodeApp
 
@@ -422,7 +422,7 @@ async def test_textual_app_clear_context_and_implement_plan_starts_build_agent_f
         assert app._plan_pending is False
         assert app._plan_reofferable is False
         assert app._latest_plan == "# Plan\n\nBuild it."
-        assert app.query_one("#planning_plan_markdown", Markdown).source == "# Plan\n\nBuild it."
+        assert app.query_one("#planning_plan_markdown", PlanningMarkdown).source == "# Plan\n\nBuild it."
         assert app.query_one("#plan_actions").display is False
         # LLM-context-only clear: the visible transcript is preserved, plus the new
         # "Implement the approved plan." entry.
@@ -439,7 +439,7 @@ async def test_textual_app_discuss_plan_preserves_old_plan_until_new_plan_is_wri
 ) -> None:
     pytest.importorskip("textual")
 
-    from textual.widgets import Markdown
+    from kolega_code.cli.tui.widgets import PlanningMarkdown
 
     from kolega_code.cli.app import KolegaCodeApp
 
@@ -494,7 +494,9 @@ async def test_textual_app_discuss_plan_preserves_old_plan_until_new_plan_is_wri
         assert app._plan_pending is False
         assert app._plan_reofferable is True
         assert app._plan_decision_active is False
-        assert app.query_one("#planning_plan_markdown", Markdown).source == "# Plan\n\nBuild it after discussing."
+        assert (
+            app.query_one("#planning_plan_markdown", PlanningMarkdown).source == "# Plan\n\nBuild it after discussing."
+        )
         assert app.query_one("#plan_actions").display is False
         loaded = store.load(session.session_id)
         assert loaded.latest_plan_markdown == "# Plan\n\nBuild it after discussing."
@@ -520,7 +522,7 @@ async def test_textual_app_discuss_plan_preserves_old_plan_until_new_plan_is_wri
         assert "# Plan\n\nBuild it after discussing." not in app.agent.messages[-1]
         assert app._latest_plan == "# New plan\n\nBuild this instead."
         assert app._plan_reofferable is False
-        assert app.query_one("#planning_plan_markdown", Markdown).source == "# New plan\n\nBuild this instead."
+        assert app.query_one("#planning_plan_markdown", PlanningMarkdown).source == "# New plan\n\nBuild this instead."
         assert app.query_one("#plan_actions").display is False
         loaded = store.load(session.session_id)
         assert loaded.latest_plan_markdown == "# New plan\n\nBuild this instead."

--- a/tests/cli/test_app_planning_restore.py
+++ b/tests/cli/test_app_planning_restore.py
@@ -50,7 +50,7 @@ async def test_textual_app_restores_saved_plan_and_interaction_mode(
 ) -> None:
     pytest.importorskip("textual")
 
-    from textual.widgets import Markdown
+    from kolega_code.cli.tui.widgets import PlanningMarkdown
 
     from kolega_code.cli.app import KolegaCodeApp
     from kolega_code.cli.tui.widgets import ActionList, ChatComposer
@@ -105,7 +105,7 @@ async def test_textual_app_restores_saved_plan_and_interaction_mode(
         assert app._latest_plan == saved_plan
         assert app._plan_pending is True
         assert app._plan_decision_active is False
-        assert app.query_one("#planning_plan_markdown", Markdown).source == saved_plan
+        assert app.query_one("#planning_plan_markdown", PlanningMarkdown).source == saved_plan
         plan_actions = app.query_one("#plan_actions", ActionList)
         assert plan_actions.display is True
         assert [option.id for option in plan_actions.options] == ["implement_plan"]
@@ -118,7 +118,7 @@ async def test_textual_app_restores_saved_plan_in_build_mode_without_plan_action
 ) -> None:
     pytest.importorskip("textual")
 
-    from textual.widgets import Markdown
+    from kolega_code.cli.tui.widgets import PlanningMarkdown
 
     from kolega_code.cli.app import KolegaCodeApp
 
@@ -160,7 +160,7 @@ async def test_textual_app_restores_saved_plan_in_build_mode_without_plan_action
         assert app.interaction_mode == "build"
         assert isinstance(app.agent, FakeCoderAgent)
         assert app._latest_plan == saved_plan
-        assert app.query_one("#planning_plan_markdown", Markdown).source == saved_plan
+        assert app.query_one("#planning_plan_markdown", PlanningMarkdown).source == saved_plan
         # Even with a pending plan, the action stays hidden outside plan mode.
         assert app.query_one("#plan_actions").display is False
 

--- a/tests/cli/test_app_rendering_status.py
+++ b/tests/cli/test_app_rendering_status.py
@@ -295,14 +295,14 @@ async def test_status_dashboard_context_note_uses_alert_level(tmp_path: Path, mo
 async def test_planning_sidebar_marks_empty_states(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     pytest.importorskip("textual")
 
-    from textual.widgets import Markdown
+    from kolega_code.cli.tui.widgets import PlanningMarkdown
 
     from kolega_code.cli.messages import PLAN_EMPTY_MESSAGE
 
     app = _build_sub_agent_test_app(tmp_path, monkeypatch)
 
     async with app.run_test():
-        plan_md = app.query_one("#planning_plan_markdown", Markdown)
+        plan_md = app.query_one("#planning_plan_markdown", PlanningMarkdown)
         assert plan_md.source == PLAN_EMPTY_MESSAGE
         assert plan_md.has_class("empty-state")
 
@@ -311,6 +311,77 @@ async def test_planning_sidebar_marks_empty_states(tmp_path: Path, monkeypatch: 
 
         assert plan_md.source == "# Plan\n\n- do the thing"
         assert not plan_md.has_class("empty-state")
+
+
+@pytest.mark.asyncio
+async def test_planning_sidebar_unchanged_refresh_preserves_scroll_position(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.containers import VerticalScroll
+    from textual.widgets import TabbedContent
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+    long_plan = "# Plan\n\n" + "\n".join(
+        f"- Step {index}: keep this planning reference visible." for index in range(160)
+    )
+    long_task_list = "\n".join(f"- [ ] Task {index}: verify the sidebar keeps its place." for index in range(160))
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.query_one("#events", TabbedContent).active = "planning_pane"
+        app._latest_plan = long_plan
+        app.session.task_list_markdown = long_task_list
+        app._refresh_planning_sidebar()
+        await pilot.pause()
+
+        planning_form = app.query_one("#planning_form", VerticalScroll)
+        assert planning_form.max_scroll_y > 0
+        planning_form.scroll_to(y=min(20, planning_form.max_scroll_y), animate=False, immediate=True)
+        await pilot.pause()
+        scroll_y = planning_form.scroll_y
+        assert scroll_y > 0
+
+        app._refresh_planning_sidebar()
+        await pilot.pause()
+
+        assert planning_form.scroll_y == scroll_y
+
+
+@pytest.mark.asyncio
+async def test_planning_markdown_uses_single_cached_renderable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("textual")
+
+    from rich.markdown import Markdown as RichMarkdown
+
+    from kolega_code.cli.tui.widgets import PlanningMarkdown
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+    long_plan = "# Plan\n\n" + "\n".join(f"- Step {index}: do the thing with `code`." for index in range(120))
+
+    async with app.run_test():
+        app._latest_plan = long_plan
+        app._refresh_planning_sidebar()
+        plan_md = app.query_one("#planning_plan_markdown", PlanningMarkdown)
+
+        assert plan_md.source == long_plan
+        assert isinstance(plan_md.content, RichMarkdown)
+        assert list(plan_md.query("MarkdownBlock")) == []
+
+        renderable = plan_md.content
+        refresh_calls = 0
+        original_refresh = plan_md.refresh
+
+        def spy_refresh(*args, **kwargs):
+            nonlocal refresh_calls
+            refresh_calls += 1
+            return original_refresh(*args, **kwargs)
+
+        monkeypatch.setattr(plan_md, "refresh", spy_refresh)
+        plan_md.update(long_plan)
+
+        assert plan_md.content is renderable
+        assert refresh_calls == 0
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_app_status_modes.py
+++ b/tests/cli/test_app_status_modes.py
@@ -357,7 +357,7 @@ async def test_textual_app_shift_tab_toggles_between_build_and_plan_agents(
 ) -> None:
     pytest.importorskip("textual")
 
-    from textual.widgets import Markdown
+    from kolega_code.cli.tui.widgets import PlanningMarkdown
 
     from kolega_code.cli.app import KolegaCodeApp
     from kolega_code.cli.tui.constants import BUILD_INTERACTION_MODE, PLAN_INTERACTION_MODE
@@ -435,7 +435,7 @@ async def test_textual_app_shift_tab_toggles_between_build_and_plan_agents(
         assert app._plan_decision_active is False
         assert app._pending_question is None
         assert question_future.cancelled()
-        assert app.query_one("#planning_plan_markdown", Markdown).source == "# Plan\n\nDo it."
+        assert app.query_one("#planning_plan_markdown", PlanningMarkdown).source == "# Plan\n\nDo it."
         assert app.query_one("#plan_actions").display is False
         assert app.query_one("#question_actions").display is False
         loaded = store.load(session.session_id)


### PR DESCRIPTION
## Summary
- Replace Planning tab Textual Markdown widgets with a cached single-widget Rich Markdown renderer.
- Preserve full plan/task-list content while avoiding repeated MarkdownBlock remounts on unchanged refreshes.
- Update planning sidebar tests and add regressions for scroll preservation and cached rendering.
- Guard deferred primary focus restore so it does not override later focus changes.

## Tests
- `git diff --check`
- `ruff check kolega_code/cli/app.py kolega_code/cli/tui/widgets.py tests/cli/test_app_bootstrap_settings.py tests/cli/test_app_plan_lifecycle.py tests/cli/test_app_planning_restore.py tests/cli/test_app_agent_wiring.py tests/cli/test_app_status_modes.py tests/cli/test_app_rendering_status.py tests/cli/test_app_persistence_history.py tests/cli/test_app_focus_behavior.py`
- `pytest tests/cli/test_app_focus_behavior.py`
- `pytest tests/cli/test_app_bootstrap_settings.py tests/cli/test_app_plan_lifecycle.py tests/cli/test_app_rendering_status.py tests/cli/test_app_agent_wiring.py tests/cli/test_app_persistence_history.py`
- `pytest tests/cli`
