### PR TITLE
fix(tui): prevent DeepSeek stream freezes

### DIFF
--- a/kolega_code/cli/theme.py
+++ b/kolega_code/cli/theme.py
@@ -88,6 +88,14 @@ CONTEXT_BAR_WIDTH = 18
 INSET_WIDTH = 2
 MARKDOWN_CODE_THEME = "monokai"
 RENDER_COALESCE_INTERVAL = 0.05
+# Coalesce less aggressively as the live streaming entry grows: each flush still costs
+# Textual an O(height) re-measure of an auto-height widget, so for very large reasoning
+# streams we trade a little update latency for far fewer full re-measures. Sizes are
+# characters of the live entry; see transcript._invalidate_conversation.
+RENDER_COALESCE_INTERVAL_MEDIUM = 0.12
+RENDER_COALESCE_INTERVAL_LARGE = 0.25
+RENDER_COALESCE_MEDIUM_CHARS = 40_000
+RENDER_COALESCE_LARGE_CHARS = 200_000
 
 
 @lru_cache(maxsize=None)

--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -214,7 +214,10 @@ class AgentRuntimeMixin:
         if queued.entry not in self.conversation_entries:
             self._add_conversation_entry(queued.entry)
         else:
-            self._render_conversation()
+            # The entry is already mounted (added when queued); just re-render that one
+            # widget for the queued->user transition instead of rebuilding the whole
+            # transcript, which on a long thread is a synchronous O(entries) hitch.
+            self._invalidate_conversation(queued.entry)
         self._refresh_queued_messages_panel()
         self._clear_composer_hint()
         self.agent_worker = self.run_worker(

--- a/kolega_code/cli/tui/state.py
+++ b/kolega_code/cli/tui/state.py
@@ -76,6 +76,24 @@ class ConversationEntry:
     full_content: str = ""  # untruncated tool output for expand-on-demand (capped)
     edit_preview: Optional[dict] = None  # UI-only structured diff/head preview for edit tools (not persisted)
     entry_id: str = field(default_factory=_next_entry_id)  # UI-only widget key, not persisted
+    # Streaming buffers (UI-only, excluded from equality/repr). Deltas accumulate in
+    # stream_parts and are joined into content once per render flush, not per chunk, to
+    # avoid O(n^2) attribute concatenation. render_cache holds the incrementally-built
+    # inset renderable so each flush appends only the new text rather than re-splitting
+    # the whole buffer. See transcript._apply_stream_chunk / _streaming_inset_renderable.
+    stream_parts: list[str] = field(default_factory=list, compare=False, repr=False)
+    render_cache: object = field(default=None, compare=False, repr=False)
+
+    def materialize(self) -> str:
+        """Fold any deferred stream deltas into ``content`` and return it.
+
+        Streaming appends land in ``stream_parts`` (O(1)); they are joined into
+        ``content`` once here — on each render flush and when the segment completes —
+        rather than on every chunk, so growth stays O(n) instead of O(n^2)."""
+        if self.stream_parts:
+            self.content += "".join(self.stream_parts)
+            self.stream_parts.clear()
+        return self.content
 
 
 @dataclass

--- a/kolega_code/cli/tui/transcript.py
+++ b/kolega_code/cli/tui/transcript.py
@@ -31,6 +31,29 @@ from .sub_agent_screen import SubAgentEntryWidget
 from .widgets import ConversationEntryWidget, JumpToBottomBar, ToolEntryWidget
 
 
+class _InsetRenderState:
+    """Incremental render cache for a streaming inset body (assistant/thinking).
+
+    Holds the Rich ``Text`` built so far plus enough state to append only newly
+    arrived characters on each flush, instead of re-splitting the whole growing
+    buffer. The output matches ``_format_inset_text`` for ``\\n``-delimited content
+    (the common case); completion does a canonical full reformat as a safety net.
+    """
+
+    __slots__ = ("text", "length", "started", "open_has_content", "deferred_newline", "style")
+
+    def __init__(self, style):
+        self.text = Text()
+        self.length = 0  # chars of entry.content already folded into `text`
+        self.started = False  # has the first line's inset bar been emitted?
+        self.open_has_content = False  # has the current (last) line emitted its " " + text?
+        # One pending line break: a "\n" defers its new line until either more content or
+        # another "\n" arrives, so a *trailing* terminator leaves no empty inset line
+        # (matching str.splitlines, which drops only the final terminator).
+        self.deferred_newline = False
+        self.style = style
+
+
 class TranscriptRenderingMixin:
     def _restore_conversation_history(self, history: list[dict]) -> None:
         self.conversation_entries = []
@@ -238,8 +261,14 @@ class TranscriptRenderingMixin:
             self.conversation_entries.append(entry)
             self._stream_entries[cache_key] = entry
 
-        entry.content += content
+        # Defer concatenation to the next render flush (see ConversationEntryWidget.
+        # refresh_content): per-chunk `content += content` is O(n^2) over the stream.
+        # On completion, materialize now so entry.content is current the moment the
+        # segment ends (one O(n) join), without waiting for the flush.
+        entry.stream_parts.append(content)
         entry.complete = complete
+        if complete:
+            entry.materialize()
         self._invalidate_conversation(entry)
 
     def _begin_turn_progress(self) -> None:
@@ -1112,15 +1141,33 @@ class TranscriptRenderingMixin:
         if self._render_pending:
             return
         self._render_pending = True
+        interval = self._render_coalesce_interval(entry)
         try:
             self.set_timer(
-                theme.RENDER_COALESCE_INTERVAL,
+                interval,
                 self._flush_conversation_render,
                 name="conversation-render",
             )
         except Exception:
             # Timers are unavailable before the app is running; render directly.
             self._flush_conversation_render()
+
+    def _render_coalesce_interval(self, entry: Optional[ConversationEntry]) -> float:
+        """Back off the flush cadence for very large live entries.
+
+        Each flush makes Textual re-measure the auto-height streaming widget (O(height)),
+        so for big reasoning streams fewer, larger flushes beat ~20/sec full re-measures.
+        Length lags one flush (deltas materialize at flush time), which is fine: the entry
+        only grows, so the cadence steps up within one interval of crossing a threshold.
+        """
+        if entry is None:
+            return theme.RENDER_COALESCE_INTERVAL
+        size = len(entry.content)
+        if size >= theme.RENDER_COALESCE_LARGE_CHARS:
+            return theme.RENDER_COALESCE_INTERVAL_LARGE
+        if size >= theme.RENDER_COALESCE_MEDIUM_CHARS:
+            return theme.RENDER_COALESCE_INTERVAL_MEDIUM
+        return theme.RENDER_COALESCE_INTERVAL
 
     def _flush_conversation_render(self) -> None:
         if not self._render_pending:
@@ -1280,11 +1327,15 @@ class TranscriptRenderingMixin:
             header = theme.role_header(Glyph.AGENT, "Agent", Color.AGENT, state=streaming)
             if entry.complete and entry.content.strip():
                 return self._markdown_entry(header, entry.content)
+            if not entry.complete:
+                return self._streaming_inset_renderable(entry, header)
             return self._entry_renderable(header, entry.content)
         if entry.kind == "thinking":
             header = theme.role_header(
                 Glyph.STATUS, "Thinking", Color.THINKING, label_style="dim italic", state=streaming
             )
+            if not entry.complete:
+                return self._streaming_inset_renderable(entry, header, body_style="italic dim")
             return self._entry_renderable(header, entry.content, body_style="italic dim")
         if entry.kind == "progress":
             color = Color.ERROR if entry.tone == "error" else Color.WARNING
@@ -1335,6 +1386,63 @@ class TranscriptRenderingMixin:
         if body is None:
             return header_text
         return Group(header_text, self._format_inset_text(body, style=body_style))
+
+    def _streaming_inset_renderable(self, entry, header: str, *, body_style: Optional[str] = None) -> Group:
+        """Inset body for a still-streaming entry, built incrementally (O(delta) per flush).
+
+        Caches the rendered Text on the entry so each flush only appends the newly
+        arrived characters instead of re-splitting and re-rendering the whole buffer
+        (the O(n^2) cliff). The header is small and rebuilt each call. On completion the
+        dispatcher routes to the canonical _entry_renderable/_markdown_entry instead.
+        """
+        state = entry.render_cache
+        content = entry.content
+        if not isinstance(state, _InsetRenderState) or state.style != body_style or state.length > len(content):
+            # First render for this entry, a body-style change, or a defensive shrink:
+            # fold the whole current buffer once.
+            state = _InsetRenderState(body_style)
+            entry.render_cache = state
+            self._extend_inset(state, content)
+        elif state.length < len(content):
+            self._extend_inset(state, content[state.length :])
+        return Group(Text.from_markup(header), state.text)
+
+    def _extend_inset(self, state: "_InsetRenderState", delta: str) -> None:
+        """Append ``delta`` to the cached inset Text, matching _format_inset_text for "\\n".
+
+        A pending newline is flushed (its new line materialized) as soon as another
+        newline *or* content follows it; only a still-pending terminator at the very end
+        is left unrendered, so the result equals ``_format_inset_text`` over the buffer.
+        """
+        if not delta and state.started:
+            return
+        bar = f"  {theme.g(Glyph.INSET_BAR)}"
+        text = state.text
+
+        def flush_deferred() -> None:
+            if state.deferred_newline:
+                text.append("\n")
+                text.append(bar, style="dim")
+                state.deferred_newline = False
+                state.open_has_content = False
+
+        if not state.started:
+            text.append(bar, style="dim")
+            state.started = True
+            state.open_has_content = False
+
+        for index, segment in enumerate(delta.split("\n")):
+            if index > 0:
+                # A "\n" boundary confirms any prior deferred line, then defers its own.
+                flush_deferred()
+                state.deferred_newline = True
+            if segment:
+                flush_deferred()
+                if not state.open_has_content:
+                    text.append(" ")
+                    state.open_has_content = True
+                text.append(segment, style=state.style)
+        state.length += len(delta)
 
     def _markdown_entry(self, header: str, content: str) -> Group:
         return Group(

--- a/kolega_code/cli/tui/widgets.py
+++ b/kolega_code/cli/tui/widgets.py
@@ -40,6 +40,10 @@ class ConversationEntryWidget(Static):
         self.refresh_content()
 
     def refresh_content(self) -> None:
+        # Join any streamed deltas into content once here (per flush) rather than on
+        # every chunk, so growth stays O(n) instead of O(n^2) attribute concatenation.
+        self.entry.materialize()
+
         kind_class = f"entry-{self.entry.kind}"
         if kind_class != self._kind_class:
             if self._kind_class:
@@ -55,13 +59,16 @@ class ConversationEntryWidget(Static):
         self.update(self._formatted)
 
     def _entry_snapshot(self) -> tuple[object, ...]:
+        # Use content lengths, not the full strings: streaming only appends, so length
+        # is a strictly-monotonic change signal and the comparison stays O(1) instead of
+        # an O(n) string compare on every coalesced flush.
         return (
             self.entry.kind,
-            self.entry.content,
+            len(self.entry.content),
             self.entry.complete,
             self.entry.tool_name,
             self.entry.tone,
-            self.entry.full_content,
+            len(self.entry.full_content),
             repr(self.entry.edit_preview),
         )
 

--- a/kolega_code/llm/providers/openai.py
+++ b/kolega_code/llm/providers/openai.py
@@ -1,4 +1,5 @@
 from typing import Any, AsyncContextManager, Dict, List, Optional
+from weakref import WeakKeyDictionary
 import json
 import logging
 import math
@@ -151,6 +152,15 @@ class OpenAIProvider(BaseLLMProvider):
         # honors retry-after and retries 429/5xx + connection errors) is actually used.
         self.async_client = AsyncOpenAI(api_key=api_key, base_url=base_url, max_retries=max_retries)
         self.sync_client = OpenAI(api_key=api_key, base_url=base_url, max_retries=max_retries)
+        # Per-message / per-tool token-count memos. count_tokens runs every agent-loop
+        # iteration over the whole history; without this it re-encodes the entire
+        # conversation each time (O(history) on the event loop, the streaming-turn
+        # freeze on slow machines). Keyed by object identity so unchanged messages are
+        # counted once; a cheap length fingerprint catches in-place edits (e.g. an
+        # oversized tool result being truncated). Compaction/adaptation/repair produce
+        # new objects, which miss naturally.
+        self._message_token_memo: "WeakKeyDictionary[Message, tuple]" = WeakKeyDictionary()
+        self._tool_token_memo: "WeakKeyDictionary[ToolDefinition, int]" = WeakKeyDictionary()
 
     @property
     def retry_decorator(self):
@@ -210,80 +220,153 @@ class OpenAIProvider(BaseLLMProvider):
             TokenCount object with input token count
         """
         encoding = tiktoken.get_encoding("cl100k_base")
-        num_tokens = 0
+        self._ensure_token_memos()
 
         # Combine system message with messages if provided
         all_messages = ([system] + list(messages)) if system else list(messages)
 
-        # Count tokens for each message
-        for message in all_messages:
-            # Base tokens for message formatting
-            num_tokens += 4  # Every message follows <im_start>{role/name}\n{content}<im_end>\n format
+        # Sum memoized per-message counts: only new or changed messages are re-encoded.
+        num_tokens = sum(self._memoized_message_tokens(encoding, message) for message in all_messages)
 
-            # Add tokens for role
-            if hasattr(message, "role") and message.role:
-                num_tokens += len(encoding.encode(message.role))
-
-            # Add tokens for content
-            if hasattr(message, "content"):
-                if isinstance(message.content, str):
-                    num_tokens += len(encoding.encode(message.content))
-                elif isinstance(message.content, list):
-                    for item in message.content:
-                        # Handle text blocks
-                        if hasattr(item, "text") and item.text:
-                            num_tokens += len(encoding.encode(item.text))
-                        elif isinstance(item, dict) and "text" in item:
-                            num_tokens += len(encoding.encode(item["text"]))
-                        # Handle image blocks
-                        elif isinstance(item, ImageBlock):
-                            num_tokens += self._estimate_image_tokens(len(item.data))
-                        elif hasattr(item, "data") and hasattr(item, "media_type"):
-                            # ImageBlock - estimate tokens based on base64 data size
-                            num_tokens += self._estimate_image_tokens(len(item.data))
-                        # Handle tool calls. OpenAI's prompt accounting uses a compact
-                        # internal representation for assistant tool calls rather than
-                        # charging the full Chat Completions JSON wrapper. Counting the
-                        # stable fields (id, function name, serialized arguments) tracks
-                        # the API much more closely for resumed/provider-shaped history.
-                        elif isinstance(item, ToolCall):
-                            tool_call_payload = item.to_openai()
-                            function_payload = tool_call_payload.get("function", {})
-                            arguments = str(function_payload.get("arguments") or "")
-                            num_tokens += len(encoding.encode(str(tool_call_payload.get("id") or "")))
-                            num_tokens += len(encoding.encode(str(function_payload.get("name") or item.name)))
-                            num_tokens += len(encoding.encode(arguments))
-                            num_tokens += 1  # Compact formatting overhead for tool calls
-                        # Handle tool results
-                        elif isinstance(item, ToolResult):
-                            # Tool results contain content that needs to be counted.
-                            # OpenAI tool messages are text-only, but image-bearing
-                            # tool results are serialized as a follow-up user image
-                            # message, so nested images contribute image tokens.
-                            if isinstance(item.content, str):
-                                num_tokens += len(encoding.encode(item.content))
-                            elif isinstance(item.content, list):
-                                for result_item in item.content:
-                                    if isinstance(result_item, ImageBlock):
-                                        num_tokens += self._estimate_image_tokens(len(result_item.data))
-                                    elif hasattr(result_item, "data") and hasattr(result_item, "media_type"):
-                                        num_tokens += self._estimate_image_tokens(len(result_item.data))
-                                    elif hasattr(result_item, "text") and result_item.text:
-                                        num_tokens += len(encoding.encode(result_item.text))
-                            num_tokens += 2  # Minimal formatting overhead for tool results
-
-        # Count tool definition tokens
+        # Tool definitions don't mutate within a session, so memoize per definition by identity.
         if tools:
-            for tool in tools:
-                tool_json = json.dumps(tool.to_openai())
-                # Count JSON tokens
-                json_tokens = len(encoding.encode(tool_json))
-                # OpenAI uses highly optimized internal format (not JSON)
-                # Empirically, their token count is ~79% of raw JSON token count
-                # Apply scaling factor to match API behavior
-                num_tokens += int(json_tokens * 0.79)
+            num_tokens += sum(self._memoized_tool_tokens(encoding, tool) for tool in tools)
 
         return TokenCount(input_tokens=num_tokens)
+
+    def _ensure_token_memos(self) -> None:
+        # Instances built via __new__ (benchmarks/tests) skip __init__, so create lazily.
+        if getattr(self, "_message_token_memo", None) is None:
+            self._message_token_memo = WeakKeyDictionary()
+        if getattr(self, "_tool_token_memo", None) is None:
+            self._tool_token_memo = WeakKeyDictionary()
+
+    def _memoized_message_tokens(self, encoding, message) -> int:
+        fingerprint = self._message_fingerprint(message)
+        try:
+            cached = self._message_token_memo.get(message)
+        except TypeError:  # message not weak-referenceable / hashable
+            cached = None
+        if cached is not None and cached[0] == fingerprint:
+            return cached[1]
+        value = self._count_message_tokens(encoding, message)
+        try:
+            self._message_token_memo[message] = (fingerprint, value)
+        except TypeError:
+            pass
+        return value
+
+    def _memoized_tool_tokens(self, encoding, tool) -> int:
+        try:
+            cached = self._tool_token_memo.get(tool)
+        except TypeError:
+            cached = None
+        if cached is not None:
+            return cached
+        # OpenAI uses a highly optimized internal format (not JSON); empirically their
+        # token count is ~79% of the raw JSON token count.
+        value = int(len(encoding.encode(json.dumps(tool.to_openai()))) * 0.79)
+        try:
+            self._tool_token_memo[tool] = value
+        except TypeError:
+            pass
+        return value
+
+    def _count_message_tokens(self, encoding, message) -> int:
+        """Token count for one message (role + content blocks). Memoized by the caller."""
+        num_tokens = 4  # Every message follows <im_start>{role/name}\n{content}<im_end>\n format
+        if hasattr(message, "role") and message.role:
+            num_tokens += len(encoding.encode(message.role))
+        if hasattr(message, "content"):
+            if isinstance(message.content, str):
+                num_tokens += len(encoding.encode(message.content))
+            elif isinstance(message.content, list):
+                for item in message.content:
+                    # Handle text blocks
+                    if hasattr(item, "text") and item.text:
+                        num_tokens += len(encoding.encode(item.text))
+                    elif isinstance(item, dict) and "text" in item:
+                        num_tokens += len(encoding.encode(item["text"]))
+                    # Handle image blocks
+                    elif isinstance(item, ImageBlock):
+                        num_tokens += self._estimate_image_tokens(len(item.data))
+                    elif hasattr(item, "data") and hasattr(item, "media_type"):
+                        # ImageBlock - estimate tokens based on base64 data size
+                        num_tokens += self._estimate_image_tokens(len(item.data))
+                    # Handle tool calls. OpenAI's prompt accounting uses a compact
+                    # internal representation for assistant tool calls rather than
+                    # charging the full Chat Completions JSON wrapper. Counting the
+                    # stable fields (id, function name, serialized arguments) tracks
+                    # the API much more closely for resumed/provider-shaped history.
+                    elif isinstance(item, ToolCall):
+                        tool_call_payload = item.to_openai()
+                        function_payload = tool_call_payload.get("function", {})
+                        arguments = str(function_payload.get("arguments") or "")
+                        num_tokens += len(encoding.encode(str(tool_call_payload.get("id") or "")))
+                        num_tokens += len(encoding.encode(str(function_payload.get("name") or item.name)))
+                        num_tokens += len(encoding.encode(arguments))
+                        num_tokens += 1  # Compact formatting overhead for tool calls
+                    # Handle tool results
+                    elif isinstance(item, ToolResult):
+                        # Tool results contain content that needs to be counted.
+                        # OpenAI tool messages are text-only, but image-bearing
+                        # tool results are serialized as a follow-up user image
+                        # message, so nested images contribute image tokens.
+                        if isinstance(item.content, str):
+                            num_tokens += len(encoding.encode(item.content))
+                        elif isinstance(item.content, list):
+                            for result_item in item.content:
+                                if isinstance(result_item, ImageBlock):
+                                    num_tokens += self._estimate_image_tokens(len(result_item.data))
+                                elif hasattr(result_item, "data") and hasattr(result_item, "media_type"):
+                                    num_tokens += self._estimate_image_tokens(len(result_item.data))
+                                elif hasattr(result_item, "text") and result_item.text:
+                                    num_tokens += len(encoding.encode(result_item.text))
+                        num_tokens += 2  # Minimal formatting overhead for tool results
+        return num_tokens
+
+    def _message_fingerprint(self, message):
+        """Cheap (lengths-only) signature mirroring _count_message_tokens' inputs.
+
+        The token count for a fixed message structure changes only when an encoded
+        length changes, so a change in this fingerprint is necessary and sufficient to
+        invalidate a memoized count for the same object (e.g. in-place truncation of an
+        oversized tool result). Structural/type changes arrive as new objects (identity
+        miss), so they need not be captured here."""
+        role = getattr(message, "role", "") or ""
+        content = getattr(message, "content", None)
+        if isinstance(content, str):
+            return (role, len(content))
+        if isinstance(content, list):
+            return (role, tuple(self._block_fingerprint(item) for item in content))
+        return (role, None)
+
+    def _block_fingerprint(self, item):
+        # Branch order mirrors _count_message_tokens so classification stays aligned.
+        if hasattr(item, "text") and getattr(item, "text", None):
+            return ("txt", len(item.text))
+        if isinstance(item, dict) and "text" in item:
+            return ("dtxt", len(item.get("text") or ""))
+        if isinstance(item, ImageBlock):
+            return ("img", len(item.data))
+        if hasattr(item, "data") and hasattr(item, "media_type"):
+            return ("img", len(item.data))
+        if isinstance(item, ToolCall):
+            payload = item.to_openai()
+            function_payload = payload.get("function", {})
+            return (
+                "tc",
+                len(str(payload.get("id") or "")),
+                len(str(function_payload.get("name") or item.name)),
+                len(str(function_payload.get("arguments") or "")),
+            )
+        if isinstance(item, ToolResult):
+            if isinstance(item.content, str):
+                return ("tr", len(item.content))
+            if isinstance(item.content, list):
+                return ("tr", tuple(self._block_fingerprint(ri) for ri in item.content))
+            return ("tr", None)
+        return ("?",)
 
     def _estimate_image_tokens(self, base64_data_length: int) -> int:
         """Estimate image token cost based on base64 data length.

--- a/scripts/bench_hotpaths.py
+++ b/scripts/bench_hotpaths.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Micro-benchmarks for the TUI streaming hot paths.
+
+These isolate the three recompute-from-scratch paths that turn a 15-30s DeepSeek
+turn into a multi-minute event-loop-blocking crawl on slow machines (see the
+"freeze / slows to a crawl" investigation):
+
+  1. token counting      - OpenAIProvider.count_tokens over the whole history
+  2. stream accumulation  - ConversationEntry text growth per chunk
+  3. streaming render      - _format_inset_text over the whole growing buffer per flush
+
+Run it before and after the optimizations and compare the printed tables:
+
+    uv run python scripts/bench_hotpaths.py
+
+The numbers that matter:
+  - token counting: the "+1 msg recount" column should collapse toward the cost of
+    a single new message once counting is incremental (it tracks the full recount today).
+  - accumulation: "concat" should grow ~quadratically vs "list+join" linear.
+  - render: "full stream" simulates flushing as the buffer grows; pre-fix it is ~O(n^2).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Callable
+
+from kolega_code.cli.tui.transcript import TranscriptRenderingMixin
+from kolega_code.llm.models import Message, MessageHistory, TextBlock
+from kolega_code.llm.providers.openai import OpenAIProvider
+
+
+def _best(fn: Callable[[], object], repeat: int = 3) -> float:
+    best = float("inf")
+    for _ in range(repeat):
+        t0 = time.perf_counter()
+        fn()
+        best = min(best, time.perf_counter() - t0)
+    return best
+
+
+def _ms(seconds: float) -> str:
+    return f"{seconds * 1000:9.2f} ms"
+
+
+# --------------------------------------------------------------------------- #
+# 1. Token counting
+# --------------------------------------------------------------------------- #
+def _make_history(n_messages: int, chars_each: int) -> MessageHistory:
+    body = ("token text " * (chars_each // 11 + 1))[:chars_each]
+    msgs = []
+    for i in range(n_messages):
+        role = "user" if i % 2 == 0 else "assistant"
+        msgs.append(Message(role=role, content=[TextBlock(text=body)]))
+    return MessageHistory(msgs)
+
+
+async def _bench_token_counting() -> None:
+    print("\n== 1. Token counting (OpenAIProvider.count_tokens) ==")
+    print(f"{'messages':>9} {'chars/msg':>10} {'full count':>14} {'+1 msg recount':>16}")
+    provider = OpenAIProvider.__new__(OpenAIProvider)  # count_tokens uses no __init__ state
+
+    async def count(history: MessageHistory) -> None:
+        await provider.count_tokens(messages=history, system=None, model="gpt-4", tools=[])
+
+    for n in (50, 200, 800):
+        chars = 2000
+        hist = _make_history(n, chars)
+        await count(hist)  # warm the memo / encoding
+
+        t0 = time.perf_counter()
+        await count(hist)
+        t_full = time.perf_counter() - t0
+
+        # Append one new message and recount: this is the per-iteration cost during a turn.
+        hist.append(Message(role="user", content=[TextBlock(text="one freshly added message " * 40)]))
+        t0 = time.perf_counter()
+        await count(hist)
+        t_recount = time.perf_counter() - t0
+
+        print(f"{n:>9} {chars:>10} {_ms(t_full):>14} {_ms(t_recount):>16}")
+
+
+# --------------------------------------------------------------------------- #
+# 2. Stream accumulation
+# --------------------------------------------------------------------------- #
+class _Holder:
+    """Mimics ConversationEntry: content lives on an attribute, so the CPython
+    in-place str-concat optimization (which needs refcount 1) does not apply."""
+
+    def __init__(self) -> None:
+        self.content = ""
+
+
+def _bench_accumulation() -> None:
+    print("\n== 2. Stream accumulation (per-chunk text growth, on an attribute) ==")
+    print(f"{'target chars':>12} {'chunks':>8} {'attr +=':>14} {'list+join':>14}")
+    chunk = "x" * 50  # DeepSeek-style ~50-char reasoning deltas
+    for target in (50_000, 200_000, 1_000_000):
+        n = target // len(chunk)
+
+        def concat() -> str:
+            holder = _Holder()
+            for _ in range(n):
+                holder.content += chunk
+            return holder.content
+
+        def list_join() -> str:
+            holder = _Holder()
+            parts: list[str] = []
+            for _ in range(n):
+                parts.append(chunk)
+            holder.content = "".join(parts)
+            return holder.content
+
+        print(f"{target:>12} {n:>8} {_ms(_best(concat)):>14} {_ms(_best(list_join)):>14}")
+
+
+# --------------------------------------------------------------------------- #
+# 3. Streaming render
+# --------------------------------------------------------------------------- #
+def _bench_render() -> None:
+    from kolega_code.cli.tui.transcript import _InsetRenderState
+
+    print("\n== 3. Streaming render (flush-as-it-grows, step=4KB) ==")
+    print(f"{'buffer chars':>12} {'OLD reformat-each-flush':>26} {'NEW incremental':>18}")
+    mixin = TranscriptRenderingMixin.__new__(TranscriptRenderingMixin)  # methods use no instance state
+    line = "a moderately sized line of reasoning output\n"
+    step = 4000
+    for size in (50_000, 200_000, 1_000_000):
+        content = (line * (size // len(line) + 1))[:size]
+
+        # OLD: re-split + rebuild the whole buffer on every flush (O(n^2)).
+        def old() -> None:
+            pos = 0
+            while pos < len(content):
+                pos = min(len(content), pos + step)
+                mixin._format_inset_text(content[:pos])
+
+        # NEW: append only the newly-arrived slice each flush (O(delta), O(n) total).
+        def new() -> None:
+            state = _InsetRenderState(None)
+            pos = 0
+            while pos < len(content):
+                nxt = min(len(content), pos + step)
+                mixin._extend_inset(state, content[pos:nxt])
+                pos = nxt
+
+        print(f"{size:>12} {_ms(_best(old)):>26} {_ms(_best(new)):>18}")
+
+
+async def _main() -> None:
+    print(f"python hot-path benchmark — {time.strftime('%Y-%m-%d %H:%M:%S')}")
+    await _bench_token_counting()
+    _bench_accumulation()
+    _bench_render()
+    print("\ndone.")
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/tests/agent/llm/test_openai_token_counting_incremental.py
+++ b/tests/agent/llm/test_openai_token_counting_incremental.py
@@ -1,0 +1,136 @@
+"""Incremental token counting must equal a from-scratch recount.
+
+count_tokens memoizes per-message token counts (keyed by object identity, guarded by a
+cheap length fingerprint) so that, per agent-loop iteration, only new or changed messages
+are re-encoded instead of the whole history. These tests pin the invariant that the
+memoized total always equals a fresh provider's full recount, including across in-place
+mutation (oversized tool-result truncation), object replacement (provider adaptation /
+compaction), and system + tool definitions. No API key required: count_tokens uses no
+client state.
+"""
+
+import asyncio
+
+from kolega_code.llm.models import (
+    Message,
+    MessageHistory,
+    TextBlock,
+    ToolCall,
+    ToolDefinition,
+    ToolParameter,
+    ToolResult,
+)
+from kolega_code.llm.providers.openai import OpenAIProvider
+
+
+def _provider() -> OpenAIProvider:
+    # __new__ skips __init__ (no API key / client needed); count_tokens lazily creates memos.
+    return OpenAIProvider.__new__(OpenAIProvider)
+
+
+def _count(provider, messages, *, system=None, tools=None) -> int:
+    return asyncio.run(
+        provider.count_tokens(messages=messages, system=system, model="gpt-4", tools=tools or [])
+    ).input_tokens
+
+
+def _fresh_count(messages, *, system=None, tools=None) -> int:
+    return _count(_provider(), messages, system=system, tools=tools)
+
+
+def _text_message(role: str, text: str) -> Message:
+    return Message(role=role, content=[TextBlock(text=text)])
+
+
+def _history(n: int) -> MessageHistory:
+    return MessageHistory(
+        [_text_message("user" if i % 2 == 0 else "assistant", f"message {i} " * 30) for i in range(n)]
+    )
+
+
+def test_repeated_count_is_stable():
+    provider = _provider()
+    history = _history(20)
+    first = _count(provider, history)
+    second = _count(provider, history)
+    assert first == second == _fresh_count(history)
+
+
+def test_incremental_matches_fresh_on_append():
+    provider = _provider()
+    history = _history(20)
+    _count(provider, history)  # warm the memo
+
+    history.append(_text_message("user", "a freshly appended follow-up message " * 10))
+    incremental = _count(provider, history)
+
+    assert incremental == _fresh_count(history)
+
+
+def test_fingerprint_invalidates_on_inplace_tool_result_truncation():
+    big = "x" * 20_000
+    result = ToolResult(tool_use_id="call_1", content=big, name="do", is_error=False)
+    history = MessageHistory(
+        [
+            _text_message("user", "run the tool"),
+            Message(role="assistant", content=[ToolCall(id="call_1", name="do", input={})]),
+            Message(role="tool", content=[result]),
+        ]
+    )
+    provider = _provider()
+    before = _count(provider, history)
+
+    # Simulate _sanitize_oversized_tool_results truncating the result in place.
+    result.content = "x" * 100
+    after = _count(provider, history)
+
+    assert after != before  # the change was detected, not served stale from the memo
+    assert after == _fresh_count(history)
+
+
+def test_incremental_matches_fresh_after_object_replacement():
+    """Provider adaptation / compaction replace message objects; the memo must not drift."""
+    provider = _provider()
+    history = _history(10)
+    _count(provider, history)
+
+    # Replace a message at a fixed position with a new object of different content,
+    # as adapt_history_for_provider does when it rewrites a message.
+    history[4] = _text_message("assistant", "ADAPTED content that differs in length " * 5)
+    incremental = _count(provider, history)
+
+    assert incremental == _fresh_count(history)
+
+
+def test_incremental_matches_fresh_with_system_and_tools():
+    provider = _provider()
+    system = _text_message("system", "You are a helpful assistant. " * 20)
+    tools = [
+        ToolDefinition(
+            name="search",
+            description="Search the web for a query.",
+            parameters=[ToolParameter("query", "string", "the search query", required=True)],
+        ),
+        ToolDefinition(
+            name="read_file",
+            description="Read a file from disk.",
+            parameters=[ToolParameter("path", "string", "absolute path", required=True)],
+        ),
+    ]
+    history = _history(12)
+    _count(provider, history, system=system, tools=tools)  # warm
+
+    history.append(_text_message("assistant", "tool planning text " * 8))
+    incremental = _count(provider, history, system=system, tools=tools)
+
+    assert incremental == _fresh_count(history, system=system, tools=tools)
+
+
+def test_shrinking_history_recounts_correctly():
+    """A shorter history (e.g. post-compaction tail) must not over-count from the memo."""
+    provider = _provider()
+    history = _history(30)
+    _count(provider, history)
+
+    shorter = MessageHistory(list(history)[:5])
+    assert _count(provider, shorter) == _fresh_count(shorter)

--- a/tests/cli/test_transcript_streaming_render.py
+++ b/tests/cli/test_transcript_streaming_render.py
@@ -1,0 +1,119 @@
+"""Incremental streaming-inset rendering must match the canonical renderer and stay O(n).
+
+The live (incomplete) assistant/thinking entries are rendered by appending only the newly
+arrived characters to a cached Rich Text (_extend_inset), instead of re-splitting and
+re-rendering the whole growing buffer on every ~50ms flush (the O(n^2) freeze on slow
+machines). These tests pin two properties:
+
+  1. correctness  - the incremental result is character-for-character / style-for-style
+                    identical to _format_inset_text for any chunk splitting.
+  2. scaling      - building a large stream incrementally stays well under a generous
+                    wall-clock bound (it was ~6s of O(n^2) CPU before; ~50ms after).
+"""
+
+import time
+
+import pytest
+
+from kolega_code.cli.tui.transcript import TranscriptRenderingMixin, _InsetRenderState
+
+
+@pytest.fixture
+def mixin() -> TranscriptRenderingMixin:
+    # _format_inset_text / _extend_inset use no instance state.
+    return TranscriptRenderingMixin.__new__(TranscriptRenderingMixin)
+
+
+def _per_char(text):
+    """(plain, [style-per-char]) — tolerant of harmless span fragmentation."""
+    styles: list[object] = [None] * len(text.plain)
+    for span in text._spans:
+        for i in range(span.start, min(span.end, len(styles))):
+            styles[i] = str(span.style)
+    return text.plain, styles
+
+
+def _incremental(mixin, content: str, style, chunk_sizes):
+    state = _InsetRenderState(style)
+    pos = 0
+    for size in chunk_sizes:
+        mixin._extend_inset(state, content[pos : pos + size])
+        pos += size
+    mixin._extend_inset(state, content[pos:])  # remainder (also handles empty content)
+    return state.text
+
+
+CASES = [
+    "",
+    "a",
+    "abc",
+    "a\n",
+    "a\nb",
+    "a\nb\n",
+    "a\n\nb",
+    "\n",
+    "\n\n",
+    "\n\n\n\n",
+    "\n\na",
+    "a\n\n",
+    "end\n\n\n",
+    "line one\nline two\nthird",
+    "trailing spaces  \n  leading",
+    "a\n\n\nb\n",
+    "no newlines just one long line " * 10,
+    ("word " * 20 + "\n") * 4,
+]
+
+
+@pytest.mark.parametrize("content", CASES)
+@pytest.mark.parametrize("style", [None, "italic dim"])
+def test_incremental_matches_canonical_for_uniform_chunks(mixin, content, style):
+    canonical = _per_char(mixin._format_inset_text(content, style=style))
+    for chunk in (1, 2, 3, 7, 4096):
+        sizes = [chunk] * (len(content) // chunk + 1)
+        assert _per_char(_incremental(mixin, content, style, sizes)) == canonical
+
+
+def test_incremental_matches_canonical_for_irregular_chunks(mixin):
+    import random
+
+    rng = random.Random(2024)
+    content = "".join(rng.choice(["alpha beta", "gamma", "\n", "  ", "delta epsilon zeta", "\n\n"]) for _ in range(400))
+    for style in (None, "italic dim"):
+        canonical = _per_char(mixin._format_inset_text(content, style=style))
+        for _ in range(20):
+            sizes = []
+            remaining = len(content)
+            while remaining > 0:
+                step = rng.randint(1, min(11, remaining))
+                sizes.append(step)
+                remaining -= step
+            assert _per_char(_incremental(mixin, content, style, sizes)) == canonical
+
+
+def test_incremental_final_state_equals_canonical_for_large_stream(mixin):
+    content = "a moderately sized line of reasoning output\n" * 12_000  # ~520 KB, many lines
+    canonical = _per_char(mixin._format_inset_text(content))
+    incremental = _per_char(_incremental(mixin, content, None, [4000] * (len(content) // 4000 + 1)))
+    assert incremental == canonical
+
+
+def test_large_stream_builds_in_linear_time(mixin):
+    """Regression guard: flush-as-it-grows must not reintroduce O(n^2).
+
+    Pre-fix this same 1 MB stream cost multiple seconds of CPU; incrementally it is tens
+    of milliseconds. The 2.0s bound is deliberately generous to avoid CI flakiness while
+    still failing loudly if the whole buffer is re-rendered on every flush again.
+    """
+    content = "a moderately sized line of reasoning output\n" * 23_000  # ~1 MB
+    step = 4000
+    state = _InsetRenderState(None)
+    start = time.perf_counter()
+    pos = 0
+    while pos < len(content):
+        nxt = min(len(content), pos + step)
+        mixin._extend_inset(state, content[pos:nxt])
+        pos = nxt
+    elapsed = time.perf_counter() - start
+    assert elapsed < 2.0, f"incremental 1MB stream took {elapsed:.2f}s (O(n^2) regression?)"
+    assert state.text.plain == mixin._format_inset_text(content).plain


### PR DESCRIPTION
## Summary

Fixes a DeepSeek build-mode UI freeze caused by synchronous, recompute-from-scratch hot paths running on the single-threaded Textual event loop. The fix makes the affected paths incremental so each update only processes new or changed work.

## Changes

- Memoize OpenAI-compatible token counting per message/tool with length fingerprints so unchanged history is not re-encoded every agent-loop iteration.
- Buffer streaming transcript deltas in `ConversationEntry.stream_parts` and materialize once per flush/completion instead of repeated string concatenation.
- Incrementally extend streaming inset renderables instead of splitting/re-rendering the entire buffer on each flush.
- Add adaptive render coalescing thresholds to reduce Textual re-measure churn on very large streams.
- Refresh only the queued message widget when transitioning queued messages to user messages.
- Add a standalone hot-path benchmark script.
- Add focused regression coverage for incremental token counting and streaming inset rendering.

## Benchmarks

From `scripts/bench_hotpaths.py` on Apple Silicon:

| Hot path | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| Streaming render, 1 MB (flush-as-it-grows) | 6347 ms | 44 ms | ~144x |
| Token counting, 800-msg recount/iteration | 57.8 ms | 0.53 ms | ~109x |
| Stream accumulation, 1 MB | 195 ms | 0.44 ms | ~440x |

## Tests

- `git diff --check`
- `uv run pytest tests/agent/llm/test_openai_token_counting_incremental.py tests/cli/test_transcript_streaming_render.py`
- Commit hooks: `ruff check`, `ruff format`, trailing whitespace, EOF, YAML, debug statements, private key checks
