### PR TITLE
fix(cli): ignore project dotenv for model config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,13 @@
-# Local test credentials. Copy this file to `.env` and fill only the keys you need.
-# `.env` is ignored by git; do not commit real secrets.
+# Developer/test credentials for this repository.
+#
+# Installed Kolega Code does NOT automatically load a target project's `.env`
+# for its own provider/model configuration. For normal CLI use, save keys in the
+# Settings tab or export environment variables in the shell that launches
+# `kolega-code`.
+#
+# This sample exists for repository-local development and live integration tests.
+# Copy it to `.env` only in this repo, fill only the keys you need, and never
+# commit real secrets.
 
 ANTHROPIC_API_KEY=
 OPENAI_API_KEY=

--- a/docs/src/content/docs/configuration/environment-variables.md
+++ b/docs/src/content/docs/configuration/environment-variables.md
@@ -3,25 +3,29 @@ title: Environment Variables
 description: Every environment variable Kolega Code reads, and how precedence works.
 ---
 
-Kolega Code reads configuration from environment variables and from a project-local
-`.env` file. This page lists everything it understands.
+Kolega Code reads configuration from CLI flags, exported environment variables,
+and saved Settings. It does **not** automatically load the target project's
+`.env` file for its own provider/model/API-key configuration. This page lists the
+environment variables it understands when they are explicitly present in the
+Kolega Code process environment.
 
 ## Precedence
 
 For any given setting, the first available source wins:
 
 1. **CLI flags** (e.g. `--provider`, `--model`)
-2. **Shell environment variables**
-3. **Project `.env` file** (in the project directory)
-4. **Saved Settings** (`settings.json`)
+2. **Exported process environment variables**
+3. **Saved Settings** (`settings.json`)
 
-Kolega Code requires an explicit provider/model selection from flags,
-environment variables, a project `.env` file, or saved settings. API key
-variables alone are not a model selection source.
+Kolega Code requires an explicit provider/model selection from flags, exported
+environment variables, or saved settings. API key variables alone are not a model
+selection source.
 
 :::note
-Within the env layer, your **shell environment takes priority over the `.env`
-file** — values exported in your shell override the same key in `.env`.
+A project `.env` file is treated as part of the project being edited. Kolega Code
+will not read it for its own LLM configuration. For persistent credentials, use
+Settings. For automation, export environment variables in the shell or CI process
+that launches Kolega Code.
 :::
 
 ## API keys
@@ -111,42 +115,26 @@ Optional [Langfuse](https://langfuse.com/) tracing of LLM usage.
 | `LANGFUSE_PUBLIC_KEY` | Langfuse public key |
 | `LANGFUSE_SECRET_KEY` | Langfuse secret key |
 
-## Using a `.env` file
+## About project `.env` files
 
-Kolega Code automatically loads a `.env` file from the project directory. A good
-starting point:
+Kolega Code does not automatically load a `.env` file from the project directory.
+That file commonly belongs to the app being edited, so consuming it as Kolega
+Code configuration can accidentally pick up unrelated application secrets such as
+`OPENAI_API_KEY`.
 
-```bash title=".env"
-# Pick one provider's key (or several)
-MOONSHOT_API_KEY=
-DEEPSEEK_API_KEY=
-FIREWORKS_API_KEY=
-ANTHROPIC_API_KEY=
-OLLAMA_API_KEY=
+Use one of these instead:
 
-# Optional: choose models per role
-KOLEGA_CODE_PROVIDER=moonshot
-KOLEGA_CODE_MODEL=kimi-k2.7-code
-KOLEGA_CODE_THINKING_EFFORT=auto
-
-# Fireworks example:
-# KOLEGA_CODE_PROVIDER=fireworks
-# KOLEGA_CODE_MODEL=accounts/fireworks/models/glm-5p2
-
-# Ollama Cloud example:
-# KOLEGA_CODE_PROVIDER=ollama_cloud
-# KOLEGA_CODE_MODEL=glm-5.2
-
-# Optional: web search
-KOLEGA_CODE_WEB_SEARCH_BACKEND=duckduckgo
-
-# Optional: Langfuse tracing
-LANGFUSE_HOST=https://us.cloud.langfuse.com
-LANGFUSE_PUBLIC_KEY=
-LANGFUSE_SECRET_KEY=
+```bash title="one-off shell configuration"
+export MOONSHOT_API_KEY=...
+export KOLEGA_CODE_PROVIDER=moonshot
+export KOLEGA_CODE_MODEL=kimi-k2.7-code
+kolega-code
 ```
 
+Or save the provider, model, and API key in the TUI Settings tab. Settings are
+the recommended persistent configuration path for interactive use.
+
 :::caution
-Keep `.env` out of version control — it holds secrets. Add it to your
-`.gitignore`.
+Keep project `.env` files out of version control — they often hold application
+secrets. Add them to your `.gitignore`.
 :::

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -47,7 +47,7 @@ from kolega_code.permissions import (
 )
 
 from . import messages, theme
-from .config import CliConfigOverrides, key_status
+from .config import CliConfigOverrides, active_model_override_message, key_status
 from .connection import CliConnectionManager
 from .file_index import WorkspaceFileIndex
 from .mentions import build_file_attachments
@@ -1467,6 +1467,11 @@ class KolegaCodeApp(
             if model
             else "not checked until a model is configured"
         )
+        override_message = (
+            active_model_override_message(self.config, self.project_path, self.overrides, self.settings)
+            if self.config is not None
+            else None
+        )
         startup_lines = [*tui_constants.STARTUP_WORDMARK, ""]
         if self.config is None:
             startup_lines.extend(
@@ -1486,6 +1491,7 @@ class KolegaCodeApp(
                 f"Interaction: {self.interaction_mode}",
                 f"Permissions: {self.permission_mode.value}",
                 f"Model: {model_display}",
+                *([override_message] if override_message else []),
                 f"Thinking effort: {effort}",
                 f"API key: {api_key}",
                 "",

--- a/kolega_code/cli/config.py
+++ b/kolega_code/cli/config.py
@@ -7,8 +7,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping, Optional
 
-from dotenv import dotenv_values
-
 from pydantic import ValidationError
 
 from kolega_code.auth.tokens import ChatGPTTokenManager, OAuthTokens
@@ -81,14 +79,14 @@ class CliConfigOverrides:
 
 
 def load_cli_env(project_path: Path, env: Optional[Mapping[str, str]] = None) -> dict[str, str]:
-    """Load process environment over a project-local .env file."""
-    base_env = dict(env if env is not None else os.environ)
-    dotenv_path = project_path / ".env"
-    if not dotenv_path.exists():
-        return base_env
+    """Load Kolega Code's explicit process environment.
 
-    file_env = {key: value for key, value in dotenv_values(dotenv_path).items() if value is not None}
-    return {**file_env, **base_env}
+    ``project_path`` is accepted for backwards-compatible call sites, but project-local
+    ``.env`` files are intentionally ignored: they belong to the project being edited,
+    not to Kolega Code's own provider/model configuration.
+    """
+    _ = project_path
+    return dict(env if env is not None else os.environ)
 
 
 def _provider(value: str) -> ModelProvider:
@@ -97,6 +95,50 @@ def _provider(value: str) -> ModelProvider:
     except ValueError as exc:
         valid = ", ".join(provider.value for provider in ModelProvider)
         raise CliConfigError(f"Unsupported provider '{value}'. Valid providers: {valid}") from exc
+
+
+def _explicit_value(
+    flag_value: Optional[str],
+    env: Mapping[str, str],
+    env_key: str,
+    flag_name: str,
+) -> tuple[Optional[str], Optional[str]]:
+    """Return an explicit CLI/process-env value plus a human-readable source."""
+    if flag_value:
+        return flag_value, flag_name
+    env_value = env.get(env_key)
+    if env_value:
+        return env_value, env_key
+    return None, None
+
+
+def _model_sources(model: str) -> list[str]:
+    return sorted(provider for provider, candidate in MODEL_SPECS if candidate == model)
+
+
+def _ensure_explicit_model_supported(
+    provider: ModelProvider,
+    model: str,
+    *,
+    model_source: Optional[str],
+    provider_source: Optional[str],
+) -> None:
+    """Raise a targeted error when an explicit model is paired with the wrong provider."""
+    if (provider.value, model) in MODEL_SPECS:
+        return
+
+    model_label = f"{model_source}={model}" if model_source else f"Model '{model}'"
+    provider_label = f"{provider_source}={provider.value}" if provider_source else f"provider {provider.value}"
+    sources = _model_sources(model)
+    if sources:
+        preferred = sources[0]
+        if provider_source:
+            suggestion = f"set {provider_source}={preferred} or remove {model_source or 'the model override'}"
+        else:
+            suggestion = f"set the provider to {preferred} or remove {model_source or 'the model override'}"
+    else:
+        suggestion = f"choose a supported model for {provider.value} or remove {model_source or 'the model override'}"
+    raise CliConfigError(f"{model_label} is not available for {provider_label}; {suggestion}.")
 
 
 def _api_key_for_provider(
@@ -177,12 +219,20 @@ def _active_provider_model(
     overrides: CliConfigOverrides,
     settings: Optional[CliSettings],
 ) -> tuple[Optional[ModelProvider], Optional[str]]:
-    provider_value = overrides.provider or env.get("KOLEGA_CODE_PROVIDER")
-    model_value = overrides.model or env.get("KOLEGA_CODE_MODEL")
+    provider_value, provider_source = _explicit_value(overrides.provider, env, "KOLEGA_CODE_PROVIDER", "--provider")
+    model_value, model_source = _explicit_value(overrides.model, env, "KOLEGA_CODE_MODEL", "--model")
 
     if provider_value or model_value:
         provider = _provider(provider_value or DEFAULT_LONG_PROVIDER.value)
-        return provider, model_value or default_model_for_provider(provider)
+        if model_value:
+            _ensure_explicit_model_supported(
+                provider,
+                model_value,
+                model_source=model_source,
+                provider_source=provider_source,
+            )
+            return provider, model_value
+        return provider, default_model_for_provider(provider)
 
     if settings and settings.active_provider and settings.active_model:
         try:
@@ -205,13 +255,31 @@ def _slot_provider_model(
     active_provider: Optional[ModelProvider],
     active_model: Optional[str],
 ) -> tuple[ModelProvider, str]:
-    provider_value = provider_override or env.get(provider_env_key)
-    model_value = model_override or env.get(model_env_key)
+    provider_value, provider_source = _explicit_value(
+        provider_override,
+        env,
+        provider_env_key,
+        f"--{provider_env_key.removeprefix('KOLEGA_CODE_').lower().replace('_', '-')}",
+    )
+    model_value, model_source = _explicit_value(
+        model_override,
+        env,
+        model_env_key,
+        f"--{model_env_key.removeprefix('KOLEGA_CODE_').lower().replace('_', '-')}",
+    )
 
     if provider_value or model_value:
         provider = _provider(provider_value or (active_provider.value if active_provider else default_provider.value))
-        return provider, model_value or (
-            active_model if active_provider == provider and active_model else default_model_for_provider(provider)
+        if model_value:
+            _ensure_explicit_model_supported(
+                provider,
+                model_value,
+                model_source=model_source,
+                provider_source=provider_source,
+            )
+            return provider, model_value
+        return provider, active_model if active_provider == provider and active_model else default_model_for_provider(
+            provider
         )
 
     if active_provider and active_model:
@@ -281,15 +349,27 @@ def _agent_model_overrides(
     for role in AgentRole:
         provider_key, model_key, effort_key = _agent_role_env_keys(role)
         entry = saved.get(role.value) or {}
-        provider_value = env.get(provider_key) or entry.get("provider")
-        model_value = env.get(model_key) or entry.get("model")
-        effort_value = env.get(effort_key) or entry.get("thinking_effort")
+        provider_env_value = env.get(provider_key)
+        model_env_value = env.get(model_key)
+        effort_env_value = env.get(effort_key)
+        provider_value = provider_env_value or entry.get("provider")
+        model_value = model_env_value or entry.get("model")
+        effort_value = effort_env_value or entry.get("thinking_effort")
 
         if not provider_value and not model_value:
             continue
 
         provider = _provider(provider_value or active_provider.value)
         if model_value:
+            if model_env_value:
+                _ensure_explicit_model_supported(
+                    provider,
+                    model_value,
+                    model_source=model_key,
+                    provider_source=provider_key if provider_env_value else None,
+                )
+            elif (provider.value, model_value) not in MODEL_SPECS:
+                model_value = default_model_for_provider(provider)
             model = model_value
         elif active_provider == provider and active_model:
             model = active_model
@@ -438,6 +518,41 @@ def key_status(provider: str, project_path: Path, settings: Optional[CliSettings
     if settings and settings.get_api_key(provider_value.value):
         return "present in local settings"
     return "missing"
+
+
+def active_model_override_message(
+    config: AgentConfig,
+    project_path: Path,
+    overrides: Optional[CliConfigOverrides] = None,
+    settings: Optional[CliSettings] = None,
+    env: Optional[Mapping[str, str]] = None,
+) -> Optional[str]:
+    """Describe an explicit CLI/process-env active-model override, if one is in effect."""
+    overrides = overrides or CliConfigOverrides()
+    loaded_env = load_cli_env(project_path, env)
+    explicit_active_override = any(
+        (
+            overrides.provider,
+            overrides.model,
+            loaded_env.get("KOLEGA_CODE_PROVIDER"),
+            loaded_env.get("KOLEGA_CODE_MODEL"),
+        )
+    )
+    if not explicit_active_override:
+        return None
+    if not settings or not (settings.active_provider and settings.active_model):
+        return None
+
+    effective_provider = config.long_context_config.provider.value
+    effective_model = config.long_context_config.model
+    if settings.active_provider == effective_provider and settings.active_model == effective_model:
+        return None
+
+    return (
+        "Environment/CLI override active: "
+        f"using {effective_provider}/{effective_model} instead of saved "
+        f"{settings.active_provider}/{settings.active_model}."
+    )
 
 
 def config_summary(config: AgentConfig) -> dict[str, object]:

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -30,6 +30,7 @@ from .config import (
     DEPRECATED_THINKING_TOKENS_MESSAGE,
     CliConfigError,
     CliConfigOverrides,
+    active_model_override_message,
     build_agent_config,
     config_summary,
 )
@@ -812,6 +813,9 @@ def _run_doctor(args: argparse.Namespace) -> int:
 
     summary = config_summary(config)
     _print_styled(f"{theme.g(Glyph.CHECK)} Configuration: valid", style="success")
+    override_message = active_model_override_message(config, project_path, _overrides_from_args(args), settings)
+    if override_message:
+        line("Override", override_message, "warning")
     line("Long model", f"{summary['long_provider']}/{summary['long_model']}")
     line("Fast model", f"{summary['fast_provider']}/{summary['fast_model']}")
     line("Thinking model", f"{summary['thinking_provider']}/{summary['thinking_model']}")

--- a/kolega_code/cli/tui/settings_panel.py
+++ b/kolega_code/cli/tui/settings_panel.py
@@ -17,7 +17,7 @@ from kolega_code.agent.tool_backend.search_backends import (
 )
 
 from .. import messages, theme
-from ..config import key_status
+from ..config import active_model_override_message, key_status
 from ..provider_registry import (
     INHERIT_SENTINEL,
     UI_DEFAULT_MODEL,
@@ -334,7 +334,16 @@ class SettingsPanelMixin:
 
         await self._ensure_agent_from_settings(rebuild=True)
         if self.config is not None:
-            self._notify_user(messages.SETTINGS_SAVED)
+            override_message = active_model_override_message(
+                self.config,
+                self.project_path,
+                self.overrides,
+                self.settings,
+            )
+            if override_message:
+                self._notify_user(f"{messages.SETTINGS_SAVED} {override_message}", severity="warning")
+            else:
+                self._notify_user(messages.SETTINGS_SAVED)
 
     def _collect_agent_models_from_ui(self) -> None:
         """Write each per-agent row into settings.agent_models (inherit rows removed)."""
@@ -388,14 +397,22 @@ class SettingsPanelMixin:
         effort = self.settings.active_thinking_effort or default_ui_thinking_effort(provider, model) or "not supported"
         status = key_status(provider, self.project_path, self.settings)
         tone = "warning" if "missing" in status.lower() else "ok"
-        text = "\n".join(
-            [
-                messages.SETTINGS_ACTIVE_MODEL.format(provider=provider, model=model),
-                messages.SETTINGS_THINKING_EFFORT_LINE.format(effort=effort),
-                messages.SETTINGS_API_KEY_LINE.format(status=status),
-            ]
-        )
-        self._set_settings_status(text, tone)
+        lines = [
+            messages.SETTINGS_ACTIVE_MODEL.format(provider=provider, model=model),
+            messages.SETTINGS_THINKING_EFFORT_LINE.format(effort=effort),
+            messages.SETTINGS_API_KEY_LINE.format(status=status),
+        ]
+        if self.config is not None:
+            override_message = active_model_override_message(
+                self.config,
+                self.project_path,
+                self.overrides,
+                self.settings,
+            )
+            if override_message:
+                lines.append(override_message)
+                tone = "warning"
+        self._set_settings_status("\n".join(lines), tone)
         self._refresh_status_dashboard()
 
     def _api_key_placeholder(self, provider: str) -> str:

--- a/tests/cli/test_app_bootstrap_settings.py
+++ b/tests/cli/test_app_bootstrap_settings.py
@@ -418,6 +418,47 @@ async def test_textual_app_does_not_select_model_from_api_key_env(
 
 
 @pytest.mark.asyncio
+async def test_textual_app_ignores_project_dotenv_api_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            raise AssertionError("agent should not be built from a project .env API key")
+
+    monkeypatch.setattr(agent_runtime_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".env").write_text("OPENAI_API_KEY=project-openai-key\n", encoding="utf-8")
+    state_dir = tmp_path / "state"
+    store = SessionStore(state_dir)
+    settings_store = SettingsStore(state_dir)
+    session = store.create(project, "code", {})
+
+    app = KolegaCodeApp(
+        project_path=project,
+        mode="code",
+        store=store,
+        settings_store=settings_store,
+        session=session,
+    )
+
+    async with app.run_test():
+        assert app.agent is None
+        composer = app.query_one("#composer", ChatComposer)
+        assert composer.disabled is True
+        startup = app.conversation_entries[0].content
+        assert "Not connected." in startup
+        assert "Model: not configured" in startup
+        assert "openai" not in startup.lower()
+
+
+@pytest.mark.asyncio
 async def test_textual_app_mounts_with_stored_kimi_settings(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
 ) -> None:
@@ -474,6 +515,72 @@ async def test_textual_app_mounts_with_stored_kimi_settings(
         assert composer.disabled is False
         assert composer.placeholder == "Ask Kolega Code..."
         assert "Not connected." not in app.conversation_entries[0].content
+
+
+@pytest.mark.asyncio
+async def test_textual_app_shows_process_env_model_override_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.widgets import Static
+
+    from kolega_code.cli.app import KolegaCodeApp
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            return None
+
+    monkeypatch.setenv("OPENAI_API_KEY", "process-openai-key")
+    monkeypatch.setenv("KOLEGA_CODE_PROVIDER", ModelProvider.OPENAI.value)
+    monkeypatch.setenv("KOLEGA_CODE_MODEL", "gpt-5.5")
+    monkeypatch.setattr(agent_runtime_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    state_dir = tmp_path / "state"
+    store = SessionStore(state_dir)
+    settings_store = SettingsStore(state_dir)
+    settings = CliSettings(active_provider=UI_DEFAULT_PROVIDER, active_model=UI_DEFAULT_MODEL)
+    settings.set_api_key(UI_DEFAULT_PROVIDER, "moonshot-key")
+    settings_store.save(settings)
+    session = store.create(project, "code", {})
+
+    app = KolegaCodeApp(
+        project_path=project,
+        mode="code",
+        store=store,
+        settings_store=settings_store,
+        session=session,
+    )
+
+    async with app.run_test():
+        assert isinstance(app.agent, FakeCoderAgent)
+        assert app.agent.kwargs["config"].long_context_config.provider == ModelProvider.OPENAI
+        startup = app.conversation_entries[0].content
+        assert "Model: openai/gpt-5.5" in startup
+        assert (
+            "Environment/CLI override active: using openai/gpt-5.5 instead of saved "
+            f"{UI_DEFAULT_PROVIDER}/{UI_DEFAULT_MODEL}."
+        ) in startup
+        assert "API key: present via OPENAI_API_KEY" in startup
+        status = str(app.query_one("#settings_status", Static).render())
+        assert "Environment/CLI override active" in status
 
 
 @pytest.mark.asyncio
@@ -566,6 +673,7 @@ async def test_textual_app_saves_settings_and_builds_agent(
 
     project = tmp_path / "project"
     project.mkdir()
+    (project / ".env").write_text("OPENAI_API_KEY=project-openai-key\n", encoding="utf-8")
     state_dir = tmp_path / "state"
     store = SessionStore(state_dir)
     settings_store = SettingsStore(state_dir)
@@ -585,6 +693,7 @@ async def test_textual_app_saves_settings_and_builds_agent(
 
         assert isinstance(app.agent, FakeCoderAgent)
         assert app.agent.kwargs["config"].long_context_config.provider == ModelProvider.MOONSHOT
+        assert app.agent.kwargs["config"].openai_api_key is None
         assert settings_store.load().get_api_key(UI_DEFAULT_PROVIDER) == "moonshot-key"
         assert settings_store.load().active_thinking_effort == "auto"
         assert app.query_one("#composer", ChatComposer).disabled is False

--- a/tests/cli/test_cli_config.py
+++ b/tests/cli/test_cli_config.py
@@ -133,7 +133,7 @@ def test_build_agent_config_requires_api_key(tmp_path: Path) -> None:
 
 
 def test_build_agent_config_rejects_unknown_model(tmp_path: Path) -> None:
-    with pytest.raises(CliConfigError, match="not supported"):
+    with pytest.raises(CliConfigError, match="not available"):
         build_agent_config(tmp_path, CliConfigOverrides(model="claude-not-real"), env={"ANTHROPIC_API_KEY": "key"})
 
 
@@ -151,6 +151,106 @@ def test_config_summary_excludes_api_keys(tmp_path: Path) -> None:
     assert summary["long_model"] == DEFAULT_LONG_MODEL
     assert "secret-value" not in str(summary)
     assert "api_key" not in str(summary).lower()
+
+
+def test_project_dotenv_openai_key_is_ignored_when_settings_choose_moonshot(tmp_path: Path) -> None:
+    (tmp_path / ".env").write_text("OPENAI_API_KEY=project-openai-key\n", encoding="utf-8")
+    settings = CliSettings(active_provider=UI_DEFAULT_PROVIDER, active_model=UI_DEFAULT_MODEL)
+    settings.set_api_key(UI_DEFAULT_PROVIDER, "moonshot-key")
+
+    config = build_agent_config(tmp_path, settings=settings, env={})
+
+    assert config.long_context_config.provider == ModelProvider.MOONSHOT
+    assert config.long_context_config.model == UI_DEFAULT_MODEL
+    assert config.openai_api_key is None
+    assert config.moonshot_api_key == "moonshot-key"
+
+
+def test_project_dotenv_api_key_alone_does_not_configure_model(tmp_path: Path) -> None:
+    (tmp_path / ".env").write_text("OPENAI_API_KEY=project-openai-key\n", encoding="utf-8")
+
+    with pytest.raises(CliConfigError, match="No provider/model configured"):
+        build_agent_config(tmp_path, env={})
+
+
+def test_project_dotenv_model_selection_is_ignored(tmp_path: Path) -> None:
+    (tmp_path / ".env").write_text(
+        "OPENAI_API_KEY=project-openai-key\nKOLEGA_CODE_PROVIDER=openai\nKOLEGA_CODE_MODEL=gpt-5.5\n",
+        encoding="utf-8",
+    )
+    settings = CliSettings(active_provider=UI_DEFAULT_PROVIDER, active_model=UI_DEFAULT_MODEL)
+    settings.set_api_key(UI_DEFAULT_PROVIDER, "moonshot-key")
+
+    config = build_agent_config(tmp_path, settings=settings, env={})
+
+    assert config.long_context_config.provider == ModelProvider.MOONSHOT
+    assert config.long_context_config.model == UI_DEFAULT_MODEL
+    assert config.openai_api_key is None
+
+
+def test_project_dotenv_model_selection_without_settings_is_unconfigured(tmp_path: Path) -> None:
+    (tmp_path / ".env").write_text(
+        "OPENAI_API_KEY=project-openai-key\nKOLEGA_CODE_PROVIDER=openai\nKOLEGA_CODE_MODEL=gpt-5.5\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CliConfigError, match="No provider/model configured"):
+        build_agent_config(tmp_path, env={})
+
+
+def test_process_openai_key_and_model_selection_still_work(tmp_path: Path) -> None:
+    config = build_agent_config(
+        tmp_path,
+        env={
+            "OPENAI_API_KEY": "process-openai-key",
+            "KOLEGA_CODE_PROVIDER": ModelProvider.OPENAI.value,
+            "KOLEGA_CODE_MODEL": "gpt-5.5",
+        },
+    )
+
+    assert config.long_context_config.provider == ModelProvider.OPENAI
+    assert config.long_context_config.model == "gpt-5.5"
+    assert config.openai_api_key == "process-openai-key"
+
+
+def test_explicit_model_override_rejects_mismatched_provider(tmp_path: Path) -> None:
+    settings = CliSettings(active_provider=UI_DEFAULT_PROVIDER, active_model=UI_DEFAULT_MODEL)
+    settings.set_api_key(UI_DEFAULT_PROVIDER, "moonshot-key")
+
+    with pytest.raises(CliConfigError, match=r"KOLEGA_CODE_MODEL=gpt-5\.5 is not available"):
+        build_agent_config(tmp_path, settings=settings, env={"KOLEGA_CODE_MODEL": "gpt-5.5"})
+
+
+@pytest.mark.parametrize(
+    ("provider_key", "model_key"),
+    [
+        ("KOLEGA_CODE_FAST_PROVIDER", "KOLEGA_CODE_FAST_MODEL"),
+        ("KOLEGA_CODE_THINKING_PROVIDER", "KOLEGA_CODE_THINKING_MODEL"),
+    ],
+)
+def test_explicit_slot_model_override_rejects_mismatched_provider(
+    tmp_path: Path, provider_key: str, model_key: str
+) -> None:
+    settings = CliSettings(active_provider=UI_DEFAULT_PROVIDER, active_model=UI_DEFAULT_MODEL)
+    settings.set_api_key(UI_DEFAULT_PROVIDER, "moonshot-key")
+
+    with pytest.raises(CliConfigError, match=rf"{model_key}=gpt-5\.5 is not available"):
+        build_agent_config(tmp_path, settings=settings, env={provider_key: UI_DEFAULT_PROVIDER, model_key: "gpt-5.5"})
+
+
+def test_explicit_agent_model_override_rejects_mismatched_provider(tmp_path: Path) -> None:
+    settings = CliSettings(active_provider=UI_DEFAULT_PROVIDER, active_model=UI_DEFAULT_MODEL)
+    settings.set_api_key(UI_DEFAULT_PROVIDER, "moonshot-key")
+
+    with pytest.raises(CliConfigError, match=r"KOLEGA_CODE_INVESTIGATION_MODEL=gpt-5\.5 is not available"):
+        build_agent_config(
+            tmp_path,
+            settings=settings,
+            env={
+                "KOLEGA_CODE_INVESTIGATION_PROVIDER": UI_DEFAULT_PROVIDER,
+                "KOLEGA_CODE_INVESTIGATION_MODEL": "gpt-5.5",
+            },
+        )
 
 
 def test_build_agent_config_uses_stored_kimi_for_model_slots(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Stop loading target project `.env` files for Kolega Code provider/model/API-key configuration
- Keep explicit CLI/process env overrides, with clearer provider/model mismatch errors
- Surface active CLI/env model overrides in startup, Settings status, Settings save notifications, and `doctor`
- Update docs and `.env.example` to recommend Settings or exported shell env vars instead of project `.env`

## Tests
- `pytest tests/cli/test_cli_config.py tests/cli/test_app_bootstrap_settings.py`
- `ruff check kolega_code/cli/config.py kolega_code/cli/app.py kolega_code/cli/tui/settings_panel.py kolega_code/cli/main.py tests/cli/test_cli_config.py tests/cli/test_app_bootstrap_settings.py`
- Attempted full `pytest`; stopped after ~5 minutes in live-provider tests with `203 passed` and no failures reported before interruption.
