### PR TITLE
fix(gigacode): persist enabled state across session resume

### DIFF
--- a/docs/src/content/docs/gigacode.mdx
+++ b/docs/src/content/docs/gigacode.mdx
@@ -52,9 +52,11 @@ Gigacode is **off by default**. Toggle it with the `/gigacode`
 | `/gigacode on` | Enable workflow orchestration for the session |
 | `/gigacode off` | Disable it |
 
-Once on, it stays on for the session, and the agent decides when a task is worth
-orchestrating. It works in both [Build and Plan modes](../tui/modes/) — see
-[Behavior and safety](#behavior-and-safety) for how each differs.
+Once on, it stays on for that resumable session — if you quit and resume the same
+session, the setting is restored. New sessions still start with Gigacode off. The
+agent decides when a task is worth orchestrating. It works in both
+[Build and Plan modes](../tui/modes/) — see [Behavior and safety](#behavior-and-safety)
+for how each differs.
 
 ## What you'll see
 

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -202,7 +202,7 @@ class KolegaCodeApp(
         self._plan_pending: bool = bool(self._latest_plan and self.session.plan_pending)
         self._plan_reofferable: bool = bool(self._latest_plan and (self.session.plan_reofferable or self._plan_pending))
         self._plan_decision_active = False
-        self._gigacode_enabled = False
+        self._gigacode_enabled = bool(self.session.gigacode_enabled)
         self._pending_question: Optional[tui_state.PendingQuestion] = None
         self._pending_approval: Optional[tui_state.PendingApproval] = None
         self._pending_image_attachments: list[dict] = []
@@ -227,6 +227,7 @@ class KolegaCodeApp(
             model=model,
             mode=self.interaction_mode,
             permission_mode=self.permission_mode.value,
+            gigacode_enabled=self._gigacode_enabled,
         )
         self._turn_started_at: Optional[float] = None
         self._turn_finished_duration: Optional[float] = None
@@ -416,6 +417,7 @@ class KolegaCodeApp(
             "term_program": os.environ.get("TERM_PROGRAM", ""),  # captures ghostty/iTerm/etc.
             "interaction_mode": self.interaction_mode,
             "permission_mode": self.permission_mode.value,
+            "gigacode_enabled": self._gigacode_enabled,
         }
         try:
             if self.config is not None:
@@ -697,6 +699,7 @@ class KolegaCodeApp(
     def _sync_planning_state_to_session(self) -> None:
         self.session.interaction_mode = self.interaction_mode
         self.session.permission_mode = self.permission_mode.value
+        self.session.gigacode_enabled = self._gigacode_enabled
         self.session.latest_plan_markdown = self._latest_plan or ""
         self.session.plan_pending = bool(self._latest_plan and self._plan_pending)
         self.session.plan_reofferable = bool(self._latest_plan and self._plan_reofferable)
@@ -729,6 +732,7 @@ class KolegaCodeApp(
             plan_reofferable=record.plan_reofferable,
             interaction_mode=record.interaction_mode,
             permission_mode=record.permission_mode,
+            gigacode_enabled=record.gigacode_enabled,
         )
 
     async def _save_session_async(self) -> None:
@@ -1536,9 +1540,11 @@ class KolegaCodeApp(
             return
 
     def _meta_content(self) -> str:
+        gigacode = "on" if self._gigacode_enabled else "off"
         return (
             f"{self.project_path} | session {self.session.session_id} | "
-            f"agent {self.mode} | {self.interaction_mode} | permissions {self.permission_mode.value}"
+            f"agent {self.mode} | {self.interaction_mode} | permissions {self.permission_mode.value} | "
+            f"gigacode {gigacode}"
         )
 
     def _update_mode_chrome(self) -> None:
@@ -1753,6 +1759,7 @@ class KolegaCodeApp(
                 f"Mode: {self.mode}",
                 f"Interaction: {self.interaction_mode}",
                 f"Permissions: {self.permission_mode.value}",
+                f"Gigacode: {'on' if self._gigacode_enabled else 'off'}",
                 f"Model: {model_display}",
                 *([override_message] if override_message else []),
                 *self._startup_prompt_override_lines(),

--- a/kolega_code/cli/session_store.py
+++ b/kolega_code/cli/session_store.py
@@ -39,6 +39,7 @@ class SessionRecord:
     plan_reofferable: bool = False
     interaction_mode: str = "build"
     permission_mode: str = "ask"
+    gigacode_enabled: bool = False
     schema_version: int = SCHEMA_VERSION
 
     @classmethod
@@ -92,6 +93,7 @@ class SessionRecord:
             plan_reofferable=bool(latest_plan_markdown and data.get("plan_reofferable", plan_pending)),
             interaction_mode=data.get("interaction_mode") or "build",
             permission_mode=data.get("permission_mode") or "ask",
+            gigacode_enabled=bool(data.get("gigacode_enabled", False)),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -114,6 +116,7 @@ class SessionRecord:
             "plan_reofferable": self.plan_reofferable,
             "interaction_mode": self.interaction_mode,
             "permission_mode": self.permission_mode,
+            "gigacode_enabled": self.gigacode_enabled,
         }
 
 

--- a/kolega_code/cli/tui/command_handlers.py
+++ b/kolega_code/cli/tui/command_handlers.py
@@ -215,6 +215,7 @@ class CommandHandlersMixin:
 
         self._gigacode_enabled = new_state
         self.agent.apply_gigacode(new_state, self._gigacode_prompt_extension() if new_state else None)
+        await self._save_session_async()
 
         if new_state:
             note = (
@@ -791,7 +792,12 @@ class CommandHandlersMixin:
         ]
         if header.get("provider"):
             lines.append(f"Model: {header['provider']}/{header.get('model')} (effort: {header.get('thinking_effort')})")
-        lines.append(f"Permission: {header.get('permission_mode')}  |  mode: {header.get('interaction_mode')}")
+        gigacode = "on" if header.get("gigacode_enabled") else "off"
+        session_modes = (
+            f"Permission: {header.get('permission_mode')}  |  "
+            f"mode: {header.get('interaction_mode')}  |  gigacode: {gigacode}"
+        )
+        lines.append(session_modes)
         if header.get("providers_with_keys"):
             lines.append(f"Providers with keys: {', '.join(header['providers_with_keys'])}")
         diag = getattr(self, "_diag", None)

--- a/kolega_code/cli/tui/state.py
+++ b/kolega_code/cli/tui/state.py
@@ -234,6 +234,7 @@ class StatusDashboardState:
     thinking_effort: Optional[str] = None
     mode: str = BUILD_INTERACTION_MODE
     permission_mode: str = PermissionMode.ASK.value
+    gigacode_enabled: bool = False
     turn_state: TurnState = TurnState.IDLE
     activity: str = "Ready"
     input_tokens: Optional[int] = None

--- a/kolega_code/cli/tui/status_dashboard.py
+++ b/kolega_code/cli/tui/status_dashboard.py
@@ -31,6 +31,7 @@ class StatusDashboardMixin:
         self._status_state.thinking_effort = self._startup_thinking_effort()
         self._status_state.mode = self.interaction_mode
         self._status_state.permission_mode = self.permission_mode.value
+        self._status_state.gigacode_enabled = self._gigacode_enabled
         try:
             self._status_dashboard.update(self._format_status_dashboard())
         except Exception:
@@ -47,6 +48,7 @@ class StatusDashboardMixin:
         effort = state.thinking_effort or "not supported"
         mode = state.mode.title()
         permission_mode = state.permission_mode.title()
+        gigacode = "On" if state.gigacode_enabled else "Off"
         turn_style = tui_state.turn_state_color(state.turn_state)
         context_style = self._context_style(state.usage_percentage, state.compression_threshold)
 
@@ -84,6 +86,7 @@ class StatusDashboardMixin:
             f"{label('Thinking effort')} [bold]{escape(effort)}[/bold]\n"
             f"{label('Mode')} [bold]{mode}[/bold]\n"
             f"{label('Permissions')} [bold]{permission_mode}[/bold]\n"
+            f"{label('Gigacode')} [bold]{gigacode}[/bold]\n"
             f"{turn_line}\n\n"
             f"{label('Context')}\n"
             f"{context_lines}\n\n"

--- a/tests/cli/test_app_status_modes.py
+++ b/tests/cli/test_app_status_modes.py
@@ -163,6 +163,158 @@ async def test_textual_app_status_dashboard_tracks_interaction_mode(
 
 
 @pytest.mark.asyncio
+async def test_textual_app_resumes_gigacode_enabled_across_mode_rebuilds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.widgets import Static
+
+    from kolega_code.cli.app import KolegaCodeApp
+
+    class FakeBaseAgent:
+        instances = []
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.prompt_extensions = kwargs.get("prompt_extensions") or []
+            self.gigacode_enabled = False
+            self.cleaned = False
+            self.__class__.instances.append(self)
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
+        def dump_message_history(self):
+            return []
+
+        async def cleanup(self):
+            self.cleaned = True
+
+    class FakeCoderAgent(FakeBaseAgent):
+        instances = []
+
+    class FakePlanningAgent(FakeBaseAgent):
+        instances = []
+
+    monkeypatch.setattr(agent_runtime_module, "CoderAgent", FakeCoderAgent)
+    monkeypatch.setattr(agent_runtime_module, "PlanningAgent", FakePlanningAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    session.gigacode_enabled = True
+    store.save(session)
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test():
+        assert app._gigacode_enabled is True
+        assert FakeCoderAgent.instances
+        coder = FakeCoderAgent.instances[-1]
+        assert coder.gigacode_enabled is True
+        assert extension_by_name(coder.prompt_extensions, "gigacode").title == "gigacode — workflow orchestration"
+        assert "Gigacode: on" in app.conversation_entries[0].content
+        assert "gigacode on" in str(app.query_one("#session_meta", Static).render())
+        dashboard = str(app.query_one("#status_dashboard", Static).render())
+        assert "Gigacode" in dashboard
+        assert "On" in dashboard
+
+        await app._set_interaction_mode("plan")
+
+        assert FakePlanningAgent.instances
+        planning = FakePlanningAgent.instances[-1]
+        assert app._gigacode_enabled is True
+        assert planning.gigacode_enabled is True
+        assert extension_by_name(planning.prompt_extensions, "gigacode").title == "gigacode — workflow orchestration"
+        assert store.load(session.session_id).gigacode_enabled is True
+
+        await app._set_interaction_mode("build")
+
+        rebuilt = FakeCoderAgent.instances[-1]
+        assert rebuilt.gigacode_enabled is True
+        assert extension_by_name(rebuilt.prompt_extensions, "gigacode").title == "gigacode — workflow orchestration"
+
+
+@pytest.mark.asyncio
+async def test_textual_app_gigacode_command_persists_and_updates_status(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.widgets import Static
+
+    from kolega_code.cli.app import KolegaCodeApp
+
+    class FakeCoderAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.gigacode_enabled = False
+            self.prompt_extensions = kwargs.get("prompt_extensions") or []
+            self.apply_calls = []
+
+        def restore_message_history(self, history):
+            return None
+
+        def dump_compaction_state(self):
+            return {}
+
+        def restore_compaction_state(self, data):
+            pass
+
+        def dump_message_history(self):
+            return []
+
+        def apply_gigacode(self, enabled, prompt_extension=None):
+            self.apply_calls.append((enabled, prompt_extension))
+            self.gigacode_enabled = enabled
+            self.prompt_extensions = [
+                extension for extension in self.prompt_extensions if getattr(extension, "id", None) != "gigacode"
+            ]
+            if enabled and prompt_extension is not None:
+                self.prompt_extensions.append(prompt_extension)
+
+        async def cleanup(self):
+            return None
+
+    monkeypatch.setattr(agent_runtime_module, "CoderAgent", FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test():
+        await app._command_gigacode("on")
+
+        assert app._gigacode_enabled is True
+        assert app.agent.apply_calls[-1][0] is True
+        assert app.agent.apply_calls[-1][1].id == "gigacode"
+        assert store.load(session.session_id).gigacode_enabled is True
+        assert "Gigacode: on" in app.conversation_entries[0].content
+        dashboard = str(app.query_one("#status_dashboard", Static).render())
+        assert "Gigacode" in dashboard
+        assert "On" in dashboard
+
+        await app._command_gigacode("off")
+
+        assert app._gigacode_enabled is False
+        assert app.agent.apply_calls[-1] == (False, None)
+        assert store.load(session.session_id).gigacode_enabled is False
+        assert "Gigacode: off" in app.conversation_entries[0].content
+        assert "gigacode off" in str(app.query_one("#session_meta", Static).render())
+
+
+@pytest.mark.asyncio
 async def test_textual_app_mode_switch_rebuild_skips_transcript_restore(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/cli/test_session_store.py
+++ b/tests/cli/test_session_store.py
@@ -42,6 +42,7 @@ def test_session_store_create_load_list_export_delete(tmp_path: Path) -> None:
     record.plan_reofferable = True
     record.interaction_mode = "plan"
     record.permission_mode = "auto"
+    record.gigacode_enabled = True
     store.save(record)
 
     loaded = store.load(record.session_id)
@@ -53,6 +54,7 @@ def test_session_store_create_load_list_export_delete(tmp_path: Path) -> None:
     assert loaded.plan_reofferable is True
     assert loaded.interaction_mode == "plan"
     assert loaded.permission_mode == "auto"
+    assert loaded.gigacode_enabled is True
     assert store.latest_for_project(project).session_id == record.session_id
     exported = store.export(record.session_id)
     assert record.session_id in exported
@@ -62,6 +64,7 @@ def test_session_store_create_load_list_export_delete(tmp_path: Path) -> None:
     assert "plan_reofferable" in exported
     assert "interaction_mode" in exported
     assert "permission_mode" in exported
+    assert "gigacode_enabled" in exported
 
     store.delete(record.session_id)
     with pytest.raises(SessionStoreError):
@@ -81,6 +84,7 @@ def test_session_store_loads_old_sessions_without_planning_state(tmp_path: Path)
     payload.pop("plan_reofferable")
     payload.pop("interaction_mode")
     payload.pop("permission_mode")
+    payload.pop("gigacode_enabled")
     store.path_for(record.session_id).write_text(json.dumps(payload), encoding="utf-8")
 
     loaded = store.load(record.session_id)
@@ -91,6 +95,7 @@ def test_session_store_loads_old_sessions_without_planning_state(tmp_path: Path)
     assert loaded.plan_reofferable is False
     assert loaded.interaction_mode == "build"
     assert loaded.permission_mode == "ask"
+    assert loaded.gigacode_enabled is False
 
 
 def test_session_store_old_pending_plan_is_reofferable(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Persist `gigacode_enabled` in session JSON so `/gigacode` status survives TUI resume.
- Restore/apply the saved gigacode state when rebuilding/resuming TUI sessions and persist `/gigacode on|off` toggles immediately.
- Surface gigacode state in startup/session/status/diagnostics UI and update docs.

## Tests
- `pytest tests/cli/test_session_store.py tests/cli/test_app_status_modes.py tests/cli/test_app_misc_commands.py tests/agent/test_gigacode_gating.py`
- `ruff check kolega_code/cli/session_store.py kolega_code/cli/app.py kolega_code/cli/tui/command_handlers.py kolega_code/cli/tui/state.py kolega_code/cli/tui/status_dashboard.py tests/cli/test_session_store.py tests/cli/test_app_status_modes.py`
- `pytest`
- `git diff --check`
