### PR TITLE
fix(tui): stabilize terminal rendering artifacts

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -9,6 +9,7 @@ import time
 from pathlib import Path
 from typing import Optional
 
+from rich.console import Group
 from rich.text import Text
 from textual import events
 from textual.app import App, ComposeResult
@@ -83,6 +84,7 @@ from .tui import settings_panel as tui_settings_panel
 from .tui import status_dashboard as tui_status_dashboard
 from .tui import state as tui_state
 from .tui import sub_agent_screen as tui_sub_agents
+from .tui import terminal_display as tui_terminal_display
 from .tui import transcript as tui_transcript
 from .tui import widgets as tui_widgets
 
@@ -91,6 +93,8 @@ LOG_MAX_LINES = 2_000
 TERMINAL_MAX_LINES = 2_000
 TERMINAL_FLUSH_INTERVAL = 0.04
 TERMINAL_IMMEDIATE_FLUSH_CHARS = 64 * 1024
+LOG_FLUSH_INTERVAL = 0.05
+LOG_IMMEDIATE_FLUSH_ITEMS = 100
 
 
 class KolegaCodeApp(
@@ -169,6 +173,7 @@ class KolegaCodeApp(
         self._sub_agent_seq = 0
         self._workflow_activities: dict[str, tui_state.WorkflowActivity] = {}
         self._render_pending = False
+        self._conversation_anchor_pending = False
         self._entry_widgets: dict[str, tui_widgets.ConversationEntryWidget | tui_widgets.ToolEntryWidget] = {}
         self._dirty_entry_ids: set[str] = set()
         self._active_progress_entry: Optional[tui_state.ConversationEntry] = None
@@ -214,6 +219,9 @@ class KolegaCodeApp(
         self._terminal_output_buffer: list[str] = []
         self._terminal_output_buffer_chars = 0
         self._terminal_flush_timer: Optional[Timer] = None
+        self._terminal_display_normalizer = tui_terminal_display.TerminalDisplayNormalizer()
+        self._log_output_buffer: list[object] = []
+        self._log_flush_timer: Optional[Timer] = None
 
     def compose(self) -> ComposeResult:
         with Horizontal(id="body"):
@@ -425,7 +433,8 @@ class KolegaCodeApp(
         )
 
     def _queue_terminal_output(self, output: str) -> None:
-        """Buffer terminal chunks so high-volume output renders in batches."""
+        """Buffer display-safe terminal chunks so high-volume output renders in batches."""
+        output = self._terminal_display_normalizer.feed(output)
         if not output:
             return
 
@@ -468,6 +477,7 @@ class KolegaCodeApp(
         terminal.write_terminal(output)
 
     def _write_terminal_command(self, command: str) -> None:
+        self._terminal_display_normalizer.reset()
         self._flush_terminal_output()
         try:
             terminal = self._terminal
@@ -484,10 +494,15 @@ class KolegaCodeApp(
         if self._terminal_flush_timer is not None:
             self._terminal_flush_timer.stop()
             self._terminal_flush_timer = None
+        if self._log_flush_timer is not None:
+            self._log_flush_timer.stop()
+            self._log_flush_timer = None
 
+        self._terminal_display_normalizer.reset()
         self._terminal_output_buffer.clear()
         self._terminal_output_buffer_chars = 0
         self._terminal_has_content = False
+        self._log_output_buffer.clear()
 
         try:
             self._terminal.clear_output()
@@ -516,12 +531,42 @@ class KolegaCodeApp(
         """Single write path into the optional Logs tab."""
         if not self.show_logs:
             return
+        self._queue_log_output(self._format_log_line(text, level))
+
+    def _queue_log_output(self, renderable: object) -> None:
+        buffer_was_empty = not self._log_output_buffer
+        self._log_output_buffer.append(renderable)
+
+        if buffer_was_empty:
+            self._mark_tab_activity("logs_pane")
+
+        if len(self._log_output_buffer) >= LOG_IMMEDIATE_FLUSH_ITEMS:
+            self._flush_log_output()
+            return
+
+        if self._log_flush_timer is None:
+            self._log_flush_timer = self.set_timer(
+                LOG_FLUSH_INTERVAL,
+                self._flush_log_output,
+                name="log-output-flush",
+            )
+
+    def _flush_log_output(self) -> None:
+        """Write any buffered log lines as one RichLog append."""
+        if self._log_flush_timer is not None:
+            self._log_flush_timer.stop()
+            self._log_flush_timer = None
+
+        if not self._log_output_buffer:
+            return
+
+        entries = list(self._log_output_buffer)
+        self._log_output_buffer.clear()
         try:
             logs = self._logs
         except Exception:
             return
-        logs.write_log(self._format_log_line(text, level))
-        self._mark_tab_activity("logs_pane")
+        logs.write_log(entries[0] if len(entries) == 1 else Group(*entries))
 
     def _mark_tab_activity(self, pane_id: str) -> None:
         """Add an activity dot to a background tab's label."""

--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -84,6 +84,8 @@ class AgentRuntimeMixin:
             self._log_status(messages.STOPPED_WITH_ERROR.format(error=exc), "error")
             raise
         finally:
+            self._flush_terminal_output()
+            self._flush_log_output()
             self._flush_conversation_render()
             self._active_progress_entry = None
             self._turn_active = False
@@ -109,6 +111,7 @@ class AgentRuntimeMixin:
                 break
             self._render_event(event)
         self._flush_terminal_output()
+        self._flush_log_output()
 
     def _render_event(self, event: AgentEvent) -> None:
         if event.event_type == "log_message":
@@ -116,7 +119,10 @@ class AgentRuntimeMixin:
                 level = str(event.content.get("level", "info"))
                 self._write_log(self._display_text_from_event(event), level)
         elif event.event_type == "terminal_output":
-            self._queue_terminal_output(event.content.get("output", ""))
+            output = event.content.get("display_output")
+            if output is None:
+                output = event.content.get("output", "")
+            self._queue_terminal_output(str(output))
         elif event.event_type == "terminal_command":
             command = str(event.content.get("command") or "")
             self._write_terminal_command(command)

--- a/kolega_code/cli/tui/styles.tcss
+++ b/kolega_code/cli/tui/styles.tcss
@@ -1,5 +1,12 @@
 Screen {
     layout: vertical;
+    scrollbar-background: $surface;
+    scrollbar-background-hover: $surface;
+    scrollbar-background-active: $surface-lighten-2;
+    scrollbar-color: $surface-lighten-2;
+    scrollbar-color-hover: $text-muted;
+    scrollbar-color-active: $text;
+    scrollbar-corner-color: $surface;
 }
 
 #body {
@@ -20,6 +27,9 @@ Screen {
 #conversation, #logs, #terminal {
     height: 1fr;
     border: round $surface;
+    background: $surface;
+    color: $text;
+    overflow-x: hidden;
 }
 
 ConversationEntryWidget {
@@ -203,7 +213,19 @@ ToolEntryWidget .tool-body {
 }
 
 #composer:disabled {
-    opacity: 0.6;
+    color: $text-muted;
+    background: $surface;
+    border: round $surface;
+}
+
+#composer:disabled .text-area--cursor {
+    background: $surface-lighten-2;
+    color: $text-muted;
+}
+
+#composer:disabled .text-area--selection {
+    background: $surface-lighten-2;
+    color: $text;
 }
 
 #plan_actions, #model_actions, #effort_actions, #theme_actions {
@@ -269,6 +291,12 @@ OptionList > .option-list--option-highlighted {
 
 Footer {
     background: $surface;
+    color: $text-muted;
+}
+
+Footer > .footer--highlight {
+    background: $surface-lighten-2;
+    color: $text;
 }
 
 Input {
@@ -289,6 +317,8 @@ Select:focus > SelectCurrent {
 
 Select > SelectOverlay {
     border: round $surface;
+    background: $surface;
+    color: $text;
 }
 
 SubAgentInspectorScreen {

--- a/kolega_code/cli/tui/terminal_display.py
+++ b/kolega_code/cli/tui/terminal_display.py
@@ -1,0 +1,137 @@
+"""Display-only terminal stream normalization for the Textual sidebar.
+
+The sidebar terminal is a readable transcript, not a terminal emulator.  Real PTY
+output may contain cursor movement, erase commands, hyperlinks, carriage-return
+progress redraws, and other control bytes that RichLog/Textual should not receive
+raw.  This module strips terminal controls and keeps stable text suitable for a
+log-style widget while leaving the model-facing command output untouched.
+"""
+
+from __future__ import annotations
+
+from enum import Enum, auto
+
+
+class _State(Enum):
+    NORMAL = auto()
+    ESC = auto()
+    CSI = auto()
+    OSC = auto()
+    STRING = auto()
+    OSC_ESC = auto()
+    STRING_ESC = auto()
+
+
+class TerminalDisplayNormalizer:
+    """Incrementally sanitize terminal output for a log-style display.
+
+    The normalizer is intentionally conservative: it strips terminal control
+    sequences instead of trying to emulate screen state. Standalone carriage
+    returns become newlines so progress redraws become readable transcript lines
+    rather than raw cursor controls. Backspace/delete remove previous characters
+    only within the currently emitted chunk; earlier RichLog lines are not
+    mutated.
+    """
+
+    def __init__(self) -> None:
+        self._state = _State.NORMAL
+
+    def reset(self) -> None:
+        """Drop any pending partial escape/control sequence."""
+        self._state = _State.NORMAL
+
+    def flush(self) -> str:
+        """Finish the stream, discarding incomplete escape/control sequences."""
+        self.reset()
+        return ""
+
+    def feed(self, text: str) -> str:
+        """Return a display-safe representation of ``text``.
+
+        Args:
+            text: Incremental terminal output text. It may split escape sequences
+                across calls.
+        """
+        if not text:
+            return ""
+
+        out: list[str] = []
+        index = 0
+        length = len(text)
+        while index < length:
+            ch = text[index]
+            code = ord(ch)
+            state = self._state
+
+            if state is _State.NORMAL:
+                if ch == "\x1b":
+                    self._state = _State.ESC
+                elif ch == "\r":
+                    # CRLF is a newline; standalone CR progress redraws become
+                    # stable transcript line breaks.
+                    if index + 1 < length and text[index + 1] == "\n":
+                        out.append("\n")
+                        index += 1
+                    else:
+                        out.append("\n")
+                elif ch == "\b" or ch == "\x7f":
+                    self._erase_previous_output_char(out)
+                elif ch == "\n" or ch == "\t":
+                    out.append(ch)
+                elif self._is_c0_or_c1_control(code):
+                    # Drop BEL, NUL, form-feed, vertical tab, etc. RichLog is a
+                    # display surface, not a control receiver.
+                    pass
+                else:
+                    out.append(ch)
+
+            elif state is _State.ESC:
+                if ch == "[":
+                    self._state = _State.CSI
+                elif ch == "]":
+                    self._state = _State.OSC
+                elif ch in {"P", "^", "_", "X"}:
+                    self._state = _State.STRING
+                elif 0x40 <= code <= 0x5F or 0x60 <= code <= 0x7E:
+                    # Two-byte escape sequence: ESC c, ESC 7, ESC 8, etc.
+                    self._state = _State.NORMAL
+                elif self._is_c0_or_c1_control(code):
+                    # Ignore controls inside escape dispatch.
+                    pass
+                else:
+                    self._state = _State.NORMAL
+
+            elif state is _State.CSI:
+                # CSI final byte range per ECMA-48.
+                if 0x40 <= code <= 0x7E:
+                    self._state = _State.NORMAL
+
+            elif state is _State.OSC:
+                if ch == "\x07":
+                    self._state = _State.NORMAL
+                elif ch == "\x1b":
+                    self._state = _State.OSC_ESC
+
+            elif state is _State.OSC_ESC:
+                self._state = _State.NORMAL if ch == "\\" else _State.OSC
+
+            elif state is _State.STRING:
+                if ch == "\x1b":
+                    self._state = _State.STRING_ESC
+
+            elif state is _State.STRING_ESC:
+                self._state = _State.NORMAL if ch == "\\" else _State.STRING
+
+            index += 1
+
+        return "".join(out)
+
+    @staticmethod
+    def _is_c0_or_c1_control(code: int) -> bool:
+        return (0 <= code < 32) or (0x7F <= code <= 0x9F)
+
+    @staticmethod
+    def _erase_previous_output_char(out: list[str]) -> None:
+        # Do not erase across emitted line boundaries.
+        if out and out[-1] != "\n":
+            out.pop()

--- a/kolega_code/cli/tui/transcript.py
+++ b/kolega_code/cli/tui/transcript.py
@@ -227,15 +227,15 @@ class TranscriptRenderingMixin:
         chunk_uuid = str(chunk.get("uuid") or "")
         content = str(chunk.get("content") or "")
         complete = bool(chunk.get("complete"))
+        cache_key = chunk_uuid or f"__nouuid__:{kind}"
 
-        entry = self._stream_entries.get(chunk_uuid) if chunk_uuid else None
-        if entry is None:
+        entry = self._stream_entries.get(cache_key)
+        if entry is None or (not chunk_uuid and entry.complete):
             if not content:
                 return
             entry = ConversationEntry(kind=kind, content="", complete=complete, uuid=chunk_uuid or None)
             self.conversation_entries.append(entry)
-            if chunk_uuid:
-                self._stream_entries[chunk_uuid] = entry
+            self._stream_entries[cache_key] = entry
 
         entry.content += content
         entry.complete = complete
@@ -1165,8 +1165,12 @@ class TranscriptRenderingMixin:
         if not view.is_attached:
             return
         view.set_auto_follow(True)
+        if getattr(self, "_conversation_anchor_pending", False):
+            return
+        self._conversation_anchor_pending = True
 
         def anchor_after_refresh() -> None:
+            self._conversation_anchor_pending = False
             if not view.is_attached:
                 return
             view.set_auto_follow(True)

--- a/kolega_code/cli/tui/widgets.py
+++ b/kolega_code/cli/tui/widgets.py
@@ -313,11 +313,13 @@ class ToolEntryWidget(Vertical):
                 if not self._preview_visible:
                     self._preview.display = True
                     self._preview_visible = True
+                    self._preview.refresh(layout=True)
             else:
                 if self._preview_visible:
                     self._preview.update("")
                     self._preview.display = False
                     self._preview_visible = False
+                    self._preview.refresh(layout=True)
 
 
 class ConversationView(VerticalScroll):

--- a/kolega_code/services/terminal.py
+++ b/kolega_code/services/terminal.py
@@ -9,6 +9,8 @@ not carry across separate ``exec_command`` calls (use ``cd x && ...`` or pass a
 """
 
 import asyncio
+import codecs
+import contextlib
 import fcntl
 import os
 import pty
@@ -102,6 +104,9 @@ class PtySession:
         self.exited = asyncio.Event()
         self._new_output = asyncio.Event()
         self._buffer = HeadTailBuffer()  # output since the last read (delta)
+        self._display_decoder = codecs.getincrementaldecoder("utf-8")("replace")
+        self._broadcast_queue: asyncio.Queue[tuple[str, str] | None] = asyncio.Queue()
+        self._broadcast_task: Optional[asyncio.Task] = None
         self._reader_added = False
         self._closed = False
 
@@ -143,6 +148,8 @@ class PtySession:
                 pass
             flags = fcntl.fcntl(master_fd, fcntl.F_GETFL)
             fcntl.fcntl(master_fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+            if self.connection_manager:
+                self._broadcast_task = asyncio.create_task(self._broadcast_worker())
             asyncio.get_event_loop().add_reader(master_fd, self._on_readable)
             self._reader_added = True
 
@@ -173,6 +180,7 @@ class PtySession:
 
     def _handle_eof(self) -> None:
         self._remove_reader()
+        self._flush_display_decoder()
         self._reap()
         self._new_output.set()
         if not self.exited.is_set():
@@ -202,18 +210,42 @@ class PtySession:
     def _broadcast(self, data: bytes) -> None:
         if not self.connection_manager:
             return
-        text = data.decode("utf-8", errors="replace")
-        event = AgentEvent(
-            event_type="terminal_output",
-            sender="agent",
-            content={
-                "output": text,
-                "terminal_id": self.session_id,
-                "session_id": self.session_id,
-                "thread_id": self.thread_id,
-            },
-        )
-        asyncio.ensure_future(self._safe_broadcast(event))
+        raw_text = data.decode("utf-8", errors="replace")
+        display_text = self._display_decoder.decode(data, final=False)
+        self._enqueue_broadcast(raw_text, display_text)
+
+    def _flush_display_decoder(self) -> None:
+        if not self.connection_manager:
+            return
+        display_text = self._display_decoder.decode(b"", final=True)
+        self._enqueue_broadcast(display_text, display_text)
+
+    def _enqueue_broadcast(self, raw_text: str, display_text: str) -> None:
+        if not raw_text and not display_text:
+            return
+        self._broadcast_queue.put_nowait((raw_text, display_text))
+
+    async def _broadcast_worker(self) -> None:
+        while True:
+            item = await self._broadcast_queue.get()
+            try:
+                if item is None:
+                    return
+                raw_text, display_text = item
+                event = AgentEvent(
+                    event_type="terminal_output",
+                    sender="agent",
+                    content={
+                        "output": raw_text,
+                        "display_output": display_text,
+                        "terminal_id": self.session_id,
+                        "session_id": self.session_id,
+                        "thread_id": self.thread_id,
+                    },
+                )
+                await self._safe_broadcast(event)
+            finally:
+                self._broadcast_queue.task_done()
 
     async def _safe_broadcast(self, event: AgentEvent) -> None:
         try:
@@ -283,6 +315,13 @@ class PtySession:
             except OSError:
                 pass
             self.master_fd = None
+        if self._broadcast_task is not None:
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(self._broadcast_queue.join(), timeout=0.5)
+            self._broadcast_queue.put_nowait(None)
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await asyncio.wait_for(self._broadcast_task, timeout=0.5)
+            self._broadcast_task = None
 
     @property
     def running(self) -> bool:

--- a/tests/agent/llm/test_live_providers.py
+++ b/tests/agent/llm/test_live_providers.py
@@ -1,22 +1,18 @@
-"""Live provider integration tests for the whole model catalog.
+"""Live provider integration tests for provider smoke coverage.
 
 These hit the real provider APIs, so they are marked ``integration`` and are
 skipped for any provider whose API key is not present in the environment (loaded
-from the repo ``.env`` by ``conftest.py``). They are the authoritative check that
-every model ID in ``MODEL_SPECS`` actually resolves at the provider — a renamed or
-retired ID surfaces here as a 4xx instead of silently shipping.
+from the repo ``.env`` by ``conftest.py``). They intentionally smoke-test one
+model per key-based provider instead of exhaustively exercising large provider
+catalogs.
 
 Run them explicitly with the relevant keys set, e.g.::
 
     pytest -m integration tests/agent/llm/test_live_providers.py -v
-
-The provider/model matrix is derived from the catalog itself, so new models are
-covered automatically.
 """
 
 import os
 
-import httpx
 import pytest
 
 from kolega_code.cli.config import API_KEY_ENV, OAUTH_PROVIDERS
@@ -43,6 +39,10 @@ SYSTEM = Message(
     content=[TextBlock(text="You are a concise math assistant. Answer with as few tokens as possible.")],
 )
 
+# Ollama Cloud has a large, mixed-access catalog. Keep live coverage to one
+# non-subscription smoke model so all-test runs avoid expensive/flaky/gated calls.
+OLLAMA_CLOUD_SMOKE_MODEL = "gpt-oss:20b"
+
 
 def _messages() -> MessageHistory:
     return MessageHistory(
@@ -50,8 +50,8 @@ def _messages() -> MessageHistory:
     )
 
 
-def _provider_default_models() -> list[tuple[str, str]]:
-    """One (provider, recommended-default-model) pair per provider in the catalog."""
+def _provider_smoke_models() -> list[tuple[str, str]]:
+    """One (provider, smoke-model) pair per key-based provider in the catalog."""
     seen: list[tuple[str, str]] = []
     added: set[str] = set()
     for provider_value, _model in MODEL_SPECS:
@@ -62,19 +62,22 @@ def _provider_default_models() -> list[tuple[str, str]]:
         if ModelProvider(provider_value) in OAUTH_PROVIDERS:
             continue
         added.add(provider_value)
-        model = default_model_for_provider(ModelProvider(provider_value))
+        if provider_value == ModelProvider.OLLAMA_CLOUD.value:
+            model = OLLAMA_CLOUD_SMOKE_MODEL
+        else:
+            model = default_model_for_provider(ModelProvider(provider_value))
         seen.append((provider_value, model))
     return seen
 
 
-PROVIDER_DEFAULT_MODELS = _provider_default_models()
-OLLAMA_CLOUD_MODELS = [model for provider, model in MODEL_SPECS if provider == ModelProvider.OLLAMA_CLOUD.value]
+PROVIDER_SMOKE_MODELS = _provider_smoke_models()
 
-# Subset whose default model exposes a thinking/reasoning-effort control.
+# Subset whose smoke model exposes a thinking/reasoning-effort control. Ollama
+# Cloud is intentionally excluded to keep live Ollama coverage to one smoke call.
 PROVIDER_THINKING_MODELS = [
     (provider, model)
-    for provider, model in PROVIDER_DEFAULT_MODELS
-    if get_thinking_effort_spec(provider, model) is not None
+    for provider, model in PROVIDER_SMOKE_MODELS
+    if provider != ModelProvider.OLLAMA_CLOUD.value and get_thinking_effort_spec(provider, model) is not None
 ]
 
 
@@ -88,81 +91,14 @@ def _require_key(provider_value: str) -> str:
     return api_key
 
 
-def test_live_ollama_cloud_model_catalog_contains_specs() -> None:
-    """Ollama Cloud advertises every model ID in our supported catalog.
-
-    The provider may advertise additional IDs that are not usable through chat
-    completions yet; those should not force us to expose a broken model.
-    """
-    api_key = _require_key(ModelProvider.OLLAMA_CLOUD.value)
-    response = httpx.get(
-        "https://ollama.com/v1/models",
-        headers={"Authorization": f"Bearer {api_key}"},
-        timeout=30,
-    )
-    response.raise_for_status()
-
-    api_models = {model["id"] for model in response.json()["data"]}
-
-    assert set(OLLAMA_CLOUD_MODELS) <= api_models
-
-
-@pytest.mark.parametrize("model", OLLAMA_CLOUD_MODELS)
-def test_live_ollama_cloud_model_metadata_matches_specs(model: str) -> None:
-    """Ollama Cloud metadata agrees with our context/capability flags."""
-    api_key = _require_key(ModelProvider.OLLAMA_CLOUD.value)
-    response = httpx.post(
-        "https://ollama.com/api/show",
-        headers={"Authorization": f"Bearer {api_key}"},
-        json={"model": model},
-        timeout=30,
-    )
-    response.raise_for_status()
-
-    metadata = response.json()
-    capabilities = set(metadata.get("capabilities") or [])
-    model_info = metadata.get("model_info") or {}
-    context_lengths = [value for key, value in model_info.items() if key.endswith(".context_length")]
-    specs = get_model_specs(ModelProvider.OLLAMA_CLOUD.value, model)
-
-    assert context_lengths == [specs["context_length"]]
-    assert ("thinking" in capabilities) == (
-        get_thinking_effort_spec(ModelProvider.OLLAMA_CLOUD.value, model) is not None
-    )
-    assert ("vision" in capabilities) == bool(specs.get("supports_vision"))
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("model", OLLAMA_CLOUD_MODELS)
-async def test_live_ollama_cloud_model_generate(model: str) -> None:
-    """Every supported Ollama Cloud model accepts our configured generation params."""
-    api_key = _require_key(ModelProvider.OLLAMA_CLOUD.value)
-    client = LLMClient(provider=ModelProvider.OLLAMA_CLOUD.value, api_key=api_key)
-    specs = get_model_specs(ModelProvider.OLLAMA_CLOUD.value, model)
-
-    response = await client.generate(
-        messages=MessageHistory(
-            [Message(role="user", content=[TextBlock(text="Reply with exactly OK and no other text.")])]
-        ),
-        model=model,
-        max_completion_tokens=specs["max_completion_tokens"],
-        temperature=specs["default_temperature"],
-        thinking=default_thinking_effort(ModelProvider.OLLAMA_CLOUD.value, model),
-    )
-
-    assert response is not None
-    assert response.role == "assistant"
-    assert response.get_text_content(), f"empty response from ollama_cloud/{model}"
-
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "provider_value,model",
-    PROVIDER_DEFAULT_MODELS,
-    ids=[p for p, _ in PROVIDER_DEFAULT_MODELS],
+    PROVIDER_SMOKE_MODELS,
+    ids=[p for p, _ in PROVIDER_SMOKE_MODELS],
 )
 async def test_live_provider_generate(provider_value: str, model: str) -> None:
-    """The provider's default model resolves and returns a non-empty assistant reply.
+    """The provider's smoke model resolves and returns a non-empty assistant reply.
 
     Uses the model's default thinking effort, mirroring how the agent calls each
     model — some models (e.g. Moonshot kimi-k2.7-code) force thinking on and reject

--- a/tests/agent/services/test_terminal.py
+++ b/tests/agent/services/test_terminal.py
@@ -1,6 +1,8 @@
+import asyncio
+
 import pytest
 
-from kolega_code.services.terminal import LocalTerminalManager
+from kolega_code.services.terminal import LocalTerminalManager, PtySession
 
 
 @pytest.fixture
@@ -137,3 +139,43 @@ async def test_close_all_terminates_sessions(manager):
     assert len(manager.sessions) == 2
     await manager.close_all()
     assert len(manager.sessions) == 0
+
+
+class _RecordingConnectionManager:
+    def __init__(self):
+        self.events = []
+
+    async def broadcast_event(self, event, workspace_id, thread_id):
+        self.events.append(event)
+
+
+@pytest.mark.asyncio
+async def test_pty_display_broadcast_decodes_split_utf8_without_replacement(tmp_path):
+    connection = _RecordingConnectionManager()
+    session = PtySession("s_test", "echo", str(tmp_path), connection, "workspace", "thread")
+    session._broadcast_task = asyncio.create_task(session._broadcast_worker())
+
+    session._broadcast("€".encode("utf-8")[:1])
+    session._broadcast("€".encode("utf-8")[1:])
+    await session._broadcast_queue.join()
+    session._broadcast_queue.put_nowait(None)
+    await session._broadcast_task
+
+    display = "".join(event.content.get("display_output", "") for event in connection.events)
+    assert display == "€"
+    assert "�" not in display
+
+
+@pytest.mark.asyncio
+async def test_pty_display_broadcast_preserves_chunk_order(tmp_path):
+    connection = _RecordingConnectionManager()
+    session = PtySession("s_test", "echo", str(tmp_path), connection, "workspace", "thread")
+    session._broadcast_task = asyncio.create_task(session._broadcast_worker())
+
+    for chunk in (b"a", b"b", b"c"):
+        session._broadcast(chunk)
+    await session._broadcast_queue.join()
+    session._broadcast_queue.put_nowait(None)
+    await session._broadcast_task
+
+    assert "".join(event.content.get("display_output", "") for event in connection.events) == "abc"

--- a/tests/cli/test_app_rendering_streaming.py
+++ b/tests/cli/test_app_rendering_streaming.py
@@ -309,3 +309,47 @@ async def test_streaming_assistant_refresh_accepts_literal_markup_tokens(
         rendered = renderable_text(widget._formatted)
         assert "[/dim]" in rendered
         assert "[bold]literal[/bold]\\" in rendered
+
+
+@pytest.mark.asyncio
+async def test_uuidless_stream_chunks_are_coalesced_by_kind(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        app._apply_stream_chunk({"content": "hello ", "complete": False}, kind="assistant")
+        app._apply_stream_chunk({"content": "world", "complete": False}, kind="assistant")
+        app._apply_stream_chunk({"content": "", "complete": True}, kind="assistant")
+
+        assistant_entries = [entry for entry in app.conversation_entries if entry.kind == "assistant"]
+        assert len(assistant_entries) == 1
+        assert assistant_entries[0].content == "hello world"
+        assert assistant_entries[0].complete is True
+        assert app._stream_entries["__nouuid__:assistant"] is assistant_entries[0]
+
+        app._apply_stream_chunk({"content": "next", "complete": True}, kind="assistant")
+        assistant_entries = [entry for entry in app.conversation_entries if entry.kind == "assistant"]
+        assert [entry.content for entry in assistant_entries] == ["hello world", "next"]
+
+
+@pytest.mark.asyncio
+async def test_conversation_bottom_anchor_is_single_flight(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        callbacks = []
+
+        def capture_callback(callback):
+            callbacks.append(callback)
+
+        monkeypatch.setattr(app, "call_after_refresh", capture_callback)
+        app._conversation_anchor_pending = False
+
+        app._schedule_conversation_bottom_anchor()
+        app._schedule_conversation_bottom_anchor()
+        app._schedule_conversation_bottom_anchor()
+
+        assert len(callbacks) == 1
+        assert app._conversation_anchor_pending is True
+
+        callbacks.pop()()
+        assert app._conversation_anchor_pending is False

--- a/tests/cli/test_app_rendering_terminal_logs.py
+++ b/tests/cli/test_app_rendering_terminal_logs.py
@@ -63,6 +63,8 @@ async def test_log_lines_carry_timestamp_and_level_glyph(tmp_path: Path, monkeyp
         app._render_event(
             AgentEvent(event_type="log_message", sender="coder", content={"level": "error", "message": "it [broke]"})
         )
+        assert written == []
+        app._flush_log_output()
         assert len(written) == 1
         assert "[error]" not in written[0].plain  # no raw level prefix
         assert "it [broke]" in written[0].plain  # brackets survive without markup errors
@@ -454,3 +456,93 @@ async def test_logs_tab_shows_activity_dot_until_visited(tmp_path: Path, monkeyp
         # Writing while the tab is active does not re-add the dot
         app._write_log("foreground activity")
         assert str(tabs.get_tab("logs_pane").label) == "Logs"
+
+
+@pytest.mark.asyncio
+async def test_terminal_output_is_sanitized_before_rendering(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.agent import AgentEvent
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        written: list[object] = []
+        monkeypatch.setattr(app._terminal, "write_terminal", written.append)
+
+        app._render_event(
+            AgentEvent(
+                event_type="terminal_output",
+                sender="coder",
+                content={
+                    "output": "raw \x1b[31mred\x1b[0m\x1b]8;;https://example.com\x1b\\link\x1b]8;;\x1b\\\rnext\b!\x07\n"
+                },
+            )
+        )
+        app._flush_terminal_output()
+
+        rendered = "".join(str(item) for item in written)
+        assert "\x1b" not in rendered
+        assert "https://example.com" not in rendered
+        assert rendered == "raw redlink\nnex!\n"
+
+
+@pytest.mark.asyncio
+async def test_terminal_output_uses_display_output_when_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.agent import AgentEvent
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        written: list[object] = []
+        monkeypatch.setattr(app._terminal, "write_terminal", written.append)
+
+        app._render_event(
+            AgentEvent(
+                event_type="terminal_output",
+                sender="coder",
+                content={"output": "\ufffd", "display_output": "€"},
+            )
+        )
+        app._flush_terminal_output()
+
+        assert written == ["€"]
+
+
+@pytest.mark.asyncio
+async def test_terminal_and_logs_hide_horizontal_scrollbars_when_wrapping(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch, show_logs=True)
+
+    async with app.run_test():
+        assert app._terminal.styles.overflow_x == "hidden"
+        assert app._logs.styles.overflow_x == "hidden"
+
+
+@pytest.mark.asyncio
+async def test_log_output_is_batched_until_flush(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("textual")
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch, show_logs=True)
+
+    async with app.run_test():
+        written: list[object] = []
+        monkeypatch.setattr(app._logs, "write_log", written.append)
+
+        for index in range(5):
+            app._write_log(f"line {index}")
+
+        assert written == []
+        app._flush_log_output()
+
+        assert len(written) == 1
+        rendered = renderable_text(written[0])
+        assert "line 0" in rendered
+        assert "line 4" in rendered

--- a/tests/cli/test_provider_registry.py
+++ b/tests/cli/test_provider_registry.py
@@ -1,5 +1,6 @@
 from kolega_code.cli.provider_registry import default_model_for_provider, ui_model_options
 from kolega_code.config import ModelProvider
+from kolega_code.llm.specs import get_model_specs
 
 
 def test_fireworks_ui_model_options_include_serverless_catalog():
@@ -17,3 +18,11 @@ def test_fireworks_ui_model_options_include_serverless_catalog():
 
 def test_fireworks_default_model_is_glm_52():
     assert default_model_for_provider(ModelProvider.FIREWORKS) == "accounts/fireworks/models/glm-5p2"
+
+
+def test_ollama_cloud_smoke_model_is_available_without_live_call():
+    options = dict(ui_model_options("ollama_cloud"))
+
+    assert options["GPT-OSS 20B"] == "gpt-oss:20b"
+    assert default_model_for_provider(ModelProvider.OLLAMA_CLOUD) == "gpt-oss:20b"
+    assert get_model_specs(ModelProvider.OLLAMA_CLOUD.value, "gpt-oss:20b")["max_completion_tokens"] > 0

--- a/tests/cli/test_terminal_display.py
+++ b/tests/cli/test_terminal_display.py
@@ -1,0 +1,42 @@
+from kolega_code.cli.tui.terminal_display import TerminalDisplayNormalizer
+
+
+def _normalize(*chunks: str) -> str:
+    normalizer = TerminalDisplayNormalizer()
+    return "".join(normalizer.feed(chunk) for chunk in chunks) + normalizer.flush()
+
+
+def test_terminal_display_normalizer_strips_ansi_sgr_and_csi_controls() -> None:
+    text = _normalize("plain \x1b[31mred\x1b[0m \x1b[Kdone\x1b[2J")
+
+    assert text == "plain red done"
+    assert "\x1b" not in text
+
+
+def test_terminal_display_normalizer_strips_osc_hyperlinks_split_across_chunks() -> None:
+    text = _normalize("before ", "\x1b]8;;https://example.com\x1b\\", "link", "\x1b]8;;\x1b\\ after")
+
+    assert text == "before link after"
+    assert "https://example.com" not in text
+    assert "\x1b" not in text
+
+
+def test_terminal_display_normalizer_converts_carriage_return_progress_to_lines() -> None:
+    assert _normalize("10%\r20%\rdone\n") == "10%\n20%\ndone\n"
+    assert _normalize("line\r\nnext\n") == "line\nnext\n"
+
+
+def test_terminal_display_normalizer_handles_backspace_rewrites_within_chunk() -> None:
+    assert _normalize("abc\b\bd\n") == "ad\n"
+
+
+def test_terminal_display_normalizer_drops_unknown_control_characters() -> None:
+    assert _normalize("a\x00\x07b\x0cc") == "abc"
+
+
+def test_terminal_display_normalizer_holds_split_escape_sequences() -> None:
+    normalizer = TerminalDisplayNormalizer()
+
+    assert normalizer.feed("a\x1b[") == "a"
+    assert normalizer.feed("31mred") == "red"
+    assert normalizer.flush() == ""

--- a/tests/cli/test_tui_stylesheet.py
+++ b/tests/cli/test_tui_stylesheet.py
@@ -79,3 +79,41 @@ async def test_tui_external_stylesheet_loads_in_textual_app(
         assert app.agent.kwargs["agent_mode"] == AgentMode.CLI
         assert app.query_one("#conversation") is not None
         assert app.query_one("#composer") is not None
+
+
+def test_tui_stylesheet_themes_scrollbars_and_avoids_disabled_opacity() -> None:
+    stylesheet = Path(__file__).parents[2] / "kolega_code" / "cli" / EXPECTED_CSS_PATH
+    css = stylesheet.read_text()
+
+    for property_name in (
+        "scrollbar-background:",
+        "scrollbar-background-hover:",
+        "scrollbar-background-active:",
+        "scrollbar-color:",
+        "scrollbar-color-hover:",
+        "scrollbar-color-active:",
+        "scrollbar-corner-color:",
+    ):
+        assert property_name in css
+
+    disabled_block = css.split("#composer:disabled", 1)[1].split("}", 1)[0]
+    assert "opacity" not in disabled_block
+    assert "background: $surface" in disabled_block
+    assert "color: $text-muted" in disabled_block
+
+
+def test_tui_stylesheet_explicitly_themes_footer_select_overlay_and_output_scrollbars() -> None:
+    stylesheet = Path(__file__).parents[2] / "kolega_code" / "cli" / EXPECTED_CSS_PATH
+    css = stylesheet.read_text()
+
+    output_block = css.split("#conversation, #logs, #terminal", 1)[1].split("}", 1)[0]
+    assert "overflow-x: hidden" in output_block
+    assert "background: $surface" in output_block
+
+    footer_block = css.split("Footer {", 1)[1].split("}", 1)[0]
+    assert "background: $surface" in footer_block
+    assert "color: $text-muted" in footer_block
+
+    select_overlay_block = css.split("Select > SelectOverlay", 1)[1].split("}", 1)[0]
+    assert "background: $surface" in select_overlay_block
+    assert "color: $text" in select_overlay_block


### PR DESCRIPTION
## Summary
- add display-only terminal output normalization for ANSI/control sequences and split UTF-8
- order PTY terminal display broadcasts and batch terminal/log rendering in the TUI
- explicitly theme scrollbars/chrome and remove opacity-based disabled composer styling
- coalesce UUID-less stream chunks and guard redundant bottom-anchor scheduling

## Tests
- ruff check kolega_code/cli/app.py kolega_code/cli/tui/agent_runtime.py kolega_code/cli/tui/transcript.py kolega_code/cli/tui/widgets.py kolega_code/cli/tui/terminal_display.py kolega_code/services/terminal.py tests/cli/test_terminal_display.py tests/agent/services/test_terminal.py tests/cli/test_app_rendering_terminal_logs.py tests/cli/test_tui_stylesheet.py tests/cli/test_app_rendering_streaming.py
- pytest tests/cli/test_terminal_display.py tests/agent/services/test_terminal.py tests/cli/test_app_rendering_terminal_logs.py tests/cli/test_tui_stylesheet.py tests/cli/test_app_rendering_streaming.py
