### PR TITLE
chore: release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.11.0 - 2026-06-26
+
+### Added
+
+- Added queued follow-up messages in the TUI so users can submit additional
+  prompts while an active turn is still running.
+
+### Changed
+
+- Moved task-list status into the sidebar and refined sidebar presentation.
+- Updated documentation and positioning copy for gigacode and queued follow-up
+  messages.
+
 ## 0.10.0 - 2026-06-25
 
 ### Added

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -44,4 +44,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.10.0"
+version = "0.11.0"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [options]
 prerelease-mode = "allow"
-exclude-newer = "2026-06-18T10:53:16.49897Z"
+exclude-newer = "2026-06-19T09:57:35.60205Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1360,7 +1360,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- Bump package metadata to `0.11.0`
- Regenerate `uv.lock` for the release version
- Add the `0.11.0` changelog entry

## Checks

- `./run_tests.sh`
- `uv run python` version parity check
- `uv build`
- `uv run twine check dist/*`

## Release notes

This is a minor `0.x` release for queued TUI follow-up messages and sidebar/status presentation refinements.

Per `RELEASING.md`, tag `v0.11.0` only after this PR is reviewed, passing CI, and merged.