### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.10.0 - 2026-06-25
+
+### Added
+
+- Added a session changes inspector to the TUI that shows git diffs for the
+  current session, renders added files as diffs, presents an empty state, and
+  hides captured edit events.
+- Added project prompt overrides, including variable rendering, override status
+  shown at startup, validation, and selective dump support.
+
+### Fixed
+
+- Preserved Ollama Cloud reasoning provider metadata.
+- Ignored project `.dotenv` files when loading model config.
+- Stabilized terminal rendering artifacts in the TUI.
+- Restored the generated root CLI help.
+- Surfaced prompt override render errors.
+
+### Changed
+
+- Split the LLM specs module into a package for maintainability.
+
 ## 0.9.0 - 2026-06-24
 
 ### Added

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -44,4 +44,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.9.0"
+version = "0.10.0"
 description = "Local-first AI coding agent for the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [options]
 prerelease-mode = "allow"
-exclude-newer = "2026-06-17T13:08:36.353346Z"
+exclude-newer = "2026-06-18T10:53:16.49897Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1360,7 +1360,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Release bump for `kolega-code` v0.10.0.

## Changes

- Bump version to `0.10.0` in `pyproject.toml`, `kolega_code/__init__.py`, and `kolega_code/agent/__init__.py` (parity enforced by the `Release` workflow).
- Refresh `uv.lock` (`uv lock`): project version updated and `exclude-newer` cutoff advanced one day, per `RELEASING.md`.
- Add `0.10.0` entry to `CHANGELOG.md`.

## What's in v0.10.0

### Added
- TUI session changes inspector (git session diffs, added-file diffs, empty state, hides captured edit events).
- Project prompt overrides (variable rendering, startup status, validation, selective dump).

### Fixed
- Preserved Ollama Cloud reasoning provider metadata.
- Ignored project `.dotenv` files when loading model config.
- Stabilized terminal rendering artifacts in the TUI.
- Restored generated root CLI help.
- Surfaced prompt override render errors.

### Changed
- Split the LLM specs module into a package.

## Checks
- `./run_tests.sh` → 1484 passed, 50 deselected.
- Pre-commit hooks passed (ruff check/format).

Follows `RELEASING.md`. Tag `v0.10.0` will be created from the merge commit after this PR is reviewed and merged.