### PR TITLE
fix(openai_chatgpt): correct GPT-5.5 context window to 272K on Codex backend

### DIFF
--- a/kolega_code/llm/exceptions.py
+++ b/kolega_code/llm/exceptions.py
@@ -248,6 +248,10 @@ def map_openai_errors(error: "OpenAIError") -> LLMError:
 
     if hasattr(error, "status_code"):
         if error.status_code == 400:
+            if getattr(error, "code", None) == "context_length_exceeded":
+                return LLMContextWindowExceededError(
+                    message=f"OpenAI APIError: {str(error)}", provider=ModelProvider.OPENAI.value
+                )
             return LLMInvalidRequestError(message=f"OpenAI APIError: {str(error)}", provider=ModelProvider.OPENAI.value)
         elif error.status_code == 401:
             return LLMAuthenticationError(message=f"OpenAI APIError: {str(error)}", provider=ModelProvider.OPENAI.value)

--- a/kolega_code/llm/specs/catalog/openai_chatgpt.py
+++ b/kolega_code/llm/specs/catalog/openai_chatgpt.py
@@ -3,9 +3,11 @@ from kolega_code.llm.specs.types import ThinkingEffortSpec
 # OpenAI via ChatGPT subscription (Responses API, OAuth). Model slugs mirror
 # the Codex model picker; context/output limits mirror the API gpt-5.x specs
 # and are server-enforced (we never send max_output_tokens).
+# Note: Codex backend caps GPT-5.5 at 400K context with 128K reserved for
+# output, giving an effective max input of ~272K tokens.
 OPENAI_CHATGPT_SPECS = {
     ("openai_chatgpt", "gpt-5.5"): {
-        "context_length": 1050000,
+        "context_length": 272000,
         "max_completion_tokens": 128000,
         "default_temperature": 1.0,
         "supports_temperature": False,

--- a/tests/agent/llm/test_exceptions.py
+++ b/tests/agent/llm/test_exceptions.py
@@ -30,9 +30,10 @@ from kolega_code.llm.exceptions import (
 # Assuming OpenAIError, GoogleAPIError, AnthropicError can be imported or mocked
 # For simplicity, we'll mock them here.
 class MockOpenAIError(Exception):
-    def __init__(self, message: str, status_code: int):
+    def __init__(self, message: str, status_code: int, code: str | None = None):
         super().__init__(message)
         self.status_code = status_code
+        self.code = code
 
 
 class MockGoogleAPIError(Exception):
@@ -123,6 +124,18 @@ def test_map_openai_errors_no_status_code():
     )  # Should be the base LLMError
     assert mapped_error.provider == ModelProvider.OPENAI.value
     assert "OpenAI APIError:" in str(mapped_error)
+
+
+def test_map_openai_context_length_exceeded():
+    """A 400 with code="context_length_exceeded" maps to LLMContextWindowExceededError."""
+    original_error = MockOpenAIError(
+        "Error code: 400 - {'error': {'code': 'context_length_exceeded', ...}}",
+        status_code=400,
+        code="context_length_exceeded",
+    )
+    mapped_error = map_openai_errors(original_error)
+    assert isinstance(mapped_error, LLMContextWindowExceededError)
+    assert mapped_error.provider == ModelProvider.OPENAI.value
 
 
 # Test Google error mapping

--- a/tests/agent/llm/test_model_specs.py
+++ b/tests/agent/llm/test_model_specs.py
@@ -1,6 +1,16 @@
 from kolega_code.llm.specs import get_model_specs, thinking_effort_options
 
 
+def test_openai_chatgpt_gpt55_context_length():
+    """GPT-5.5 on ChatGPT subscription is capped at 400K context by the Codex
+    backend, with 128K reserved for output → effective max input is ~272K."""
+    specs = get_model_specs("openai_chatgpt", "gpt-5.5")
+
+    assert specs["context_length"] == 272000
+    assert specs["max_completion_tokens"] == 128000
+    assert specs["thinking_effort"].default == "medium"
+
+
 def test_kimi_k27_code_model_specs():
     specs = get_model_specs("moonshot", "kimi-k2.7-code")
 


### PR DESCRIPTION
## Problem

The Codex/chatgpt.com backend caps GPT-5.5 at **400K context** with 128K reserved for output, giving an effective max input of **~272K tokens**. But `openai_chatgpt` specs advertised `context_length: 1050000`, so compression (which triggers at 80% = 840K) never ran before the backend rejected requests around 250-270K input tokens with `context_length_exceeded` errors.

Additionally, `map_openai_errors()` had no detection for the `context_length_exceeded` error code, so users saw a confusing generic message instead of a clear recovery hint.

## Changes

1. **Lower `context_length` from 1,050,000 → 272,000** for `openai_chatgpt`/gpt-5.5. Compression now triggers at ~218K, well before the ~250K failure point.

2. **Add `context_length_exceeded` detection** in `map_openai_errors()`. The OpenAI SDK unwraps the `"error"` envelope before constructing `BadRequestError`, so `error.code` is directly populated. When detected, maps to `LLMContextWindowExceededError` with the recovery message: *"The conversation context became too large for the model. Oversized tool output is trimmed automatically; please retry the message."*

3. **New tests**: model spec test for `context_length == 272000`, error mapping test for `code="context_length_exceeded"` → `LLMContextWindowExceededError`.

## References

- [openai/codex #19464](https://github.com/openai/codex/issues/19464) — Codex caps GPT-5.5 at 400K
- [OpenAI Community](https://community.openai.com/t/huge-gpt-5-documentation-gap-flaw-causing-bugs-input-tokens-exceed-the-configured-limit-of-272-000-tokens/1344734) — max input = context − 128K output reservation
- [Kilo Code #11801](https://github.com/Kilo-Org/kilocode/issues/11801) — same bug in another tool