### PR TITLE
ci: fast-pass coverage badge PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect changed files
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      coverage-badge-only: ${{ steps.detect.outputs.coverage-badge-only }}
+    steps:
+      - name: Detect coverage-badge-only PR
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "coverage-badge-only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename')
+          echo "Changed files:"
+          echo "$files"
+
+          file_count=$(printf '%s\n' "$files" | sed '/^$/d' | wc -l | tr -d ' ')
+          if [ "$file_count" = "1" ] && [ "$files" = "docs/src/assets/coverage.svg" ]; then
+            echo "coverage-badge-only=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "coverage-badge-only=false" >> "$GITHUB_OUTPUT"
+          fi
+
   tests:
     name: Python ${{ matrix.python-version }}
+    needs: changes
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -25,30 +55,41 @@ jobs:
         python-version: ["3.11", "3.12"]
 
     steps:
+      - name: Skip coverage-badge-only PR
+        if: needs.changes.outputs.coverage-badge-only == 'true'
+        run: echo "Skipping Python checks for coverage badge-only PR."
+
       - name: Checkout
+        if: needs.changes.outputs.coverage-badge-only != 'true'
         uses: actions/checkout@v5
 
       - name: Setup Python
+        if: needs.changes.outputs.coverage-badge-only != 'true'
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup uv
+        if: needs.changes.outputs.coverage-badge-only != 'true'
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
 
       - name: Install dependencies
+        if: needs.changes.outputs.coverage-badge-only != 'true'
         run: uv sync --extra dev --frozen
 
       - name: Run pre-commit hooks
+        if: needs.changes.outputs.coverage-badge-only != 'true'
         run: uv run pre-commit run --all-files --show-diff-on-failure
 
       - name: Run fast tests with coverage
+        if: needs.changes.outputs.coverage-badge-only != 'true'
         run: ./run_tests.sh --coverage
 
       - name: Upload coverage report
+        if: needs.changes.outputs.coverage-badge-only != 'true'
         uses: actions/upload-artifact@v6
         with:
           name: coverage-xml-python-${{ matrix.python-version }}
@@ -120,21 +161,30 @@ jobs:
 
   dependency-audit:
     name: Dependency audit
+    needs: changes
     runs-on: ubuntu-latest
     steps:
+      - name: Skip coverage-badge-only PR
+        if: needs.changes.outputs.coverage-badge-only == 'true'
+        run: echo "Skipping dependency audit for coverage badge-only PR."
+
       - name: Checkout
+        if: needs.changes.outputs.coverage-badge-only != 'true'
         uses: actions/checkout@v5
 
       - name: Setup Python
+        if: needs.changes.outputs.coverage-badge-only != 'true'
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
       - name: Setup uv
+        if: needs.changes.outputs.coverage-badge-only != 'true'
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
 
       - name: Audit locked dependencies
+        if: needs.changes.outputs.coverage-badge-only != 'true'
         run: uv audit --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,21 +20,25 @@ jobs:
     name: Detect changed files
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       coverage-badge-only: ${{ steps.detect.outputs.coverage-badge-only }}
     steps:
-      - name: Detect coverage-badge-only PR
+      - name: Detect coverage-badge-only change
         id: detect
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename')
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            files=$(gh api "repos/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.sha }}" --jq '.files[].filename')
+          else
             echo "coverage-badge-only=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename')
           echo "Changed files:"
           echo "$files"
 
@@ -55,9 +59,9 @@ jobs:
         python-version: ["3.11", "3.12"]
 
     steps:
-      - name: Skip coverage-badge-only PR
+      - name: Skip coverage-badge-only change
         if: needs.changes.outputs.coverage-badge-only == 'true'
-        run: echo "Skipping Python checks for coverage badge-only PR."
+        run: echo "Skipping Python checks for coverage badge-only change."
 
       - name: Checkout
         if: needs.changes.outputs.coverage-badge-only != 'true'
@@ -98,8 +102,8 @@ jobs:
 
   coverage-badge:
     name: Update coverage badge
-    needs: tests
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [changes, tests]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.coverage-badge-only != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -164,9 +168,9 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - name: Skip coverage-badge-only PR
+      - name: Skip coverage-badge-only change
         if: needs.changes.outputs.coverage-badge-only == 'true'
-        run: echo "Skipping dependency audit for coverage badge-only PR."
+        run: echo "Skipping dependency audit for coverage badge-only change."
 
       - name: Checkout
         if: needs.changes.outputs.coverage-badge-only != 'true'


### PR DESCRIPTION
## Summary
- add a lightweight changed-files detector for PR and push events
- fast-pass the Python 3.11, Python 3.12, and Dependency audit required checks when the change only touches docs/src/assets/coverage.svg
- skip the coverage badge refresh job on badge-only pushes to main, preventing a badge-update merge loop
- leave CodeQL unchanged

## Checks
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'yaml ok'"
- uv run pre-commit run --files .github/workflows/ci.yml
- git diff --check