### PR TITLE
feat(tui): add session changes inspector

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -83,6 +83,7 @@ from .tui import changes_screen as tui_changes
 from .tui import command_handlers as tui_command_handlers
 from .tui import prompt_flows as tui_prompt_flows
 from .tui import settings_panel as tui_settings_panel
+from .tui import session_diff as tui_session_diff
 from .tui import status_dashboard as tui_status_dashboard
 from .tui import state as tui_state
 from .tui import sub_agent_screen as tui_sub_agents
@@ -175,6 +176,8 @@ class KolegaCodeApp(
         self._sub_agent_by_tool_call: dict[str, str] = {}
         self._sub_agent_seq = 0
         self._session_file_changes: list[tui_state.SessionFileChange] = []
+        self._session_diff_tracker: Optional[tui_session_diff.GitSessionDiffTracker] = None
+        self._session_diff_files: list[tui_session_diff.SessionDiffFile] = []
         self._workflow_activities: dict[str, tui_state.WorkflowActivity] = {}
         self._render_pending = False
         self._conversation_anchor_pending = False
@@ -398,6 +401,7 @@ class KolegaCodeApp(
         except Exception:
             pass
         self._populate_settings_controls()
+        self._initialize_session_diff_tracker()
         self._refresh_status_dashboard()
         self._restore_plan_action_visibility()
         self._set_question_actions_visible(False)
@@ -979,13 +983,14 @@ class KolegaCodeApp(
         self.push_screen(screen)
 
     def action_open_changes(self, path: Optional[str] = None) -> None:
-        """Open the full-screen session changes inspector."""
-        if self._changes_inspector is not None:
+        """Open the full-screen git session changes inspector."""
+        if not self._changes_available() or self._changes_inspector is not None:
             return
-        if not self._session_file_changes:
+        self._refresh_session_diff()
+        if not self._session_diff_files:
             self._notify_user(messages.CHANGES_INSPECTOR_EMPTY, severity="information")
             return
-        paths = {change.path for change in self._session_file_changes}
+        paths = {change.path for change in self._session_diff_files}
         if path is None or path not in paths:
             path = self._default_changes_path()
         if path is None:
@@ -993,6 +998,38 @@ class KolegaCodeApp(
         screen = tui_changes.ChangesInspectorScreen(self, path)
         self._changes_inspector = screen
         self.push_screen(screen)
+
+    def _initialize_session_diff_tracker(self) -> None:
+        """Set up git-only net diff tracking for the Changes inspector."""
+        self._session_diff_tracker = tui_session_diff.GitSessionDiffTracker.create(self.project_path)
+        self._session_diff_files = []
+        if self._session_diff_tracker is None:
+            return
+        try:
+            self._session_diff_tracker.capture_baseline()
+        except Exception:
+            self._session_diff_tracker = None
+            self._session_diff_files = []
+
+    def _changes_available(self) -> bool:
+        return self._session_diff_tracker is not None
+
+    def _refresh_session_diff(self) -> None:
+        tracker = self._session_diff_tracker
+        if tracker is None:
+            self._session_diff_files = []
+            return
+        try:
+            event_paths = [change.path for change in self._session_file_changes]
+            self._session_diff_files = tracker.refresh(event_paths=event_paths)
+        except Exception:
+            self._session_diff_files = []
+        self._invalidate_changes_detail()
+
+    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
+        if action == "open_changes":
+            return self._changes_available()
+        return True
 
     def _default_sub_agent_key(self) -> Optional[str]:
         """Most-recently-started running agent, else the most recent overall."""
@@ -1002,10 +1039,10 @@ class KolegaCodeApp(
         return max(pool, key=lambda a: a.index).agent_id
 
     def _default_changes_path(self) -> Optional[str]:
-        """Most recently changed file in the live TUI session."""
-        if not self._session_file_changes:
+        """Most recent net-changed file in the live TUI session."""
+        if not self._session_diff_files:
             return None
-        return self._session_file_changes[-1].path
+        return self._session_diff_files[-1].path
 
     def _close_sub_agent_inspector(self) -> None:
         screen = self._sub_agent_inspector

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -987,14 +987,9 @@ class KolegaCodeApp(
         if not self._changes_available() or self._changes_inspector is not None:
             return
         self._refresh_session_diff()
-        if not self._session_diff_files:
-            self._notify_user(messages.CHANGES_INSPECTOR_EMPTY, severity="information")
-            return
         paths = {change.path for change in self._session_diff_files}
         if path is None or path not in paths:
-            path = self._default_changes_path()
-        if path is None:
-            return
+            path = self._default_changes_path() or ""
         screen = tui_changes.ChangesInspectorScreen(self, path)
         self._changes_inspector = screen
         self.push_screen(screen)

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -79,6 +79,7 @@ from .theme import Color, Glyph
 from .updater import check_for_update, update_status_message
 from .tui import constants as tui_constants
 from .tui import agent_runtime as tui_agent_runtime
+from .tui import changes_screen as tui_changes
 from .tui import command_handlers as tui_command_handlers
 from .tui import prompt_flows as tui_prompt_flows
 from .tui import settings_panel as tui_settings_panel
@@ -118,6 +119,7 @@ class KolegaCodeApp(
         Binding("ctrl+p", "toggle_permission_mode", "Permissions", show=True, key_display="Ctrl+P", priority=True),
         Binding("ctrl+o", "toggle_sidebar", "Sidebar", show=True, key_display="Ctrl+O", priority=True),
         Binding("ctrl+g", "open_sub_agent", "Agents", show=True, key_display="Ctrl+G", priority=True),
+        Binding("ctrl+r", "open_changes", "Changes", show=True, key_display="Ctrl+R", priority=True),
         Binding("ctrl+c", "cancel_generation", "Cancel", show=True),
         Binding("escape", "cancel_generation", "Cancel", show=False),
         Binding("ctrl+q", "quit", "Quit", show=True),
@@ -172,6 +174,7 @@ class KolegaCodeApp(
         self._sub_agent_activities: dict[str, tui_state.SubAgentActivity] = {}
         self._sub_agent_by_tool_call: dict[str, str] = {}
         self._sub_agent_seq = 0
+        self._session_file_changes: list[tui_state.SessionFileChange] = []
         self._workflow_activities: dict[str, tui_state.WorkflowActivity] = {}
         self._render_pending = False
         self._conversation_anchor_pending = False
@@ -216,6 +219,7 @@ class KolegaCodeApp(
         self._spinner_frame = 0
         self._last_sub_agent_tick = 0.0
         self._sub_agent_inspector: Optional[tui_sub_agents.SubAgentInspectorScreen] = None
+        self._changes_inspector: Optional[tui_changes.ChangesInspectorScreen] = None
         self._terminal_has_content = False
         self._terminal_output_buffer: list[str] = []
         self._terminal_output_buffer_chars = 0
@@ -974,6 +978,22 @@ class KolegaCodeApp(
         self._sub_agent_inspector = screen
         self.push_screen(screen)
 
+    def action_open_changes(self, path: Optional[str] = None) -> None:
+        """Open the full-screen session changes inspector."""
+        if self._changes_inspector is not None:
+            return
+        if not self._session_file_changes:
+            self._notify_user(messages.CHANGES_INSPECTOR_EMPTY, severity="information")
+            return
+        paths = {change.path for change in self._session_file_changes}
+        if path is None or path not in paths:
+            path = self._default_changes_path()
+        if path is None:
+            return
+        screen = tui_changes.ChangesInspectorScreen(self, path)
+        self._changes_inspector = screen
+        self.push_screen(screen)
+
     def _default_sub_agent_key(self) -> Optional[str]:
         """Most-recently-started running agent, else the most recent overall."""
         pool = self._running_sub_agents() or list(self._sub_agent_activities.values())
@@ -981,11 +1001,27 @@ class KolegaCodeApp(
             return None
         return max(pool, key=lambda a: a.index).agent_id
 
+    def _default_changes_path(self) -> Optional[str]:
+        """Most recently changed file in the live TUI session."""
+        if not self._session_file_changes:
+            return None
+        return self._session_file_changes[-1].path
+
     def _close_sub_agent_inspector(self) -> None:
         screen = self._sub_agent_inspector
         if screen is None:
             return
         self._sub_agent_inspector = None
+        try:
+            screen.dismiss()
+        except Exception:
+            pass
+
+    def _close_changes_inspector(self) -> None:
+        screen = self._changes_inspector
+        if screen is None:
+            return
+        self._changes_inspector = None
         try:
             screen.dismiss()
         except Exception:

--- a/kolega_code/cli/messages.py
+++ b/kolega_code/cli/messages.py
@@ -57,7 +57,7 @@ SUB_AGENT_INSPECTOR_EMPTY = "No sub-agents have run in this turn yet."
 SUB_AGENT_INSPECTOR_NO_SELECTION = "No sub-agent selected."
 SUB_AGENT_INSPECTOR_NO_STEPS = "No trajectory captured yet…"
 SUB_AGENT_TRAJECTORY_COPIED = "Copied the sub-agent trajectory to the clipboard."
-CHANGES_INSPECTOR_EMPTY = "No file changes have been captured in this session yet."
+CHANGES_INSPECTOR_EMPTY = "No file changes since this session started."
 CHANGES_INSPECTOR_NO_SELECTION = "No file selected."
 CHANGES_COPIED = "Copied file changes to the clipboard."
 

--- a/kolega_code/cli/messages.py
+++ b/kolega_code/cli/messages.py
@@ -57,6 +57,9 @@ SUB_AGENT_INSPECTOR_EMPTY = "No sub-agents have run in this turn yet."
 SUB_AGENT_INSPECTOR_NO_SELECTION = "No sub-agent selected."
 SUB_AGENT_INSPECTOR_NO_STEPS = "No trajectory captured yet…"
 SUB_AGENT_TRAJECTORY_COPIED = "Copied the sub-agent trajectory to the clipboard."
+CHANGES_INSPECTOR_EMPTY = "No file changes have been captured in this session yet."
+CHANGES_INSPECTOR_NO_SELECTION = "No file selected."
+CHANGES_COPIED = "Copied file changes to the clipboard."
 
 # Confirmations
 SWITCHED_MODE = "Switched to {mode} mode."

--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -154,8 +154,13 @@ class AgentRuntimeMixin:
             else:
                 self._apply_tool_streaming_update(event.content)
         elif event.event_type == "file_edit_preview":
-            # UI-only inline diff/head preview. Sub-agent edits are not shown inline (v1).
-            if not event.sub_agent_info:
+            # UI-only diff/head preview. Main-agent edits stay inline; every edit is
+            # also captured in the session changes inspector. Sub-agent previews attach
+            # to their trajectory steps so Ctrl+G and Ctrl+R can both reveal them.
+            self._record_file_change_event(event)
+            if event.sub_agent_info:
+                self._apply_sub_agent_edit_preview(event)
+            else:
                 self._apply_edit_preview(event.content)
         elif event.event_type == "llm_context_update":
             if event.sub_agent_info:

--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -46,6 +46,7 @@ class AgentRuntimeMixin:
                     if content and self.show_logs:
                         self._write_log(content, "debug")
             await self._drain_pending_events()
+            self._refresh_session_diff()
             self._finalize_sub_agent_activities()
             self._finalize_workflow_activities()
             await self._save_session_history_async()
@@ -57,6 +58,7 @@ class AgentRuntimeMixin:
             self._cancel_pending_question()
             self._cancel_pending_approval()
             await self._drain_pending_events()
+            self._refresh_session_diff()
             self._finalize_sub_agent_activities()
             self._finalize_workflow_activities()
             await self._save_session_history_async()
@@ -66,6 +68,7 @@ class AgentRuntimeMixin:
             self._cancel_pending_question()
             self._cancel_pending_approval()
             await self._drain_pending_events()
+            self._refresh_session_diff()
             self._finalize_sub_agent_activities()
             self._finalize_workflow_activities()
             await self._save_session_history_async()
@@ -77,6 +80,7 @@ class AgentRuntimeMixin:
             self._cancel_pending_question()
             self._cancel_pending_approval()
             await self._drain_pending_events()
+            self._refresh_session_diff()
             self._finalize_sub_agent_activities()
             self._finalize_workflow_activities()
             await self._save_session_history_async()
@@ -123,6 +127,7 @@ class AgentRuntimeMixin:
             if output is None:
                 output = event.content.get("output", "")
             self._queue_terminal_output(str(output))
+            self._refresh_session_diff()
         elif event.event_type == "terminal_command":
             command = str(event.content.get("command") or "")
             self._write_terminal_command(command)
@@ -162,6 +167,7 @@ class AgentRuntimeMixin:
                 self._apply_sub_agent_edit_preview(event)
             else:
                 self._apply_edit_preview(event.content)
+            self._refresh_session_diff()
         elif event.event_type == "llm_context_update":
             if event.sub_agent_info:
                 self._note_sub_agent_context(event)

--- a/kolega_code/cli/tui/changes_screen.py
+++ b/kolega_code/cli/tui/changes_screen.py
@@ -210,7 +210,7 @@ class ChangesInspectorScreen(ModalScreen):
             return
         change = self._diff_for_path(self._selected_path)
         if change is None:
-            header.update(messages.CHANGES_INSPECTOR_NO_SELECTION)
+            header.update(messages.CHANGES_INSPECTOR_EMPTY)
             return
         sep = theme.g(Glyph.BULLET_SEP)
         line = Text.from_markup(theme.role_header(Glyph.TOOL, escape(change.path), Color.ACCENT, state=change.status))
@@ -238,7 +238,7 @@ class ChangesInspectorScreen(ModalScreen):
             if not self._empty_shown:
                 view.remove_children()
                 self._preview_widgets = {}
-                view.mount(Static(messages.CHANGES_INSPECTOR_NO_SELECTION, classes="changes-empty"))
+                view.mount(Static(messages.CHANGES_INSPECTOR_EMPTY, classes="changes-empty"))
                 self._empty_shown = True
             return
 

--- a/kolega_code/cli/tui/changes_screen.py
+++ b/kolega_code/cli/tui/changes_screen.py
@@ -1,0 +1,352 @@
+"""Session file changes inspector screen for the CLI TUI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+from rich.console import Group
+from rich.markup import escape
+from rich.padding import Padding
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.message import Message as TextualMessage
+from textual.screen import ModalScreen
+from textual.widgets import Static
+
+from .. import messages, theme
+from ..theme import Color, Glyph
+from .state import SessionFileChange
+
+if TYPE_CHECKING:
+    from ..app import KolegaCodeApp
+
+
+class ChangeFileRosterRow(Static):
+    """One selectable changed-file row in the changes inspector."""
+
+    @dataclass
+    class Selected(TextualMessage):
+        path: str
+
+    def __init__(self, path: str) -> None:
+        super().__init__("", markup=False)
+        self.path = path
+
+    def on_click(self) -> None:
+        self.post_message(self.Selected(self.path))
+
+
+class ChangesInspectorScreen(ModalScreen):
+    """Full-screen view of file edit previews captured in this TUI session.
+
+    Left: a roster of changed files. Right: chronological edit previews for the
+    selected file, with source/tool attribution. The screen updates live while
+    the agent runs and new ``file_edit_preview`` events arrive.
+    """
+
+    BINDINGS = [
+        Binding("escape", "close", "Close", show=True, priority=True),
+        Binding("q", "close", "Close", show=False, priority=True),
+        Binding("down", "next_file", "Next file", show=True, priority=True),
+        Binding("up", "prev_file", "Prev file", show=False, priority=True),
+        Binding("o", "toggle_follow", "Follow", show=True, priority=True),
+        Binding("y", "copy_changes", "Copy", show=True, priority=True),
+    ]
+
+    def __init__(self, owner: "KolegaCodeApp", selected_path: str) -> None:
+        super().__init__()
+        self._owner = owner
+        self._selected_path = selected_path
+        self._follow = True
+        self._rows: dict[str, ChangeFileRosterRow] = {}
+        self._preview_widgets: dict[str, Static] = {}
+        self._rendered_path: Optional[str] = None
+        self._empty_shown = False
+        self._flush_pending = False
+
+    def compose(self) -> ComposeResult:
+        with Horizontal(id="changes_body"):
+            yield VerticalScroll(id="changes_roster")
+            with Vertical(id="changes_main"):
+                yield Static("", id="changes_header", markup=True)
+                yield VerticalScroll(id="changes_previews")
+        yield Static("", id="changes_footer", markup=False)
+
+    def on_mount(self) -> None:
+        self.border_title = f"{theme.g(Glyph.TOOL)} Changes"
+        self._sync_roster()
+        self._refresh_header()
+        self._sync_previews()
+        self._refresh_footer()
+
+    def on_unmount(self) -> None:
+        if self._owner._changes_inspector is self:
+            self._owner._changes_inspector = None
+
+    # ---- live updates ---------------------------------------------------------
+
+    def note_change_updated(self, change: Optional[SessionFileChange] = None) -> None:
+        """Called by the owner when a new file edit preview is captured."""
+        if self._follow and change is not None:
+            self._selected_path = change.path
+        self._schedule_flush()
+
+    def _schedule_flush(self) -> None:
+        if self._flush_pending:
+            return
+        self._flush_pending = True
+        try:
+            self.set_timer(theme.RENDER_COALESCE_INTERVAL, self._flush)
+        except Exception:
+            self._flush()
+
+    def _flush(self) -> None:
+        self._flush_pending = False
+        self._sync_roster()
+        self._refresh_header()
+        self._sync_previews()
+
+    # ---- data helpers ---------------------------------------------------------
+
+    def _ordered_paths(self) -> list[str]:
+        paths: list[str] = []
+        seen: set[str] = set()
+        for change in self._owner._session_file_changes:
+            if change.path not in seen:
+                seen.add(change.path)
+                paths.append(change.path)
+        return paths
+
+    def _changes_for_path(self, path: str) -> list[SessionFileChange]:
+        return [change for change in self._owner._session_file_changes if change.path == path]
+
+    def _selected_changes(self) -> list[SessionFileChange]:
+        return self._changes_for_path(self._selected_path)
+
+    # ---- selection ------------------------------------------------------------
+
+    def action_next_file(self) -> None:
+        self._move_selection(1)
+
+    def action_prev_file(self) -> None:
+        self._move_selection(-1)
+
+    def _move_selection(self, delta: int) -> None:
+        paths = self._ordered_paths()
+        if not paths:
+            return
+        if self._selected_path in paths:
+            index = (paths.index(self._selected_path) + delta) % len(paths)
+        else:
+            index = 0
+        self._selected_path = paths[index]
+        self._select_changed()
+
+    def on_change_file_roster_row_selected(self, message: ChangeFileRosterRow.Selected) -> None:
+        if message.path != self._selected_path:
+            self._selected_path = message.path
+            self._select_changed()
+
+    def _select_changed(self) -> None:
+        self._sync_roster()
+        self._refresh_header()
+        self._sync_previews()
+        row = self._rows.get(self._selected_path)
+        if row is not None:
+            try:
+                row.scroll_visible()
+            except Exception:
+                pass
+
+    # ---- rendering ------------------------------------------------------------
+
+    def _sync_roster(self) -> None:
+        try:
+            roster = self.query_one("#changes_roster", VerticalScroll)
+        except Exception:
+            return
+        if not roster.is_attached:
+            return
+        paths = self._ordered_paths()
+        if paths != list(self._rows):
+            roster.remove_children()
+            self._rows = {}
+            rows = []
+            for path in paths:
+                row = ChangeFileRosterRow(path)
+                self._rows[path] = row
+                rows.append(row)
+            if rows:
+                roster.mount(*rows)
+        for path in paths:
+            row = self._rows.get(path)
+            if row is not None:
+                row.update(self._roster_row(path, selected=path == self._selected_path))
+
+    def _roster_row(self, path: str, *, selected: bool) -> Text:
+        changes = self._changes_for_path(path)
+        adds = sum(int(change.preview.get("adds") or 0) for change in changes)
+        dels = sum(int(change.preview.get("dels") or 0) for change in changes)
+        row_style = "bold" if selected else ""
+        line = Text()
+        line.append("> " if selected else "  ", style=row_style)
+        line.append(f"{theme.g(Glyph.TOOL)} ", style=Color.ACCENT)
+        line.append(path, style=row_style)
+        meta = f"\n    {len(changes)} edit{'' if len(changes) == 1 else 's'}"
+        if adds or dels:
+            meta += f"  +{adds} -{dels}"
+        line.append(meta, style="dim")
+        return line
+
+    def _refresh_header(self) -> None:
+        try:
+            header = self.query_one("#changes_header", Static)
+        except Exception:
+            return
+        changes = self._selected_changes()
+        if not changes:
+            header.update(messages.CHANGES_INSPECTOR_NO_SELECTION)
+            return
+        adds = sum(int(change.preview.get("adds") or 0) for change in changes)
+        dels = sum(int(change.preview.get("dels") or 0) for change in changes)
+        sep = theme.g(Glyph.BULLET_SEP)
+        line = theme.role_header(Glyph.TOOL, escape(self._selected_path), Color.ACCENT, state="session changes")
+        line += theme.styled(
+            f" {sep} {len(changes)} edit{'' if len(changes) == 1 else 's'} {sep} +{adds} -{dels}",
+            "dim",
+        )
+        header.update(Text.from_markup(line))
+
+    def _sync_previews(self) -> None:
+        try:
+            view = self.query_one("#changes_previews", VerticalScroll)
+        except Exception:
+            return
+        if not view.is_attached:
+            return
+        changes = self._selected_changes()
+        if self._rendered_path != self._selected_path:
+            view.remove_children()
+            self._preview_widgets = {}
+            self._empty_shown = False
+            self._rendered_path = self._selected_path
+        if not changes:
+            if not self._empty_shown:
+                view.remove_children()
+                self._preview_widgets = {}
+                view.mount(Static(messages.CHANGES_INSPECTOR_NO_SELECTION, classes="changes-empty"))
+                self._empty_shown = True
+            return
+        if self._empty_shown:
+            view.remove_children()
+            self._preview_widgets = {}
+            self._empty_shown = False
+
+        rendered_ids = list(self._preview_widgets)
+        current_ids = [change.change_id for change in changes]
+        if current_ids[: len(rendered_ids)] != rendered_ids:
+            view.remove_children()
+            self._preview_widgets = {}
+            rendered_ids = []
+
+        for change_id, widget in self._preview_widgets.items():
+            change = next((item for item in changes if item.change_id == change_id), None)
+            if change is not None:
+                widget.update(self._preview_renderable(change))
+
+        new_changes = changes[len(rendered_ids) :]
+        if new_changes:
+            widgets = []
+            for change in new_changes:
+                widget = Static(self._preview_renderable(change), markup=False, classes="change-preview")
+                self._preview_widgets[change.change_id] = widget
+                widgets.append(widget)
+            view.mount(*widgets)
+        if self._follow:
+            self._scroll_previews_end()
+
+    def _preview_renderable(self, change: SessionFileChange) -> Group:
+        sep = theme.g(Glyph.BULLET_SEP)
+        title = Text()
+        title.append(f"#{change.index} ", style="bold")
+        title.append(change.source_label or "Agent", style=Color.ACCENT)
+        if change.tool_name:
+            title.append(f" {sep} {change.tool_name}", style="dim")
+        if change.tool_call_id:
+            title.append(f" {sep} {change.tool_call_id}", style="dim")
+        try:
+            preview = self._owner._build_edit_preview(change.preview)
+        except Exception:
+            preview = Text("Preview unavailable", style="dim")
+        return Group(title, Padding(preview, (0, 0, 1, theme.INSET_WIDTH)))
+
+    def _scroll_previews_end(self) -> None:
+        def _do() -> None:
+            try:
+                self.query_one("#changes_previews", VerticalScroll).scroll_end(animate=False)
+            except Exception:
+                pass
+
+        try:
+            self.call_after_refresh(_do)
+        except Exception:
+            _do()
+
+    def _refresh_footer(self) -> None:
+        try:
+            footer = self.query_one("#changes_footer", Static)
+        except Exception:
+            return
+        sep = theme.g(Glyph.BULLET_SEP)
+        follow = "on" if self._follow else "off"
+        footer.update(f"Esc close  {sep}  Up/Down switch file  {sep}  o follow:{follow}  {sep}  y copy")
+
+    # ---- actions --------------------------------------------------------------
+
+    def action_close(self) -> None:
+        self._owner._changes_inspector = None
+        self.dismiss()
+        self._owner._schedule_primary_focus_restore()
+
+    def action_toggle_follow(self) -> None:
+        self._follow = not self._follow
+        self._refresh_footer()
+        if self._follow:
+            self._sync_previews()
+
+    def action_copy_changes(self) -> None:
+        changes = self._selected_changes()
+        if not changes:
+            return
+        self._owner.copy_to_clipboard(self._changes_text(self._selected_path, changes))
+        try:
+            self._owner._notify_user(messages.CHANGES_COPIED, severity="information")
+        except Exception:
+            pass
+
+    def _changes_text(self, path: str, changes: list[SessionFileChange]) -> str:
+        lines = [f"Changes for {path}", ""]
+        for change in changes:
+            header = f"#{change.index} {change.source_label or 'Agent'}"
+            if change.tool_name:
+                header += f" · {change.tool_name}"
+            if change.tool_call_id:
+                header += f" · {change.tool_call_id}"
+            lines.append(header)
+            preview = change.preview
+            kind = str(preview.get("kind") or "")
+            if kind == "diff":
+                lines.append(f"+{int(preview.get('adds') or 0)} -{int(preview.get('dels') or 0)}")
+            for row in preview.get("lines") or []:
+                if isinstance(row, (list, tuple)) and len(row) >= 2:
+                    lines.append(str(row[1]))
+                else:
+                    lines.append(str(row))
+            more = int(preview.get("more") or 0)
+            if more > 0:
+                lines.append(f"… +{more} more lines")
+            lines.append("")
+        return "\n".join(lines).rstrip() + "\n"

--- a/kolega_code/cli/tui/changes_screen.py
+++ b/kolega_code/cli/tui/changes_screen.py
@@ -270,9 +270,6 @@ class ChangesInspectorScreen(ModalScreen):
         return f"{change.path}:{change.status}:{change.adds}:{change.dels}:{repr(change.preview)}:{event_ids}"
 
     def _net_diff_renderable(self, change: SessionDiffFile) -> Group:
-        title = Text()
-        title.append("Net session diff", style="bold")
-        title.append(f"  {theme.g(Glyph.BULLET_SEP)}  {change.status}", style="dim")
         if change.message:
             body = Text(change.message, style="dim")
         elif change.preview:
@@ -282,7 +279,7 @@ class ChangesInspectorScreen(ModalScreen):
                 body = Text("Preview unavailable", style="dim")
         else:
             body = Text("Preview unavailable", style="dim")
-        return Group(title, Padding(body, (0, 0, 1, theme.INSET_WIDTH)))
+        return Group(Padding(body, (0, 0, 1, 0)))
 
     def _event_renderable(self, change: SessionFileChange) -> Group:
         sep = theme.g(Glyph.BULLET_SEP)

--- a/kolega_code/cli/tui/changes_screen.py
+++ b/kolega_code/cli/tui/changes_screen.py
@@ -19,7 +19,6 @@ from textual.widgets import Static
 from .. import messages, theme
 from ..theme import Color, Glyph
 from .session_diff import SessionDiffFile
-from .state import SessionFileChange
 
 if TYPE_CHECKING:
     from ..app import KolegaCodeApp
@@ -89,7 +88,7 @@ class ChangesInspectorScreen(ModalScreen):
 
     # ---- live updates ---------------------------------------------------------
 
-    def note_change_updated(self, change: Optional[SessionFileChange] = None) -> None:
+    def note_change_updated(self, change: Optional[object] = None) -> None:
         """Called by the owner when net diff state or edit-event history changes."""
         if self._follow:
             self._selected_path = self._owner._default_changes_path() or self._selected_path
@@ -125,9 +124,6 @@ class ChangesInspectorScreen(ModalScreen):
             if change.path == path:
                 return change
         return None
-
-    def _events_for_path(self, path: str) -> list[SessionFileChange]:
-        return [change for change in self._owner._session_file_changes if change.path == path]
 
     # ---- selection ------------------------------------------------------------
 
@@ -251,16 +247,6 @@ class ChangesInspectorScreen(ModalScreen):
         else:
             net_widget.update(self._net_diff_renderable(change))
 
-        event_changes = self._events_for_path(change.path)
-        for event_change in event_changes:
-            widget_key = event_change.change_id
-            widget = self._preview_widgets.get(widget_key)
-            if widget is None:
-                widget = Static(self._event_renderable(event_change), markup=False, classes="change-preview")
-                self._preview_widgets[widget_key] = widget
-                widgets.append(widget)
-            else:
-                widget.update(self._event_renderable(event_change))
         if widgets:
             view.mount(*widgets)
         if self._follow:
@@ -269,8 +255,7 @@ class ChangesInspectorScreen(ModalScreen):
     def _render_key(self, change: Optional[SessionDiffFile]) -> str:
         if change is None:
             return ""
-        event_ids = ",".join(event.change_id for event in self._events_for_path(change.path))
-        return f"{change.path}:{change.status}:{change.adds}:{change.dels}:{repr(change.preview)}:{event_ids}"
+        return f"{change.path}:{change.status}:{change.adds}:{change.dels}:{repr(change.preview)}"
 
     def _net_diff_renderable(self, change: SessionDiffFile) -> Group:
         if change.message:
@@ -295,21 +280,6 @@ class ChangesInspectorScreen(ModalScreen):
                 return Group(body, footer)
             return body
         return self._owner._build_edit_preview(preview)
-
-    def _event_renderable(self, change: SessionFileChange) -> Group:
-        sep = theme.g(Glyph.BULLET_SEP)
-        title = Text()
-        title.append(f"Captured edit #{change.index} ", style="bold")
-        title.append(change.source_label or "Agent", style=Color.ACCENT)
-        if change.tool_name:
-            title.append(f" {sep} {change.tool_name}", style="dim")
-        if change.tool_call_id:
-            title.append(f" {sep} {change.tool_call_id}", style="dim")
-        try:
-            preview = self._owner._build_edit_preview(change.preview)
-        except Exception:
-            preview = Text("Preview unavailable", style="dim")
-        return Group(title, Padding(preview, (0, 0, 1, theme.INSET_WIDTH)))
 
     def _scroll_previews_end(self) -> None:
         def _do() -> None:
@@ -373,14 +343,4 @@ class ChangesInspectorScreen(ModalScreen):
                 lines.append(f"… +{more} more lines")
             lines.append("")
 
-        events = self._events_for_path(change.path)
-        if events:
-            lines.append("Captured edit events:")
-            for event in events:
-                header = f"#{event.index} {event.source_label or 'Agent'}"
-                if event.tool_name:
-                    header += f" · {event.tool_name}"
-                if event.tool_call_id:
-                    header += f" · {event.tool_call_id}"
-                lines.append(header)
         return "\n".join(lines).rstrip() + "\n"

--- a/kolega_code/cli/tui/changes_screen.py
+++ b/kolega_code/cli/tui/changes_screen.py
@@ -1,4 +1,4 @@
-"""Session file changes inspector screen for the CLI TUI."""
+"""Session net-diff inspector screen for the CLI TUI."""
 
 from __future__ import annotations
 
@@ -18,6 +18,7 @@ from textual.widgets import Static
 
 from .. import messages, theme
 from ..theme import Color, Glyph
+from .session_diff import SessionDiffFile
 from .state import SessionFileChange
 
 if TYPE_CHECKING:
@@ -40,11 +41,11 @@ class ChangeFileRosterRow(Static):
 
 
 class ChangesInspectorScreen(ModalScreen):
-    """Full-screen view of file edit previews captured in this TUI session.
+    """Full-screen view of net git changes since the TUI session began.
 
-    Left: a roster of changed files. Right: chronological edit previews for the
-    selected file, with source/tool attribution. The screen updates live while
-    the agent runs and new ``file_edit_preview`` events arrive.
+    Left: a roster of files whose current disk state differs from the session
+    baseline. Right: the selected file's net diff, followed by any captured edit
+    events for attribution/history.
     """
 
     BINDINGS = [
@@ -63,7 +64,7 @@ class ChangesInspectorScreen(ModalScreen):
         self._follow = True
         self._rows: dict[str, ChangeFileRosterRow] = {}
         self._preview_widgets: dict[str, Static] = {}
-        self._rendered_path: Optional[str] = None
+        self._rendered_key = ""
         self._empty_shown = False
         self._flush_pending = False
 
@@ -89,8 +90,10 @@ class ChangesInspectorScreen(ModalScreen):
     # ---- live updates ---------------------------------------------------------
 
     def note_change_updated(self, change: Optional[SessionFileChange] = None) -> None:
-        """Called by the owner when a new file edit preview is captured."""
-        if self._follow and change is not None:
+        """Called by the owner when net diff state or edit-event history changes."""
+        if self._follow:
+            self._selected_path = self._owner._default_changes_path() or self._selected_path
+        elif change is not None and self._diff_for_path(self._selected_path) is None:
             self._selected_path = change.path
         self._schedule_flush()
 
@@ -111,20 +114,20 @@ class ChangesInspectorScreen(ModalScreen):
 
     # ---- data helpers ---------------------------------------------------------
 
+    def _ordered_diffs(self) -> list[SessionDiffFile]:
+        return list(self._owner._session_diff_files)
+
     def _ordered_paths(self) -> list[str]:
-        paths: list[str] = []
-        seen: set[str] = set()
-        for change in self._owner._session_file_changes:
-            if change.path not in seen:
-                seen.add(change.path)
-                paths.append(change.path)
-        return paths
+        return [change.path for change in self._ordered_diffs()]
 
-    def _changes_for_path(self, path: str) -> list[SessionFileChange]:
+    def _diff_for_path(self, path: str) -> Optional[SessionDiffFile]:
+        for change in self._owner._session_diff_files:
+            if change.path == path:
+                return change
+        return None
+
+    def _events_for_path(self, path: str) -> list[SessionFileChange]:
         return [change for change in self._owner._session_file_changes if change.path == path]
-
-    def _selected_changes(self) -> list[SessionFileChange]:
-        return self._changes_for_path(self._selected_path)
 
     # ---- selection ------------------------------------------------------------
 
@@ -153,7 +156,7 @@ class ChangesInspectorScreen(ModalScreen):
     def _select_changed(self) -> None:
         self._sync_roster()
         self._refresh_header()
-        self._sync_previews()
+        self._sync_previews(force=True)
         row = self._rows.get(self._selected_path)
         if row is not None:
             try:
@@ -181,23 +184,22 @@ class ChangesInspectorScreen(ModalScreen):
                 rows.append(row)
             if rows:
                 roster.mount(*rows)
-        for path in paths:
-            row = self._rows.get(path)
+        for change in self._ordered_diffs():
+            row = self._rows.get(change.path)
             if row is not None:
-                row.update(self._roster_row(path, selected=path == self._selected_path))
+                row.update(self._roster_row(change, selected=change.path == self._selected_path))
 
-    def _roster_row(self, path: str, *, selected: bool) -> Text:
-        changes = self._changes_for_path(path)
-        adds = sum(int(change.preview.get("adds") or 0) for change in changes)
-        dels = sum(int(change.preview.get("dels") or 0) for change in changes)
+    def _roster_row(self, change: SessionDiffFile, *, selected: bool) -> Text:
         row_style = "bold" if selected else ""
         line = Text()
         line.append("> " if selected else "  ", style=row_style)
         line.append(f"{theme.g(Glyph.TOOL)} ", style=Color.ACCENT)
-        line.append(path, style=row_style)
-        meta = f"\n    {len(changes)} edit{'' if len(changes) == 1 else 's'}"
-        if adds or dels:
-            meta += f"  +{adds} -{dels}"
+        line.append(change.path, style=row_style)
+        meta = f"\n    {change.status}"
+        if change.adds or change.dels:
+            meta += f"  +{change.adds} -{change.dels}"
+        if change.message:
+            meta += "  diff unavailable"
         line.append(meta, style="dim")
         return line
 
@@ -206,72 +208,86 @@ class ChangesInspectorScreen(ModalScreen):
             header = self.query_one("#changes_header", Static)
         except Exception:
             return
-        changes = self._selected_changes()
-        if not changes:
+        change = self._diff_for_path(self._selected_path)
+        if change is None:
             header.update(messages.CHANGES_INSPECTOR_NO_SELECTION)
             return
-        adds = sum(int(change.preview.get("adds") or 0) for change in changes)
-        dels = sum(int(change.preview.get("dels") or 0) for change in changes)
         sep = theme.g(Glyph.BULLET_SEP)
-        line = theme.role_header(Glyph.TOOL, escape(self._selected_path), Color.ACCENT, state="session changes")
-        line += theme.styled(
-            f" {sep} {len(changes)} edit{'' if len(changes) == 1 else 's'} {sep} +{adds} -{dels}",
-            "dim",
-        )
+        line = theme.role_header(Glyph.TOOL, escape(change.path), Color.ACCENT, state=change.status)
+        line += theme.styled(f" {sep} +{change.adds} -{change.dels}", "dim")
         header.update(Text.from_markup(line))
 
-    def _sync_previews(self) -> None:
+    def _sync_previews(self, *, force: bool = False) -> None:
         try:
             view = self.query_one("#changes_previews", VerticalScroll)
         except Exception:
             return
         if not view.is_attached:
             return
-        changes = self._selected_changes()
-        if self._rendered_path != self._selected_path:
+        change = self._diff_for_path(self._selected_path)
+        key = self._render_key(change)
+        if force or key != self._rendered_key:
             view.remove_children()
             self._preview_widgets = {}
             self._empty_shown = False
-            self._rendered_path = self._selected_path
-        if not changes:
+            self._rendered_key = key
+        if change is None:
             if not self._empty_shown:
                 view.remove_children()
                 self._preview_widgets = {}
                 view.mount(Static(messages.CHANGES_INSPECTOR_NO_SELECTION, classes="changes-empty"))
                 self._empty_shown = True
             return
-        if self._empty_shown:
-            view.remove_children()
-            self._preview_widgets = {}
-            self._empty_shown = False
 
-        rendered_ids = list(self._preview_widgets)
-        current_ids = [change.change_id for change in changes]
-        if current_ids[: len(rendered_ids)] != rendered_ids:
-            view.remove_children()
-            self._preview_widgets = {}
-            rendered_ids = []
+        widgets = []
+        net_widget = self._preview_widgets.get("net")
+        if net_widget is None:
+            net_widget = Static(self._net_diff_renderable(change), markup=False, classes="change-preview")
+            self._preview_widgets["net"] = net_widget
+            widgets.append(net_widget)
+        else:
+            net_widget.update(self._net_diff_renderable(change))
 
-        for change_id, widget in self._preview_widgets.items():
-            change = next((item for item in changes if item.change_id == change_id), None)
-            if change is not None:
-                widget.update(self._preview_renderable(change))
-
-        new_changes = changes[len(rendered_ids) :]
-        if new_changes:
-            widgets = []
-            for change in new_changes:
-                widget = Static(self._preview_renderable(change), markup=False, classes="change-preview")
-                self._preview_widgets[change.change_id] = widget
+        event_changes = self._events_for_path(change.path)
+        for event_change in event_changes:
+            widget_key = event_change.change_id
+            widget = self._preview_widgets.get(widget_key)
+            if widget is None:
+                widget = Static(self._event_renderable(event_change), markup=False, classes="change-preview")
+                self._preview_widgets[widget_key] = widget
                 widgets.append(widget)
+            else:
+                widget.update(self._event_renderable(event_change))
+        if widgets:
             view.mount(*widgets)
         if self._follow:
             self._scroll_previews_end()
 
-    def _preview_renderable(self, change: SessionFileChange) -> Group:
+    def _render_key(self, change: Optional[SessionDiffFile]) -> str:
+        if change is None:
+            return ""
+        event_ids = ",".join(event.change_id for event in self._events_for_path(change.path))
+        return f"{change.path}:{change.status}:{change.adds}:{change.dels}:{repr(change.preview)}:{event_ids}"
+
+    def _net_diff_renderable(self, change: SessionDiffFile) -> Group:
+        title = Text()
+        title.append("Net session diff", style="bold")
+        title.append(f"  {theme.g(Glyph.BULLET_SEP)}  {change.status}", style="dim")
+        if change.message:
+            body = Text(change.message, style="dim")
+        elif change.preview:
+            try:
+                body = self._owner._build_edit_preview(change.preview)
+            except Exception:
+                body = Text("Preview unavailable", style="dim")
+        else:
+            body = Text("Preview unavailable", style="dim")
+        return Group(title, Padding(body, (0, 0, 1, theme.INSET_WIDTH)))
+
+    def _event_renderable(self, change: SessionFileChange) -> Group:
         sep = theme.g(Glyph.BULLET_SEP)
         title = Text()
-        title.append(f"#{change.index} ", style="bold")
+        title.append(f"Captured edit #{change.index} ", style="bold")
         title.append(change.source_label or "Agent", style=Color.ACCENT)
         if change.tool_name:
             title.append(f" {sep} {change.tool_name}", style="dim")
@@ -315,38 +331,44 @@ class ChangesInspectorScreen(ModalScreen):
         self._follow = not self._follow
         self._refresh_footer()
         if self._follow:
-            self._sync_previews()
+            self._sync_previews(force=True)
 
     def action_copy_changes(self) -> None:
-        changes = self._selected_changes()
-        if not changes:
+        change = self._diff_for_path(self._selected_path)
+        if change is None:
             return
-        self._owner.copy_to_clipboard(self._changes_text(self._selected_path, changes))
+        self._owner.copy_to_clipboard(self._changes_text(change))
         try:
             self._owner._notify_user(messages.CHANGES_COPIED, severity="information")
         except Exception:
             pass
 
-    def _changes_text(self, path: str, changes: list[SessionFileChange]) -> str:
-        lines = [f"Changes for {path}", ""]
-        for change in changes:
-            header = f"#{change.index} {change.source_label or 'Agent'}"
-            if change.tool_name:
-                header += f" · {change.tool_name}"
-            if change.tool_call_id:
-                header += f" · {change.tool_call_id}"
-            lines.append(header)
-            preview = change.preview
-            kind = str(preview.get("kind") or "")
-            if kind == "diff":
-                lines.append(f"+{int(preview.get('adds') or 0)} -{int(preview.get('dels') or 0)}")
-            for row in preview.get("lines") or []:
+    def _changes_text(self, change: SessionDiffFile) -> str:
+        lines = [f"Changes for {change.path}", f"Status: {change.status}", ""]
+        if change.message:
+            lines.append(change.message)
+            lines.append("")
+        elif change.preview:
+            if str(change.preview.get("kind") or "") == "diff":
+                lines.append(f"+{int(change.preview.get('adds') or 0)} -{int(change.preview.get('dels') or 0)}")
+            for row in change.preview.get("lines") or []:
                 if isinstance(row, (list, tuple)) and len(row) >= 2:
                     lines.append(str(row[1]))
                 else:
                     lines.append(str(row))
-            more = int(preview.get("more") or 0)
+            more = int(change.preview.get("more") or 0)
             if more > 0:
                 lines.append(f"… +{more} more lines")
             lines.append("")
+
+        events = self._events_for_path(change.path)
+        if events:
+            lines.append("Captured edit events:")
+            for event in events:
+                header = f"#{event.index} {event.source_label or 'Agent'}"
+                if event.tool_name:
+                    header += f" · {event.tool_name}"
+                if event.tool_call_id:
+                    header += f" · {event.tool_call_id}"
+                lines.append(header)
         return "\n".join(lines).rstrip() + "\n"

--- a/kolega_code/cli/tui/changes_screen.py
+++ b/kolega_code/cli/tui/changes_screen.py
@@ -213,9 +213,12 @@ class ChangesInspectorScreen(ModalScreen):
             header.update(messages.CHANGES_INSPECTOR_NO_SELECTION)
             return
         sep = theme.g(Glyph.BULLET_SEP)
-        line = theme.role_header(Glyph.TOOL, escape(change.path), Color.ACCENT, state=change.status)
-        line += theme.styled(f" {sep} +{change.adds} -{change.dels}", "dim")
-        header.update(Text.from_markup(line))
+        line = Text.from_markup(theme.role_header(Glyph.TOOL, escape(change.path), Color.ACCENT, state=change.status))
+        line.append(f" {sep} ", style="dim")
+        line.append(f"+{change.adds}", style=Color.SUCCESS)
+        line.append(" ", style="dim")
+        line.append(f"-{change.dels}", style=Color.ERROR)
+        header.update(line)
 
     def _sync_previews(self, *, force: bool = False) -> None:
         try:
@@ -274,12 +277,24 @@ class ChangesInspectorScreen(ModalScreen):
             body = Text(change.message, style="dim")
         elif change.preview:
             try:
-                body = self._owner._build_edit_preview(change.preview)
+                body = self._preview_body_without_meta(change.preview)
             except Exception:
                 body = Text("Preview unavailable", style="dim")
         else:
             body = Text("Preview unavailable", style="dim")
         return Group(Padding(body, (0, 0, 1, 0)))
+
+    def _preview_body_without_meta(self, preview: dict):
+        """Render only the diff body; the selected file and +/- counts are in the header."""
+        kind = str(preview.get("kind") or "")
+        if kind == "diff":
+            body = self._owner._edit_preview_diff(preview.get("lines") or [])
+            more = int(preview.get("more") or 0)
+            if more > 0:
+                footer = Text(f"{theme.g(Glyph.ELLIPSIS)} +{more} more lines", style="dim")
+                return Group(body, footer)
+            return body
+        return self._owner._build_edit_preview(preview)
 
     def _event_renderable(self, change: SessionFileChange) -> Group:
         sep = theme.g(Glyph.BULLET_SEP)

--- a/kolega_code/cli/tui/session_diff.py
+++ b/kolega_code/cli/tui/session_diff.py
@@ -1,0 +1,266 @@
+"""Git-backed net session diff tracking for the CLI TUI Changes inspector."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from subprocess import DEVNULL, PIPE, run as subprocess_run
+from typing import Iterable, Literal, Optional
+
+from kolega_code.agent.tool_backend.edit_preview import build_diff_preview, build_head_preview
+
+
+@dataclass
+class FileBaseline:
+    """A session-start baseline for one git path."""
+
+    path: str  # git-root-relative, posix-style path
+    exists: bool
+    content: Optional[str] = None
+    binary_or_unreadable: bool = False
+
+
+@dataclass
+class SessionDiffFile:
+    """One file whose current state differs from the TUI session baseline."""
+
+    path: str  # project-relative display path
+    status: Literal["modified", "added", "deleted"]
+    preview: Optional[dict]
+    adds: int = 0
+    dels: int = 0
+    message: str = ""
+
+
+class GitSessionDiffTracker:
+    """Compute net file changes since a TUI session began, for git repos only.
+
+    The tracker avoids whole-repo snapshots. It snapshots only files that are dirty
+    at session start, then uses HEAD as the baseline for files that were clean.
+    """
+
+    def __init__(self, project_path: Path, git_root: Path) -> None:
+        self.project_path = project_path.resolve()
+        self.git_root = git_root.resolve()
+        self._baseline: dict[str, FileBaseline] = {}
+        self._baseline_paths: set[str] = set()
+
+    @classmethod
+    def create(cls, project_path: Path) -> "GitSessionDiffTracker | None":
+        git_root = cls._detect_git_root(project_path)
+        if git_root is None:
+            return None
+        return cls(project_path, git_root)
+
+    @staticmethod
+    def _detect_git_root(project_path: Path) -> Path | None:
+        try:
+            completed = subprocess_run(
+                ["git", "rev-parse", "--show-toplevel"],
+                cwd=str(project_path),
+                stdout=PIPE,
+                stderr=DEVNULL,
+                text=True,
+                check=False,
+            )
+        except (OSError, ValueError):
+            return None
+        if completed.returncode != 0:
+            return None
+        root = completed.stdout.strip()
+        return Path(root).resolve() if root else None
+
+    def capture_baseline(self) -> None:
+        """Snapshot files that are already dirty at session start."""
+        self._baseline = {}
+        for repo_path in self._git_status_paths():
+            self._baseline[repo_path] = self._snapshot_repo_path(repo_path)
+        self._baseline_paths = set(self._baseline)
+
+    def refresh(self, event_paths: Iterable[str] = ()) -> list[SessionDiffFile]:
+        """Return current net changes relative to the session-start baseline."""
+        candidates = set(self._git_status_paths()) | set(self._baseline_paths)
+        candidates.update(self._repo_paths_from_event_paths(event_paths))
+
+        diffs: list[SessionDiffFile] = []
+        for repo_path in sorted(candidates):
+            if not self._is_under_project(repo_path):
+                continue
+            baseline = self._baseline.get(repo_path)
+            if baseline is None:
+                baseline = self._head_baseline(repo_path)
+            current = self._snapshot_repo_path(repo_path)
+            diff = self._build_diff(repo_path, baseline, current)
+            if diff is not None:
+                diffs.append(diff)
+        return diffs
+
+    # ---- git/status helpers --------------------------------------------------
+
+    def _git_status_paths(self) -> set[str]:
+        try:
+            completed = subprocess_run(
+                ["git", "-c", "core.quotePath=false", "status", "--porcelain", "-z"],
+                cwd=str(self.git_root),
+                stdout=PIPE,
+                stderr=DEVNULL,
+                check=False,
+            )
+        except (OSError, ValueError):
+            return set()
+        if completed.returncode != 0:
+            return set()
+        return self._parse_porcelain_z(completed.stdout)
+
+    @staticmethod
+    def _parse_porcelain_z(output: bytes) -> set[str]:
+        paths: set[str] = set()
+        entries = [entry for entry in output.decode("utf-8", errors="surrogateescape").split("\0") if entry]
+        index = 0
+        while index < len(entries):
+            entry = entries[index]
+            if len(entry) < 4:
+                index += 1
+                continue
+            status = entry[:2]
+            path = entry[3:]
+            if path:
+                paths.add(path)
+            # In porcelain v1 -z, rename/copy records are followed by the other path.
+            if status[0] in {"R", "C"} or status[1] in {"R", "C"}:
+                index += 1
+                if index < len(entries) and entries[index]:
+                    paths.add(entries[index])
+            index += 1
+        return paths
+
+    def _head_baseline(self, repo_path: str) -> FileBaseline:
+        try:
+            completed = subprocess_run(
+                ["git", "show", f"HEAD:{repo_path}"],
+                cwd=str(self.git_root),
+                stdout=PIPE,
+                stderr=DEVNULL,
+                check=False,
+            )
+        except (OSError, ValueError):
+            return FileBaseline(path=repo_path, exists=False)
+        if completed.returncode != 0:
+            return FileBaseline(path=repo_path, exists=False)
+        return self._baseline_from_bytes(repo_path, completed.stdout, exists=True)
+
+    # ---- path/content helpers ------------------------------------------------
+
+    def _snapshot_repo_path(self, repo_path: str) -> FileBaseline:
+        abs_path = self.git_root / repo_path
+        if not abs_path.exists() or not abs_path.is_file():
+            return FileBaseline(path=repo_path, exists=False)
+        try:
+            data = abs_path.read_bytes()
+        except OSError:
+            return FileBaseline(path=repo_path, exists=True, binary_or_unreadable=True)
+        return self._baseline_from_bytes(repo_path, data, exists=True)
+
+    @staticmethod
+    def _baseline_from_bytes(repo_path: str, data: bytes, *, exists: bool) -> FileBaseline:
+        if b"\x00" in data:
+            return FileBaseline(path=repo_path, exists=exists, binary_or_unreadable=True)
+        try:
+            content = data.decode("utf-8")
+        except UnicodeDecodeError:
+            content = data.decode("utf-8", errors="replace")
+        return FileBaseline(path=repo_path, exists=exists, content=content)
+
+    def _repo_paths_from_event_paths(self, event_paths: Iterable[str]) -> set[str]:
+        paths: set[str] = set()
+        for event_path in event_paths:
+            repo_path = self._event_path_to_repo_path(event_path)
+            if repo_path:
+                paths.add(repo_path)
+        return paths
+
+    def _event_path_to_repo_path(self, event_path: str) -> str:
+        if not event_path:
+            return ""
+        path = Path(event_path)
+        abs_path = path if path.is_absolute() else self.project_path / path
+        try:
+            resolved = abs_path.resolve(strict=False)
+            rel = resolved.relative_to(self.git_root)
+        except ValueError:
+            return ""
+        return self._posix(rel)
+
+    def _is_under_project(self, repo_path: str) -> bool:
+        try:
+            (self.git_root / repo_path).resolve(strict=False).relative_to(self.project_path)
+            return True
+        except ValueError:
+            return False
+
+    def _display_path(self, repo_path: str) -> str:
+        try:
+            rel = (self.git_root / repo_path).resolve(strict=False).relative_to(self.project_path)
+            return self._posix(rel)
+        except ValueError:
+            return repo_path
+
+    @staticmethod
+    def _posix(path: Path) -> str:
+        rel = str(PurePosixPath(path.as_posix()))
+        return "" if rel == "." else rel
+
+    # ---- diff construction ---------------------------------------------------
+
+    def _build_diff(
+        self,
+        repo_path: str,
+        baseline: FileBaseline,
+        current: FileBaseline,
+    ) -> SessionDiffFile | None:
+        if self._same_state(baseline, current):
+            return None
+
+        display_path = self._display_path(repo_path)
+        if not baseline.exists and current.exists:
+            status: Literal["modified", "added", "deleted"] = "added"
+        elif baseline.exists and not current.exists:
+            status = "deleted"
+        else:
+            status = "modified"
+
+        if baseline.binary_or_unreadable or current.binary_or_unreadable:
+            return SessionDiffFile(
+                path=display_path,
+                status=status,
+                preview=None,
+                message="Binary or unreadable file changed; textual diff unavailable.",
+            )
+
+        old = baseline.content or ""
+        new = current.content or ""
+        preview = (
+            build_head_preview(new, display_path) if status == "added" else build_diff_preview(old, new, display_path)
+        )
+        if preview is None and old != new:
+            message = "File changed; textual diff unavailable."
+        else:
+            message = ""
+        return SessionDiffFile(
+            path=display_path,
+            status=status,
+            preview=preview,
+            adds=int((preview or {}).get("adds") or 0),
+            dels=int((preview or {}).get("dels") or 0),
+            message=message,
+        )
+
+    @staticmethod
+    def _same_state(left: FileBaseline, right: FileBaseline) -> bool:
+        if left.exists != right.exists:
+            return False
+        if not left.exists and not right.exists:
+            return True
+        if left.binary_or_unreadable or right.binary_or_unreadable:
+            return left.binary_or_unreadable == right.binary_or_unreadable and left.content == right.content
+        return (left.content or "") == (right.content or "")

--- a/kolega_code/cli/tui/session_diff.py
+++ b/kolega_code/cli/tui/session_diff.py
@@ -7,7 +7,7 @@ from pathlib import Path, PurePosixPath
 from subprocess import DEVNULL, PIPE, run as subprocess_run
 from typing import Iterable, Literal, Optional
 
-from kolega_code.agent.tool_backend.edit_preview import build_diff_preview, build_head_preview
+from kolega_code.agent.tool_backend.edit_preview import build_diff_preview
 
 
 @dataclass
@@ -239,9 +239,7 @@ class GitSessionDiffTracker:
 
         old = baseline.content or ""
         new = current.content or ""
-        preview = (
-            build_head_preview(new, display_path) if status == "added" else build_diff_preview(old, new, display_path)
-        )
+        preview = build_diff_preview(old, new, display_path)
         if preview is None and old != new:
             message = "File changed; textual diff unavailable."
         else:

--- a/kolega_code/cli/tui/state.py
+++ b/kolega_code/cli/tui/state.py
@@ -79,6 +79,22 @@ class ConversationEntry:
 
 
 @dataclass
+class SessionFileChange:
+    """One UI-only file edit preview captured during the live TUI session."""
+
+    change_id: str
+    index: int
+    path: str
+    preview: dict
+    tool_name: str = ""
+    tool_call_id: str = ""
+    agent_id: str = ""
+    agent_name: str = ""
+    source_label: str = "Agent"
+    created_at: float = 0.0
+
+
+@dataclass
 class SubAgentActivity:
     """Live display state for one dispatched sub-agent."""
 
@@ -101,6 +117,7 @@ class SubAgentActivity:
     steps: list[ConversationEntry] = field(default_factory=list)
     tool_steps: dict[str, ConversationEntry] = field(default_factory=dict)  # tool_call_id/name -> step
     stream_steps: dict[str, ConversationEntry] = field(default_factory=dict)  # chunk uuid -> step
+    pending_edit_previews: dict[str, dict] = field(default_factory=dict)  # tool_call_id -> preview payload
     tokens: Optional[int] = None  # cumulative tokens consumed, from lifecycle events
     # Context-window occupancy (how full this sub-agent's own context is right now),
     # from llm_context_update events. Distinct from cumulative `tokens` above.

--- a/kolega_code/cli/tui/styles.tcss
+++ b/kolega_code/cli/tui/styles.tcss
@@ -370,3 +370,58 @@ SubAgentInspectorScreen #inspector_footer {
     background: $surface;
     color: $text-muted;
 }
+
+ChangesInspectorScreen {
+    align: center middle;
+}
+
+ChangesInspectorScreen #changes_body {
+    width: 100%;
+    height: 1fr;
+}
+
+ChangesInspectorScreen #changes_roster {
+    width: 44;
+    height: 100%;
+    border: round $surface;
+    padding: 0 1;
+}
+
+ChangesInspectorScreen #changes_main {
+    width: 1fr;
+    height: 100%;
+}
+
+ChangesInspectorScreen #changes_header {
+    height: auto;
+    border: round $surface;
+    padding: 0 1;
+}
+
+ChangesInspectorScreen #changes_previews {
+    height: 1fr;
+    border: round $surface;
+    padding: 0 1;
+}
+
+ChangeFileRosterRow {
+    height: auto;
+    padding: 0 0 1 0;
+}
+
+ChangesInspectorScreen .changes-empty {
+    color: $text-muted;
+    padding: 1;
+}
+
+ChangesInspectorScreen .change-preview {
+    height: auto;
+    padding-bottom: 1;
+}
+
+ChangesInspectorScreen #changes_footer {
+    height: 1;
+    padding: 0 1;
+    background: $surface;
+    color: $text-muted;
+}

--- a/kolega_code/cli/tui/transcript.py
+++ b/kolega_code/cli/tui/transcript.py
@@ -20,6 +20,7 @@ from .constants import QUESTION_TOOL_NAME, STARTUP_WORDMARK
 from .state import (
     ConversationEntry,
     PhaseState,
+    SessionFileChange,
     SubAgentActivity,
     TurnState,
     WorkflowActivity,
@@ -418,6 +419,70 @@ class TranscriptRenderingMixin:
         entry.edit_preview = content
         self._invalidate_conversation(entry)
 
+    def _record_file_change_event(self, event: AgentEvent) -> Optional[SessionFileChange]:
+        """Capture a UI-only edit preview in the live session changes list."""
+        content = event.content or {}
+        path = str(content.get("path") or "").strip()
+        kind = str(content.get("kind") or "").strip()
+        if not path or kind not in {"diff", "head"}:
+            return None
+
+        agent_id = ""
+        agent_name = ""
+        source_label = "Agent"
+        if event.sub_agent_info:
+            activity = self._ensure_sub_agent_activity(event)
+            agent_id = activity.agent_id
+            agent_name = activity.agent_name
+            source_label = f"Sub-agent {activity.agent_name} #{activity.index}"
+        elif event.sender:
+            agent_name = str(event.sender)
+
+        index = len(self._session_file_changes) + 1
+        change = SessionFileChange(
+            change_id=f"change-{index}",
+            index=index,
+            path=path,
+            preview=dict(content),
+            tool_name=str(content.get("tool_name") or ""),
+            tool_call_id=str(content.get("tool_call_id") or ""),
+            agent_id=agent_id,
+            agent_name=agent_name,
+            source_label=source_label,
+            created_at=self._now(),
+        )
+        self._session_file_changes.append(change)
+        self._invalidate_changes_detail(change)
+        return change
+
+    def _apply_sub_agent_edit_preview(self, event: AgentEvent) -> None:
+        """Attach a file edit preview to the matching sub-agent tool step."""
+        content = event.content or {}
+        tool_call_id = str(content.get("tool_call_id") or "").strip()
+        if not tool_call_id:
+            return
+        activity = self._ensure_sub_agent_activity(event)
+        step = activity.tool_steps.get(tool_call_id)
+        if step is None:
+            activity.pending_edit_previews[tool_call_id] = dict(content)
+        else:
+            step.edit_preview = dict(content)
+        self._invalidate_sub_agent_detail(activity)
+
+    def _attach_pending_sub_agent_edit_preview(self, activity: SubAgentActivity, step: ConversationEntry) -> None:
+        tool_call_id = step.tool_call_id or ""
+        if not tool_call_id:
+            return
+        preview = activity.pending_edit_previews.pop(tool_call_id, None)
+        if preview:
+            step.edit_preview = preview
+
+    def _invalidate_changes_detail(self, change: Optional[SessionFileChange] = None) -> None:
+        """Refresh the open changes inspector if present (no-op when closed)."""
+        screen = getattr(self, "_changes_inspector", None)
+        if screen is not None:
+            screen.note_change_updated(change)
+
     def _find_tool_entry(self, tool_call_id: str, tool_name: str) -> Optional[ConversationEntry]:
         if tool_call_id and tool_call_id in self._tool_entries:
             return self._tool_entries[tool_call_id]
@@ -565,12 +630,14 @@ class TranscriptRenderingMixin:
             activity.steps.append(step)
             if tool_call_id:
                 activity.tool_steps[tool_call_id] = step
+            self._attach_pending_sub_agent_edit_preview(activity, step)
             return
         step.kind = message_type
         step.content = entry_content
         step.complete = complete
         step.tool_name = tool_name
         step.full_content = full_content or step.full_content
+        self._attach_pending_sub_agent_edit_preview(activity, step)
 
     def _last_unpaired_sub_agent_tool_step(
         self, activity: SubAgentActivity, tool_name: str

--- a/tests/cli/test_app_changes_inspector.py
+++ b/tests/cli/test_app_changes_inspector.py
@@ -197,6 +197,27 @@ async def test_changes_inspector_header_owns_path_and_counts_body_is_just_diff(
 
 
 @pytest.mark.asyncio
+async def test_git_project_opens_empty_changes_inspector_when_no_changes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from kolega_code.cli import messages as cli_messages
+    from textual.widgets import Static
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+    _init_git_project(app.project_path)
+
+    async with app.run_test() as pilot:
+        app.action_open_changes()
+        await pilot.pause()
+
+        screen = app._changes_inspector
+        assert screen is not None
+        assert screen._rows == {}
+        assert cli_messages.CHANGES_INSPECTOR_EMPTY in str(screen.query_one("#changes_header", Static).render())
+        assert cli_messages.CHANGES_INSPECTOR_EMPTY in str(screen.query_one(".changes-empty", Static).render())
+
+
+@pytest.mark.asyncio
 async def test_non_git_project_disables_changes_inspector(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     app = _build_sub_agent_test_app(tmp_path, monkeypatch)
 

--- a/tests/cli/test_app_changes_inspector.py
+++ b/tests/cli/test_app_changes_inspector.py
@@ -1,3 +1,4 @@
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -7,6 +8,21 @@ from kolega_code.events import AgentEvent
 from kolega_code.cli.tui.widgets import ChatComposer
 
 from ._app_test_utils import _build_sub_agent_test_app, _sub_agent_event
+
+
+def _git(project: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=project, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def _init_git_project(project: Path) -> None:
+    _git(project, "init")
+    _git(project, "config", "user.email", "test@example.com")
+    _git(project, "config", "user.name", "Test User")
+    (project / "src").mkdir(exist_ok=True)
+    (project / "src" / "a.py").write_text("old a\n", encoding="utf-8")
+    (project / "src" / "b.py").write_text("old b\n", encoding="utf-8")
+    _git(project, "add", ".")
+    _git(project, "commit", "-m", "initial")
 
 
 def _binding_keys(bindings) -> set[str]:
@@ -123,17 +139,17 @@ async def test_sub_agent_preview_is_recorded_and_attached_to_trajectory(
 
 
 @pytest.mark.asyncio
-async def test_changes_inspector_opens_and_renders_grouped_changes(
+async def test_changes_inspector_opens_and_renders_git_shell_changes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     from kolega_code.cli.tui.changes_screen import ChangesInspectorScreen
 
     app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+    _init_git_project(app.project_path)
 
     async with app.run_test() as pilot:
-        app._render_event(_file_edit_preview_event("src/a.py", tool_call_id="a1"))
-        app._render_event(_file_edit_preview_event("src/b.py", tool_call_id="b1"))
-        app._render_event(_file_edit_preview_event("src/a.py", tool_call_id="a2"))
+        (app.project_path / "src" / "a.py").write_text("new a\n", encoding="utf-8")
+        (app.project_path / "src" / "b.py").unlink()
 
         app.action_open_changes()
         await pilot.pause()
@@ -141,28 +157,34 @@ async def test_changes_inspector_opens_and_renders_grouped_changes(
         assert isinstance(app._changes_inspector, ChangesInspectorScreen)
         screen = app._changes_inspector
         assert len(screen._rows) == 2
-        assert screen._selected_path == "src/a.py"
-        assert len(screen._preview_widgets) == 2
+        assert {change.path: change.status for change in app._session_diff_files} == {
+            "src/a.py": "modified",
+            "src/b.py": "deleted",
+        }
+        assert screen._selected_path in {"src/a.py", "src/b.py"}
+        assert "net" in screen._preview_widgets
 
 
 @pytest.mark.asyncio
-async def test_empty_changes_inspector_action_does_not_open(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_non_git_project_disables_changes_inspector(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     app = _build_sub_agent_test_app(tmp_path, monkeypatch)
 
     async with app.run_test():
+        assert app._session_diff_tracker is None
+        assert app.check_action("open_changes", ()) is False
         app.action_open_changes()
         assert app._changes_inspector is None
 
 
 @pytest.mark.asyncio
-async def test_copy_selected_changes_includes_metadata_and_preview_lines(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_copy_selected_changes_includes_net_diff_lines(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+    _init_git_project(app.project_path)
     copied: list[str] = []
     monkeypatch.setattr(app, "copy_to_clipboard", lambda text: copied.append(text))
 
     async with app.run_test() as pilot:
+        (app.project_path / "src" / "a.py").write_text("new a\n", encoding="utf-8")
         app._render_event(_file_edit_preview_event("src/a.py", tool_call_id="a1"))
         app.action_open_changes("src/a.py")
         await pilot.pause()
@@ -174,8 +196,9 @@ async def test_copy_selected_changes_includes_metadata_and_preview_lines(
         assert copied
         text = copied[0]
         assert "Changes for src/a.py" in text
-        assert "#1 Agent · search_and_replace · a1" in text
+        assert "Status: modified" in text
         assert "+1 -1" in text
-        assert "@@ -1 +1 @@" in text
-        assert "-old" in text
-        assert "+new" in text
+        assert "-old a" in text
+        assert "+new a" in text
+        assert "Captured edit events:" in text
+        assert "#1 Agent · search_and_replace · a1" in text

--- a/tests/cli/test_app_changes_inspector.py
+++ b/tests/cli/test_app_changes_inspector.py
@@ -252,5 +252,5 @@ async def test_copy_selected_changes_includes_net_diff_lines(tmp_path: Path, mon
         assert "+1 -1" in text
         assert "-old a" in text
         assert "+new a" in text
-        assert "Captured edit events:" in text
-        assert "#1 Agent · search_and_replace · a1" in text
+        assert "Captured edit events:" not in text
+        assert "#1 Agent · search_and_replace · a1" not in text

--- a/tests/cli/test_app_changes_inspector.py
+++ b/tests/cli/test_app_changes_inspector.py
@@ -1,0 +1,181 @@
+from pathlib import Path
+
+import pytest
+from textual.widgets import TextArea
+
+from kolega_code.events import AgentEvent
+from kolega_code.cli.tui.widgets import ChatComposer
+
+from ._app_test_utils import _build_sub_agent_test_app, _sub_agent_event
+
+
+def _binding_keys(bindings) -> set[str]:
+    keys: set[str] = set()
+    for binding in bindings:
+        for key in str(getattr(binding, "key", "")).split(","):
+            if key.strip():
+                keys.add(key.strip())
+    return keys
+
+
+def _preview(path: str, *, tool_call_id: str = "t1", tool_name: str = "search_and_replace") -> dict:
+    return {
+        "tool_call_id": tool_call_id,
+        "tool_name": tool_name,
+        "kind": "diff",
+        "path": path,
+        "language": "python",
+        "lines": [["meta", "@@ -1 +1 @@"], ["del", "-old"], ["add", "+new"]],
+        "more": 0,
+        "adds": 1,
+        "dels": 1,
+    }
+
+
+def _file_edit_preview_event(path: str, *, tool_call_id: str = "t1", sub_agent_info: dict | None = None) -> AgentEvent:
+    return AgentEvent(
+        event_type="file_edit_preview",
+        sender="coder",
+        content=_preview(path, tool_call_id=tool_call_id),
+        sub_agent_info=sub_agent_info,
+    )
+
+
+def test_changes_hotkey_uses_ctrl_r_without_known_composer_conflict() -> None:
+    from kolega_code.cli.app import KolegaCodeApp
+
+    app_bindings = {binding.action: binding for binding in KolegaCodeApp.BINDINGS}
+    assert app_bindings["open_changes"].key == "ctrl+r"
+    assert app_bindings["open_changes"].key_display == "Ctrl+R"
+
+    assert "ctrl+r" not in _binding_keys(TextArea.BINDINGS)
+    assert "ctrl+r" not in _binding_keys(ChatComposer.BINDINGS)
+    # Keep Ctrl+D free for the composer/TextArea delete-right behavior.
+    assert "ctrl+d" in _binding_keys(TextArea.BINDINGS)
+
+
+@pytest.mark.asyncio
+async def test_main_agent_preview_is_recorded_and_still_attaches_inline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        app._render_event(
+            AgentEvent(
+                event_type="chat_message",
+                sender="coder",
+                content={
+                    "message_type": "tool_call",
+                    "tool_call_id": "t1",
+                    "tool_name": "search_and_replace",
+                    "text": "Editing src/a.py",
+                },
+            )
+        )
+        app._render_event(_file_edit_preview_event("src/a.py", tool_call_id="t1"))
+
+        assert len(app._session_file_changes) == 1
+        change = app._session_file_changes[0]
+        assert change.path == "src/a.py"
+        assert change.tool_call_id == "t1"
+        assert change.source_label == "Agent"
+
+        entry = app._tool_entries["t1"]
+        assert entry.edit_preview is not None
+        assert entry.edit_preview["path"] == "src/a.py"
+
+
+@pytest.mark.asyncio
+async def test_sub_agent_preview_is_recorded_and_attached_to_trajectory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        app._render_event(
+            _sub_agent_event(
+                message_type="tool_call",
+                text="Editing",
+                tool_description="search_and_replace",
+                tool_call_id="t1",
+            )
+        )
+        sub_info = {
+            "agent_id": "agent-1",
+            "agent_name": "general-agent",
+            "task": "inspect sessions",
+            "parent_tool_call_id": "tc-1",
+            "conversation_id": None,
+            "depth": 1,
+        }
+        app._render_event(_file_edit_preview_event("src/sub.py", tool_call_id="t1", sub_agent_info=sub_info))
+
+        assert len(app._session_file_changes) == 1
+        change = app._session_file_changes[0]
+        assert change.path == "src/sub.py"
+        assert change.source_label == "Sub-agent general-agent #1"
+
+        activity = app._sub_agent_activities["agent-1"]
+        step = activity.tool_steps["t1"]
+        assert step.edit_preview is not None
+        assert step.edit_preview["path"] == "src/sub.py"
+
+
+@pytest.mark.asyncio
+async def test_changes_inspector_opens_and_renders_grouped_changes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from kolega_code.cli.tui.changes_screen import ChangesInspectorScreen
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        app._render_event(_file_edit_preview_event("src/a.py", tool_call_id="a1"))
+        app._render_event(_file_edit_preview_event("src/b.py", tool_call_id="b1"))
+        app._render_event(_file_edit_preview_event("src/a.py", tool_call_id="a2"))
+
+        app.action_open_changes()
+        await pilot.pause()
+
+        assert isinstance(app._changes_inspector, ChangesInspectorScreen)
+        screen = app._changes_inspector
+        assert len(screen._rows) == 2
+        assert screen._selected_path == "src/a.py"
+        assert len(screen._preview_widgets) == 2
+
+
+@pytest.mark.asyncio
+async def test_empty_changes_inspector_action_does_not_open(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        app.action_open_changes()
+        assert app._changes_inspector is None
+
+
+@pytest.mark.asyncio
+async def test_copy_selected_changes_includes_metadata_and_preview_lines(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+    copied: list[str] = []
+    monkeypatch.setattr(app, "copy_to_clipboard", lambda text: copied.append(text))
+
+    async with app.run_test() as pilot:
+        app._render_event(_file_edit_preview_event("src/a.py", tool_call_id="a1"))
+        app.action_open_changes("src/a.py")
+        await pilot.pause()
+
+        screen = app._changes_inspector
+        assert screen is not None
+        screen.action_copy_changes()
+
+        assert copied
+        text = copied[0]
+        assert "Changes for src/a.py" in text
+        assert "#1 Agent · search_and_replace · a1" in text
+        assert "+1 -1" in text
+        assert "@@ -1 +1 @@" in text
+        assert "-old" in text
+        assert "+new" in text

--- a/tests/cli/test_app_changes_inspector.py
+++ b/tests/cli/test_app_changes_inspector.py
@@ -7,7 +7,7 @@ from textual.widgets import TextArea
 from kolega_code.events import AgentEvent
 from kolega_code.cli.tui.widgets import ChatComposer
 
-from ._app_test_utils import _build_sub_agent_test_app, _sub_agent_event
+from ._app_test_utils import _build_sub_agent_test_app, _sub_agent_event, renderable_text
 
 
 def _git(project: Path, *args: str) -> None:
@@ -163,6 +163,37 @@ async def test_changes_inspector_opens_and_renders_git_shell_changes(
         }
         assert screen._selected_path in {"src/a.py", "src/b.py"}
         assert "net" in screen._preview_widgets
+
+
+@pytest.mark.asyncio
+async def test_changes_inspector_header_owns_path_and_counts_body_is_just_diff(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from textual.widgets import Static
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+    _init_git_project(app.project_path)
+
+    async with app.run_test() as pilot:
+        (app.project_path / "src" / "a.py").write_text("new a\n", encoding="utf-8")
+        app.action_open_changes("src/a.py")
+        await pilot.pause()
+
+        screen = app._changes_inspector
+        assert screen is not None
+        change = screen._diff_for_path("src/a.py")
+        assert change is not None
+
+        body_text = renderable_text(screen._net_diff_renderable(change))
+        assert "src/a.py" not in body_text
+        assert "+1 -1" not in body_text
+        assert "-old a" in body_text
+        assert "+new a" in body_text
+
+        header_text = screen.query_one("#changes_header", Static).render()
+        spans = {str(span.style) for span in getattr(header_text, "spans", [])}
+        assert any("green" in style for style in spans)
+        assert any("red" in style for style in spans)
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_session_diff.py
+++ b/tests/cli/test_session_diff.py
@@ -80,7 +80,8 @@ def test_new_untracked_file_after_baseline(tmp_path: Path) -> None:
 
     assert change.status == "added"
     assert change.adds == 1
-    assert change.preview["kind"] == "head"
+    assert change.preview["kind"] == "diff"
+    assert any(row[1] == "+print('new')" for row in change.preview["lines"])
 
 
 def test_pre_existing_dirty_file_is_session_baseline(tmp_path: Path) -> None:

--- a/tests/cli/test_session_diff.py
+++ b/tests/cli/test_session_diff.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from kolega_code.cli.tui.session_diff import GitSessionDiffTracker
+
+
+def _git(project: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=project, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def _init_repo(project: Path) -> None:
+    _git(project, "init")
+    _git(project, "config", "user.email", "test@example.com")
+    _git(project, "config", "user.name", "Test User")
+
+
+def _commit_all(project: Path, message: str = "initial") -> None:
+    _git(project, "add", ".")
+    _git(project, "commit", "-m", message)
+
+
+def _by_path(changes):
+    return {change.path: change for change in changes}
+
+
+def test_tracked_file_modified_after_baseline(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    project.mkdir()
+    _init_repo(project)
+    (project / "a.py").write_text("old\n", encoding="utf-8")
+    _commit_all(project)
+
+    tracker = GitSessionDiffTracker.create(project)
+    assert tracker is not None
+    tracker.capture_baseline()
+
+    (project / "a.py").write_text("new\n", encoding="utf-8")
+    change = _by_path(tracker.refresh())["a.py"]
+
+    assert change.status == "modified"
+    assert change.adds == 1
+    assert change.dels == 1
+    assert [row[1] for row in change.preview["lines"] if row[0] in {"add", "del"}] == ["-old", "+new"]
+
+
+def test_tracked_file_deleted_after_baseline(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    project.mkdir()
+    _init_repo(project)
+    (project / "a.py").write_text("old\n", encoding="utf-8")
+    _commit_all(project)
+
+    tracker = GitSessionDiffTracker.create(project)
+    assert tracker is not None
+    tracker.capture_baseline()
+
+    (project / "a.py").unlink()
+    change = _by_path(tracker.refresh())["a.py"]
+
+    assert change.status == "deleted"
+    assert change.dels == 1
+    assert any(row[1] == "-old" for row in change.preview["lines"])
+
+
+def test_new_untracked_file_after_baseline(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    project.mkdir()
+    _init_repo(project)
+    (project / "README.md").write_text("# Repo\n", encoding="utf-8")
+    _commit_all(project)
+
+    tracker = GitSessionDiffTracker.create(project)
+    assert tracker is not None
+    tracker.capture_baseline()
+
+    (project / "new.py").write_text("print('new')\n", encoding="utf-8")
+    change = _by_path(tracker.refresh())["new.py"]
+
+    assert change.status == "added"
+    assert change.adds == 1
+    assert change.preview["kind"] == "head"
+
+
+def test_pre_existing_dirty_file_is_session_baseline(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    project.mkdir()
+    _init_repo(project)
+    (project / "a.py").write_text("head\n", encoding="utf-8")
+    _commit_all(project)
+    (project / "a.py").write_text("dirty\n", encoding="utf-8")
+
+    tracker = GitSessionDiffTracker.create(project)
+    assert tracker is not None
+    tracker.capture_baseline()
+
+    assert tracker.refresh() == []
+
+    (project / "a.py").write_text("session\n", encoding="utf-8")
+    change = _by_path(tracker.refresh())["a.py"]
+
+    assert change.status == "modified"
+    lines = [row[1] for row in change.preview["lines"] if row[0] in {"add", "del"}]
+    assert lines == ["-dirty", "+session"]
+
+
+def test_reverted_to_session_start_state_disappears(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    project.mkdir()
+    _init_repo(project)
+    (project / "a.py").write_text("old\n", encoding="utf-8")
+    _commit_all(project)
+
+    tracker = GitSessionDiffTracker.create(project)
+    assert tracker is not None
+    tracker.capture_baseline()
+
+    (project / "a.py").write_text("new\n", encoding="utf-8")
+    assert _by_path(tracker.refresh())["a.py"].status == "modified"
+
+    (project / "a.py").write_text("old\n", encoding="utf-8")
+    assert tracker.refresh() == []
+
+
+def test_non_git_create_returns_none(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+
+    assert GitSessionDiffTracker.create(project) is None


### PR DESCRIPTION
## Summary
- add Ctrl+R Changes inspector for file edit previews captured in the live TUI session
- record main-agent and sub-agent file edit previews with source/tool attribution
- attach sub-agent edit previews to their inspector trajectories

## Tests
- pytest tests/cli/test_app_changes_inspector.py -q
- pytest tests/cli/test_app_sub_agents_workflows.py -q
- ruff check kolega_code/cli/app.py kolega_code/cli/messages.py kolega_code/cli/tui/state.py kolega_code/cli/tui/transcript.py kolega_code/cli/tui/agent_runtime.py kolega_code/cli/tui/changes_screen.py tests/cli/test_app_changes_inspector.py
- pytest tests/cli -q