### PR TITLE
fix(tui): clear runtime output on reset

### DIFF
--- a/docs/src/content/docs/tui/slash-commands.md
+++ b/docs/src/content/docs/tui/slash-commands.md
@@ -22,8 +22,8 @@ These operate on the conversation itself.
 | --- | --- |
 | `/help` | Show the list of available agent commands |
 | `/compress` | Compress the message history to reclaim context |
-| `/clear` | Clear the message history |
-| `/reset` | Clear the message history (alias of `/clear`) |
+| `/clear` | Clear message history; in the TUI, also clears Terminal output and Logs |
+| `/reset` | Clear message history, Terminal output, and Logs (alias of `/clear` in the TUI) |
 | `/context` | Show the current context token count |
 
 ## TUI commands

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -479,6 +479,30 @@ class KolegaCodeApp(
         self._terminal_has_content = True
         self._mark_tab_activity("terminal_pane")
 
+    def _clear_runtime_output(self) -> None:
+        """Clear runtime-only terminal/log sidebar output for thread resets."""
+        if self._terminal_flush_timer is not None:
+            self._terminal_flush_timer.stop()
+            self._terminal_flush_timer = None
+
+        self._terminal_output_buffer.clear()
+        self._terminal_output_buffer_chars = 0
+        self._terminal_has_content = False
+
+        try:
+            self._terminal.clear_output()
+        except Exception:
+            pass
+
+        if self.show_logs:
+            try:
+                self._logs.clear_output()
+            except Exception:
+                pass
+
+        self._clear_tab_activity("terminal_pane")
+        self._clear_tab_activity("logs_pane")
+
     def _format_log_line(self, text: str, level: str = "info") -> Text:
         """One log line: muted HH:MM:SS, a level-colored glyph, then the text."""
         body_style = Color.MUTED if level == "debug" else ""
@@ -1382,6 +1406,7 @@ class KolegaCodeApp(
         self._plan_pending = False
         self._plan_reofferable = False
         self._plan_decision_active = False
+        self._clear_runtime_output()
         await self._save_session_async()
         self._set_plan_actions_visible(False)
         self._cancel_pending_question()
@@ -1398,7 +1423,6 @@ class KolegaCodeApp(
         self._add_conversation_entry(
             tui_state.ConversationEntry(kind="progress", content=messages.THREAD_RESET_MESSAGE, complete=True)
         )
-        self._notify_user(messages.THREAD_RESET_MESSAGE)
 
     def _add_conversation_entry(self, entry: tui_state.ConversationEntry) -> None:
         self.conversation_entries.append(entry)

--- a/kolega_code/cli/slash_commands.py
+++ b/kolega_code/cli/slash_commands.py
@@ -36,6 +36,10 @@ class SlashCommandEntry:
 
 
 THREAD_RESET_COMMANDS: frozenset[str] = frozenset({"/clear", "/reset"})
+TUI_AGENT_COMMAND_DESCRIPTION_OVERRIDES: dict[str, str] = {
+    "/clear": "Clear message history, terminal output, and logs",
+    "/reset": "Clear message history, terminal output, and logs (alias of /clear)",
+}
 SKILLS_LIST_COMMAND = "/skills"
 
 TUI_COMMAND_ENTRIES: tuple[SlashCommandEntry, ...] = (
@@ -66,7 +70,11 @@ TUI_COMMAND_NAMES: frozenset[str] = frozenset(entry.token for entry in TUI_COMMA
 def agent_command_entries() -> tuple[SlashCommandEntry, ...]:
     """Agent built-in commands, derived from the agent's own declarations."""
     return tuple(
-        SlashCommandEntry(spec.name.removeprefix("/"), spec.description, CommandScope.AGENT)
+        SlashCommandEntry(
+            spec.name.removeprefix("/"),
+            TUI_AGENT_COMMAND_DESCRIPTION_OVERRIDES.get(spec.name, spec.description),
+            CommandScope.AGENT,
+        )
         for spec in CommandProcessor.SPECS
     )
 

--- a/kolega_code/cli/tui/widgets.py
+++ b/kolega_code/cli/tui/widgets.py
@@ -377,6 +377,11 @@ class StickyRichLog(RichLog):
         should_follow = self.auto_follow_bottom or self.is_at_bottom()
         self.write(content, scroll_end=should_follow)
 
+    def clear_output(self) -> None:
+        """Clear rendered output and restore sticky-follow defaults."""
+        self.clear()
+        self.auto_follow_bottom = True
+
 
 class TerminalOutputLog(StickyRichLog):
     """Sticky log for terminal output."""

--- a/tests/cli/test_app_rendering_terminal_logs.py
+++ b/tests/cli/test_app_rendering_terminal_logs.py
@@ -184,6 +184,140 @@ async def test_terminal_rendered_history_is_capped(tmp_path: Path, monkeypatch: 
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("command", ["/clear", "/reset"])
+async def test_reset_command_clears_terminal_logs_and_pending_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, command: str
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.widgets import TabbedContent
+
+    from kolega_code.cli import theme
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch, show_logs=True)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        tabs = app.query_one("#events", TabbedContent)
+        assert tabs.active == "status_pane"
+
+        terminal = app._terminal
+        logs = app._logs
+        clear_calls = {"terminal": 0, "logs": 0}
+        terminal_clear_output = terminal.clear_output
+        logs_clear_output = logs.clear_output
+
+        def clear_terminal_output() -> None:
+            clear_calls["terminal"] += 1
+            terminal_clear_output()
+
+        def clear_logs_output() -> None:
+            clear_calls["logs"] += 1
+            logs_clear_output()
+
+        monkeypatch.setattr(terminal, "clear_output", clear_terminal_output)
+        monkeypatch.setattr(logs, "clear_output", clear_logs_output)
+
+        tabs.active = "terminal_pane"
+        await pilot.pause()
+        terminal.write_terminal("old terminal output\n")
+        await pilot.pause()
+        assert "old terminal output" in "\n".join(strip.text for strip in terminal.lines)
+
+        tabs.active = "logs_pane"
+        await pilot.pause()
+        logs.write_log("old log entry")
+        await pilot.pause()
+        tabs.active = "status_pane"
+        await pilot.pause()
+        app._queue_terminal_output("stale buffered output\n")
+        app._write_log("background log entry")
+        terminal.auto_follow_bottom = False
+        logs.auto_follow_bottom = False
+
+        assert app._terminal_flush_timer is not None
+        assert app._terminal_output_buffer == ["stale buffered output\n"]
+        assert app._terminal_output_buffer_chars == len("stale buffered output\n")
+        assert app._terminal_has_content is True
+        dot = theme.g(theme.Glyph.STATUS)
+        assert str(tabs.get_tab("terminal_pane").label) == f"Terminal {dot}"
+        assert str(tabs.get_tab("logs_pane").label) == f"Logs {dot}"
+
+        composer = app.query_one("#composer", ChatComposer)
+        composer.load_text(command)
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+        await pilot.pause(0.1)
+
+        assert clear_calls == {"terminal": 1, "logs": 1}
+        assert terminal.lines == []
+        assert logs.lines == []
+        assert app._terminal_output_buffer == []
+        assert app._terminal_output_buffer_chars == 0
+        assert app._terminal_flush_timer is None
+        assert app._terminal_has_content is False
+        assert terminal.auto_follow_bottom is True
+        assert logs.auto_follow_bottom is True
+        assert str(tabs.get_tab("terminal_pane").label) == "Terminal"
+        assert str(tabs.get_tab("logs_pane").label) == "Logs"
+        assert composer.text == ""
+
+        await pilot.pause(0.1)
+        assert terminal.lines == []
+        assert logs.lines == []
+
+
+@pytest.mark.asyncio
+async def test_blocked_reset_command_preserves_terminal_and_logs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.widgets import TabbedContent
+
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch, show_logs=True)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        tabs = app.query_one("#events", TabbedContent)
+        terminal = app._terminal
+        logs = app._logs
+
+        def fail_clear_output() -> None:
+            raise AssertionError("blocked reset must not clear runtime output")
+
+        monkeypatch.setattr(terminal, "clear_output", fail_clear_output)
+        monkeypatch.setattr(logs, "clear_output", fail_clear_output)
+
+        tabs.active = "terminal_pane"
+        await pilot.pause()
+        terminal.write_terminal("old terminal output\n")
+        await pilot.pause()
+
+        tabs.active = "logs_pane"
+        await pilot.pause()
+        logs.write_log("old log entry")
+        await pilot.pause()
+
+        tabs.active = "status_pane"
+        await pilot.pause()
+        app._queue_terminal_output("pending output\n")
+
+        composer = app.query_one("#composer", ChatComposer)
+        composer.load_text("/clear")
+        app._turn_active = True
+
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+
+        assert "old terminal output" in "\n".join(strip.text for strip in terminal.lines)
+        assert app._terminal_output_buffer == ["pending output\n"]
+        assert app._terminal_output_buffer_chars == len("pending output\n")
+        assert app._terminal_flush_timer is not None
+        assert app._terminal_has_content is True
+        assert composer.text == "/clear"
+
+
+@pytest.mark.asyncio
 async def test_logs_tab_hidden_by_default_and_write_log_is_noop(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- Clear Terminal output, pending terminal output buffers/timers, and optional Logs output when `/clear` or `/reset` resets the TUI thread.
- Keep the active-turn guard intact so blocked resets do not clear runtime output.
- Avoid immediately repopulating Logs with the reset confirmation; the confirmation remains in the chat transcript.
- Update TUI slash-command descriptions/docs for the expanded reset behavior.

## Tests
- `git diff --check`
- `ruff check kolega_code/cli/app.py kolega_code/cli/tui/widgets.py tests/cli/test_app_persistence_history.py tests/cli/test_app_rendering_terminal_logs.py kolega_code/cli/slash_commands.py`
- `pytest tests/cli/test_app_persistence_history.py tests/cli/test_app_rendering_terminal_logs.py`
- `pytest tests/cli`

## Notes
- This branch is stacked on `fix/planning-sidebar-scroll-performance` / PR #115 as discussed, but this PR targets `main`.
