### PR TITLE
fix(llm): replay reasoning through native provider fields for OpenAI-compatible providers

### DIFF
--- a/kolega_code/llm/models.py
+++ b/kolega_code/llm/models.py
@@ -7,6 +7,8 @@ from google.genai import types as genai_types
 
 from kolega_code.utils.images import ascii_thumbnail_from_base64
 
+from .specs.accessors import _provider_value
+from .specs.thinking import reasoning_replay_field
 from .tool_execution_ids import ToolExecutionIdRegistry, new_tool_execution_id
 
 # Mapping from type string to class
@@ -1011,25 +1013,68 @@ class Message:
 
         return {"role": self.role, "content": content}
 
-    def to_openai(self) -> Dict[str, Any]:
+    def to_openai(self, provider: Optional[str] = None, model: Optional[str] = None) -> Dict[str, Any]:
         """
         Converts the Message instance to an OpenAI-compatible dictionary format.
+
+        When ``provider``/``model`` identify a Chat-Completions reasoning model
+        (see ``reasoning_replay_field``), prior ThinkingBlocks on a same-provider
+        assistant message are replayed via the provider-native reasoning field
+        (e.g. ``reasoning_content``) instead of being rendered as visible
+        ``*Thinking:*`` text. With no provider/model (the default), behavior is
+        unchanged.
 
         Returns:
             Dict[str, Any]: A dictionary in OpenAI's expected format
         """
+        # Native reasoning replay applies only when the target is a configured
+        # reasoning model AND this assistant message was produced by that same
+        # provider. adapt_history_for_provider already converts foreign reasoning
+        # to text upstream; this source==target check is defense-in-depth so
+        # foreign reasoning can never serialize as native replay metadata.
+        reasoning_field: Optional[str] = None
+        source_provider = (self.usage_metadata or {}).get("provider")
+        if (
+            provider
+            and model
+            and self.role == "assistant"
+            and source_provider is not None
+            and _provider_value(source_provider) == _provider_value(provider)
+        ):
+            reasoning_field = reasoning_replay_field(provider, model)
+
+        reasoning_text: Optional[str] = None
         if isinstance(self.content, str):
             content = self.content
         elif isinstance(self.content, list):
             # Exclude tool call and tool result blocks from assistant content; they are handled separately
             non_tool_blocks = [item for item in self.content if not isinstance(item, (ToolCall, ToolResult))]
+            if reasoning_field is not None:
+                thinking_blocks = [b for b in non_tool_blocks if isinstance(b, ThinkingBlock)]
+                rest_blocks = [b for b in non_tool_blocks if not isinstance(b, ThinkingBlock)]
+                has_tool_calls = any(isinstance(item, ToolCall) for item in self.content)
+                # Only replay reasoning natively if the message still has answer
+                # content or tool calls afterwards; otherwise keep the visible-text
+                # fallback so a reasoning-only message isn't dropped by the
+                # empty-content guard in MessageHistory.to_openai.
+                if thinking_blocks and (rest_blocks or has_tool_calls):
+                    reasoning_text = "\n\n".join(b.thinking for b in thinking_blocks)
+                    non_tool_blocks = rest_blocks
             content = [item.to_openai() for item in non_tool_blocks]
+            # Strict OpenAI-compatible servers (e.g. DeepSeek) prefer an empty
+            # string over an empty list when an assistant message carries only
+            # tool_calls and/or native reasoning.
+            if not content:
+                content = ""
         else:
             # Fallback for unexpected content type
             content = ""
 
         # Handle tool calls if present
-        result = {"role": self.role, "content": content}
+        result: Dict[str, Any] = {"role": self.role, "content": content}
+
+        if reasoning_field is not None and reasoning_text is not None:
+            result[reasoning_field] = reasoning_text
 
         # Extract tool calls from content if they exist
         tool_calls = (
@@ -1462,7 +1507,7 @@ class MessageHistory(list):
     def to_anthropic(self) -> list:
         return [m.to_anthropic() for m in self]
 
-    def to_openai(self) -> list:
+    def to_openai(self, provider: Optional[str] = None, model: Optional[str] = None) -> list:
         processed_messages = []
         consumed_tool_result_ids = set()
         messages = list(self)
@@ -1495,7 +1540,7 @@ class MessageHistory(list):
         for index, message in enumerate(messages):
             # No list content: pass through
             if not isinstance(message.content, list):
-                processed_messages.append(message.to_openai())
+                processed_messages.append(message.to_openai(provider, model))
                 continue
 
             # Partition ToolResult blocks so they become separate 'tool' messages
@@ -1515,7 +1560,7 @@ class MessageHistory(list):
                     tool_calls=message.tool_calls,
                     usage_metadata=message.usage_metadata,
                 )
-                temp_payload = temp_message.to_openai()
+                temp_payload = temp_message.to_openai(provider, model)
 
                 # Avoid emitting empty assistant/user messages with neither content nor tool_calls
                 if payload_has_content(temp_payload) or temp_payload.get("tool_calls"):
@@ -1550,7 +1595,7 @@ class MessageHistory(list):
                     continue
 
                 # No ToolResult in this message. If it has tool_calls, ensure immediate tool responses.
-                temp_payload = message.to_openai()
+                temp_payload = message.to_openai(provider, model)
                 if payload_has_content(temp_payload) or temp_payload.get("tool_calls"):
                     processed_messages.append(temp_payload)
 

--- a/kolega_code/llm/providers/openai.py
+++ b/kolega_code/llm/providers/openai.py
@@ -438,7 +438,9 @@ class OpenAIProvider(BaseLLMProvider):
         # retried, instead of hanging on the SDK's 600s default.
         return OpenAIStreamWrapper(
             await self.async_client.chat.completions.create(
-                messages=messages.to_openai(), timeout=streaming_timeout(), **generation_params
+                messages=messages.to_openai(provider=self.provider_name, model=generation_params["model"]),
+                timeout=streaming_timeout(),
+                **generation_params,
             ),
             requested_include_usage=True,
             provider_name=self.provider_name,
@@ -468,7 +470,10 @@ class OpenAIProvider(BaseLLMProvider):
             messages = MessageHistory([system] + messages)
 
         await self.rate_limiter.acquire()
-        response = await self.async_client.chat.completions.create(messages=messages.to_openai(), **generation_params)
+        response = await self.async_client.chat.completions.create(
+            messages=messages.to_openai(provider=self.provider_name, model=generation_params["model"]),
+            **generation_params,
+        )
 
         # Extract message and add usage data
         message = Message.from_openai(response.choices[0].message)

--- a/kolega_code/llm/specs/thinking.py
+++ b/kolega_code/llm/specs/thinking.py
@@ -99,3 +99,50 @@ def build_thinking_request_params(provider: str, model_name: str, effort: Option
         return {"reasoning": {"effort": normalized, "summary": "auto"}}
 
     raise ValueError(f"Unknown thinking effort mode '{spec.mode}' for {_provider_value(provider)}/{model_name}.")
+
+
+# Provider-native assistant-message field for replaying prior reasoning on the
+# Chat Completions path. Streaming capture reads delta.reasoning_content /
+# delta.reasoning (see OpenAIStreamWrapper); replay must echo back the same field
+# the provider emits so the model continues its chain-of-thought across tool-call
+# rounds instead of re-deriving it. Providers absent here fall back to the
+# visible-text ThinkingBlock.to_openai() placeholder. The field is per provider,
+# not per mode: Fireworks and Ollama Cloud share mode "openai_reasoning_effort"
+# but use different field names.
+_REASONING_REPLAY_FIELDS: Dict[str, str] = {
+    "deepseek": "reasoning_content",
+    "fireworks": "reasoning_content",
+    "ollama_cloud": "reasoning",
+    # xAI's Chat Completions endpoint returns and accepts reasoning_content even
+    # though its public docs only describe the Responses API (verified live
+    # against grok-4.3: streaming emits reasoning_content deltas and replaying it
+    # on a multi-turn tool-call request is accepted).
+    "xai": "reasoning_content",
+}
+
+# Chat-Completions reasoning modes whose reasoning text is replayable via a flat
+# top-level field. Responses/Anthropic/Google modes carry reasoning differently
+# and are excluded.
+_REASONING_REPLAY_MODES = frozenset({"openai_reasoning_effort", "deepseek_effort"})
+
+
+def reasoning_replay_field(provider: str, model_name: str) -> Optional[str]:
+    """Return the assistant-message field for replaying prior reasoning, if any.
+
+    Returns the provider-native field name (e.g. ``"reasoning_content"``) only
+    when ``model_name`` is a Chat-Completions reasoning model for ``provider`` and
+    that provider has a configured replay field. Returns ``None`` for
+    non-reasoning models, unknown provider/model pairs, and providers whose
+    reasoning is not replayable via a flat field.
+    """
+    field = _REASONING_REPLAY_FIELDS.get(_provider_value(provider))
+    if field is None:
+        return None
+    try:
+        spec = get_thinking_effort_spec(provider, model_name)
+    except ValueError:
+        # get_model_specs raises for unknown provider/model; treat as non-reasoning.
+        return None
+    if spec is None or spec.mode not in _REASONING_REPLAY_MODES:
+        return None
+    return field

--- a/tests/agent/llm/test_openai_reasoning_replay.py
+++ b/tests/agent/llm/test_openai_reasoning_replay.py
@@ -1,0 +1,214 @@
+"""Reasoning replay for the OpenAI-compatible Chat Completions path.
+
+Prior reasoning captured from reasoning models (DeepSeek, Fireworks, Ollama
+Cloud) must be replayed via each provider's native reasoning field
+(``reasoning_content`` / ``reasoning``) on the assistant message, not re-injected
+as visible ``*Thinking:*`` prompt text. Providers/models without native support
+keep the visible-text fallback. Foreign-provider reasoning never serializes as
+native replay metadata.
+"""
+
+from kolega_code.llm.models import (
+    Message,
+    MessageHistory,
+    TextBlock,
+    ThinkingBlock,
+    ToolCall,
+    ToolResult,
+)
+from kolega_code.llm.specs.thinking import reasoning_replay_field
+
+DEEPSEEK_MODEL = "deepseek-v4-pro"
+FIREWORKS_MODEL = "accounts/fireworks/models/glm-5p2"
+OLLAMA_MODEL = "deepseek-v3.2"
+
+
+def _assistant(*blocks, provider):
+    return Message(role="assistant", content=list(blocks), usage_metadata={"provider": provider})
+
+
+# --- resolver -------------------------------------------------------------
+
+
+def test_reasoning_replay_field_deepseek_fireworks_xai_use_reasoning_content():
+    assert reasoning_replay_field("deepseek", DEEPSEEK_MODEL) == "reasoning_content"
+    assert reasoning_replay_field("fireworks", FIREWORKS_MODEL) == "reasoning_content"
+    # xAI's Chat Completions endpoint returns/accepts reasoning_content (verified live).
+    assert reasoning_replay_field("xai", "grok-4.3") == "reasoning_content"
+
+
+def test_reasoning_replay_field_ollama_uses_reasoning():
+    assert reasoning_replay_field("ollama_cloud", OLLAMA_MODEL) == "reasoning"
+
+
+def test_reasoning_replay_field_none_for_unmapped_provider_unknown_and_non_reasoning():
+    # Provider not in the map at all.
+    assert reasoning_replay_field("together", "anything") is None
+    assert reasoning_replay_field("groq", "anything") is None
+    # Mapped provider but a non-reasoning model on it (no thinking_effort spec).
+    assert reasoning_replay_field("xai", "grok-build-0.1") is None
+    # Unknown provider/model pair (get_model_specs raises -> None).
+    assert reasoning_replay_field("deepseek", "no-such-model") is None
+
+
+# --- native serialization -------------------------------------------------
+
+
+def test_deepseek_thinking_block_serializes_as_reasoning_content():
+    asst = _assistant(
+        ThinkingBlock(thinking="let me think"),
+        TextBlock("the answer"),
+        ToolCall(id="t1", name="get_weather", input={"city": "Paris"}),
+        provider="deepseek",
+    )
+
+    out = MessageHistory([asst]).to_openai(provider="deepseek", model=DEEPSEEK_MODEL)[0]
+
+    assert out["reasoning_content"] == "let me think"
+    # Answer text stays in content; thinking is pulled out.
+    assert out["content"] == [{"type": "text", "text": "the answer"}]
+    assert "*Thinking:*" not in str(out["content"])
+    # Tool calls preserved.
+    assert out["tool_calls"][0]["id"] == "t1"
+    assert out["tool_calls"][0]["function"]["name"] == "get_weather"
+
+
+def test_ollama_cloud_uses_reasoning_not_reasoning_content():
+    asst = _assistant(ThinkingBlock(thinking="r"), TextBlock("a"), provider="ollama_cloud")
+
+    out = MessageHistory([asst]).to_openai(provider="ollama_cloud", model=OLLAMA_MODEL)[0]
+
+    assert out["reasoning"] == "r"
+    assert "reasoning_content" not in out
+    assert out["content"] == [{"type": "text", "text": "a"}]
+
+
+def test_fireworks_uses_reasoning_content():
+    asst = _assistant(ThinkingBlock(thinking="r"), TextBlock("a"), provider="fireworks")
+
+    out = MessageHistory([asst]).to_openai(provider="fireworks", model=FIREWORKS_MODEL)[0]
+
+    assert out["reasoning_content"] == "r"
+    assert out["content"] == [{"type": "text", "text": "a"}]
+
+
+def test_multiple_thinking_blocks_join_with_blank_line():
+    asst = _assistant(
+        ThinkingBlock(thinking="first"),
+        ThinkingBlock(thinking="second"),
+        TextBlock("a"),
+        provider="deepseek",
+    )
+
+    out = MessageHistory([asst]).to_openai(provider="deepseek", model=DEEPSEEK_MODEL)[0]
+
+    assert out["reasoning_content"] == "first\n\nsecond"
+
+
+def test_empty_content_normalized_to_empty_string_with_tool_calls():
+    # [ThinkingBlock, ToolCall]: after pulling reasoning out, content is empty.
+    asst = _assistant(
+        ThinkingBlock(thinking="r"),
+        ToolCall(id="t1", name="read_file", input={"path": "a.py"}),
+        provider="deepseek",
+    )
+
+    out = MessageHistory([asst]).to_openai(provider="deepseek", model=DEEPSEEK_MODEL)[0]
+
+    assert out["content"] == ""
+    assert out["reasoning_content"] == "r"
+    assert out["tool_calls"][0]["id"] == "t1"
+
+
+def test_native_serialization_through_tool_result_partition_path():
+    # An assistant message that also carries a ToolResult goes through the
+    # temp_message branch of MessageHistory.to_openai; it must still serialize
+    # reasoning natively.
+    asst = _assistant(
+        ThinkingBlock(thinking="r"),
+        TextBlock("a"),
+        ToolCall(id="t1", name="f", input={}),
+        ToolResult(tool_use_id="t1", name="f", content="ok", is_error=False),
+        provider="deepseek",
+    )
+
+    out = MessageHistory([asst]).to_openai(provider="deepseek", model=DEEPSEEK_MODEL)
+
+    assistant_msg = out[0]
+    assert assistant_msg["role"] == "assistant"
+    assert assistant_msg["reasoning_content"] == "r"
+    assert assistant_msg["content"] == [{"type": "text", "text": "a"}]
+    # The tool result becomes its own role=tool message.
+    assert any(m.get("role") == "tool" and m.get("tool_call_id") == "t1" for m in out)
+
+
+# --- fallback / safety ----------------------------------------------------
+
+
+def test_non_reasoning_target_keeps_visible_text_fallback():
+    asst = _assistant(ThinkingBlock(thinking="r"), TextBlock("a"), provider="together")
+
+    out = MessageHistory([asst]).to_openai(provider="together", model="some-chat-model")[0]
+
+    assert "reasoning_content" not in out
+    assert out["content"] == [{"type": "text", "text": "*Thinking:*\nr"}, {"type": "text", "text": "a"}]
+
+
+def test_default_call_without_provider_is_unchanged():
+    asst = _assistant(ThinkingBlock(thinking="r"), TextBlock("a"), provider="deepseek")
+
+    out = MessageHistory([asst]).to_openai()[0]
+
+    assert "reasoning_content" not in out
+    assert out["content"][0] == {"type": "text", "text": "*Thinking:*\nr"}
+
+
+def test_foreign_provider_reasoning_not_replayed_natively():
+    # Reasoning produced by anthropic, target deepseek: must NOT become
+    # reasoning_content (same-provider gate); falls back to visible text.
+    asst = _assistant(ThinkingBlock(thinking="secret"), TextBlock("a"), provider="anthropic")
+
+    out = MessageHistory([asst]).to_openai(provider="deepseek", model=DEEPSEEK_MODEL)[0]
+
+    assert "reasoning_content" not in out
+    assert {"type": "text", "text": "*Thinking:*\nsecret"} in out["content"]
+
+
+def test_cross_provider_chat_reasoning_not_replayed_natively():
+    # deepseek-origin reasoning, target fireworks: different provider -> fallback.
+    asst = _assistant(ThinkingBlock(thinking="r"), TextBlock("a"), provider="deepseek")
+
+    out = MessageHistory([asst]).to_openai(provider="fireworks", model=FIREWORKS_MODEL)[0]
+
+    assert "reasoning_content" not in out
+    assert {"type": "text", "text": "*Thinking:*\nr"} in out["content"]
+
+
+def test_reasoning_only_message_not_dropped():
+    # No answer text, no tool calls: pulling reasoning out would empty the
+    # message; keep the visible-text fallback so it isn't dropped.
+    asst = _assistant(ThinkingBlock(thinking="only"), provider="deepseek")
+
+    out = MessageHistory([asst]).to_openai(provider="deepseek", model=DEEPSEEK_MODEL)
+
+    assert len(out) == 1
+    assert out[0]["content"] == [{"type": "text", "text": "*Thinking:*\nonly"}]
+    assert "reasoning_content" not in out[0]
+
+
+def test_streamed_deepseek_reasoning_round_trips_to_reasoning_content():
+    # Capture: streamed reasoning_content becomes a ThinkingBlock.
+    msg = Message.from_openai_stream(
+        role="assistant",
+        reasoning_content="streamed cot",
+        content="final",
+        stop_reason="stop",
+    )
+    assert isinstance(msg.content[0], ThinkingBlock)
+    # Stamp provider as the live provider does, then replay.
+    msg.usage_metadata["provider"] = "deepseek"
+
+    out = MessageHistory([msg]).to_openai(provider="deepseek", model=DEEPSEEK_MODEL)[0]
+
+    assert out["reasoning_content"] == "streamed cot"
+    assert out["content"] == [{"type": "text", "text": "final"}]


### PR DESCRIPTION
## Summary

OpenAI-compatible reasoning replay fixed and verified.

### What was wrong

Reasoning captured from Chat Completions providers was stored correctly as ThinkingBlocks, but ThinkingBlock.to_openai() re-serialized it as visible `*Thinking:*` prompt text instead of replaying it through each provider's native reasoning field. The Responses API path was already correct and was left untouched.

### Changes

- **`kolega_code/llm/specs/thinking.py`** — new `reasoning_replay_field(provider, model)` resolver + `_REASONING_REPLAY_FIELDS` map, gated on a Chat-Completions reasoning mode.
- **`kolega_code/llm/models.py`** — `Message.to_openai(provider, model)` and `MessageHistory.to_openai(provider, model)` are now provider/model-aware (backward compatible). For a same-provider assistant message they pull ThinkingBlocks into the native field, keep answer text in `content`, preserve `tool_calls`, normalize empty content to `""`, and fall back to visible text for reasoning-only messages (so none get dropped). A `source==target` gate ensures foreign reasoning never serializes natively.
- **`kolega_code/llm/providers/openai.py`** — both `stream()` and `generate()` pass `provider=self.provider_name`, `model=...`.
- **`tests/agent/llm/test_openai_reasoning_replay.py`** — 15 new regression tests.

### Verified live

| Provider | field | result |
|---|---|---|
| DeepSeek deepseek-v4-pro | reasoning_content | replay accepted ✓ |
| Fireworks glm-5p2 | reasoning_content | replay accepted ✓ |
| Ollama Cloud deepseek-v3.2 | reasoning | replay accepted ✓ |
| xAI grok-4.3 | reasoning_content | replay accepted ✓ |

### Two things your instincts were right about

1. **DeepSeek does not 400 when reasoning is omitted** — confirmed against deepseek-v4-pro. The fix is for continuity/conformance, not crash-avoidance.
2. **xAI needed proper research** — its docs claim reasoning is Responses-API-only, but the live Chat Completions endpoint does emit and accept `reasoning_content` (verified on grok-4/4.3/fast-reasoning). So I enabled it with `reasoning_content` rather than leaving it on fallback.

Tests: 1590 passed, 0 failures.