### PR TITLE
perf(tui): reduce Logs and Terminal scrollback caps to 2000 lines

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -87,8 +87,8 @@ from .tui import transcript as tui_transcript
 from .tui import widgets as tui_widgets
 
 CLI_AGENT_MODE = AgentMode.CLI.value
-LOG_MAX_LINES = 10_000
-TERMINAL_MAX_LINES = 10_000
+LOG_MAX_LINES = 2_000
+TERMINAL_MAX_LINES = 2_000
 TERMINAL_FLUSH_INTERVAL = 0.04
 TERMINAL_IMMEDIATE_FLUSH_CHARS = 64 * 1024
 

--- a/tests/cli/test_app_rendering_terminal_logs.py
+++ b/tests/cli/test_app_rendering_terminal_logs.py
@@ -422,6 +422,13 @@ async def test_logs_rendered_history_is_capped(tmp_path: Path, monkeypatch: pyte
         assert "line 11" in rendered
 
 
+def test_default_scrollback_caps_are_bounded() -> None:
+    from kolega_code.cli.app import LOG_MAX_LINES, TERMINAL_MAX_LINES
+
+    assert LOG_MAX_LINES == 2_000
+    assert TERMINAL_MAX_LINES == 2_000
+
+
 @pytest.mark.asyncio
 async def test_logs_tab_shows_activity_dot_until_visited(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     pytest.importorskip("textual")


### PR DESCRIPTION
## Summary

The Logs and Terminal sidebar tabs kept up to 10,000 lines of scrollback each — excessive for diagnostic panes, costing memory and rendering effort. This lowers both caps to 2,000 lines.

## Changes

- `kolega_code/cli/app.py`: lower `LOG_MAX_LINES` and `TERMINAL_MAX_LINES` from `10_000` to `2_000`. These feed Textual's `RichLog(max_lines=...)` for the `#logs` and `#terminal` widgets, so the oldest lines now drop off at 2,000.
- `tests/cli/test_app_rendering_terminal_logs.py`: add `test_default_scrollback_caps_are_bounded` to lock in the default caps against regression. (Existing cap tests set `max_lines` explicitly on the widget and don't cover the default.)

Only the rendered sidebar history is bounded; command output returned to the agent is unaffected. No new configuration surface is introduced.

## Test plan

- [x] `uv run pytest tests/cli/test_app_rendering_terminal_logs.py` → 14 passed
- [ ] Manual: launch the TUI, run a high-volume command, confirm Terminal scrollback stays ≤ ~2,000 lines; repeat for Logs (`--show-logs`)
