### PR TITLE
fix(llm): route DeepSeek through OpenAI-compatible /v1 endpoint

### DIFF
--- a/kolega_code/llm/client.py
+++ b/kolega_code/llm/client.py
@@ -132,7 +132,11 @@ class LLMClient:
                 "xai": OpenAIProvider,
                 "dashscope": OpenAIProvider,
                 "moonshot": AnthropicProvider,
-                "deepseek": AnthropicProvider,
+                # DeepSeek's OpenAI-compatible /v1 endpoint streams reasoning_content
+                # continuously; its Anthropic-compatible endpoint goes silent during
+                # reasoning, so an idle-connection drop hangs streaming turns. Route
+                # through the OpenAI Chat path (matches opencode/openclaw, which work).
+                "deepseek": OpenAIProvider,
                 "zai": AnthropicProvider,
                 "kimi_coding": AnthropicProvider,
                 "ollama_cloud": OpenAIProvider,
@@ -148,7 +152,7 @@ class LLMClient:
                 "xai": "https://api.x.ai/v1",
                 "dashscope": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
                 "moonshot": "https://api.moonshot.ai/anthropic",
-                "deepseek": "https://api.deepseek.com/anthropic",
+                "deepseek": "https://api.deepseek.com/v1",
                 "zai": "https://api.z.ai/api/anthropic",
                 "kimi_coding": "https://api.kimi.com/coding",
                 "ollama_cloud": "https://ollama.com/v1",

--- a/kolega_code/llm/instrumented_client.py
+++ b/kolega_code/llm/instrumented_client.py
@@ -89,12 +89,22 @@ class InstrumentedLLMClient(LLMClient):
 
         provider = usage_metadata.get("provider", self.provider_name)
 
-        if provider in ["anthropic", "moonshot", "deepseek", "kimi_coding"]:
+        if provider in ["anthropic", "moonshot", "kimi_coding"]:
             input_tokens = usage_metadata.get("input_tokens", 0)
             output_tokens = usage_metadata.get("output_tokens", 0)
             cache_read_tokens = usage_metadata.get("cache_read_input_tokens", 0)
             cache_write_tokens = usage_metadata.get("cache_write_input_tokens", 0)
-        elif provider in ["openai", "openai_chatgpt", "together", "groq", "fireworks", "llama", "xai", "dashscope"]:
+        elif provider in [
+            "openai",
+            "openai_chatgpt",
+            "together",
+            "groq",
+            "fireworks",
+            "llama",
+            "xai",
+            "dashscope",
+            "deepseek",
+        ]:
             input_tokens = usage_metadata.get("prompt_tokens", 0)
             output_tokens = usage_metadata.get("completion_tokens", 0)
             cache_read_tokens = usage_metadata.get("cache_read_input_tokens", 0)
@@ -246,7 +256,7 @@ class InstrumentedLLMClient(LLMClient):
             normalized_usage = None
             if usage_details:
                 provider = usage_details.get("provider", self.provider_name)
-                if provider in ["anthropic", "moonshot", "deepseek", "kimi_coding"]:
+                if provider in ["anthropic", "moonshot", "kimi_coding"]:
                     normalized_usage = {
                         "input": usage_details.get("input_tokens", 0),
                         "output": usage_details.get("output_tokens", 0),
@@ -254,7 +264,7 @@ class InstrumentedLLMClient(LLMClient):
                         "cache_read_input_tokens": usage_details.get("cache_read_input_tokens", 0),
                         "cache_creation_input_tokens": usage_details.get("cache_write_input_tokens", 0),
                     }
-                elif provider in ["openai", "openai_chatgpt", "fireworks"]:
+                elif provider in ["openai", "openai_chatgpt", "fireworks", "deepseek"]:
                     normalized_usage = {
                         "input": usage_details.get("prompt_tokens", 0),
                         "output": usage_details.get("completion_tokens", 0),
@@ -495,7 +505,7 @@ class MinimalLangfuseStreamWrapper:
         usage_metadata = message.usage_metadata
         provider = usage_metadata.get("provider", "")
 
-        if provider in ["anthropic", "moonshot", "deepseek", "kimi_coding"]:
+        if provider in ["anthropic", "moonshot", "kimi_coding"]:
             return {
                 "input": usage_metadata.get("input_tokens", 0),
                 "output": usage_metadata.get("output_tokens", 0),
@@ -503,7 +513,7 @@ class MinimalLangfuseStreamWrapper:
                 "cache_read_input_tokens": usage_metadata.get("cache_read_input_tokens", 0),
                 "cache_creation_input_tokens": usage_metadata.get("cache_write_input_tokens", 0),
             }
-        elif provider in ["openai", "openai_chatgpt", "fireworks"]:
+        elif provider in ["openai", "openai_chatgpt", "fireworks", "deepseek"]:
             return {
                 "input": usage_metadata.get("prompt_tokens", 0),
                 "output": usage_metadata.get("completion_tokens", 0),

--- a/kolega_code/llm/providers/anthropic.py
+++ b/kolega_code/llm/providers/anthropic.py
@@ -118,7 +118,7 @@ class AnthropicProvider(BaseLLMProvider):
         # so local counting is only a preflight context-size estimate for those models.
         # Billing/accounting must use provider response usage metadata instead.
         self.use_local_token_counting = (
-            provider_name in {"moonshot", "deepseek", "kimi_coding"}
+            provider_name in {"moonshot", "kimi_coding"}
             or os.getenv("ANTHROPIC_USE_LOCAL_TOKEN_COUNTING", "false").lower() == "true"
         )
 

--- a/kolega_code/llm/specs/thinking.py
+++ b/kolega_code/llm/specs/thinking.py
@@ -54,12 +54,13 @@ def build_thinking_request_params(provider: str, model_name: str, effort: Option
         }
 
     if spec.mode == "deepseek_effort":
+        # DeepSeek's OpenAI-compatible /v1 endpoint: reasoning is on by default and graded
+        # via the standard reasoning_effort param (high/max; it also accepts low/medium/xhigh,
+        # collapsing low/medium->high and xhigh->max). There is no reasoning_effort=none, so
+        # "none" disables thinking via the documented extra_body toggle instead.
         if normalized == "none":
-            return {"thinking": {"type": "disabled"}}
-        return {
-            "thinking": {"type": "enabled"},
-            "output_config": {"effort": normalized},
-        }
+            return {"extra_body": {"thinking": {"type": "disabled"}}}
+        return {"reasoning_effort": normalized}
 
     if spec.mode == "zai_effort":
         # Z.AI GLM toggles thinking via {"thinking": {"type": "enabled"|"disabled"}}.

--- a/tests/agent/llm/test_dashscope_mapping.py
+++ b/tests/agent/llm/test_dashscope_mapping.py
@@ -21,12 +21,13 @@ def test_llm_client_maps_moonshot_to_anthropic_provider():
     assert thinking == "auto"
 
 
-def test_llm_client_maps_deepseek_to_anthropic_provider():
+def test_llm_client_maps_deepseek_to_openai_v1_provider():
+    # DeepSeek's Anthropic-compatible endpoint stalls during reasoning; route through the
+    # OpenAI-compatible /v1 endpoint (matches opencode/openclaw, which work).
     client = LLMClient(provider="deepseek", api_key="sk-test")
-    assert isinstance(client.provider, AnthropicProvider)
-    assert client.provider.base_url == "https://api.deepseek.com/anthropic"
+    assert isinstance(client.provider, OpenAIProvider)
+    assert client.provider.base_url == "https://api.deepseek.com/v1"
     assert client.provider.provider_name == "deepseek"
-    assert client.provider.use_local_token_counting is True
 
     thinking = client._prepare_thinking_param("max", model="deepseek-v4-pro")
     assert thinking == "max"

--- a/tests/agent/llm/test_instrumented_client.py
+++ b/tests/agent/llm/test_instrumented_client.py
@@ -167,11 +167,13 @@ class TestInstrumentedLLMClient:
         assert usage["total_token_count"] == 150
 
     def test_normalize_usage_data_deepseek(self, instrumented_client):
+        # DeepSeek uses the OpenAI-compatible endpoint → OpenAI-shaped usage keys.
         usage = instrumented_client._normalize_usage_data(
             {
                 "provider": "deepseek",
-                "input_tokens": 100,
-                "output_tokens": 50,
+                "prompt_tokens": 100,
+                "completion_tokens": 50,
+                "total_tokens": 150,
                 "cache_read_input_tokens": 25,
                 "cache_write_input_tokens": 5,
             },

--- a/tests/agent/llm/test_langfuse_normalization.py
+++ b/tests/agent/llm/test_langfuse_normalization.py
@@ -27,13 +27,16 @@ def test_langfuse_normalizes_openai_cache_tokens():
 
 
 def test_langfuse_normalizes_deepseek_usage():
+    # DeepSeek now uses the OpenAI-compatible endpoint, so its usage is OpenAI-shaped
+    # (prompt_tokens/completion_tokens).
     msg = Message(
         role="assistant",
         content="ok",
         usage_metadata={
             "provider": "deepseek",
-            "input_tokens": 10,
-            "output_tokens": 2,
+            "prompt_tokens": 10,
+            "completion_tokens": 2,
+            "total_tokens": 12,
             "cache_read_input_tokens": 3,
             "cache_write_input_tokens": 4,
         },

--- a/tests/agent/llm/test_thinking_effort.py
+++ b/tests/agent/llm/test_thinking_effort.py
@@ -53,21 +53,31 @@ def test_anthropic_opus_effort_uses_adaptive_thinking_without_budget_tokens() ->
     assert "budget_tokens" not in generation_params["thinking"]
 
 
+def test_deepseek_routes_to_openai_v1_endpoint() -> None:
+    # DeepSeek's Anthropic-compatible endpoint stalls during reasoning (idle-connection
+    # drop). Route through the OpenAI-compatible /v1 endpoint, which streams reasoning
+    # continuously (matches opencode/openclaw).
+    client = LLMClient(provider="deepseek", api_key="test-key")
+    assert isinstance(client.provider, OpenAIProvider)
+    assert "api.deepseek.com/v1" in str(client.provider.async_client.base_url)
+
+
 def test_deepseek_thinking_effort_serialization() -> None:
-    provider = AnthropicProvider(api_key="test-key", provider_name="deepseek")
+    # DeepSeek routes through the OpenAI-compatible /v1 endpoint, so reasoning is graded via
+    # the standard reasoning_effort param, and "none" disables it via extra_body.
+    provider = OpenAIProvider(api_key="test-key", provider_name="deepseek")
 
     disabled_params = {"model": "deepseek-v4-pro"}
     provider._apply_thinking_params(disabled_params, GenerationParams(thinking="none"))
-    assert disabled_params == {"model": "deepseek-v4-pro", "thinking": {"type": "disabled"}}
+    assert disabled_params == {"model": "deepseek-v4-pro", "extra_body": {"thinking": {"type": "disabled"}}}
 
     high_params = {"model": "deepseek-v4-pro"}
     provider._apply_thinking_params(high_params, GenerationParams(thinking="high"))
-    assert high_params["thinking"] == {"type": "enabled"}
-    assert high_params["output_config"] == {"effort": "high"}
+    assert high_params["reasoning_effort"] == "high"
 
     max_params = {"model": "deepseek-v4-pro"}
     provider._apply_thinking_params(max_params, GenerationParams(thinking="max"))
-    assert max_params["output_config"] == {"effort": "max"}
+    assert max_params["reasoning_effort"] == "max"
 
 
 def test_zai_glm52_thinking_effort_serialization() -> None:


### PR DESCRIPTION
DeepSeek's Anthropic-compatible endpoint goes silent during reasoning, which causes idle-connection drops that hang streaming turns (manifesting as CLOSE_WAIT stalls). This routes DeepSeek through the OpenAI-compatible /v1 endpoint instead, which streams reasoning_content continuously.

## What changed

- **client.py**: DeepSeek now uses `OpenAIProvider` (was `AnthropicProvider`) with base URL `https://api.deepseek.com/v1`
- **thinking.py**: `deepseek_effort` emits `reasoning_effort` (high/max) and `extra_body` disable (none) instead of Anthropic `thinking`/`output_config` shape
- **anthropic.py**: removed deepseek from `use_local_token_counting` (no longer routes through Anthropic provider)
- **instrumented_client.py**: moved deepseek to OpenAI usage-normalization branches so token telemetry reads `prompt_tokens`/`completion_tokens` (3 normalization sites)
- **tests**: updated 4 tests that hard-coded the old Anthropic-shaped behavior; added a routing test verifying `OpenAIProvider` + `/v1` base URL

## Why

DeepSeek's [`/anthropic`](https://api.deepseek.com/anthropic) endpoint is Mesop-protocol-compatible but stops producing bytes during extended reasoning — leading to idle-connection drops that stall streaming turns indefinitely. Their `/v1` OpenAI-compatible endpoint streams `reasoning_content` deltas continuously, so the connection stays alive. The streaming timeout (300s) and `LLMConnectionError` retry from the previous round remain as a safety net.

## Verified

- **reasoning=high**: 108+ live thinking chunks streamed, final answer delivered
- **reasoning=none**: zero thinking chunks (reasoning disabled via `extra_body`)
- **reasoning=max**: 113+ thinking chunks streamed
- **Usage metadata**: OpenAI-shaped (`prompt_tokens`/`completion_tokens`/`cache_read_input_tokens`)
- **Tests**: 302/302 pass, ruff clean