### PR TITLE
docs: reposition marketing copy around gigacode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kolega Code
 
-**An AI coding agent that runs in your terminal — local-first, model-agnostic, plan-then-build.**
+**Multi-agent coding in the terminal.**
 
 [![PyPI version](https://img.shields.io/pypi/v/kolega-code)](https://pypi.org/project/kolega-code/)
 [![Python versions](https://img.shields.io/pypi/pyversions/kolega-code)](https://pypi.org/project/kolega-code/)
@@ -10,41 +10,64 @@
 [![Docs](https://img.shields.io/badge/docs-kolega--ai.github.io-blue)](https://kolega-ai.github.io/kolega-code/)
 [![Changelog](https://img.shields.io/badge/changelog-keep%20up-blue)](CHANGELOG.md)
 
-Point Kolega Code at a project directory and it opens an interactive UI where you talk to an
-agent that can read and edit your code, run shell commands, search the codebase, browse the
-web, and dispatch specialized sub-agents to get work done.
-
-It's **local-first**: the agent operates on your actual filesystem and terminal, and your
-sessions, settings, and API keys stay on your own machine.
+Kolega Code is a local-first terminal coding agent built for work that is too wide
+for one loop: fan out specialized sub-agents with **Gigacode**, route different
+models to different jobs, search the web, drive a browser, and keep sessions,
+settings, permissions, and credentials on your machine.
 
 ![Kolega Code in action](docs/src/assets/demo.gif)
 
-## Why Kolega Code
+## Built for work one agent cannot cover
 
-- **Plans before it builds.** A read-only **Plan mode** produces a reviewable plan and a
-  shared task list before anything changes; **Build mode** implements it. Toggle with `Shift+Tab`.
-- **Orchestrates many agents.** For larger jobs, the main agent dispatches specialized
-  sub-agents (investigation, browser, coding, general) and can fan them out in parallel for
-  broad audits, large migrations, or implementing a plan's independent parts at once.
-- **Local-first by design.** It works on your real files and terminal; sessions, settings,
-  and credentials live on your machine, not in someone else's cloud.
-- **Bring your own model.** Talks to a range of providers and lets you assign different models
-  to different roles.
+Most terminal agents are strongest when one model can reason through one task at a
+time. Kolega Code keeps that familiar workflow, then adds orchestration for broad work:
+large audits, sweeping migrations, cross-file checks, adversarial reviews, and
+implementation plans whose pieces can run independently.
 
-## What it does
+With [Gigacode](https://kolega-ai.github.io/kolega-code/gigacode/), Kolega Code can:
 
-- **Reads and edits your code.** Opens files, searches across the codebase, creates new files,
-  and applies precise edits.
-- **Runs commands.** Executes shell commands and watches their output in a dedicated terminal view.
-- **Plans before it builds.** Plan mode investigates and proposes; Build mode executes.
-- **Searches and browses the web.** The agent can search for relevant pages, fetch URLs
-  directly, or use the built-in browser agent (powered by Playwright) when a task needs
-  site interaction.
-- **Dispatches sub-agents.** Hands work off to specialized agents and tracks their activity live.
-- **Orchestrates workflows.** With [gigacode](https://kolega-ai.github.io/kolega-code/gigacode/),
-  it fans out many sub-agents in parallel.
-- **Works non-interactively too.** Run a single prompt with `kolega-code ask`, get JSON output,
-  and save or resume sessions.
+- **Fan out many sub-agents at once.** Split a wide codebase review by package,
+  assign independent implementation tasks, or run checks across many directories in
+  parallel.
+- **Use real workflow shapes.** The agent can generate parallel phases, pipelines,
+  loops, judge panels, and synthesis steps instead of only delegating one task at a
+  time.
+- **Keep orchestration visible.** Workflow phase headers and progress lines appear
+  in the transcript; the sub-agent inspector shows each agent's live trajectory.
+- **Save inspectable artifacts.** Each run keeps the generated workflow script,
+  result files, a Markdown transcript, raw JSONL, a resume journal, and debug
+  sub-agent transcripts under Kolega Code's state directory.
+- **Run in either mode.** In Plan mode, workflow sub-agents stay read-only for
+  parallel investigation. In Build mode, they can use the full coding toolset.
+- **Resume interrupted runs.** Finished workflow steps are journaled so a deliberate
+  resume does not have to restart the whole fan-out.
+
+Use normal chat for focused changes. Turn on Gigacode when the problem is broad
+enough that one serial agent pass would be the bottleneck.
+
+## Features
+
+- **Gigacode orchestration:** parallel, pipelined, looped, judged, and synthesized
+  multi-agent workflows with saved artifacts and resume support.
+- **Specialized sub-agents:** planning, building/coder, investigation, general, and
+  browser agents, with live activity tracking in the TUI.
+- **Repo tools:** read and search code, create files, apply precise edits, and inspect
+  session changes/diffs.
+- **Terminal execution:** run shell commands with streamed output and project-level
+  permission controls.
+- **Plan/build workflow:** use read-only Plan mode for investigation and a reviewable
+  task list, then Build mode to implement.
+- **Web search and browsing:** DuckDuckGo works by default with no key; Firecrawl,
+  Tavily, and SearXNG are configurable search backends. Kolega Code can also fetch URLs
+  directly and use a Playwright-powered browser agent for interactive sites.
+- **Model routing:** choose provider/model combinations, set thinking effort, split
+  long-context/fast/thinking roles, and override models per agent role.
+- **Interactive or scriptable:** use the Textual TUI, run `kolega-code ask`, request
+  JSON output, list/export/resume sessions, and diagnose setup with `doctor`.
+- **Extensibility:** add agent skills, override prompts with project templates, run
+  lifecycle hooks, and persist project permission rules.
+- **Local-first state:** sessions, settings, permissions, OAuth tokens, and API-key
+  settings stay on your machine with restrictive permissions where applicable.
 
 ## Quick start
 
@@ -73,8 +96,9 @@ kolega-code --version
 kolega-code .
 ```
 
-**3. Add a provider key.** Open the **Settings** tab to pick a provider and model and save your
-API key. Then press `Shift+Tab` anytime to switch between **Plan** and **Build** mode.
+**3. Add a provider key.** Open the **Settings** tab to pick a provider/model and
+save your API key. Use `Shift+Tab` to switch between **Plan** and **Build** mode,
+or run `/gigacode on` when a task is broad enough for fan-out.
 
 Resume a previous conversation:
 
@@ -87,7 +111,7 @@ kolega-code . --resume <id>       # a specific thread or session
 
 | Mode | Command | Best for |
 | --- | --- | --- |
-| **Interactive TUI** | `kolega-code .` | Day-to-day development, exploration, pair-programming |
+| **Interactive TUI** | `kolega-code .` | Day-to-day development, exploration, orchestration |
 | **One-shot** | `kolega-code ask "…"` | Scripting, automation, quick questions, CI |
 
 There are also helper commands for managing sessions and checking your setup:
@@ -98,25 +122,60 @@ kolega-code sessions list --project .
 kolega-code doctor --project .
 ```
 
-## Bring your own model
+## Supported providers
 
-Kolega Code talks to a range of LLM providers — including Anthropic, OpenAI, Google, Moonshot,
-and DeepSeek — and lets you assign **different models to different roles**: a strong
-long-context model for coding, a fast cheap model for small utility calls, and one for extended
-"thinking". See [Providers & Models](https://kolega-ai.github.io/kolega-code/configuration/providers-and-models/).
+Kolega Code supports a broad model-provider catalog and lets you route models by
+role instead of forcing one model to do every job.
+
+Supported model providers:
+
+- Anthropic
+- OpenAI API
+- OpenAI via ChatGPT subscription sign-in
+- Google
+- Groq
+- Together.ai
+- Fireworks.ai
+- xAI / Grok
+- DashScope / Qwen
+- Moonshot / Kimi
+- DeepSeek
+- Z.AI / GLM Coding Plan
+- Kimi Coding Plan
+- Ollama Cloud
+- local Llama
+
+Supported web-search backends:
+
+- DuckDuckGo — default, no key required
+- Firecrawl
+- Tavily
+- SearXNG — self-hosted option
+
+See [Providers & Models](https://kolega-ai.github.io/kolega-code/configuration/providers-and-models/)
+for model IDs, role configuration, API-key variables, and thinking-effort options.
+
+## Model routing
+
+Kolega Code can assign different models to different operational roles: a strong
+long-context model for the main coding loop, a faster model for utility calls, and
+a dedicated model for extended thinking. You can also override models per agent
+role — planning, building, investigation, general, and browser — so wide workflows
+can use cheaper models where they fit and stronger models where they matter.
 
 ## Sign in with ChatGPT
 
-If you have a paid **ChatGPT** plan (Plus, Pro, or Business), you can use it to run OpenAI models
-instead of a separate API key. Run `/login chatgpt` in the TUI, complete the browser sign-in, and
-Kolega Code switches to the **OpenAI (ChatGPT subscription)** provider (default `gpt-5.5`). Tokens are
-stored locally (chmod `600`) and refreshed automatically; `/logout chatgpt` removes them. See
+If you have a paid **ChatGPT** plan (Plus, Pro, or Business), you can use it to run
+OpenAI models instead of a separate API key. Run `/login chatgpt` in the TUI,
+complete the browser sign-in, and Kolega Code switches to the **OpenAI (ChatGPT
+subscription)** provider (default `gpt-5.5`). Tokens are stored locally (chmod
+`600`) and refreshed automatically; `/logout chatgpt` removes them. See
 [Sign in with ChatGPT](https://kolega-ai.github.io/kolega-code/configuration/sign-in-with-chatgpt/).
 
 ## Configuration
 
-Set your provider, model, and API keys from the **Settings** tab in the UI, or via environment
-variables and flags for non-interactive use:
+Set your provider, model, and API keys from the **Settings** tab in the UI, or via
+environment variables and flags for non-interactive use:
 
 ```bash
 export KOLEGA_CODE_PROVIDER=deepseek
@@ -124,27 +183,28 @@ export DEEPSEEK_API_KEY=...
 kolega-code ask "summarize this repository" --project . --provider deepseek --model deepseek-v4-pro
 ```
 
-API key variables only provide credentials — pick a provider/model explicitly or save one in
-Settings. Local session state lives under your platform's state directory unless
-`KOLEGA_CODE_STATE_DIR` is set. See the
+API key variables only provide credentials — pick a provider/model explicitly or
+save one in Settings. Local session state lives under your platform's state
+directory unless `KOLEGA_CODE_STATE_DIR` is set. See the
 [Configuration docs](https://kolega-ai.github.io/kolega-code/configuration/settings-and-api-keys/)
 for the full story.
 
-The `web_search` tool uses DuckDuckGo by default without a key. To choose another backend,
-set it in **Settings** or export `KOLEGA_CODE_WEB_SEARCH_BACKEND` as `firecrawl`, `tavily`,
-or `searxng`; use `FIRECRAWL_API_KEY`, `TAVILY_API_KEY`, or `SEARXNG_BASE_URL` as needed.
+The `web_search` tool uses DuckDuckGo by default without a key. To choose another
+backend, set it in **Settings** or export `KOLEGA_CODE_WEB_SEARCH_BACKEND` as
+`firecrawl`, `tavily`, or `searxng`; use `FIRECRAWL_API_KEY`, `TAVILY_API_KEY`, or
+`SEARXNG_BASE_URL` as needed.
 
-Projects can also override Kolega Code's base prompts with uppercase Markdown templates in
-`.kolega/prompts/`. Generate editable starters with Jinja replacement tags using `/prompts dump`
-in the TUI or `kolega-code prompts dump --project .` in a terminal. To dump only selected
-starters, pass prompt names such as `coder`, `planning`, or `compaction` (filename aliases
-like `CODER.md` work too). Validate existing overrides with `/prompts validate` or
-`kolega-code prompts validate --project .`.
+Projects can override Kolega Code's base prompts with uppercase Markdown templates
+in `.kolega/prompts/`. Generate editable starters with Jinja replacement tags using
+`/prompts dump` in the TUI or `kolega-code prompts dump --project .` in a terminal.
+To dump only selected starters, pass prompt names such as `coder`, `planning`, or
+`compaction` (filename aliases like `CODER.md` work too). Validate existing
+overrides with `/prompts validate` or `kolega-code prompts validate --project .`.
 
 ## Requirements
 
 - **Python 3.11+**
-- An **API key** for at least one supported provider
+- An **API key**, ChatGPT sign-in, or local model for at least one supported model provider
 - A terminal that supports a modern TUI (most do)
 
 ## Documentation
@@ -167,9 +227,9 @@ Full documentation lives at **[kolega-ai.github.io/kolega-code](https://kolega-a
 
 ## Contributing
 
-Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, running the
-test suite, and building the docs site. Please report security issues privately per
-[SECURITY.md](SECURITY.md).
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup,
+running the test suite, and building the docs site. Please report security issues
+privately per [SECURITY.md](SECURITY.md).
 
 ## License
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -13,8 +13,8 @@ export default defineConfig({
     starlight({
       title: "Kolega Code",
       description:
-        "A local-first, terminal AI coding agent. Plan, build, and ship from your CLI.",
-      // The Kolega "</>" mark, alongside the "Kolega Code" wordmark in the nav.
+        "Multi-agent terminal coding with local state, model routing, web search, and browser automation.",
+      // The company "</>" mark, alongside the "Kolega Code" wordmark in the nav.
       logo: {
         light: "./src/assets/kolega-light.svg",
         dark: "./src/assets/kolega-dark.svg",

--- a/docs/src/content/docs/concepts/how-it-works.md
+++ b/docs/src/content/docs/concepts/how-it-works.md
@@ -3,9 +3,13 @@ title: Architecture
 description: A high-level look at how Kolega Code works under the hood.
 ---
 
-You don't need to know the internals to use Kolega Code, but a mental model helps
-when you're debugging behavior or extending it. This is a light overview — not an
-API reference.
+A terminal agent loop with tools is the baseline. Kolega Code keeps that loop, then
+adds the pieces that matter for wider work: mode boundaries, evented local
+execution, specialized sub-agent dispatch, role-specific models, and
+[Gigacode](../../gigacode/) workflow orchestration.
+
+You don't need the internals for everyday use, but this mental model helps when
+you're debugging behavior, choosing models, or deciding when a task should fan out.
 
 ## The agent loop
 
@@ -38,12 +42,31 @@ work — investigating the codebase, driving a browser, or handling a self-conta
 coding task — and track their progress. Different agent types expose different
 toolsets. See [Agents](../agents/).
 
+Sub-agents are useful one at a time, but they become more powerful when a task can
+be split across independent workstreams. That's what Gigacode automates.
+
+## Gigacode workflows
+
+With [Gigacode](../../gigacode/) enabled, Kolega Code can write a small workflow that
+launches many sub-agents, organizes them into phases, and synthesizes their
+results. Workflows can run broad audits, migration checks, implementation batches,
+or review panels without forcing one model to do every step serially.
+
+Workflow runs are evented like normal agent work, so the TUI can show phase
+progress and sub-agent activity. They also save artifacts — result files,
+transcripts, raw JSONL, and a resume journal — under Kolega Code's state directory.
+
 ## Models per role
 
 A single turn may use more than one model. The main reasoning runs on the
 **long-context** model, small utility calls use the **fast** model, and extended
 reasoning uses the **thinking** model. You control each independently — see
 [Providers & Models](../../configuration/providers-and-models/).
+
+Kolega Code can also override models per agent role: planning, building, investigation,
+general, and browser. This lets wide workflows put cheaper or faster models on
+routine investigation while reserving stronger models for implementation or
+synthesis.
 
 ## Local execution
 
@@ -53,5 +76,6 @@ Kolega Code runs against your real environment:
 - **Terminal** — runs shell commands and streams their output.
 - **Browser** — automates a real browser (via Playwright) for web tasks.
 
-Sessions and settings are persisted locally. This local-first design is what makes
-the agent useful for real development work rather than a sandboxed demo.
+Sessions, settings, permissions, and credentials are persisted locally. That local
+state is what lets Kolega Code operate on a real development workspace while preserving
+resumable sessions and project-specific controls.

--- a/docs/src/content/docs/configuration/providers-and-models.mdx
+++ b/docs/src/content/docs/configuration/providers-and-models.mdx
@@ -8,6 +8,10 @@ import { Aside, Steps } from '@astrojs/starlight/components';
 Kolega Code is provider-agnostic. You choose which LLM provider to use and which
 model to use for each of several **roles**.
 
+Provider breadth is table stakes; Kolega Code's extra control is assigning models by
+operational role and by agent role, so cheap/fast models can investigate while
+stronger models plan, build, or think.
+
 ## Supported providers
 
 The agent runtime recognizes these providers:
@@ -51,7 +55,7 @@ with thinking effort `auto` (enabled) requests route to **K2.7 Code**, and with 
 OpenAI-compatible API at `https://ollama.com/v1` with `OLLAMA_API_KEY`. Kolega
 Code uses the direct API model IDs returned by Ollama, such as **`glm-5.2`** and
 **`gpt-oss:120b`**, rather than local Ollama aliases such as `:cloud` or
-`-cloud`. Ollama may deprecate or retire older cloud models, so the supported
+`-cloud`. Ollama may deprecate or retire older cloud models, so Kolega Code's supported
 model catalog should be refreshed periodically from Ollama's model library/API.
 </Aside>
 
@@ -165,7 +169,7 @@ Thinking effort is model-specific. Kolega Code validates the selected value
 against the active model and resets it to the new model's default when you switch
 models in the TUI.
 
-| Provider/model | Values | Kolega default |
+| Provider/model | Values | Kolega Code default |
 | --- | --- | --- |
 | Anthropic `claude-opus-4-7` | `low`, `medium`, `high`, `xhigh`, `max` | `medium` |
 | DeepSeek `deepseek-v4-pro` | `none`, `high`, `max` | `high` |

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -5,7 +5,9 @@ description: Launch Kolega Code, pick a model, and run your first session.
 
 import { Steps, Aside } from '@astrojs/starlight/components';
 
-This walks you from a fresh install to a working session in a few minutes.
+This gets a repo into a working Kolega Code session: pick a provider, verify local
+permissions, try a normal turn, then use Plan mode or Gigacode when the task is
+broad enough to benefit from fan-out.
 
 <Steps>
 
@@ -49,18 +51,31 @@ This walks you from a fresh install to a working session in a few minutes.
    - Run a command with `/` — e.g. `/help`, `/model`, `/context`.
    - Insert a newline without sending with `Shift+Enter`.
 
-4. **Plan before a bigger change.**
+4. **Turn on Gigacode for broad work.**
+
+   For tasks that are too wide for one serial agent pass — audits across many
+   packages, large migrations, adversarial reviews, or independent implementation
+   chunks — enable orchestration:
+
+   ```text
+   /gigacode on
+   ```
+
+   Once enabled, Kolega Code decides when a request is broad enough to fan out into a
+   workflow. Focused edits still run directly.
+
+5. **Use Plan mode when you want a read-only pass first.**
 
    Press `Shift+Tab` to switch to **Plan mode**. The agent works read-only and
    proposes a plan in the **Planning** tab. When it submits a complete plan,
    choose whether to implement it or keep discussing.
 
-5. **Build it.**
+6. **Build it.**
 
    Press `Shift+Tab` again to return to **Build mode** and let the agent
    implement the plan, updating the shared task list as it goes.
 
-6. **Save and exit.**
+7. **Save and exit.**
 
    Press `Ctrl+Q` (or run `/quit`) to save the session and exit. Resume later
    with:
@@ -84,6 +99,7 @@ Add `--save` to keep the session, or `--json` for machine-readable output. See
 
 ## Where to go next
 
+- [Gigacode](../../gigacode/) — multi-agent workflow orchestration for fan-out work.
 - [Build & Plan Modes](../../tui/modes/) — how the two modes differ.
 - [Chat Composer](../../tui/composer/) — `@` mentions, `/` commands, and keys.
 - [Slash Commands](../../tui/slash-commands/) — the full command reference.

--- a/docs/src/content/docs/gigacode.mdx
+++ b/docs/src/content/docs/gigacode.mdx
@@ -5,21 +5,41 @@ description: Dynamic multi-agent workflow orchestration — fan out many sub-age
 
 import { Aside } from '@astrojs/starlight/components';
 
-**Gigacode** lets the agent take on work that's too big for a single pass by
-**orchestrating many sub-agents at once**. When it's enabled and a task calls for
-it, the agent writes a small workflow that fans sub-agents out in parallel,
-pipelines them, or loops over them — then collects the results.
+**Gigacode** is Kolega Code's answer to coding work that is too wide for a single agent
+loop. Instead of asking one model to serially inspect a whole repo, Kolega Code can
+launch many focused sub-agents, run them in phases, and synthesize their results.
 
-It's built for work that's wide rather than deep:
+It's built for work where breadth matters:
 
-- Broad audits and multi-file reviews.
-- Large migrations or mechanical changes spread across many files.
-- Judge panels and adversarial verification, where several agents cross-check each
-  other.
-- Implementing a plan whose parts are independent, in parallel.
+- Audit every package, module, or service area in parallel.
+- Run migration checks across many directories.
+- Assign independent implementation tasks after a plan is agreed.
+- Run several review agents against the same change and synthesize disagreements.
+- Use browser or investigation agents for external research while code agents
+  inspect the repo.
 
 For a quick question or a small, focused edit, the agent just does it directly —
-gigacode is for genuine fan-out.
+Gigacode is for genuine fan-out.
+
+## What Gigacode adds
+
+When it's enabled and a task calls for it, the agent writes a small workflow that
+can:
+
+- **Run parallel phases** — launch many sub-agents at once, wait for their results,
+  then synthesize.
+- **Pipeline work** — send each package, directory, or topic through a sequence of
+  stages independently.
+- **Loop over broad surfaces** — repeat a focused agent task across a list of files,
+  modules, services, issues, or review targets.
+- **Run judge panels** — ask several agents to evaluate a change or plan from
+  different angles, then reconcile disagreements.
+- **Preserve artifacts** — save the workflow script, result files, transcripts, raw
+  JSONL, and resume journal so the run is inspectable after the fact.
+
+This is the main difference from ordinary one-off delegation: the agent can design
+a workflow, execute the wide parts concurrently, and return with the aggregate
+result.
 
 ## Turning it on
 
@@ -49,6 +69,7 @@ The `run_workflow` result is a compact artifact manifest. It includes paths like
 should read those main files and avoid reading individual sub-agent transcripts.
 Raw and per-agent debug artifacts may exist under the run directory for explicit
 workflow debugging.
+
 The agent should read those paths first — not re-run the workflow just to recover
 output text.
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,60 +1,90 @@
 ---
 title: Introduction
-description: What Kolega Code is, what it does, and who it's for.
+description: Multi-agent terminal coding with local state, model routing, web search, and browser automation.
 ---
 
-**Kolega Code** is an AI coding agent that runs in your terminal. You point it at
-a project directory, and it opens an interactive UI where you can talk to an agent
-that can read and edit your code, run shell commands, search the codebase, browse
-the web, and dispatch specialized sub-agents to get work done.
+**Multi-agent coding in the terminal.**
 
-It's **local-first**: the agent operates on your actual filesystem and terminal,
-and your sessions, settings, and API keys are stored on your own machine.
+Kolega Code is for developers who already know the terminal-agent workflow and
+want more control when the work gets wide: Gigacode fan-out, observable
+sub-agents, local sessions and credentials, per-role model routing, web search,
+and browser automation.
 
-## What it does
+Point it at a project and use it like a normal coding agent for focused work. When
+a task needs breadth — auditing many packages, migrating a large surface area,
+running competing reviews, or implementing independent chunks — Kolega Code can split
+that work across specialized agents and synthesize the results.
 
-- **Reads and edits your code.** The agent can open files, search across the
-  codebase, create new files, and apply precise edits.
-- **Runs commands.** It can execute shell commands and watch their output, with a
-  dedicated terminal view in the UI.
-- **Plans before it builds.** A read-only **Plan mode** produces a reviewable plan
-  and a shared task list; **Build mode** implements it.
-- **Searches and browses the web.** The agent can search for relevant pages,
-  fetch URLs directly, or use the built-in browser agent (powered by Playwright)
-  when a task needs site interaction.
-- **Dispatches sub-agents.** For larger tasks, the main agent can hand off to
-  specialized agents (investigation, browser, coding, general) and track their
-  activity live.
-- **Orchestrates workflows.** With [gigacode](gigacode/), the agent can fan out
-  many sub-agents in parallel — for broad audits, large migrations, or
-  implementing a plan's independent parts at once.
-- **Works non-interactively too.** Run a single prompt with
-  [`kolega-code ask`](cli/ask/), get JSON output, and save or resume
-  sessions.
+## Built for fan-out work
+
+[Gigacode](gigacode/) is Kolega Code's multi-agent workflow layer. When enabled, the
+agent can write and run small workflows that launch many sub-agents in parallel,
+pipe work through phases, loop over sets of files or modules, and collect the
+results into a final answer.
+
+Use it for work such as:
+
+- Auditing every package, module, or service area in parallel.
+- Running migration checks across many directories.
+- Assigning independent implementation tasks after a plan is agreed.
+- Running several review agents against the same change and synthesizing
+  disagreements.
+- Pairing browser or investigation agents with code agents when external research
+  and repo inspection both matter.
+
+Workflow runs are visible in the TUI, produce saved artifacts, and can be resumed
+instead of restarted when intentionally continuing an interrupted run.
+
+## Feature map
+
+- **Gigacode orchestration:** parallel phases, pipelines, loops, judge panels,
+  synthesis, saved artifacts, and resume support.
+- **Specialized sub-agents:** planning, building/coder, investigation, general,
+  and browser agents with live activity tracking.
+- **Repo and terminal tools:** read/search/edit files, create files, inspect
+  diffs/session changes, and run shell commands with streamed output.
+- **Web search and browsing:** DuckDuckGo works by default with no key; Firecrawl,
+  Tavily, and SearXNG are configurable backends. Kolega Code can fetch URLs directly or
+  drive a Playwright browser for interactive sites.
+- **Provider and model routing:** choose supported providers/models, configure
+  thinking effort, split long-context/fast/thinking roles, and override models per
+  agent role.
+- **Local-first state:** sessions, settings, project permissions, OAuth tokens, and
+  API-key settings stay on your machine.
+- **Plan/build workflow:** use read-only Plan mode for investigation and a
+  reviewable task list, then Build mode to edit and test.
+- **Interactive or scriptable:** use the TUI for day-to-day work or
+  [`kolega-code ask`](cli/ask/) with JSON output for automation.
+- **Extensibility:** package reusable workflows as [Agent Skills](skills/), adjust
+  prompts with project overrides, and run lifecycle hooks.
 
 ## Two ways to use it
 
 | Mode | Command | Best for |
 | --- | --- | --- |
-| **Interactive TUI** | `kolega-code .` | Day-to-day development, exploration, pair-programming |
+| **Interactive TUI** | `kolega-code .` | Day-to-day development, exploration, orchestration |
 | **One-shot** | `kolega-code ask "…"` | Scripting, automation, quick questions, CI |
 
 There are also helper commands for managing
 [sessions](cli/sessions/) and checking your
 [configuration](cli/doctor/).
 
-## Bring your own model
+## Supported providers
 
-Kolega Code talks to a range of LLM providers — including Anthropic, OpenAI,
-Google, Moonshot, and DeepSeek — and lets you assign **different models to
-different roles** (a strong long-context model for coding, a fast cheap model for
-small utility calls, and one for extended "thinking"). See
+Kolega Code supports Anthropic, OpenAI API, OpenAI via ChatGPT subscription
+sign-in, Google, Groq, Together.ai, Fireworks.ai, xAI/Grok, DashScope/Qwen,
+Moonshot/Kimi, DeepSeek, Z.AI/GLM Coding Plan, Kimi Coding Plan, Ollama Cloud, and
+local Llama.
+
+Provider breadth is only part of the control surface: Kolega Code can assign different
+models to the long-context, fast, and thinking roles, and can also override models
+for planning, building, investigation, general, and browser agents. See
 [Providers & Models](configuration/providers-and-models/).
 
 ## What you need
 
 - **Python 3.11+**
-- An **API key** for at least one supported provider
+- An **API key**, ChatGPT sign-in, or local model for at least one supported model provider
 - A terminal that supports a modern TUI (most do)
 
 ## Install
@@ -83,5 +113,6 @@ methods, and upgrade/uninstall commands.
 
 ## Next steps
 
-Once you're installed and have a provider key set, head to the
-[Quick Start](getting-started/quick-start/) to run your first session.
+Once you're installed and have a provider configured, head to the
+[Quick Start](getting-started/quick-start/) to run your first session and try a
+Gigacode-ready workflow.

--- a/docs/src/content/docs/skills.mdx
+++ b/docs/src/content/docs/skills.mdx
@@ -6,8 +6,8 @@ description: Package reusable workflows as skills and invoke them as slash comma
 import { FileTree, Aside } from '@astrojs/starlight/components';
 
 **Agent Skills** are reusable, project-specific (or user-wide) workflows. Each skill
-is a folder with a `SKILL.md` file describing what it does and how to do it. Kolega
-Code discovers them automatically and exposes each one as a `/skill-name`
+is a folder with a `SKILL.md` file describing what it does and how to do it. Kolega Code
+discovers them automatically and exposes each one as a `/skill-name`
 [slash command](../tui/slash-commands/).
 
 When you activate a skill, its instructions — and a manifest of any bundled

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "kolega-code"
 version = "0.10.0"
-description = "Local-first AI coding agent for the terminal"
+description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- Reposition README and marketing docs around multi-agent terminal coding and Gigacode
- Add explicit supported model providers and web-search backends
- Strengthen Gigacode, quick start, architecture, provider docs, and metadata copy

## Checks

- npm run build (from docs/)
- pre-commit hooks during commit: ruff check, ruff format, trailing whitespace, EOF, YAML, debug statements, private key detection
