### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.9.0 - 2026-06-24
+
+### Added
+
+- Added Ollama Cloud as a supported provider, including its model catalog and reasoning-field capture.
+
+### Fixed
+
+- Clarified the disconnected state shown on first run when no provider is configured.
+
 ## 0.8.4 - 2026-06-24
 
 ### Added

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.8.4"
+__version__ = "0.9.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -44,4 +44,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.8.4"
+__version__ = "0.9.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.8.4"
+version = "0.9.0"
 description = "Local-first AI coding agent for the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [options]
 prerelease-mode = "allow"
-exclude-newer = "2026-06-17T10:09:01.397164Z"
+exclude-newer = "2026-06-17T13:08:36.353346Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1360,7 +1360,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.8.4"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Release version bump to v0.9.0.

## Changes

Version bump + changelog for the v0.9.0 release. Minor bump from v0.8.4 for the new Ollama Cloud provider feature.

### Added
- Added Ollama Cloud as a supported provider, including its model catalog and reasoning-field capture.

### Fixed
- Clarified the disconnected state shown on first run when no provider is configured.

## Version metadata

Updated in all three locations enforced by the release workflow version-parity check:
- \`pyproject.toml\`
- \`kolega_code/__init__.py\`
- \`kolega_code/agent/__init__.py\`

Lockfile refreshed with \`uv lock\` (advances the \`exclude-newer\` cutoff as expected).

## Verification

- \`./run_tests.sh\` (fast suite): **1467 passed, 50 deselected**.
- Pre-commit hooks passed.

After merge, tag \`v0.9.0\` from the merge commit and let the \`release.yml\` workflow publish to PyPI and create the GitHub Release.