### PR TITLE
docs: document queued follow-up messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ enough that one serial agent pass would be the bottleneck.
   directly and use a Playwright-powered browser agent for interactive sites.
 - **Model routing:** choose provider/model combinations, set thinking effort, split
   long-context/fast/thinking roles, and override models per agent role.
-- **Interactive or scriptable:** use the Textual TUI, run `kolega-code ask`, request
-  JSON output, list/export/resume sessions, and diagnose setup with `doctor`.
+- **Interactive or scriptable:** use the Textual TUI, queue follow-up prompts
+  while the agent is working, run `kolega-code ask`, request JSON output,
+  list/export/resume sessions, and diagnose setup with `doctor`.
 - **Extensibility:** add agent skills, override prompts with project templates, run
   lifecycle hooks, and persist project permission rules.
 - **Local-first state:** sessions, settings, permissions, OAuth tokens, and API-key

--- a/docs/src/content/docs/tui/composer.md
+++ b/docs/src/content/docs/tui/composer.md
@@ -24,6 +24,27 @@ terminal-style line navigation. Some macOS terminal emulators reserve `Cmd+A` fo
 terminal scrollback selection before the TUI can see it; `Ctrl+L` still works in
 the composer.
 
+## Queuing follow-up prompts
+
+You can keep typing while the agent is still generating. Pressing `Enter` during
+an active turn does **not** interrupt the current response — it queues your text as
+a follow-up prompt. While a turn is active, the composer status changes to
+`Queue a follow-up…` to make this clear.
+
+Queued follow-ups appear in the transcript as `Queued` entries and are summarized
+in a small queued-messages panel above the composer. When the current turn
+finishes, Kolega Code sends queued prompts automatically in FIFO order, and each
+queued entry becomes a normal user message as it is sent.
+
+File mentions and image attachments submitted with a queued prompt stay attached
+to that prompt. Interactive prompts still take precedence: explicit questions,
+tool approval prompts, and planning decisions must be answered before queued
+follow-ups can drain.
+
+If you cancel the active turn with `Ctrl+C` or `Escape`, queued follow-ups are
+restored into the composer instead of being silently sent. To discard pending
+follow-ups without stopping the active turn, run [`/queue-clear`](../slash-commands/).
+
 ## File mentions with `@`
 
 Type `@` to reference a file. A fuzzy-searchable dropdown of project files appears

--- a/docs/src/content/docs/tui/interface.md
+++ b/docs/src/content/docs/tui/interface.md
@@ -18,7 +18,9 @@ The screen is split into two columns:
   and settings. Toggle it with `Ctrl+O` or `/sidebar`. The diagnostic Logs tab is
   opt-in; launch with `--show-logs` when you want it.
 
-At the bottom sits the **composer** — the text box where you type prompts. See
+At the bottom sits the **composer** — the text box where you type prompts. When
+you submit follow-ups while the agent is working, a small queued-messages panel
+appears above the composer until those prompts are sent. See
 [Chat Composer](../composer/) for everything it can do.
 
 ## Side-panel tabs
@@ -36,6 +38,9 @@ At the bottom sits the **composer** — the text box where you type prompts. See
 - **Streaming** — the view stays anchored to the bottom while the agent is
   responding. When you scroll up, a **jump-to-bottom** affordance appears so you
   can return to the live edge.
+- **Queued follow-ups** — prompts submitted while the agent is still running show
+  as `Queued` transcript entries. When the active turn finishes, they are sent
+  automatically in FIFO order and become normal user messages.
 - **Tool results** — shown as collapsible blocks with a state indicator
   (running / done / failed). Expand to see the full result.
 - **Sub-agents** — when the main agent dispatches a sub-agent, a live card tracks

--- a/docs/src/content/docs/tui/slash-commands.md
+++ b/docs/src/content/docs/tui/slash-commands.md
@@ -43,6 +43,7 @@ These control the app and your session.
 | `/login` | Sign in to a provider, e.g. `/login chatgpt` |
 | `/logout` | Sign out of a provider, e.g. `/logout chatgpt` |
 | `/gigacode` | Toggle [gigacode](../../gigacode/) workflow orchestration on or off |
+| `/queue-clear` | Clear queued follow-up messages |
 | `/copy` | Copy the last response to the clipboard |
 | `/version` | Show the Kolega Code version |
 | `/update` | Update Kolega Code to the latest version |
@@ -58,6 +59,10 @@ active model. You can also switch directly with `/effort <level>`.
 Run `/login chatgpt` to sign in with a ChatGPT subscription and use OpenAI models
 without an API key; `/logout chatgpt` removes the stored credentials. See
 [Sign in with ChatGPT](../../configuration/sign-in-with-chatgpt/).
+
+Run `/queue-clear` to discard follow-up prompts that you queued while the current
+turn is running. It removes their `Queued` transcript entries, but it does not
+cancel or otherwise stop the active agent turn.
 
 Run `/init` to have the agent inspect the repository and create or update a
 concise root `AGENTS.md`. Extra text after the command is passed as focus or


### PR DESCRIPTION
## Summary
- document queued follow-up prompts in the TUI composer guide
- add queued-message panel and transcript behavior to the interface tour
- document /queue-clear and mention the feature in the README

## Validation
- npm run build (in docs)
