### PR TITLE
fix(ollama): preserve cloud reasoning provider metadata

### DIFF
--- a/kolega_code/agent/conversation.py
+++ b/kolega_code/agent/conversation.py
@@ -343,7 +343,11 @@ class Conversation:
 
                         if replaced_any:
                             self.history[i] = Message(
-                                role=msg.role, content=updated_content, stop_reason=msg.stop_reason
+                                role=msg.role,
+                                content=updated_content,
+                                stop_reason=msg.stop_reason,
+                                tool_calls=msg.tool_calls,
+                                usage_metadata=msg.usage_metadata,
                             )
 
                 # Add any remaining new tool results along with other blocks
@@ -368,6 +372,7 @@ class Conversation:
                 content=[TextBlock(text="[Assistant returned no message content]")],
                 stop_reason=message.stop_reason,
                 tool_calls=message.tool_calls,
+                usage_metadata=message.usage_metadata,
             )
 
         self.history.append(message)
@@ -541,7 +546,11 @@ class Conversation:
                                     if remaining_content:
                                         # Message has other content - keep it but remove tool results
                                         updated_msg = Message(
-                                            role=msg.role, content=remaining_content, stop_reason=msg.stop_reason
+                                            role=msg.role,
+                                            content=remaining_content,
+                                            stop_reason=msg.stop_reason,
+                                            tool_calls=msg.tool_calls,
+                                            usage_metadata=msg.usage_metadata,
                                         )
                                         messages[j] = updated_msg
                                     else:
@@ -572,6 +581,8 @@ class Conversation:
                             role="user",
                             content=all_content,
                             stop_reason=next_user_message.stop_reason if next_user_message else None,
+                            tool_calls=next_user_message.tool_calls if next_user_message else None,
+                            usage_metadata=next_user_message.usage_metadata if next_user_message else None,
                         )
                         fixed_messages.append(complete_user_message)
 

--- a/tests/agent/llm/test_openai_message_conversion.py
+++ b/tests/agent/llm/test_openai_message_conversion.py
@@ -10,7 +10,7 @@ from kolega_code.llm.models import (
     ToolResult,
     TextBlock,
 )
-from kolega_code.llm.providers.openai import OpenAIStreamWrapper
+from kolega_code.llm.providers.openai import OpenAIProvider, OpenAIStreamWrapper
 
 
 def _image() -> ImageBlock:
@@ -241,3 +241,40 @@ def test_openai_stream_wrapper_accumulates_reasoning_field_in_final_message():
     assert message.content[1].text == "final answer"
     assert message.stop_reason == "end_turn"
     assert message.usage_metadata["provider"] == "ollama_cloud"
+
+
+def test_openai_provider_generate_stamps_ollama_cloud_provider_name_without_usage():
+    class OpenAIMessage:
+        content = "final answer"
+        reasoning = "ollama reasoning"
+        tool_calls = None
+
+    class Choice:
+        message = OpenAIMessage()
+
+    class Response:
+        choices = [Choice()]
+        usage = None
+
+    class FakeCompletions:
+        async def create(self, **kwargs):
+            return Response()
+
+    class FakeChat:
+        completions = FakeCompletions()
+
+    class FakeAsyncClient:
+        chat = FakeChat()
+
+    async def run_generate():
+        provider = OpenAIProvider(api_key="sk-test", provider_name="ollama_cloud")
+        provider.async_client = FakeAsyncClient()
+        return await provider.generate(MessageHistory([]), model="gpt-oss:20b")
+
+    message = asyncio.run(run_generate())
+
+    assert message.usage_metadata["provider"] == "ollama_cloud"
+    assert isinstance(message.content[0], ThinkingBlock)
+    assert message.content[0].thinking == "ollama reasoning"
+    assert isinstance(message.content[1], TextBlock)
+    assert message.content[1].text == "final answer"

--- a/tests/agent/test_empty_message_handling.py
+++ b/tests/agent/test_empty_message_handling.py
@@ -24,6 +24,18 @@ def test_append_assistant_message_with_empty_content(caplog):
     assert appended_msg.content[0].text == "[Assistant returned no message content]"
 
 
+def test_append_assistant_message_with_empty_content_preserves_usage_metadata(caplog):
+    """Replacing empty assistant content must not lose provider metadata used for reasoning replay."""
+    conversation = Conversation()
+
+    empty_message = Message(role="assistant", content=[], usage_metadata={"provider": "ollama_cloud"})
+
+    with caplog.at_level(logging.WARNING, logger="kolega_code.agent.conversation"):
+        conversation.append_assistant(empty_message)
+
+    assert conversation.history[0].usage_metadata["provider"] == "ollama_cloud"
+
+
 def test_append_user_message_with_empty_content(caplog):
     """Empty user messages get placeholder text."""
     conversation = Conversation()

--- a/tests/agent/test_history_adapter_thinking.py
+++ b/tests/agent/test_history_adapter_thinking.py
@@ -121,6 +121,51 @@ def test_adapt_preserves_fireworks_thinking_when_targeting_fireworks():
     assert out[0].content[0].thinking == "native reasoning"
 
 
+def test_adapt_preserves_ollama_cloud_thinking_when_targeting_ollama_cloud():
+    history = [_assistant(ThinkingBlock(thinking="ollama reasoning"), provider="ollama_cloud")]
+
+    out = adapt_history_for_provider(
+        history,
+        target_provider="ollama_cloud",
+        target_model="gpt-oss:20b",
+        supports_vision=False,
+    )
+
+    assert out is history
+    assert isinstance(out[0].content[0], ThinkingBlock)
+    assert out[0].content[0].thinking == "ollama reasoning"
+
+
+def test_adapt_converts_ollama_cloud_thinking_when_targeting_foreign_provider():
+    history = [_assistant(ThinkingBlock(thinking="ollama reasoning"), provider="ollama_cloud")]
+
+    out = adapt_history_for_provider(
+        history,
+        target_provider="anthropic",
+        target_model="claude-opus-4-8",
+        supports_vision=True,
+    )
+
+    assert out[0] is not history[0]
+    assert isinstance(out[0].content[0], TextBlock)
+    assert "Prior reasoning from ollama_cloud omitted" in out[0].content[0].text
+
+
+def test_adapt_converts_ollama_cloud_thinking_without_source_provider():
+    history = [_assistant(ThinkingBlock(thinking="ollama reasoning"))]
+
+    out = adapt_history_for_provider(
+        history,
+        target_provider="ollama_cloud",
+        target_model="gpt-oss:20b",
+        supports_vision=False,
+    )
+
+    assert out[0] is not history[0]
+    assert isinstance(out[0].content[0], TextBlock)
+    assert "Prior reasoning from unknown provider omitted" in out[0].content[0].text
+
+
 def test_adapt_converts_thinking_without_source_provider():
     history = [_assistant(ThinkingBlock(thinking="unknown-source reasoning"))]
 
@@ -196,6 +241,21 @@ def test_adapt_does_not_mutate_stored_history():
     assert isinstance(history[1].content[0], ThinkingBlock)
     assert history[1].content[0] is thinking
     assert isinstance(out[1].content[0], TextBlock)
+
+
+def test_repaired_preserves_usage_metadata_when_rebuilding_tool_result_message():
+    conversation = Conversation()
+    tool_call = ToolCall(id="tool1", name="read_file", input={"path": "README.md"})
+    tool_result = ToolResult(tool_use_id="tool1", name="read_file", content="ok", is_error=False)
+    messages = [
+        _assistant(tool_call, provider="ollama_cloud"),
+        Message(role="user", content=[tool_result], usage_metadata={"provider": "tool_runner"}),
+    ]
+
+    repaired = conversation.repaired(messages)
+
+    assert repaired[0].usage_metadata["provider"] == "ollama_cloud"
+    assert repaired[1].usage_metadata["provider"] == "tool_runner"
 
 
 def test_adapted_kimi_thinking_is_not_serialized_as_anthropic_thinking():


### PR DESCRIPTION
## Summary
- preserve usage metadata when conversation messages are reconstructed during append/repair flows
- add regressions ensuring Ollama Cloud reasoning is preserved only for same-provider replay
- verify OpenAI-compatible Ollama streaming/generate paths stamp provider metadata as `ollama_cloud`

## Validation
- `pytest tests/agent/test_history_adapter_thinking.py tests/agent/llm/test_openai_message_conversion.py tests/agent/test_empty_message_handling.py -q`
- `pytest tests/agent -q`
- live Ollama Cloud validation with `gpt-oss:20b`: captured live reasoning, verified provider metadata stayed `ollama_cloud`, adapted same-provider history without stripping, and replayed the preserved reasoning in a second live request