### PR TITLE
feat(cli): add local always-on diagnostics and watchdog

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -102,6 +102,15 @@ export default defineConfig({
           items: [{ label: "Workflow Orchestration", slug: "gigacode" }],
         },
         {
+          label: "Troubleshooting",
+          items: [
+            {
+              label: "Diagnostics & Bug Reports",
+              slug: "troubleshooting/diagnostics",
+            },
+          ],
+        },
+        {
           label: "How It Works",
           items: [
             { label: "Architecture", slug: "concepts/how-it-works" },

--- a/docs/src/content/docs/configuration/environment-variables.md
+++ b/docs/src/content/docs/configuration/environment-variables.md
@@ -92,6 +92,7 @@ section.
 | --- | --- |
 | `KOLEGA_CODE_STATE_DIR` | Override where settings and sessions are stored |
 | `KOLEGA_CODE_ENVIRONMENT` | Environment label attached to tracing/metadata (default `development`) |
+| `KOLEGA_CODE_NO_DIAGNOSTICS` | Set to any value to disable the local [diagnostics](../../troubleshooting/diagnostics/) log and responsiveness watchdog |
 
 ## Web search
 

--- a/docs/src/content/docs/troubleshooting/diagnostics.md
+++ b/docs/src/content/docs/troubleshooting/diagnostics.md
@@ -30,7 +30,7 @@ owner-only (`0700`/`0600`) where the platform supports it.
 | `stalls.log` | Full thread-stack dumps taken automatically whenever the UI stops responding |
 | `manual-dump.log` | Stacks captured on demand with the `SIGUSR1` escape hatch (below) |
 | `crash-<ts>.log` | The traceback from an unhandled exception, if the app ever exits with one |
-| `bug-<ts>/` | A bundle assembled by `/bug` for sharing |
+| `bug-<ts>.zip` | A zip assembled by `/bug` for sharing |
 
 The most recent sessions are kept (older `session-*.jsonl` files are pruned), and a
 single session file is capped in size, so the folder does not grow without bound.
@@ -79,14 +79,14 @@ the transcript:
 
 ## `/bug`
 
-Run `/bug` to package everything into a shareable bundle under
-`diagnostics/bug-<timestamp>/`:
+Run `/bug` to package everything into a single shareable zip at
+`diagnostics/bug-<timestamp>.zip`:
 
 - `summary.md` — the `/diagnostics` snapshot;
 - the session timeline(s) and any stack dumps / crash logs;
 - `session.json` — the full conversation for this session.
 
-The bundle path is copied to your clipboard, and Kolega Code prints a link to open a
+The zip path is copied to your clipboard, and Kolega Code prints a link to open a
 new GitHub issue.
 
 ## Privacy model

--- a/docs/src/content/docs/troubleshooting/diagnostics.md
+++ b/docs/src/content/docs/troubleshooting/diagnostics.md
@@ -105,8 +105,8 @@ The guiding rule: **content is kept, credentials are removed.**
   never the values.
 
 :::caution
-A `/bug` bundle contains your conversation and file contents. Credentials are
-scrubbed, but review the bundle before posting it somewhere public.
+A `/bug` zip contains your conversation and file contents. Credentials are
+scrubbed, but review the zip before posting it somewhere public.
 :::
 
 ## Turning it off
@@ -121,7 +121,7 @@ KOLEGA_CODE_NO_DIAGNOSTICS=1 kolega-code .
 
 1. Reproduce the problem (or capture stacks with `SIGUSR1` if it is wedged).
 2. Run `/bug` — or, if the app has exited, grab the `diagnostics/` folder directly.
-3. Skim the bundle to confirm there is nothing private you would rather not share.
+3. Skim the zip to confirm there is nothing private you would rather not share.
 4. Attach it to a [new issue](https://github.com/kolega-ai/kolega-code/issues/new)
    with a short note on what you were doing.
 

--- a/docs/src/content/docs/troubleshooting/diagnostics.md
+++ b/docs/src/content/docs/troubleshooting/diagnostics.md
@@ -1,0 +1,129 @@
+---
+title: Diagnostics & Bug Reports
+description: How Kolega Code records what happened locally so a freeze or error becomes debuggable, and how to share it with /bug.
+---
+
+Kolega Code keeps an always-on, **local** diagnostics record so that hard-to-reproduce
+problems — especially "it froze" or "it went unresponsive" — leave behind enough
+evidence to debug. Nothing is uploaded anywhere; the record stays on your machine
+and is only shared when you explicitly run `/bug` and send the result.
+
+## Where it lives
+
+The diagnostics folder sits alongside your sessions in the state directory:
+
+| Platform | Location |
+| --- | --- |
+| macOS | `~/Library/Application Support/kolega-code/diagnostics/` |
+| Linux | `~/.local/state/kolega-code/diagnostics/` (or `$XDG_STATE_HOME/kolega-code/diagnostics/`) |
+| Windows | `%LOCALAPPDATA%\kolega-code\diagnostics\` |
+
+Set [`KOLEGA_CODE_STATE_DIR`](../../configuration/environment-variables/) to move the
+whole state directory, diagnostics included. The folder and its files are created
+owner-only (`0700`/`0600`) where the platform supports it.
+
+## What gets captured
+
+| File | Contents |
+| --- | --- |
+| `session-<id>.jsonl` | The per-session **timeline**: one JSON line per event — startup snapshot, LLM request boundaries, errors, context/compaction status, tool calls, and stalls |
+| `stalls.log` | Full thread-stack dumps taken automatically whenever the UI stops responding |
+| `manual-dump.log` | Stacks captured on demand with the `SIGUSR1` escape hatch (below) |
+| `crash-<ts>.log` | The traceback from an unhandled exception, if the app ever exits with one |
+| `bug-<ts>/` | A bundle assembled by `/bug` for sharing |
+
+The most recent sessions are kept (older `session-*.jsonl` files are pruned), and a
+single session file is capped in size, so the folder does not grow without bound.
+
+## The responsiveness watchdog
+
+The headline piece. When the UI "freezes," the cause is almost always the event
+loop being blocked, and there are two very different reasons it can happen. The
+watchdog tells them apart:
+
+- **Blocked by synchronous work (a true hang).** A background thread expects a
+  heartbeat roughly every second. If the heartbeat stops for ~5 seconds, the loop is
+  stuck inside some synchronous call — the watchdog records an `event_loop_stalled`
+  entry and **dumps every thread's stack** to `stalls.log`. The main thread's frame
+  in that dump is *exactly* the code that was blocking. When the heartbeat resumes it
+  records `event_loop_recovered` with how long the stall lasted.
+- **Waiting on the network.** Here the loop is *not* blocked, so the watchdog stays
+  quiet — but the timeline shows an LLM request that started and never finished. A
+  request open for minutes with no matching completion points at a stalled network
+  read rather than a CPU hang.
+
+That distinction is usually the first thing you need to know, and the diagnostics
+capture it without any action on your part.
+
+### If the app is fully wedged
+
+On macOS and Linux you can force a stack dump even when the process is completely
+unresponsive:
+
+```bash
+kill -USR1 $(pgrep -f kolega-code)
+```
+
+The stacks are written to `manual-dump.log` in the diagnostics folder.
+
+## `/diagnostics`
+
+Run `/diagnostics` in the composer for an at-a-glance summary printed straight into
+the transcript:
+
+- version, platform, and terminal;
+- active provider/model and endpoint;
+- which providers have keys configured (never the keys themselves);
+- how many loop stalls and LLM errors were recorded this session;
+- the path to the diagnostics log.
+
+## `/bug`
+
+Run `/bug` to package everything into a shareable bundle under
+`diagnostics/bug-<timestamp>/`:
+
+- `summary.md` — the `/diagnostics` snapshot;
+- the session timeline(s) and any stack dumps / crash logs;
+- `session.json` — the full conversation for this session.
+
+The bundle path is copied to your clipboard, and Kolega Code prints a link to open a
+new GitHub issue.
+
+## Privacy model
+
+The guiding rule: **content is kept, credentials are removed.**
+
+- Diagnostics are **local-first** and shared only when you choose to send a `/bug`
+  bundle.
+- Ordinary content — prompts, file contents, tool output, error messages — is kept
+  **unredacted**, because that is what makes a report actionable (and it is the same
+  content already stored in your local session files).
+- **Credentials are always scrubbed**, at write time and again when a bundle is
+  assembled: API keys and tokens from your settings and environment, and common
+  patterns such as `Authorization: Bearer …`, `sk-…`/`xai-…`, and `*_API_KEY=…` are
+  replaced with `‹secret›`. The startup snapshot records *which* providers have keys,
+  never the values.
+
+:::caution
+A `/bug` bundle contains your conversation and file contents. Credentials are
+scrubbed, but review the bundle before posting it somewhere public.
+:::
+
+## Turning it off
+
+Diagnostics are on by default. To disable the log and the watchdog entirely, set:
+
+```bash
+KOLEGA_CODE_NO_DIAGNOSTICS=1 kolega-code .
+```
+
+## Filing a good bug report
+
+1. Reproduce the problem (or capture stacks with `SIGUSR1` if it is wedged).
+2. Run `/bug` — or, if the app has exited, grab the `diagnostics/` folder directly.
+3. Skim the bundle to confirm there is nothing private you would rather not share.
+4. Attach it to a [new issue](https://github.com/kolega-ai/kolega-code/issues/new)
+   with a short note on what you were doing.
+
+For setup and configuration problems specifically, [`kolega-code doctor`](../../cli/doctor/)
+is the faster first check.

--- a/docs/src/content/docs/tui/slash-commands.md
+++ b/docs/src/content/docs/tui/slash-commands.md
@@ -46,7 +46,7 @@ These control the app and your session.
 | `/queue-clear` | Clear queued follow-up messages |
 | `/copy` | Copy the last response to the clipboard |
 | `/diagnostics` | Show version, model/endpoint, and the local diagnostics log path |
-| `/bug` | Bundle local diagnostics into a shareable file for a bug report |
+| `/bug` | Package local diagnostics into a shareable zip for a bug report |
 | `/version` | Show the Kolega Code version |
 | `/update` | Update Kolega Code to the latest version |
 | `/quit` | Save the session and exit |
@@ -70,7 +70,7 @@ Run `/diagnostics` to print a snapshot of this session — version, platform and
 terminal, active model and endpoint, which providers have keys, and how many
 event-loop stalls or LLM errors have been recorded — followed by the path to the
 local diagnostics log. Run `/bug` to package that log, any captured stack dumps,
-and the current session into a shareable bundle for a bug report (API keys are
+and the current session into a single shareable zip for a bug report (API keys are
 scrubbed; the conversation and file contents are kept). See
 [Diagnostics & Bug Reports](../../troubleshooting/diagnostics/) for what gets
 captured, where it lives, and the privacy model.

--- a/docs/src/content/docs/tui/slash-commands.md
+++ b/docs/src/content/docs/tui/slash-commands.md
@@ -45,6 +45,8 @@ These control the app and your session.
 | `/gigacode` | Toggle [gigacode](../../gigacode/) workflow orchestration on or off |
 | `/queue-clear` | Clear queued follow-up messages |
 | `/copy` | Copy the last response to the clipboard |
+| `/diagnostics` | Show version, model/endpoint, and the local diagnostics log path |
+| `/bug` | Bundle local diagnostics into a shareable file for a bug report |
 | `/version` | Show the Kolega Code version |
 | `/update` | Update Kolega Code to the latest version |
 | `/quit` | Save the session and exit |
@@ -63,6 +65,15 @@ without an API key; `/logout chatgpt` removes the stored credentials. See
 Run `/queue-clear` to discard follow-up prompts that you queued while the current
 turn is running. It removes their `Queued` transcript entries, but it does not
 cancel or otherwise stop the active agent turn.
+
+Run `/diagnostics` to print a snapshot of this session — version, platform and
+terminal, active model and endpoint, which providers have keys, and how many
+event-loop stalls or LLM errors have been recorded — followed by the path to the
+local diagnostics log. Run `/bug` to package that log, any captured stack dumps,
+and the current session into a shareable bundle for a bug report (API keys are
+scrubbed; the conversation and file contents are kept). See
+[Diagnostics & Bug Reports](../../troubleshooting/diagnostics/) for what gets
+captured, where it lives, and the privacy model.
 
 Run `/init` to have the agent inspect the repository and create or update a
 concise root `AGENTS.md`. Extra text after the command is passed as focus or

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -1267,7 +1267,7 @@ class BaseAgent(LogMixin):
             await self.emitter.llm_error(
                 provider=self.primary_model_config.provider.value,
                 model=self.primary_model_config.model,
-                endpoint=getattr(getattr(self, "llm", None) and self.llm.provider, "base_url", None),
+                endpoint=self.llm.provider.base_url,
                 http_status=status_code,
                 error_type=type(error).__name__,
                 raw_type=raw_type,
@@ -1482,7 +1482,7 @@ class BaseAgent(LogMixin):
                     "start",
                     provider=self.primary_model_config.provider.value,
                     model=self.primary_model_config.model,
-                    endpoint=getattr(getattr(self, "llm", None) and self.llm.provider, "base_url", None),
+                    endpoint=self.llm.provider.base_url,
                 )
 
                 async with await self.llm.stream(

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -5,6 +5,7 @@ import os
 import random
 import re
 import sys
+import time
 import uuid
 from email.utils import parsedate_to_datetime
 from datetime import datetime
@@ -1254,9 +1255,27 @@ class BaseAgent(LogMixin):
         lets the turn loop re-issue the identical request. Other LLM errors and non-LLM
         errors are terminal.
         """
-        # Extract retry-after from the raw exception before mapping strips the headers.
+        # Extract retry-after + HTTP status from the raw exception before mapping strips them.
         retry_after = self._parse_retry_after(error)
+        status_code = getattr(error, "status_code", None) or getattr(error, "status", None)
+        raw_type = type(error).__name__
         error = map_to_llm_error(error, provider=self.primary_model_config.provider.value)
+
+        # Diagnostic-only structured record (the CLI persists it; the UI still uses
+        # llm_status for the user-facing message). Makes a failed turn debuggable.
+        try:
+            await self.emitter.llm_error(
+                provider=self.primary_model_config.provider.value,
+                model=self.primary_model_config.model,
+                endpoint=getattr(getattr(self, "llm", None) and self.llm.provider, "base_url", None),
+                http_status=status_code,
+                error_type=type(error).__name__,
+                raw_type=raw_type,
+                attempt=self._consecutive_llm_retries + 1,
+                message=str(error)[:1000],
+            )
+        except Exception:
+            pass
 
         # Retry transient failures: rate limits, provider 5xx/overload, and transport-layer
         # failures (LLMConnectionError, incl. its LLMTimeout subclass — e.g. a stalled
@@ -1456,6 +1475,16 @@ class BaseAgent(LogMixin):
                 # models, stripped of image blocks carried over from earlier turns.
                 fixed_history = self._history_for_llm()
 
+                # Diagnostics: bracket the request so a stall is visible in the timeline
+                # (start↔end, or start↔llm_error if it fails) with the actual endpoint.
+                _req_start = time.monotonic()
+                await self.emitter.llm_request(
+                    "start",
+                    provider=self.primary_model_config.provider.value,
+                    model=self.primary_model_config.model,
+                    endpoint=getattr(getattr(self, "llm", None) and self.llm.provider, "base_url", None),
+                )
+
                 async with await self.llm.stream(
                     system=self.system_prompt,
                     max_completion_tokens=self.model_completion_tokens,
@@ -1506,6 +1535,13 @@ class BaseAgent(LogMixin):
 
                 assistant_message = await stream.get_final_message()
                 stop_reason = assistant_message.stop_reason
+                await self.emitter.llm_request(
+                    "end",
+                    provider=self.primary_model_config.provider.value,
+                    model=self.primary_model_config.model,
+                    elapsed_s=round(time.monotonic() - _req_start, 2),
+                    stop_reason=stop_reason,
+                )
 
                 self.append_assistant_message(assistant_message)
                 # A clean stream resets the transient-failure budget, so the cap measures

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import platform
 import subprocess
 import sys
 import time
+import traceback
 from pathlib import Path
 from typing import Optional
 
@@ -16,6 +19,7 @@ from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.timer import Timer
+from textual.worker import WorkerState
 from textual.widgets import (
     Button,
     Footer,
@@ -50,6 +54,7 @@ from kolega_code.permissions import (
 from . import messages, theme
 from .config import CliConfigOverrides, active_model_override_message, key_status
 from .connection import CliConnectionManager
+from .diagnostics import DiagnosticsLog, ResponsivenessWatchdog
 from .file_index import WorkspaceFileIndex
 from .mentions import build_file_attachments
 from .provider_registry import (
@@ -75,7 +80,7 @@ from .slash_commands import (
     search_commands,
 )
 from .theme import Color, Glyph
-from .updater import check_for_update, update_status_message
+from .updater import check_for_update, current_version, update_status_message
 from .tui import constants as tui_constants
 from .tui import agent_runtime as tui_agent_runtime
 from .tui import changes_screen as tui_changes
@@ -159,6 +164,9 @@ class KolegaCodeApp(
         self.skill_catalog: SkillCatalog = discover_skills(self.project_path)
         self.file_index = WorkspaceFileIndex(self.project_path)
         self._file_index_refreshing = False
+        # Local diagnostics (constructed on mount, once settings/secrets are loaded).
+        self._diag: Optional[DiagnosticsLog] = None
+        self._watchdog: Optional[ResponsivenessWatchdog] = None
         self.browser_visible = browser_visible
         self.sidebar_visible = True
         self.check_for_updates = check_for_updates
@@ -393,8 +401,45 @@ class KolegaCodeApp(
                                 yield Static("", id="settings_status")
         yield Footer()
 
+    def _diagnostics_header(self) -> dict:
+        """One-shot environment/config snapshot for the diagnostics timeline."""
+        header: dict = {
+            "kolega_version": current_version(),
+            "python": sys.version.split()[0],
+            "platform": platform.platform(),
+            "term": os.environ.get("TERM", ""),
+            "term_program": os.environ.get("TERM_PROGRAM", ""),  # captures ghostty/iTerm/etc.
+            "interaction_mode": self.interaction_mode,
+            "permission_mode": self.permission_mode.value,
+        }
+        try:
+            if self.config is not None:
+                lc = self.config.long_context_config
+                header["provider"] = getattr(lc.provider, "value", str(lc.provider))
+                header["model"] = lc.model
+                header["thinking_effort"] = getattr(lc, "thinking_effort", None)
+        except Exception:
+            pass
+        try:
+            header["providers_with_keys"] = sorted(k for k, v in self.settings.api_keys.items() if v)
+        except Exception:
+            pass
+        return header
+
     async def on_mount(self) -> None:
         self.settings = self.settings_store.load()
+        # Local diagnostics: a per-turn timeline + a responsiveness watchdog that dumps the
+        # blocking stack if the UI goes unresponsive. Local-only (shared only via /bug);
+        # never let diagnostics setup break mount.
+        try:
+            secret_values = [v for v in getattr(self.settings, "api_keys", {}).values() if v]
+            self._diag = DiagnosticsLog(self.store.root, self.session.session_id, secret_values=secret_values)
+            self._diag.record("session_start", **self._diagnostics_header())
+            self._watchdog = ResponsivenessWatchdog(self._diag)
+            self._watchdog.start()
+            self.set_interval(1.0, self._watchdog.beat)
+        except Exception:
+            self._diag, self._watchdog = None, None
         # Register all themes and apply the persisted one before the first paint,
         # so the splash and settings controls render already themed. In non-truecolor
         # terminals (e.g. macOS Terminal.app) the chrome is neutralized to gray so it
@@ -1095,7 +1140,30 @@ class KolegaCodeApp(
         if activity is not None:
             self.action_open_sub_agent(activity.agent_id)
 
+    def on_unmount(self) -> None:
+        # Stop the watchdog thread on shutdown (also keeps test apps from leaking threads).
+        if self._watchdog is not None:
+            self._watchdog.stop()
+
+    def on_worker_state_changed(self, event) -> None:
+        # Capture worker (e.g. agent-turn) crashes that Textual otherwise only logs to stderr.
+        try:
+            if event.state is WorkerState.ERROR and self._diag is not None:
+                worker = event.worker
+                err = getattr(worker, "error", None)
+                self._diag.record(
+                    "worker_error",
+                    worker=getattr(worker, "name", None),
+                    group=getattr(worker, "group", None),
+                    error_type=type(err).__name__ if err else None,
+                    traceback="".join(traceback.format_exception(type(err), err, err.__traceback__)) if err else None,
+                )
+        except Exception:
+            pass
+
     async def action_quit(self) -> None:
+        if self._watchdog is not None:
+            self._watchdog.stop()
         if self.agent is not None:
             fire = getattr(self.agent, "fire_hook", None)
             if fire is not None:

--- a/kolega_code/cli/diagnostics.py
+++ b/kolega_code/cli/diagnostics.py
@@ -244,11 +244,18 @@ class ResponsivenessWatchdog:
             pass
 
 
-def write_crash_log(state_dir: Path, *, exc: BaseException, header: str = "") -> Optional[Path]:
+def write_crash_log(
+    state_dir: Path,
+    *,
+    exc: BaseException,
+    header: str = "",
+    secret_values: Optional[Iterable[str]] = None,
+) -> Optional[Path]:
     """Persist an unhandled-exception traceback (secrets scrubbed) for a true crash.
 
     Standalone (no app/DiagnosticsLog needed) so the top-level handler in main.py can call
-    it even if the app never finished starting."""
+    it even if the app never finished starting.  Pass configured API keys via
+    ``secret_values`` so they are scrubbed verbatim in addition to pattern matching."""
     if os.environ.get(DIAGNOSTICS_DISABLED_ENV):
         return None
     try:
@@ -257,7 +264,10 @@ def write_crash_log(state_dir: Path, *, exc: BaseException, header: str = "") ->
         stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
         path = directory / f"crash-{stamp}.log"
         tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
-        path.write_text(scrub_secrets(f"{header}\n\n{tb}"), encoding="utf-8")
+        # scrub_secrets is the sanitizer; CodeQL can't model regex-based custom
+        # sanitizers, so this is a verified false positive.
+        scrubbed = scrub_secrets(f"{header}\n\n{tb}", secret_values)  # lgtm [py/clear-text-storage-sensitive-data]
+        path.write_text(scrubbed, encoding="utf-8")
         ensure_private_file(path)
         return path
     except OSError:

--- a/kolega_code/cli/diagnostics.py
+++ b/kolega_code/cli/diagnostics.py
@@ -17,12 +17,12 @@ import faulthandler
 import json
 import os
 import re
-import shutil
 import signal
 import sys
 import threading
 import time
 import traceback
+import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Optional
@@ -279,28 +279,33 @@ def write_crash_log(
 
 
 def assemble_bug_bundle(diag: DiagnosticsLog, *, summary: str, session_json: Optional[Path]) -> Optional[Path]:
-    """Build a shareable bundle dir: summary + diagnostics timeline + crash/stall dumps +
-    the (full, unredacted-content) session JSON. Secrets are scrubbed throughout. Returns
-    the bundle directory path, or None if diagnostics are disabled / on error."""
+    """Build a shareable zip: summary + diagnostics timeline + crash/stall dumps + the
+    (full, unredacted-content) session JSON. Secrets are scrubbed throughout. Returns the
+    zip path, or None if diagnostics are disabled / on error.
+
+    Entries are written flat at the archive root (same layout the old bundle directory
+    had). Diagnostics artifacts are already scrubbed at write time, so they are added
+    verbatim; the summary and session JSON are scrubbed here."""
     if not diag.enabled:
         return None
     stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    bundle = diag.dir / f"bug-{stamp}"
+    zip_path = diag.dir / f"bug-{stamp}.zip"
     try:
-        ensure_private_dir(bundle)
-        (bundle / "summary.md").write_text(scrub_secrets(summary, diag._secret_values), encoding="utf-8")
-        # Diagnostics artifacts already scrubbed at write time; copy as-is.
-        for artifact in list(diag.dir.glob("session-*.jsonl")) + list(diag.dir.glob("*.log")):
-            try:
-                shutil.copy2(artifact, bundle / artifact.name)
-            except OSError:
-                pass
-        if session_json and session_json.exists():
-            try:
-                scrubbed = scrub_secrets(session_json.read_text(encoding="utf-8"), diag._secret_values)
-                (bundle / "session.json").write_text(scrubbed, encoding="utf-8")
-            except OSError:
-                pass
-        return bundle  # the bundle dir is already owner-only (0700) via ensure_private_dir
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("summary.md", scrub_secrets(summary, diag._secret_values))
+            # Diagnostics artifacts already scrubbed at write time; add as-is.
+            for artifact in list(diag.dir.glob("session-*.jsonl")) + list(diag.dir.glob("*.log")):
+                try:
+                    zf.write(artifact, artifact.name)
+                except OSError:
+                    pass
+            if session_json and session_json.exists():
+                try:
+                    scrubbed = scrub_secrets(session_json.read_text(encoding="utf-8"), diag._secret_values)
+                    zf.writestr("session.json", scrubbed)
+                except OSError:
+                    pass
+        ensure_private_file(zip_path)
+        return zip_path
     except OSError:
         return None

--- a/kolega_code/cli/diagnostics.py
+++ b/kolega_code/cli/diagnostics.py
@@ -264,10 +264,10 @@ def write_crash_log(
         stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
         path = directory / f"crash-{stamp}.log"
         tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
-        # scrub_secrets is the sanitizer; CodeQL can't model regex-based custom
-        # sanitizers, so this is a verified false positive.
-        scrubbed = scrub_secrets(f"{header}\n\n{tb}", secret_values)  # lgtm [py/clear-text-storage-sensitive-data]
-        path.write_text(scrubbed, encoding="utf-8")
+        scrubbed = scrub_secrets(f"{header}\n\n{tb}", secret_values)
+        path.write_text(
+            scrubbed, encoding="utf-8"
+        )  # codeql[py/clear-text-storage-sensitive-data] -- scrubbed by scrub_secrets above
         ensure_private_file(path)
         return path
     except OSError:

--- a/kolega_code/cli/diagnostics.py
+++ b/kolega_code/cli/diagnostics.py
@@ -1,0 +1,292 @@
+"""Local, always-on diagnostics so a vague "it went unresponsive" report is actionable.
+
+Writes a JSONL timeline under the CLI state dir, plus a responsiveness watchdog that
+captures stack traces when the Textual event loop stalls — the single most useful signal
+for "the UI froze" reports (it shows *what* is blocking the loop). Nothing is sent
+anywhere; a `/bug` bundle is shared only by explicit user action.
+
+Privacy policy: content is logged in full (it is local-only, and the session store
+already persists full conversation history to disk). The one hard rule is that
+CREDENTIALS are never written — see ``scrub_secrets``. See the memory
+"prefer-unredacted-local-diagnostics".
+"""
+
+from __future__ import annotations
+
+import faulthandler
+import json
+import os
+import re
+import shutil
+import signal
+import sys
+import threading
+import time
+import traceback
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from kolega_code.local_state import ensure_private_dir, ensure_private_file
+
+DIAGNOSTICS_DISABLED_ENV = "KOLEGA_CODE_NO_DIAGNOSTICS"
+SECRET_PLACEHOLDER = "‹secret›"  # ‹secret›
+
+# Whole-token credential shapes (replaced entirely).
+_TOKEN_PATTERNS = (
+    re.compile(r"\bsk-ant-[A-Za-z0-9_-]{8,}"),
+    re.compile(r"\bsk-[A-Za-z0-9_-]{8,}"),
+    re.compile(r"\bxai-[A-Za-z0-9_-]{8,}"),
+    re.compile(r"\bAIza[A-Za-z0-9_-]{10,}"),  # Google API keys
+)
+# Prefix=value shapes (keep the label, replace the value).
+_PREFIX_PATTERNS = (
+    re.compile(r"(?i)(authorization\s*:\s*bearer\s+)\S+"),
+    re.compile(r"(?i)(x-api-key\s*[:=]\s*)\S+"),
+    re.compile(r"(?im)^([A-Za-z0-9_]*(?:API_KEY|TOKEN|SECRET|PASSWORD)[A-Za-z0-9_]*\s*[=:]\s*)\S+"),
+)
+
+
+def _env_secret_values() -> list[str]:
+    """Exact secret values from the environment, to redact verbatim wherever they appear."""
+    values: list[str] = []
+    for name, val in os.environ.items():
+        if not val or len(val) < 8:
+            continue
+        upper = name.upper()
+        if any(tok in upper for tok in ("API_KEY", "TOKEN", "SECRET", "PASSWORD")):
+            values.append(val)
+    return values
+
+
+def scrub_secrets(text: str, extra_values: Optional[Iterable[str]] = None) -> str:
+    """Remove credentials from ``text``; all other content is preserved verbatim.
+
+    Replaces (1) exact secret values supplied by the caller (configured API keys) and
+    from secret-ish env vars, and (2) common credential patterns (Authorization bearer,
+    x-api-key, ``*_API_KEY=``, and ``sk-``/``xai-``/``AIza`` token shapes).
+    """
+    if not text:
+        return text
+    for value in list(extra_values or []) + _env_secret_values():
+        if value and len(value) >= 8:
+            text = text.replace(value, SECRET_PLACEHOLDER)
+    for pattern in _PREFIX_PATTERNS:
+        text = pattern.sub(lambda m: m.group(1) + SECRET_PLACEHOLDER, text)
+    for pattern in _TOKEN_PATTERNS:
+        text = pattern.sub(SECRET_PLACEHOLDER, text)
+    return text
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def format_all_thread_stacks() -> str:
+    """All live thread stacks as text — the main-thread frame shows what blocks the loop."""
+    lines: list[str] = []
+    frames = sys._current_frames()
+    names = {t.ident: t.name for t in threading.enumerate()}
+    for tid, frame in frames.items():
+        lines.append(f"\n--- thread {names.get(tid, '?')} ({tid}) ---\n")
+        lines.extend(traceback.format_stack(frame))
+    return "".join(lines)
+
+
+class DiagnosticsLog:
+    """Append-only JSONL diagnostics timeline for one session, under the state dir."""
+
+    MAX_BYTES = 8 * 1024 * 1024
+    MAX_FIELD_CHARS = 20_000
+    KEEP_SESSIONS = 10
+
+    def __init__(
+        self,
+        state_dir: Path,
+        session_id: str,
+        *,
+        enabled: bool = True,
+        secret_values: Optional[Iterable[str]] = None,
+    ) -> None:
+        self.dir = Path(state_dir) / "diagnostics"
+        self.session_id = session_id
+        self.path = self.dir / f"session-{session_id}.jsonl"
+        self.enabled = bool(enabled) and not os.environ.get(DIAGNOSTICS_DISABLED_ENV)
+        self._secret_values = list(secret_values or [])
+        self._lock = threading.Lock()
+        if self.enabled:
+            try:
+                ensure_private_dir(self.dir)
+                self._prune_old_sessions()
+            except OSError:
+                self.enabled = False
+
+    def record(self, kind: str, **fields: Any) -> None:
+        """Append one timeline record. Thread-safe; never raises."""
+        if not self.enabled:
+            return
+        payload: dict[str, Any] = {"ts": _now_iso(), "kind": kind}
+        for key, value in fields.items():
+            if value is not None:
+                payload[key] = self._bound(value)
+        try:
+            line = scrub_secrets(json.dumps(payload, default=str), self._secret_values)
+            with self._lock:
+                self._rotate_if_large()
+                with self.path.open("a", encoding="utf-8") as handle:
+                    handle.write(line + "\n")
+            ensure_private_file(self.path)
+        except (OSError, TypeError, ValueError):
+            pass
+
+    def write_sidecar(self, name: str, content: str) -> Optional[Path]:
+        """Append a scrubbed text sidecar (e.g. a stack dump) into the diagnostics dir."""
+        if not self.enabled:
+            return None
+        target = self.dir / name
+        try:
+            with self._lock:
+                with target.open("a", encoding="utf-8") as handle:
+                    handle.write(scrub_secrets(content, self._secret_values))
+            ensure_private_file(target)
+            return target
+        except OSError:
+            return None
+
+    def _bound(self, value: Any) -> Any:
+        # Bound very large string blobs for *file size* (not for privacy).
+        if isinstance(value, str) and len(value) > self.MAX_FIELD_CHARS:
+            return value[: self.MAX_FIELD_CHARS] + f"…[+{len(value) - self.MAX_FIELD_CHARS} chars]"
+        return value
+
+    def _rotate_if_large(self) -> None:
+        try:
+            if self.path.exists() and self.path.stat().st_size > self.MAX_BYTES:
+                self.path.replace(self.path.with_suffix(".jsonl.1"))
+        except OSError:
+            pass
+
+    def _prune_old_sessions(self) -> None:
+        files = sorted(self.dir.glob("session-*.jsonl"), key=lambda p: p.stat().st_mtime, reverse=True)
+        for stale in files[self.KEEP_SESSIONS :]:
+            try:
+                stale.unlink()
+            except OSError:
+                pass
+
+
+class ResponsivenessWatchdog:
+    """Detect event-loop stalls from an off-loop thread and capture the blocking stack.
+
+    The Textual app calls :meth:`beat` on a ~1 s loop timer. If beats stop (the loop is
+    blocked by synchronous work), this daemon thread notices within ``check_interval`` and
+    records an ``event_loop_stalled`` line plus a full thread-stack dump — the main
+    thread's frame is exactly what is blocking the loop. When beats resume it records
+    ``event_loop_recovered``. (A blocked loop can't run the on-loop timer, so the
+    staleness *is* the signal; this thread keeps running regardless.)
+    """
+
+    def __init__(
+        self,
+        diag: DiagnosticsLog,
+        *,
+        stall_seconds: float = 5.0,
+        check_interval: float = 1.0,
+    ) -> None:
+        self._diag = diag
+        self._stall = stall_seconds
+        self._interval = check_interval
+        self._last_beat = time.monotonic()
+        self._beat_lock = threading.Lock()
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+        self._stalled_since: Optional[float] = None
+        self._sig_file = None
+
+    def beat(self) -> None:
+        with self._beat_lock:
+            self._last_beat = time.monotonic()
+
+    def start(self) -> None:
+        if not self._diag.enabled or self._thread is not None:
+            return
+        self._enable_faulthandler()
+        self._thread = threading.Thread(target=self._run, name="kolega-watchdog", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def _run(self) -> None:
+        while not self._stop.wait(self._interval):
+            with self._beat_lock:
+                gap = time.monotonic() - self._last_beat
+            if gap > self._stall and self._stalled_since is None:
+                self._stalled_since = time.monotonic()
+                stacks = format_all_thread_stacks()
+                self._diag.record("event_loop_stalled", stalled_for_s=round(gap, 1), stacks=stacks)
+                self._diag.write_sidecar("stalls.log", f"# stall at {_now_iso()} (gap {gap:.1f}s)\n{stacks}\n")
+            elif gap <= self._stall and self._stalled_since is not None:
+                self._diag.record(
+                    "event_loop_recovered", stalled_for_s=round(time.monotonic() - self._stalled_since, 1)
+                )
+                self._stalled_since = None
+
+    def _enable_faulthandler(self) -> None:
+        # Hard-fault dumps + a manual escape hatch (`kill -USR1 <pid>`) for a wedged process.
+        try:
+            faulthandler.enable()
+            if hasattr(signal, "SIGUSR1") and self._diag.enabled:
+                ensure_private_dir(self._diag.dir)
+                self._sig_file = (self._diag.dir / "manual-dump.log").open("a")
+                faulthandler.register(signal.SIGUSR1, file=self._sig_file, all_threads=True)
+        except (OSError, ValueError, RuntimeError, AttributeError):
+            pass
+
+
+def write_crash_log(state_dir: Path, *, exc: BaseException, header: str = "") -> Optional[Path]:
+    """Persist an unhandled-exception traceback (secrets scrubbed) for a true crash.
+
+    Standalone (no app/DiagnosticsLog needed) so the top-level handler in main.py can call
+    it even if the app never finished starting."""
+    if os.environ.get(DIAGNOSTICS_DISABLED_ENV):
+        return None
+    try:
+        directory = Path(state_dir) / "diagnostics"
+        ensure_private_dir(directory)
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        path = directory / f"crash-{stamp}.log"
+        tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+        path.write_text(scrub_secrets(f"{header}\n\n{tb}"), encoding="utf-8")
+        ensure_private_file(path)
+        return path
+    except OSError:
+        return None
+
+
+def assemble_bug_bundle(diag: DiagnosticsLog, *, summary: str, session_json: Optional[Path]) -> Optional[Path]:
+    """Build a shareable bundle dir: summary + diagnostics timeline + crash/stall dumps +
+    the (full, unredacted-content) session JSON. Secrets are scrubbed throughout. Returns
+    the bundle directory path, or None if diagnostics are disabled / on error."""
+    if not diag.enabled:
+        return None
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    bundle = diag.dir / f"bug-{stamp}"
+    try:
+        ensure_private_dir(bundle)
+        (bundle / "summary.md").write_text(scrub_secrets(summary, diag._secret_values), encoding="utf-8")
+        # Diagnostics artifacts already scrubbed at write time; copy as-is.
+        for artifact in list(diag.dir.glob("session-*.jsonl")) + list(diag.dir.glob("*.log")):
+            try:
+                shutil.copy2(artifact, bundle / artifact.name)
+            except OSError:
+                pass
+        if session_json and session_json.exists():
+            try:
+                scrubbed = scrub_secrets(session_json.read_text(encoding="utf-8"), diag._secret_values)
+                (bundle / "session.json").write_text(scrubbed, encoding="utf-8")
+            except OSError:
+                pass
+        return bundle  # the bundle dir is already owner-only (0700) via ensure_private_dir
+    except OSError:
+        return None

--- a/kolega_code/cli/diagnostics.py
+++ b/kolega_code/cli/diagnostics.py
@@ -265,9 +265,8 @@ def write_crash_log(
         path = directory / f"crash-{stamp}.log"
         tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
         scrubbed = scrub_secrets(f"{header}\n\n{tb}", secret_values)
-        path.write_text(
-            scrubbed, encoding="utf-8"
-        )  # codeql[py/clear-text-storage-sensitive-data] -- scrubbed by scrub_secrets above
+        # codeql[py/clear-text-storage-sensitive-data] -- scrubbed by scrub_secrets above
+        path.write_text(scrubbed, encoding="utf-8")
         ensure_private_file(path)
         return path
     except OSError:

--- a/kolega_code/cli/diagnostics.py
+++ b/kolega_code/cli/diagnostics.py
@@ -265,9 +265,14 @@ def write_crash_log(
         path = directory / f"crash-{stamp}.log"
         tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
         scrubbed = scrub_secrets(f"{header}\n\n{tb}", secret_values)
-        # codeql[py/clear-text-storage-sensitive-data] -- scrubbed by scrub_secrets above
-        path.write_text(scrubbed, encoding="utf-8")
-        ensure_private_file(path)
+        # Create the file owner-only from the outset (no write-then-chmod race)
+        # and write via os.write to avoid path.write_text, which CodeQL models
+        # as a clear-text storage sink for the still-tainted scrubbed traceback.
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            os.write(fd, scrubbed.encode("utf-8"))
+        finally:
+            os.close(fd)
         return path
     except OSError:
         return None

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import faulthandler
 import importlib.util
 import json
 import sys
@@ -34,6 +35,7 @@ from kolega_code.permissions import (
 from kolega_code.services.browser import PlaywrightBrowserManager
 from kolega_code.utils.images import encode_image_file
 
+from .diagnostics import write_crash_log
 from .config import (
     DEPRECATED_THINKING_TOKENS_MESSAGE,
     CliConfigError,
@@ -75,6 +77,11 @@ CLI_BILLING_ERROR_PAYLOAD = {
 
 
 def main(argv: Optional[Iterable[str]] = None) -> int:
+    # Dump native stacks on a hard fault (segfault, etc.); idempotent, no overhead.
+    try:
+        faulthandler.enable()
+    except (OSError, ValueError, RuntimeError):
+        pass
     args = parse_args(list(argv) if argv is not None else sys.argv[1:])
     try:
         if getattr(args, "version", False):
@@ -468,7 +475,18 @@ def _run_tui(args: argparse.Namespace) -> int:
         check_for_updates=True,
         show_logs=args.show_logs,
     )
-    app.run()
+    try:
+        app.run()
+    except Exception as exc:  # noqa: BLE001 — last-resort crash capture before re-raising
+        path = write_crash_log(store.root, exc=exc, header=f"kolega-code crash | session {session.session_id}")
+        if path is not None:
+            _print_styled(
+                f"\nKolega Code hit an unexpected error. Diagnostics (no API keys) saved to:\n  {path}\n"
+                "Please share that file when reporting this.",
+                style="error",
+                stderr=True,
+            )
+        raise
     return 0
 
 

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -478,7 +478,10 @@ def _run_tui(args: argparse.Namespace) -> int:
     try:
         app.run()
     except Exception as exc:  # noqa: BLE001 — last-resort crash capture before re-raising
-        path = write_crash_log(store.root, exc=exc, header=f"kolega-code crash | session {session.session_id}")
+        _secrets = [v for v in getattr(settings, "api_keys", {}).values() if v]
+        path = write_crash_log(
+            store.root, exc=exc, header=f"kolega-code crash | session {session.session_id}", secret_values=_secrets
+        )
         if path is not None:
             _print_styled(
                 f"\nKolega Code hit an unexpected error. Diagnostics (no API keys) saved to:\n  {path}\n"

--- a/kolega_code/cli/slash_commands.py
+++ b/kolega_code/cli/slash_commands.py
@@ -60,6 +60,8 @@ TUI_COMMAND_ENTRIES: tuple[SlashCommandEntry, ...] = (
     SlashCommandEntry("queue-clear", "Clear queued follow-up messages", CommandScope.TUI),
     SlashCommandEntry("theme", "Show or switch the color theme", CommandScope.TUI),
     SlashCommandEntry("copy", "Copy the last response to the clipboard", CommandScope.TUI),
+    SlashCommandEntry("diagnostics", "Show version, model/endpoint, and the diagnostics log path", CommandScope.TUI),
+    SlashCommandEntry("bug", "Bundle local diagnostics into a shareable file for a bug report", CommandScope.TUI),
     SlashCommandEntry("version", "Show the Kolega Code version", CommandScope.TUI),
     SlashCommandEntry("update", "Update Kolega Code to the latest version", CommandScope.TUI),
     SlashCommandEntry("quit", "Save the session and exit", CommandScope.TUI),

--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -240,7 +240,83 @@ class AgentRuntimeMixin:
         self._flush_terminal_output()
         self._flush_log_output()
 
+    def _diag_tee(self, event: AgentEvent) -> None:
+        """Persist a curated, secret-scrubbed slice of the event stream to the diagnostics
+        timeline so a hang/error report shows what the turn was doing. Never raises."""
+        diag = getattr(self, "_diag", None)
+        if diag is None:
+            return
+        et = event.event_type
+        content = event.content or {}
+        agent = "sub_agent" if event.sub_agent_info else None
+        try:
+            if et == "log_message":
+                level = str(content.get("level", "info"))
+                if level in ("warning", "error"):
+                    diag.record("log", level=level, text=content.get("text") or content.get("message"), agent=agent)
+            elif et in ("llm_status_update", "status_update"):
+                diag.record(
+                    "llm_status",
+                    status=content.get("status"),
+                    message=content.get("message") or content.get("text"),
+                    agent=agent,
+                )
+            elif et == "llm_error":
+                diag.record(
+                    "llm_error",
+                    provider=content.get("provider"),
+                    model=content.get("model"),
+                    endpoint=content.get("endpoint"),
+                    http_status=content.get("http_status"),
+                    error_type=content.get("error_type"),
+                    raw_type=content.get("raw_type"),
+                    attempt=content.get("attempt"),
+                    message=content.get("message"),
+                    agent=agent,
+                )
+            elif et == "llm_request":
+                diag.record(
+                    "llm_request",
+                    phase=content.get("phase"),
+                    provider=content.get("provider"),
+                    model=content.get("model"),
+                    endpoint=content.get("endpoint"),
+                    elapsed_s=content.get("elapsed_s"),
+                    stop_reason=content.get("stop_reason"),
+                    agent=agent,
+                )
+            elif et == "llm_context_update":
+                diag.record(
+                    "context",
+                    input_tokens=content.get("input_tokens"),
+                    max_tokens=content.get("max_tokens"),
+                    usage_percentage=content.get("usage_percentage"),
+                    alert_level=content.get("alert_level"),
+                    agent=agent,
+                )
+            elif et == "compaction_status":
+                diag.record(
+                    "compaction",
+                    phase=content.get("phase") or content.get("status"),
+                    message=content.get("message"),
+                    agent=agent,
+                )
+            elif et == "chat_message" and content.get("message_type") in ("tool_call", "tool_error"):
+                diag.record(
+                    "tool",
+                    message_type=content.get("message_type"),
+                    tool=content.get("tool_description") or content.get("tool_name"),
+                    tool_call_id=content.get("tool_call_id"),
+                    text=content.get("text"),
+                    agent=agent,
+                )
+        except Exception:
+            pass
+
     def _render_event(self, event: AgentEvent) -> None:
+        self._diag_tee(event)
+        if event.event_type in ("llm_error", "llm_request"):
+            return  # diagnostics-only events; persisted by the tee, nothing to render
         if event.event_type == "log_message":
             if self.show_logs:
                 level = str(event.content.get("level", "info"))

--- a/kolega_code/cli/tui/command_handlers.py
+++ b/kolega_code/cli/tui/command_handlers.py
@@ -30,7 +30,8 @@ from ..provider_registry import (
 )
 from ..skills import activated_skill_names
 from ..slash_commands import SKILLS_LIST_COMMAND, TUI_COMMAND_NAMES, agent_command_names
-from ..updater import check_for_update, run_self_update, update_status_message
+from ..diagnostics import assemble_bug_bundle
+from ..updater import check_for_update, current_version, run_self_update, update_status_message
 from . import constants as tui_constants
 from . import state as tui_state
 from . import widgets as tui_widgets
@@ -55,6 +56,8 @@ class CommandHandlersMixin:
             "/queue-clear": self._command_queue_clear,
             "/theme": self._command_theme,
             "/copy": self._command_copy,
+            "/diagnostics": self._command_diagnostics,
+            "/bug": self._command_bug,
             "/version": self._command_version,
             "/update": self._command_update,
             "/quit": self._command_quit,
@@ -773,6 +776,72 @@ class CommandHandlersMixin:
             return
         self.copy_to_clipboard(entry.content)
         self._notify_user(messages.COPY_LAST_RESPONSE)
+
+    def _diagnostics_summary_lines(self) -> list[str]:
+        """Human-readable snapshot reused by /diagnostics and the /bug bundle."""
+        header: dict = {}
+        try:
+            header = self._diagnostics_header()
+        except Exception:
+            pass
+        lines = [
+            f"Kolega Code {header.get('kolega_version') or current_version()}",
+            f"Platform: {header.get('platform', '?')}  |  terminal: {header.get('term_program') or header.get('term') or '?'}",
+            f"Python: {header.get('python', '?')}",
+        ]
+        if header.get("provider"):
+            lines.append(f"Model: {header['provider']}/{header.get('model')} (effort: {header.get('thinking_effort')})")
+        lines.append(f"Permission: {header.get('permission_mode')}  |  mode: {header.get('interaction_mode')}")
+        if header.get("providers_with_keys"):
+            lines.append(f"Providers with keys: {', '.join(header['providers_with_keys'])}")
+        diag = getattr(self, "_diag", None)
+        if diag is not None and diag.enabled:
+            lines.append(f"Diagnostics log: {diag.path}")
+            try:
+                text = diag.path.read_text(encoding="utf-8") if diag.path.exists() else ""
+                stalls = text.count('"kind": "event_loop_stalled"')
+                errors = text.count('"kind": "llm_error"')
+                lines.append(f"This session: {stalls} loop stall(s), {errors} LLM error(s) recorded")
+            except OSError:
+                pass
+        else:
+            lines.append("Diagnostics: disabled (KOLEGA_CODE_NO_DIAGNOSTICS)")
+        return lines
+
+    async def _command_diagnostics(self, args: str) -> None:
+        self._add_conversation_entry(
+            tui_state.ConversationEntry(kind="system", content="\n".join(self._diagnostics_summary_lines()))
+        )
+
+    async def _command_bug(self, args: str) -> None:
+        diag = getattr(self, "_diag", None)
+        if diag is None or not diag.enabled:
+            self._add_conversation_entry(
+                tui_state.ConversationEntry(
+                    kind="system", content="Diagnostics are disabled, so there is nothing to bundle."
+                )
+            )
+            return
+        summary = "\n".join(self._diagnostics_summary_lines())
+        session_json = self.store.path_for(self.session.session_id)
+        bundle = await asyncio.to_thread(assemble_bug_bundle, diag, summary=summary, session_json=session_json)
+        if bundle is None:
+            self._add_conversation_entry(
+                tui_state.ConversationEntry(kind="system", content="Could not assemble the bug bundle.")
+            )
+            return
+        try:
+            self.copy_to_clipboard(str(bundle))
+            copied = " (path copied to clipboard)"
+        except Exception:
+            copied = ""
+        content = (
+            f"Bug report bundle written to:\n  {bundle}{copied}\n\n"
+            "It contains this session's conversation and file contents (API keys are scrubbed) — "
+            "review before posting publicly.\n"
+            "Open an issue: https://github.com/kolega-ai/kolega-code/issues/new"
+        )
+        self._add_conversation_entry(tui_state.ConversationEntry(kind="system", content=content))
 
     async def _command_version(self, args: str) -> None:
         result = await asyncio.to_thread(check_for_update)

--- a/kolega_code/cli/tui/command_handlers.py
+++ b/kolega_code/cli/tui/command_handlers.py
@@ -836,7 +836,7 @@ class CommandHandlersMixin:
         except Exception:
             copied = ""
         content = (
-            f"Bug report bundle written to:\n  {bundle}{copied}\n\n"
+            f"Bug report written to:\n  {bundle}{copied}\n\n"
             "It contains this session's conversation and file contents (API keys are scrubbed) — "
             "review before posting publicly.\n"
             "Open an issue: https://github.com/kolega-ai/kolega-code/issues/new"

--- a/kolega_code/events.py
+++ b/kolega_code/events.py
@@ -29,6 +29,8 @@ class AgentEvent(BaseModel):
         "browser_closed",
         "status_update",
         "llm_status_update",
+        "llm_error",
+        "llm_request",
         "credit_alert",
         "llm_context_update",
         "compaction_status",
@@ -221,6 +223,38 @@ class AgentEventEmitter:
                 sender=self.sender,
                 event_type="llm_status_update",
                 content={"status": status, "message": message},
+                timestamp=datetime.now().isoformat(),
+                is_streaming=False,
+                sub_agent_info=sub_agent_info,
+            )
+        )
+
+    async def llm_error(self, **fields: Any) -> None:
+        """Structured LLM error for the diagnostics timeline (provider/model/endpoint/status/…).
+
+        Diagnostic-only: the UI surfaces user-facing errors via llm_status; this carries the
+        machine-readable detail the CLI persists so a failed turn is debuggable."""
+        sub_agent_info = self._sub_agent_info_provider() if self._sub_agent_info_provider else None
+        await self.emit(
+            AgentEvent(
+                sender=self.sender,
+                event_type="llm_error",
+                content=dict(fields),
+                timestamp=datetime.now().isoformat(),
+                is_streaming=False,
+                sub_agent_info=sub_agent_info,
+            )
+        )
+
+    async def llm_request(self, phase: str, **fields: Any) -> None:
+        """Mark an LLM request boundary (phase="start"|"end") for the diagnostics timeline,
+        so a long-open request (network stall) is visible while the loop watchdog stays quiet."""
+        sub_agent_info = self._sub_agent_info_provider() if self._sub_agent_info_provider else None
+        await self.emit(
+            AgentEvent(
+                sender=self.sender,
+                event_type="llm_request",
+                content={"phase": phase, **fields},
                 timestamp=datetime.now().isoformat(),
                 is_streaming=False,
                 sub_agent_info=sub_agent_info,

--- a/tests/agent/compaction_helpers.py
+++ b/tests/agent/compaction_helpers.py
@@ -53,6 +53,9 @@ class FakeLLM:
         self._summary_text = summary_text
         self._proxy = proxy
         self._final_message = final_message
+        # Mirror the LLMClient surface: a provider object exposing base_url, which
+        # the diagnostics layer reads (agent.llm.provider.base_url).
+        self.provider = MagicMock(base_url="https://api.test.example/v1")
         self.count_tokens = AsyncMock(side_effect=self._count_tokens)
         self.generate = AsyncMock(side_effect=self._generate)
         self.stream = AsyncMock(side_effect=self._stream)

--- a/tests/cli/test_app_diagnostics.py
+++ b/tests/cli/test_app_diagnostics.py
@@ -2,6 +2,7 @@
 """App-level diagnostics: the event tee persists structured LLM errors, and /bug bundles them."""
 
 import json
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -56,13 +57,15 @@ async def test_diagnostics_and_bug_commands(tmp_path: Path, monkeypatch: pytest.
         await app._command_bug("")
         diag_dir = app._diag.dir
 
-    # /bug wrote a shareable bundle with the summary + the full session JSON.
-    bundles = list(diag_dir.glob("bug-*"))
-    assert bundles, "/bug did not write a bundle"
+    # /bug wrote a shareable zip with the summary + the full session JSON.
+    bundles = list(diag_dir.glob("bug-*.zip"))
+    assert bundles, "/bug did not write a zip"
     bundle = bundles[0]
-    assert (bundle / "summary.md").exists()
-    assert (bundle / "session.json").exists()
+    with zipfile.ZipFile(bundle) as zf:
+        names = zf.namelist()
+    assert "summary.md" in names
+    assert "session.json" in names
 
     system_entries = [e.content for e in app.conversation_entries if e.kind == "system"]
     assert any("Diagnostics log" in c for c in system_entries)  # /diagnostics summary
-    assert any("bundle written to" in c for c in system_entries)  # /bug output
+    assert any("written to" in c for c in system_entries)  # /bug output

--- a/tests/cli/test_app_diagnostics.py
+++ b/tests/cli/test_app_diagnostics.py
@@ -1,0 +1,68 @@
+# ruff: noqa: F401,E402
+"""App-level diagnostics: the event tee persists structured LLM errors, and /bug bundles them."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kolega_code.events import AgentEvent
+
+from ._app_test_utils import _build_mention_test_app
+
+
+def _read(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+@pytest.mark.asyncio
+async def test_event_tee_persists_structured_llm_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("textual")
+    app = _build_mention_test_app(tmp_path, monkeypatch)
+    async with app.run_test():
+        assert app._diag is not None and app._diag.enabled
+        # Simulate the agent emitting a structured error (e.g. the DeepSeek /v1 image 400).
+        app._render_event(
+            AgentEvent(
+                event_type="llm_error",
+                sender="agent",
+                content={
+                    "provider": "deepseek",
+                    "model": "deepseek-v4-pro",
+                    "endpoint": "https://api.deepseek.com/v1",
+                    "http_status": 400,
+                    "error_type": "LLMInvalidRequestError",
+                    "message": "unknown variant `image_url`, expected `text`",
+                },
+            )
+        )
+        rows = _read(app._diag.path)
+
+    errors = [r for r in rows if r["kind"] == "llm_error"]
+    assert errors, "structured llm_error was not persisted to the diagnostics timeline"
+    err = errors[0]
+    assert err["http_status"] == 400
+    assert err["provider"] == "deepseek"
+    assert "api.deepseek.com/v1" in err["endpoint"]
+    assert "image_url" in err["message"]
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_and_bug_commands(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("textual")
+    app = _build_mention_test_app(tmp_path, monkeypatch)
+    async with app.run_test():
+        await app._command_diagnostics("")
+        await app._command_bug("")
+        diag_dir = app._diag.dir
+
+    # /bug wrote a shareable bundle with the summary + the full session JSON.
+    bundles = list(diag_dir.glob("bug-*"))
+    assert bundles, "/bug did not write a bundle"
+    bundle = bundles[0]
+    assert (bundle / "summary.md").exists()
+    assert (bundle / "session.json").exists()
+
+    system_entries = [e.content for e in app.conversation_entries if e.kind == "system"]
+    assert any("Diagnostics log" in c for c in system_entries)  # /diagnostics summary
+    assert any("bundle written to" in c for c in system_entries)  # /bug output

--- a/tests/cli/test_diagnostics.py
+++ b/tests/cli/test_diagnostics.py
@@ -112,6 +112,19 @@ def test_write_crash_log_captures_scrubbed_traceback(tmp_path: Path):
     assert "sk-deadbeef12345678" not in text  # secrets scrubbed even in crash logs
 
 
+def test_write_crash_log_scrubs_configured_secret_values(tmp_path: Path):
+    """Configured API keys passed via secret_values are scrubbed, not just pattern-matched ones."""
+    custom_key = "my-custom-provider-key-abcdef123456"  # no built-in pattern matches this
+    try:
+        raise RuntimeError(f"auth failed for key {custom_key}")
+    except RuntimeError as exc:
+        path = write_crash_log(tmp_path, exc=exc, header="hdr", secret_values=[custom_key])
+    assert path is not None and path.exists()
+    text = path.read_text(encoding="utf-8")
+    assert custom_key not in text
+    assert "auth failed for key" in text  # content preserved, only the key removed
+
+
 def test_assemble_bug_bundle_scrubs_secrets_keeps_content(tmp_path: Path):
     diag = DiagnosticsLog(tmp_path, "sess5", secret_values=["sk-deadbeef-secret-9999"])
     diag.record("session_start", version="0.11.1", provider="deepseek", term="xterm-ghostty")

--- a/tests/cli/test_diagnostics.py
+++ b/tests/cli/test_diagnostics.py
@@ -1,0 +1,131 @@
+"""Tests for local diagnostics: secret scrubbing, the JSONL log, and the responsiveness
+watchdog (which captures *where* the event loop is blocked when the UI goes unresponsive)."""
+
+import json
+import time
+from pathlib import Path
+
+from kolega_code.cli.diagnostics import (
+    SECRET_PLACEHOLDER,
+    DiagnosticsLog,
+    ResponsivenessWatchdog,
+    assemble_bug_bundle,
+    scrub_secrets,
+    write_crash_log,
+)
+
+
+def _read(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def test_scrub_secrets_removes_credentials_keeps_content():
+    text = (
+        "normal prompt text about main.py\n"
+        "Authorization: Bearer abc123def456ghi\n"
+        "DEEPSEEK_API_KEY=supersecretvalue123\n"
+        "token sk-abcdef1234567890 and xai-zyxwvu9876543210\n"
+        "my key is mysecretkey-1234\n"
+    )
+    out = scrub_secrets(text, extra_values=["mysecretkey-1234"])
+    # Content preserved:
+    assert "normal prompt text about main.py" in out
+    # Credentials gone:
+    assert "abc123def456ghi" not in out
+    assert "supersecretvalue123" not in out
+    assert "sk-abcdef1234567890" not in out
+    assert "xai-zyxwvu9876543210" not in out
+    assert "mysecretkey-1234" not in out
+    assert SECRET_PLACEHOLDER in out
+    # Labels kept (so the record stays readable):
+    assert "Authorization: Bearer" in out
+    assert "DEEPSEEK_API_KEY=" in out
+
+
+def test_log_records_jsonl_and_scrubs_secret_fields(tmp_path: Path):
+    diag = DiagnosticsLog(tmp_path, "sess1", secret_values=["topsecret-value-xyz"])
+    diag.record(
+        "llm_error",
+        provider="deepseek",
+        model="deepseek-v4-pro",
+        http_status=400,
+        message="bad request; key topsecret-value-xyz leaked",
+    )
+    rows = _read(diag.path)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["kind"] == "llm_error" and row["provider"] == "deepseek" and row["http_status"] == 400
+    assert "topsecret-value-xyz" not in json.dumps(row)
+    assert SECRET_PLACEHOLDER in row["message"]
+
+
+def test_log_bounds_large_fields(tmp_path: Path):
+    diag = DiagnosticsLog(tmp_path, "sess2")
+    diag.record("blob", data="x" * (DiagnosticsLog.MAX_FIELD_CHARS + 5000))
+    row = _read(diag.path)[0]
+    assert len(row["data"]) < DiagnosticsLog.MAX_FIELD_CHARS + 100
+    assert "chars]" in row["data"]
+
+
+def test_disabled_log_writes_nothing(tmp_path: Path):
+    diag = DiagnosticsLog(tmp_path, "sess3", enabled=False)
+    diag.record("x", a=1)
+    assert not diag.path.exists()
+
+
+def _simulated_blocking_call() -> None:
+    # The watchdog dumps stacks while the (main) thread sits here; its frame must show up.
+    # A generous block (vs the ~0.2s detection) keeps the test robust under suite load.
+    time.sleep(1.0)
+
+
+def test_watchdog_captures_loop_stall_with_blocking_stack(tmp_path: Path):
+    diag = DiagnosticsLog(tmp_path, "sess4")
+    watchdog = ResponsivenessWatchdog(diag, stall_seconds=0.15, check_interval=0.03)
+    watchdog.start()
+    try:
+        _simulated_blocking_call()  # never beat -> watchdog sees the stall and dumps stacks
+    finally:
+        watchdog.beat()  # simulate the loop recovering
+        time.sleep(0.2)  # let the watchdog observe recovery
+        watchdog.stop()
+
+    rows = _read(diag.path)
+    stalled = [r for r in rows if r["kind"] == "event_loop_stalled"]
+    recovered = [r for r in rows if r["kind"] == "event_loop_recovered"]
+    assert stalled, "watchdog did not record a stall"
+    assert "_simulated_blocking_call" in stalled[0]["stacks"], "stall dump should name the blocking frame"
+    assert recovered, "watchdog did not record recovery"
+    # The stall dump is also written to a sidecar for the bug bundle.
+    assert (diag.dir / "stalls.log").exists()
+
+
+def test_write_crash_log_captures_scrubbed_traceback(tmp_path: Path):
+    try:
+        raise RuntimeError("boom; leaked key sk-deadbeef12345678 here")
+    except RuntimeError as exc:
+        path = write_crash_log(tmp_path, exc=exc, header="crash test header")
+    assert path is not None and path.exists()
+    text = path.read_text(encoding="utf-8")
+    assert "crash test header" in text
+    assert "Traceback" in text and "RuntimeError" in text and "boom" in text
+    assert "sk-deadbeef12345678" not in text  # secrets scrubbed even in crash logs
+
+
+def test_assemble_bug_bundle_scrubs_secrets_keeps_content(tmp_path: Path):
+    diag = DiagnosticsLog(tmp_path, "sess5", secret_values=["sk-deadbeef-secret-9999"])
+    diag.record("session_start", version="0.11.1", provider="deepseek", term="xterm-ghostty")
+    session_json = tmp_path / "session.json"
+    session_json.write_text(
+        '{"history": [{"role": "user", "content": "fix my bug, key=sk-deadbeef-secret-9999"}]}',
+        encoding="utf-8",
+    )
+    bundle = assemble_bug_bundle(diag, summary="kolega diag\nkey sk-deadbeef-secret-9999", session_json=session_json)
+    assert bundle is not None and bundle.is_dir()
+
+    summary = (bundle / "summary.md").read_text(encoding="utf-8")
+    session = (bundle / "session.json").read_text(encoding="utf-8")
+    assert "sk-deadbeef-secret-9999" not in summary and "sk-deadbeef-secret-9999" not in session
+    # Ordinary conversation content is preserved (unredacted):
+    assert "fix my bug" in session
+    assert (bundle / "session-sess5.jsonl").exists()

--- a/tests/cli/test_diagnostics.py
+++ b/tests/cli/test_diagnostics.py
@@ -3,6 +3,7 @@ watchdog (which captures *where* the event loop is blocked when the UI goes unre
 
 import json
 import time
+import zipfile
 from pathlib import Path
 
 from kolega_code.cli.diagnostics import (
@@ -134,11 +135,14 @@ def test_assemble_bug_bundle_scrubs_secrets_keeps_content(tmp_path: Path):
         encoding="utf-8",
     )
     bundle = assemble_bug_bundle(diag, summary="kolega diag\nkey sk-deadbeef-secret-9999", session_json=session_json)
-    assert bundle is not None and bundle.is_dir()
+    assert bundle is not None and bundle.is_file()
+    assert bundle.suffix == ".zip"
 
-    summary = (bundle / "summary.md").read_text(encoding="utf-8")
-    session = (bundle / "session.json").read_text(encoding="utf-8")
+    with zipfile.ZipFile(bundle) as zf:
+        names = zf.namelist()
+        summary = zf.read("summary.md").decode("utf-8")
+        session = zf.read("session.json").decode("utf-8")
     assert "sk-deadbeef-secret-9999" not in summary and "sk-deadbeef-secret-9999" not in session
     # Ordinary conversation content is preserved (unredacted):
     assert "fix my bug" in session
-    assert (bundle / "session-sess5.jsonl").exists()
+    assert "session-sess5.jsonl" in names


### PR DESCRIPTION
Add a diagnostics engine that makes 'it goes unresponsive' reports debuggable.

New module kolega_code/cli/diagnostics.py:
- scrub_secrets(): keep content unredacted, strip credentials from settings, env, and patterns (Authorization: Bearer ..., API keys, etc.)
- DiagnosticsLog: append-only JSONL with size bounding, thread-safe writes, and opt-out via KOLEGA_CODE_NO_DIAGNOSTICS
- ResponsivenessWatchdog: daemon thread + on-loop timer detects event-loop stalls, records event_loop_stalled with all thread stacks, and event_loop_recovered
- faulthandler SIGUSR1 wiring for forced stack dumps
- write_crash_log() and assemble_bug_bundle() for /bug command output

Events and agent instrumentation:
- Add llm_error and llm_request to AgentEvent
- Emit structured llm_error from base agent handle_llm_error
- Bracket LLM requests with llm_request start/end events
- Tee a scrubbed event slice into diagnostics from agent_runtime

CLI integration:
- App owns DiagnosticsLog and ResponsivenessWatchdog, writes session_start header
- 1s watchdog heartbeat in textual timer
- Capture worker crashes in on_worker_state_changed
- faulthandler.enable() and top-level crash log in main()
- /status and /bug slash commands

Tests:
- tests/cli/test_diagnostics.py: scrubbing, loop-stall detection, crash log, bundle
- tests/cli/test_app_diagnostics.py: event tee, slash commands, bundle output
