### PR TITLE
fix(tui): consistent footer key display (duplicate Ctrl+P + Ctrl+Q/Ctrl+C)

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -130,9 +130,9 @@ class KolegaCodeApp(
         Binding("ctrl+o", "toggle_sidebar", "Sidebar", show=True, key_display="Ctrl+O", priority=True),
         Binding("ctrl+g", "open_sub_agent", "Agents", show=True, key_display="Ctrl+G", priority=True),
         Binding("ctrl+r", "open_changes", "Changes", show=True, key_display="Ctrl+R", priority=True),
-        Binding("ctrl+c", "cancel_generation", "Cancel", show=True),
+        Binding("ctrl+c", "cancel_generation", "Cancel", show=True, key_display="Ctrl+C"),
         Binding("escape", "cancel_generation", "Cancel", show=False),
-        Binding("ctrl+q", "quit", "Quit", show=True),
+        Binding("ctrl+q", "quit", "Quit", show=True, key_display="Ctrl+Q"),
     ]
 
     def __init__(

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -116,6 +116,11 @@ class KolegaCodeApp(
     """Interactive terminal UI for Kolega Code."""
 
     CSS_PATH = "tui/styles.tcss"
+    # kolega-code uses its own / slash-command system, so disable Textual's
+    # command palette. Its default binding is ctrl+p, which collides with the
+    # toggle_permission_mode binding below and made "Ctrl+P Permissions" render
+    # twice in the footer.
+    ENABLE_COMMAND_PALETTE = False
 
     BINDINGS = [
         Binding(

--- a/tests/cli/test_app_status_modes.py
+++ b/tests/cli/test_app_status_modes.py
@@ -511,6 +511,71 @@ async def test_textual_app_ctrl_p_toggles_permission_mode(tmp_path: Path, monkey
 
 
 @pytest.mark.asyncio
+async def test_footer_renders_ctrl_p_permissions_exactly_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression: "Ctrl+P Permissions" must appear once, not twice, in the footer.
+
+    Textual's command palette defaults to ctrl+p, which collided with the
+    toggle_permission_mode binding and rendered "Ctrl+P Permissions" twice.
+    Disabling the command palette on KolegaCodeApp resolves the collision.
+    """
+    pytest.importorskip("textual")
+
+    from textual.widgets import Footer
+    from textual.widgets._footer import FooterKey
+
+    from kolega_code.cli.app import KolegaCodeApp
+
+    # The command palette (default ctrl+p) is disabled to avoid the collision.
+    assert KolegaCodeApp.ENABLE_COMMAND_PALETTE is False
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.permission_mode = kwargs["permission_mode"]
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
+        def dump_message_history(self):
+            return []
+
+        def set_permission_mode(self, permission_mode):
+            self.permission_mode = permission_mode
+
+        def set_permission_callback(self, permission_callback):
+            self.permission_callback = permission_callback
+
+        async def cleanup(self):
+            return None
+
+    monkeypatch.setattr(agent_runtime_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.pause()
+
+        footer = app.query_one(Footer)
+        ctrl_p_keys = [key for key in footer.query(FooterKey) if key.key == "ctrl+p"]
+
+        assert len(ctrl_p_keys) == 1
+        assert ctrl_p_keys[0].key_display == "Ctrl+P"
+        assert ctrl_p_keys[0].description == "Permissions"
+
+
+@pytest.mark.asyncio
 async def test_textual_app_ctrl_o_toggles_sidebar_and_keeps_active_tab(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/cli/test_app_status_modes.py
+++ b/tests/cli/test_app_status_modes.py
@@ -575,6 +575,25 @@ async def test_footer_renders_ctrl_p_permissions_exactly_once(tmp_path: Path, mo
         assert ctrl_p_keys[0].description == "Permissions"
 
 
+def test_app_ctrl_bindings_use_explicit_key_display() -> None:
+    """Every Ctrl binding must set a ``Ctrl+X`` key_display.
+
+    Without an explicit key_display, Textual falls back to caret notation
+    (e.g. ctrl+q renders as "^q"), which is inconsistent with the other
+    Ctrl bindings. This guards against that regression at the source.
+    """
+    from kolega_code.cli.app import KolegaCodeApp
+
+    ctrl_bindings = [binding for binding in KolegaCodeApp.BINDINGS if binding.key.startswith("ctrl+")]
+    assert ctrl_bindings, "expected at least one ctrl binding"
+
+    for binding in ctrl_bindings:
+        expected = "Ctrl+" + binding.key.split("+", 1)[1].upper()
+        assert binding.key_display == expected, (
+            f"binding {binding.key!r} ({binding.action}) should display as {expected!r}, got {binding.key_display!r}"
+        )
+
+
 @pytest.mark.asyncio
 async def test_textual_app_ctrl_o_toggles_sidebar_and_keeps_active_tab(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Two footer (bottom bar) display fixes.

## 1. Duplicate `Ctrl+P Permissions`
**Problem:** `Ctrl+P Permissions` rendered **twice** in the footer.

**Root cause:** Textual's `App` enables a command palette bound to `ctrl+p` by default (`ENABLE_COMMAND_PALETTE = True`, `COMMAND_PALETTE_BINDING = 'ctrl+p'`). `KolegaCodeApp` also binds `ctrl+p` -> `toggle_permission_mode`. The `Footer` renders the permissions binding once in its main section, then its command-palette section looks up `active_bindings["ctrl+p"]` -- which resolves to the *permissions* binding -- and renders it a second time. kolega-code never uses Textual's command palette (it has its own `/` slash-command system).

**Fix:** `ENABLE_COMMAND_PALETTE = False` on `KolegaCodeApp`. Removes both the dead `ctrl+p` -> `command_palette` binding and the duplicate footer entry. `Ctrl+P` still toggles permission mode.

## 2. `Quit` showed as `^q` instead of `Ctrl+Q`
**Problem:** `Quit` rendered as `^q` while the other Ctrl bindings showed `Ctrl+X`.

**Root cause:** The `ctrl+q` (Quit) and `ctrl+c` (Cancel) bindings had no `key_display`, so Textual's `get_key_display` fell back to caret notation (`^q`/`^c`). The other Ctrl bindings set `key_display="Ctrl+X"` explicitly.

**Fix:** Add `key_display="Ctrl+Q"` and `key_display="Ctrl+C"` for consistency.

## Tests
- `test_footer_renders_ctrl_p_permissions_exactly_once` -- footer renders `ctrl+p` exactly once.
- `test_app_ctrl_bindings_use_explicit_key_display` -- every app Ctrl binding uses a `Ctrl+X` display (guards against the `^x` caret fallback recurring).
- Existing `ctrl+p` toggle, `ctrl+o` sidebar, and changes-inspector binding tests still pass.

## Verification
- Reproduced both issues via a headless Textual pilot run; confirmed fixed (`Ctrl+P` once, `Ctrl+Q`/`Ctrl+C` style).
- `Ctrl+P` still toggles permission mode; no other footer entries change.
