### PR TITLE
fix(llm): avoid token counting UI freezes

### DIFF
--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -642,11 +642,21 @@ class BaseAgent(LogMixin):
     # Context budget
     # ------------------------------------------------------------------
 
-    async def count_current_context(self) -> TokenCount:
-        self._sanitize_oversized_tool_results()
-        # History sent to the LLM (and to token counting): tool-call-repaired and,
-        # for non-vision models, stripped of image blocks from earlier turns.
-        fixed_history = self._history_for_llm()
+    async def count_current_context(self, fixed_history: Optional[MessageHistory] = None) -> TokenCount:
+        """Count the current context's tokens and emit a context-budget update.
+
+        Building the request history (``_history_for_llm``: tool-call repair +
+        provider adaptation, and image stripping for non-vision models) is an
+        O(history) pass that runs on the event loop. The agent loop already builds
+        that history for the request, so it passes it in here as ``fixed_history`` to
+        avoid rebuilding it a second time per iteration. Callers that only need a
+        count (``/context``, ``/compact``) omit it and the history is built here.
+        """
+        if fixed_history is None:
+            self._sanitize_oversized_tool_results()
+            # History sent to the LLM (and to token counting): tool-call-repaired and,
+            # for non-vision models, stripped of image blocks from earlier turns.
+            fixed_history = self._history_for_llm()
         token_count = await self.llm.count_tokens(
             system=self.system_prompt,
             messages=fixed_history,
@@ -1432,7 +1442,12 @@ class BaseAgent(LogMixin):
             self.mark_cache_checkpoint()
 
             try:
-                token_count = await self.count_current_context()
+                # Build the request history once and reuse it for both the token
+                # count and the request below — the repair+adapt+image-strip pass is
+                # O(history) and ran twice per iteration before.
+                self._sanitize_oversized_tool_results()
+                fixed_history = self._history_for_llm()
+                token_count = await self.count_current_context(fixed_history)
                 logger.debug("Input token count: %s", token_count)
 
                 if self.compressor.over_budget(token_count.input_tokens, self.model_context_length):
@@ -1447,7 +1462,12 @@ class BaseAgent(LogMixin):
                         },
                     )
                     result = await self.compress_history()
-                    token_count = await self.count_current_context()
+                    # Rebuild after compaction (history changed) and re-mark the cache
+                    # checkpoint before re-counting so the reused history reflects it.
+                    self.mark_cache_checkpoint()
+                    self._sanitize_oversized_tool_results()
+                    fixed_history = self._history_for_llm()
+                    token_count = await self.count_current_context(fixed_history)
 
                     # PostCompact hooks (advisory): observe the outcome. There is no
                     # destructive fallback — a bounded summary plus capped tool results
@@ -1466,18 +1486,12 @@ class BaseAgent(LogMixin):
                         },
                     )
 
-                    self.mark_cache_checkpoint()
-
                 current_response = ""
                 current_thinking = ""
                 thinking_started = False
                 # Use the same UUID for each segment of the response
                 response_uuid = str(uuid.uuid4())
                 thinking_uuid = str(uuid.uuid4())
-
-                # History sent to the LLM: tool-call-repaired and, for non-vision
-                # models, stripped of image blocks carried over from earlier turns.
-                fixed_history = self._history_for_llm()
 
                 # Diagnostics: bracket the request so a stall is visible in the timeline
                 # (start↔end, or start↔llm_error if it fails) with the actual endpoint.

--- a/kolega_code/cli/tui/sub_agent_screen.py
+++ b/kolega_code/cli/tui/sub_agent_screen.py
@@ -362,6 +362,8 @@ class SubAgentInspectorScreen(ModalScreen):
                 continue
             label = step.tool_name or step.kind
             lines.append(f"[{step.kind}] {label}")
+            # Fold any deferred stream deltas so a copy mid-stream isn't missing the tail.
+            step.materialize()
             body = step.full_content or step.content
             if body:
                 lines.append(body)

--- a/kolega_code/cli/tui/transcript.py
+++ b/kolega_code/cli/tui/transcript.py
@@ -390,7 +390,13 @@ class TranscriptRenderingMixin:
             entry_content = self._tool_result_preview(text)
             full_content = self._capped_tool_text(text)
         elif stream_mode == "append":
-            buffer_text = self._tool_stream_buffers.get(buffer_key, "") + text
+            # Bound the live buffer to the full-content cap window. The preview is the
+            # tail and the live expand view is capped to this many chars anyway, and on
+            # completion the entry is recomputed from the complete text. Storing the
+            # whole stream via `get()+text` per delta is O(n^2) and stalled the UI on
+            # long streamed tool output.
+            cap = theme.TOOL_FULL_CONTENT_CAP_CHARS
+            buffer_text = (self._tool_stream_buffers.get(buffer_key, "") + text)[-cap:]
             self._tool_stream_buffers[buffer_key] = buffer_text
             entry_content = self._tool_stream_preview(buffer_text)
             full_content = self._capped_tool_text(buffer_text)
@@ -611,7 +617,13 @@ class TranscriptRenderingMixin:
         else:  # streamed response text - accumulate by chunk uuid
             activity.current_action = "responding"
             if event.uuid and text:
-                buffer = activity.stream_buffers.get(event.uuid, "") + text
+                # Keep only a bounded tail. The card shows just the last
+                # SUB_AGENT_TAIL_CHARS (whitespace-collapsed), so storing the whole
+                # response via `get()+text` per delta was pure O(n^2) waste that froze
+                # the UI on long reasoning streams. A small multiple of the display
+                # window preserves the truncation/ellipsis behavior at O(1) per delta.
+                tail_cap = theme.SUB_AGENT_TAIL_CHARS * 4
+                buffer = (activity.stream_buffers.get(event.uuid, "") + text)[-tail_cap:]
                 activity.stream_buffers[event.uuid] = buffer
                 activity.active_stream_uuid = event.uuid
             self._accumulate_sub_agent_stream(activity, "assistant", event, text)
@@ -696,8 +708,16 @@ class TranscriptRenderingMixin:
             step = ConversationEntry(kind=kind, content="", complete=complete, uuid=chunk_uuid or None)
             activity.steps.append(step)
             activity.stream_steps[cache_key] = step
-        step.content += text
+        # Defer concatenation: deltas land in stream_parts (O(1)) and are folded into
+        # content once on completion (and at render time by ConversationEntryWidget.
+        # refresh_content), mirroring _apply_stream_chunk. A per-delta `step.content +=
+        # text` is O(n^2) over a long reasoning stream — on DeepSeek-class sub-agents it
+        # grew to seconds of event-loop CPU and froze scrolling while sub-agents ran.
+        if text:
+            step.stream_parts.append(text)
         step.complete = complete
+        if complete:
+            step.materialize()
 
     def _note_sub_agent_tool_stream(self, event: AgentEvent) -> None:
         activity = self._ensure_sub_agent_activity(event)

--- a/kolega_code/llm/providers/anthropic.py
+++ b/kolega_code/llm/providers/anthropic.py
@@ -1,5 +1,7 @@
+import asyncio
 import json
 import os
+import threading
 from typing import Any, AsyncContextManager, Dict, List, Optional
 from weakref import WeakKeyDictionary
 
@@ -129,6 +131,8 @@ class AnthropicProvider(BaseLLMProvider):
         # adaptation / repair produce new objects, which miss naturally.
         self._local_token_memo: "WeakKeyDictionary[Message, tuple]" = WeakKeyDictionary()
         self._local_tool_token_memo: "WeakKeyDictionary[ToolDefinition, int]" = WeakKeyDictionary()
+        # Guards the memos when local counting is offloaded to a worker thread.
+        self._local_token_memo_lock = threading.Lock()
 
     @property
     def retry_decorator(self):
@@ -192,7 +196,9 @@ class AnthropicProvider(BaseLLMProvider):
         if self.use_local_token_counting:
             # Use local tiktoken-based counting (no API call). This is an
             # estimate for context management, not authoritative billing usage.
-            return self._count_tokens_local(messages, system, model, tools)
+            # Offload the pure-CPU encode to a worker thread so it never blocks the
+            # Textual/asyncio event loop (the remote branch already yields on I/O).
+            return await asyncio.to_thread(self._count_tokens_local, messages, system, model, tools)
         else:
             # Use Anthropic API for token counting
             await self.rate_limiter.acquire()
@@ -236,15 +242,16 @@ class AnthropicProvider(BaseLLMProvider):
         self._ensure_local_token_memos()
         tools = tools or []
 
-        # Sum memoized per-message content counts: only new or changed messages are
-        # re-encoded each iteration (system is a Message too).
-        num_tokens = 0
-        if system:
-            num_tokens += self.SYSTEM_OVERHEAD + self._memoized_content_tokens(encoding, system)
-        for message in messages:
-            num_tokens += self.MESSAGE_OVERHEAD + self._memoized_content_tokens(encoding, message)
-        for tool in tools:
-            num_tokens += self._memoized_tool_tokens(encoding, tool)
+        with self._local_token_memo_lock:
+            # Sum memoized per-message content counts: only new or changed messages are
+            # re-encoded each iteration (system is a Message too).
+            num_tokens = 0
+            if system:
+                num_tokens += self.SYSTEM_OVERHEAD + self._memoized_content_tokens(encoding, system)
+            for message in messages:
+                num_tokens += self.MESSAGE_OVERHEAD + self._memoized_content_tokens(encoding, message)
+            for tool in tools:
+                num_tokens += self._memoized_tool_tokens(encoding, tool)
 
         return TokenCount(input_tokens=num_tokens, output_tokens=None)
 
@@ -254,6 +261,8 @@ class AnthropicProvider(BaseLLMProvider):
             self._local_token_memo = WeakKeyDictionary()
         if getattr(self, "_local_tool_token_memo", None) is None:
             self._local_tool_token_memo = WeakKeyDictionary()
+        if getattr(self, "_local_token_memo_lock", None) is None:
+            self._local_token_memo_lock = threading.Lock()
 
     def _memoized_content_tokens(self, encoding, message) -> int:
         fingerprint = self._content_fingerprint(message.content)

--- a/kolega_code/llm/providers/openai.py
+++ b/kolega_code/llm/providers/openai.py
@@ -1,26 +1,64 @@
 from typing import Any, AsyncContextManager, Dict, List, Optional
 from weakref import WeakKeyDictionary
+import asyncio
 import json
 import logging
 import math
+import threading
 
 import tiktoken
 from openai import AsyncOpenAI
 
-from ..models import ImageBlock, Message, MessageChunk, MessageHistory, ToolCall, ToolDefinition, ToolResult
+from ..models import (
+    ImageBlock,
+    Message,
+    MessageChunk,
+    MessageHistory,
+    RedactedThinkingBlock,
+    ResponsesReasoningBlock,
+    ThinkingBlock,
+    ToolCall,
+    ToolDefinition,
+    ToolResult,
+)
 from ..specs import build_thinking_request_params
 from ..timeouts import streaming_timeout
 from ..tool_execution_ids import ToolExecutionIdRegistry
 from .base import BaseLLMProvider
 from .models import GenerationParams, TokenCount
 
+# tiktoken caches Encoding objects in a module-level registry after the first
+# (BPE-table-loading) call, but we also hold our own reference so the hot
+# count_tokens path never does even a registry dict lookup. cl100k_base is the
+# de-facto encoding for every OpenAI-compatible provider (DeepSeek, xAI, Fireworks,
+# ... have no native tiktoken table); the count is an estimate for context
+# management, not billing.
+_ENCODING_NAME = "cl100k_base"
+_encoding = None
+
+
+def _get_encoding():
+    global _encoding
+    if _encoding is None:
+        _encoding = tiktoken.get_encoding(_ENCODING_NAME)
+    return _encoding
+
 
 class OpenAIStreamWrapper:
     def __init__(self, openai_stream, requested_include_usage: bool = False, provider_name: str = "openai"):
         self.openai_stream = openai_stream
-        self.final_content = ""
-        self.final_reasoning_content = ""
+        # Accumulate streamed deltas into lists and ''.join once at finalize. A
+        # running ``str += delta`` is O(n^2) here because the buffer is an instance
+        # attribute (CPython's in-place concat optimization only fires for locals
+        # with refcount 1), and DeepSeek max-effort reasoning streams build enormous
+        # buffers over thousands of tiny chunks. Lists make accumulation O(n).
+        self._content_parts: List[str] = []
+        self._reasoning_parts: List[str] = []
+        # Per-index tool-call: the first delta's object (kept for id/name/index) plus
+        # its argument fragments collected separately so the JSON arg string (which can
+        # be large, e.g. a file-writing tool) is also joined once instead of grown.
         self.final_tool_calls = {}
+        self._tool_call_arg_parts: Dict[int, List[str]] = {}
         self.stop_reason = None
         self.usage_data = None
         self.tool_execution_ids = ToolExecutionIdRegistry()
@@ -28,6 +66,14 @@ class OpenAIStreamWrapper:
 
         self._closed = False
         self._requested_include_usage = requested_include_usage
+
+    @property
+    def final_content(self) -> str:
+        return "".join(self._content_parts)
+
+    @property
+    def final_reasoning_content(self) -> str:
+        return "".join(self._reasoning_parts)
 
     async def __aenter__(self):
         return self
@@ -56,25 +102,27 @@ class OpenAIStreamWrapper:
                 if delta is not None:
                     content = getattr(delta, "content", None) or ""
                     if content:
-                        self.final_content += content
+                        self._content_parts.append(content)
 
                     reasoning_content = (
                         getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None) or ""
                     )
                     if reasoning_content:
-                        self.final_reasoning_content += reasoning_content
+                        self._reasoning_parts.append(reasoning_content)
 
                     for tool_call in getattr(delta, "tool_calls", []) or []:
                         index = tool_call.index
 
                         if index not in self.final_tool_calls:
+                            # Keep the first delta's object for id/name/index; seed its
+                            # argument fragments and clear the live attribute (the joined
+                            # value is written back in get_final_message).
                             self.final_tool_calls[index] = tool_call
-
-                        if self.final_tool_calls[index].function.arguments != tool_call.function.arguments:
-                            if self.final_tool_calls[index].function.arguments is None:
-                                self.final_tool_calls[index].function.arguments = ""
-
-                            self.final_tool_calls[index].function.arguments += tool_call.function.arguments
+                            self._tool_call_arg_parts[index] = [tool_call.function.arguments or ""]
+                        else:
+                            fragment = tool_call.function.arguments
+                            if fragment:
+                                self._tool_call_arg_parts[index].append(fragment)
 
                 # Capture stop reason if present
                 self.stop_reason = getattr(choice0, "finish_reason", self.stop_reason)
@@ -106,6 +154,13 @@ class OpenAIStreamWrapper:
             raise
 
     async def get_final_message(self):
+        # Materialize the accumulated tool-call argument fragments into each delta
+        # object exactly once (the O(n) join the per-chunk path deliberately avoided).
+        for index, parts in self._tool_call_arg_parts.items():
+            tool_call = self.final_tool_calls.get(index)
+            if tool_call is not None:
+                tool_call.function.arguments = "".join(parts)
+
         message = Message.from_openai_stream(
             role="assistant",
             content=self.final_content,
@@ -161,6 +216,8 @@ class OpenAIProvider(BaseLLMProvider):
         # new objects, which miss naturally.
         self._message_token_memo: "WeakKeyDictionary[Message, tuple]" = WeakKeyDictionary()
         self._tool_token_memo: "WeakKeyDictionary[ToolDefinition, int]" = WeakKeyDictionary()
+        # Guards the memos when count_tokens is offloaded to a worker thread.
+        self._token_memo_lock = threading.Lock()
 
     @property
     def retry_decorator(self):
@@ -219,20 +276,28 @@ class OpenAIProvider(BaseLLMProvider):
         Returns:
             TokenCount object with input token count
         """
-        encoding = tiktoken.get_encoding("cl100k_base")
-        self._ensure_token_memos()
-
         # Combine system message with messages if provided
         all_messages = ([system] + list(messages)) if system else list(messages)
 
-        # Sum memoized per-message counts: only new or changed messages are re-encoded.
-        num_tokens = sum(self._memoized_message_tokens(encoding, message) for message in all_messages)
-
-        # Tool definitions don't mutate within a session, so memoize per definition by identity.
-        if tools:
-            num_tokens += sum(self._memoized_tool_tokens(encoding, tool) for tool in tools)
-
+        # tiktoken encoding is pure-CPU work. The agent loop runs on the Textual/asyncio
+        # event loop, so encoding inline freezes the UI — worst on memo-cold passes
+        # (compaction, /model switch) that re-encode the whole history at once. Offload
+        # to a worker thread so a count never blocks rendering. The per-instance lock
+        # keeps the (non-thread-safe) WeakKeyDictionary memos consistent if two agents
+        # share this provider and count concurrently from different threads.
+        num_tokens = await asyncio.to_thread(self._count_tokens_sync, all_messages, tools)
         return TokenCount(input_tokens=num_tokens)
+
+    def _count_tokens_sync(self, all_messages: List[Message], tools: Optional[List[ToolDefinition]]) -> int:
+        encoding = _get_encoding()
+        self._ensure_token_memos()
+        with self._token_memo_lock:
+            # Sum memoized per-message counts: only new or changed messages are re-encoded.
+            num_tokens = sum(self._memoized_message_tokens(encoding, message) for message in all_messages)
+            # Tool definitions don't mutate within a session, so memoize per definition by identity.
+            if tools:
+                num_tokens += sum(self._memoized_tool_tokens(encoding, tool) for tool in tools)
+        return num_tokens
 
     def _ensure_token_memos(self) -> None:
         # Instances built via __new__ (benchmarks/tests) skip __init__, so create lazily.
@@ -240,6 +305,8 @@ class OpenAIProvider(BaseLLMProvider):
             self._message_token_memo = WeakKeyDictionary()
         if getattr(self, "_tool_token_memo", None) is None:
             self._tool_token_memo = WeakKeyDictionary()
+        if getattr(self, "_token_memo_lock", None) is None:
+            self._token_memo_lock = threading.Lock()
 
     def _memoized_message_tokens(self, encoding, message) -> int:
         fingerprint = self._message_fingerprint(message)
@@ -293,6 +360,21 @@ class OpenAIProvider(BaseLLMProvider):
                     elif hasattr(item, "data") and hasattr(item, "media_type"):
                         # ImageBlock - estimate tokens based on base64 data size
                         num_tokens += self._estimate_image_tokens(len(item.data))
+                    # Handle reasoning blocks. DeepSeek (and other reasoning models)
+                    # replay prior reasoning back to the same provider, so it counts
+                    # toward the input budget. Without these branches ThinkingBlocks
+                    # (.thinking, not .text) scored 0, the gauge undercounted, and
+                    # auto-compaction fired late while payloads stayed large.
+                    elif isinstance(item, ThinkingBlock):
+                        num_tokens += len(encoding.encode(item.thinking or ""))
+                        if item.signature:
+                            num_tokens += len(encoding.encode(str(item.signature)))
+                    elif isinstance(item, RedactedThinkingBlock):
+                        num_tokens += len(encoding.encode(str(item.data)))
+                    elif isinstance(item, ResponsesReasoningBlock):
+                        num_tokens += len(encoding.encode(str(item.encrypted_content or "")))
+                        for part in item.summary:
+                            num_tokens += len(encoding.encode(str(part)))
                     # Handle tool calls. OpenAI's prompt accounting uses a compact
                     # internal representation for assistant tool calls rather than
                     # charging the full Chat Completions JSON wrapper. Counting the
@@ -351,6 +433,12 @@ class OpenAIProvider(BaseLLMProvider):
             return ("img", len(item.data))
         if hasattr(item, "data") and hasattr(item, "media_type"):
             return ("img", len(item.data))
+        if isinstance(item, ThinkingBlock):
+            return ("think", len(item.thinking or ""), len(str(item.signature or "")))
+        if isinstance(item, RedactedThinkingBlock):
+            return ("rthink", len(str(item.data)))
+        if isinstance(item, ResponsesReasoningBlock):
+            return ("rreason", len(str(item.encrypted_content or "")), tuple(len(str(p)) for p in item.summary))
         if isinstance(item, ToolCall):
             payload = item.to_openai()
             function_payload = payload.get("function", {})

--- a/tests/agent/llm/test_openai_stream_accumulation.py
+++ b/tests/agent/llm/test_openai_stream_accumulation.py
@@ -1,0 +1,111 @@
+"""OpenAIStreamWrapper accumulates streamed deltas into the final message.
+
+The wrapper collects content / reasoning_content / tool-call argument fragments into
+lists and ``''.join``s them once at finalize (instead of a per-chunk ``str +=``, which
+is O(n^2) for large DeepSeek reasoning streams because the buffers are instance
+attributes). These tests pin that the joined result is byte-identical to a naive
+concatenation of every fragment, in order.
+"""
+
+import pytest
+
+from kolega_code.llm.models import ThinkingBlock
+from kolega_code.llm.providers.openai import OpenAIStreamWrapper
+
+
+class _Fn:
+    def __init__(self, name=None, arguments=None):
+        self.name = name
+        self.arguments = arguments
+
+
+class _ToolCallDelta:
+    def __init__(self, index, name=None, arguments=None, id=None):
+        self.index = index
+        self.id = id
+        self.function = _Fn(name=name, arguments=arguments)
+
+
+class _Delta:
+    def __init__(self, content=None, reasoning_content=None, tool_calls=None):
+        self.content = content
+        self.reasoning_content = reasoning_content
+        self.tool_calls = tool_calls or []
+
+
+class _Choice:
+    def __init__(self, delta, finish_reason=None):
+        self.delta = delta
+        self.finish_reason = finish_reason
+
+
+class _Chunk:
+    def __init__(self, delta, finish_reason=None):
+        self.choices = [_Choice(delta, finish_reason)]
+        self.usage = None
+
+
+class _AsyncStream:
+    def __init__(self, chunks):
+        self._chunks = chunks
+        self._i = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._i >= len(self._chunks):
+            raise StopAsyncIteration
+        chunk = self._chunks[self._i]
+        self._i += 1
+        return chunk
+
+    async def aclose(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_stream_accumulation_is_byte_identical():
+    # A DeepSeek-shaped stream: a flood of tiny reasoning + content deltas, plus a tool
+    # call whose JSON arguments arrive in fragments across several chunks.
+    reasoning_parts = [f"r{i} " for i in range(500)]
+    content_parts = [f"c{i} " for i in range(300)]
+    arg_parts = ['{"path": "', "a/b/c.txt", '", "data": "', "x" * 100, '"}']
+
+    chunks = []
+    for r in reasoning_parts:
+        chunks.append(_Chunk(_Delta(reasoning_content=r)))
+    for c in content_parts:
+        chunks.append(_Chunk(_Delta(content=c)))
+    chunks.append(_Chunk(_Delta(tool_calls=[_ToolCallDelta(0, name="write", arguments=arg_parts[0], id="call_0")])))
+    for frag in arg_parts[1:]:
+        chunks.append(_Chunk(_Delta(tool_calls=[_ToolCallDelta(0, arguments=frag)])))
+    chunks.append(_Chunk(_Delta(), finish_reason="tool_calls"))
+
+    wrapper = OpenAIStreamWrapper(_AsyncStream(chunks), provider_name="deepseek")
+    async with wrapper as stream:
+        async for _ in stream:
+            pass
+
+        assert stream.final_reasoning_content == "".join(reasoning_parts)
+        assert stream.final_content == "".join(content_parts)
+
+        final = await stream.get_final_message()
+
+    # Tool-call arguments are joined once at finalize, in arrival order.
+    assert stream.final_tool_calls[0].function.arguments == "".join(arg_parts)
+
+    # The final message carries the full reasoning as a ThinkingBlock and the answer text.
+    thinking = [b for b in final.content if isinstance(b, ThinkingBlock)]
+    assert thinking and thinking[0].thinking == "".join(reasoning_parts)
+    assert final.tool_calls and final.tool_calls[0].name == "write"
+
+
+@pytest.mark.asyncio
+async def test_empty_stream_yields_empty_buffers():
+    wrapper = OpenAIStreamWrapper(_AsyncStream([]), provider_name="deepseek")
+    async with wrapper as stream:
+        async for _ in stream:
+            pass
+        assert stream.final_content == ""
+        assert stream.final_reasoning_content == ""

--- a/tests/agent/llm/test_openai_token_counting_incremental.py
+++ b/tests/agent/llm/test_openai_token_counting_incremental.py
@@ -10,11 +10,13 @@ client state.
 """
 
 import asyncio
+import threading
 
 from kolega_code.llm.models import (
     Message,
     MessageHistory,
     TextBlock,
+    ThinkingBlock,
     ToolCall,
     ToolDefinition,
     ToolParameter,
@@ -134,3 +136,38 @@ def test_shrinking_history_recounts_correctly():
 
     shorter = MessageHistory(list(history)[:5])
     assert _count(provider, shorter) == _fresh_count(shorter)
+
+
+def test_thinking_blocks_are_counted():
+    """Reasoning replayed to the same provider (DeepSeek ThinkingBlocks) counts toward
+    the input budget. Before this branch existed they scored 0, so the gauge undercounted
+    replayed reasoning and auto-compaction fired late while payloads stayed large."""
+    reasoning = "a deliberate reasoning step. " * 200
+    with_thinking = MessageHistory(
+        [Message(role="assistant", content=[ThinkingBlock(thinking=reasoning), TextBlock(text="final answer")])]
+    )
+    without_thinking = MessageHistory([Message(role="assistant", content=[TextBlock(text="final answer")])])
+
+    delta = _fresh_count(with_thinking) - _fresh_count(without_thinking)
+    # The reasoning text alone is hundreds of tokens; require a substantial contribution.
+    assert delta > 100
+
+
+def test_count_tokens_runs_off_the_event_loop_thread():
+    """The tiktoken encode must be offloaded to a worker thread so it never blocks the
+    Textual/asyncio event loop (the 'freeze between steps' on long DeepSeek sessions)."""
+    provider = _provider()
+    main_thread = threading.main_thread()
+    observed = {}
+
+    original = provider._count_tokens_sync
+
+    def spy(all_messages, tools):
+        observed["ran_on_main_thread"] = threading.current_thread() is main_thread
+        return original(all_messages, tools)
+
+    provider._count_tokens_sync = spy
+    asyncio.run(provider.count_tokens(messages=_history(5), model="gpt-4", tools=[]))
+
+    # asyncio.run drives the loop on the main thread; the encode must run elsewhere.
+    assert observed["ran_on_main_thread"] is False

--- a/tests/cli/test_sub_agent_stream_accumulation.py
+++ b/tests/cli/test_sub_agent_stream_accumulation.py
@@ -1,0 +1,92 @@
+"""Sub-agent streamed steps must accumulate O(n), not O(n^2).
+
+`_accumulate_sub_agent_stream` used to do `step.content += text` on every streamed
+delta. Because `step.content` is an instance attribute (no CPython in-place concat
+optimization), that is O(n^2) over the stream — on DeepSeek-class sub-agents emitting
+long reasoning it grew to seconds of event-loop CPU and froze scrolling while
+sub-agents ran. The fix mirrors the main transcript's `_apply_stream_chunk`: deltas
+land in `stream_parts` (O(1)) and are folded once via `materialize()`.
+
+These tests pin:
+  1. correctness - the materialized step equals the naive concatenation of all deltas,
+                   and content is deferred (stays empty) until materialize.
+  2. scaling     - a large stream materializes in well under a generous wall-clock bound
+                   (it was seconds of O(n^2) before; milliseconds after).
+"""
+
+import time
+
+import pytest
+
+from kolega_code.cli.tui.state import ConversationEntry, SubAgentActivity
+from kolega_code.cli.tui.transcript import TranscriptRenderingMixin
+from kolega_code.events import AgentEvent
+
+
+@pytest.fixture
+def mixin() -> TranscriptRenderingMixin:
+    # _accumulate_sub_agent_stream uses only the passed `activity`, no instance state.
+    return TranscriptRenderingMixin.__new__(TranscriptRenderingMixin)
+
+
+def _activity() -> SubAgentActivity:
+    return SubAgentActivity(
+        agent_id="agent-1",
+        agent_name="sub",
+        task="task",
+        index=1,
+        entry=ConversationEntry(kind="sub_agent", content=""),
+    )
+
+
+def _feed(mixin, activity, kind, uuid, text, *, streaming=True):
+    event = AgentEvent(event_type="chat_message", sender="sub", uuid=uuid, is_streaming=streaming, content={})
+    mixin._accumulate_sub_agent_stream(activity, kind, event, text)
+
+
+def test_materialized_step_equals_concatenation(mixin):
+    activity = _activity()
+    deltas = [f"reasoning token {i} " for i in range(2000)]
+    for d in deltas:
+        _feed(mixin, activity, "thinking", "u1", d, streaming=True)
+
+    step = activity.stream_steps["u1"]
+    # Deferred: nothing is folded into content until materialize().
+    assert step.content == ""
+    assert step.stream_parts  # deltas are buffered as parts
+
+    _feed(mixin, activity, "thinking", "u1", "", streaming=False)  # completion
+    assert step.complete is True
+    assert step.content == "".join(deltas)  # materialized on completion
+    assert step.stream_parts == []
+
+
+def test_thinking_and_response_stay_separate_steps(mixin):
+    activity = _activity()
+    _feed(mixin, activity, "thinking", "u1", "thinking part ", streaming=True)
+    _feed(mixin, activity, "assistant", "u2", "answer part ", streaming=True)
+    _feed(mixin, activity, "thinking", "u1", "more thinking", streaming=False)
+    _feed(mixin, activity, "assistant", "u2", "more answer", streaming=False)
+
+    assert activity.stream_steps["u1"].content == "thinking part more thinking"
+    assert activity.stream_steps["u2"].content == "answer part more answer"
+    assert activity.stream_steps["u1"].kind == "thinking"
+    assert activity.stream_steps["u2"].kind == "assistant"
+
+
+def test_large_stream_is_linear_not_quadratic(mixin):
+    activity = _activity()
+    # ~1 MB of reasoning in tiny deltas: O(n^2) `+=` would be seconds; O(n) is ms.
+    delta = "x" * 18
+    n = (1024 * 1024) // len(delta)
+
+    start = time.perf_counter()
+    for _ in range(n):
+        _feed(mixin, activity, "thinking", "u1", delta, streaming=True)
+    _feed(mixin, activity, "thinking", "u1", "", streaming=False)
+    elapsed = time.perf_counter() - start
+
+    step = activity.stream_steps["u1"]
+    assert len(step.content) == n * len(delta)
+    # Generous bound: the O(n^2) version took multiple seconds at this size.
+    assert elapsed < 1.0, f"accumulation took {elapsed:.2f}s — likely regressed to O(n^2)"


### PR DESCRIPTION
## Summary
- offload local tiktoken token counting for OpenAI-compatible and Anthropic providers to worker threads with memo locks
- count reasoning/thinking blocks in OpenAI token estimates so context compaction triggers on time
- switch OpenAI stream accumulation to list+join and reuse built request history per agent loop iteration
- add regression coverage for off-main-thread token counting, reasoning token accounting, and byte-identical stream accumulation

## Tests
- uv run ruff check kolega_code/agent/baseagent.py kolega_code/llm/providers/anthropic.py kolega_code/llm/providers/openai.py tests/agent/llm/test_openai_token_counting_incremental.py tests/agent/llm/test_openai_stream_accumulation.py
- uv run pytest tests/agent/llm/test_openai_token_counting_incremental.py tests/agent/llm/test_openai_stream_accumulation.py