### PR TITLE
fix(llm): bound streaming timeouts and retry transport errors

### DIFF
--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -28,6 +28,7 @@ from kolega_code.hooks import (
     LifecycleEvent,
 )
 from kolega_code.llm.exceptions import (
+    LLMConnectionError,
     LLMError,
     LLMInternalServerError,
     LLMRateLimitError,
@@ -1257,8 +1258,10 @@ class BaseAgent(LogMixin):
         retry_after = self._parse_retry_after(error)
         error = map_to_llm_error(error, provider=self.primary_model_config.provider.value)
 
-        # LLMInternalServerError covers 500/529 overloaded plus connection/transport errors.
-        if isinstance(error, (LLMRateLimitError, LLMInternalServerError)):
+        # Retry transient failures: rate limits, provider 5xx/overload, and transport-layer
+        # failures (LLMConnectionError, incl. its LLMTimeout subclass — e.g. a stalled
+        # streaming read hitting the per-request timeout, or a dropped connection).
+        if isinstance(error, (LLMRateLimitError, LLMInternalServerError, LLMConnectionError)):
             cap = self.primary_model_config.rate_limits.loop_max_retries
             self._consecutive_llm_retries += 1
             if self._consecutive_llm_retries > cap:
@@ -1276,6 +1279,12 @@ class BaseAgent(LogMixin):
             await self.log_warning(
                 f"Transient LLM error ({error}); retry {self._consecutive_llm_retries}/{cap} in {delay:.1f}s.",
                 sender=self.agent_name,
+            )
+            # Surface the retry in the UI so a stalled stream (which now fails fast on the
+            # per-request timeout instead of hanging) reads as "retrying", not a freeze.
+            await self.emitter.llm_status(
+                "info",
+                f"Connection issue — retrying ({self._consecutive_llm_retries}/{cap}) in {delay:.0f}s…",
             )
             await asyncio.sleep(delay)
             await self.log_info("Resuming after backoff.", sender=self.agent_name)

--- a/kolega_code/llm/exceptions.py
+++ b/kolega_code/llm/exceptions.py
@@ -39,11 +39,17 @@ import asyncio
 
 from anthropic import (
     AnthropicError,
+    APIConnectionError as AnthropicAPIConnectionError,
     APIStatusError as AnthropicAPIStatusError,
+    APITimeoutError as AnthropicAPITimeoutError,
     InternalServerError as AnthropicInternalServerError,
 )
 from google.genai.errors import APIError as GoogleAPIError
-from openai import OpenAIError
+from openai import (
+    APIConnectionError as OpenAIAPIConnectionError,
+    APITimeoutError as OpenAIAPITimeoutError,
+    OpenAIError,
+)
 
 try:
     import aiohttp
@@ -99,8 +105,15 @@ class LLMNotFoundError(LLMError):
     """Raised when the requested resource is not found."""
 
 
-class LLMTimeout(LLMError):
-    """Raised when the request to the LLM service times out."""
+class LLMConnectionError(LLMError):
+    """Raised when the transport layer fails — a connection that couldn't be established,
+    was dropped/reset, or stalled. Distinct from LLMInternalServerError (a provider 5xx):
+    nothing reached the model, or the connection died mid-stream. Transient and retryable."""
+
+
+class LLMTimeout(LLMConnectionError):
+    """Raised when a request to the LLM service times out (a stalled connection). A
+    specific kind of LLMConnectionError, e.g. a streaming read exceeding its timeout."""
 
 
 class LLMUnprocessableEntityError(LLMError):
@@ -191,6 +204,9 @@ def llm_error_message(error: LLMError, model: str | None = None) -> str:
     if isinstance(error, LLMTimeout):
         return f"{provider_model} timed out while processing this request. Please try again."
 
+    if isinstance(error, LLMConnectionError):
+        return f"{provider_model} could not be reached (connection error). Please try again."
+
     if isinstance(error, LLMContentPolicyViolationError):
         return f"{provider_model} blocked this request due to the provider's content policy."
 
@@ -247,6 +263,14 @@ def map_openai_errors(error: OpenAIError) -> LLMError:
             return LLMRateLimitError(message=f"OpenAI APIError: {str(error)}", provider=ModelProvider.OPENAI.value)
         elif error.status_code == 500:
             return LLMInternalServerError(message=f"OpenAI APIError: {str(error)}", provider=ModelProvider.OPENAI.value)
+
+    # Transport failures (a stalled streaming read hitting the per-request timeout, a
+    # dropped/reset connection) are retryable. APITimeoutError subclasses APIConnectionError,
+    # so check the timeout case first for the more specific error/message.
+    if isinstance(error, OpenAIAPITimeoutError):
+        return LLMTimeout(message=f"OpenAI APIError: {str(error)}", provider=ModelProvider.OPENAI.value)
+    if isinstance(error, OpenAIAPIConnectionError):
+        return LLMConnectionError(message=f"OpenAI APIError: {str(error)}", provider=ModelProvider.OPENAI.value)
 
     return LLMError(message=f"OpenAI APIError: {str(error)}", provider=ModelProvider.OPENAI.value)
 
@@ -333,6 +357,14 @@ def map_anthropic_errors(error: AnthropicError, provider: str | None = None) -> 
         if error.status_code == 529:
             return LLMInternalServerError(message=f"AnthropicError: {str(error)}", provider=provider)
 
+    # Transport failures (a stalled streaming read hitting the per-request timeout, a
+    # dropped/reset connection) are retryable. APITimeoutError subclasses APIConnectionError,
+    # so check the timeout case first for the more specific error/message.
+    if isinstance(error, AnthropicAPITimeoutError):
+        return LLMTimeout(message=f"AnthropicError: {str(error)}", provider=provider)
+    if isinstance(error, AnthropicAPIConnectionError):
+        return LLMConnectionError(message=f"AnthropicError: {str(error)}", provider=provider)
+
     return LLMError(message=f"AnthropicError: {str(error)}", provider=provider)
 
 
@@ -365,14 +397,20 @@ def map_to_llm_error(error: Exception, provider: str = None) -> LLMError:
     # Map common Python exceptions
     if isinstance(error, ValueError):
         return LLMInvalidRequestError(message=f"Invalid parameter: {str(error)}", provider=provider)
+    elif httpx and isinstance(error, httpx.TimeoutException):
+        # Read/connect/pool/write timeouts (e.g. a stalled streaming read). Check before
+        # the broader TransportError below; LLMTimeout is an LLMConnectionError subclass.
+        return LLMTimeout(message=f"Request timeout: {str(error)}", provider=provider)
     elif isinstance(error, (TimeoutError, asyncio.TimeoutError)):
         return LLMTimeout(message=f"Request timeout: {str(error)}", provider=provider)
     elif isinstance(error, ConnectionError):
-        return LLMInternalServerError(message=f"Connection error: {str(error)}", provider=provider)
+        return LLMConnectionError(message=f"Connection error: {str(error)}", provider=provider)
     elif aiohttp and isinstance(error, aiohttp.ClientError):
-        return LLMInternalServerError(message=f"HTTP client error: {str(error)}", provider=provider)
-    elif httpx and isinstance(error, httpx.RemoteProtocolError):
-        return LLMInternalServerError(message=f"HTTPX protocol error: {str(error)}", provider=provider)
+        return LLMConnectionError(message=f"HTTP client error: {str(error)}", provider=provider)
+    elif httpx and isinstance(error, httpx.TransportError):
+        # Connect/read/protocol/reset errors — transient transport failures (e.g. a dropped
+        # streaming connection), so retryable.
+        return LLMConnectionError(message=f"HTTPX transport error: {str(error)}", provider=provider)
     elif isinstance(error, KeyError):
         return LLMInvalidRequestError(message=f"Missing required parameter: {str(error)}", provider=provider)
     elif isinstance(error, TypeError):

--- a/kolega_code/llm/providers/anthropic.py
+++ b/kolega_code/llm/providers/anthropic.py
@@ -1,12 +1,14 @@
 import json
 import os
 from typing import Any, AsyncContextManager, Dict, List, Optional
+from weakref import WeakKeyDictionary
 
 import tiktoken
 from anthropic import Anthropic, AsyncAnthropic
 
 from ..models import Message, MessageChunk, MessageHistory, ToolDefinition
 from ..specs import build_thinking_request_params, get_model_specs
+from ..timeouts import streaming_timeout
 from ..tool_execution_ids import ToolExecutionIdRegistry
 from .base import BaseLLMProvider
 from .models import GenerationParams, TokenCount
@@ -120,6 +122,15 @@ class AnthropicProvider(BaseLLMProvider):
             or os.getenv("ANTHROPIC_USE_LOCAL_TOKEN_COUNTING", "false").lower() == "true"
         )
 
+        # Per-message / per-tool memos for local token counting. _count_tokens_local runs
+        # every agent-loop iteration over the whole history; without this it re-encodes the
+        # entire conversation each time (O(history) on the event loop). Keyed by object
+        # identity so unchanged messages are counted once; a recursive length fingerprint
+        # catches in-place edits (an oversized tool result being truncated). Compaction /
+        # adaptation / repair produce new objects, which miss naturally.
+        self._local_token_memo: "WeakKeyDictionary[Message, tuple]" = WeakKeyDictionary()
+        self._local_tool_token_memo: "WeakKeyDictionary[ToolDefinition, int]" = WeakKeyDictionary()
+
     @property
     def retry_decorator(self):
         """Get retry decorator with configured max retries"""
@@ -223,22 +234,102 @@ class AnthropicProvider(BaseLLMProvider):
             TokenCount object with estimated input token count
         """
         encoding = tiktoken.get_encoding("p50k_base")
-        num_tokens = 0
+        self._ensure_local_token_memos()
         tools = tools or []
 
+        # Sum memoized per-message content counts: only new or changed messages are
+        # re-encoded each iteration (system is a Message too).
+        num_tokens = 0
         if system:
-            num_tokens += self.SYSTEM_OVERHEAD
-            num_tokens += self._count_message_content_tokens(encoding, system.content)
-
+            num_tokens += self.SYSTEM_OVERHEAD + self._memoized_content_tokens(encoding, system)
         for message in messages:
-            num_tokens += self.MESSAGE_OVERHEAD
-            num_tokens += self._count_message_content_tokens(encoding, message.content)
-
+            num_tokens += self.MESSAGE_OVERHEAD + self._memoized_content_tokens(encoding, message)
         for tool in tools:
-            num_tokens += self._count_value_tokens(encoding, tool.to_anthropic())
-            num_tokens += self.TOOL_DEFINITION_OVERHEAD
+            num_tokens += self._memoized_tool_tokens(encoding, tool)
 
         return TokenCount(input_tokens=num_tokens, output_tokens=None)
+
+    def _ensure_local_token_memos(self) -> None:
+        # Instances built via __new__ (tests) skip __init__, so create lazily.
+        if getattr(self, "_local_token_memo", None) is None:
+            self._local_token_memo = WeakKeyDictionary()
+        if getattr(self, "_local_tool_token_memo", None) is None:
+            self._local_tool_token_memo = WeakKeyDictionary()
+
+    def _memoized_content_tokens(self, encoding, message) -> int:
+        fingerprint = self._content_fingerprint(message.content)
+        try:
+            cached = self._local_token_memo.get(message)
+        except TypeError:  # message not weak-referenceable / hashable
+            cached = None
+        if cached is not None and cached[0] == fingerprint:
+            return cached[1]
+        value = self._count_message_content_tokens(encoding, message.content)
+        try:
+            self._local_token_memo[message] = (fingerprint, value)
+        except TypeError:
+            pass
+        return value
+
+    def _memoized_tool_tokens(self, encoding, tool) -> int:
+        try:
+            cached = self._local_tool_token_memo.get(tool)
+        except TypeError:
+            cached = None
+        if cached is not None:
+            return cached
+        value = self._count_value_tokens(encoding, tool.to_anthropic()) + self.TOOL_DEFINITION_OVERHEAD
+        try:
+            self._local_tool_token_memo[tool] = value
+        except TypeError:
+            pass
+        return value
+
+    # Cheap (lengths-only) signatures mirroring _count_*_tokens branch-for-branch. The
+    # count for a fixed message structure changes only when an encoded length changes, so
+    # a fingerprint change is necessary and sufficient to invalidate a memoized count for
+    # the same object (e.g. in-place truncation of an oversized tool result). Structural /
+    # type changes arrive as new objects (identity miss), so need not be captured here.
+    def _content_fingerprint(self, content: Any):
+        if isinstance(content, str):
+            return len(content)
+        if isinstance(content, list):
+            return tuple(self._block_fingerprint(block) for block in content)
+        return self._value_fingerprint(content)
+
+    def _block_fingerprint(self, block: Any):
+        if hasattr(block, "text"):
+            return ("text", len(block.text))
+        if getattr(block, "type", None) == "image_url":
+            data = getattr(block, "data", None)
+            return ("image_url", len(data) if isinstance(data, str) else None)
+        if getattr(block, "type", None) == "tool_result":
+            return ("tool_result", self._content_fingerprint(getattr(block, "content", "")))
+        if hasattr(block, "thinking"):
+            return ("thinking", len(block.thinking))
+        if hasattr(block, "data"):
+            return ("data", len(str(block.data)))
+        if hasattr(block, "to_anthropic"):
+            return ("to_anthropic", self._value_fingerprint(block.to_anthropic()))
+        return ("value", self._value_fingerprint(block))
+
+    def _value_fingerprint(self, value: Any):
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return len(value)
+        if isinstance(value, (int, float, bool)):
+            return ("scalar", str(value))
+        if isinstance(value, list):
+            return tuple(self._value_fingerprint(item) for item in value)
+        if isinstance(value, dict):
+            if value.get("type") == "image":
+                source = value.get("source") or {}
+                data = source.get("data")
+                if isinstance(data, str):
+                    return ("image", len(data))
+            return tuple((str(key), self._value_fingerprint(item)) for key, item in value.items())
+        return ("other",)
 
     def _count_message_content_tokens(self, encoding, content: Any) -> int:
         if isinstance(content, str):
@@ -356,11 +447,14 @@ class AnthropicProvider(BaseLLMProvider):
 
         await self.rate_limiter.acquire()
 
-        # Return the stream context manager
+        # Return the stream context manager. A per-request streaming timeout bounds the
+        # inter-chunk read wait (see kolega_code/llm/timeouts.py) so a stalled connection
+        # fails in minutes and is retried, instead of hanging on the SDK's 600s default.
         return AnthropicStreamWrapper(
             self.async_client.messages.stream(
                 messages=messages.to_anthropic(),
                 system=[c.to_anthropic() for c in system.content],
+                timeout=streaming_timeout(),
                 **generation_params,
             ),
             provider_name=self.provider_name,

--- a/kolega_code/llm/providers/chatgpt_oauth.py
+++ b/kolega_code/llm/providers/chatgpt_oauth.py
@@ -94,7 +94,12 @@ class ChatGPTOAuthProvider(ResponsesProviderBase):
             base_url=self.base_url,
             max_retries=max_retries,
             default_headers=default_headers,
-            http_client=httpx.AsyncClient(auth=ChatGPTAuth(token_manager), timeout=600.0),
+            # Bound connect (the flat 600.0 also meant a 600s *connect* timeout); the
+            # per-request streaming timeout in responses_common.stream() caps the read.
+            http_client=httpx.AsyncClient(
+                auth=ChatGPTAuth(token_manager),
+                timeout=httpx.Timeout(connect=10.0, read=600.0, write=30.0, pool=10.0),
+            ),
         )
         # The Responses path is async-only; the sync client is unused.
         self.sync_client = None

--- a/kolega_code/llm/providers/google.py
+++ b/kolega_code/llm/providers/google.py
@@ -155,6 +155,12 @@ class GoogleProvider(BaseLLMProvider):
 
         await self.rate_limiter.acquire()
 
+        # NOTE: no per-request streaming read timeout here. Unlike the httpx-based
+        # providers (see kolega_code/llm/timeouts.py), google-genai's HttpOptions exposes
+        # only a single *total-request* timeout, not a per-read (inter-chunk) one. A total
+        # bound would wrongly cut legitimately long streams, so bounding a silent stall on
+        # Google would require an inactivity watchdog around the loop instead. Left as-is
+        # until a Google stall is actually observed.
         return GoogleStreamWrapper(
             await self.async_client.aio.models.generate_content_stream(
                 model=model, contents=messages.to_google(), config=config

--- a/kolega_code/llm/providers/openai.py
+++ b/kolega_code/llm/providers/openai.py
@@ -9,6 +9,7 @@ from openai import AsyncOpenAI, OpenAI
 
 from ..models import ImageBlock, Message, MessageChunk, MessageHistory, ToolCall, ToolDefinition, ToolResult
 from ..specs import build_thinking_request_params
+from ..timeouts import streaming_timeout
 from ..tool_execution_ids import ToolExecutionIdRegistry
 from .base import BaseLLMProvider
 from .models import GenerationParams, TokenCount
@@ -432,8 +433,13 @@ class OpenAIProvider(BaseLLMProvider):
 
         await self.rate_limiter.acquire()
 
+        # Per-request streaming timeout bounds the inter-chunk read wait (see
+        # kolega_code/llm/timeouts.py): a stalled connection fails in minutes and is
+        # retried, instead of hanging on the SDK's 600s default.
         return OpenAIStreamWrapper(
-            await self.async_client.chat.completions.create(messages=messages.to_openai(), **generation_params),
+            await self.async_client.chat.completions.create(
+                messages=messages.to_openai(), timeout=streaming_timeout(), **generation_params
+            ),
             requested_include_usage=True,
             provider_name=self.provider_name,
         )

--- a/kolega_code/llm/providers/responses_common.py
+++ b/kolega_code/llm/providers/responses_common.py
@@ -23,6 +23,7 @@ from typing import Any, AsyncIterator, Dict, List, Optional
 
 from kolega_code.auth import constants as chatgpt_constants
 
+from ..timeouts import streaming_timeout
 from ..models import (
     ImageBlock,
     Message,
@@ -551,7 +552,9 @@ class ResponsesProviderBase(OpenAIProvider):
     ) -> ResponsesStreamWrapper:
         request = self._build_request(messages, system, params, kwargs)
         await self.rate_limiter.acquire()
-        responses_stream = await self.async_client.responses.create(**request)
+        # Per-request streaming timeout bounds the inter-chunk read wait (see
+        # kolega_code/llm/timeouts.py) instead of the SDK's 600s default.
+        responses_stream = await self.async_client.responses.create(timeout=streaming_timeout(), **request)
         return ResponsesStreamWrapper(responses_stream, provider_name=self.provider_name)
 
     async def generate(

--- a/kolega_code/llm/timeouts.py
+++ b/kolega_code/llm/timeouts.py
@@ -1,0 +1,37 @@
+"""Shared HTTP timeout policy for LLM provider clients.
+
+Provider SDK clients otherwise inherit the SDK default of a 600s (10 min) read
+timeout. On a streaming turn that means a stalled connection — a reasoning model
+that goes silent, or an idle connection dropped by a load balancer in front of the
+endpoint — blocks for up to 10 minutes before erroring, leaving sockets in CLOSE_WAIT
+and the turn apparently frozen.
+
+For streaming we bound the *per-read* (inter-chunk) wait instead: if no bytes arrive
+for ``STREAM_READ_TIMEOUT`` seconds the connection is treated as dead, the request
+fails, and the agent loop retries it (a stream read timeout is classified as a
+retryable transport error). 300s is deliberately generous so it never cuts a slow
+time-to-first-token on a large context, while still being far below the 600s hang.
+
+Use per-request on the streaming call (not the client default) so non-streaming
+``generate``/``count_tokens`` keep the SDK's generous read budget.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+# Seconds.
+STREAM_CONNECT_TIMEOUT = 10.0
+STREAM_READ_TIMEOUT = 300.0
+STREAM_WRITE_TIMEOUT = 30.0
+STREAM_POOL_TIMEOUT = 10.0
+
+
+def streaming_timeout() -> httpx.Timeout:
+    """httpx.Timeout for streaming requests (bounded per-read inter-chunk wait)."""
+    return httpx.Timeout(
+        connect=STREAM_CONNECT_TIMEOUT,
+        read=STREAM_READ_TIMEOUT,
+        write=STREAM_WRITE_TIMEOUT,
+        pool=STREAM_POOL_TIMEOUT,
+    )

--- a/tests/agent/llm/test_anthropic_local_token_counting_incremental.py
+++ b/tests/agent/llm/test_anthropic_local_token_counting_incremental.py
@@ -1,0 +1,107 @@
+"""Incremental local (tiktoken) token counting for the Anthropic provider must equal a
+from-scratch recount.
+
+DeepSeek/moonshot/kimi route through AnthropicProvider with ``use_local_token_counting``,
+so ``_count_tokens_local`` runs every agent-loop iteration over the whole history. It now
+memoizes per-message counts (identity-keyed, guarded by a recursive length fingerprint) so
+only new/changed messages are re-encoded. These tests pin that the memoized total always
+equals a fresh provider's full recount — including across in-place tool-result truncation,
+object replacement (adaptation/compaction), shrink, and system + tools. No API key needed.
+"""
+
+import asyncio
+
+from kolega_code.llm.models import (
+    Message,
+    MessageHistory,
+    TextBlock,
+    ToolDefinition,
+    ToolParameter,
+    ToolResult,
+)
+from kolega_code.llm.providers.anthropic import AnthropicProvider
+
+
+def _provider() -> AnthropicProvider:
+    # __new__ skips __init__ (no API key / client). Force the local-counting branch.
+    provider = AnthropicProvider.__new__(AnthropicProvider)
+    provider.use_local_token_counting = True
+    return provider
+
+
+def _count(provider, messages, *, system=None, tools=None) -> int:
+    return asyncio.run(
+        provider.count_tokens(messages=messages, system=system, model="x", tools=tools or [])
+    ).input_tokens
+
+
+def _fresh_count(messages, *, system=None, tools=None) -> int:
+    return _count(_provider(), messages, system=system, tools=tools)
+
+
+def _text(role: str, text: str) -> Message:
+    return Message(role=role, content=[TextBlock(text=text)])
+
+
+def _history(n: int) -> MessageHistory:
+    return MessageHistory([_text("user" if i % 2 == 0 else "assistant", f"message {i} " * 20) for i in range(n)])
+
+
+def test_repeated_count_is_stable():
+    provider = _provider()
+    history = _history(15)
+    first = _count(provider, history)
+    second = _count(provider, history)
+    assert first == second == _fresh_count(history)
+
+
+def test_incremental_matches_fresh_on_append():
+    provider = _provider()
+    history = _history(15)
+    _count(provider, history)
+    history.append(_text("user", "appended follow-up " * 12))
+    assert _count(provider, history) == _fresh_count(history)
+
+
+def test_fingerprint_invalidates_on_inplace_tool_result_truncation():
+    result = ToolResult(tool_use_id="t1", content="X" * 8000, name="do", is_error=False)
+    history = MessageHistory([_text("user", "run it"), Message(role="tool", content=[result])])
+    provider = _provider()
+    before = _count(provider, history)
+    result.content = "X" * 40  # simulate _sanitize_oversized_tool_results
+    after = _count(provider, history)
+    assert after != before
+    assert after == _fresh_count(history)
+
+
+def test_incremental_matches_fresh_after_object_replacement():
+    provider = _provider()
+    history = _history(10)
+    _count(provider, history)
+    history[3] = _text("assistant", "REPLACED content that differs " * 5)
+    assert _count(provider, history) == _fresh_count(history)
+
+
+def test_incremental_matches_fresh_with_system_and_tools():
+    provider = _provider()
+    system = _text("system", "You are helpful. " * 12)
+    tools = [
+        ToolDefinition(
+            name="search", description="Search the web.", parameters=[ToolParameter("q", "string", "query", True)]
+        ),
+        ToolDefinition(
+            name="read", description="Read a file.", parameters=[ToolParameter("path", "string", "path", True)]
+        ),
+    ]
+    history = _history(8)
+    _count(provider, history, system=system, tools=tools)
+    history.append(_text("user", "follow-up"))
+    assert _count(provider, history, system=system, tools=tools) == _fresh_count(history, system=system, tools=tools)
+
+
+def test_shrinking_history_recounts_correctly():
+    provider = _provider()
+    history = _history(30)
+    _count(provider, history)
+    shorter = MessageHistory(list(history)[:5])
+    assert _count(provider, shorter) == _fresh_count(shorter)

--- a/tests/agent/llm/test_error_boundary.py
+++ b/tests/agent/llm/test_error_boundary.py
@@ -16,6 +16,7 @@ from kolega_code.llm.client import LLMClient
 from kolega_code.llm.exceptions import (
     LLMBillingError,
     LLMAuthenticationError,
+    LLMConnectionError,
     LLMContextWindowExceededError,
     LLMError,
     LLMInternalServerError,
@@ -61,10 +62,11 @@ class TestErrorMapping:
         assert isinstance(mapped, LLMTimeout)
 
     def test_connection_error_mapping(self):
-        """Test that ConnectionError maps to LLMInternalServerError."""
+        """Test that ConnectionError maps to LLMConnectionError (a transport failure, not a 5xx)."""
         error = ConnectionError("Connection failed")
         mapped = map_to_llm_error(error, "test_provider")
-        assert isinstance(mapped, LLMInternalServerError)
+        assert isinstance(mapped, LLMConnectionError)
+        assert not isinstance(mapped, LLMInternalServerError)
         assert "Connection error" in str(mapped)
 
     def test_key_error_mapping(self):
@@ -102,7 +104,7 @@ class TestErrorMapping:
         assert mapped.provider == "test_provider"
 
     def test_httpx_remote_protocol_error_mapping(self):
-        """Test that httpx.RemoteProtocolError maps to LLMInternalServerError."""
+        """httpx.RemoteProtocolError (a TransportError) maps to the retryable LLMConnectionError."""
         try:
             import httpx  # type: ignore
         except Exception:
@@ -112,8 +114,8 @@ class TestErrorMapping:
             "peer closed connection without sending complete message body (incomplete chunked read)"
         )
         mapped = map_to_llm_error(error, "anthropic")
-        assert isinstance(mapped, LLMInternalServerError)
-        assert "HTTPX protocol error" in str(mapped)
+        assert isinstance(mapped, LLMConnectionError)
+        assert "HTTPX transport error" in str(mapped)
 
     def test_provider_error_mapping(self):
         """Test that provider-specific errors are mapped correctly."""
@@ -170,9 +172,9 @@ class TestLLMClientErrorBoundary:
         assert "Invalid parameter" in str(exc_info.value)
         assert exc_info.value.provider == "openai"
 
-        # Test ConnectionError
+        # Test ConnectionError (a transport failure → retryable LLMConnectionError, not a 5xx)
         client.provider.generate = AsyncMock(side_effect=ConnectionError("Connection lost"))
-        with pytest.raises(LLMInternalServerError) as exc_info:
+        with pytest.raises(LLMConnectionError) as exc_info:
             await client.generate(messages)
         assert "Connection error" in str(exc_info.value)
 

--- a/tests/agent/llm/test_streaming_timeouts.py
+++ b/tests/agent/llm/test_streaming_timeouts.py
@@ -1,0 +1,109 @@
+"""Streaming requests must carry a bounded per-request timeout, and a stalled-stream
+timeout must be classified as retryable.
+
+Without an explicit timeout the SDK clients inherit a 600s read default, so a stalled
+DeepSeek stream hangs ~10 min and leaks CLOSE_WAIT sockets. Each provider's stream() now
+passes ``streaming_timeout()`` (300s read), and SDK connection/timeout errors map to the
+retryable ``LLMInternalServerError`` so the agent loop re-issues the request.
+"""
+
+from unittest.mock import AsyncMock, Mock
+
+import httpx
+import pytest
+
+from anthropic import APITimeoutError as AnthropicAPITimeoutError
+from openai import APITimeoutError as OpenAIAPITimeoutError
+
+from kolega_code.llm.exceptions import LLMConnectionError, LLMTimeout, map_to_llm_error
+from kolega_code.llm.models import Message, MessageHistory, TextBlock
+from kolega_code.llm.providers.anthropic import AnthropicProvider
+from kolega_code.llm.providers.openai import OpenAIProvider
+from kolega_code.llm.providers.models import GenerationParams
+from kolega_code.llm.timeouts import STREAM_READ_TIMEOUT, streaming_timeout
+
+
+class _RateLimiter:
+    async def acquire(self) -> None:
+        return None
+
+
+def _system() -> Message:
+    return Message(role="system", content=[TextBlock(text="system prompt")])
+
+
+def _messages() -> MessageHistory:
+    return MessageHistory([Message(role="user", content=[TextBlock(text="hello")])])
+
+
+def test_streaming_timeout_value():
+    timeout = streaming_timeout()
+    assert isinstance(timeout, httpx.Timeout)
+    assert timeout.read == STREAM_READ_TIMEOUT == 300.0
+    # Far below the 600s SDK default that caused the hang.
+    assert timeout.read < 600.0
+
+
+@pytest.mark.asyncio
+async def test_anthropic_stream_passes_timeout():
+    provider = AnthropicProvider.__new__(AnthropicProvider)
+    provider.provider_name = "deepseek"
+    provider.rate_limiter = _RateLimiter()
+    provider.async_client = Mock()
+    provider.async_client.messages.stream = Mock(return_value=Mock())
+
+    await provider.stream(_messages(), system=_system(), params=GenerationParams())
+
+    _, kwargs = provider.async_client.messages.stream.call_args
+    assert "timeout" in kwargs
+    assert kwargs["timeout"].read == 300.0
+
+
+@pytest.mark.asyncio
+async def test_openai_stream_passes_timeout():
+    provider = OpenAIProvider.__new__(OpenAIProvider)
+    provider.provider_name = "deepseek"
+    provider.rate_limiter = _RateLimiter()
+    provider.async_client = Mock()
+    provider.async_client.chat.completions.create = AsyncMock(return_value=Mock())
+
+    await provider.stream(_messages(), system=_system(), params=GenerationParams())
+
+    _, kwargs = provider.async_client.chat.completions.create.call_args
+    assert "timeout" in kwargs
+    assert kwargs["timeout"].read == 300.0
+
+
+def test_anthropic_timeout_error_maps_to_llm_timeout():
+    request = httpx.Request("POST", "https://api.deepseek.com/anthropic/v1/messages")
+    mapped = map_to_llm_error(AnthropicAPITimeoutError(request=request), "deepseek")
+    assert isinstance(mapped, LLMTimeout)
+    assert isinstance(mapped, LLMConnectionError)  # retryable family, not a 5xx
+
+
+def test_openai_timeout_error_maps_to_llm_timeout():
+    request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    mapped = map_to_llm_error(OpenAIAPITimeoutError(request=request), "openai")
+    assert isinstance(mapped, LLMTimeout)
+    assert isinstance(mapped, LLMConnectionError)
+
+
+def test_httpx_read_timeout_maps_to_llm_timeout():
+    mapped = map_to_llm_error(httpx.ReadTimeout("timed out"), "deepseek")
+    assert isinstance(mapped, LLMTimeout)
+
+
+def test_connection_drop_maps_to_connection_error():
+    # A dropped/reset connection (not a timeout) is a plain LLMConnectionError, still retryable.
+    mapped = map_to_llm_error(httpx.ConnectError("connection refused"), "deepseek")
+    assert isinstance(mapped, LLMConnectionError)
+    assert not isinstance(mapped, LLMTimeout)
+
+
+def test_connection_errors_are_retryable_by_the_agent_loop():
+    # Pin the contract handle_llm_error relies on: connection failures are the retryable family.
+    from kolega_code.llm.exceptions import LLMRateLimitError
+
+    assert issubclass(LLMTimeout, LLMConnectionError)
+    # Distinct from the server-error family (mislabeling a transport error as a 5xx was the bug).
+    assert not issubclass(LLMConnectionError, LLMRateLimitError)


### PR DESCRIPTION
## Problem

No LLM provider set an explicit HTTP timeout, so every SDK client inherited the 600s (10 min) read default. On a streaming turn this meant a stalled connection — a reasoning model going silent, or an idle connection dropped by a load balancer in front of the endpoint — blocked for up to 10 minutes before erroring. The turn appeared frozen, sockets leaked into `CLOSE_WAIT`, and a mid-stream timeout wasn't even retryable. Transport errors (connect/drop/reset/protocol) were also mislabeled as server 5xx (`LLMInternalServerError`), which is the wrong category.

Separately, `AnthropicProvider._count_tokens_local` (the local-counting path DeepSeek and other Anthropic-compatible providers use) re-encoded the entire conversation every agent-loop iteration, adding avoidable per-turn CPU cost.

## Fix

**Streaming timeouts.** New `kolega_code/llm/timeouts.py` defines a shared policy (`connect=10`, `read=300`, `write=30`, `pool=10`) passed per-request on `stream()` for the Anthropic, OpenAI, Responses, and ChatGPT-OAuth providers. The flat `600.0` on the ChatGPT-OAuth client (which was also a 600s *connect* timeout) is fixed. A stall now fails in ≤300s instead of 600s. Per-request (not client-default) so non-streaming `generate`/`count_tokens` keep the SDK's generous read budget.

**Retryable transport errors.** Added a dedicated `LLMConnectionError` for transport-layer failures, with `LLMTimeout` as its subclass (a timeout is a stalled connection). SDK `APITimeoutError`/`APIConnectionError`, `httpx.TimeoutException`/`TransportError`, and builtin `ConnectionError`/`TimeoutError` all map into this retryable family. The agent retry set is now `(LLMRateLimitError, LLMInternalServerError, LLMConnectionError)`, so a stalled or dropped stream is retried and surfaces a "Connection issue — retrying (n/N)…" status instead of a silent freeze.

**Incremental token counting.** Memoized `_count_tokens_local` per-message (identity-keyed, guarded by a recursive length fingerprint that catches in-place edits like tool-result truncation), matching the existing OpenAI fix — only new/changed messages are re-encoded each iteration.

**Google** is intentionally excluded: its SDK exposes only a total-request timeout, which would wrongly cut legitimately long streams; bounding a stall there needs an inactivity watchdog (out of scope).

## Verification

- `tests/agent/llm/`: 300 passed (the single failure is a live `together` provider test requiring network/API access, unrelated to this change).
- New/changed tests (32) pass: incremental Anthropic-local token counting (equals a fresh recount across append/truncation/replace/shrink/system+tools), streaming timeout passed to each provider's stream call, and the `LLMConnectionError`/`LLMTimeout` taxonomy + retryability. Three existing `test_error_boundary.py` assertions updated to encode the corrected mapping.
- `ruff check` + `ruff format` clean.
