### PR TITLE
chore: release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.12.0 - 2026-06-30
+
+### Added
+
+- Added local always-on diagnostics and watchdog support, including `/bug` output
+  packaged as a single zip for issue reports.
+- Made `search_codebase` regex-by-default and backed it with ripgrep for more
+  capable code searches.
+
+### Changed
+
+- Consolidated file-editing tools into a single edit tool interface.
+- Reduced per-session memory usage by deferring heavy LLM imports.
+- Relicensed the project under the Apache License 2.0.
+
+### Fixed
+
+- Prevented token counting from freezing the UI during LLM activity.
+- Improved sub-agent stream handling so long streams accumulate efficiently.
+- Replayed reasoning through native provider fields for OpenAI-compatible
+  providers.
+- Cleaned up duplicate/conflicting footer shortcuts in the TUI.
+- Hardened diagnostics crash-log handling and secret scrubbing.
+
 ## 0.11.1 - 2026-06-26
 
 ### Added

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.11.1"
+__version__ = "0.12.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -44,4 +44,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.11.1"
+__version__ = "0.12.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.11.1"
+version = "0.12.0"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [options]
 prerelease-mode = "allow"
-exclude-newer = "2026-06-19T17:11:13.979694Z"
+exclude-newer = "2026-06-23T15:22:36.504632Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1360,7 +1360,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.11.1"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- bump package version metadata from 0.11.1 to 0.12.0
- refresh uv.lock for the release version and current exclude-newer cutoff
- update CHANGELOG.md with the v0.12.0 release notes

## Validation
- ./run_tests.sh
- uv build
- metadata spot check for v0.12.0 wheel METADATA
- pre-commit hooks passed during commit

## Post-merge
Do not tag until this PR is merged. After merge, tag the merge commit with v0.12.0 and push the tag to trigger the release workflow.