### PR TITLE
fix(tui): clarify disconnected first-run state

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -714,6 +714,9 @@ class KolegaCodeApp(
         if not stripped_text or self.agent is None:
             if stripped_text:
                 self._set_settings_status(messages.SETTINGS_REQUIRED, tone="warning")
+                if self.config is None:
+                    self._set_composer_status(messages.DISCONNECTED_COMPOSER_PLACEHOLDER)
+                    self._show_composer_hint(messages.DISCONNECTED_ACTIVITY, tone="warning")
             return
         # Build attachments first (without clearing pending) so the vision gate
         # can block before we consume the composer text and pending images.
@@ -1340,6 +1343,10 @@ class KolegaCodeApp(
     def _set_chat_enabled(self, enabled: bool) -> None:
         composer = self.query_one("#composer", tui_widgets.ChatComposer)
         composer.disabled = not enabled or self._plan_decision_active or self._pending_approval is not None
+        if self.config is None and self.agent is None:
+            composer.placeholder = messages.DISCONNECTED_COMPOSER_PLACEHOLDER
+        elif enabled and composer.placeholder == messages.DISCONNECTED_COMPOSER_PLACEHOLDER:
+            composer.placeholder = messages.COMPOSER_PLACEHOLDER
 
     def _set_composer_status(self, status: str) -> None:
         self.query_one("#composer", tui_widgets.ChatComposer).placeholder = status
@@ -1460,10 +1467,19 @@ class KolegaCodeApp(
             if model
             else "not checked until a model is configured"
         )
-        return "\n".join(
+        startup_lines = [*tui_constants.STARTUP_WORDMARK, ""]
+        if self.config is None:
+            startup_lines.extend(
+                [
+                    messages.DISCONNECTED_HEADLINE,
+                    "",
+                    messages.DISCONNECTED_STARTUP_GUIDANCE,
+                    messages.DISCONNECTED_SIDEBAR_GUIDANCE,
+                    "",
+                ]
+            )
+        startup_lines.extend(
             [
-                *tui_constants.STARTUP_WORDMARK,
-                "",
                 f"Project: {self.project_path}",
                 f"Session: {session_id}",
                 f"Mode: {self.mode}",
@@ -1477,6 +1493,7 @@ class KolegaCodeApp(
                 f"Ctrl+C stop turn {theme.g(Glyph.BULLET_SEP)} Cmd+C copy selection {theme.g(Glyph.BULLET_SEP)} / commands",
             ]
         )
+        return "\n".join(startup_lines)
 
     def _startup_model(self) -> tuple[str, str]:
         if self.config is not None:

--- a/kolega_code/cli/messages.py
+++ b/kolega_code/cli/messages.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 # Composer placeholders and modal prompts
 COMPOSER_PLACEHOLDER = "Ask Kolega Code..."
+DISCONNECTED_COMPOSER_PLACEHOLDER = "Connect a model in Settings before chatting."
 PLAN_READY_PLACEHOLDER = "Plan ready. Choose Implement plan or Discuss further."
 QUESTION_PLACEHOLDER = "Choose an option below or type a custom answer..."
 APPROVAL_PLACEHOLDER = "Choose whether to allow this action..."
@@ -18,6 +19,11 @@ THEME_PLACEHOLDER = "Choose a theme below or type a theme name..."
 
 # Durable transcript messages
 THREAD_RESET_MESSAGE = "Thread reset. Previous messages were cleared."
+DISCONNECTED_HEADLINE = "Not connected."
+DISCONNECTED_STARTUP_GUIDANCE = "Choose a provider and add an API key or sign in from the Settings tab before chatting."
+DISCONNECTED_SIDEBAR_GUIDANCE = "Press Ctrl+O to open the sidebar, then select Settings."
+DISCONNECTED_ACTIVITY = "Open Settings and connect a provider to start chatting."
+DISCONNECTED_MODEL = "not connected"
 TASK_LIST_EMPTY_MESSAGE = "No task list has been set."
 PLAN_EMPTY_MESSAGE = "No plan captured yet."
 

--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import asyncio
 
-from textual.widgets import TabbedContent
-
 from kolega_code.agent import AgentConfig, AgentEvent, CoderAgent, PlanningAgent, PromptExtension, ToolExtension
 from kolega_code.agent.prompt_provider import AgentMode
 from kolega_code.hooks import HookDispatcher, HookEvent, load_hook_config, project_hooks_present
@@ -198,7 +196,6 @@ class AgentRuntimeMixin:
             self._refresh_status_dashboard()
             self._set_settings_status(messages.SETTINGS_INCOMPLETE.format(error=exc), tone="error")
             self._ensure_startup_entry()
-            self.query_one("#events", TabbedContent).active = "settings_pane"
             return
 
         self.config = config

--- a/kolega_code/cli/tui/status_dashboard.py
+++ b/kolega_code/cli/tui/status_dashboard.py
@@ -38,7 +38,12 @@ class StatusDashboardMixin:
 
     def _format_status_dashboard(self) -> str:
         state = self._status_state
-        provider_model = f"{state.provider}/{state.model}" if state.model else state.provider
+        disconnected = self.config is None
+        provider_model = (
+            messages.DISCONNECTED_MODEL
+            if disconnected
+            else (f"{state.provider}/{state.model}" if state.model else state.provider)
+        )
         effort = state.thinking_effort or "not supported"
         mode = state.mode.title()
         permission_mode = state.permission_mode.title()
@@ -83,7 +88,7 @@ class StatusDashboardMixin:
             f"{label('Context')}\n"
             f"{context_lines}\n\n"
             f"{label('Activity')}\n"
-            f"{escape(state.activity)}"
+            f"{escape(messages.DISCONNECTED_ACTIVITY if disconnected else state.activity)}"
         )
 
     def _context_bar(self, usage_percentage: float) -> str:

--- a/tests/cli/test_app_bootstrap_settings.py
+++ b/tests/cli/test_app_bootstrap_settings.py
@@ -346,16 +346,30 @@ async def test_textual_app_mounts_settings_without_api_key(
 
     async with app.run_test():
         assert app.agent is None
-        assert app.query_one("#composer", ChatComposer).disabled is True
+        composer = app.query_one("#composer", ChatComposer)
+        assert composer.disabled is True
+        assert composer.placeholder == "Connect a model in Settings before chatting."
+        assert app.query_one("#events").active == "status_pane"
         startup = app.conversation_entries[0].content
+        assert "Not connected." in startup
+        assert "Choose a provider and add an API key or sign in from the Settings tab before chatting." in startup
+        assert "Press Ctrl+O to open the sidebar, then select Settings." in startup
         assert "Model: not configured" in startup
         assert "API key: not checked until a model is configured" in startup
-        stored_settings = settings_store.load()
-        assert stored_settings.active_provider is None
-        assert stored_settings.active_model is None
+        dashboard = str(app.query_one("#status_dashboard").render())
+        assert "not connected" in dashboard
+        assert "Open Settings and connect a provider to start chatting." in dashboard
         status = str(app.query_one("#settings_status").render())
         assert "Configuration incomplete" in status
         assert "No provider/model configured" in status
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, "fix this"))
+        assert composer.placeholder == "Connect a model in Settings before chatting."
+        assert "Open Settings and connect a provider to start chatting." in str(
+            app.query_one("#composer_hint").render()
+        )
+        stored_settings = settings_store.load()
+        assert stored_settings.active_provider is None
+        assert stored_settings.active_model is None
 
 
 @pytest.mark.asyncio
@@ -391,8 +405,11 @@ async def test_textual_app_does_not_select_model_from_api_key_env(
 
     async with app.run_test():
         assert app.agent is None
-        assert app.query_one("#composer", ChatComposer).disabled is True
+        composer = app.query_one("#composer", ChatComposer)
+        assert composer.disabled is True
+        assert composer.placeholder == "Connect a model in Settings before chatting."
         startup = app.conversation_entries[0].content
+        assert "Not connected." in startup
         assert "Model: not configured" in startup
         assert f"Model: {UI_DEFAULT_PROVIDER}/{UI_DEFAULT_MODEL}" not in startup
         stored_settings = settings_store.load()
@@ -453,7 +470,10 @@ async def test_textual_app_mounts_with_stored_kimi_settings(
         assert app.agent.kwargs["config"].long_context_config.provider == ModelProvider.MOONSHOT
         assert app.agent.kwargs["config"].long_context_config.model == UI_DEFAULT_MODEL
         assert app.agent.kwargs["config"].long_context_config.thinking_effort == "auto"
-        assert app.query_one("#composer", ChatComposer).disabled is False
+        composer = app.query_one("#composer", ChatComposer)
+        assert composer.disabled is False
+        assert composer.placeholder == "Ask Kolega Code..."
+        assert "Not connected." not in app.conversation_entries[0].content
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add explicit Not connected messaging to the startup card when no model config is available
- show disconnected guidance in the composer and status dashboard
- keep the Status tab focused instead of automatically jumping to Settings

## Tests
- ruff check kolega_code/cli/tui/agent_runtime.py tests/cli/test_app_bootstrap_settings.py
- pytest tests/cli/test_app_bootstrap_settings.py -q
- pytest tests/cli/test_app_rendering_status.py tests/cli/test_app_status_modes.py -q