### PR TITLE
fix(cli): move task list to status sidebar

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -18,7 +18,6 @@ from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.timer import Timer
 from textual.widgets import (
     Button,
-    Collapsible,
     Footer,
     Input,
     Label,
@@ -270,8 +269,17 @@ class KolegaCodeApp(
             with Vertical(id="side_panel"):
                 with TabbedContent(id="events"):
                     with TabPane("Status", id="status_pane"):
-                        with Vertical(id="status_container"):
-                            yield Static("", id="status_dashboard", markup=True)
+                        with VerticalScroll(id="status_form"):
+                            with Vertical(classes="status-section", id="status_summary_section") as status_section:
+                                status_section.border_title = "Status"
+                                yield Static("", id="status_dashboard", markup=True)
+                            with Vertical(classes="status-section", id="status_task_list_section") as task_section:
+                                task_section.border_title = "Task List"
+                                yield tui_widgets.PlanningMarkdown(
+                                    messages.TASK_LIST_EMPTY_MESSAGE,
+                                    id="status_task_list_markdown",
+                                    empty_source=messages.TASK_LIST_EMPTY_MESSAGE,
+                                )
                     if self.show_logs:
                         with TabPane("Logs", id="logs_pane"):
                             yield tui_widgets.LogOutputLog(
@@ -289,19 +297,14 @@ class KolegaCodeApp(
                             markup=False,
                             max_lines=TERMINAL_MAX_LINES,
                         )
-                    with TabPane("Planning", id="planning_pane"):
+                    with TabPane("Plan", id="planning_pane"):
                         with VerticalScroll(id="planning_form"):
-                            with Collapsible(title="Plan", collapsed=False, id="planning_plan"):
+                            with Vertical(classes="planning-section", id="planning_plan") as plan_section:
+                                plan_section.border_title = "Plan"
                                 yield tui_widgets.PlanningMarkdown(
                                     messages.PLAN_EMPTY_MESSAGE,
                                     id="planning_plan_markdown",
                                     empty_source=messages.PLAN_EMPTY_MESSAGE,
-                                )
-                            with Collapsible(title="Task List", collapsed=False, id="planning_task_list"):
-                                yield tui_widgets.PlanningMarkdown(
-                                    messages.TASK_LIST_EMPTY_MESSAGE,
-                                    id="planning_task_list_markdown",
-                                    empty_source=messages.TASK_LIST_EMPTY_MESSAGE,
                                 )
                     with TabPane("Settings", id="settings_pane"):
                         with VerticalScroll(id="settings_form"):
@@ -1457,7 +1460,7 @@ class KolegaCodeApp(
         task_list_content = self.session.task_list_markdown or messages.TASK_LIST_EMPTY_MESSAGE
         try:
             plan_markdown = self.query_one("#planning_plan_markdown", tui_widgets.PlanningMarkdown)
-            task_list_markdown = self.query_one("#planning_task_list_markdown", tui_widgets.PlanningMarkdown)
+            task_list_markdown = self.query_one("#status_task_list_markdown", tui_widgets.PlanningMarkdown)
             plan_markdown.update(plan_content)
             task_list_markdown.update(task_list_content)
             plan_markdown.set_class(plan_content == messages.PLAN_EMPTY_MESSAGE, "empty-state")

--- a/kolega_code/cli/tui/styles.tcss
+++ b/kolega_code/cli/tui/styles.tcss
@@ -24,6 +24,47 @@ Screen {
     height: 100%;
 }
 
+#events {
+    background: $surface;
+    color: $text;
+}
+
+#events > ContentTabs,
+#events ContentTabs > #tabs-scroll,
+#events ContentTabs #tabs-list-bar,
+#events ContentTabs #tabs-list {
+    background: $surface;
+    color: $text;
+}
+
+#events ContentTabs Tab,
+#events ContentTabs Tab:hover,
+#events ContentTabs Tab.-active,
+#events ContentTabs:focus Tab,
+#events ContentTabs:focus Tab.-active {
+    background: $surface;
+    background-tint: transparent;
+}
+
+#events ContentTabs Tab {
+    color: $text-muted;
+}
+
+#events ContentTabs Tab:hover,
+#events ContentTabs Tab.-active,
+#events ContentTabs:focus Tab.-active {
+    color: $text;
+}
+
+#events ContentTabs Tab.-active,
+#events ContentTabs:focus Tab.-active {
+    text-style: bold;
+}
+
+#events ContentTabs:focus .underline--bar {
+    background: $surface-lighten-2;
+}
+
 #conversation {
     height: 1fr;
     border: none;
@@ -74,29 +115,50 @@ ToolEntryWidget .tool-body {
     text-align: center;
 }
 
-#status_container {
+#status_form, #settings_form, #planning_form {
     height: 1fr;
+    background: $surface;
+    color: $text;
+    padding: 1;
 }
 
 #status_dashboard {
-    height: 1fr;
+    height: auto;
     min-height: 15;
-    border: round $surface;
-    padding: 1;
+    border: none;
+    background: $surface;
+    color: $text;
+    padding: 0;
 }
 
-#settings_form, #planning_form {
-    height: 1fr;
-    padding: 1;
-}
-
+.status-section,
+.planning-section,
 .settings-section {
     height: auto;
-    border: round $surface;
+    border: round $surface-lighten-2;
     border-title-color: $text;
     border-title-style: bold;
+    background: $surface;
     padding: 0 1;
     margin-bottom: 1;
+}
+
+#settings_form Select > SelectCurrent {
+    background: $panel;
+    border: round $surface-lighten-2;
+    color: $text;
+}
+
+#settings_form Select:focus > SelectCurrent {
+    background: $panel;
+    border: round $surface-lighten-2;
+    background-tint: transparent;
+}
+
+#settings_form Select > SelectOverlay {
+    background: $panel;
+    border: round $surface-lighten-2;
+    color: $text;
 }
 
 #settings_status {
@@ -147,10 +209,12 @@ ToolEntryWidget .tool-body {
     margin-top: 1;
 }
 
+#status_form PlanningMarkdown,
 #planning_form PlanningMarkdown {
     height: auto;
 }
 
+#status_form PlanningMarkdown.empty-state,
 #planning_form PlanningMarkdown.empty-state {
     color: $text-muted;
 }

--- a/kolega_code/cli/tui/styles.tcss
+++ b/kolega_code/cli/tui/styles.tcss
@@ -426,8 +426,13 @@ OptionList > .option-list--option-highlighted {
     color: $text-muted;
 }
 
+#session_meta {
+    background: $background;
+    color: $text-muted;
+}
+
 Footer {
-    background: $surface;
+    background: $background;
     color: $text-muted;
 }
 

--- a/kolega_code/cli/tui/styles.tcss
+++ b/kolega_code/cli/tui/styles.tcss
@@ -22,10 +22,11 @@ Screen {
     width: 1fr;
     min-width: 34;
     height: 100%;
+    background: $background;
 }
 
 #events {
-    background: $surface;
+    background: $background;
     color: $text;
 }
 
@@ -33,7 +34,7 @@ Screen {
 #events ContentTabs > #tabs-scroll,
 #events ContentTabs #tabs-list-bar,
 #events ContentTabs #tabs-list {
-    background: $surface;
+    background: $background;
     color: $text;
 }
 
@@ -42,7 +43,7 @@ Screen {
 #events ContentTabs Tab.-active,
 #events ContentTabs:focus Tab,
 #events ContentTabs:focus Tab.-active {
-    background: $surface;
+    background: $background;
     background-tint: transparent;
 }
 
@@ -75,8 +76,8 @@ Screen {
 
 #logs, #terminal {
     height: 1fr;
-    border: round $surface;
-    background: $surface;
+    border: none;
+    background: $background;
     color: $text;
     overflow-x: hidden;
 }
@@ -117,7 +118,7 @@ ToolEntryWidget .tool-body {
 
 #status_form, #settings_form, #planning_form {
     height: 1fr;
-    background: $surface;
+    background: $background;
     color: $text;
     padding: 1;
 }
@@ -126,7 +127,7 @@ ToolEntryWidget .tool-body {
     height: auto;
     min-height: 15;
     border: none;
-    background: $surface;
+    background: $background;
     color: $text;
     padding: 0;
 }
@@ -138,7 +139,7 @@ ToolEntryWidget .tool-body {
     border: round $surface-lighten-2;
     border-title-color: $text;
     border-title-style: bold;
-    background: $surface;
+    background: $background;
     padding: 0 1;
     margin-bottom: 1;
 }

--- a/tests/cli/test_app_agent_wiring.py
+++ b/tests/cli/test_app_agent_wiring.py
@@ -108,7 +108,7 @@ async def test_textual_app_passes_shared_task_list_tools_to_build_agent_only(
         assert await build_tools["get_task_list"]() == "No task list has been set."
         assert await build_tools["update_task_list"]("- [ ] inspect\n- [x] plan") == "Task list updated."
         assert app.session.task_list_markdown == "- [ ] inspect\n- [x] plan"
-        assert app.query_one("#planning_task_list_markdown", PlanningMarkdown).source == "- [ ] inspect\n- [x] plan"
+        assert app.query_one("#status_task_list_markdown", PlanningMarkdown).source == "- [ ] inspect\n- [x] plan"
         assert store.load(session.session_id).task_list_markdown == "- [ ] inspect\n- [x] plan"
 
         await pilot.press("shift+tab")

--- a/tests/cli/test_app_bootstrap_settings.py
+++ b/tests/cli/test_app_bootstrap_settings.py
@@ -48,8 +48,8 @@ from ._app_test_utils import (
 async def test_textual_app_mounts_with_fake_agent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     pytest.importorskip("textual")
 
-    from textual.containers import VerticalScroll
-    from textual.widgets import Collapsible, Header
+    from textual.containers import Vertical, VerticalScroll
+    from textual.widgets import Header
 
     from kolega_code.cli.app import KolegaCodeApp
     from kolega_code.cli.tui.widgets import PlanningMarkdown
@@ -101,10 +101,12 @@ async def test_textual_app_mounts_with_fake_agent(tmp_path: Path, monkeypatch: p
         assert app.query_one("#composer") is not None
         assert app.query_one("#planning_pane") is not None
         assert app.query_one("#planning_form", VerticalScroll) is not None
-        assert app.query_one("#planning_plan", Collapsible).collapsed is False
-        assert app.query_one("#planning_task_list", Collapsible).collapsed is False
+        assert app.query_one("#planning_plan", Vertical) is not None
+        assert app.query_one("#status_form", VerticalScroll) is not None
+        assert app.query_one("#status_summary_section", Vertical) is not None
+        assert app.query_one("#status_task_list_section", Vertical) is not None
         assert app.query_one("#planning_plan_markdown", PlanningMarkdown).source == "No plan captured yet."
-        assert app.query_one("#planning_task_list_markdown", PlanningMarkdown).source == "No task list has been set."
+        assert app.query_one("#status_task_list_markdown", PlanningMarkdown).source == "No task list has been set."
         assert app.conversation_entries[0].kind == "startup"
         startup = app.conversation_entries[0].content
         assert "____          _" in startup
@@ -171,6 +173,7 @@ async def test_textual_app_startup_shows_prompt_overrides_and_errors(
 async def test_textual_app_status_tab_is_default_dashboard(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     pytest.importorskip("textual")
 
+    from textual.containers import Vertical
     from textual.widgets import Static, TabbedContent
 
     from kolega_code.cli.app import KolegaCodeApp
@@ -213,7 +216,10 @@ async def test_textual_app_status_tab_is_default_dashboard(tmp_path: Path, monke
         assert "Build" in dashboard
         assert "Idle" in dashboard
         assert "Waiting for first context count" in dashboard
-        assert dashboard_widget.styles.border == app.query_one("#terminal").styles.border
+        assert str(dashboard_widget.styles.border) == "Edges()"
+        assert str(app.query_one("#status_summary_section", Vertical).styles.border) != "Edges()"
+        assert str(app.query_one("#status_task_list_section", Vertical).styles.border) != "Edges()"
+        assert str(app.query_one("#terminal").styles.border) != "Edges()"
         assert list(app.query("#logs")) == []
         assert list(app.query("#status")) == []
 

--- a/tests/cli/test_app_bootstrap_settings.py
+++ b/tests/cli/test_app_bootstrap_settings.py
@@ -219,7 +219,7 @@ async def test_textual_app_status_tab_is_default_dashboard(tmp_path: Path, monke
         assert str(dashboard_widget.styles.border) == "Edges()"
         assert str(app.query_one("#status_summary_section", Vertical).styles.border) != "Edges()"
         assert str(app.query_one("#status_task_list_section", Vertical).styles.border) != "Edges()"
-        assert str(app.query_one("#terminal").styles.border) != "Edges()"
+        assert str(app.query_one("#terminal").styles.border) == "Edges()"
         assert list(app.query("#logs")) == []
         assert list(app.query("#status")) == []
 

--- a/tests/cli/test_app_persistence_history.py
+++ b/tests/cli/test_app_persistence_history.py
@@ -366,7 +366,7 @@ async def test_textual_app_reset_command_clears_current_thread(
         assert app.query_one("#plan_actions").display is False
         assert app.query_one("#question_actions").display is False
         assert app.query_one("#planning_plan_markdown", PlanningMarkdown).source == "No plan captured yet."
-        assert app.query_one("#planning_task_list_markdown", PlanningMarkdown).source == "No task list has been set."
+        assert app.query_one("#status_task_list_markdown", PlanningMarkdown).source == "No task list has been set."
         assert store.load(session.session_id).history == []
         assert store.load(session.session_id).task_list_markdown == ""
         assert store.load(session.session_id).latest_plan_markdown == ""

--- a/tests/cli/test_app_rendering_status.py
+++ b/tests/cli/test_app_rendering_status.py
@@ -297,20 +297,26 @@ async def test_planning_sidebar_marks_empty_states(tmp_path: Path, monkeypatch: 
 
     from kolega_code.cli.tui.widgets import PlanningMarkdown
 
-    from kolega_code.cli.messages import PLAN_EMPTY_MESSAGE
+    from kolega_code.cli.messages import PLAN_EMPTY_MESSAGE, TASK_LIST_EMPTY_MESSAGE
 
     app = _build_sub_agent_test_app(tmp_path, monkeypatch)
 
     async with app.run_test():
         plan_md = app.query_one("#planning_plan_markdown", PlanningMarkdown)
+        task_list_md = app.query_one("#status_task_list_markdown", PlanningMarkdown)
         assert plan_md.source == PLAN_EMPTY_MESSAGE
         assert plan_md.has_class("empty-state")
+        assert task_list_md.source == TASK_LIST_EMPTY_MESSAGE
+        assert task_list_md.has_class("empty-state")
 
         app._latest_plan = "# Plan\n\n- do the thing"
+        app.session.task_list_markdown = "- [ ] do the task"
         app._refresh_planning_sidebar()
 
         assert plan_md.source == "# Plan\n\n- do the thing"
         assert not plan_md.has_class("empty-state")
+        assert task_list_md.source == "- [ ] do the task"
+        assert not task_list_md.has_class("empty-state")
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_tui_stylesheet.py
+++ b/tests/cli/test_tui_stylesheet.py
@@ -184,6 +184,187 @@ def test_tui_stylesheet_themes_scrollbars_and_avoids_disabled_opacity() -> None:
     assert "#plan_actions" not in model_actions_block
 
 
+def test_tui_stylesheet_keeps_sidebar_tabs_consistent_and_restores_card_contrast() -> None:
+    stylesheet = Path(__file__).parents[2] / "kolega_code" / "cli" / EXPECTED_CSS_PATH
+    css = stylesheet.read_text()
+
+    events_block = css.split("#events {", 1)[1].split("}", 1)[0]
+    assert "background: $surface" in events_block
+    assert "color: $text" in events_block
+
+    tab_container_block = css.split("#events > ContentTabs,", 1)[1].split("}", 1)[0]
+    assert "#events ContentTabs > #tabs-scroll" in tab_container_block
+    assert "#events ContentTabs #tabs-list-bar" in tab_container_block
+    assert "#events ContentTabs #tabs-list" in tab_container_block
+    assert "background: $surface" in tab_container_block
+    assert "color: $text" in tab_container_block
+
+    tab_background_block = css.split("#events ContentTabs Tab,", 1)[1].split("}", 1)[0]
+    assert "#events ContentTabs:focus Tab.-active" in tab_background_block
+    assert "background: $surface" in tab_background_block
+    assert "background-tint: transparent" in tab_background_block
+    assert "$block-cursor-background" not in tab_background_block
+
+    inactive_tab_block = css.split("#events ContentTabs Tab {", 1)[1].split("}", 1)[0]
+    assert "color: $text-muted" in inactive_tab_block
+
+    active_tab_block = css.split(
+        "#events ContentTabs Tab:hover,\n#events ContentTabs Tab.-active,\n#events ContentTabs:focus Tab.-active",
+        1,
+    )[1].split("}", 1)[0]
+    assert "color: $text" in active_tab_block
+
+    active_tab_style_block = css.rsplit(
+        "#events ContentTabs Tab.-active,\n#events ContentTabs:focus Tab.-active",
+        1,
+    )[1].split("}", 1)[0]
+    assert "text-style: bold" in active_tab_style_block
+
+    sidebar_form_block = css.split("#status_form, #settings_form, #planning_form", 1)[1].split("}", 1)[0]
+    assert "height: 1fr" in sidebar_form_block
+    assert "background: $surface" in sidebar_form_block
+    assert "color: $text" in sidebar_form_block
+    assert "padding: 1" in sidebar_form_block
+    assert "#logs" not in sidebar_form_block
+    assert "#terminal" not in sidebar_form_block
+
+    status_dashboard_block = css.split("#status_dashboard {", 1)[1].split("}", 1)[0]
+    assert "height: auto" in status_dashboard_block
+    assert "border: none" in status_dashboard_block
+    assert "background: $surface" in status_dashboard_block
+    assert "color: $text" in status_dashboard_block
+    assert "padding: 0" in status_dashboard_block
+    assert "border: round" not in status_dashboard_block
+
+    section_block = css.split(".status-section,", 1)[1].split("}", 1)[0]
+    assert ".planning-section" in section_block
+    assert ".settings-section" in section_block
+    assert "border: round $surface-lighten-2" in section_block
+    assert "background: $surface" in section_block
+    assert "padding: 0 1" in section_block
+    assert "margin-bottom: 1" in section_block
+    assert "border: none" not in section_block
+    assert "#planning_form Collapsible" not in css
+
+    settings_select_current_block = css.split("#settings_form Select > SelectCurrent", 1)[1].split("}", 1)[0]
+    assert "background: $panel" in settings_select_current_block
+    assert "border: round $surface-lighten-2" in settings_select_current_block
+    assert "color: $text" in settings_select_current_block
+    assert "background: $surface" not in settings_select_current_block
+
+    settings_select_focus_block = css.split("#settings_form Select:focus > SelectCurrent", 1)[1].split("}", 1)[0]
+    assert "background: $panel" in settings_select_focus_block
+    assert "border: round $surface-lighten-2" in settings_select_focus_block
+    assert "background-tint: transparent" in settings_select_focus_block
+
+    settings_select_overlay_block = css.split("#settings_form Select > SelectOverlay", 1)[1].split("}", 1)[0]
+    assert "background: $panel" in settings_select_overlay_block
+    assert "border: round $surface-lighten-2" in settings_select_overlay_block
+    assert "color: $text" in settings_select_overlay_block
+
+    sidebar_output_block = css.split("#logs, #terminal", 1)[1].split("}", 1)[0]
+    assert "height: 1fr" in sidebar_output_block
+    assert "border: round $surface" in sidebar_output_block
+    assert "background: $surface" in sidebar_output_block
+    assert "overflow-x: hidden" in sidebar_output_block
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("show_logs", "expected_tabs"), [(False, 4), (True, 5)])
+async def test_sidebar_tab_and_settings_planning_computed_styles_keep_contrast(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    show_logs: bool,
+    expected_tabs: int,
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.app import KolegaCodeApp
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def restore_message_history(self, history):
+            pass
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            return None
+
+    monkeypatch.setattr(agent_runtime_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+
+    app = KolegaCodeApp(
+        project_path=project,
+        config=config,
+        mode="code",
+        store=store,
+        session=session,
+        show_logs=show_logs,
+    )
+
+    async with app.run_test() as pilot:
+        tabs = app.query_one("ContentTabs")
+        tabs.focus()
+        await pilot.pause()
+
+        rendered_tabs = list(app.query("#events ContentTabs Tab"))
+        assert len(rendered_tabs) == expected_tabs
+        assert "Plan" in {str(tab.render()) for tab in rendered_tabs}
+        assert "Planning" not in {str(tab.render()) for tab in rendered_tabs}
+        tab_backgrounds = {tab.styles.background for tab in rendered_tabs}
+        assert len(tab_backgrounds) == 1
+        assert app.query_one("#events").styles.background in tab_backgrounds
+        assert "block-cursor" not in str(next(iter(tab_backgrounds))).lower()
+
+        active_tabs = [tab for tab in rendered_tabs if "-active" in tab.classes]
+        assert len(active_tabs) == 1
+        assert active_tabs[0].styles.background == rendered_tabs[0].styles.background
+        assert str(active_tabs[0].styles.text_style) == "bold"
+
+        assert app.query_one("#status_form").styles.padding.left == 1
+        assert app.query_one("#planning_form").styles.padding.left == 1
+        assert str(app.query_one("#status_dashboard").styles.border) == "Edges()"
+        assert app.query_one("#status_dashboard").styles.padding.left == 0
+        assert app.query_one("#status_task_list_markdown") is not None
+
+        settings_background = app.query_one("#settings_form").styles.background
+        select_current_widgets = list(app.query("#settings_form SelectCurrent"))
+        assert select_current_widgets
+        for current in select_current_widgets:
+            assert current.styles.background != settings_background
+            assert str(current.styles.border) != "Edges()"
+
+        for section in app.query(".status-section"):
+            assert str(section.styles.border) != "Edges()"
+        for section in app.query(".planning-section"):
+            assert str(section.styles.border) != "Edges()"
+        for section in app.query(".settings-section"):
+            assert str(section.styles.border) != "Edges()"
+
+        terminal_block = app.query_one("#terminal").styles
+        assert terminal_block.padding.left == 0
+        assert str(terminal_block.border) != "Edges()"
+        if show_logs:
+            logs_block = app.query_one("#logs").styles
+            assert logs_block.padding.left == 0
+            assert str(logs_block.border) != "Edges()"
+
+
 def test_tui_stylesheet_explicitly_themes_footer_select_overlay_and_output_scrollbars() -> None:
     stylesheet = Path(__file__).parents[2] / "kolega_code" / "cli" / EXPECTED_CSS_PATH
     css = stylesheet.read_text()
@@ -205,6 +386,6 @@ def test_tui_stylesheet_explicitly_themes_footer_select_overlay_and_output_scrol
     assert "background: $surface" in footer_block
     assert "color: $text-muted" in footer_block
 
-    select_overlay_block = css.split("Select > SelectOverlay", 1)[1].split("}", 1)[0]
+    select_overlay_block = css.rsplit("\nSelect > SelectOverlay", 1)[1].split("}", 1)[0]
     assert "background: $surface" in select_overlay_block
     assert "color: $text" in select_overlay_block

--- a/tests/cli/test_tui_stylesheet.py
+++ b/tests/cli/test_tui_stylesheet.py
@@ -100,6 +100,7 @@ def test_tui_stylesheet_themes_scrollbars_and_avoids_disabled_opacity() -> None:
     assert "border: none" in composer_block
     assert "border-top: solid $surface-lighten-2" in composer_block
     assert "background: $surface" in composer_block
+    assert "background: $background" not in composer_block
     assert "color: $text" in composer_block
     assert "border: round" not in composer_block
     assert "margin-top" not in composer_block
@@ -194,6 +195,11 @@ def test_tui_stylesheet_keeps_sidebar_tabs_consistent_and_restores_card_contrast
 
     side_panel_block = css.split("#side_panel {", 1)[1].split("}", 1)[0]
     assert "background: $background" in side_panel_block
+
+    session_meta_block = css.split("#session_meta {", 1)[1].split("}", 1)[0]
+    assert "background: $background" in session_meta_block
+    assert "background: $surface" not in session_meta_block
+    assert "color: $text-muted" in session_meta_block
 
     events_block = css.split("#events {", 1)[1].split("}", 1)[0]
     assert "background: $background" in events_block
@@ -351,6 +357,7 @@ async def test_sidebar_tab_and_settings_planning_computed_styles_keep_contrast(
         assert active_tabs[0].styles.background == rendered_tabs[0].styles.background
         assert str(active_tabs[0].styles.text_style) == "bold"
 
+        assert app.query_one("#session_meta").styles.background == app.query_one("#side_panel").styles.background
         assert app.query_one("#status_form").styles.padding.left == 1
         assert app.query_one("#planning_form").styles.padding.left == 1
         assert str(app.query_one("#status_dashboard").styles.border) == "Edges()"
@@ -404,9 +411,19 @@ def test_tui_stylesheet_explicitly_themes_footer_select_overlay_and_output_scrol
     assert "background: $surface" not in sidebar_output_block
     assert "overflow-x: hidden" in sidebar_output_block
 
+    session_meta_block = css.split("#session_meta {", 1)[1].split("}", 1)[0]
+    assert "background: $background" in session_meta_block
+    assert "background: $surface" not in session_meta_block
+    assert "color: $text-muted" in session_meta_block
+
     footer_block = css.split("Footer {", 1)[1].split("}", 1)[0]
-    assert "background: $surface" in footer_block
+    assert "background: $background" in footer_block
+    assert "background: $surface" not in footer_block
     assert "color: $text-muted" in footer_block
+
+    footer_highlight_block = css.split("Footer > .footer--highlight", 1)[1].split("}", 1)[0]
+    assert "background: $surface-lighten-2" in footer_highlight_block
+    assert "color: $text" in footer_highlight_block
 
     select_overlay_block = css.rsplit("\nSelect > SelectOverlay", 1)[1].split("}", 1)[0]
     assert "background: $surface" in select_overlay_block

--- a/tests/cli/test_tui_stylesheet.py
+++ b/tests/cli/test_tui_stylesheet.py
@@ -188,20 +188,30 @@ def test_tui_stylesheet_keeps_sidebar_tabs_consistent_and_restores_card_contrast
     stylesheet = Path(__file__).parents[2] / "kolega_code" / "cli" / EXPECTED_CSS_PATH
     css = stylesheet.read_text()
 
+    conversation_block = css.split("#conversation {", 1)[1].split("}", 1)[0]
+    assert "background: $surface" in conversation_block
+    assert "background: $background" not in conversation_block
+
+    side_panel_block = css.split("#side_panel {", 1)[1].split("}", 1)[0]
+    assert "background: $background" in side_panel_block
+
     events_block = css.split("#events {", 1)[1].split("}", 1)[0]
-    assert "background: $surface" in events_block
+    assert "background: $background" in events_block
+    assert "background: $surface" not in events_block
     assert "color: $text" in events_block
 
     tab_container_block = css.split("#events > ContentTabs,", 1)[1].split("}", 1)[0]
     assert "#events ContentTabs > #tabs-scroll" in tab_container_block
     assert "#events ContentTabs #tabs-list-bar" in tab_container_block
     assert "#events ContentTabs #tabs-list" in tab_container_block
-    assert "background: $surface" in tab_container_block
+    assert "background: $background" in tab_container_block
+    assert "background: $surface" not in tab_container_block
     assert "color: $text" in tab_container_block
 
     tab_background_block = css.split("#events ContentTabs Tab,", 1)[1].split("}", 1)[0]
     assert "#events ContentTabs:focus Tab.-active" in tab_background_block
-    assert "background: $surface" in tab_background_block
+    assert "background: $background" in tab_background_block
+    assert "background: $surface" not in tab_background_block
     assert "background-tint: transparent" in tab_background_block
     assert "$block-cursor-background" not in tab_background_block
 
@@ -222,7 +232,8 @@ def test_tui_stylesheet_keeps_sidebar_tabs_consistent_and_restores_card_contrast
 
     sidebar_form_block = css.split("#status_form, #settings_form, #planning_form", 1)[1].split("}", 1)[0]
     assert "height: 1fr" in sidebar_form_block
-    assert "background: $surface" in sidebar_form_block
+    assert "background: $background" in sidebar_form_block
+    assert "background: $surface" not in sidebar_form_block
     assert "color: $text" in sidebar_form_block
     assert "padding: 1" in sidebar_form_block
     assert "#logs" not in sidebar_form_block
@@ -231,7 +242,8 @@ def test_tui_stylesheet_keeps_sidebar_tabs_consistent_and_restores_card_contrast
     status_dashboard_block = css.split("#status_dashboard {", 1)[1].split("}", 1)[0]
     assert "height: auto" in status_dashboard_block
     assert "border: none" in status_dashboard_block
-    assert "background: $surface" in status_dashboard_block
+    assert "background: $background" in status_dashboard_block
+    assert "background: $surface" not in status_dashboard_block
     assert "color: $text" in status_dashboard_block
     assert "padding: 0" in status_dashboard_block
     assert "border: round" not in status_dashboard_block
@@ -240,7 +252,8 @@ def test_tui_stylesheet_keeps_sidebar_tabs_consistent_and_restores_card_contrast
     assert ".planning-section" in section_block
     assert ".settings-section" in section_block
     assert "border: round $surface-lighten-2" in section_block
-    assert "background: $surface" in section_block
+    assert "background: $background" in section_block
+    assert "background: $surface" not in section_block
     assert "padding: 0 1" in section_block
     assert "margin-bottom: 1" in section_block
     assert "border: none" not in section_block
@@ -264,8 +277,10 @@ def test_tui_stylesheet_keeps_sidebar_tabs_consistent_and_restores_card_contrast
 
     sidebar_output_block = css.split("#logs, #terminal", 1)[1].split("}", 1)[0]
     assert "height: 1fr" in sidebar_output_block
-    assert "border: round $surface" in sidebar_output_block
-    assert "background: $surface" in sidebar_output_block
+    assert "border: none" in sidebar_output_block
+    assert "border: round" not in sidebar_output_block
+    assert "background: $background" in sidebar_output_block
+    assert "background: $surface" not in sidebar_output_block
     assert "overflow-x: hidden" in sidebar_output_block
 
 
@@ -339,6 +354,7 @@ async def test_sidebar_tab_and_settings_planning_computed_styles_keep_contrast(
         assert app.query_one("#status_form").styles.padding.left == 1
         assert app.query_one("#planning_form").styles.padding.left == 1
         assert str(app.query_one("#status_dashboard").styles.border) == "Edges()"
+        assert app.query_one("#status_dashboard").styles.background == app.query_one("#status_form").styles.background
         assert app.query_one("#status_dashboard").styles.padding.left == 0
         assert app.query_one("#status_task_list_markdown") is not None
 
@@ -350,19 +366,22 @@ async def test_sidebar_tab_and_settings_planning_computed_styles_keep_contrast(
             assert str(current.styles.border) != "Edges()"
 
         for section in app.query(".status-section"):
+            assert section.styles.background == app.query_one("#status_form").styles.background
             assert str(section.styles.border) != "Edges()"
         for section in app.query(".planning-section"):
+            assert section.styles.background == app.query_one("#planning_form").styles.background
             assert str(section.styles.border) != "Edges()"
         for section in app.query(".settings-section"):
+            assert section.styles.background == settings_background
             assert str(section.styles.border) != "Edges()"
 
         terminal_block = app.query_one("#terminal").styles
         assert terminal_block.padding.left == 0
-        assert str(terminal_block.border) != "Edges()"
+        assert str(terminal_block.border) == "Edges()"
         if show_logs:
             logs_block = app.query_one("#logs").styles
             assert logs_block.padding.left == 0
-            assert str(logs_block.border) != "Edges()"
+            assert str(logs_block.border) == "Edges()"
 
 
 def test_tui_stylesheet_explicitly_themes_footer_select_overlay_and_output_scrollbars() -> None:
@@ -373,13 +392,16 @@ def test_tui_stylesheet_explicitly_themes_footer_select_overlay_and_output_scrol
     assert "height: 1fr" in conversation_block
     assert "border: none" in conversation_block
     assert "background: $surface" in conversation_block
+    assert "background: $background" not in conversation_block
     assert "color: $text" in conversation_block
     assert "overflow-x: hidden" in conversation_block
 
     sidebar_output_block = css.split("#logs, #terminal", 1)[1].split("}", 1)[0]
     assert "height: 1fr" in sidebar_output_block
-    assert "border: round $surface" in sidebar_output_block
-    assert "background: $surface" in sidebar_output_block
+    assert "border: none" in sidebar_output_block
+    assert "border: round" not in sidebar_output_block
+    assert "background: $background" in sidebar_output_block
+    assert "background: $surface" not in sidebar_output_block
     assert "overflow-x: hidden" in sidebar_output_block
 
     footer_block = css.split("Footer {", 1)[1].split("}", 1)[0]


### PR DESCRIPTION
## Summary
- Move the shared task list display from the Plan tab to the Status tab
- Replace planning collapsibles with bordered sidebar sections
- Restore sidebar tab/card/select contrast styling and update coverage tests

## Tests
- pytest tests/cli/test_app_agent_wiring.py tests/cli/test_app_bootstrap_settings.py tests/cli/test_app_persistence_history.py tests/cli/test_app_rendering_status.py tests/cli/test_tui_stylesheet.py