### PR TITLE
ci: use trusted token for coverage badge PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,14 +142,24 @@ jobs:
           badge.write_text(badge.read_text().rstrip("\n") + "\n")
           PY
 
+      - name: Verify coverage badge PR token
+        env:
+          COVERAGE_BADGE_PR_TOKEN: ${{ secrets.COVERAGE_BADGE_PR_TOKEN }}
+        run: |
+          if [ -z "$COVERAGE_BADGE_PR_TOKEN" ]; then
+            echo "::error::Set the COVERAGE_BADGE_PR_TOKEN repository secret to a trusted bot/user token."
+            exit 1
+          fi
+
       - name: Create coverage badge pull request
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
+          token: ${{ secrets.COVERAGE_BADGE_PR_TOKEN }}
           add-paths: docs/src/assets/coverage.svg
           commit-message: "chore: update coverage badge"
-          committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
-          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          committer: "${{ vars.COVERAGE_BADGE_COMMITTER || 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>' }}"
+          author: "${{ vars.COVERAGE_BADGE_AUTHOR || 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>' }}"
           branch: chore/update-coverage-badge
           delete-branch: true
           title: "chore: update coverage badge"
@@ -159,7 +169,7 @@ jobs:
       - name: Enable auto-merge for coverage badge PR
         if: steps.cpr.outputs.pull-request-number != '' && steps.cpr.outputs.pull-request-operation != 'none'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.COVERAGE_BADGE_PR_TOKEN }}
         run: |
           gh pr merge "${{ steps.cpr.outputs.pull-request-number }}" --auto --squash --delete-branch
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,31 @@ npm run build
 
 Use `npm run dev` from `docs/` for local documentation development.
 
+## Maintainer automation
+
+The CI workflow updates `docs/src/assets/coverage.svg` by opening an automated pull
+request. Configure the repository secret `COVERAGE_BADGE_PR_TOKEN` with a trusted
+bot or maintainer token instead of `GITHUB_TOKEN`; GitHub requires manual approval
+before workflows run on pull requests opened by `github-actions[bot]`.
+
+Use a fine-grained personal access token or GitHub App token scoped to this
+repository with:
+
+- Contents: read and write
+- Pull requests: read and write
+- Metadata: read-only, included automatically
+
+The token owner should be a trusted repository member or bot account. Do not use
+a first-time external contributor account, and never commit the token value.
+
+Optional repository variables can customize the Git commit identity used for the
+badge update commit:
+
+- `COVERAGE_BADGE_AUTHOR`
+- `COVERAGE_BADGE_COMMITTER`
+
+Use values like `Name <email@example.com>`.
+
 ## Pull Requests
 
 - Keep changes focused and avoid unrelated refactors.


### PR DESCRIPTION
## Summary
- use `COVERAGE_BADGE_PR_TOKEN` when creating and auto-merging coverage badge PRs
- fail clearly if the trusted token secret is missing
- document the secret and optional commit identity variables for maintainers

## Checks
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'yaml ok'"\n- git diff --check\n- commit hooks: ruff check, ruff format, trim trailing whitespace, fix end of files, check yaml, debug statements, detect private key