### PR TITLE
feat: move file-index walk off the event loop and make images @-mentionable

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -158,6 +158,7 @@ class KolegaCodeApp(
         self.settings: CliSettings = CliSettings()
         self.skill_catalog: SkillCatalog = discover_skills(self.project_path)
         self.file_index = WorkspaceFileIndex(self.project_path)
+        self._file_index_refreshing = False
         self.browser_visible = browser_visible
         self.sidebar_visible = True
         self.check_for_updates = check_for_updates
@@ -419,6 +420,9 @@ class KolegaCodeApp(
         self._update_detach_button()
         if self.check_for_updates:
             self.run_worker(self._check_for_update_on_startup(), name="kolega-update-check", group="updates")
+        # Warm the @-mention file index off the event loop so the first mention has
+        # results without blocking the UI on os.walk (slow on iCloud/large trees).
+        self._maybe_refresh_file_index()
         self._schedule_conversation_bottom_anchor()
         self.run_worker(self._consume_events(), name="kolega-events", group="events")
         if self.config is not None:
@@ -832,11 +836,29 @@ class KolegaCodeApp(
         if active is None:
             dropdown.close()
             return
-        entries = self.file_index.search(active[0], limit=8)
+        # Search the cached snapshot only — never block the keystroke on os.walk. A
+        # stale/empty cache triggers a background refresh that re-runs this when done.
+        self._maybe_refresh_file_index()
+        entries = self.file_index.cached_search(active[0], limit=8)
         if not entries:
             dropdown.close()
             return
         dropdown.open_with([tui_widgets.file_completion_item(entry) for entry in entries])
+
+    def _maybe_refresh_file_index(self) -> None:
+        """Refresh the file index on a worker thread if it's stale and not already running."""
+        if self._file_index_refreshing or not self.file_index.is_stale():
+            return
+        self._file_index_refreshing = True
+        self.run_worker(self._refresh_file_index(), name="kolega-file-index", group="file-index")
+
+    async def _refresh_file_index(self) -> None:
+        try:
+            await asyncio.to_thread(self.file_index.refresh)
+        finally:
+            self._file_index_refreshing = False
+        # Surface freshly-walked results if an @-mention is still being typed.
+        self._refresh_completion_dropdown()
 
     def on_descendant_focus(self, event: events.DescendantFocus) -> None:
         # Fires after screen.focused settles. Catches AUTO_FOCUS landing on the

--- a/kolega_code/cli/file_index.py
+++ b/kolega_code/cli/file_index.py
@@ -11,6 +11,7 @@ from typing import List, Optional
 import pathspec
 
 from kolega_code.agent.tool_backend.glob_tool import GlobTool
+from kolega_code.utils.images import image_media_type
 
 
 @dataclass(frozen=True)
@@ -31,10 +32,15 @@ class WorkspaceFileIndex:
         self._refreshed_at: Optional[float] = None
 
     def entries(self) -> List[IndexEntry]:
-        now = time.monotonic()
-        if self._refreshed_at is None or now - self._refreshed_at > self.TTL_SECONDS:
+        if self.is_stale():
             self.refresh()
         return self._entries
+
+    def is_stale(self) -> bool:
+        """Whether the cache is empty or older than the TTL (a refresh is due)."""
+        if self._refreshed_at is None:
+            return True
+        return time.monotonic() - self._refreshed_at > self.TTL_SECONDS
 
     def refresh(self) -> None:
         gitignore = self._load_gitignore_spec()
@@ -54,7 +60,10 @@ class WorkspaceFileIndex:
             dirnames[:] = kept_dirs
 
             for name in sorted(filenames):
-                if Path(name).suffix.lower() in GlobTool.BINARY_EXTENSIONS:
+                # Exclude binaries, but keep attachable images: @-mentioning an image
+                # attaches it (build_file_attachments handles it via the same
+                # image_media_type), so it belongs in completions for vision models.
+                if Path(name).suffix.lower() in GlobTool.BINARY_EXTENSIONS and image_media_type(name) is None:
                     continue
                 rel = self._posix(rel_dir / name)
                 if gitignore is not None and gitignore.match_file(rel):
@@ -69,8 +78,21 @@ class WorkspaceFileIndex:
         self._refreshed_at = time.monotonic()
 
     def search(self, query: str, limit: int = 8) -> List[IndexEntry]:
+        """Search, refreshing the cache first if stale (may block on os.walk)."""
+        return self._rank(self.entries(), query, limit)
+
+    def cached_search(self, query: str, limit: int = 8) -> List[IndexEntry]:
+        """Search the current cached entries WITHOUT refreshing.
+
+        The UI uses this so a keystroke never blocks on ``os.walk``; a background
+        refresh (see ``app._refresh_file_index``) updates the cache out-of-band.
+        """
+        return self._rank(self._entries, query, limit)
+
+    @staticmethod
+    def _rank(entries: List[IndexEntry], query: str, limit: int) -> List[IndexEntry]:
         scored = []
-        for entry in self.entries():
+        for entry in entries:
             score = fuzzy_score(query, entry.path)
             if score is not None:
                 scored.append((score, entry))

--- a/tests/cli/_app_test_utils.py
+++ b/tests/cli/_app_test_utils.py
@@ -224,4 +224,9 @@ def _build_mention_test_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
-    return KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+    # Pre-warm the @-mention index so cached_search is populated deterministically in tests.
+    # In production the app warms it off-thread on mount; the completion dropdown reads the
+    # cached snapshot only (never walks on a keystroke).
+    app.file_index.refresh()
+    return app

--- a/tests/cli/test_app_mention_dropdown.py
+++ b/tests/cli/test_app_mention_dropdown.py
@@ -71,6 +71,43 @@ async def test_textual_app_mention_dropdown_opens_and_escape_dismisses(
 
 
 @pytest.mark.asyncio
+async def test_mention_dropdown_uses_cached_search_not_blocking_walk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.widgets import ChatComposer, CompletionDropdown
+
+    app = _build_mention_test_app(tmp_path, monkeypatch)
+
+    # The keystroke path must read the cached snapshot only — never the blocking
+    # search()/refresh() (which os.walks and would freeze the UI on a slow FS).
+    calls = {"cached": 0}
+    real_cached = app.file_index.cached_search
+
+    def spy_cached(query, limit=8):
+        calls["cached"] += 1
+        return real_cached(query, limit)
+
+    def blocking_search_must_not_be_called(*args, **kwargs):
+        raise AssertionError("completion must use cached_search, not the blocking search()")
+
+    monkeypatch.setattr(app.file_index, "cached_search", spy_cached)
+    monkeypatch.setattr(app.file_index, "search", blocking_search_must_not_be_called)
+
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        dropdown = app.query_one("#completion_dropdown", CompletionDropdown)
+        composer.focus()
+        composer.insert("@alp")
+        await pilot.pause()
+
+        assert calls["cached"] >= 1  # keystroke used the non-blocking cached search
+        assert dropdown.is_open
+        assert dropdown.option_count > 0
+
+
+@pytest.mark.asyncio
 async def test_textual_app_mention_dropdown_not_opened_by_email_address(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/cli/test_file_index.py
+++ b/tests/cli/test_file_index.py
@@ -42,13 +42,25 @@ def test_index_respects_gitignore(tmp_path: Path) -> None:
     assert all(not path.startswith("secrets") for path in paths)
 
 
-def test_index_skips_binary_extensions(tmp_path: Path) -> None:
-    (tmp_path / "image.png").write_bytes(b"png")
+def test_index_skips_non_image_binaries(tmp_path: Path) -> None:
+    (tmp_path / "archive.zip").write_bytes(b"zip")
+    (tmp_path / "vector.svg").write_text("<svg/>", encoding="utf-8")  # not an attachable raster image
     (tmp_path / "code.py").write_text("", encoding="utf-8")
     index = WorkspaceFileIndex(tmp_path)
     paths = _paths(index.entries())
     assert "code.py" in paths
-    assert "image.png" not in paths
+    assert "archive.zip" not in paths
+    assert "vector.svg" not in paths
+
+
+def test_index_includes_attachable_images(tmp_path: Path) -> None:
+    # Images are @-mentionable (build_file_attachments attaches them), so they belong in completions.
+    (tmp_path / "logo.png").write_bytes(b"png")
+    (tmp_path / "photo.JPG").write_bytes(b"jpg")  # case-insensitive
+    index = WorkspaceFileIndex(tmp_path)
+    paths = _paths(index.entries())
+    assert "logo.png" in paths
+    assert "photo.JPG" in paths
 
 
 def test_index_caps_total_entries(tmp_path: Path, monkeypatch) -> None:
@@ -65,6 +77,24 @@ def test_index_refreshes_after_ttl(tmp_path: Path, monkeypatch) -> None:
     assert index.entries() == []
     (tmp_path / "late.txt").write_text("", encoding="utf-8")
     assert _paths(index.entries()) == ["late.txt"]
+
+
+def test_cached_search_does_not_walk_until_refreshed(tmp_path: Path) -> None:
+    (tmp_path / "main.py").write_text("", encoding="utf-8")
+    index = WorkspaceFileIndex(tmp_path)
+    # No refresh yet: cached_search must not trigger a walk, so it returns nothing.
+    assert index.cached_search("main") == []
+    index.refresh()
+    assert _paths(index.cached_search("main")) == ["main.py"]
+
+
+def test_is_stale_tracks_refresh_and_ttl(tmp_path: Path, monkeypatch) -> None:
+    index = WorkspaceFileIndex(tmp_path)
+    assert index.is_stale() is True  # never refreshed
+    index.refresh()
+    assert index.is_stale() is False  # just refreshed, within TTL
+    monkeypatch.setattr(WorkspaceFileIndex, "TTL_SECONDS", 0.0)
+    assert index.is_stale() is True  # past (zero) TTL
 
 
 def test_search_ranks_substring_above_subsequence(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Two related @-mention improvements that make the file completion dropdown faster and more useful.

### Part A — @-mention file index no longer blocks the UI

**Problem:** `os.walk` on large or slow filesystems (iCloud, large monorepos) could freeze the text input while the @-mention dropdown was computing completions.

**Solution:**

- **`cli/file_index.py`**: added `is_stale()` and `cached_search()` — searches the cached snapshot without ever calling `os.walk` on a keystroke. The existing `refresh()` / `entries()` / `search()` are preserved as-is.
- **`cli/app.py`**: the @-mention completion dropdown now calls `cached_search` (instant) and schedules a background refresh via `asyncio.to_thread(self.file_index.refresh)`, guarded by an in-flight flag (`_file_index_refreshing`). When the background walk finishes, it re-renders the dropdown so fresh results appear. The index is warmed off-thread on mount so the first `@` usually has results.

### Part B — images are now @-mentionable

**Problem:** Image files were filtered out by the binary-extension check, so you could never @-mention a PNG/JPG/etc.

**Solution:**

- **`cli/file_index.py`**: the binary filter now keeps attachable raster images (`.png` / `.jpg` / `.jpeg` / `.gif` / `.webp` / `.bmp`), gated by the existing `image_media_type()` function. Non-image binaries and non-vision formats (`.svg`, `.ico`, `.zip`, `.exe`, `.mp4`, …) remain excluded.
- No additional wiring needed: `build_file_attachments` already attaches an @-mentioned image as a base64 `ImageBlock`, and the pre-send vision gate blocks image attachments on non-vision models.

## Test plan

- **New unit tests:** `cached_search` doesn't walk until refreshed; `is_stale` tracks refresh/TTL; images (`.png`/`.jpg`) are indexed while `.zip`/`.svg` are excluded.
- **New app test:** the keystroke path uses `cached_search`, never the blocking `search()`, and the dropdown still opens.
- Pre-warmed the index in the shared mention-test harness (mirrors the production on-mount warm) so the async change stays deterministic.
- 512/512 tests pass in `tests/cli/`; ruff clean.
- Diff: 2 source files (~54 lines) + 3 test files (~71 lines).
