### PR TITLE
feat(tui): queue follow-up messages

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -1495,7 +1495,11 @@ class KolegaCodeApp(
         self.query_one("#composer", tui_widgets.ChatComposer).placeholder = status
 
     def _restore_composer_placeholder(self) -> None:
-        self.query_one("#composer", tui_widgets.ChatComposer).placeholder = messages.COMPOSER_PLACEHOLDER
+        try:
+            composer = self.query_one("#composer", tui_widgets.ChatComposer)
+        except Exception:
+            return
+        composer.placeholder = messages.COMPOSER_PLACEHOLDER
         self._clear_composer_hint()
 
     def _show_composer_hint(self, text: str, tone: str = "warning") -> None:

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -193,6 +193,8 @@ class KolegaCodeApp(
         self._pending_question: Optional[tui_state.PendingQuestion] = None
         self._pending_approval: Optional[tui_state.PendingApproval] = None
         self._pending_image_attachments: list[dict] = []
+        self._queued_messages: list[tui_state.QueuedMessage] = []
+        self._queued_message_seq = 0
         # Dedup flag: one vision-mismatch system message per non-vision model
         # session. Reset in _switch_model so a new model gets a fresh warning.
         self._vision_warning_shown = False
@@ -259,6 +261,7 @@ class KolegaCodeApp(
                 yield tui_widgets.ActionList(id="effort_actions")
                 yield tui_widgets.ActionList(id="theme_actions")
                 yield Static("", id="turn_status", markup=True)
+                yield Static("", id="queued_messages", markup=False)
                 with Horizontal(id="composer_hint_row"):
                     yield Static("", id="composer_hint", markup=False)
                     yield Button(theme.g(Glyph.CROSS), id="detach_btn", classes="hint-detach")
@@ -792,10 +795,13 @@ class KolegaCodeApp(
                 self._show_composer_hint(messages.MODEL_NON_VISION_IMAGE_BLOCKED, tone="warning")
                 return
         # Safe to consume — clear the composer, pending attachments, and the
-        # attach hint (which would otherwise linger during generation).
+        # attach hint (which would otherwise linger during generation or queueing).
         event.composer.load_text("")
         self._pending_image_attachments.clear()
         self._clear_composer_hint()
+        if self._turn_active or self.agent_worker is not None:
+            self._queue_user_message(text, attachments)
+            return
         self._add_conversation_entry(tui_state.ConversationEntry(kind="user", content=text))
         self.agent_worker = self.run_worker(
             self._process_message(text, attachments), name="kolega-turn", group="turns", exclusive=True
@@ -1096,11 +1102,13 @@ class KolegaCodeApp(
         self._plan_decision_active = False
         await self._save_session_async()
         self._restore_plan_action_visibility()
+        self._refresh_input_area_visibility()
         self._cancel_pending_question()
         self._cancel_pending_approval()
         self._cancel_pending_model_selection()
         self._cancel_pending_effort_selection()
         self._cancel_pending_theme_selection()
+        self._clear_queued_messages()
 
         if self.config is not None:
             await self._build_agent(self.config, rebuild=True, restore_transcript=False)
@@ -1152,6 +1160,7 @@ class KolegaCodeApp(
         self._set_plan_actions_visible(True, allow_discuss=True)
         self._set_composer_status(messages.PLAN_READY_PLACEHOLDER)
         self._set_chat_enabled(False)
+        self._refresh_input_area_visibility()
         self._notify_user(notification)
 
     async def _implement_pending_plan(self, *, clear_context: bool = False) -> None:
@@ -1172,6 +1181,7 @@ class KolegaCodeApp(
         await self._set_interaction_mode(tui_constants.BUILD_INTERACTION_MODE)
         self._refresh_planning_sidebar()
         self._set_plan_actions_visible(False)
+        self._refresh_input_area_visibility()
 
         prompt = build_implement_plan_prompt(plan, gigacode_enabled=self._gigacode_enabled)
         self._add_conversation_entry(tui_state.ConversationEntry(kind="user", content="Implement the approved plan."))
@@ -1189,6 +1199,7 @@ class KolegaCodeApp(
         await self._save_session_async()
         self._refresh_planning_sidebar()
         self._set_plan_actions_visible(False)
+        self._refresh_input_area_visibility()
         self._restore_composer_placeholder()
         self._set_chat_enabled(self.agent is not None)
         self._schedule_primary_focus_restore()
@@ -1454,6 +1465,24 @@ class KolegaCodeApp(
         except Exception:
             pass
 
+    def _refresh_input_area_visibility(self) -> None:
+        prompt_or_decision_pending = (
+            self._pending_approval is not None or self._pending_question is not None or self._plan_decision_active
+        )
+        try:
+            composer = self.query_one("#composer", tui_widgets.ChatComposer)
+            composer.display = True
+        except Exception:
+            pass
+        try:
+            queued_panel = self.query_one("#queued_messages")
+        except Exception:
+            return
+        if prompt_or_decision_pending:
+            queued_panel.display = False
+        else:
+            self._refresh_queued_messages_panel()
+
     def _set_chat_enabled(self, enabled: bool) -> None:
         composer = self.query_one("#composer", tui_widgets.ChatComposer)
         composer.disabled = not enabled or self._plan_decision_active or self._pending_approval is not None
@@ -1506,6 +1535,7 @@ class KolegaCodeApp(
             self.agent.last_compression_index = None
         self.session.history = []
         self.session.compaction = {}
+        self._clear_queued_messages()
 
     async def _reset_current_thread(self) -> None:
         self._close_sub_agent_inspector()
@@ -1523,6 +1553,7 @@ class KolegaCodeApp(
         self._sub_agent_seq = 0
         self._workflow_activities = {}
         self._active_progress_entry = None
+        self._clear_queued_messages()
         self._latest_plan = None
         self._plan_pending = False
         self._plan_reofferable = False

--- a/kolega_code/cli/messages.py
+++ b/kolega_code/cli/messages.py
@@ -39,6 +39,11 @@ STOPPED_WITH_ERROR = "Stopped due to an error: {error}"
 CANCEL_REQUESTED = "Cancellation requested."
 WAITING_FOR_ANSWER = "Waiting for your answer…"
 WAITING_FOR_PERMISSION = "Waiting for permission…"
+QUEUED_MESSAGE = "Queued. It will be sent when the current turn finishes."
+QUEUE_PLACEHOLDER = "Queue a follow-up…"
+QUEUE_EMPTY = "No queued messages."
+QUEUE_CLEARED = "Cleared {count} queued message(s)."
+QUEUE_LIST_TITLE = "Queued messages:"
 
 # Turn status strip finals
 DONE_IN = "Done in {duration}"

--- a/kolega_code/cli/slash_commands.py
+++ b/kolega_code/cli/slash_commands.py
@@ -57,6 +57,7 @@ TUI_COMMAND_ENTRIES: tuple[SlashCommandEntry, ...] = (
     SlashCommandEntry("logout", "Sign out of a provider, e.g. /logout chatgpt", CommandScope.TUI),
     SlashCommandEntry("gigacode", "Toggle gigacode workflow orchestration on or off", CommandScope.TUI),
     SlashCommandEntry("prompts", "Dump, list, or validate project prompt override files", CommandScope.TUI),
+    SlashCommandEntry("queue-clear", "Clear queued follow-up messages", CommandScope.TUI),
     SlashCommandEntry("theme", "Show or switch the color theme", CommandScope.TUI),
     SlashCommandEntry("copy", "Copy the last response to the clipboard", CommandScope.TUI),
     SlashCommandEntry("version", "Show the Kolega Code version", CommandScope.TUI),

--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -18,33 +18,35 @@ from . import state as tui_state
 
 
 class AgentRuntimeMixin:
-    async def _process_message(self, message: str, attachments: list[dict] | None = None) -> None:
-        if self.agent is None:
-            return
+    def _agent_turn_stream(self, message: str, attachments: list[dict] | None = None):
+        if attachments:
+            return self.agent.process_message_stream(message, attachments)
+        return self.agent.process_message_stream(message)
+
+    async def _consume_agent_stream(self, stream) -> None:
+        async for chunk in stream:
+            if chunk.get("type") == "response":
+                if chunk.get("content"):
+                    self._update_progress(
+                        messages.READING_RESPONSE, complete=False, state=tui_state.TurnState.GENERATING
+                    )
+                self._apply_stream_chunk(chunk, kind="assistant")
+                continue
+
+            content = chunk.get("content")
+            if chunk.get("type") == "thinking":
+                self._update_progress(messages.THINKING, complete=False, state=tui_state.TurnState.THINKING)
+                self._apply_stream_chunk(chunk, kind="thinking")
+                if content and self.show_logs:
+                    self._write_log(content, "debug")
+
+    async def _run_turn_stream(self, stream_factory) -> bool:
+        """Run one agent stream and return whether it was cancelled by the user."""
         cancelled_by_user = False
         self._begin_turn_progress()
         self._log_status(messages.GENERATING, "ok")
         try:
-            stream = (
-                self.agent.process_message_stream(message, attachments)
-                if attachments
-                else self.agent.process_message_stream(message)
-            )
-            async for chunk in stream:
-                if chunk.get("type") == "response":
-                    if chunk.get("content"):
-                        self._update_progress(
-                            messages.READING_RESPONSE, complete=False, state=tui_state.TurnState.GENERATING
-                        )
-                    self._apply_stream_chunk(chunk, kind="assistant")
-                    continue
-
-                content = chunk.get("content")
-                if chunk.get("type") == "thinking":
-                    self._update_progress(messages.THINKING, complete=False, state=tui_state.TurnState.THINKING)
-                    self._apply_stream_chunk(chunk, kind="thinking")
-                    if content and self.show_logs:
-                        self._write_log(content, "debug")
+            await self._consume_agent_stream(stream_factory())
             await self._drain_pending_events()
             self._refresh_session_diff()
             self._finalize_sub_agent_activities()
@@ -101,6 +103,124 @@ class AgentRuntimeMixin:
             self._set_chat_enabled(self.agent is not None and not self._plan_decision_active)
             if cancelled_by_user:
                 self._schedule_primary_focus_restore()
+        return cancelled_by_user
+
+    async def _process_message(self, message: str, attachments: list[dict] | None = None) -> None:
+        if self.agent is None:
+            return
+        cancelled_by_user = await self._run_turn_stream(lambda: self._agent_turn_stream(message, attachments))
+        if not cancelled_by_user:
+            self._schedule_maybe_start_queued_message()
+
+    def _queue_user_message(self, text: str, attachments: list[dict] | None = None) -> None:
+        self._queued_message_seq += 1
+        entry = tui_state.ConversationEntry(kind="queued", content=text)
+        queued = tui_state.QueuedMessage(
+            queue_id=f"queued-{self._queued_message_seq}",
+            text=text,
+            attachments=[dict(item) for item in attachments] if attachments else None,
+            entry=entry,
+        )
+        self._queued_messages.append(queued)
+        self._add_conversation_entry(entry)
+        self._refresh_queued_messages_panel()
+        self._log_status(messages.QUEUED_MESSAGE, "info")
+
+    def _queued_messages_preview(self) -> str:
+        if not self._queued_messages:
+            return messages.QUEUE_EMPTY
+        lines = [f"{messages.QUEUE_LIST_TITLE} {len(self._queued_messages)}"]
+        for index, queued in enumerate(self._queued_messages, start=1):
+            preview = " ".join(queued.text.strip().split()) or "(empty)"
+            if len(preview) > 120:
+                preview = preview[:117] + "…"
+            suffix = ""
+            if queued.attachments:
+                suffix = f" ({len(queued.attachments)} attachment(s))"
+            lines.append(f"{index}. {preview}{suffix}")
+        return "\n".join(lines)
+
+    def _refresh_queued_messages_panel(self) -> None:
+        try:
+            panel = self.query_one("#queued_messages")
+        except Exception:
+            return
+        if not self._queued_messages:
+            panel.update("")
+            panel.display = False
+            return
+        panel.update(self._queued_messages_preview())
+        panel.display = (
+            self._pending_approval is None and self._pending_question is None and not self._plan_decision_active
+        )
+
+    def _remove_queued_entries_from_transcript(self, queued: list[tui_state.QueuedMessage]) -> None:
+        entry_ids = {item.entry.entry_id for item in queued}
+        before = len(self.conversation_entries)
+        self.conversation_entries = [entry for entry in self.conversation_entries if entry.entry_id not in entry_ids]
+        if len(self.conversation_entries) != before:
+            self._render_conversation()
+
+    def _clear_queued_messages(self) -> int:
+        queued = list(self._queued_messages)
+        self._queued_messages.clear()
+        self._remove_queued_entries_from_transcript(queued)
+        self._refresh_queued_messages_panel()
+        return len(queued)
+
+    def _restore_queued_messages_to_composer(self) -> int:
+        queued = list(self._queued_messages)
+        if not queued:
+            return 0
+
+        queued_text = "\n\n".join(item.text for item in queued)
+        try:
+            composer = self.query_one("#composer")
+            existing_text = getattr(composer, "text", "") or ""
+            restored_text = f"{queued_text}\n\n{existing_text}" if existing_text else queued_text
+            composer.load_text(restored_text)
+        except Exception:
+            pass
+
+        self._queued_messages.clear()
+        self._remove_queued_entries_from_transcript(queued)
+        self._refresh_queued_messages_panel()
+        return len(queued)
+
+    def _schedule_maybe_start_queued_message(self) -> None:
+        try:
+            self.set_timer(0.01, self._maybe_start_queued_message, name="queued-message-drain")
+        except Exception:
+            self._maybe_start_queued_message()
+
+    def _maybe_start_queued_message(self) -> bool:
+        if not self._queued_messages or self.agent is None:
+            return False
+        if self._turn_active or self.agent_worker is not None:
+            return False
+        if (
+            self._pending_question is not None
+            or self._pending_approval is not None
+            or self._pending_model_selection is not None
+            or self._pending_effort_selection is not None
+            or self._pending_theme_selection is not None
+            or self._plan_decision_active
+        ):
+            return False
+
+        queued = self._queued_messages.pop(0)
+        queued.entry.kind = "user"
+        queued.entry.tone = None
+        if queued.entry not in self.conversation_entries:
+            self._add_conversation_entry(queued.entry)
+        else:
+            self._render_conversation()
+        self._refresh_queued_messages_panel()
+        self._clear_composer_hint()
+        self.agent_worker = self.run_worker(
+            self._process_message(queued.text, queued.attachments), name="kolega-turn", group="turns", exclusive=True
+        )
+        return True
 
     async def _consume_events(self) -> None:
         while True:
@@ -199,6 +319,7 @@ class AgentRuntimeMixin:
             self._update_progress(messages.STOP_REQUESTED, complete=False, state=tui_state.TurnState.STOPPING)
             self._cancel_pending_question()
             self._cancel_pending_approval()
+            self._restore_queued_messages_to_composer()
             self.agent_worker.cancel()
             self._notify_user(messages.CANCEL_REQUESTED, severity="warning")
 
@@ -233,6 +354,8 @@ class AgentRuntimeMixin:
     ) -> None:
         history = self.session.history
         compaction = self.session.compaction
+        if rebuild:
+            self._clear_queued_messages()
         if self.agent is not None:
             await self._save_session_history_async()
             history = self.session.history

--- a/kolega_code/cli/tui/command_handlers.py
+++ b/kolega_code/cli/tui/command_handlers.py
@@ -52,6 +52,7 @@ class CommandHandlersMixin:
             "/logout": self._command_logout,
             "/gigacode": self._command_gigacode,
             "/prompts": self._command_prompts,
+            "/queue-clear": self._command_queue_clear,
             "/theme": self._command_theme,
             "/copy": self._command_copy,
             "/version": self._command_version,
@@ -806,6 +807,12 @@ class CommandHandlersMixin:
         content = "\n".join(lines)
         self._add_conversation_entry(tui_state.ConversationEntry(kind="system", content=content))
         self._notify_user(lines[0], severity=severity)
+
+    async def _command_queue_clear(self, args: str) -> None:
+        count = self._clear_queued_messages()
+        message = messages.QUEUE_CLEARED.format(count=count)
+        self._add_conversation_entry(tui_state.ConversationEntry(kind="system", content=message))
+        self._notify_user(message)
 
     async def _command_quit(self, args: str) -> None:
         await self.action_quit()

--- a/kolega_code/cli/tui/prompt_flows.py
+++ b/kolega_code/cli/tui/prompt_flows.py
@@ -194,6 +194,7 @@ class PromptFlowMixin:
         self._show_question_options(question, options, descriptions)
         self._set_composer_status(messages.QUESTION_PLACEHOLDER)
         self._set_chat_enabled(True)
+        self._refresh_input_area_visibility()
         self._update_activity_progress(messages.WAITING_FOR_ANSWER, state=TurnState.WAITING_FOR_USER)
 
         try:
@@ -202,6 +203,7 @@ class PromptFlowMixin:
             if self._pending_question is not None and self._pending_question.future is future:
                 self._pending_question = None
                 self._set_question_actions_visible(False)
+                self._refresh_input_area_visibility()
 
     async def _answer_question_option(self, option_index: int) -> None:
         if self._pending_question is None:
@@ -222,14 +224,16 @@ class PromptFlowMixin:
 
         self._pending_question = None
         self._set_question_actions_visible(False)
+        self._refresh_input_area_visibility()
         self._add_conversation_entry(ConversationEntry(kind="question", content=pending_question.question))
         self._add_conversation_entry(ConversationEntry(kind="user", content=clean_answer))
         if not pending_question.future.done():
             pending_question.future.set_result(clean_answer)
 
         if self._turn_active:
-            self._restore_composer_placeholder()
-            self._set_chat_enabled(False)
+            self._set_composer_status(messages.QUEUE_PLACEHOLDER)
+            self._clear_composer_hint()
+            self._set_chat_enabled(True)
             self._update_progress(messages.WORKING, complete=False, state=TurnState.GENERATING)
         else:
             self._restore_composer_placeholder()
@@ -277,6 +281,7 @@ class PromptFlowMixin:
         self._show_approval_options(rule_options)
         self._set_composer_status(messages.APPROVAL_PLACEHOLDER)
         self._set_chat_enabled(False)
+        self._refresh_input_area_visibility()
         self._update_activity_progress(messages.WAITING_FOR_PERMISSION, state=TurnState.WAITING_FOR_USER)
 
         try:
@@ -285,6 +290,7 @@ class PromptFlowMixin:
             if self._pending_approval is not None and self._pending_approval.future is future:
                 self._pending_approval = None
                 self._set_approval_actions_visible(False)
+                self._refresh_input_area_visibility()
 
     def _show_approval_options(self, rule_options: list[PermissionRuleOption]) -> None:
         self._set_approval_actions_visible(True)
@@ -317,6 +323,7 @@ class PromptFlowMixin:
 
         self._pending_approval = None
         self._set_approval_actions_visible(False)
+        self._refresh_input_area_visibility()
         self._add_conversation_entry(
             ConversationEntry(kind="question", content=self._format_permission_content(pending.request))
         )
@@ -325,8 +332,9 @@ class PromptFlowMixin:
             pending.future.set_result(decision)
 
         if self._turn_active:
-            self._restore_composer_placeholder()
-            self._set_chat_enabled(False)
+            self._set_composer_status(messages.QUEUE_PLACEHOLDER)
+            self._clear_composer_hint()
+            self._set_chat_enabled(True)
             self._update_progress(messages.WORKING, complete=False, state=TurnState.GENERATING)
         else:
             self._restore_composer_placeholder()
@@ -384,6 +392,7 @@ class PromptFlowMixin:
             pending_question.future.cancel()
         self._pending_question = None
         self._set_question_actions_visible(False)
+        self._refresh_input_area_visibility()
 
     def _cancel_pending_approval(self) -> None:
         pending_approval = self._pending_approval
@@ -391,6 +400,7 @@ class PromptFlowMixin:
             pending_approval.future.cancel()
         self._pending_approval = None
         self._set_approval_actions_visible(False)
+        self._refresh_input_area_visibility()
 
     def _question_option_label(self, index: int, option: str, description: str = "") -> str:
         if description:

--- a/kolega_code/cli/tui/state.py
+++ b/kolega_code/cli/tui/state.py
@@ -79,6 +79,16 @@ class ConversationEntry:
 
 
 @dataclass
+class QueuedMessage:
+    """One UI-local follow-up queued while the current turn is running."""
+
+    queue_id: str
+    text: str
+    attachments: list[dict] | None
+    entry: ConversationEntry
+
+
+@dataclass
 class SessionFileChange:
     """One UI-only file edit preview captured during the live TUI session."""
 

--- a/kolega_code/cli/tui/styles.tcss
+++ b/kolega_code/cli/tui/styles.tcss
@@ -24,7 +24,15 @@ Screen {
     height: 100%;
 }
 
-#conversation, #logs, #terminal {
+#conversation {
+    height: 1fr;
+    border: none;
+    background: $surface;
+    color: $text;
+    overflow-x: hidden;
+}
+
+#logs, #terminal {
     height: 1fr;
     border: round $surface;
     background: $surface;
@@ -147,13 +155,70 @@ ToolEntryWidget .tool-body {
     color: $text-muted;
 }
 
+#queued_messages {
+    display: none;
+    height: auto;
+    max-height: 8;
+    padding: 0 1;
+    border-top: solid $surface-lighten-2;
+    background: $surface;
+    color: $warning;
+}
+
 #composer {
     dock: bottom;
     height: auto;
     min-height: 5;
     max-height: 15;
     padding: 0 0 0 1;
-    border: round $surface;
+    border: none;
+    border-top: solid $surface-lighten-2;
+    background: $surface;
+    color: $text;
+}
+
+#composer:focus,
+#composer:disabled,
+#composer:disabled:focus {
+    opacity: 1;
+    color: $text;
+    background: $surface;
+    background-tint: transparent;
+    border: none;
+    border-top: solid $surface-lighten-2;
+}
+
+#composer:disabled .text-area--cursor {
+    background: $surface-lighten-2;
+    color: $text-muted;
+}
+
+#composer .text-area--selection,
+#composer:disabled .text-area--selection {
+    background: $surface-lighten-2;
+    color: $text;
+}
+
+#composer .text-area--cursor-line,
+#composer:disabled .text-area--cursor-line {
+    background: transparent;
+}
+
+#composer .text-area--gutter,
+#composer:disabled .text-area--gutter {
+    color: $text;
+    background: $surface;
+}
+
+#composer .text-area--cursor-gutter,
+#composer:disabled .text-area--cursor-gutter {
+    color: $text;
+    background: $surface;
+}
+
+#composer .text-area--placeholder,
+#composer:disabled .text-area--placeholder {
+    color: $text 40%;
 }
 
 #turn_status {
@@ -212,23 +277,23 @@ ToolEntryWidget .tool-body {
     color: $text-muted;
 }
 
-#composer:disabled {
-    color: $text-muted;
+#plan_actions,
+#plan_actions:focus {
+    display: none;
+    height: auto;
+    max-height: 12;
+    border: none;
     background: $surface;
-    border: round $surface;
+    background-tint: transparent;
+    padding: 0;
+    margin: 0;
 }
 
-#composer:disabled .text-area--cursor {
-    background: $surface-lighten-2;
-    color: $text-muted;
+#plan_actions > .option-list--option {
+    padding: 0 1;
 }
 
-#composer:disabled .text-area--selection {
-    background: $surface-lighten-2;
-    color: $text;
-}
-
-#plan_actions, #model_actions, #effort_actions, #theme_actions {
+#model_actions, #effort_actions, #theme_actions {
     display: none;
     height: auto;
     max-height: 12;
@@ -236,18 +301,17 @@ ToolEntryWidget .tool-body {
     background: $surface;
 }
 
-/* Question / approval prompts: the question is folded into the panel header
-   (the border title) above its options, so the whole prompt reads as one
-   bordered unit. The inner ActionList drops its own border. */
+/* Question / approval prompts align flush with the transcript/composer edges.
+   The prompt text and choices should not add their own box/border chrome; the
+   active row highlight is enough to show selection. */
 #question_prompt, #approval_prompt {
     display: none;
     height: auto;
     max-height: 14;
-    border: round $surface;
+    border: none;
     background: $surface;
-    border-title-color: $text;
-    border-title-style: bold;
-    padding: 0 1;
+    padding: 0;
+    margin: 0;
 }
 
 #question_prompt > .prompt-header-scroll, #approval_prompt > .prompt-header-scroll {
@@ -255,11 +319,14 @@ ToolEntryWidget .tool-body {
     max-height: 6;
     overflow-y: auto;
     background: $surface;
+    margin-bottom: 1;
 }
 
-#question_prompt > ActionList, #approval_prompt > ActionList {
+#question_prompt > ActionList, #approval_prompt > ActionList,
+#question_prompt > ActionList:focus, #approval_prompt > ActionList:focus {
     border: none;
     background: $surface;
+    background-tint: transparent;
     height: auto;
     max-height: 6;
     padding: 0;
@@ -267,8 +334,13 @@ ToolEntryWidget .tool-body {
 
 .prompt-header {
     height: auto;
-    padding: 0 0 1 0;
+    padding: 0 1 1 1;
     background: $surface;
+}
+
+#question_prompt > ActionList > .option-list--option,
+#approval_prompt > ActionList > .option-list--option {
+    padding: 0 1;
 }
 
 /* Neutralize the selected-row highlight on every choice list. Textual paints

--- a/kolega_code/cli/tui/transcript.py
+++ b/kolega_code/cli/tui/transcript.py
@@ -252,7 +252,8 @@ class TranscriptRenderingMixin:
         self._workflow_activities = {}
         self._active_progress_entry = None
         self._turn_active = True
-        self._set_chat_enabled(False)
+        self._set_chat_enabled(True)
+        self._set_composer_status(messages.QUEUE_PLACEHOLDER)
         self._start_turn_timer(messages.WORKING)
         self._set_status_activity(messages.WORKING, turn_state=TurnState.GENERATING)
         self._update_progress(messages.WORKING, complete=False, state=TurnState.GENERATING)
@@ -1289,6 +1290,9 @@ class TranscriptRenderingMixin:
             color = Color.ERROR if entry.tone == "error" else Color.WARNING
             header = theme.role_header(Glyph.STATUS, "Status", color, state=streaming)
             return self._entry_renderable(header, entry.content)
+        if entry.kind == "queued":
+            header = theme.role_header(Glyph.STATUS, "Queued", Color.ACCENT)
+            return self._entry_renderable(header, entry.content, body_style="dim")
         if entry.kind == "plan":
             header = theme.role_header(Glyph.PLAN, "Plan", Color.SUCCESS)
             if entry.content.strip():

--- a/tests/cli/test_app_composer_input.py
+++ b/tests/cli/test_app_composer_input.py
@@ -6,6 +6,7 @@ import time
 
 import pytest
 
+from kolega_code.cli import messages
 from kolega_code.cli.tui import agent_runtime as agent_runtime_module
 from kolega_code.cli.tui import state as tui_state
 
@@ -492,3 +493,260 @@ async def test_chat_composer_active_slash_query(tmp_path: Path, monkeypatch: pyt
         composer.load_text("")
         composer.insert("/model kimi")
         assert composer.active_slash_query() is None
+
+
+@pytest.mark.asyncio
+async def test_textual_app_queues_multiple_active_turn_messages_fifo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.messages: list[str] = []
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            return None
+
+        async def process_message_stream(self, message, attachments=None):
+            self.messages.append(message)
+            first_started.set()
+            await release_first.wait()
+            yield {"type": "response", "content": "first done", "complete": True, "uuid": "response-1"}
+
+    monkeypatch.setattr(agent_runtime_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        composer.focus()
+
+        composer.load_text("first")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+        first_worker = app.agent_worker
+        assert first_worker is not None
+        await asyncio.wait_for(first_started.wait(), timeout=2)
+
+        composer.load_text("second")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+        composer.load_text("third")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+        await pilot.pause()
+
+        assert [item.text for item in app._queued_messages] == ["second", "third"]
+        assert [entry.kind for entry in app.conversation_entries if entry.content in {"second", "third"}] == [
+            "queued",
+            "queued",
+        ]
+        queued_panel = app.query_one("#queued_messages")
+        assert queued_panel.display is True
+        queued_text = renderable_text(queued_panel.render())
+        assert "second" in queued_text
+        assert "third" in queued_text
+
+        release_first.set()
+        await first_worker.wait()
+        for _ in range(20):
+            await pilot.pause()
+            if (
+                app.agent is not None
+                and app.agent.messages == ["first", "second", "third"]
+                and app.agent_worker is None
+            ):
+                break
+        if app.agent_worker is not None:
+            await app.agent_worker.wait()
+        await pilot.pause()
+
+        assert app.agent is not None
+        assert app.agent.messages == ["first", "second", "third"]
+        assert [entry.kind for entry in app.conversation_entries if entry.content in {"second", "third"}] == [
+            "user",
+            "user",
+        ]
+        user_contents = [entry.content for entry in app.conversation_entries if entry.kind == "user"]
+        assert user_contents.count("second") == 1
+        assert user_contents.count("third") == 1
+
+
+@pytest.mark.asyncio
+async def test_textual_app_queue_clear_command_discards_active_turn_followups(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.messages: list[str] = []
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            return None
+
+        async def process_message_stream(self, message, attachments=None):
+            self.messages.append(message)
+            first_started.set()
+            await release_first.wait()
+            yield {"type": "response", "content": "first done", "complete": True, "uuid": "response-1"}
+
+    monkeypatch.setattr(agent_runtime_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        composer.focus()
+
+        composer.load_text("first")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+        first_worker = app.agent_worker
+        assert first_worker is not None
+        await asyncio.wait_for(first_started.wait(), timeout=2)
+
+        for text in ("second", "third"):
+            composer.load_text(text)
+            await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+        assert len(app._queued_messages) == 2
+
+        composer.load_text("/queue-clear")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+        assert app._queued_messages == []
+
+        release_first.set()
+        await first_worker.wait()
+        await pilot.pause()
+        if app.agent_worker is not None:
+            await app.agent_worker.wait()
+
+        assert app.agent is not None
+        assert app.agent.messages == ["first"]
+        assert app.query_one("#queued_messages").display is False
+        assert not [entry for entry in app.conversation_entries if entry.content in {"second", "third"}]
+        assert any(messages.QUEUE_CLEARED.format(count=2) in entry.content for entry in app.conversation_entries)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("draft", "expected_text"),
+    [
+        ("draft", "second\n\nthird\n\ndraft"),
+        ("", "second\n\nthird"),
+    ],
+)
+async def test_textual_app_cancel_restores_queued_followups_to_composer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, draft: str, expected_text: str
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    first_started = asyncio.Event()
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            return None
+
+        async def process_message_stream(self, message, attachments=None):
+            first_started.set()
+            await asyncio.Event().wait()
+            yield {"type": "response", "content": "unreachable", "complete": True, "uuid": "response-1"}
+
+    monkeypatch.setattr(agent_runtime_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+
+        composer.load_text("first")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+        assert app.agent_worker is not None
+        await asyncio.wait_for(first_started.wait(), timeout=2)
+
+        for text in ("second", "third"):
+            composer.load_text(text)
+            await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+        assert [item.text for item in app._queued_messages] == ["second", "third"]
+        assert app.query_one("#queued_messages").display is True
+
+        composer.load_text(draft)
+        app.action_cancel_generation()
+        for _ in range(10):
+            await pilot.pause()
+            if app.agent_worker is None:
+                break
+
+        assert app.agent_worker is None
+        assert app._queued_messages == []
+        assert app.query_one("#queued_messages").display is False
+        assert composer.text == expected_text
+        assert not [entry for entry in app.conversation_entries if entry.content in {"second", "third"}]

--- a/tests/cli/test_app_permission_prompts.py
+++ b/tests/cli/test_app_permission_prompts.py
@@ -6,7 +6,9 @@ import time
 
 import pytest
 
+from kolega_code.cli import messages
 from kolega_code.cli.tui import agent_runtime as agent_runtime_module
+from kolega_code.cli.tui import state as tui_state
 
 from kolega_code.config import ModelProvider
 from kolega_code.llm.exceptions import (
@@ -30,6 +32,7 @@ from kolega_code.cli.session_store import SessionStore
 from kolega_code.cli.settings import CliSettings, SettingsStore
 
 from ._app_test_utils import (
+    MinimalFakeCoderAgent,
     _build_mention_test_app,
     _build_sub_agent_test_app,
     _sub_agent_context_event,
@@ -39,9 +42,22 @@ from ._app_test_utils import (
     build_test_config,
     extension_by_name,
     first_text_styles,
+    install_fake_agents,
     question_payload,
     renderable_text,
 )
+
+
+def _build_permission_test_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from kolega_code.cli.app import KolegaCodeApp
+
+    install_fake_agents(monkeypatch, coder_cls=MinimalFakeCoderAgent)
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    return KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
 
 
 @pytest.mark.asyncio
@@ -127,7 +143,7 @@ async def test_textual_app_long_permission_command_keeps_approval_actions_visibl
 
     from kolega_code.cli.app import KolegaCodeApp
     from kolega_code.cli.tui.state import PendingApproval
-    from kolega_code.cli.tui.widgets import ActionList, PromptPanel
+    from kolega_code.cli.tui.widgets import ActionList, ChatComposer, PromptPanel
     from kolega_code.permissions import PermissionDecision, allow_rule_options, permission_request_for_tool
 
     class FakeCoderAgent:
@@ -159,6 +175,14 @@ async def test_textual_app_long_permission_command_keeps_approval_actions_visibl
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
 
     async with app.run_test(size=(100, 40)) as pilot:
+        for index in range(30):
+            app._add_conversation_entry(
+                tui_state.ConversationEntry(
+                    kind="agent",
+                    content=f"transcript entry {index}\nmore content\nmore content",
+                    complete=True,
+                )
+            )
         long_command = 'python -c "' + "print('approval layout') ; " * 80 + '"'
         request = permission_request_for_tool("exec_command", {"command": long_command})
         assert request is not None
@@ -173,11 +197,29 @@ async def test_textual_app_long_permission_command_keeps_approval_actions_visibl
         await pilot.pause()
 
         approval_prompt = app.query_one("#approval_prompt", PromptPanel)
+        approval_header = approval_prompt.query_one(".prompt-header-scroll")
         approval_actions = app.query_one("#approval_actions", ActionList)
+        conversation = app.query_one("#conversation")
+        composer = app.query_one("#composer", ChatComposer)
         assert approval_prompt.display is True
         assert approval_actions.display is True
         assert approval_actions.option_count == 5
         assert app.focused is approval_actions
+        assert approval_prompt.region.x == composer.region.x
+        assert approval_prompt.region.width == composer.region.width
+        assert approval_header.region.x == composer.region.x
+        assert approval_header.region.width == composer.region.width
+        assert approval_actions.region.x == composer.region.x
+        assert approval_actions.region.width == composer.region.width
+        composer_right_edge = composer.region.x + composer.region.width
+        assert approval_header.vertical_scrollbar.display is True
+        assert approval_header.vertical_scrollbar.region.x + approval_header.vertical_scrollbar.region.width == (
+            composer_right_edge
+        )
+        assert conversation.vertical_scrollbar.display is True
+        assert conversation.vertical_scrollbar.region.x + conversation.vertical_scrollbar.region.width == (
+            composer_right_edge
+        )
         assert approval_actions.region.y + approval_actions.region.height <= (
             approval_prompt.region.y + approval_prompt.region.height
         )
@@ -199,7 +241,7 @@ async def test_textual_app_long_question_keeps_actions_visible_and_selectable(
 
     from kolega_code.cli.app import KolegaCodeApp
     from kolega_code.cli.tui.state import PendingQuestion
-    from kolega_code.cli.tui.widgets import ActionList, PromptPanel
+    from kolega_code.cli.tui.widgets import ActionList, ChatComposer, PromptPanel
 
     class FakeCoderAgent:
         def __init__(self, **kwargs):
@@ -230,6 +272,14 @@ async def test_textual_app_long_question_keeps_actions_visible_and_selectable(
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
 
     async with app.run_test(size=(100, 40)) as pilot:
+        for index in range(30):
+            app._add_conversation_entry(
+                tui_state.ConversationEntry(
+                    kind="agent",
+                    content=f"transcript entry {index}\nmore content\nmore content",
+                    complete=True,
+                )
+            )
         long_question = "Which migration path should we use? " + "Consider all edge cases and rollout steps. " * 80
         options = ["Keep current path", "Use bounded prompt header", "Defer the decision"]
         future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
@@ -244,11 +294,29 @@ async def test_textual_app_long_question_keeps_actions_visible_and_selectable(
         await pilot.pause()
 
         question_prompt = app.query_one("#question_prompt", PromptPanel)
+        question_header = question_prompt.query_one(".prompt-header-scroll")
         question_actions = app.query_one("#question_actions", ActionList)
+        conversation = app.query_one("#conversation")
+        composer = app.query_one("#composer", ChatComposer)
         assert question_prompt.display is True
         assert question_actions.display is True
         assert question_actions.option_count == 3
         assert app.focused is question_actions
+        assert question_prompt.region.x == composer.region.x
+        assert question_prompt.region.width == composer.region.width
+        assert question_header.region.x == composer.region.x
+        assert question_header.region.width == composer.region.width
+        assert question_actions.region.x == composer.region.x
+        assert question_actions.region.width == composer.region.width
+        composer_right_edge = composer.region.x + composer.region.width
+        assert question_header.vertical_scrollbar.display is True
+        assert question_header.vertical_scrollbar.region.x + question_header.vertical_scrollbar.region.width == (
+            composer_right_edge
+        )
+        assert conversation.vertical_scrollbar.display is True
+        assert conversation.vertical_scrollbar.region.x + conversation.vertical_scrollbar.region.width == (
+            composer_right_edge
+        )
         assert question_actions.region.y + question_actions.region.height <= (
             question_prompt.region.y + question_prompt.region.height
         )
@@ -260,3 +328,348 @@ async def test_textual_app_long_question_keeps_actions_visible_and_selectable(
         assert answer == "Use bounded prompt header"
         assert app._pending_question is None
         assert question_actions.display is False
+
+
+@pytest.mark.asyncio
+async def test_textual_app_approval_answer_reenables_active_turn_composer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.state import PendingApproval
+    from kolega_code.cli.tui.widgets import ChatComposer
+    from kolega_code.permissions import PermissionDecision, allow_rule_options, permission_request_for_tool
+
+    app = _build_permission_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        request = permission_request_for_tool("exec_command", {"command": "npm run test"})
+        assert request is not None
+        future: asyncio.Future[PermissionDecision] = asyncio.get_running_loop().create_future()
+        app._turn_active = True
+        app._pending_approval = PendingApproval(
+            request=request,
+            future=future,
+            rule_options=allow_rule_options(request),
+        )
+        app._set_composer_status(messages.APPROVAL_PLACEHOLDER)
+        app._set_chat_enabled(False)
+        app._refresh_input_area_visibility()
+
+        composer = app.query_one("#composer", ChatComposer)
+        assert composer.disabled is True
+        assert composer.display is True
+
+        await app._answer_approval_option(0)
+        decision = await asyncio.wait_for(future, timeout=1)
+
+        assert decision.allowed is True
+        assert app._pending_approval is None
+        assert composer.display is True
+        assert composer.disabled is False
+        assert composer.placeholder == messages.QUEUE_PLACEHOLDER
+
+
+@pytest.mark.asyncio
+async def test_textual_app_queued_messages_hide_during_permission_and_restore_after_answer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.widgets import ChatComposer
+    from kolega_code.permissions import permission_request_for_tool
+
+    app = _build_permission_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        app._turn_active = True
+        app._set_chat_enabled(True)
+        app._set_composer_status(messages.QUEUE_PLACEHOLDER)
+        app._queue_user_message("second")
+        app._queue_user_message("third")
+
+        queued_panel = app.query_one("#queued_messages")
+        assert queued_panel.display is True
+        assert [item.text for item in app._queued_messages] == ["second", "third"]
+
+        request = permission_request_for_tool("exec_command", {"command": "npm run test"})
+        assert request is not None
+        permission_task = asyncio.create_task(app._ask_permission(request))
+        await pilot.pause()
+
+        composer = app.query_one("#composer", ChatComposer)
+        assert app._pending_approval is not None
+        assert queued_panel.display is False
+        assert composer.display is True
+        assert composer.disabled is True
+        assert [item.text for item in app._queued_messages] == ["second", "third"]
+
+        await app._answer_approval_option(0)
+        decision = await asyncio.wait_for(permission_task, timeout=1)
+        await pilot.pause()
+
+        assert decision.allowed is True
+        assert app._pending_approval is None
+        assert queued_panel.display is True
+        assert composer.display is True
+        assert composer.disabled is False
+        assert [item.text for item in app._queued_messages] == ["second", "third"]
+        queued_text = renderable_text(queued_panel.render())
+        assert "second" in queued_text
+        assert "third" in queued_text
+
+
+@pytest.mark.asyncio
+async def test_textual_app_queued_messages_do_not_drain_while_permission_pending(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.state import PendingApproval
+    from kolega_code.permissions import PermissionDecision, allow_rule_options, permission_request_for_tool
+
+    app = _build_permission_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        request = permission_request_for_tool("exec_command", {"command": "npm run test"})
+        assert request is not None
+        future: asyncio.Future[PermissionDecision] = asyncio.get_running_loop().create_future()
+        app._queue_user_message("second")
+        app._queue_user_message("third")
+        app._pending_approval = PendingApproval(
+            request=request,
+            future=future,
+            rule_options=allow_rule_options(request),
+        )
+        app._refresh_input_area_visibility()
+
+        assert app._maybe_start_queued_message() is False
+
+        assert [item.text for item in app._queued_messages] == ["second", "third"]
+        assert app.agent_worker is None
+        assert app.query_one("#queued_messages").display is False
+
+
+@pytest.mark.asyncio
+async def test_textual_app_question_answer_reenables_active_turn_composer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.state import PendingQuestion
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    app = _build_permission_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+        app._turn_active = True
+        app._pending_question = PendingQuestion(
+            question="Which path?",
+            options=["A", "B"],
+            future=future,
+        )
+        app._set_composer_status(messages.QUESTION_PLACEHOLDER)
+        app._set_chat_enabled(True)
+
+        await app._answer_pending_question("A")
+        answer = await asyncio.wait_for(future, timeout=1)
+
+        composer = app.query_one("#composer", ChatComposer)
+        assert answer == "A"
+        assert app._pending_question is None
+        assert composer.display is True
+        assert composer.disabled is False
+        assert composer.placeholder == messages.QUEUE_PLACEHOLDER
+
+
+@pytest.mark.asyncio
+async def test_textual_app_queued_messages_hide_during_question_and_restore_after_answer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.widgets import ChatComposer, PromptPanel
+
+    app = _build_permission_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        app._turn_active = True
+        app._set_chat_enabled(True)
+        app._set_composer_status(messages.QUEUE_PLACEHOLDER)
+        app._queue_user_message("second")
+        app._queue_user_message("third")
+
+        queued_panel = app.query_one("#queued_messages")
+        assert queued_panel.display is True
+        assert [item.text for item in app._queued_messages] == ["second", "third"]
+
+        question_task = asyncio.create_task(app._ask_user_choice("Which path?", ["A", "B"]))
+        await pilot.pause()
+
+        composer = app.query_one("#composer", ChatComposer)
+        question_prompt = app.query_one("#question_prompt", PromptPanel)
+        assert app._pending_question is not None
+        assert question_prompt.display is True
+        assert queued_panel.display is False
+        assert composer.display is True
+        assert composer.disabled is False
+        assert composer.placeholder == messages.QUESTION_PLACEHOLDER
+        assert [item.text for item in app._queued_messages] == ["second", "third"]
+
+        composer.load_text("custom answer")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+        answer = await asyncio.wait_for(question_task, timeout=1)
+        await pilot.pause()
+
+        assert answer == "custom answer"
+        assert app._pending_question is None
+        assert question_prompt.display is False
+        assert queued_panel.display is True
+        assert composer.display is True
+        assert composer.disabled is False
+        assert composer.placeholder == messages.QUEUE_PLACEHOLDER
+        assert [item.text for item in app._queued_messages] == ["second", "third"]
+        queued_text = renderable_text(queued_panel.render())
+        assert "second" in queued_text
+        assert "third" in queued_text
+
+
+@pytest.mark.asyncio
+async def test_textual_app_queued_messages_hide_during_question_and_restore_after_cancel(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.state import PendingQuestion
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    app = _build_permission_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+        app._turn_active = True
+        app._queue_user_message("second")
+        app._queue_user_message("third")
+        app._pending_question = PendingQuestion(question="Which path?", options=["A", "B"], future=future)
+        app._refresh_input_area_visibility()
+
+        queued_panel = app.query_one("#queued_messages")
+        composer = app.query_one("#composer", ChatComposer)
+        assert queued_panel.display is False
+        assert composer.display is True
+
+        app._cancel_pending_question()
+
+        assert future.cancelled() is True
+        assert app._pending_question is None
+        assert [item.text for item in app._queued_messages] == ["second", "third"]
+        assert queued_panel.display is True
+        assert composer.display is True
+
+
+@pytest.mark.asyncio
+async def test_textual_app_queued_messages_do_not_drain_while_question_pending(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.state import PendingQuestion
+
+    app = _build_permission_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+        app._queue_user_message("second")
+        app._queue_user_message("third")
+        app._pending_question = PendingQuestion(question="Which path?", options=["A", "B"], future=future)
+        app._refresh_input_area_visibility()
+
+        assert app._maybe_start_queued_message() is False
+
+        assert [item.text for item in app._queued_messages] == ["second", "third"]
+        assert app.agent_worker is None
+        assert app.query_one("#queued_messages").display is False
+
+
+@pytest.mark.asyncio
+async def test_textual_app_queued_messages_hide_during_plan_decision_actions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.widgets import ActionList, ChatComposer
+
+    app = _build_permission_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        app._queue_user_message("second")
+        app._queue_user_message("third")
+        queued_panel = app.query_one("#queued_messages")
+        assert queued_panel.display is True
+
+        await app._show_plan_for_decision("# Plan\n\nDo the thing.", notification="Plan ready")
+        await pilot.pause()
+
+        plan_actions = app.query_one("#plan_actions", ActionList)
+        composer = app.query_one("#composer", ChatComposer)
+        assert app._plan_decision_active is True
+        assert plan_actions.display is True
+        assert plan_actions.region.x == composer.region.x
+        assert plan_actions.region.width == composer.region.width
+        assert [item.text for item in app._queued_messages] == ["second", "third"]
+        assert queued_panel.display is False
+        assert composer.display is True
+        assert composer.disabled is True
+        assert composer.placeholder == messages.PLAN_READY_PLACEHOLDER
+
+
+@pytest.mark.asyncio
+async def test_textual_app_queued_messages_restore_after_discussing_plan_further(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    app = _build_permission_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        plan = "# Plan\n\nDo the thing."
+        app._latest_plan = plan
+        app._queue_user_message("second")
+        app._queue_user_message("third")
+        await app._show_plan_for_decision(plan, notification="Plan ready")
+        queued_panel = app.query_one("#queued_messages")
+        assert queued_panel.display is False
+
+        await app._discuss_pending_plan()
+        await pilot.pause()
+
+        composer = app.query_one("#composer", ChatComposer)
+        assert app._plan_decision_active is False
+        assert [item.text for item in app._queued_messages] == ["second", "third"]
+        assert queued_panel.display is True
+        assert composer.display is True
+        assert composer.disabled is False
+
+
+@pytest.mark.asyncio
+async def test_textual_app_queued_messages_do_not_drain_while_plan_decision_active(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    app = _build_permission_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        app._queue_user_message("second")
+        app._queue_user_message("third")
+        app._plan_decision_active = True
+        app._refresh_input_area_visibility()
+
+        assert app._maybe_start_queued_message() is False
+
+        assert [item.text for item in app._queued_messages] == ["second", "third"]
+        assert app.agent_worker is None
+        assert app.query_one("#queued_messages").display is False

--- a/tests/cli/test_app_planning_questions.py
+++ b/tests/cli/test_app_planning_questions.py
@@ -54,7 +54,7 @@ async def test_textual_app_planning_question_tool_accepts_option_list_answer(
 
     from kolega_code.cli.app import KolegaCodeApp
     from kolega_code.cli.tui.widgets import ActionList, ChatComposer
-    from kolega_code.cli.messages import COMPOSER_PLACEHOLDER
+    from kolega_code.cli.messages import COMPOSER_PLACEHOLDER, QUEUE_PLACEHOLDER
 
     class FakeBaseAgent:
         def __init__(self, **kwargs):
@@ -126,8 +126,8 @@ async def test_textual_app_planning_question_tool_accepts_option_list_answer(
         assert json.loads(await answer_task) == {"Approach": "Persist it"}
         assert app._pending_question is None
         assert app.query_one("#question_actions").display is False
-        assert app.query_one("#composer", ChatComposer).disabled is True
-        assert app.query_one("#composer", ChatComposer).placeholder == COMPOSER_PLACEHOLDER
+        assert app.query_one("#composer", ChatComposer).disabled is False
+        assert app.query_one("#composer", ChatComposer).placeholder == QUEUE_PLACEHOLDER
         # After answering, the question is recorded followed by the chosen answer.
         assert app.conversation_entries[-2].kind == "question"
         assert app.conversation_entries[-2].content == "Which approach should we use?"

--- a/tests/cli/test_app_rendering_errors.py
+++ b/tests/cli/test_app_rendering_errors.py
@@ -52,7 +52,7 @@ async def test_textual_app_cancellation_is_visible_in_chat(tmp_path: Path, monke
 
     from kolega_code.cli.app import KolegaCodeApp
     from kolega_code.cli.tui.widgets import ChatComposer
-    from kolega_code.cli.messages import COMPOSER_PLACEHOLDER
+    from kolega_code.cli.messages import COMPOSER_PLACEHOLDER, QUEUE_PLACEHOLDER
 
     started = asyncio.Event()
 
@@ -101,7 +101,8 @@ async def test_textual_app_cancellation_is_visible_in_chat(tmp_path: Path, monke
 
         app.screen.set_focus(app.query_one("#conversation"))
         await pilot.pause()
-        assert composer.disabled is True
+        assert composer.disabled is False
+        assert composer.placeholder == QUEUE_PLACEHOLDER
 
         now = 52.0
         await pilot.press("ctrl+c")

--- a/tests/cli/test_app_rendering_status.py
+++ b/tests/cli/test_app_rendering_status.py
@@ -124,7 +124,7 @@ async def test_textual_app_shows_working_progress_during_active_turn(
 
     from kolega_code.cli.app import KolegaCodeApp
     from kolega_code.cli.tui.widgets import ChatComposer
-    from kolega_code.cli.messages import COMPOSER_PLACEHOLDER
+    from kolega_code.cli.messages import COMPOSER_PLACEHOLDER, QUEUE_PLACEHOLDER
 
     started = asyncio.Event()
     release = asyncio.Event()
@@ -174,8 +174,8 @@ async def test_textual_app_shows_working_progress_during_active_turn(
 
         progress_entries = [entry for entry in app.conversation_entries if entry.kind == "progress"]
         assert progress_entries == []
-        assert composer.placeholder == COMPOSER_PLACEHOLDER
-        assert composer.disabled is True
+        assert composer.placeholder == QUEUE_PLACEHOLDER
+        assert composer.disabled is False
         assert "Working…" in str(turn_status.render())
         assert "0s" in str(turn_status.render())
 
@@ -183,7 +183,7 @@ async def test_textual_app_shows_working_progress_during_active_turn(
         app._render_event(
             AgentEvent(event_type="status_update", sender="coder", content={"text": "Indexing workspace"})
         )
-        assert composer.placeholder == COMPOSER_PLACEHOLDER
+        assert composer.placeholder == QUEUE_PLACEHOLDER
         app._refresh_turn_status_strip()
         assert "Indexing workspace" in str(turn_status.render())
         assert "3s" in str(turn_status.render())

--- a/tests/cli/test_app_rendering_tools.py
+++ b/tests/cli/test_app_rendering_tools.py
@@ -367,7 +367,7 @@ async def test_textual_app_renders_queued_tool_events_during_active_turn(
 
     from kolega_code.cli.app import KolegaCodeApp
     from kolega_code.cli.tui.widgets import ChatComposer
-    from kolega_code.cli.messages import COMPOSER_PLACEHOLDER
+    from kolega_code.cli.messages import COMPOSER_PLACEHOLDER, QUEUE_PLACEHOLDER
 
     started = asyncio.Event()
     release = asyncio.Event()
@@ -461,7 +461,7 @@ async def test_textual_app_renders_queued_tool_events_during_active_turn(
         tool_entries = await asyncio.wait_for(wait_for_tool_entries(app, 1), timeout=1)
         assert tool_entries[0].kind == "tool_call"
         assert tool_entries[0].content == "Calling read_file"
-        assert composer.placeholder == COMPOSER_PLACEHOLDER
+        assert composer.placeholder == QUEUE_PLACEHOLDER
         assert "Running read_file…" in str(turn_status.render())
 
         now = 25.0

--- a/tests/cli/test_slash_commands.py
+++ b/tests/cli/test_slash_commands.py
@@ -35,6 +35,8 @@ def test_agent_command_names_match_command_processor():
     assert "/init" in TUI_COMMAND_NAMES
     assert "/sidebar" in TUI_COMMAND_NAMES
     assert "/prompts" in TUI_COMMAND_NAMES
+    assert "/queue-clear" in TUI_COMMAND_NAMES
+    assert "/queue" not in TUI_COMMAND_NAMES
     assert "/exit" in TUI_COMMAND_NAMES
 
 
@@ -55,6 +57,8 @@ def test_all_command_entries_include_each_scope():
     assert by_name["effort"].scope is CommandScope.TUI
     assert by_name["sidebar"].scope is CommandScope.TUI
     assert by_name["prompts"].scope is CommandScope.TUI
+    assert by_name["queue-clear"].scope is CommandScope.TUI
+    assert "queue" not in by_name
     assert by_name["exit"].scope is CommandScope.TUI
     assert by_name["demo-skill"].scope is CommandScope.SKILL
 

--- a/tests/cli/test_tui_stylesheet.py
+++ b/tests/cli/test_tui_stylesheet.py
@@ -96,19 +96,110 @@ def test_tui_stylesheet_themes_scrollbars_and_avoids_disabled_opacity() -> None:
     ):
         assert property_name in css
 
+    composer_block = css.split("#composer {", 1)[1].split("}", 1)[0]
+    assert "border: none" in composer_block
+    assert "border-top: solid $surface-lighten-2" in composer_block
+    assert "background: $surface" in composer_block
+    assert "color: $text" in composer_block
+    assert "border: round" not in composer_block
+    assert "margin-top" not in composer_block
+    assert "background: $panel" not in composer_block
+
+    queued_messages_block = css.split("#queued_messages", 1)[1].split("}", 1)[0]
+    assert "background: $surface" in queued_messages_block
+    assert "text-style: italic" not in queued_messages_block
+    assert "color: $warning" in queued_messages_block
+    assert "border-top: solid $surface-lighten-2" in queued_messages_block
+    assert "border-top: solid $warning" not in queued_messages_block
+    assert "margin-top" not in queued_messages_block
+
     disabled_block = css.split("#composer:disabled", 1)[1].split("}", 1)[0]
-    assert "opacity" not in disabled_block
-    assert "background: $surface" in disabled_block
-    assert "color: $text-muted" in disabled_block
+
+    def property_value(block: str, property_name: str) -> str:
+        return block.split(f"{property_name}:", 1)[1].split(";", 1)[0].strip()
+
+    for property_name in ("background", "color", "border", "border-top"):
+        assert property_value(disabled_block, property_name) == property_value(composer_block, property_name)
+    assert property_value(disabled_block, "background") == "$surface"
+    assert property_value(disabled_block, "color") == "$text"
+    assert property_value(disabled_block, "opacity") == "1"
+    assert property_value(disabled_block, "background-tint") == "transparent"
+    assert "color: $text-muted" not in disabled_block
+
+    # Leave the normal blinking cursor on Textual's default styling (main-branch
+    # behavior: bright/white in dark terminals). Only pin the disabled cursor so
+    # disabled-state composer colors remain stable.
+    assert "#composer .text-area--cursor,\n#composer:disabled .text-area--cursor" not in css
+    disabled_cursor_selector = "#composer:disabled .text-area--cursor"
+    assert disabled_cursor_selector in css
+    cursor_block = css.split(disabled_cursor_selector, 1)[1].split("}", 1)[0]
+    assert property_value(cursor_block, "background") == "$surface-lighten-2"
+    assert property_value(cursor_block, "color") == "$text-muted"
+
+    for selector in (
+        "#composer .text-area--selection,\n#composer:disabled .text-area--selection",
+        "#composer .text-area--cursor-line,\n#composer:disabled .text-area--cursor-line",
+        "#composer .text-area--gutter,\n#composer:disabled .text-area--gutter",
+        "#composer .text-area--cursor-gutter,\n#composer:disabled .text-area--cursor-gutter",
+        "#composer .text-area--placeholder,\n#composer:disabled .text-area--placeholder",
+    ):
+        assert selector in css
+
+    prompt_panel_block = css.split("#question_prompt, #approval_prompt", 1)[1].split("}", 1)[0]
+    assert "border: none" in prompt_panel_block
+    assert "padding: 0" in prompt_panel_block
+    assert "margin: 0" in prompt_panel_block
+    assert "border: round" not in prompt_panel_block
+
+    prompt_header_scroll_block = css.split(
+        "#question_prompt > .prompt-header-scroll, #approval_prompt > .prompt-header-scroll", 1
+    )[1].split("}", 1)[0]
+    assert "margin-bottom: 1" in prompt_header_scroll_block
+
+    prompt_actions_block = css.split("#question_prompt > ActionList, #approval_prompt > ActionList", 1)[1].split(
+        "}", 1
+    )[0]
+    assert "border: none" in prompt_actions_block
+    assert "padding: 0" in prompt_actions_block
+    assert "background-tint: transparent" in prompt_actions_block
+
+    prompt_header_block = css.split(".prompt-header {", 1)[1].split("}", 1)[0]
+    assert "padding: 0 1 1 1" in prompt_header_block
+
+    prompt_option_rows_block = css.split("#question_prompt > ActionList > .option-list--option,", 1)[1].split("}", 1)[0]
+    assert "#approval_prompt > ActionList > .option-list--option" in prompt_option_rows_block
+    assert "padding: 0 1" in prompt_option_rows_block
+
+    plan_actions_block = css.split("#plan_actions,", 1)[1].split("}", 1)[0]
+    assert "border: none" in plan_actions_block
+    assert "padding: 0" in plan_actions_block
+    assert "margin: 0" in plan_actions_block
+    assert "background-tint: transparent" in plan_actions_block
+
+    plan_option_rows_block = css.split("#plan_actions > .option-list--option", 1)[1].split("}", 1)[0]
+    assert "padding: 0 1" in plan_option_rows_block
+
+    model_actions_block = css.split("#model_actions, #effort_actions, #theme_actions", 1)[1].split("}", 1)[0]
+    assert "border: round $surface" in model_actions_block
+    assert "#plan_actions" not in model_actions_block
 
 
 def test_tui_stylesheet_explicitly_themes_footer_select_overlay_and_output_scrollbars() -> None:
     stylesheet = Path(__file__).parents[2] / "kolega_code" / "cli" / EXPECTED_CSS_PATH
     css = stylesheet.read_text()
 
-    output_block = css.split("#conversation, #logs, #terminal", 1)[1].split("}", 1)[0]
-    assert "overflow-x: hidden" in output_block
-    assert "background: $surface" in output_block
+    conversation_block = css.split("#conversation {", 1)[1].split("}", 1)[0]
+    assert "height: 1fr" in conversation_block
+    assert "border: none" in conversation_block
+    assert "background: $surface" in conversation_block
+    assert "color: $text" in conversation_block
+    assert "overflow-x: hidden" in conversation_block
+
+    sidebar_output_block = css.split("#logs, #terminal", 1)[1].split("}", 1)[0]
+    assert "height: 1fr" in sidebar_output_block
+    assert "border: round $surface" in sidebar_output_block
+    assert "background: $surface" in sidebar_output_block
+    assert "overflow-x: hidden" in sidebar_output_block
 
     footer_block = css.split("Footer {", 1)[1].split("}", 1)[0]
     assert "background: $surface" in footer_block


### PR DESCRIPTION
## Summary
- keep the composer available during active turns and queue ordinary follow-up prompts
- drain queued prompts together as one batch at the next safe opportunity while preserving user-message boundaries
- add /queue list, /queue clear, and /queue send plus targeted TUI and agent tests

## Tests
- uv run pytest tests/cli/test_app_composer_input.py tests/cli/test_app_misc_commands.py tests/agent/test_base_agent_runtime.py
- uv run ruff check kolega_code/agent/baseagent.py kolega_code/cli/app.py kolega_code/cli/tui/agent_runtime.py kolega_code/cli/tui/state.py kolega_code/cli/tui/transcript.py kolega_code/cli/tui/command_handlers.py kolega_code/cli/messages.py kolega_code/cli/slash_commands.py tests/cli/test_app_composer_input.py tests/agent/test_base_agent_runtime.py