### PR TITLE
feat(mcp): add first-class MCP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ enough that one serial agent pass would be the bottleneck.
 - **Web search and browsing:** DuckDuckGo works by default with no key; Firecrawl,
   Tavily, and SearXNG are configurable search backends. Kolega Code can also fetch URLs
   directly and use a Playwright-powered browser agent for interactive sites.
+- **MCP servers:** connect verified `streamable_http`, `sse`, and `stdio` MCP servers
+  (including OAuth-enabled HTTP servers) as permission-gated tools.
 - **Model routing:** choose provider/model combinations, set thinking effort, split
   long-context/fast/thinking roles, and override models per agent role.
 - **Interactive or scriptable:** use the Textual TUI, queue follow-up prompts

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -65,6 +65,10 @@ export default defineConfig({
               slug: "configuration/settings-and-api-keys",
             },
             {
+              label: "MCP Servers",
+              slug: "configuration/mcp",
+            },
+            {
               label: "Environment Variables",
               slug: "configuration/environment-variables",
             },

--- a/docs/src/content/docs/configuration/mcp.md
+++ b/docs/src/content/docs/configuration/mcp.md
@@ -112,7 +112,7 @@ Run verification to start the OAuth flow:
 kolega-code mcp verify oauth-server --project .
 ```
 
-Use `--no-browser` to print the authorization URL instead of opening a browser. Tokens and dynamic client registration data are stored locally in `<state_dir>/mcp_oauth_tokens.json` with private file permissions and are redacted from diagnostics.
+Use `--no-browser` to print the authorization URL instead of opening a browser. Tokens and dynamic client registration data are stored locally in `<state_dir>/mcp_oauth_tokens.json`. Kolega Code writes this file with owner-only permissions where the platform supports POSIX modes, redacts those values from diagnostics, and does not encrypt the file beyond the protection provided by the OS and filesystem permissions.
 
 ## CLI management
 

--- a/docs/src/content/docs/configuration/mcp.md
+++ b/docs/src/content/docs/configuration/mcp.md
@@ -1,0 +1,209 @@
+---
+title: MCP servers
+description: Configure Model Context Protocol servers for Kolega Code tools.
+---
+
+Kolega Code can expose verified [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server tools as first-class agent tools.
+
+MCP support is local-first and opt-in:
+
+- Global servers are read from `<state_dir>/mcp_servers.json`.
+- Project servers are read from `<project>/.kolega/mcp_servers.json` only after the project is trusted for MCP.
+- Agent startup never opens a browser and never starts an OAuth flow. OAuth is only started by an explicit `kolega-code mcp verify` command or the TUI **Verify** button.
+- MCP tools are not propagated to sub-agents.
+- In `ask` permission mode, every MCP tool call prompts unless you save an exact-tool or whole-server allow rule.
+
+## Config locations
+
+| Scope | Path | Enabled when |
+| --- | --- | --- |
+| Global | `<state_dir>/mcp_servers.json` | Always loaded |
+| Project | `<project>/.kolega/mcp_servers.json` | Project is trusted with `--trust-mcp` or from the TUI |
+
+`<state_dir>` is the Kolega Code state directory. You can override it with `--state-dir` for CLI management commands.
+
+Project MCP config is intentionally gated because it can point at local executables or remote services controlled by the repository. Trust a project only after reviewing `.kolega/mcp_servers.json`.
+
+## Config format
+
+```json
+{
+  "schema_version": 1,
+  "servers": [
+    {
+      "id": "docs",
+      "name": "Docs search",
+      "transport": "streamable_http",
+      "url": "https://mcp.example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ..."
+      },
+      "enabled": true
+    }
+  ]
+}
+```
+
+`servers` may be an array, or an object keyed by server ID. Server IDs may contain letters, numbers, `_`, and `-`.
+
+### `streamable_http`
+
+```json
+{
+  "id": "remote-http",
+  "transport": "streamable_http",
+  "url": "https://mcp.example.com/mcp",
+  "headers": {
+    "Authorization": "Bearer ..."
+  }
+}
+```
+
+### `sse`
+
+```json
+{
+  "id": "remote-sse",
+  "transport": "sse",
+  "url": "https://mcp.example.com/sse",
+  "headers": {
+    "Authorization": "Bearer ..."
+  },
+  "sse_read_timeout_seconds": 300
+}
+```
+
+### `stdio`
+
+```json
+{
+  "id": "local-server",
+  "transport": "stdio",
+  "command": "npx",
+  "args": ["-y", "@vendor/mcp-server"],
+  "env": {
+    "TOKEN": "..."
+  },
+  "cwd": "."
+}
+```
+
+`stdio` servers execute a local command. `kolega-code mcp verify` refuses to start `stdio` commands in non-interactive mode unless you pass `--yes`.
+
+## OAuth
+
+Enable OAuth for HTTP transports with the `oauth` object:
+
+```json
+{
+  "id": "oauth-server",
+  "transport": "streamable_http",
+  "url": "https://mcp.example.com/mcp",
+  "oauth": {
+    "enabled": true,
+    "scope": "read write"
+  }
+}
+```
+
+Run verification to start the OAuth flow:
+
+```bash
+kolega-code mcp verify oauth-server --project .
+```
+
+Use `--no-browser` to print the authorization URL instead of opening a browser. Tokens and dynamic client registration data are stored locally in `<state_dir>/mcp_oauth_tokens.json` with private file permissions and are redacted from diagnostics.
+
+## CLI management
+
+List servers and status:
+
+```bash
+kolega-code mcp --project . list
+```
+
+Add a remote server to global config:
+
+```bash
+kolega-code mcp --project . add docs \
+  --transport streamable_http \
+  --url https://mcp.example.com/mcp \
+  --header 'Authorization=Bearer ...'
+```
+
+Add a project config server:
+
+```bash
+kolega-code mcp --project . add repo-local \
+  --project-config \
+  --transport stdio \
+  --command npx \
+  --arg -y \
+  --arg @vendor/mcp-server
+```
+
+Trust project MCP config:
+
+```bash
+kolega-code . --trust-mcp
+# or for one-shot use:
+kolega-code ask "use repo tools" --project . --trust-mcp
+```
+
+Verify one server or all enabled servers:
+
+```bash
+kolega-code mcp --project . verify docs
+kolega-code mcp --project . verify --all --yes
+```
+
+Enable, disable, or remove servers:
+
+```bash
+kolega-code mcp --project . disable docs
+kolega-code mcp --project . enable docs
+kolega-code mcp --project . remove docs
+```
+
+## TUI management
+
+Open the **Settings** tab and use the **MCP Servers** section to:
+
+- Refresh status.
+- Trust project MCP config.
+- Create, update, delete, enable, and disable global MCP servers.
+- Verify a selected server.
+- Clear stored OAuth tokens for a selected server.
+
+Project servers are shown in the TUI but are read-only there. Edit `.kolega/mcp_servers.json` directly or use `kolega-code mcp ... --project-config`.
+
+## Verification and tool exposure
+
+Verification opens a real MCP session, calls `initialize`, lists all tools (including paginated results), and stores a fingerprinted status in `<state_dir>/mcp_server_status.json`.
+
+A server's tools are exposed only when:
+
+1. the server is enabled,
+2. verification succeeded, and
+3. the saved fingerprint still matches the current server config.
+
+Changing connection details, command args, headers, env, OAuth settings, or URL makes the saved status stale and hides tools until you verify again. Changing only `enabled` does not invalidate verification.
+
+Exposed tools are named:
+
+```text
+mcp__{server_id}__{tool_id}
+```
+
+The server-provided `inputSchema` is preserved verbatim.
+
+## Permissions
+
+MCP tools participate in the same project permission flow as shell and edit tools.
+
+In `ask` mode, the TUI can save:
+
+- an exact-tool allow rule for `mcp__server__tool`, or
+- a whole-server allow rule for all verified tools from one server.
+
+Saved rules live in `<project>/.kolega/permissions.json`.

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -42,6 +42,9 @@ class ToolExtension:
     # schema is used verbatim instead of introspecting the callable signature,
     # allowing nested input shapes the introspector cannot express.
     tool_schemas: dict[str, dict[str, Any]] = field(default_factory=dict)
+    # Optional cleanup hook. May be sync or async; ToolCollection.cleanup awaits
+    # it when needed.
+    cleanup: Optional[Callable[[], Any]] = None
     # Whether this extension is inherited by sub-agents. Interactive or
     # session-shared host tools (task list, planning questions) belong to the
     # single top-level agent only; leaving them on for parallel sub-agents lets
@@ -1581,6 +1584,18 @@ class ToolCollection(LogMixin):
                             print(f"Cleaned up sub-agent: {agent_id}")
                         except Exception as e:
                             print(f"Error cleaning up sub-agent {agent_id}: {e}")
+
+            # Clean up host-provided tool extensions (MCP transports, etc.).
+            for extension in self.tool_extensions:
+                cleanup = getattr(extension, "cleanup", None)
+                if cleanup is None:
+                    continue
+                try:
+                    result = cleanup()
+                    if inspect.isawaitable(result):
+                        await result
+                except Exception as e:
+                    print(f"Error cleaning up tool extension {extension.name}: {e}")
 
         except Exception as e:
             await self.log_error(f"Error during tool cleanup: {str(e)}", sender="ToolCollection")

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -46,6 +46,8 @@ from kolega_code.agent.tool_backend.search_backends import (
 )
 from kolega_code.hooks import HookDispatcher, HookEvent
 from kolega_code.llm.models import MessageHistory
+from kolega_code.mcp.config import load_mcp_config, mcp_secret_values
+from kolega_code.mcp.state import MCPOAuthTokenStore
 from kolega_code.permissions import (
     PermissionMode,
     normalize_permission_mode,
@@ -393,6 +395,75 @@ class KolegaCodeApp(
                                     id="web_search_base_url_input",
                                     placeholder="https://searxng.example.com",
                                 )
+                            with Vertical(classes="settings-section", id="settings_mcp") as mcp_section:
+                                mcp_section.border_title = "MCP Servers"
+                                yield Static(
+                                    "Manage global MCP servers and trust project MCP configs. Verify before tools are "
+                                    "exposed; stdio verification executes the configured command.",
+                                    classes="settings-hint",
+                                )
+                                yield Static("", id="mcp_status")
+                                yield Label("Server")
+                                yield Select(
+                                    [("New user server", tui_settings_panel.MCP_NEW_SERVER_VALUE)],
+                                    id="mcp_server_select",
+                                    allow_blank=False,
+                                    value=tui_settings_panel.MCP_NEW_SERVER_VALUE,
+                                )
+                                yield Static("", id="mcp_source_hint", classes="settings-hint")
+                                yield Label("ID")
+                                yield Input(id="mcp_server_id_input", placeholder="github")
+                                yield Label("Display name")
+                                yield Input(id="mcp_name_input", placeholder="GitHub MCP")
+                                yield Label("Transport")
+                                yield Select(
+                                    tui_settings_panel.MCP_TRANSPORT_OPTIONS,
+                                    id="mcp_transport_select",
+                                    allow_blank=False,
+                                    value="streamable_http",
+                                )
+                                yield Label("Enabled")
+                                yield Select(
+                                    tui_settings_panel.MCP_ENABLED_OPTIONS,
+                                    id="mcp_enabled_select",
+                                    allow_blank=False,
+                                    value="true",
+                                )
+                                yield Label("HTTP URL", id="mcp_url_label")
+                                yield Input(id="mcp_url_input", placeholder="https://example.com/mcp")
+                                yield Label("HTTP headers JSON", id="mcp_headers_label")
+                                yield Input(
+                                    id="mcp_headers_input",
+                                    placeholder='{"Authorization":"Bearer ..."}',
+                                    password=True,
+                                )
+                                yield Label("OAuth", id="mcp_oauth_label")
+                                yield Select(
+                                    [("Disabled", "false"), ("Enabled", "true")],
+                                    id="mcp_oauth_select",
+                                    allow_blank=False,
+                                    value="false",
+                                )
+                                yield Label("Command", id="mcp_command_label")
+                                yield Input(id="mcp_command_input", placeholder="npx")
+                                yield Label("Arguments", id="mcp_args_label")
+                                yield Input(id="mcp_args_input", placeholder="-y @vendor/mcp-server")
+                                yield Label("Environment JSON", id="mcp_env_label")
+                                yield Input(id="mcp_env_input", placeholder='{"TOKEN":"..."}', password=True)
+                                yield Label("Working directory", id="mcp_cwd_label")
+                                yield Input(id="mcp_cwd_input", placeholder="optional project-relative path")
+                                with Horizontal(classes="settings-button-row"):
+                                    yield Button("Refresh", id="mcp_refresh")
+                                    yield Button("Trust Project MCP", id="mcp_trust_project")
+                                with Horizontal(classes="settings-button-row"):
+                                    yield Button("Save Server", variant="primary", id="mcp_save_server")
+                                    yield Button("Delete", variant="error", id="mcp_delete_server")
+                                with Horizontal(classes="settings-button-row"):
+                                    yield Button("Verify", id="mcp_verify_server")
+                                    yield Button("Clear OAuth Tokens", id="mcp_clear_tokens")
+                                with Horizontal(classes="settings-button-row"):
+                                    yield Button("Enable", id="mcp_enable_server")
+                                    yield Button("Disable", id="mcp_disable_server")
                             with Vertical(classes="settings-section", id="settings_appearance") as appearance_section:
                                 appearance_section.border_title = "Appearance"
                                 yield Label("Theme")
@@ -440,6 +511,15 @@ class KolegaCodeApp(
         # never let diagnostics setup break mount.
         try:
             secret_values = [v for v in getattr(self.settings, "api_keys", {}).values() if v]
+            mcp_config = getattr(self.config, "mcp_config", None)
+            if mcp_config is None:
+                mcp_config = load_mcp_config(
+                    self.project_path,
+                    self.settings_store.root,
+                    project_trusted=self.settings.is_mcp_project_trusted(self.project_path),
+                )
+            secret_values.extend(mcp_secret_values(mcp_config))
+            secret_values.extend(MCPOAuthTokenStore(self.settings_store.root).secret_values())
             self._diag = DiagnosticsLog(self.store.root, self.session.session_id, secret_values=secret_values)
             self._diag.record("session_start", **self._diagnostics_header())
             self._watchdog = ResponsivenessWatchdog(self._diag)
@@ -994,6 +1074,10 @@ class KolegaCodeApp(
             return
         if event.button.id == "save_settings":
             await self._save_settings_from_ui()
+            return
+        if event.button.id and event.button.id.startswith("mcp_"):
+            if await self._handle_mcp_settings_button(event.button.id):
+                return
 
     def copy_to_clipboard(self, text: str) -> None:
         super().copy_to_clipboard(text)

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -397,11 +397,6 @@ class KolegaCodeApp(
                                 )
                             with Vertical(classes="settings-section", id="settings_mcp") as mcp_section:
                                 mcp_section.border_title = "MCP Servers"
-                                yield Static(
-                                    "Manage global MCP servers and trust project MCP configs. Verify before tools are "
-                                    "exposed; stdio verification executes the configured command.",
-                                    classes="settings-hint",
-                                )
                                 yield Static("", id="mcp_status")
                                 yield Label("Server")
                                 yield Select(
@@ -411,8 +406,9 @@ class KolegaCodeApp(
                                     value=tui_settings_panel.MCP_NEW_SERVER_VALUE,
                                 )
                                 yield Static("", id="mcp_source_hint", classes="settings-hint")
-                                yield Label("ID")
-                                yield Input(id="mcp_server_id_input", placeholder="github")
+                                with Horizontal(classes="settings-button-row"):
+                                    yield Button("Reload MCP List", id="mcp_refresh")
+                                    yield Button("Trust Project MCP", id="mcp_trust_project")
                                 yield Label("Display name")
                                 yield Input(id="mcp_name_input", placeholder="GitHub MCP")
                                 yield Label("Transport")
@@ -453,13 +449,10 @@ class KolegaCodeApp(
                                 yield Label("Working directory", id="mcp_cwd_label")
                                 yield Input(id="mcp_cwd_input", placeholder="optional project-relative path")
                                 with Horizontal(classes="settings-button-row"):
-                                    yield Button("Refresh", id="mcp_refresh")
-                                    yield Button("Trust Project MCP", id="mcp_trust_project")
-                                with Horizontal(classes="settings-button-row"):
-                                    yield Button("Save Server", variant="primary", id="mcp_save_server")
-                                    yield Button("Delete", variant="error", id="mcp_delete_server")
-                                with Horizontal(classes="settings-button-row"):
+                                    yield Button("Save MCP Server", variant="primary", id="mcp_save_server")
                                     yield Button("Verify", id="mcp_verify_server")
+                                with Horizontal(classes="settings-button-row"):
+                                    yield Button("Delete", variant="error", id="mcp_delete_server")
                                     yield Button("Clear OAuth Tokens", id="mcp_clear_tokens")
                                 with Horizontal(classes="settings-button-row"):
                                     yield Button("Enable", id="mcp_enable_server")

--- a/kolega_code/cli/config.py
+++ b/kolega_code/cli/config.py
@@ -12,6 +12,7 @@ from pydantic import ValidationError
 from kolega_code.auth.tokens import ChatGPTTokenManager, OAuthTokens
 from kolega_code.config import AgentConfig, AgentRole, ModelConfig, ModelProvider, RateLimitConfig
 from kolega_code.llm.specs import MODEL_SPECS, get_model_specs, normalize_thinking_effort
+from kolega_code.mcp.config import load_mcp_config
 
 from .provider_registry import default_model_for_provider
 from .settings import CliSettings, SettingsStore
@@ -447,6 +448,12 @@ def build_agent_config(
 
     agent_model_overrides = _agent_model_overrides(loaded_env, settings, active_provider, active_model)
     web_search_backend, web_search_api_key, web_search_base_url = _search_config(loaded_env, settings)
+    state_dir = settings_store.root if settings_store is not None else SettingsStore().root
+    mcp_config = load_mcp_config(
+        project_path,
+        state_dir,
+        project_trusted=bool(settings and settings.is_mcp_project_trusted(project_path)),
+    )
 
     required_providers = {long_provider, fast_provider, thinking_provider}
     required_providers.update(override.provider for override in agent_model_overrides.values())
@@ -490,6 +497,7 @@ def build_agent_config(
             web_search_api_key=web_search_api_key,
             web_search_base_url=web_search_base_url,
             openai_chatgpt_tokens=chatgpt_tokens,
+            mcp_config=mcp_config,
         )
     except ValueError as exc:
         raise CliConfigError(str(exc)) from exc
@@ -557,6 +565,9 @@ def active_model_override_message(
 
 def config_summary(config: AgentConfig) -> dict[str, object]:
     """Return a session-safe summary of model configuration."""
+    mcp_config = getattr(config, "mcp_config", None)
+    mcp_servers = getattr(mcp_config, "servers", {}) or {}
+    mcp_enabled = [server for server in mcp_servers.values() if getattr(server, "enabled", False)]
     return {
         "environment": config.environment,
         "long_provider": config.long_context_config.provider.value,
@@ -570,4 +581,7 @@ def config_summary(config: AgentConfig) -> dict[str, object]:
             role: f"{model_config.provider.value}/{model_config.model}"
             for role, model_config in config.agent_models.items()
         },
+        "mcp_servers": len(mcp_servers),
+        "mcp_enabled_servers": len(mcp_enabled),
+        "mcp_project_trusted": bool(getattr(mcp_config, "project_trusted", False)),
     }

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -9,7 +9,7 @@ import importlib.util
 import json
 import sys
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Any, Iterable, Optional
 
 from kolega_code.agent import CoderAgent
 from kolega_code.agent.prompt_dump import (
@@ -23,6 +23,18 @@ from kolega_code.agent.prompt_dump import (
 from kolega_code.hooks import HookDispatcher, HookEvent, load_hook_config
 from kolega_code.llm.exceptions import LLMBillingError, billing_error_message
 from kolega_code.llm.models import TextBlock
+from kolega_code.mcp.config import (
+    MCPConfigError,
+    MCPServerConfig,
+    global_mcp_config_path,
+    load_mcp_config,
+    project_mcp_config_path,
+    remove_server_config,
+    set_server_enabled,
+    upsert_server_config,
+)
+from kolega_code.mcp.service import MCPService
+from kolega_code.mcp.tools import build_mcp_tool_extension
 from kolega_code.agent.prompt_provider import AgentMode
 from kolega_code.permissions import (
     PermissionDecision,
@@ -58,7 +70,7 @@ from .skills import (
 )
 from .updater import check_for_update, run_self_update, update_status_message
 
-SUBCOMMANDS = {"ask", "sessions", "doctor", "update", "prompts", "tui"}
+SUBCOMMANDS = {"ask", "sessions", "doctor", "update", "prompts", "mcp", "tui"}
 RESUME_LATEST = "__latest__"
 CLI_AGENT_MODE = AgentMode.CLI.value
 ASK_DEFAULT_PERMISSION_MODE = PermissionMode.AUTO.value
@@ -94,6 +106,8 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
             return _run_doctor(args)
         if args.command == "prompts":
             return _run_prompts(args)
+        if args.command == "mcp":
+            return asyncio.run(_run_mcp(args))
         if args.command == "update":
             return _run_update()
         if args.command == "tui":
@@ -187,6 +201,11 @@ def _add_tui_args(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Trust and enable this project's .kolega/hooks.json (persisted for future runs).",
     )
+    parser.add_argument(
+        "--trust-mcp",
+        action="store_true",
+        help="Trust and enable this project's .kolega/mcp_servers.json (persisted for future runs).",
+    )
     _add_session_args(parser, session_help="Legacy alias for --resume THREAD_ID.")
     _add_common_model_args(parser)
 
@@ -231,6 +250,11 @@ def _build_subcommand_parser() -> argparse.ArgumentParser:
         help="Trust and enable this project's .kolega/hooks.json (persisted for future runs).",
     )
     ask.add_argument(
+        "--trust-mcp",
+        action="store_true",
+        help="Trust and enable this project's .kolega/mcp_servers.json (persisted for future runs).",
+    )
+    ask.add_argument(
         "--image",
         action="append",
         default=[],
@@ -273,6 +297,49 @@ def _build_subcommand_parser() -> argparse.ArgumentParser:
     prompts_list.add_argument("--project", default=".", type=Path, help="Project directory to inspect.")
     prompts_validate = prompts_sub.add_parser("validate", help="Validate existing prompt override files.")
     prompts_validate.add_argument("--project", default=".", type=Path, help="Project directory to inspect.")
+
+    mcp = subparsers.add_parser("mcp", help="Manage MCP servers and verification state.")
+    mcp.add_argument(
+        "--project", default=".", type=Path, help="Project directory to use for trusted project MCP config."
+    )
+    mcp.add_argument("--state-dir", type=Path, help="Directory for CLI state and global MCP config.")
+    mcp.add_argument(
+        "--trust-mcp",
+        action="store_true",
+        help="Trust this project's .kolega/mcp_servers.json before running the command.",
+    )
+    mcp_sub = mcp.add_subparsers(dest="mcp_command", required=True)
+    mcp_sub.add_parser("list", help="List configured MCP servers and verification status.")
+    verify = mcp_sub.add_parser("verify", help="Verify one MCP server, or all enabled servers with --all.")
+    verify.add_argument("server_id", nargs="?", help="MCP server id to verify.")
+    verify.add_argument("--all", action="store_true", help="Verify all enabled MCP servers.")
+    verify.add_argument("--yes", action="store_true", help="Confirm starting stdio MCP commands without prompting.")
+    verify.add_argument("--no-browser", action="store_true", help="Print OAuth URL without opening a browser.")
+    verify.add_argument("--json", action="store_true", help="Print verification results as JSON.")
+    add = mcp_sub.add_parser("add", help="Add or update an MCP server in global config (or project config).")
+    add.add_argument("server_id")
+    add.add_argument("--project-config", action="store_true", help="Write to <project>/.kolega/mcp_servers.json.")
+    add.add_argument("--name")
+    add.add_argument("--transport", choices=["streamable_http", "sse", "stdio"], required=True)
+    add.add_argument("--url", help="HTTP MCP endpoint for streamable_http or sse transports.")
+    add.add_argument("--header", action="append", default=[], help="HTTP header as Name=Value (repeatable).")
+    add.add_argument("--command", dest="stdio_command", help="Command for stdio transport.")
+    add.add_argument("--arg", action="append", default=[], help="Argument for stdio command (repeatable).")
+    add.add_argument("--env", action="append", default=[], help="Environment variable as NAME=VALUE (repeatable).")
+    add.add_argument("--cwd", help="Working directory for stdio command; relative paths resolve under project.")
+    add.add_argument("--oauth", action="store_true", help="Enable OAuth for this HTTP MCP server.")
+    add.add_argument("--oauth-scope", help="OAuth scopes to request.")
+    add.add_argument("--redirect-uri", help="OAuth redirect URI; defaults to an ephemeral localhost callback.")
+    add.add_argument("--disabled", action="store_true", help="Add the server disabled.")
+    remove = mcp_sub.add_parser("remove", help="Remove an MCP server from global or project config.")
+    remove.add_argument("server_id")
+    remove.add_argument("--project-config", action="store_true", help="Remove from <project>/.kolega/mcp_servers.json.")
+    enable = mcp_sub.add_parser("enable", help="Enable an MCP server in global or project config.")
+    enable.add_argument("server_id")
+    enable.add_argument("--project-config", action="store_true", help="Update <project>/.kolega/mcp_servers.json.")
+    disable = mcp_sub.add_parser("disable", help="Disable an MCP server in global or project config.")
+    disable.add_argument("server_id")
+    disable.add_argument("--project-config", action="store_true", help="Update <project>/.kolega/mcp_servers.json.")
 
     subparsers.add_parser("update", help="Update Kolega Code to the latest version.")
 
@@ -432,12 +499,20 @@ def _run_tui(args: argparse.Namespace) -> int:
     store = _store_from_args(args)
     settings_store = _settings_store_from_args(args)
     settings = settings_store.load()
+    settings_changed = False
     if getattr(args, "trust_hooks", False):
         settings.trust_hook_project(project_path)
+        settings_changed = True
+    if getattr(args, "trust_mcp", False):
+        settings.trust_mcp_project(project_path)
+        settings_changed = True
+    if settings_changed:
         settings_store.save(settings)
     summary = {}
     try:
-        config = build_agent_config(project_path, _overrides_from_args(args), settings=settings)
+        config = build_agent_config(
+            project_path, _overrides_from_args(args), settings=settings, settings_store=settings_store
+        )
         summary = config_summary(config)
     except CliConfigError as exc:
         if str(exc) == DEPRECATED_THINKING_TOKENS_MESSAGE:
@@ -479,6 +554,21 @@ def _run_tui(args: argparse.Namespace) -> int:
         app.run()
     except Exception as exc:  # noqa: BLE001 — last-resort crash capture before re-raising
         _secrets = [v for v in getattr(settings, "api_keys", {}).values() if v]
+        try:
+            from kolega_code.mcp.config import load_mcp_config, mcp_secret_values
+            from kolega_code.mcp.state import MCPOAuthTokenStore
+
+            mcp_config = getattr(config, "mcp_config", None) if config is not None else None
+            if mcp_config is None:
+                mcp_config = load_mcp_config(
+                    project_path,
+                    settings_store.root,
+                    project_trusted=settings.is_mcp_project_trusted(project_path),
+                )
+            _secrets.extend(mcp_secret_values(mcp_config))
+            _secrets.extend(MCPOAuthTokenStore(settings_store.root).secret_values())
+        except Exception:
+            pass
         path = write_crash_log(
             store.root, exc=exc, header=f"kolega-code crash | session {session.session_id}", secret_values=_secrets
         )
@@ -516,6 +606,10 @@ def _permission_callback_for_ask(project_path: Path):
         if request.kind.value == "command":
             print("Allow the agent to run this command?", file=sys.stderr)
             print(f"  {request.command}", file=sys.stderr)
+        elif request.kind.value == "mcp":
+            print("Allow the agent to call this MCP tool?", file=sys.stderr)
+            print(f"  server: {request.mcp_server}", file=sys.stderr)
+            print(f"  tool:   {request.mcp_tool}", file=sys.stderr)
         else:
             target = f" on {request.path}" if request.path else ""
             print(f"Allow the agent to run {request.tool_name}{target}?", file=sys.stderr)
@@ -588,10 +682,18 @@ async def _run_ask(args: argparse.Namespace) -> int:
     store = _store_from_args(args)
     settings_store = _settings_store_from_args(args)
     settings = settings_store.load()
+    settings_changed = False
     if getattr(args, "trust_hooks", False):
         settings.trust_hook_project(project_path)
+        settings_changed = True
+    if getattr(args, "trust_mcp", False):
+        settings.trust_mcp_project(project_path)
+        settings_changed = True
+    if settings_changed:
         settings_store.save(settings)
-    config = build_agent_config(project_path, _overrides_from_args(args), settings=settings)
+    config = build_agent_config(
+        project_path, _overrides_from_args(args), settings=settings, settings_store=settings_store
+    )
     summary = config_summary(config)
 
     hook_config = load_hook_config(
@@ -625,6 +727,18 @@ async def _run_ask(args: argparse.Namespace) -> int:
         prompt_extensions.append(skill_prompt_extension)
     if skill_tool_extension is not None:
         tool_extensions.append(skill_tool_extension)
+    mcp_config = getattr(config, "mcp_config", None)
+    if not args.json and mcp_config is not None:
+        for diagnostic in getattr(mcp_config, "diagnostics", []) or []:
+            print(f"mcp: {diagnostic}", file=sys.stderr)
+    mcp_extension = build_mcp_tool_extension(
+        project_path,
+        settings_store.root,
+        project_trusted=settings.is_mcp_project_trusted(project_path),
+        loaded_config=mcp_config,
+    )
+    if mcp_extension is not None:
+        tool_extensions.append(mcp_extension)
     permission_mode = normalize_permission_mode(
         getattr(args, "permission_mode", ASK_DEFAULT_PERMISSION_MODE),
         default=PermissionMode.AUTO,
@@ -855,6 +969,182 @@ def _run_prompts(args: argparse.Namespace) -> int:
     raise ValueError(f"Unknown prompts command: {args.prompts_command}")
 
 
+async def _run_mcp(args: argparse.Namespace) -> int:
+    project_path = _validate_project(args.project)
+    settings_store = _settings_store_from_args(args)
+    settings = settings_store.load()
+    if getattr(args, "trust_mcp", False):
+        settings.trust_mcp_project(project_path)
+        settings_store.save(settings)
+
+    config = load_mcp_config(
+        project_path,
+        settings_store.root,
+        project_trusted=settings.is_mcp_project_trusted(project_path),
+    )
+    service = MCPService(config, state_dir=settings_store.root, project_path=project_path)
+
+    if args.mcp_command == "list":
+        _print_mcp_list(config, service)
+        return 0
+
+    if args.mcp_command == "verify":
+        server_ids = _mcp_verify_server_ids(args, config)
+        if not server_ids:
+            raise ValueError("No MCP servers to verify.")
+        if not _confirm_stdio_verification(args, config, server_ids):
+            return 2
+        results = []
+        for server_id in server_ids:
+            results.append(
+                await service.verify_server(
+                    server_id,
+                    interactive_oauth=True,
+                    open_browser=not getattr(args, "no_browser", False),
+                    output=sys.stderr,
+                )
+            )
+        if getattr(args, "json", False):
+            print(json.dumps([result.__dict__ for result in results], default=str))
+        else:
+            for result in results:
+                glyph = "✓" if result.ok else "✗"
+                print(f"{glyph} {result.server_id}: {result.message}")
+        return 0 if all(result.ok for result in results) else 1
+
+    if args.mcp_command == "add":
+        path, source = _mcp_mutation_target(args, project_path, settings_store.root)
+        server = _server_config_from_add_args(args)
+        try:
+            upsert_server_config(path, server, source=source)
+        except MCPConfigError as exc:
+            raise ValueError(str(exc)) from exc
+        print(f"Saved MCP server {server.id} to {path}")
+        if source == "project" and not settings.is_mcp_project_trusted(project_path):
+            print("Project MCP config is not trusted yet. Re-run with --trust-mcp to enable it.", file=sys.stderr)
+        return 0
+
+    if args.mcp_command == "remove":
+        path, source = _mcp_mutation_target(args, project_path, settings_store.root)
+        try:
+            removed = remove_server_config(path, args.server_id, source=source)
+        except MCPConfigError as exc:
+            raise ValueError(str(exc)) from exc
+        if not removed:
+            raise ValueError(f"MCP server not found in {path}: {args.server_id}")
+        service.status_store.clear(args.server_id)
+        service.oauth_store.clear(args.server_id)
+        print(f"Removed MCP server {args.server_id} from {path}")
+        return 0
+
+    if args.mcp_command in {"enable", "disable"}:
+        path, source = _mcp_mutation_target(args, project_path, settings_store.root)
+        enabled = args.mcp_command == "enable"
+        try:
+            changed = set_server_enabled(path, args.server_id, enabled, source=source)
+        except MCPConfigError as exc:
+            raise ValueError(str(exc)) from exc
+        if not changed:
+            raise ValueError(f"MCP server not found in {path}: {args.server_id}")
+        print(f"{'Enabled' if enabled else 'Disabled'} MCP server {args.server_id} in {path}")
+        return 0
+
+    raise ValueError(f"Unknown mcp command: {args.mcp_command}")
+
+
+def _print_mcp_list(config, service: MCPService) -> None:
+    for diagnostic in config.diagnostics:
+        print(f"mcp: {diagnostic}", file=sys.stderr)
+    if not config.servers:
+        print("No MCP servers configured.")
+        print(f"Global config: {config.global_path}")
+        if config.project_config_path:
+            print(
+                f"Project config: {config.project_config_path} ({'trusted' if config.project_trusted else 'untrusted'})"
+            )
+        return
+    print("ID\tSOURCE\tTRANSPORT\tENABLED\tOAUTH\tSTATUS\tTOOLS\tMESSAGE")
+    for row in service.list_status_rows():
+        print(
+            f"{row['id']}\t{row['source']}\t{row['transport']}\t{row['enabled']}\t{row['oauth']}\t"
+            f"{row['status']}\t{row['tool_count']}\t{row['message']}"
+        )
+
+
+def _mcp_verify_server_ids(args: argparse.Namespace, config) -> list[str]:
+    if args.all and args.server_id:
+        raise ValueError("Use either `mcp verify SERVER_ID` or `mcp verify --all`, not both.")
+    if args.all:
+        return [server.id for server in config.enabled_servers]
+    if not args.server_id:
+        raise ValueError("Specify an MCP server id or --all.")
+    return [args.server_id]
+
+
+def _confirm_stdio_verification(args: argparse.Namespace, config, server_ids: list[str]) -> bool:
+    stdio_servers = [
+        config.servers[server_id]
+        for server_id in server_ids
+        if config.servers.get(server_id) and config.servers[server_id].transport == "stdio"
+    ]
+    if not stdio_servers:
+        return True
+    if getattr(args, "yes", False):
+        return True
+    if not sys.stdin.isatty():
+        print("Refusing to start stdio MCP server command(s) without --yes in non-interactive mode.", file=sys.stderr)
+        return False
+    print("Verifying stdio MCP servers starts local commands:", file=sys.stderr)
+    for server in stdio_servers:
+        command = " ".join([server.command or "", *server.args]).strip()
+        print(f"  {server.id}: {command}", file=sys.stderr)
+    print("Continue? [y/N] ", end="", file=sys.stderr, flush=True)
+    answer = sys.stdin.readline().strip().lower()
+    return answer in {"y", "yes"}
+
+
+def _mcp_mutation_target(args: argparse.Namespace, project_path: Path, state_dir: Path) -> tuple[Path, str]:
+    if getattr(args, "project_config", False):
+        return project_mcp_config_path(project_path), "project"
+    return global_mcp_config_path(state_dir), "global"
+
+
+def _server_config_from_add_args(args: argparse.Namespace) -> MCPServerConfig:
+    headers = _parse_key_value_options(getattr(args, "header", []) or [], "--header")
+    env = _parse_key_value_options(getattr(args, "env", []) or [], "--env")
+    payload: dict[str, Any] = {
+        "id": args.server_id,
+        "name": args.name,
+        "transport": args.transport,
+        "enabled": not bool(args.disabled),
+        "url": args.url,
+        "headers": headers,
+        "command": getattr(args, "stdio_command", None),
+        "args": getattr(args, "arg", []) or [],
+        "env": env,
+        "cwd": args.cwd,
+        "oauth": {
+            "enabled": bool(args.oauth),
+            "scope": args.oauth_scope,
+            "redirect_uri": args.redirect_uri,
+        },
+    }
+    return MCPServerConfig.model_validate(payload)
+
+
+def _parse_key_value_options(values: list[str], flag_name: str) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for item in values:
+        if "=" not in item:
+            raise ValueError(f"{flag_name} values must be NAME=VALUE")
+        key, value = item.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError(f"{flag_name} values must include a non-empty name")
+        parsed[key] = value
+    return parsed
+
+
 def _run_doctor(args: argparse.Namespace) -> int:
     from . import theme
     from .theme import Glyph
@@ -890,7 +1180,9 @@ def _run_doctor(args: argparse.Namespace) -> int:
         line("Stored active model", "not configured", "warning")
 
     try:
-        config = build_agent_config(project_path, _overrides_from_args(args), settings=settings)
+        config = build_agent_config(
+            project_path, _overrides_from_args(args), settings=settings, settings_store=settings_store
+        )
     except CliConfigError as exc:
         _print_styled(f"{theme.g(Glyph.CROSS)} Configuration: invalid ({exc})", style="error")
         return 2

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -30,6 +30,7 @@ from kolega_code.mcp.config import (
     load_mcp_config,
     project_mcp_config_path,
     remove_server_config,
+    server_fingerprint,
     set_server_enabled,
     upsert_server_config,
 )
@@ -1064,18 +1065,37 @@ def _print_mcp_list(config, service: MCPService) -> None:
             )
         return
     print("ID\tSOURCE\tTRANSPORT\tENABLED\tOAUTH\tSTATUS\tTOOLS\tMESSAGE")
-    for row in service.list_status_rows():
-        message = _mcp_cli_list_message(row)
+    for server in config.servers.values():
+        status_text, tool_count, message = _mcp_cli_status_parts(server, service)
         print(
-            f"{row['id']}\t{row['source']}\t{row['transport']}\t{row['enabled']}\t{row['oauth']}\t"
-            f"{row['status']}\t{row['tool_count']}\t{message}"
+            f"{server.id}\t{server.source}\t{server.transport}\t{server.enabled}\t{server.oauth.enabled}\t"
+            f"{status_text}\t{tool_count}\t{message}"
         )
 
 
-def _mcp_cli_list_message(row: dict[str, object]) -> str:
-    status = str(row.get("status", "unverified"))
+def _mcp_cli_status_parts(server: MCPServerConfig, service: MCPService) -> tuple[str, int, str]:
+    status = service.server_status(server)
+    current_fingerprint = server_fingerprint(server)
+    verified = bool(status and status.status == "verified" and status.fingerprint == current_fingerprint)
+    stale = bool(status and status.fingerprint and status.fingerprint != current_fingerprint)
+    if verified and status:
+        status_text = "verified"
+        tool_count = status.tool_count
+    elif stale:
+        status_text = "stale"
+        tool_count = 0
+    elif status and status.status == "failed":
+        status_text = "failed"
+        tool_count = 0
+    else:
+        status_text = "unverified"
+        tool_count = 0
+    return status_text, tool_count, _mcp_cli_list_message(status_text, tool_count)
+
+
+def _mcp_cli_list_message(status: str, tool_count: int) -> str:
     if status == "verified":
-        return f"Verified {row.get('tool_count', 0)} tool(s)."
+        return f"Verified {tool_count} tool(s)."
     if status == "stale":
         return "Configuration changed since last verification. Verify again."
     if status == "failed":

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -33,7 +33,7 @@ from kolega_code.mcp.config import (
     set_server_enabled,
     upsert_server_config,
 )
-from kolega_code.mcp.service import MCPService
+from kolega_code.mcp.service import MCP_FAILURE_MESSAGE_GENERIC, MCPService
 from kolega_code.mcp.tools import build_mcp_tool_extension
 from kolega_code.agent.prompt_provider import AgentMode
 from kolega_code.permissions import (
@@ -1065,10 +1065,22 @@ def _print_mcp_list(config, service: MCPService) -> None:
         return
     print("ID\tSOURCE\tTRANSPORT\tENABLED\tOAUTH\tSTATUS\tTOOLS\tMESSAGE")
     for row in service.list_status_rows():
+        message = _mcp_cli_list_message(row)
         print(
             f"{row['id']}\t{row['source']}\t{row['transport']}\t{row['enabled']}\t{row['oauth']}\t"
-            f"{row['status']}\t{row['tool_count']}\t{row['message']}"
+            f"{row['status']}\t{row['tool_count']}\t{message}"
         )
+
+
+def _mcp_cli_list_message(row: dict[str, object]) -> str:
+    status = str(row.get("status", "unverified"))
+    if status == "verified":
+        return f"Verified {row.get('tool_count', 0)} tool(s)."
+    if status == "stale":
+        return "Configuration changed since last verification. Verify again."
+    if status == "failed":
+        return MCP_FAILURE_MESSAGE_GENERIC
+    return "Not verified."
 
 
 def _mcp_verify_server_ids(args: argparse.Namespace, config) -> list[str]:

--- a/kolega_code/cli/settings.py
+++ b/kolega_code/cli/settings.py
@@ -84,6 +84,8 @@ class CliSettings:
     agent_models: dict[str, dict] = field(default_factory=dict)
     # Resolved project paths whose .kolega/hooks.json the user has opted to trust.
     trusted_hook_projects: list[str] = field(default_factory=list)
+    # Resolved project paths whose .kolega/mcp_servers.json the user has opted to trust.
+    trusted_mcp_projects: list[str] = field(default_factory=list)
     # Web search backend selection. Additive optional fields (absent -> None -> the
     # "duckduckgo" default is applied downstream), so no schema bump is needed — same
     # convention as active_theme. Cloud backend API keys live in api_keys under the
@@ -107,6 +109,7 @@ class CliSettings:
             raise SettingsStoreError(f"Unsupported settings schema version: {data.get('schema_version')}")
         api_keys = data.get("api_keys") or {}
         trusted = data.get("trusted_hook_projects") or []
+        trusted_mcp = data.get("trusted_mcp_projects") or []
         return cls(
             schema_version=SETTINGS_SCHEMA_VERSION,
             active_provider=data.get("active_provider"),
@@ -119,6 +122,7 @@ class CliSettings:
             # Additive optional field; absent in pre-v3 files -> empty mapping.
             agent_models=_coerce_agent_models(data.get("agent_models")),
             trusted_hook_projects=[str(path) for path in trusted if path],
+            trusted_mcp_projects=[str(path) for path in trusted_mcp if path],
             # Additive optional fields; absent in older files -> None -> default backend.
             web_search_backend=data.get("web_search_backend"),
             web_search_base_url=data.get("web_search_base_url"),
@@ -138,6 +142,7 @@ class CliSettings:
             "api_keys": self.api_keys,
             "agent_models": self.agent_models,
             "trusted_hook_projects": self.trusted_hook_projects,
+            "trusted_mcp_projects": self.trusted_mcp_projects,
             "web_search_backend": self.web_search_backend,
             "web_search_base_url": self.web_search_base_url,
             "oauth_tokens": self.oauth_tokens,
@@ -192,6 +197,14 @@ class CliSettings:
         resolved = str(Path(project_path).resolve())
         if resolved not in self.trusted_hook_projects:
             self.trusted_hook_projects.append(resolved)
+
+    def is_mcp_project_trusted(self, project_path) -> bool:
+        return str(Path(project_path).resolve()) in self.trusted_mcp_projects
+
+    def trust_mcp_project(self, project_path) -> None:
+        resolved = str(Path(project_path).resolve())
+        if resolved not in self.trusted_mcp_projects:
+            self.trusted_mcp_projects.append(resolved)
 
 
 class SettingsStore:

--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -8,6 +8,7 @@ from kolega_code.agent import AgentConfig, AgentEvent, CoderAgent, PlanningAgent
 from kolega_code.agent.prompt_provider import AgentMode
 from kolega_code.hooks import HookDispatcher, HookEvent, load_hook_config, project_hooks_present
 from kolega_code.llm.exceptions import LLMError, llm_error_message
+from kolega_code.mcp.tools import build_mcp_tool_extension
 from kolega_code.services.browser import PlaywrightBrowserManager
 
 from .. import messages
@@ -465,6 +466,19 @@ class AgentRuntimeMixin:
         if self.interaction_mode == tui_constants.PLAN_INTERACTION_MODE:
             prompt_extensions.append(self._planning_question_prompt_extension())
             tool_extensions.append(self._planning_question_tool_extension())
+
+        mcp_config = getattr(config, "mcp_config", None)
+        if mcp_config is not None:
+            for diagnostic in getattr(mcp_config, "diagnostics", []) or []:
+                self._log_status(f"mcp: {diagnostic}", level="warn")
+            mcp_extension = build_mcp_tool_extension(
+                self.project_path,
+                self.settings_store.root,
+                project_trusted=self.settings.is_mcp_project_trusted(self.project_path),
+                loaded_config=mcp_config,
+            )
+            if mcp_extension is not None:
+                tool_extensions.append(mcp_extension)
 
         # gigacode applies to any top-level agent and is carried across rebuilds.
         # In plan mode the orchestrating agent is read-only, so its workflow

--- a/kolega_code/cli/tui/prompt_flows.py
+++ b/kolega_code/cli/tui/prompt_flows.py
@@ -343,6 +343,15 @@ class PromptFlowMixin:
     def _format_permission_content(self, request: PermissionRequest) -> str:
         if request.kind.value == "command":
             return "\n".join(["Allow the agent to run this command?", "", request.command])
+        if request.kind.value == "mcp":
+            return "\n".join(
+                [
+                    "Allow the agent to call this MCP tool?",
+                    "",
+                    f"Server: {request.mcp_server}",
+                    f"Tool: {request.mcp_tool}",
+                ]
+            )
         target = f" on {request.path}" if request.path else ""
         return f"Allow the agent to run {request.tool_name}{target}?"
 

--- a/kolega_code/cli/tui/settings_panel.py
+++ b/kolega_code/cli/tui/settings_panel.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import shlex
 from typing import Optional
 
 from textual.css.query import NoMatches
@@ -15,6 +17,18 @@ from kolega_code.agent.tool_backend.search_backends import (
     available_backends,
     get_backend_class,
 )
+from kolega_code.mcp.config import (
+    MCPConfigError,
+    MCPOAuthConfig,
+    MCPServerConfig,
+    global_mcp_config_path,
+    load_mcp_config,
+    remove_server_config,
+    set_server_enabled,
+    upsert_server_config,
+)
+from kolega_code.mcp.service import MCPService
+from kolega_code.mcp.state import MCPStatusStore, MCPOAuthTokenStore
 
 from .. import messages, theme
 from ..config import active_model_override_message, key_status
@@ -31,6 +45,14 @@ from ..provider_registry import (
 )
 from ..settings import WEB_SEARCH_KEY_NAMES
 from ..theme import Color, Glyph
+
+MCP_NEW_SERVER_VALUE = "__new_mcp_server__"
+MCP_TRANSPORT_OPTIONS = [
+    ("Streamable HTTP", "streamable_http"),
+    ("Server-Sent Events (SSE)", "sse"),
+    ("stdio command", "stdio"),
+]
+MCP_ENABLED_OPTIONS = [("Enabled", "true"), ("Disabled", "false")]
 
 
 class SettingsPanelMixin:
@@ -63,6 +85,14 @@ class SettingsPanelMixin:
 
         if select_id == "web_search_backend_select":
             self._update_search_backend_fields(str(event.value))
+            return
+
+        if select_id == "mcp_server_select":
+            self._populate_mcp_server_form(str(event.value))
+            return
+
+        if select_id == "mcp_transport_select":
+            self._update_mcp_transport_fields(str(event.value))
             return
 
         if select_id.startswith("am_provider_"):
@@ -141,6 +171,7 @@ class SettingsPanelMixin:
         api_key_input.disabled = provider == chatgpt_constants.PROVIDER_KEY
         self._populate_agent_model_rows()
         self._populate_web_search_controls()
+        self._populate_mcp_controls()
         self._update_settings_status()
 
     def _populate_agent_model_rows(self) -> None:
@@ -242,6 +273,373 @@ class SettingsPanelMixin:
             self.settings.set_api_key(backend, key)
         key_input.value = ""
         self._update_search_backend_fields(backend)
+
+    def _load_mcp_config_for_ui(self):
+        """Load MCP config for the settings panel and attach it to the active AgentConfig."""
+        trusted = bool(self.settings.is_mcp_project_trusted(self.project_path))
+        config = load_mcp_config(self.project_path, self.settings_store.root, project_trusted=trusted)
+        if self.config is not None:
+            self.config.mcp_config = config
+        return config
+
+    def _populate_mcp_controls(self) -> None:
+        """Seed the MCP settings controls from global/trusted project config and status."""
+        try:
+            config = self._load_mcp_config_for_ui()
+            server_select = self.query_one("#mcp_server_select", Select)
+        except NoMatches:
+            return
+        except Exception as exc:
+            self._set_mcp_status(f"MCP config could not be loaded: {exc}", tone="error")
+            return
+
+        options = [("New user server", MCP_NEW_SERVER_VALUE)]
+        options.extend((self._mcp_server_option_label(server), server.id) for server in config.servers.values())
+        selected = getattr(self, "_mcp_selected_server_id", MCP_NEW_SERVER_VALUE)
+        if selected not in {value for _, value in options}:
+            selected = MCP_NEW_SERVER_VALUE
+        server_select.set_options(options)
+        server_select.value = selected
+        self._populate_mcp_server_form(selected)
+        self._update_mcp_status_text(config)
+
+    def _mcp_server_option_label(self, server: MCPServerConfig) -> str:
+        enabled = "on" if server.enabled else "off"
+        return f"{server.id} ({server.source}, {server.transport}, {enabled})"
+
+    def _populate_mcp_server_form(self, server_id: str) -> None:
+        self._mcp_selected_server_id = server_id
+        try:
+            config = self._load_mcp_config_for_ui()
+        except Exception:
+            config = None
+        server = None if server_id == MCP_NEW_SERVER_VALUE or config is None else config.servers.get(server_id)
+
+        def set_input(widget_id: str, value: str) -> None:
+            try:
+                self.query_one(f"#{widget_id}", Input).value = value
+            except NoMatches:
+                pass
+
+        def set_select(widget_id: str, value: str) -> None:
+            try:
+                select = self.query_one(f"#{widget_id}", Select)
+                if value is not Select.NULL:
+                    select.value = value
+            except NoMatches:
+                pass
+
+        if server is None:
+            set_input("mcp_server_id_input", "")
+            set_input("mcp_name_input", "")
+            set_select("mcp_transport_select", "streamable_http")
+            set_select("mcp_enabled_select", "true")
+            set_input("mcp_url_input", "")
+            set_input("mcp_headers_input", "")
+            set_select("mcp_oauth_select", "false")
+            set_input("mcp_command_input", "")
+            set_input("mcp_args_input", "")
+            set_input("mcp_env_input", "")
+            set_input("mcp_cwd_input", "")
+            self._set_mcp_source_hint("Create or update a user MCP server in the global state config.")
+            self._update_mcp_transport_fields("streamable_http")
+            return
+
+        set_input("mcp_server_id_input", server.id)
+        set_input("mcp_name_input", server.name or "")
+        set_select("mcp_transport_select", server.transport)
+        set_select("mcp_enabled_select", "true" if server.enabled else "false")
+        set_input("mcp_url_input", server.url or "")
+        set_input("mcp_headers_input", json.dumps(server.headers, sort_keys=True) if server.headers else "")
+        set_select("mcp_oauth_select", "true" if server.oauth.enabled else "false")
+        set_input("mcp_command_input", server.command or "")
+        set_input("mcp_args_input", " ".join(shlex.quote(arg) for arg in server.args))
+        set_input("mcp_env_input", json.dumps(server.env, sort_keys=True) if server.env else "")
+        set_input("mcp_cwd_input", server.cwd or "")
+        if server.source == "project":
+            self._set_mcp_source_hint(
+                "This server comes from the trusted project config and is read-only here; edit .kolega/mcp_servers.json."
+            )
+        else:
+            self._set_mcp_source_hint("This server is stored in your global MCP config.")
+        self._update_mcp_transport_fields(server.transport)
+
+    def _update_mcp_transport_fields(self, transport: str) -> None:
+        http = transport in {"streamable_http", "sse"}
+        for widget_id, visible in (
+            ("mcp_url_label", http),
+            ("mcp_url_input", http),
+            ("mcp_headers_label", http),
+            ("mcp_headers_input", http),
+            ("mcp_oauth_label", http),
+            ("mcp_oauth_select", http),
+            ("mcp_command_label", not http),
+            ("mcp_command_input", not http),
+            ("mcp_args_label", not http),
+            ("mcp_args_input", not http),
+            ("mcp_env_label", not http),
+            ("mcp_env_input", not http),
+            ("mcp_cwd_label", not http),
+            ("mcp_cwd_input", not http),
+        ):
+            try:
+                self.query_one(f"#{widget_id}").display = visible
+            except NoMatches:
+                pass
+        try:
+            url_input = self.query_one("#mcp_url_input", Input)
+            if transport == "streamable_http":
+                url_input.placeholder = "https://example.com/mcp"
+            elif transport == "sse":
+                url_input.placeholder = "https://example.com/sse"
+        except NoMatches:
+            pass
+
+    def _update_mcp_status_text(self, config=None) -> None:
+        try:
+            config = config or self._load_mcp_config_for_ui()
+        except Exception as exc:
+            self._set_mcp_status(f"MCP config could not be loaded: {exc}", tone="error")
+            return
+
+        lines: list[str] = [f"Global config: {global_mcp_config_path(self.settings_store.root)}"]
+        if config.project_config_present:
+            if config.project_trusted:
+                lines.append(f"Project config trusted: {config.project_config_path}")
+            else:
+                lines.append(f"Project config present but not trusted: {config.project_config_path}")
+        elif config.project_config_path is not None:
+            lines.append(f"Project config: {config.project_config_path} (not present)")
+        lines.extend(config.diagnostics)
+
+        rows = MCPService(config, self.settings_store.root, self.project_path).list_status_rows()
+        if not rows:
+            lines.append("No MCP servers configured.")
+        else:
+            for row in rows:
+                status = row["status"]
+                icon = "✓" if status == "verified" else ("!" if status in {"failed", "stale"} else "•")
+                state = "enabled" if row["enabled"] else "disabled"
+                oauth = ", oauth" if row["oauth"] else ""
+                lines.append(
+                    f"{icon} {row['id']} [{row['source']}/{row['transport']}, {state}{oauth}] "
+                    f"{status}; tools={row['tool_count']}; {row['message']}"
+                )
+        self._set_mcp_status(
+            "\n".join(lines),
+            tone="ok" if rows and all(r["status"] == "verified" for r in rows if r["enabled"]) else "info",
+        )
+
+    def _set_mcp_status(self, text: str, tone: str = "info") -> None:
+        glyph, style = {
+            "ok": (Glyph.CHECK, Color.SUCCESS),
+            "error": (Glyph.CROSS, Color.ERROR),
+            "warning": (Glyph.STATUS, Color.WARNING),
+        }.get(tone, (Glyph.STATUS, Color.MUTED))
+        content = Text()
+        content.append(theme.g(glyph) + " ", style=style)
+        content.append(text)
+        try:
+            self.query_one("#mcp_status", Static).update(content)
+        except NoMatches:
+            return
+
+    def _set_mcp_source_hint(self, text: str) -> None:
+        try:
+            self.query_one("#mcp_source_hint", Static).update(text)
+        except NoMatches:
+            pass
+
+    def _collect_mcp_server_from_ui(self) -> MCPServerConfig:
+        server_id = self.query_one("#mcp_server_id_input", Input).value.strip()
+        name = self.query_one("#mcp_name_input", Input).value.strip() or None
+        transport = str(self.query_one("#mcp_transport_select", Select).value)
+        enabled = str(self.query_one("#mcp_enabled_select", Select).value) == "true"
+        url = self.query_one("#mcp_url_input", Input).value.strip() or None
+        headers_text = self.query_one("#mcp_headers_input", Input).value.strip()
+        oauth_enabled = str(self.query_one("#mcp_oauth_select", Select).value) == "true"
+        command = self.query_one("#mcp_command_input", Input).value.strip() or None
+        args_text = self.query_one("#mcp_args_input", Input).value.strip()
+        env_text = self.query_one("#mcp_env_input", Input).value.strip()
+        cwd = self.query_one("#mcp_cwd_input", Input).value.strip() or None
+
+        headers = self._parse_mcp_json_object(headers_text, "headers")
+        env = self._parse_mcp_json_object(env_text, "env")
+        try:
+            args = shlex.split(args_text) if args_text else []
+        except ValueError as exc:
+            raise ValueError(f"MCP args must be shell-like tokens: {exc}") from exc
+
+        return MCPServerConfig(
+            id=server_id,
+            name=name,
+            transport=transport,
+            enabled=enabled,
+            url=url,
+            headers=headers,
+            oauth=MCPOAuthConfig(enabled=oauth_enabled),
+            command=command,
+            args=args,
+            env=env,
+            cwd=cwd,
+            source="global",
+        )
+
+    def _parse_mcp_json_object(self, value: str, label: str) -> dict[str, str]:
+        if not value:
+            return {}
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"MCP {label} must be a JSON object: {exc.msg}") from exc
+        if not isinstance(parsed, dict):
+            raise ValueError(f"MCP {label} must be a JSON object")
+        return {str(key): str(item) for key, item in parsed.items() if item is not None}
+
+    async def _handle_mcp_settings_button(self, button_id: str) -> bool:
+        if button_id == "mcp_refresh":
+            self._populate_mcp_controls()
+            return True
+        if button_id == "mcp_trust_project":
+            self.settings.trust_mcp_project(self.project_path)
+            self.settings_store.save(self.settings)
+            self._populate_mcp_controls()
+            await self._ensure_agent_from_settings(rebuild=True)
+            self._notify_user("Trusted project MCP config for this project.")
+            return True
+        if button_id == "mcp_save_server":
+            await self._save_mcp_server_from_ui()
+            return True
+        if button_id == "mcp_delete_server":
+            await self._delete_mcp_server_from_ui()
+            return True
+        if button_id == "mcp_verify_server":
+            await self._verify_mcp_server_from_ui()
+            return True
+        if button_id == "mcp_clear_tokens":
+            self._clear_mcp_tokens_from_ui()
+            return True
+        if button_id in {"mcp_enable_server", "mcp_disable_server"}:
+            await self._set_mcp_enabled_from_ui(enabled=button_id == "mcp_enable_server")
+            return True
+        return False
+
+    def _selected_mcp_server_id(self) -> str:
+        try:
+            value = self.query_one("#mcp_server_select", Select).value
+        except NoMatches:
+            return MCP_NEW_SERVER_VALUE
+        return MCP_NEW_SERVER_VALUE if value is Select.NULL else str(value)
+
+    async def _save_mcp_server_from_ui(self) -> None:
+        selected = self._selected_mcp_server_id()
+        try:
+            server = self._collect_mcp_server_from_ui()
+            config = self._load_mcp_config_for_ui()
+            existing = config.servers.get(selected) if selected != MCP_NEW_SERVER_VALUE else None
+            target_existing = config.servers.get(server.id)
+            if (existing is not None and existing.source == "project") or (
+                target_existing is not None and target_existing.source == "project"
+            ):
+                self._set_mcp_status(
+                    "Project MCP servers are read-only in the TUI; edit .kolega/mcp_servers.json.", "warning"
+                )
+                return
+            path = global_mcp_config_path(self.settings_store.root)
+            if selected != MCP_NEW_SERVER_VALUE and selected != server.id:
+                remove_server_config(path, selected, source="global")
+            upsert_server_config(path, server, source="global")
+        except (MCPConfigError, ValueError) as exc:
+            self._set_mcp_status(str(exc), "error")
+            return
+        self._mcp_selected_server_id = server.id
+        self._populate_mcp_controls()
+        await self._ensure_agent_from_settings(rebuild=True)
+        self._notify_user(f"Saved MCP server '{server.id}'.")
+
+    async def _delete_mcp_server_from_ui(self) -> None:
+        selected = self._selected_mcp_server_id()
+        if selected == MCP_NEW_SERVER_VALUE:
+            self._set_mcp_status("Select a user MCP server to delete.", "warning")
+            return
+        try:
+            config = self._load_mcp_config_for_ui()
+            existing = config.servers.get(selected)
+            if existing is not None and existing.source == "project":
+                self._set_mcp_status(
+                    "Project MCP servers are read-only in the TUI; edit .kolega/mcp_servers.json.", "warning"
+                )
+                return
+            removed = remove_server_config(global_mcp_config_path(self.settings_store.root), selected, source="global")
+            MCPStatusStore(self.settings_store.root).clear(selected)
+            MCPOAuthTokenStore(self.settings_store.root).clear(selected)
+        except MCPConfigError as exc:
+            self._set_mcp_status(str(exc), "error")
+            return
+        if not removed:
+            self._set_mcp_status(f"No user MCP server named '{selected}' was found.", "warning")
+            return
+        self._mcp_selected_server_id = MCP_NEW_SERVER_VALUE
+        self._populate_mcp_controls()
+        await self._ensure_agent_from_settings(rebuild=True)
+        self._notify_user(f"Deleted MCP server '{selected}'.")
+
+    async def _set_mcp_enabled_from_ui(self, *, enabled: bool) -> None:
+        selected = self._selected_mcp_server_id()
+        if selected == MCP_NEW_SERVER_VALUE:
+            self._set_mcp_status("Select a user MCP server first.", "warning")
+            return
+        try:
+            config = self._load_mcp_config_for_ui()
+            existing = config.servers.get(selected)
+            if existing is not None and existing.source == "project":
+                self._set_mcp_status(
+                    "Project MCP servers are read-only in the TUI; edit .kolega/mcp_servers.json.", "warning"
+                )
+                return
+            changed = set_server_enabled(
+                global_mcp_config_path(self.settings_store.root), selected, enabled, source="global"
+            )
+        except MCPConfigError as exc:
+            self._set_mcp_status(str(exc), "error")
+            return
+        if not changed:
+            self._set_mcp_status(f"No user MCP server named '{selected}' was found.", "warning")
+            return
+        self._populate_mcp_controls()
+        await self._ensure_agent_from_settings(rebuild=True)
+        self._notify_user(f"{'Enabled' if enabled else 'Disabled'} MCP server '{selected}'.")
+
+    async def _verify_mcp_server_from_ui(self) -> None:
+        selected = self._selected_mcp_server_id()
+        if selected == MCP_NEW_SERVER_VALUE:
+            self._set_mcp_status("Select a configured MCP server to verify.", "warning")
+            return
+        self._set_mcp_status(
+            f"Verifying MCP server '{selected}'... stdio servers execute their configured command.", "warning"
+        )
+        config = self._load_mcp_config_for_ui()
+        result = await MCPService(config, self.settings_store.root, self.project_path).verify_server(
+            selected,
+            interactive_oauth=True,
+            open_browser=True,
+            output=self.console,
+        )
+        self._populate_mcp_controls()
+        await self._ensure_agent_from_settings(rebuild=True)
+        if result.ok:
+            self._notify_user(f"Verified MCP server '{selected}' ({result.tool_count} tool(s)).")
+        else:
+            self._notify_user(f"MCP verification failed for '{selected}': {result.message}", severity="warning")
+
+    def _clear_mcp_tokens_from_ui(self) -> None:
+        selected = self._selected_mcp_server_id()
+        if selected == MCP_NEW_SERVER_VALUE:
+            self._set_mcp_status("Select an MCP server before clearing tokens.", "warning")
+            return
+        MCPOAuthTokenStore(self.settings_store.root).clear(selected)
+        self._set_mcp_status(f"Cleared stored MCP OAuth tokens for '{selected}'.", "ok")
+        self._notify_user(f"Cleared MCP OAuth tokens for '{selected}'.")
 
     def _set_effort_select_default(
         self, provider: str, model: str, effort_id: str = "thinking_effort_select", *, preferred: Optional[str] = None

--- a/kolega_code/cli/tui/settings_panel.py
+++ b/kolega_code/cli/tui/settings_panel.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import re
 import shlex
 from typing import Optional
+from urllib.parse import urlparse
 
 from textual.css.query import NoMatches
 from rich.text import Text
@@ -49,7 +51,7 @@ from ..theme import Color, Glyph
 MCP_NEW_SERVER_VALUE = "__new_mcp_server__"
 MCP_TRANSPORT_OPTIONS = [
     ("Streamable HTTP", "streamable_http"),
-    ("Server-Sent Events (SSE)", "sse"),
+    ("Server-Sent Events (legacy/deprecated)", "sse"),
     ("stdio command", "stdio"),
 ]
 MCP_ENABLED_OPTIONS = [("Enabled", "true"), ("Disabled", "false")]
@@ -330,7 +332,6 @@ class SettingsPanelMixin:
                 pass
 
         if server is None:
-            set_input("mcp_server_id_input", "")
             set_input("mcp_name_input", "")
             set_select("mcp_transport_select", "streamable_http")
             set_select("mcp_enabled_select", "true")
@@ -345,7 +346,6 @@ class SettingsPanelMixin:
             self._update_mcp_transport_fields("streamable_http")
             return
 
-        set_input("mcp_server_id_input", server.id)
         set_input("mcp_name_input", server.name or "")
         set_select("mcp_transport_select", server.transport)
         set_select("mcp_enabled_select", "true" if server.enabled else "false")
@@ -402,15 +402,7 @@ class SettingsPanelMixin:
             self._set_mcp_status(f"MCP config could not be loaded: {exc}", tone="error")
             return
 
-        lines: list[str] = [f"Global config: {global_mcp_config_path(self.settings_store.root)}"]
-        if config.project_config_present:
-            if config.project_trusted:
-                lines.append(f"Project config trusted: {config.project_config_path}")
-            else:
-                lines.append(f"Project config present but not trusted: {config.project_config_path}")
-        elif config.project_config_path is not None:
-            lines.append(f"Project config: {config.project_config_path} (not present)")
-        lines.extend(config.diagnostics)
+        lines: list[str] = list(config.diagnostics)
 
         rows = MCPService(config, self.settings_store.root, self.project_path).list_status_rows()
         if not rows:
@@ -450,8 +442,51 @@ class SettingsPanelMixin:
         except NoMatches:
             pass
 
+    def _slug_mcp_server_id(self, value: str) -> str:
+        slug = re.sub(r"[^A-Za-z0-9_-]+", "-", value.strip().lower())
+        slug = re.sub(r"-+", "-", slug).strip("-_")
+        return slug[:64].strip("-_")
+
+    def _auto_mcp_server_id(
+        self,
+        *,
+        name: Optional[str],
+        url: Optional[str],
+        command: Optional[str],
+        args: list[str],
+    ) -> str:
+        candidates: list[str] = []
+        if name:
+            candidates.append(name)
+        if url:
+            parsed = urlparse(url)
+            if parsed.hostname:
+                candidates.append(parsed.hostname.removeprefix("www."))
+        if args:
+            transport_args = {"stdio", "sse", "streamableHttp", "streamable_http"}
+            meaningful_args = [arg for arg in args if not arg.startswith("-") and arg not in transport_args]
+            candidates.extend(reversed(meaningful_args))
+        if command:
+            candidates.append(command)
+        candidates.append("mcp-server")
+
+        base = next((slug for candidate in candidates if (slug := self._slug_mcp_server_id(candidate))), "mcp-server")
+        try:
+            config = self._load_mcp_config_for_ui()
+            existing_ids = set(config.servers)
+        except Exception:
+            existing_ids = set()
+        selected = self._selected_mcp_server_id()
+        if selected != MCP_NEW_SERVER_VALUE:
+            existing_ids.discard(selected)
+        if base not in existing_ids:
+            return base
+        suffix = 2
+        while f"{base}-{suffix}" in existing_ids:
+            suffix += 1
+        return f"{base}-{suffix}"
+
     def _collect_mcp_server_from_ui(self) -> MCPServerConfig:
-        server_id = self.query_one("#mcp_server_id_input", Input).value.strip()
         name = self.query_one("#mcp_name_input", Input).value.strip() or None
         transport = str(self.query_one("#mcp_transport_select", Select).value)
         enabled = str(self.query_one("#mcp_enabled_select", Select).value) == "true"
@@ -469,6 +504,12 @@ class SettingsPanelMixin:
             args = shlex.split(args_text) if args_text else []
         except ValueError as exc:
             raise ValueError(f"MCP args must be shell-like tokens: {exc}") from exc
+        selected = self._selected_mcp_server_id()
+        server_id = (
+            self._auto_mcp_server_id(name=name, url=url, command=command, args=args)
+            if selected == MCP_NEW_SERVER_VALUE
+            else selected
+        )
 
         return MCPServerConfig(
             id=server_id,

--- a/kolega_code/cli/tui/settings_panel.py
+++ b/kolega_code/cli/tui/settings_panel.py
@@ -55,6 +55,155 @@ MCP_TRANSPORT_OPTIONS = [
     ("stdio command", "stdio"),
 ]
 MCP_ENABLED_OPTIONS = [("Enabled", "true"), ("Disabled", "false")]
+MCP_STATUS_MESSAGE_MAX = 96
+MCP_STATUS_NAME_MAX = 34
+MCP_ATTENTION_STATUSES = {"failed", "stale", "unverified"}
+MCP_TRANSPORT_LABELS = {
+    "streamable_http": "HTTP",
+    "sse": "SSE",
+    "stdio": "stdio",
+}
+
+
+def _mcp_separator() -> str:
+    return f" {theme.g(Glyph.BULLET_SEP)} "
+
+
+def _mcp_transport_label(transport: object) -> str:
+    """Human-friendly transport label for the TUI."""
+    return MCP_TRANSPORT_LABELS.get(str(transport), str(transport))
+
+
+def _mcp_plural(count: int, singular: str, plural: Optional[str] = None) -> str:
+    return f"{count} {singular if count == 1 else (plural or singular + 's')}"
+
+
+def _mcp_ellipsize(value: str, max_chars: int) -> str:
+    value = " ".join(str(value).split())
+    if len(value) <= max_chars:
+        return value
+    if max_chars <= 1:
+        return value[:max_chars]
+    return f"{value[: max_chars - 1]}{theme.g(Glyph.ELLIPSIS)}"
+
+
+def _mcp_server_display_label(row: dict[str, object]) -> str:
+    server_id = str(row.get("id") or "").strip()
+    return str(row.get("name") or server_id).strip() or server_id
+
+
+def _mcp_status_label(row: dict[str, object]) -> tuple[str, str]:
+    """Return the row-level status label and Rich style."""
+    if not bool(row.get("enabled")):
+        return "disabled", Color.MUTED
+
+    status = str(row.get("status") or "unverified")
+    if status == "verified":
+        return "verified", Color.SUCCESS
+    if status == "stale":
+        return "needs re-verify", Color.WARNING
+    if status == "failed":
+        return "verify failed", Color.ERROR
+    if status == "unverified":
+        return "not verified", Color.WARNING
+    return status.replace("_", " "), Color.MUTED
+
+
+def _mcp_status_attention_message(row: dict[str, object]) -> str:
+    if not bool(row.get("enabled")):
+        return ""
+    status = str(row.get("status") or "unverified")
+    if status not in MCP_ATTENTION_STATUSES:
+        return ""
+    if status == "stale":
+        return "Config changed; verify again."
+
+    message = " ".join(str(row.get("message") or "").split())
+    if status == "unverified" and message.rstrip(".") == "Not verified":
+        return ""
+    if not message and status == "failed":
+        message = "Verification failed."
+    return _mcp_ellipsize(message, MCP_STATUS_MESSAGE_MAX) if message else ""
+
+
+def _mcp_status_metadata(row: dict[str, object]) -> list[str]:
+    metadata: list[str] = []
+    if bool(row.get("enabled")) and str(row.get("status") or "") == "verified":
+        try:
+            tool_count = int(row.get("tool_count") or 0)
+        except (TypeError, ValueError):
+            tool_count = 0
+        metadata.append(_mcp_plural(tool_count, "tool"))
+    metadata.append(str(row.get("source") or "unknown"))
+    metadata.append(_mcp_transport_label(row.get("transport") or "unknown"))
+    if bool(row.get("oauth")):
+        metadata.append("oauth")
+    return metadata
+
+
+def _mcp_status_summary(rows: list[dict[str, object]]) -> tuple[str, str]:
+    server_count = len(rows)
+    if server_count == 0:
+        return "No MCP servers configured. Add one below, then Verify.", "info"
+
+    separator = _mcp_separator()
+    enabled_rows = [row for row in rows if bool(row.get("enabled"))]
+    if not enabled_rows:
+        return f"{_mcp_plural(server_count, 'MCP server')} configured{separator}all disabled", "info"
+
+    attention_count = sum(1 for row in enabled_rows if str(row.get("status") or "unverified") != "verified")
+    if attention_count:
+        verb = "needs" if attention_count == 1 else "need"
+        return (
+            f"{_mcp_plural(server_count, 'MCP server')} configured{separator}{attention_count} {verb} verification",
+            "warning",
+        )
+
+    return f"{_mcp_plural(server_count, 'MCP server')} configured{separator}all enabled verified", "ok"
+
+
+def _render_mcp_status_text(diagnostics: list[str], rows: list[dict[str, object]]) -> tuple[Text, str]:
+    """Build the styled MCP status block shown in Settings."""
+    summary, tone = _mcp_status_summary(rows)
+    content = Text(summary)
+
+    for diagnostic in diagnostics:
+        message = " ".join(str(diagnostic).split())
+        if not message:
+            continue
+        content.append("\n  ")
+        content.append(message, style=Color.WARNING)
+
+    if not rows:
+        return content, tone
+
+    display_labels = [_mcp_ellipsize(_mcp_server_display_label(row), MCP_STATUS_NAME_MAX) for row in rows]
+    label_width = max(len(label) for label in display_labels)
+    separator = _mcp_separator()
+
+    for row, display_label in zip(rows, display_labels):
+        content.append("\n  ")
+        content.append(display_label.ljust(label_width))
+        content.append("  ")
+        status_label, status_style = _mcp_status_label(row)
+        content.append(status_label, style=status_style)
+        for item in _mcp_status_metadata(row):
+            content.append(separator)
+            content.append(item)
+        message = _mcp_status_attention_message(row)
+        if message:
+            content.append(" — ")
+            content.append(message, style=Color.MUTED)
+
+    return content, tone
+
+
+def _mcp_server_select_label(server: MCPServerConfig) -> str:
+    state = "enabled" if server.enabled else "disabled"
+    separator = _mcp_separator()
+    return (
+        f"{server.display_name} — {server.source}{separator}{_mcp_transport_label(server.transport)}{separator}{state}"
+    )
 
 
 class SettingsPanelMixin:
@@ -306,8 +455,7 @@ class SettingsPanelMixin:
         self._update_mcp_status_text(config)
 
     def _mcp_server_option_label(self, server: MCPServerConfig) -> str:
-        enabled = "on" if server.enabled else "off"
-        return f"{server.id} ({server.source}, {server.transport}, {enabled})"
+        return _mcp_server_select_label(server)
 
     def _populate_mcp_server_form(self, server_id: str) -> None:
         self._mcp_selected_server_id = server_id
@@ -402,27 +550,11 @@ class SettingsPanelMixin:
             self._set_mcp_status(f"MCP config could not be loaded: {exc}", tone="error")
             return
 
-        lines: list[str] = list(config.diagnostics)
-
         rows = MCPService(config, self.settings_store.root, self.project_path).list_status_rows()
-        if not rows:
-            lines.append("No MCP servers configured.")
-        else:
-            for row in rows:
-                status = row["status"]
-                icon = "✓" if status == "verified" else ("!" if status in {"failed", "stale"} else "•")
-                state = "enabled" if row["enabled"] else "disabled"
-                oauth = ", oauth" if row["oauth"] else ""
-                lines.append(
-                    f"{icon} {row['id']} [{row['source']}/{row['transport']}, {state}{oauth}] "
-                    f"{status}; tools={row['tool_count']}; {row['message']}"
-                )
-        self._set_mcp_status(
-            "\n".join(lines),
-            tone="ok" if rows and all(r["status"] == "verified" for r in rows if r["enabled"]) else "info",
-        )
+        content, tone = _render_mcp_status_text(list(config.diagnostics), rows)
+        self._set_mcp_status(content, tone=tone)
 
-    def _set_mcp_status(self, text: str, tone: str = "info") -> None:
+    def _set_mcp_status(self, text: str | Text, tone: str = "info") -> None:
         glyph, style = {
             "ok": (Glyph.CHECK, Color.SUCCESS),
             "error": (Glyph.CROSS, Color.ERROR),
@@ -430,7 +562,10 @@ class SettingsPanelMixin:
         }.get(tone, (Glyph.STATUS, Color.MUTED))
         content = Text()
         content.append(theme.g(glyph) + " ", style=style)
-        content.append(text)
+        if isinstance(text, Text):
+            content.append_text(text)
+        else:
+            content.append(text)
         try:
             self.query_one("#mcp_status", Static).update(content)
         except NoMatches:

--- a/kolega_code/cli/tui/styles.tcss
+++ b/kolega_code/cli/tui/styles.tcss
@@ -174,6 +174,17 @@ ToolEntryWidget .tool-body {
     margin-top: 1;
 }
 
+.settings-button-row {
+    height: auto;
+    min-height: 4;
+    margin-top: 1;
+}
+
+.settings-button-row Button {
+    margin-top: 0;
+    width: 1fr;
+}
+
 .settings-hint {
     color: $text-muted;
     margin-top: 0;

--- a/kolega_code/cli/tui/styles.tcss
+++ b/kolega_code/cli/tui/styles.tcss
@@ -166,6 +166,11 @@ ToolEntryWidget .tool-body {
     margin-top: 1;
 }
 
+#mcp_status {
+    height: auto;
+    margin-bottom: 1;
+}
+
 #settings_form Label {
     margin-top: 1;
 }

--- a/kolega_code/config.py
+++ b/kolega_code/config.py
@@ -189,6 +189,10 @@ class AgentConfig(BaseModel):
         description="Per-agent-role model overrides keyed by AgentRole value",
     )
 
+    # Host-loaded MCP configuration. Excluded from serialized model config because
+    # it can contain local paths, headers/env secrets, and non-Pydantic dataclasses.
+    mcp_config: Optional[Any] = Field(default=None, exclude=True, description="Loaded MCP server configuration")
+
     def model_config_for_agent(self, agent_name: Optional[str]) -> ModelConfig:
         """Return the model configuration an agent should use for its main loop.
 

--- a/kolega_code/local_state.py
+++ b/kolega_code/local_state.py
@@ -19,7 +19,11 @@ def write_private_text(path: Path, content: str, *, encoding: str = "utf-8") -> 
     """Atomically write text to a file and make the final file owner-only."""
     ensure_private_dir(path.parent)
     temp = path.with_suffix(path.suffix + ".tmp")
-    temp.write_text(content, encoding=encoding)
+    fd = os.open(temp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, PRIVATE_FILE_MODE)
+    try:
+        os.write(fd, content.encode(encoding))
+    finally:
+        os.close(fd)
     _chmod(temp, PRIVATE_FILE_MODE)
     temp.replace(path)
     _chmod(path, PRIVATE_FILE_MODE)

--- a/kolega_code/local_state.py
+++ b/kolega_code/local_state.py
@@ -25,6 +25,29 @@ def write_private_text(path: Path, content: str, *, encoding: str = "utf-8") -> 
     _chmod(path, PRIVATE_FILE_MODE)
 
 
+def write_private_secret_text(path: Path, content: str, *, encoding: str = "utf-8") -> None:
+    """Atomically write deliberate local credential state to an owner-only file.
+
+    This mirrors the existing private-file provider API key model: data is kept
+    local with POSIX owner-only permissions where supported, but it is not
+    encrypted beyond filesystem/OS protections.
+    """
+    ensure_private_dir(path.parent)
+    temp = path.with_suffix(path.suffix + ".tmp")
+    fd = os.open(temp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, PRIVATE_FILE_MODE)
+    try:
+        # Intentional credential persistence for local OAuth state. Keep this
+        # suppression at the credential-specific sink so generic private writes
+        # continue to be analyzed normally.
+        # codeql[py/clear-text-storage-sensitive-data]
+        os.write(fd, content.encode(encoding))
+    finally:
+        os.close(fd)
+    _chmod(temp, PRIVATE_FILE_MODE)
+    temp.replace(path)
+    _chmod(path, PRIVATE_FILE_MODE)
+
+
 def ensure_private_file(path: Path) -> None:
     """Best-effort chmod for an existing local state file."""
     _chmod(path, PRIVATE_FILE_MODE)

--- a/kolega_code/mcp/__init__.py
+++ b/kolega_code/mcp/__init__.py
@@ -1,0 +1,26 @@
+"""Model Context Protocol (MCP) integration for Kolega Code."""
+
+from .config import (
+    MCP_CONFIG_RELATIVE_PATH,
+    MCP_GLOBAL_CONFIG_FILENAME,
+    LoadedMCPConfig,
+    MCPOAuthConfig,
+    MCPServerConfig,
+    load_mcp_config,
+    server_fingerprint,
+)
+from .service import MCPService, MCPVerificationResult
+from .tools import build_mcp_tool_extension
+
+__all__ = [
+    "MCP_CONFIG_RELATIVE_PATH",
+    "MCP_GLOBAL_CONFIG_FILENAME",
+    "LoadedMCPConfig",
+    "MCPOAuthConfig",
+    "MCPServerConfig",
+    "MCPService",
+    "MCPVerificationResult",
+    "build_mcp_tool_extension",
+    "load_mcp_config",
+    "server_fingerprint",
+]

--- a/kolega_code/mcp/config.py
+++ b/kolega_code/mcp/config.py
@@ -1,0 +1,310 @@
+"""MCP server configuration loading and fingerprinting."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
+
+from kolega_code.local_state import write_private_text
+
+MCP_CONFIG_SCHEMA_VERSION = 1
+MCP_GLOBAL_CONFIG_FILENAME = "mcp_servers.json"
+MCP_CONFIG_RELATIVE_PATH = Path(".kolega") / MCP_GLOBAL_CONFIG_FILENAME
+MCP_TRANSPORTS = ("streamable_http", "sse", "stdio")
+_SERVER_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+class MCPConfigError(ValueError):
+    """Raised when an MCP configuration file cannot be parsed for mutation."""
+
+
+class MCPOAuthConfig(BaseModel):
+    """OAuth settings for an HTTP MCP server."""
+
+    enabled: bool = False
+    redirect_uri: Optional[str] = None
+    scope: Optional[str] = None
+    client_name: str = "Kolega Code"
+    client_uri: Optional[str] = None
+    client_metadata_url: Optional[str] = None
+    timeout_seconds: float = Field(default=300.0, gt=0)
+
+
+class MCPServerConfig(BaseModel):
+    """One configured MCP server."""
+
+    id: str
+    name: Optional[str] = None
+    transport: Literal["streamable_http", "sse", "stdio"] = "streamable_http"
+    enabled: bool = True
+
+    # HTTP transports (streamable_http and sse)
+    url: Optional[str] = None
+    headers: dict[str, str] = Field(default_factory=dict)
+    timeout_seconds: float = Field(default=30.0, gt=0)
+    sse_read_timeout_seconds: float = Field(default=300.0, gt=0)
+    oauth: MCPOAuthConfig = Field(default_factory=MCPOAuthConfig)
+
+    # stdio transport
+    command: Optional[str] = None
+    args: list[str] = Field(default_factory=list)
+    env: dict[str, str] = Field(default_factory=dict)
+    cwd: Optional[str] = None
+
+    # Loader metadata. Kept out of fingerprints and serialized config files.
+    source: str = Field(default="global", exclude=True)
+
+    @field_validator("id")
+    @classmethod
+    def _validate_id(cls, value: str) -> str:
+        value = str(value).strip()
+        if not value:
+            raise ValueError("server id is required")
+        if not _SERVER_ID_RE.match(value):
+            raise ValueError("server id may contain only letters, numbers, '_' and '-'")
+        return value
+
+    @field_validator("headers", "env", mode="before")
+    @classmethod
+    def _string_mapping(cls, value: object) -> dict[str, str]:
+        if value is None:
+            return {}
+        if not isinstance(value, dict):
+            raise ValueError("must be an object")
+        return {str(k): str(v) for k, v in value.items() if v is not None}
+
+    @field_validator("args", mode="before")
+    @classmethod
+    def _string_list(cls, value: object) -> list[str]:
+        if value is None:
+            return []
+        if not isinstance(value, list):
+            raise ValueError("args must be an array")
+        return [str(item) for item in value]
+
+    @model_validator(mode="after")
+    def _validate_transport_fields(self) -> "MCPServerConfig":
+        if self.transport in {"streamable_http", "sse"}:
+            if not self.url:
+                raise ValueError(f"{self.transport} server '{self.id}' requires url")
+            if self.oauth.enabled and self.transport not in {"streamable_http", "sse"}:
+                raise ValueError("OAuth is only supported for HTTP MCP transports")
+        elif self.transport == "stdio":
+            if not self.command:
+                raise ValueError(f"stdio server '{self.id}' requires command")
+            if self.oauth.enabled:
+                raise ValueError("OAuth is not supported for stdio MCP servers")
+        return self
+
+    @property
+    def display_name(self) -> str:
+        return self.name or self.id
+
+    def sanitized_for_display(self) -> dict[str, Any]:
+        payload = self.model_dump(mode="json", exclude={"source"})
+        if payload.get("headers"):
+            payload["headers"] = {key: "‹secret›" for key in payload["headers"]}
+        if payload.get("env"):
+            payload["env"] = {key: "‹secret›" for key in payload["env"]}
+        return payload
+
+
+class MCPConfigFile(BaseModel):
+    schema_version: int = MCP_CONFIG_SCHEMA_VERSION
+    servers: list[MCPServerConfig] = Field(default_factory=list)
+
+    @field_validator("servers", mode="before")
+    @classmethod
+    def _coerce_servers(cls, value: object) -> list[object]:
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return value
+        if isinstance(value, dict):
+            servers: list[object] = []
+            for server_id, entry in value.items():
+                if isinstance(entry, dict):
+                    merged = dict(entry)
+                    merged.setdefault("id", str(server_id))
+                    servers.append(merged)
+            return servers
+        raise ValueError("servers must be an array or object")
+
+    @model_validator(mode="after")
+    def _validate_schema_version(self) -> "MCPConfigFile":
+        if self.schema_version != MCP_CONFIG_SCHEMA_VERSION:
+            raise ValueError(f"Unsupported MCP config schema version: {self.schema_version}")
+        seen: set[str] = set()
+        for server in self.servers:
+            if server.id in seen:
+                raise ValueError(f"Duplicate MCP server id: {server.id}")
+            seen.add(server.id)
+        return self
+
+    def to_file_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": MCP_CONFIG_SCHEMA_VERSION,
+            "servers": [
+                server.model_dump(mode="json", exclude={"source"}, exclude_none=True) for server in self.servers
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class LoadedMCPConfig:
+    """Merged global + trusted project MCP configuration."""
+
+    servers: dict[str, MCPServerConfig] = field(default_factory=dict)
+    diagnostics: list[str] = field(default_factory=list)
+    global_path: Optional[Path] = None
+    project_path: Optional[Path] = None
+    project_config_path: Optional[Path] = None
+    project_trusted: bool = False
+    project_config_present: bool = False
+
+    @property
+    def enabled_servers(self) -> list[MCPServerConfig]:
+        return [server for server in self.servers.values() if server.enabled]
+
+
+def global_mcp_config_path(state_dir: Path) -> Path:
+    return Path(state_dir).expanduser() / MCP_GLOBAL_CONFIG_FILENAME
+
+
+def project_mcp_config_path(project_path: Path) -> Path:
+    return Path(project_path).expanduser().resolve() / MCP_CONFIG_RELATIVE_PATH
+
+
+def parse_mcp_config_text(text: str, *, source: str) -> MCPConfigFile:
+    data = json.loads(text)
+    parsed = MCPConfigFile.model_validate(data)
+    parsed.servers = [server.model_copy(update={"source": source}) for server in parsed.servers]
+    return parsed
+
+
+def load_mcp_config_file(path: Path, *, source: str) -> MCPConfigFile:
+    return parse_mcp_config_text(path.read_text(encoding="utf-8"), source=source)
+
+
+def load_mcp_config(project_path: Path, state_dir: Path, *, project_trusted: bool) -> LoadedMCPConfig:
+    """Load global MCP config plus trusted project config.
+
+    Invalid files are reported as diagnostics instead of crashing agent startup.
+    The explicit `mcp` management commands use the stricter mutation helpers below
+    when they need to fail loudly.
+    """
+    global_path = global_mcp_config_path(state_dir)
+    project_config = project_mcp_config_path(project_path)
+    diagnostics: list[str] = []
+    merged: dict[str, MCPServerConfig] = {}
+
+    for path, source, trusted in (
+        (global_path, "global", True),
+        (project_config, "project", project_trusted),
+    ):
+        if source == "project" and path.exists() and not trusted:
+            diagnostics.append(
+                f"Project MCP config exists at {path}, but this project is not trusted for MCP; project servers disabled."
+            )
+            continue
+        if not trusted or not path.exists():
+            continue
+        try:
+            config_file = load_mcp_config_file(path, source=source)
+        except (OSError, json.JSONDecodeError, ValidationError, ValueError) as exc:
+            diagnostics.append(f"Could not load {source} MCP config {path}: {exc}")
+            continue
+        for server in config_file.servers:
+            if server.id in merged:
+                diagnostics.append(f"MCP server '{server.id}' from {source} overrides earlier configuration.")
+            merged[server.id] = server
+
+    return LoadedMCPConfig(
+        servers=merged,
+        diagnostics=diagnostics,
+        global_path=global_path,
+        project_path=Path(project_path).expanduser().resolve(),
+        project_config_path=project_config,
+        project_trusted=project_trusted,
+        project_config_present=project_config.exists(),
+    )
+
+
+def load_config_file_for_edit(path: Path, *, source: str) -> MCPConfigFile:
+    """Load a config file for mutation, returning an empty config if absent."""
+    if not path.exists():
+        return MCPConfigFile()
+    try:
+        return load_mcp_config_file(path, source=source)
+    except (OSError, json.JSONDecodeError, ValidationError, ValueError) as exc:
+        raise MCPConfigError(f"Could not load MCP config {path}: {exc}") from exc
+
+
+def save_config_file(path: Path, config: MCPConfigFile) -> None:
+    payload = json.dumps(config.to_file_dict(), indent=2, sort_keys=True)
+    write_private_text(path, payload + "\n")
+
+
+def upsert_server_config(path: Path, server: MCPServerConfig, *, source: str) -> None:
+    config = load_config_file_for_edit(path, source=source)
+    updated: list[MCPServerConfig] = []
+    replaced = False
+    for existing in config.servers:
+        if existing.id == server.id:
+            updated.append(server.model_copy(update={"source": source}))
+            replaced = True
+        else:
+            updated.append(existing)
+    if not replaced:
+        updated.append(server.model_copy(update={"source": source}))
+    config.servers = updated
+    save_config_file(path, config)
+
+
+def remove_server_config(path: Path, server_id: str, *, source: str) -> bool:
+    config = load_config_file_for_edit(path, source=source)
+    before = len(config.servers)
+    config.servers = [server for server in config.servers if server.id != server_id]
+    if len(config.servers) == before:
+        return False
+    save_config_file(path, config)
+    return True
+
+
+def set_server_enabled(path: Path, server_id: str, enabled: bool, *, source: str) -> bool:
+    config = load_config_file_for_edit(path, source=source)
+    updated: list[MCPServerConfig] = []
+    changed = False
+    for server in config.servers:
+        if server.id == server_id:
+            updated.append(server.model_copy(update={"enabled": enabled, "source": source}))
+            changed = True
+        else:
+            updated.append(server)
+    if not changed:
+        return False
+    config.servers = updated
+    save_config_file(path, config)
+    return True
+
+
+def server_fingerprint(server: MCPServerConfig) -> str:
+    """Stable fingerprint used to invalidate verification after config changes."""
+    payload = server.model_dump(mode="json", exclude={"source", "enabled"}, exclude_none=True)
+    serialized = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def mcp_secret_values(config: LoadedMCPConfig) -> list[str]:
+    """Exact configured MCP secret values for diagnostics redaction."""
+    values: list[str] = []
+    for server in config.servers.values():
+        values.extend(value for value in server.headers.values() if value)
+        values.extend(value for value in server.env.values() if value)
+    return values

--- a/kolega_code/mcp/config.py
+++ b/kolega_code/mcp/config.py
@@ -11,7 +11,7 @@ from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 
-from kolega_code.local_state import write_private_text
+from kolega_code.local_state import write_private_secret_text
 
 MCP_CONFIG_SCHEMA_VERSION = 1
 MCP_GLOBAL_CONFIG_FILENAME = "mcp_servers.json"
@@ -248,7 +248,7 @@ def load_config_file_for_edit(path: Path, *, source: str) -> MCPConfigFile:
 
 def save_config_file(path: Path, config: MCPConfigFile) -> None:
     payload = json.dumps(config.to_file_dict(), indent=2, sort_keys=True)
-    write_private_text(path, payload + "\n")
+    write_private_secret_text(path, payload + "\n")
 
 
 def upsert_server_config(path: Path, server: MCPServerConfig, *, source: str) -> None:

--- a/kolega_code/mcp/oauth.py
+++ b/kolega_code/mcp/oauth.py
@@ -1,0 +1,241 @@
+"""OAuth helpers for MCP HTTP transports."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import sys
+import webbrowser
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Optional
+from urllib.parse import parse_qs, urlparse
+
+from .config import MCPServerConfig
+from .state import MCPOAuthTokenStore
+
+
+class MCPOAuthError(RuntimeError):
+    """Raised when MCP OAuth setup or callback handling fails."""
+
+
+class MCPFileTokenStorage:
+    """Adapter from Kolega's token store to the MCP SDK TokenStorage protocol."""
+
+    def __init__(self, server_id: str, token_store: MCPOAuthTokenStore) -> None:
+        self.server_id = server_id
+        self.token_store = token_store
+
+    async def get_tokens(self):
+        from mcp.shared.auth import OAuthToken
+
+        raw = self.token_store.get(self.server_id).tokens
+        if not raw:
+            return None
+        return OAuthToken.model_validate(raw)
+
+    async def set_tokens(self, tokens) -> None:
+        if tokens is None:
+            self.token_store.set_tokens(self.server_id, None)
+            return
+        self.token_store.set_tokens(self.server_id, tokens.model_dump(mode="json"))
+
+    async def get_client_info(self):
+        from mcp.shared.auth import OAuthClientInformationFull
+
+        raw = self.token_store.get(self.server_id).client_info
+        if not raw:
+            return None
+        return OAuthClientInformationFull.model_validate(raw)
+
+    async def set_client_info(self, client_info) -> None:
+        if client_info is None:
+            self.token_store.set_client_info(self.server_id, None)
+            return
+        self.token_store.set_client_info(self.server_id, client_info.model_dump(mode="json"))
+
+
+@dataclass
+class OAuthInteraction:
+    """Handlers used by the MCP SDK during an interactive OAuth flow."""
+
+    redirect_uri: str
+    redirect_handler: Callable[[str], Awaitable[None]]
+    callback_handler: Callable[[], Awaitable[tuple[str, Optional[str]]]]
+    close: Callable[[], Awaitable[None]]
+
+
+class LocalOAuthCallbackServer:
+    """Tiny one-shot loopback HTTP server for OAuth authorization-code redirects."""
+
+    def __init__(self, redirect_uri: Optional[str] = None, *, timeout_seconds: float = 300.0) -> None:
+        self._configured_redirect_uri = redirect_uri
+        self.timeout_seconds = timeout_seconds
+        self.redirect_uri = redirect_uri or ""
+        self._server: Optional[asyncio.AbstractServer] = None
+        self._future: Optional[asyncio.Future[tuple[str, Optional[str]]]] = None
+        self._path = "/callback"
+
+    async def __aenter__(self) -> "LocalOAuthCallbackServer":
+        parsed = urlparse(self._configured_redirect_uri or "http://127.0.0.1:0/callback")
+        if parsed.scheme != "http" or parsed.hostname not in {"127.0.0.1", "localhost"}:
+            raise MCPOAuthError("MCP OAuth redirect_uri must be a localhost http URL")
+        self._path = parsed.path or "/callback"
+        host = parsed.hostname or "127.0.0.1"
+        port = parsed.port or 0
+        self._future = asyncio.get_running_loop().create_future()
+        self._server = await asyncio.start_server(self._handle_client, host=host, port=port)
+        socket = self._server.sockets[0]
+        bound_host, bound_port = socket.getsockname()[:2]
+        # Prefer 127.0.0.1 in metadata even if the OS reports localhost/::1.
+        if bound_host in {"0.0.0.0", "::", "::1"}:
+            bound_host = "127.0.0.1"
+        self.redirect_uri = f"http://{bound_host}:{bound_port}{self._path}"
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()
+
+    async def close(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+    async def _handle_client(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            line = await asyncio.wait_for(reader.readline(), timeout=10)
+            request_line = line.decode("latin-1", errors="replace").strip()
+            parts = request_line.split()
+            target = parts[1] if len(parts) >= 2 else "/"
+            # Drain headers.
+            while True:
+                header = await asyncio.wait_for(reader.readline(), timeout=10)
+                if header in {b"\r\n", b"\n", b""}:
+                    break
+            parsed = urlparse(target)
+            params = parse_qs(parsed.query)
+            code = (params.get("code") or [""])[0]
+            state = (params.get("state") or [None])[0]
+            error = (params.get("error") or [""])[0]
+            if parsed.path != self._path:
+                await self._write_response(writer, 404, "Not found")
+                return
+            if error:
+                if self._future and not self._future.done():
+                    self._future.set_exception(MCPOAuthError(f"OAuth authorization failed: {error}"))
+                await self._write_response(writer, 400, "Authorization failed. You can close this tab.")
+                return
+            if code:
+                if self._future and not self._future.done():
+                    self._future.set_result((code, state))
+                await self._write_response(writer, 200, "Authorization complete. You can close this tab.")
+                return
+            await self._write_response(writer, 400, "Missing authorization code. You can close this tab.")
+        except Exception as exc:  # noqa: BLE001 - never let HTTP callback exceptions leak
+            if self._future and not self._future.done():
+                self._future.set_exception(exc)
+        finally:
+            with contextlib.suppress(Exception):
+                writer.close()
+                await writer.wait_closed()
+
+    async def _write_response(self, writer: asyncio.StreamWriter, status: int, body: str) -> None:
+        reason = {200: "OK", 400: "Bad Request", 404: "Not Found"}.get(status, "OK")
+        html = f"<html><body><p>{body}</p></body></html>".encode("utf-8")
+        writer.write(
+            f"HTTP/1.1 {status} {reason}\r\n"
+            "Content-Type: text/html; charset=utf-8\r\n"
+            f"Content-Length: {len(html)}\r\n"
+            "Connection: close\r\n\r\n".encode("ascii")
+            + html
+        )
+        await writer.drain()
+
+    async def wait_for_callback(self) -> tuple[str, Optional[str]]:
+        if self._future is None:
+            raise MCPOAuthError("OAuth callback server is not running")
+        return await asyncio.wait_for(self._future, timeout=self.timeout_seconds)
+
+
+async def default_redirect_handler(url: str, *, open_browser: bool = True, output=None) -> None:
+    stream = output or sys.stderr
+    print("MCP OAuth authorization required:", file=stream)
+    print(url, file=stream)
+    if open_browser:
+        try:
+            await asyncio.to_thread(webbrowser.open, url)
+        except Exception:
+            print("Could not open a browser automatically; open the URL above manually.", file=stream)
+
+
+async def build_oauth_provider(
+    server: MCPServerConfig,
+    token_store: MCPOAuthTokenStore,
+    *,
+    interaction: Optional[OAuthInteraction] = None,
+):
+    """Build an MCP SDK OAuthClientProvider for a server."""
+    if not server.oauth.enabled:
+        return None
+    if not server.url:
+        raise MCPOAuthError(f"MCP server '{server.id}' has OAuth enabled but no URL")
+
+    from mcp.client.auth import OAuthClientProvider
+    from mcp.shared.auth import OAuthClientMetadata
+
+    redirect_uri = interaction.redirect_uri if interaction else server.oauth.redirect_uri
+    if not redirect_uri:
+        # Non-interactive agent paths should not invent a callback URL. They can
+        # use existing/refreshable tokens, but a full browser flow is only allowed
+        # during explicit verification.
+        redirect_uri = "http://127.0.0.1:1/callback"
+
+    metadata_kwargs = {
+        "redirect_uris": [redirect_uri],
+        "client_name": server.oauth.client_name or "Kolega Code",
+    }
+    if server.oauth.scope:
+        metadata_kwargs["scope"] = server.oauth.scope
+    if server.oauth.client_uri:
+        metadata_kwargs["client_uri"] = server.oauth.client_uri
+
+    return OAuthClientProvider(
+        server_url=server.url,
+        client_metadata=OAuthClientMetadata(**metadata_kwargs),
+        storage=MCPFileTokenStorage(server.id, token_store),
+        redirect_handler=interaction.redirect_handler if interaction else None,
+        callback_handler=interaction.callback_handler if interaction else None,
+        timeout=server.oauth.timeout_seconds,
+        client_metadata_url=server.oauth.client_metadata_url,
+    )
+
+
+@contextlib.asynccontextmanager
+async def interactive_oauth_interaction(
+    server: MCPServerConfig,
+    *,
+    open_browser: bool = True,
+    output=None,
+):
+    """Create handlers for an explicit interactive verification OAuth flow."""
+    async with LocalOAuthCallbackServer(
+        server.oauth.redirect_uri,
+        timeout_seconds=server.oauth.timeout_seconds,
+    ) as callback_server:
+
+        async def redirect_handler(url: str) -> None:
+            await default_redirect_handler(url, open_browser=open_browser, output=output)
+
+        async def callback_handler() -> tuple[str, Optional[str]]:
+            return await callback_server.wait_for_callback()
+
+        yield OAuthInteraction(
+            redirect_uri=callback_server.redirect_uri,
+            redirect_handler=redirect_handler,
+            callback_handler=callback_handler,
+            close=callback_server.close,
+        )
+
+
+def oauth_secret_values(token_store: MCPOAuthTokenStore) -> list[str]:
+    return token_store.secret_values()

--- a/kolega_code/mcp/service.py
+++ b/kolega_code/mcp/service.py
@@ -1,0 +1,288 @@
+"""High-level MCP verification, status, and tool-call service."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from kolega_code.llm.models import ImageBlock, TextBlock
+from kolega_code.tools import ToolError
+
+from .config import LoadedMCPConfig, MCPServerConfig, server_fingerprint
+from .oauth import interactive_oauth_interaction
+from .state import MCPServerStatus, MCPStatusStore, MCPToolStatus, MCPOAuthTokenStore
+from .transport import open_mcp_session
+
+MCP_TOOL_PREFIX = "mcp__"
+MCP_TOOL_SEPARATOR = "__"
+
+
+@dataclass(frozen=True)
+class MCPVerificationResult:
+    server_id: str
+    ok: bool
+    message: str
+    tool_count: int = 0
+    status: Optional[MCPServerStatus] = None
+
+
+@dataclass(frozen=True)
+class MCPExposedTool:
+    server: MCPServerConfig
+    tool: MCPToolStatus
+
+    @property
+    def name(self) -> str:
+        return mcp_tool_name(self.server.id, self.tool.id)
+
+    @property
+    def description(self) -> str:
+        base = self.tool.description or f"MCP tool `{self.tool.id}` from server `{self.server.display_name}`."
+        return f"MCP server: {self.server.display_name} ({self.server.id}).\n\n{base}"
+
+
+def mcp_tool_name(server_id: str, tool_id: str) -> str:
+    return f"{MCP_TOOL_PREFIX}{server_id}{MCP_TOOL_SEPARATOR}{tool_id}"
+
+
+def parse_mcp_tool_name(name: str) -> Optional[tuple[str, str]]:
+    if not name.startswith(MCP_TOOL_PREFIX):
+        return None
+    rest = name[len(MCP_TOOL_PREFIX) :]
+    if MCP_TOOL_SEPARATOR not in rest:
+        return None
+    server_id, tool_id = rest.split(MCP_TOOL_SEPARATOR, 1)
+    if not server_id or not tool_id:
+        return None
+    return server_id, tool_id
+
+
+class MCPService:
+    """Coordinates MCP config, verification state, OAuth tokens, and calls."""
+
+    def __init__(self, config: LoadedMCPConfig, state_dir: Path, project_path: Path) -> None:
+        self.config = config
+        self.state_dir = Path(state_dir).expanduser()
+        self.project_path = Path(project_path).expanduser().resolve()
+        self.status_store = MCPStatusStore(self.state_dir)
+        self.oauth_store = MCPOAuthTokenStore(self.state_dir)
+
+    def server_status(self, server: MCPServerConfig) -> Optional[MCPServerStatus]:
+        return self.status_store.get(server.id)
+
+    def is_verified(self, server: MCPServerConfig) -> bool:
+        status = self.server_status(server)
+        return bool(status and status.status == "verified" and status.fingerprint == server_fingerprint(server))
+
+    def exposed_tools(self) -> list[MCPExposedTool]:
+        tools: list[MCPExposedTool] = []
+        for server in self.config.enabled_servers:
+            status = self.server_status(server)
+            if not status or status.status != "verified":
+                continue
+            if status.fingerprint != server_fingerprint(server):
+                continue
+            for tool in status.tools:
+                tools.append(MCPExposedTool(server=server, tool=tool))
+        return tools
+
+    def list_status_rows(self) -> list[dict[str, Any]]:
+        rows: list[dict[str, Any]] = []
+        for server in self.config.servers.values():
+            status = self.server_status(server)
+            current_fingerprint = server_fingerprint(server)
+            verified = bool(status and status.status == "verified" and status.fingerprint == current_fingerprint)
+            stale = bool(status and status.fingerprint and status.fingerprint != current_fingerprint)
+            rows.append(
+                {
+                    "id": server.id,
+                    "name": server.display_name,
+                    "source": server.source,
+                    "transport": server.transport,
+                    "enabled": server.enabled,
+                    "oauth": server.oauth.enabled,
+                    "status": "verified"
+                    if verified
+                    else ("stale" if stale else (status.status if status else "unverified")),
+                    "tool_count": status.tool_count if verified and status else 0,
+                    "message": status.message if status else "Not verified.",
+                }
+            )
+        return rows
+
+    async def verify_server(
+        self,
+        server_id: str,
+        *,
+        interactive_oauth: bool = False,
+        open_browser: bool = True,
+        output=None,
+    ) -> MCPVerificationResult:
+        server = self.config.servers.get(server_id)
+        if server is None:
+            return MCPVerificationResult(server_id=server_id, ok=False, message=f"Unknown MCP server: {server_id}")
+        fingerprint = server_fingerprint(server)
+        try:
+            async with self._maybe_interactive_oauth(server, interactive_oauth, open_browser, output) as interaction:
+                async with open_mcp_session(
+                    server,
+                    project_path=self.project_path,
+                    token_store=self.oauth_store,
+                    oauth_interaction=interaction,
+                ) as session:
+                    tools = await self._list_all_tools(session)
+            tool_statuses = [_tool_status_from_mcp_tool(tool) for tool in tools]
+            status = MCPServerStatus.verified(
+                fingerprint=fingerprint,
+                transport=server.transport,
+                source=server.source,
+                tools=tool_statuses,
+                oauth=server.oauth.enabled,
+            )
+            self.status_store.update(server.id, status)
+            return MCPVerificationResult(
+                server_id=server.id,
+                ok=True,
+                message=status.message,
+                tool_count=len(tool_statuses),
+                status=status,
+            )
+        except Exception as exc:  # noqa: BLE001 - verification failures are reported in status
+            message = str(exc) or exc.__class__.__name__
+            status = MCPServerStatus.failed(
+                fingerprint=fingerprint,
+                transport=server.transport,
+                source=server.source,
+                message=message,
+                oauth=server.oauth.enabled,
+            )
+            self.status_store.update(server.id, status)
+            return MCPVerificationResult(server_id=server.id, ok=False, message=message, status=status)
+
+    async def verify_all(
+        self,
+        *,
+        interactive_oauth: bool = False,
+        open_browser: bool = True,
+        output=None,
+    ) -> list[MCPVerificationResult]:
+        results: list[MCPVerificationResult] = []
+        for server in self.config.enabled_servers:
+            results.append(
+                await self.verify_server(
+                    server.id,
+                    interactive_oauth=interactive_oauth,
+                    open_browser=open_browser,
+                    output=output,
+                )
+            )
+        return results
+
+    async def call_tool(self, server_id: str, tool_id: str, arguments: dict[str, Any]) -> Any:
+        server = self.config.servers.get(server_id)
+        if server is None:
+            raise ToolError(f"Unknown MCP server: {server_id}")
+        if not server.enabled:
+            raise ToolError(f"MCP server '{server_id}' is disabled")
+        if not self.is_verified(server):
+            raise ToolError(f"MCP server '{server_id}' is not verified for its current configuration")
+        async with open_mcp_session(server, project_path=self.project_path, token_store=self.oauth_store) as session:
+            result = await session.call_tool(tool_id, arguments or {})
+        output = _tool_result_to_agent_output(result)
+        if bool(getattr(result, "is_error", False)):
+            if isinstance(output, list):
+                text = "\n\n".join(block.to_markdown() for block in output)
+            else:
+                text = str(output)
+            raise ToolError(text or f"MCP tool '{tool_id}' failed")
+        return output
+
+    async def cleanup(self) -> None:
+        """Hook for ToolExtension cleanup; sessions are per-call today."""
+        return None
+
+    @contextlib.asynccontextmanager
+    async def _maybe_interactive_oauth(self, server: MCPServerConfig, interactive: bool, open_browser: bool, output):
+        if server.oauth.enabled and interactive:
+            async with interactive_oauth_interaction(server, open_browser=open_browser, output=output) as interaction:
+                yield interaction
+        else:
+            yield None
+
+    async def _list_all_tools(self, session) -> list[Any]:
+        try:
+            from mcp.types import PaginatedRequestParams
+        except Exception:  # pragma: no cover - older SDK fallback
+            PaginatedRequestParams = None
+
+        tools: list[Any] = []
+        cursor: Optional[str] = None
+        while True:
+            if cursor and PaginatedRequestParams is not None:
+                result = await session.list_tools(params=PaginatedRequestParams(cursor=cursor))
+            else:
+                result = await session.list_tools()
+            tools.extend(list(getattr(result, "tools", []) or []))
+            cursor = getattr(result, "next_cursor", None) or getattr(result, "nextCursor", None)
+            if not cursor:
+                break
+        return tools
+
+
+def _tool_status_from_mcp_tool(tool: Any) -> MCPToolStatus:
+    tool_id = str(getattr(tool, "name", ""))
+    name = getattr(tool, "title", None) or tool_id
+    description = getattr(tool, "description", None) or ""
+    schema = getattr(tool, "input_schema", None) or getattr(tool, "inputSchema", None) or {}
+    if not isinstance(schema, dict):
+        schema = {"type": "object", "properties": {}}
+    schema.setdefault("type", "object")
+    schema.setdefault("properties", {})
+    return MCPToolStatus(id=tool_id, name=name, description=description, input_schema=schema)
+
+
+def _tool_result_to_agent_output(result: Any) -> Any:
+    blocks: list[Any] = []
+    for item in getattr(result, "content", []) or []:
+        block = _content_item_to_block(item)
+        if block is not None:
+            blocks.append(block)
+    structured = getattr(result, "structured_content", None)
+    if structured is not None:
+        blocks.append(TextBlock(text="Structured content:\n" + json.dumps(structured, indent=2, default=str)))
+
+    if any(isinstance(block, ImageBlock) for block in blocks):
+        return blocks
+    text = "\n\n".join(block.text for block in blocks if isinstance(block, TextBlock)).strip()
+    return text if text else ""
+
+
+def _content_item_to_block(item: Any) -> Optional[Any]:
+    item_type = getattr(item, "type", None)
+    if item_type == "text" or hasattr(item, "text"):
+        text = getattr(item, "text", None)
+        return TextBlock(text=str(text or ""))
+    if item_type == "image" or (hasattr(item, "data") and hasattr(item, "mime_type")):
+        data = getattr(item, "data", "")
+        mime_type = getattr(item, "mime_type", None) or getattr(item, "mimeType", None) or "image/png"
+        return ImageBlock(image_type="base64", media_type=str(mime_type), data=str(data))
+    if item_type == "resource" and hasattr(item, "resource"):
+        resource = getattr(item, "resource")
+        text = getattr(resource, "text", None)
+        uri = getattr(resource, "uri", "resource")
+        if text is not None:
+            return TextBlock(text=f"Resource {uri}:\n{text}")
+        blob = getattr(resource, "blob", None)
+        mime_type = getattr(resource, "mime_type", None) or getattr(resource, "mimeType", "application/octet-stream")
+        if blob is not None:
+            return TextBlock(text=f"Resource {uri}: <{mime_type} blob, {len(str(blob))} base64 chars>")
+    if item_type == "audio":
+        mime_type = getattr(item, "mime_type", None) or getattr(item, "mimeType", "audio/*")
+        data = getattr(item, "data", "")
+        return TextBlock(text=f"Audio content ({mime_type}, {len(str(data))} base64 chars) returned by MCP tool.")
+    if item is not None:
+        return TextBlock(text=str(item))
+    return None

--- a/kolega_code/mcp/service.py
+++ b/kolega_code/mcp/service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
@@ -58,6 +59,99 @@ def parse_mcp_tool_name(name: str) -> Optional[tuple[str, str]]:
     if not server_id or not tool_id:
         return None
     return server_id, tool_id
+
+
+@contextlib.contextmanager
+def _suppress_mcp_sdk_terminal_logs():
+    """Prevent caught MCP SDK errors from also printing raw tracebacks to stderr.
+
+    Some SDK transport/auth tasks log exceptions before re-raising them. The
+    service catches those errors and writes a concise MCP status, so the raw
+    logger output is duplicate noise and can corrupt the Textual UI.
+    """
+    logger = logging.getLogger("mcp")
+    null_handler = logging.NullHandler()
+    old_propagate = logger.propagate
+    logger.addHandler(null_handler)
+    logger.propagate = False
+    try:
+        yield
+    finally:
+        logger.propagate = old_propagate
+        logger.removeHandler(null_handler)
+
+
+def _mcp_failure_message(server: MCPServerConfig, exc: BaseException) -> str:
+    messages = _dedupe_messages(_leaf_exception_messages(exc))
+    if not messages:
+        messages = [_single_exception_message(exc)]
+    message = "; ".join(messages[:3])
+    if len(messages) > 3:
+        message = f"{message}; ... ({len(messages) - 3} more)"
+    return _add_known_mcp_failure_hint(server, message)
+
+
+def _leaf_exception_messages(exc: BaseException, seen: Optional[set[int]] = None) -> list[str]:
+    seen = seen or set()
+    if id(exc) in seen:
+        return []
+    seen.add(id(exc))
+
+    if isinstance(exc, BaseExceptionGroup):
+        messages: list[str] = []
+        for child in exc.exceptions:
+            messages.extend(_leaf_exception_messages(child, seen))
+        if messages:
+            return messages
+
+    messages = [_single_exception_message(exc)]
+    cause = exc.__cause__ or (None if exc.__suppress_context__ else exc.__context__)
+    if cause is not None:
+        messages.extend(_leaf_exception_messages(cause, seen))
+    return messages
+
+
+def _single_exception_message(exc: BaseException) -> str:
+    name = exc.__class__.__name__
+    text = str(exc).strip()
+    if not text:
+        return name
+    if text.startswith(f"{name}:"):
+        return text
+    return f"{name}: {text}"
+
+
+def _dedupe_messages(messages: list[str]) -> list[str]:
+    seen: set[str] = set()
+    unique: list[str] = []
+    for message in messages:
+        normalized = " ".join(message.split())
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        unique.append(normalized)
+    return unique
+
+
+def _add_known_mcp_failure_hint(server: MCPServerConfig, message: str) -> str:
+    if not server.oauth.enabled:
+        return message
+
+    lower = message.lower()
+    url = (server.url or "").lower()
+    if "registration failed" in lower:
+        if "api.githubcopilot.com" in url:
+            return (
+                "GitHub remote MCP OAuth failed: GitHub's endpoint does not support generic MCP dynamic client "
+                "registration. Use a PAT Authorization header for this endpoint, or a client with GitHub-provided "
+                f"OAuth support. Underlying error: {message}"
+            )
+        if "404" in lower:
+            return (
+                "OAuth dynamic client registration failed (404). This server likely requires a pre-registered "
+                f"OAuth client or bearer-token header. Underlying error: {message}"
+            )
+    return message
 
 
 class MCPService:
@@ -126,14 +220,17 @@ class MCPService:
             return MCPVerificationResult(server_id=server_id, ok=False, message=f"Unknown MCP server: {server_id}")
         fingerprint = server_fingerprint(server)
         try:
-            async with self._maybe_interactive_oauth(server, interactive_oauth, open_browser, output) as interaction:
-                async with open_mcp_session(
-                    server,
-                    project_path=self.project_path,
-                    token_store=self.oauth_store,
-                    oauth_interaction=interaction,
-                ) as session:
-                    tools = await self._list_all_tools(session)
+            with _suppress_mcp_sdk_terminal_logs():
+                async with self._maybe_interactive_oauth(
+                    server, interactive_oauth, open_browser, output
+                ) as interaction:
+                    async with open_mcp_session(
+                        server,
+                        project_path=self.project_path,
+                        token_store=self.oauth_store,
+                        oauth_interaction=interaction,
+                    ) as session:
+                        tools = await self._list_all_tools(session)
             tool_statuses = [_tool_status_from_mcp_tool(tool) for tool in tools]
             status = MCPServerStatus.verified(
                 fingerprint=fingerprint,
@@ -151,7 +248,7 @@ class MCPService:
                 status=status,
             )
         except Exception as exc:  # noqa: BLE001 - verification failures are reported in status
-            message = str(exc) or exc.__class__.__name__
+            message = _mcp_failure_message(server, exc)
             status = MCPServerStatus.failed(
                 fingerprint=fingerprint,
                 transport=server.transport,
@@ -189,8 +286,11 @@ class MCPService:
             raise ToolError(f"MCP server '{server_id}' is disabled")
         if not self.is_verified(server):
             raise ToolError(f"MCP server '{server_id}' is not verified for its current configuration")
-        async with open_mcp_session(server, project_path=self.project_path, token_store=self.oauth_store) as session:
-            result = await session.call_tool(tool_id, arguments or {})
+        with _suppress_mcp_sdk_terminal_logs():
+            async with open_mcp_session(
+                server, project_path=self.project_path, token_store=self.oauth_store
+            ) as session:
+                result = await session.call_tool(tool_id, arguments or {})
         output = _tool_result_to_agent_output(result)
         if bool(getattr(result, "is_error", False)):
             if isinstance(output, list):

--- a/kolega_code/mcp/service.py
+++ b/kolega_code/mcp/service.py
@@ -8,6 +8,7 @@ import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
+from urllib.parse import urlsplit
 
 from kolega_code.llm.models import ImageBlock, TextBlock
 from kolega_code.tools import ToolError
@@ -19,6 +20,66 @@ from .transport import open_mcp_session
 
 MCP_TOOL_PREFIX = "mcp__"
 MCP_TOOL_SEPARATOR = "__"
+
+MCP_FAILURE_MESSAGE_GENERIC = "Verification failed. Check the MCP server configuration and try again."
+MCP_FAILURE_MESSAGE_GITHUB_COPILOT_OAUTH = (
+    "GitHub remote MCP OAuth failed: this endpoint does not support generic MCP dynamic client registration. "
+    "Use a PAT Authorization header for this endpoint, or a client with GitHub-provided OAuth support."
+)
+MCP_FAILURE_MESSAGE_OAUTH_REGISTRATION = (
+    "OAuth dynamic client registration failed. This server may require a pre-registered OAuth client or "
+    "bearer-token header."
+)
+MCP_FAILURE_MESSAGE_OAUTH_UNAUTHORIZED = (
+    "MCP OAuth authorization failed. Check the server credentials or bearer-token header."
+)
+MCP_FAILURE_MESSAGE_UNAUTHORIZED = (
+    "MCP authentication failed. Check the configured credentials or Authorization header."
+)
+MCP_FAILURE_MESSAGE_NOT_FOUND = "MCP server endpoint was not found. Check the configured URL."
+MCP_FAILURE_MESSAGE_TIMEOUT = "MCP server verification timed out. Check the server URL and network connectivity."
+MCP_FAILURE_MESSAGE_CONNECTION = (
+    "Could not connect to the MCP server. Check the command, URL, and network connectivity."
+)
+MCP_FAILURE_MESSAGE_COMMAND = "Could not start the MCP server command. Check the configured command and arguments."
+MCP_FAILURE_MESSAGE_PERMISSION = "Permission denied while starting or contacting the MCP server."
+
+_SAFE_FAILED_STATUS_MESSAGES = (
+    MCP_FAILURE_MESSAGE_GENERIC,
+    MCP_FAILURE_MESSAGE_GITHUB_COPILOT_OAUTH,
+    MCP_FAILURE_MESSAGE_OAUTH_REGISTRATION,
+    MCP_FAILURE_MESSAGE_OAUTH_UNAUTHORIZED,
+    MCP_FAILURE_MESSAGE_UNAUTHORIZED,
+    MCP_FAILURE_MESSAGE_NOT_FOUND,
+    MCP_FAILURE_MESSAGE_TIMEOUT,
+    MCP_FAILURE_MESSAGE_CONNECTION,
+    MCP_FAILURE_MESSAGE_COMMAND,
+    MCP_FAILURE_MESSAGE_PERMISSION,
+)
+_UNAUTHORIZED_MARKERS = ("unauthorized", "401", "forbidden", "403", "invalid token", "invalid_token")
+_NOT_FOUND_MARKERS = ("404", "not found")
+_TIMEOUT_MARKERS = ("timeout", "timed out", "readtimeout", "connecttimeout")
+_COMMAND_FAILURE_MARKERS = (
+    "command not found",
+    "executable file not found",
+    "no such file or directory",
+    "filenotfounderror",
+)
+_CONNECTION_FAILURE_MARKERS = (
+    "connection refused",
+    "connection reset",
+    "connection aborted",
+    "connecterror",
+    "connect error",
+    "clientconnectorerror",
+    "network is unreachable",
+    "nodename nor servname",
+    "name or service not known",
+    "gaierror",
+    "could not connect",
+    "connect call failed",
+)
+_PERMISSION_MARKERS = ("permission denied", "permissionerror")
 
 
 @dataclass(frozen=True)
@@ -82,13 +143,56 @@ def _suppress_mcp_sdk_terminal_logs():
 
 
 def _mcp_failure_message(server: MCPServerConfig, exc: BaseException) -> str:
+    """Return a fixed, credential-safe status message for a caught MCP failure."""
+    return _safe_mcp_failure_message(server, _exception_text_for_matching(exc))
+
+
+def _exception_text_for_matching(exc: BaseException) -> str:
     messages = _dedupe_messages(_leaf_exception_messages(exc))
     if not messages:
         messages = [_single_exception_message(exc)]
-    message = "; ".join(messages[:3])
-    if len(messages) > 3:
-        message = f"{message}; ... ({len(messages) - 3} more)"
-    return _add_known_mcp_failure_hint(server, message)
+    return " ".join(messages).lower()
+
+
+def _safe_mcp_failure_message(server: MCPServerConfig, lower_message: str) -> str:
+    if server.oauth.enabled and _contains_any(lower_message, ("registration failed", "dynamic client")):
+        if _is_github_copilot_api_url(server.url):
+            return MCP_FAILURE_MESSAGE_GITHUB_COPILOT_OAUTH
+        return MCP_FAILURE_MESSAGE_OAUTH_REGISTRATION
+    if _contains_any(lower_message, _UNAUTHORIZED_MARKERS):
+        return MCP_FAILURE_MESSAGE_OAUTH_UNAUTHORIZED if server.oauth.enabled else MCP_FAILURE_MESSAGE_UNAUTHORIZED
+    if _contains_any(lower_message, _NOT_FOUND_MARKERS):
+        return MCP_FAILURE_MESSAGE_NOT_FOUND
+    if _contains_any(lower_message, _TIMEOUT_MARKERS):
+        return MCP_FAILURE_MESSAGE_TIMEOUT
+    if _contains_any(lower_message, _COMMAND_FAILURE_MARKERS):
+        return MCP_FAILURE_MESSAGE_COMMAND
+    if _contains_any(lower_message, _PERMISSION_MARKERS):
+        return MCP_FAILURE_MESSAGE_PERMISSION
+    if _contains_any(lower_message, _CONNECTION_FAILURE_MARKERS):
+        return MCP_FAILURE_MESSAGE_CONNECTION
+    return MCP_FAILURE_MESSAGE_GENERIC
+
+
+def _safe_failed_status_message(message: str) -> str:
+    for safe_message in _SAFE_FAILED_STATUS_MESSAGES:
+        if message == safe_message:
+            return safe_message
+    return MCP_FAILURE_MESSAGE_GENERIC
+
+
+def _contains_any(text: str, needles: tuple[str, ...]) -> bool:
+    return any(needle in text for needle in needles)
+
+
+def _is_github_copilot_api_url(url: Optional[str]) -> bool:
+    if not url:
+        return False
+    try:
+        hostname = urlsplit(url).hostname
+    except ValueError:
+        return False
+    return bool(hostname and hostname.rstrip(".").lower() == "api.githubcopilot.com")
 
 
 def _leaf_exception_messages(exc: BaseException, seen: Optional[set[int]] = None) -> list[str]:
@@ -133,25 +237,16 @@ def _dedupe_messages(messages: list[str]) -> list[str]:
     return unique
 
 
-def _add_known_mcp_failure_hint(server: MCPServerConfig, message: str) -> str:
-    if not server.oauth.enabled:
-        return message
-
-    lower = message.lower()
-    url = (server.url or "").lower()
-    if "registration failed" in lower:
-        if "api.githubcopilot.com" in url:
-            return (
-                "GitHub remote MCP OAuth failed: GitHub's endpoint does not support generic MCP dynamic client "
-                "registration. Use a PAT Authorization header for this endpoint, or a client with GitHub-provided "
-                f"OAuth support. Underlying error: {message}"
-            )
-        if "404" in lower:
-            return (
-                "OAuth dynamic client registration failed (404). This server likely requires a pre-registered "
-                f"OAuth client or bearer-token header. Underlying error: {message}"
-            )
-    return message
+def _status_row_message(status: Optional[MCPServerStatus], *, verified: bool, stale: bool) -> str:
+    if status is None:
+        return "Not verified."
+    if stale:
+        return "Configuration changed since last verification. Verify again."
+    if verified:
+        return f"Verified {status.tool_count} tool(s)."
+    if status.status == "failed":
+        return _safe_failed_status_message(status.message)
+    return "Not verified."
 
 
 class MCPService:
@@ -202,7 +297,7 @@ class MCPService:
                     if verified
                     else ("stale" if stale else (status.status if status else "unverified")),
                     "tool_count": status.tool_count if verified and status else 0,
-                    "message": status.message if status else "Not verified.",
+                    "message": _status_row_message(status, verified=verified, stale=stale),
                 }
             )
         return rows

--- a/kolega_code/mcp/state.py
+++ b/kolega_code/mcp/state.py
@@ -1,0 +1,211 @@
+"""Local MCP verification/status state."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
+
+from kolega_code.local_state import write_private_text
+
+MCP_STATUS_SCHEMA_VERSION = 1
+MCP_STATUS_FILENAME = "mcp_server_status.json"
+MCP_OAUTH_TOKENS_FILENAME = "mcp_oauth_tokens.json"
+
+
+class MCPToolStatus(BaseModel):
+    id: str
+    name: Optional[str] = None
+    description: str = ""
+    input_schema: dict[str, Any] = Field(default_factory=lambda: {"type": "object", "properties": {}})
+
+
+class MCPServerStatus(BaseModel):
+    status: Literal["unverified", "verified", "failed"] = "unverified"
+    fingerprint: Optional[str] = None
+    verified_at: Optional[str] = None
+    message: str = ""
+    transport: Optional[str] = None
+    source: Optional[str] = None
+    tool_count: int = 0
+    tools: list[MCPToolStatus] = Field(default_factory=list)
+    oauth: bool = False
+
+    @classmethod
+    def verified(
+        cls,
+        *,
+        fingerprint: str,
+        transport: str,
+        source: str,
+        tools: list[MCPToolStatus],
+        message: str = "",
+        oauth: bool = False,
+    ) -> "MCPServerStatus":
+        return cls(
+            status="verified",
+            fingerprint=fingerprint,
+            verified_at=_now_iso(),
+            message=message or f"Verified {len(tools)} tool(s).",
+            transport=transport,
+            source=source,
+            tool_count=len(tools),
+            tools=tools,
+            oauth=oauth,
+        )
+
+    @classmethod
+    def failed(
+        cls,
+        *,
+        fingerprint: str,
+        transport: str,
+        source: str,
+        message: str,
+        oauth: bool = False,
+    ) -> "MCPServerStatus":
+        return cls(
+            status="failed",
+            fingerprint=fingerprint,
+            verified_at=_now_iso(),
+            message=message,
+            transport=transport,
+            source=source,
+            tool_count=0,
+            tools=[],
+            oauth=oauth,
+        )
+
+
+class MCPStatusFile(BaseModel):
+    schema_version: int = MCP_STATUS_SCHEMA_VERSION
+    servers: dict[str, MCPServerStatus] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_schema_version(self) -> "MCPStatusFile":
+        if self.schema_version != MCP_STATUS_SCHEMA_VERSION:
+            raise ValueError(f"Unsupported MCP status schema version: {self.schema_version}")
+        return self
+
+
+class MCPOAuthServerTokens(BaseModel):
+    tokens: Optional[dict[str, Any]] = None
+    client_info: Optional[dict[str, Any]] = None
+    updated_at: str = Field(default_factory=lambda: _now_iso())
+
+
+class MCPOAuthTokenFile(BaseModel):
+    schema_version: int = MCP_STATUS_SCHEMA_VERSION
+    servers: dict[str, MCPOAuthServerTokens] = Field(default_factory=dict)
+
+    @field_validator("servers", mode="before")
+    @classmethod
+    def _coerce_servers(cls, value: object) -> dict[str, object]:
+        if not isinstance(value, dict):
+            return {}
+        return {str(k): v for k, v in value.items() if isinstance(v, dict)}
+
+    @model_validator(mode="after")
+    def _validate_schema_version(self) -> "MCPOAuthTokenFile":
+        if self.schema_version != MCP_STATUS_SCHEMA_VERSION:
+            raise ValueError(f"Unsupported MCP OAuth token schema version: {self.schema_version}")
+        return self
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class MCPStatusStore:
+    """Filesystem-backed verification/status store."""
+
+    def __init__(self, state_dir: Path) -> None:
+        self.root = Path(state_dir).expanduser()
+        self.path = self.root / MCP_STATUS_FILENAME
+
+    def load(self) -> MCPStatusFile:
+        if not self.path.exists():
+            return MCPStatusFile()
+        try:
+            return MCPStatusFile.model_validate_json(self.path.read_text(encoding="utf-8"))
+        except (OSError, ValidationError, ValueError, json.JSONDecodeError):
+            return MCPStatusFile()
+
+    def save(self, data: MCPStatusFile) -> None:
+        payload = json.dumps(data.model_dump(mode="json"), indent=2, sort_keys=True)
+        write_private_text(self.path, payload + "\n")
+
+    def get(self, server_id: str) -> Optional[MCPServerStatus]:
+        return self.load().servers.get(server_id)
+
+    def update(self, server_id: str, status: MCPServerStatus) -> None:
+        data = self.load()
+        data.servers[server_id] = status
+        self.save(data)
+
+    def clear(self, server_id: str) -> None:
+        data = self.load()
+        if server_id in data.servers:
+            data.servers.pop(server_id, None)
+            self.save(data)
+
+
+class MCPOAuthTokenStore:
+    """Filesystem-backed OAuth token/client-registration store."""
+
+    def __init__(self, state_dir: Path) -> None:
+        self.root = Path(state_dir).expanduser()
+        self.path = self.root / MCP_OAUTH_TOKENS_FILENAME
+
+    def load(self) -> MCPOAuthTokenFile:
+        if not self.path.exists():
+            return MCPOAuthTokenFile()
+        try:
+            return MCPOAuthTokenFile.model_validate_json(self.path.read_text(encoding="utf-8"))
+        except (OSError, ValidationError, ValueError, json.JSONDecodeError):
+            return MCPOAuthTokenFile()
+
+    def save(self, data: MCPOAuthTokenFile) -> None:
+        payload = json.dumps(data.model_dump(mode="json"), indent=2, sort_keys=True)
+        write_private_text(self.path, payload + "\n")
+
+    def get(self, server_id: str) -> MCPOAuthServerTokens:
+        return self.load().servers.get(server_id, MCPOAuthServerTokens())
+
+    def set_tokens(self, server_id: str, tokens: Optional[dict[str, Any]]) -> None:
+        data = self.load()
+        record = data.servers.get(server_id, MCPOAuthServerTokens())
+        record.tokens = dict(tokens) if tokens else None
+        record.updated_at = _now_iso()
+        data.servers[server_id] = record
+        self.save(data)
+
+    def set_client_info(self, server_id: str, client_info: Optional[dict[str, Any]]) -> None:
+        data = self.load()
+        record = data.servers.get(server_id, MCPOAuthServerTokens())
+        record.client_info = dict(client_info) if client_info else None
+        record.updated_at = _now_iso()
+        data.servers[server_id] = record
+        self.save(data)
+
+    def clear(self, server_id: str) -> None:
+        data = self.load()
+        if server_id in data.servers:
+            data.servers.pop(server_id, None)
+            self.save(data)
+
+    def secret_values(self) -> list[str]:
+        values: list[str] = []
+        for record in self.load().servers.values():
+            tokens = record.tokens or {}
+            for key in ("access_token", "refresh_token", "id_token"):
+                value = tokens.get(key)
+                if value:
+                    values.append(str(value))
+            client_secret = (record.client_info or {}).get("client_secret")
+            if client_secret:
+                values.append(str(client_secret))
+        return values

--- a/kolega_code/mcp/state.py
+++ b/kolega_code/mcp/state.py
@@ -9,7 +9,7 @@ from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 
-from kolega_code.local_state import write_private_text
+from kolega_code.local_state import write_private_secret_text, write_private_text
 
 MCP_STATUS_SCHEMA_VERSION = 1
 MCP_STATUS_FILENAME = "mcp_server_status.json"
@@ -170,7 +170,7 @@ class MCPOAuthTokenStore:
 
     def save(self, data: MCPOAuthTokenFile) -> None:
         payload = json.dumps(data.model_dump(mode="json"), indent=2, sort_keys=True)
-        write_private_text(self.path, payload + "\n")
+        write_private_secret_text(self.path, payload + "\n")
 
     def get(self, server_id: str) -> MCPOAuthServerTokens:
         return self.load().servers.get(server_id, MCPOAuthServerTokens())

--- a/kolega_code/mcp/tools.py
+++ b/kolega_code/mcp/tools.py
@@ -1,0 +1,68 @@
+"""Expose verified MCP tools through Kolega's ToolExtension API."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from kolega_code.agent.tools import ToolExtension
+from kolega_code.llm.models import ToolDefinition
+
+from .config import LoadedMCPConfig, load_mcp_config
+from .service import MCPService
+
+
+def build_mcp_tool_extension(
+    project_path: Path,
+    state_dir: Path,
+    *,
+    project_trusted: bool,
+    loaded_config: Optional[LoadedMCPConfig] = None,
+) -> Optional[ToolExtension]:
+    """Build a ToolExtension for currently verified MCP tools.
+
+    This never performs network I/O or launches OAuth. It only reads MCP config and
+    the local verification cache, so agent construction stays non-interactive.
+    """
+    config = loaded_config or load_mcp_config(project_path, state_dir, project_trusted=project_trusted)
+    service = MCPService(config, state_dir=state_dir, project_path=project_path)
+    exposed = service.exposed_tools()
+    if not exposed:
+        return None
+
+    callbacks = {}
+    schemas = {}
+    tool_names = []
+
+    for exposed_tool in exposed:
+        tool_name = exposed_tool.name
+        server_id = exposed_tool.server.id
+        tool_id = exposed_tool.tool.id
+
+        async def _call_mcp_tool(_server_id=server_id, _tool_id=tool_id, **inputs):
+            return await service.call_tool(_server_id, _tool_id, inputs)
+
+        _call_mcp_tool.__name__ = tool_name
+        _call_mcp_tool.__doc__ = exposed_tool.description
+        callbacks[tool_name] = _call_mcp_tool
+        schemas[tool_name] = exposed_tool.tool.input_schema
+        tool_names.append(tool_name)
+
+    return ToolExtension(
+        name="mcp",
+        tools=callbacks,
+        tool_groups={"mcp_tools": tool_names},
+        tool_schemas=schemas,
+        cleanup=service.cleanup,
+        propagate_to_sub_agents=False,
+    )
+
+
+def mcp_tool_definition(exposed_tool) -> ToolDefinition:
+    """Build a ToolDefinition for tests and callers that need explicit definitions."""
+    return ToolDefinition(
+        name=exposed_tool.name,
+        description=exposed_tool.description,
+        parameters=[],
+        input_schema=exposed_tool.tool.input_schema,
+    )

--- a/kolega_code/mcp/transport.py
+++ b/kolega_code/mcp/transport.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import contextlib
 import inspect
+import os
 from pathlib import Path
-from typing import Optional
+from typing import Optional, TextIO
 
 import httpx
 
@@ -34,8 +35,14 @@ async def open_mcp_session(
     project_path: Path,
     token_store: MCPOAuthTokenStore,
     oauth_interaction: Optional[OAuthInteraction] = None,
+    stdio_errlog: Optional[TextIO] = None,
 ):
-    """Open and initialize a ClientSession for a configured MCP server."""
+    """Open and initialize a ClientSession for a configured MCP server.
+
+    The MCP SDK defaults stdio server stderr to ``sys.stderr``. In the Textual UI
+    that bypasses rendering and can draw child-process logs over the composer, so
+    stdio stderr is sent to a non-terminal sink unless a caller explicitly opts in.
+    """
     from mcp.client.session import ClientSession
 
     if server.transport == "stdio":
@@ -47,11 +54,15 @@ async def open_mcp_session(
             env=server.env or None,
             cwd=_resolve_cwd(project_path, server.cwd),
         )
-        async with stdio_client(params) as streams:
-            read_stream, write_stream = streams
-            async with ClientSession(read_stream, write_stream, read_timeout_seconds=server.timeout_seconds) as session:
-                await session.initialize()
-                yield session
+        errlog_context = contextlib.nullcontext(stdio_errlog) if stdio_errlog is not None else open(os.devnull, "w")
+        with errlog_context as errlog:
+            async with stdio_client(params, errlog=errlog) as streams:
+                read_stream, write_stream = streams
+                async with ClientSession(
+                    read_stream, write_stream, read_timeout_seconds=server.timeout_seconds
+                ) as session:
+                    await session.initialize()
+                    yield session
         return
 
     auth = await build_oauth_provider(server, token_store, interaction=oauth_interaction)

--- a/kolega_code/mcp/transport.py
+++ b/kolega_code/mcp/transport.py
@@ -1,0 +1,112 @@
+"""MCP transport/session adapters."""
+
+from __future__ import annotations
+
+import contextlib
+import inspect
+from pathlib import Path
+from typing import Optional
+
+import httpx
+
+from .config import MCPServerConfig
+from .oauth import OAuthInteraction, build_oauth_provider
+from .state import MCPOAuthTokenStore
+
+
+class MCPTransportError(RuntimeError):
+    """Raised when an MCP transport cannot be opened."""
+
+
+def _resolve_cwd(project_path: Path, cwd: Optional[str]) -> Optional[str]:
+    if not cwd:
+        return None
+    path = Path(cwd).expanduser()
+    if not path.is_absolute():
+        path = project_path / path
+    return str(path.resolve())
+
+
+@contextlib.asynccontextmanager
+async def open_mcp_session(
+    server: MCPServerConfig,
+    *,
+    project_path: Path,
+    token_store: MCPOAuthTokenStore,
+    oauth_interaction: Optional[OAuthInteraction] = None,
+):
+    """Open and initialize a ClientSession for a configured MCP server."""
+    from mcp.client.session import ClientSession
+
+    if server.transport == "stdio":
+        from mcp.client.stdio import StdioServerParameters, stdio_client
+
+        params = StdioServerParameters(
+            command=server.command or "",
+            args=server.args,
+            env=server.env or None,
+            cwd=_resolve_cwd(project_path, server.cwd),
+        )
+        async with stdio_client(params) as streams:
+            read_stream, write_stream = streams
+            async with ClientSession(read_stream, write_stream, read_timeout_seconds=server.timeout_seconds) as session:
+                await session.initialize()
+                yield session
+        return
+
+    auth = await build_oauth_provider(server, token_store, interaction=oauth_interaction)
+    if server.transport == "sse":
+        from mcp.client.sse import sse_client
+
+        async with sse_client(
+            server.url or "",
+            headers=server.headers or None,
+            timeout=server.timeout_seconds,
+            sse_read_timeout=server.sse_read_timeout_seconds,
+            auth=auth,
+        ) as streams:
+            read_stream, write_stream = streams
+            async with ClientSession(read_stream, write_stream, read_timeout_seconds=server.timeout_seconds) as session:
+                await session.initialize()
+                yield session
+        return
+
+    if server.transport == "streamable_http":
+        async with _streamable_http_client(server, auth=auth) as streams:
+            read_stream, write_stream = streams
+            async with ClientSession(read_stream, write_stream, read_timeout_seconds=server.timeout_seconds) as session:
+                await session.initialize()
+                yield session
+        return
+
+    raise MCPTransportError(f"Unsupported MCP transport: {server.transport}")
+
+
+@contextlib.asynccontextmanager
+async def _streamable_http_client(server: MCPServerConfig, *, auth=None):
+    """Compatibility wrapper for MCP SDK streamable HTTP client naming/signatures."""
+    try:
+        from mcp.client.streamable_http import create_mcp_http_client, streamable_http_client
+    except ImportError:  # pragma: no cover - older SDK compatibility
+        from mcp.client.streamable_http import create_mcp_http_client, streamablehttp_client as streamable_http_client
+
+    signature = inspect.signature(streamable_http_client)
+    params = signature.parameters
+    timeout = httpx.Timeout(server.timeout_seconds)
+
+    if "http_client" in params:
+        client = create_mcp_http_client(headers=server.headers or None, timeout=timeout, auth=auth)
+        async with client:
+            async with streamable_http_client(server.url or "", http_client=client) as streams:
+                yield streams
+        return
+
+    kwargs = {}
+    if "headers" in params:
+        kwargs["headers"] = server.headers or None
+    if "timeout" in params:
+        kwargs["timeout"] = server.timeout_seconds
+    if "auth" in params:
+        kwargs["auth"] = auth
+    async with streamable_http_client(server.url or "", **kwargs) as streams:  # pragma: no cover - older SDK
+        yield streams

--- a/kolega_code/permissions.py
+++ b/kolega_code/permissions.py
@@ -22,6 +22,7 @@ class PermissionMode(str, Enum):
 class PermissionKind(str, Enum):
     COMMAND = "command"
     EDIT = "edit"
+    MCP = "mcp"
 
 
 class PermissionStoreError(RuntimeError):
@@ -55,11 +56,15 @@ class PermissionRequest:
     inputs: dict[str, Any]
     command: str = ""
     path: str = ""
+    mcp_server: str = ""
+    mcp_tool: str = ""
 
     @property
     def summary(self) -> str:
         if self.kind == PermissionKind.COMMAND:
             return self.command
+        if self.kind == PermissionKind.MCP:
+            return f"{self.mcp_server}/{self.mcp_tool}" if self.mcp_server else self.tool_name
         if self.path:
             return f"{self.tool_name} {self.path}"
         return self.tool_name
@@ -119,6 +124,8 @@ class PermissionRule:
 
         if self.kind == PermissionKind.COMMAND:
             return _matches_command(self.match_type, self.pattern, request.command)
+        if self.kind == PermissionKind.MCP:
+            return _matches_mcp(self, request)
 
         return _matches_edit(self, request)
 
@@ -210,12 +217,25 @@ def permission_request_for_tool(tool_name: str, inputs: dict[str, Any]) -> Optio
             path=path,
         )
 
+    mcp_target = _mcp_target_from_tool_name(tool_name)
+    if mcp_target is not None:
+        server_id, mcp_tool = mcp_target
+        return PermissionRequest(
+            kind=PermissionKind.MCP,
+            tool_name=tool_name,
+            inputs=inputs,
+            mcp_server=server_id,
+            mcp_tool=mcp_tool,
+        )
+
     return None
 
 
 def allow_rule_options(request: PermissionRequest) -> list[PermissionRuleOption]:
     if request.kind == PermissionKind.COMMAND:
         return _command_rule_options(request)
+    if request.kind == PermissionKind.MCP:
+        return _mcp_rule_options(request)
     return _edit_rule_options(request)
 
 
@@ -251,6 +271,30 @@ def _matches_edit(rule: PermissionRule, request: PermissionRequest) -> bool:
     if rule.match_type == "path":
         return bool(request.path) and request.path == rule.pattern
     return False
+
+
+def _matches_mcp(rule: PermissionRule, request: PermissionRequest) -> bool:
+    if rule.match_type == "tool":
+        # MCP tool rules are exact exposed-tool rules (`mcp__server__tool`).
+        # Whole-server allows are represented separately by match_type="server".
+        return rule.pattern in {"*", request.tool_name}
+    if rule.match_type == "server":
+        return bool(request.mcp_server) and request.mcp_server == rule.pattern
+    return False
+
+
+def _mcp_target_from_tool_name(tool_name: str) -> Optional[tuple[str, str]]:
+    prefix = "mcp__"
+    separator = "__"
+    if not tool_name.startswith(prefix):
+        return None
+    rest = tool_name[len(prefix) :]
+    if separator not in rest:
+        return None
+    server_id, mcp_tool = rest.split(separator, 1)
+    if not server_id or not mcp_tool:
+        return None
+    return server_id, mcp_tool
 
 
 def _path_from_edit_inputs(inputs: dict[str, Any]) -> str:
@@ -338,6 +382,35 @@ def _edit_rule_options(request: PermissionRequest) -> list[PermissionRuleOption]
         )
     )
     return options
+
+
+def _mcp_rule_options(request: PermissionRequest) -> list[PermissionRuleOption]:
+    options = [
+        PermissionRuleOption(
+            label=f"Always allow MCP tool `{request.tool_name}`",
+            description="Allow this exact MCP tool.",
+            rule=PermissionRule.create(
+                kind=PermissionKind.MCP,
+                tool=request.tool_name,
+                match_type="tool",
+                pattern=request.tool_name,
+            ),
+        )
+    ]
+    if request.mcp_server:
+        options.append(
+            PermissionRuleOption(
+                label=f"Always allow MCP server `{request.mcp_server}`",
+                description="Allow all verified MCP tools from this server.",
+                rule=PermissionRule.create(
+                    kind=PermissionKind.MCP,
+                    tool="*",
+                    match_type="server",
+                    pattern=request.mcp_server,
+                ),
+            )
+        )
+    return _dedupe_options(options)
 
 
 def _shell_tokens(command: str) -> list[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "jinja2==3.1.6",
     "langfuse==3.14.5",
     "lxml-html-clean==0.4.4",
+    "mcp>=1.21.2",
     "nest-asyncio==1.6.0",
     "openai==1.109.1",
     "packaging==25.0",

--- a/tests/cli/test_app_bootstrap_settings.py
+++ b/tests/cli/test_app_bootstrap_settings.py
@@ -857,6 +857,57 @@ async def test_save_settings_logs_on_success_without_toast(tmp_path: Path, monke
 
 
 @pytest.mark.asyncio
+async def test_mcp_server_save_auto_generates_id_without_visible_id_field(tmp_path: Path) -> None:
+    pytest.importorskip("textual")
+
+    from textual.css.query import NoMatches
+    from textual.widgets import Input, Select
+
+    from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.mcp.config import global_mcp_config_path
+
+    class NoAgentApp(KolegaCodeApp):
+        CSS_PATH = str(Path(__file__).parents[2] / "kolega_code/cli/tui/styles.tcss")
+
+        async def _ensure_agent_from_settings(self, *args, **kwargs):
+            return None
+
+    project = tmp_path / "project"
+    project.mkdir()
+    state_dir = tmp_path / "state"
+    store = SessionStore(state_dir)
+    settings_store = SettingsStore(state_dir)
+    session = store.create(project, "code", {})
+    app = NoAgentApp(
+        project_path=project,
+        mode="code",
+        store=store,
+        settings_store=settings_store,
+        session=session,
+    )
+
+    async with app.run_test():
+        with pytest.raises(NoMatches):
+            app.query_one("#mcp_server_id_input", Input)
+
+        app.query_one("#mcp_name_input", Input).value = "DeepWiki Docs"
+        app.query_one("#mcp_transport_select", Select).value = "streamable_http"
+        app.query_one("#mcp_url_input", Input).value = "https://mcp.deepwiki.com/mcp"
+
+        await app._save_mcp_server_from_ui()
+
+        assert app.query_one("#mcp_server_select", Select).value == "deepwiki-docs"
+        payload = json.loads(global_mcp_config_path(state_dir).read_text(encoding="utf-8"))
+        assert len(payload["servers"]) == 1
+        server = payload["servers"][0]
+        assert server["id"] == "deepwiki-docs"
+        assert server["name"] == "DeepWiki Docs"
+        assert server["transport"] == "streamable_http"
+        assert server["url"] == "https://mcp.deepwiki.com/mcp"
+        assert server["enabled"] is True
+
+
+@pytest.mark.asyncio
 async def test_agent_models_section_saves_override_and_builds_agent(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
 ) -> None:

--- a/tests/cli/test_mcp_cli.py
+++ b/tests/cli/test_mcp_cli.py
@@ -7,7 +7,9 @@ from kolega_code.cli.config import API_KEY_ENV, CliConfigOverrides, build_agent_
 from kolega_code.cli.main import main, parse_args
 from kolega_code.cli.settings import CliSettings, SettingsStore
 from kolega_code.config import ModelProvider
-from kolega_code.mcp.config import global_mcp_config_path
+from kolega_code.mcp.config import MCPServerConfig, global_mcp_config_path, server_fingerprint
+from kolega_code.mcp.service import MCP_FAILURE_MESSAGE_GENERIC
+from kolega_code.mcp.state import MCPServerStatus, MCPStatusStore
 
 
 def test_mcp_subcommands_parse() -> None:
@@ -72,6 +74,46 @@ def test_mcp_add_and_list_use_state_dir(tmp_path: Path, capsys) -> None:
     assert exit_code == 0
     assert "docs" in captured.out
     assert "streamable_http" in captured.out
+
+
+def test_mcp_list_does_not_print_legacy_failed_status_message(tmp_path: Path, capsys) -> None:
+    project = tmp_path / "project"
+    state = tmp_path / "state"
+    project.mkdir()
+    server = MCPServerConfig(id="docs", transport="streamable_http", url="https://docs.example/mcp")
+
+    exit_code = main(
+        [
+            "mcp",
+            "--project",
+            str(project),
+            "--state-dir",
+            str(state),
+            "add",
+            server.id,
+            "--transport",
+            server.transport,
+            "--url",
+            server.url or "",
+        ]
+    )
+    assert exit_code == 0
+    MCPStatusStore(state).update(
+        server.id,
+        MCPServerStatus.failed(
+            fingerprint=server_fingerprint(server),
+            transport=server.transport,
+            source=server.source,
+            message="RuntimeError: password=legacy-secret",
+        ),
+    )
+
+    exit_code = main(["mcp", "--project", str(project), "--state-dir", str(state), "list"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "legacy-secret" not in captured.out
+    assert MCP_FAILURE_MESSAGE_GENERIC in captured.out
 
 
 def test_build_agent_config_loads_trusted_project_mcp(tmp_path: Path, monkeypatch, isolated_cli_env) -> None:

--- a/tests/cli/test_mcp_cli.py
+++ b/tests/cli/test_mcp_cli.py
@@ -113,6 +113,7 @@ def test_mcp_list_does_not_print_legacy_failed_status_message(tmp_path: Path, ca
 
     assert exit_code == 0
     assert "legacy-secret" not in captured.out
+    assert "docs\tglobal\tstreamable_http\tTrue\tFalse\tfailed\t0" in captured.out
     assert MCP_FAILURE_MESSAGE_GENERIC in captured.out
 
 

--- a/tests/cli/test_mcp_cli.py
+++ b/tests/cli/test_mcp_cli.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from kolega_code.cli.config import API_KEY_ENV, CliConfigOverrides, build_agent_config
+from kolega_code.cli.main import main, parse_args
+from kolega_code.cli.settings import CliSettings, SettingsStore
+from kolega_code.config import ModelProvider
+from kolega_code.mcp.config import global_mcp_config_path
+
+
+def test_mcp_subcommands_parse() -> None:
+    args = parse_args(
+        [
+            "mcp",
+            "--project",
+            ".",
+            "--state-dir",
+            "state",
+            "add",
+            "docs",
+            "--transport",
+            "streamable_http",
+            "--url",
+            "https://docs.example/mcp",
+            "--oauth",
+        ]
+    )
+
+    assert args.command == "mcp"
+    assert args.mcp_command == "add"
+    assert args.server_id == "docs"
+    assert args.transport == "streamable_http"
+    assert args.stdio_command is None
+    assert args.oauth is True
+
+
+def test_mcp_add_and_list_use_state_dir(tmp_path: Path, capsys) -> None:
+    project = tmp_path / "project"
+    state = tmp_path / "state"
+    project.mkdir()
+
+    exit_code = main(
+        [
+            "mcp",
+            "--project",
+            str(project),
+            "--state-dir",
+            str(state),
+            "add",
+            "docs",
+            "--transport",
+            "streamable_http",
+            "--url",
+            "https://docs.example/mcp",
+            "--header",
+            "Authorization=Bearer secret",
+            "--oauth",
+            "--oauth-scope",
+            "read write",
+        ]
+    )
+    assert exit_code == 0
+    payload = json.loads(global_mcp_config_path(state).read_text(encoding="utf-8"))
+    assert payload["servers"][0]["id"] == "docs"
+    assert payload["servers"][0]["headers"] == {"Authorization": "Bearer secret"}
+    assert payload["servers"][0]["oauth"]["enabled"] is True
+
+    exit_code = main(["mcp", "--project", str(project), "--state-dir", str(state), "list"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "docs" in captured.out
+    assert "streamable_http" in captured.out
+
+
+def test_build_agent_config_loads_trusted_project_mcp(tmp_path: Path, monkeypatch, isolated_cli_env) -> None:
+    project = tmp_path / "project"
+    state = tmp_path / "state"
+    project.mkdir()
+    (project / ".kolega").mkdir()
+    (project / ".kolega" / "mcp_servers.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "servers": [{"id": "project-docs", "transport": "streamable_http", "url": "https://docs.example/mcp"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(API_KEY_ENV[ModelProvider.ANTHROPIC], "test-key")
+    settings = CliSettings(active_provider="anthropic", active_model="claude-opus-4-8")
+    settings.trust_mcp_project(project)
+    settings_store = SettingsStore(state)
+    settings_store.save(settings)
+
+    config = build_agent_config(project, CliConfigOverrides(), settings=settings, settings_store=settings_store)
+
+    assert config.mcp_config is not None
+    assert set(config.mcp_config.servers) == {"project-docs"}
+    assert config.mcp_config.project_trusted is True

--- a/tests/cli/test_mcp_settings_formatting.py
+++ b/tests/cli/test_mcp_settings_formatting.py
@@ -1,0 +1,185 @@
+import pytest
+
+
+def _rows(*rows):
+    return list(rows)
+
+
+def test_mcp_status_rendering_all_verified_has_single_aggregate_tick() -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui import settings_panel
+
+    rows = _rows(
+        {
+            "id": "context7",
+            "name": "Context7",
+            "source": "global",
+            "transport": "streamable_http",
+            "enabled": True,
+            "oauth": False,
+            "status": "verified",
+            "tool_count": 2,
+            "message": "OK",
+        },
+        {
+            "id": "repo-tools",
+            "name": "Repo Tools",
+            "source": "project",
+            "transport": "stdio",
+            "enabled": True,
+            "oauth": False,
+            "status": "verified",
+            "tool_count": 1,
+            "message": "OK",
+        },
+    )
+
+    content, tone = settings_panel._render_mcp_status_text([], rows)
+    fake_panel = _FakeMCPStatusPanel()
+    settings_panel.SettingsPanelMixin._set_mcp_status(fake_panel, content, tone=tone)
+
+    plain = fake_panel.updated.plain
+    check = settings_panel.theme.g(settings_panel.Glyph.CHECK)
+    sep = f" {settings_panel.theme.g(settings_panel.Glyph.BULLET_SEP)} "
+
+    assert tone == "ok"
+    assert plain.startswith(f"{check} 2 MCP servers configured{sep}all enabled verified")
+    assert plain.count(check) == 1
+    assert "\n  ✓" not in plain
+    assert "\n  !" not in plain
+    assert "\n  •" not in plain
+    assert "Context7 (context7)" not in plain
+    assert "Repo Tools (repo-tools)" not in plain
+    assert f"verified{sep}2 tools{sep}global{sep}HTTP" in plain
+    assert f"verified{sep}1 tool{sep}project{sep}stdio" in plain
+
+
+def test_mcp_status_rendering_mixed_attention_states_use_text_labels() -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui import settings_panel
+
+    rows = _rows(
+        {
+            "id": "docs",
+            "name": "Docs",
+            "source": "global",
+            "transport": "streamable_http",
+            "enabled": True,
+            "oauth": True,
+            "status": "failed",
+            "tool_count": 0,
+            "message": "Unauthorized. Please check your API key.",
+        },
+        {
+            "id": "repo-tools",
+            "name": "Repo Tools",
+            "source": "project",
+            "transport": "stdio",
+            "enabled": True,
+            "oauth": False,
+            "status": "stale",
+            "tool_count": 0,
+            "message": "Previously verified.",
+        },
+    )
+
+    content, tone = settings_panel._render_mcp_status_text(["Project MCP config is untrusted."], rows)
+    plain = content.plain
+    sep = f" {settings_panel.theme.g(settings_panel.Glyph.BULLET_SEP)} "
+
+    assert tone == "warning"
+    assert f"2 MCP servers configured{sep}2 need verification" in plain
+    assert "Project MCP config is untrusted." in plain
+    assert f"verify failed{sep}global{sep}HTTP{sep}oauth — Unauthorized. Please check your API key." in plain
+    assert f"needs re-verify{sep}project{sep}stdio — Config changed; verify again." in plain
+    assert "\n  !" not in plain
+    assert "\n  ✓" not in plain
+
+
+def test_mcp_status_rendering_disabled_servers_do_not_force_warning() -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui import settings_panel
+
+    rows = _rows(
+        {
+            "id": "disabled-docs",
+            "name": "Disabled Docs",
+            "source": "global",
+            "transport": "streamable_http",
+            "enabled": False,
+            "oauth": False,
+            "status": "failed",
+            "tool_count": 0,
+            "message": "Connection refused.",
+        }
+    )
+
+    content, tone = settings_panel._render_mcp_status_text([], rows)
+    plain = content.plain
+    sep = f" {settings_panel.theme.g(settings_panel.Glyph.BULLET_SEP)} "
+
+    assert tone == "info"
+    assert f"1 MCP server configured{sep}all disabled" in plain
+    assert f"disabled{sep}global{sep}HTTP" in plain
+    assert "verify failed" not in plain
+    assert "Connection refused" not in plain
+    assert "tools" not in plain
+
+
+def test_mcp_status_rendering_no_servers_has_add_and_verify_hint() -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui import settings_panel
+
+    content, tone = settings_panel._render_mcp_status_text([], [])
+
+    assert tone == "info"
+    assert content.plain == "No MCP servers configured. Add one below, then Verify."
+
+
+def test_mcp_server_selector_labels_are_readable() -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui import settings_panel
+    from kolega_code.mcp.config import MCPServerConfig
+
+    http_server = MCPServerConfig(
+        id="context7",
+        name="Context7",
+        transport="streamable_http",
+        url="https://mcp.context7.com/mcp",
+        enabled=True,
+        source="global",
+    )
+    stdio_server = MCPServerConfig(
+        id="repo-tools",
+        name="Repo Tools",
+        transport="stdio",
+        command="npx",
+        args=["-y", "@vendor/mcp-server"],
+        enabled=False,
+        source="project",
+    )
+
+    sep = settings_panel._mcp_separator()
+
+    assert settings_panel._mcp_server_select_label(http_server) == f"Context7 — global{sep}HTTP{sep}enabled"
+    assert settings_panel._mcp_server_select_label(stdio_server) == f"Repo Tools — project{sep}stdio{sep}disabled"
+    assert (
+        settings_panel.SettingsPanelMixin._mcp_server_option_label(object(), http_server)
+        == f"Context7 — global{sep}HTTP{sep}enabled"
+    )
+
+
+class _FakeMCPStatusPanel:
+    def __init__(self) -> None:
+        self.updated = None
+
+    def query_one(self, *_args, **_kwargs):
+        return self
+
+    def update(self, content) -> None:
+        self.updated = content

--- a/tests/mcp/test_config_state_tools.py
+++ b/tests/mcp/test_config_state_tools.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -81,7 +82,8 @@ def test_server_fingerprint_ignores_enabled_and_source_but_not_connection_detail
 
 
 def test_status_and_oauth_token_stores_round_trip_and_redact(tmp_path: Path) -> None:
-    status_store = MCPStatusStore(tmp_path)
+    state_dir = tmp_path / "state"
+    status_store = MCPStatusStore(state_dir)
     status = MCPServerStatus.verified(
         fingerprint="fp",
         transport="streamable_http",
@@ -97,10 +99,16 @@ def test_status_and_oauth_token_stores_round_trip_and_redact(tmp_path: Path) -> 
     assert loaded.tool_count == 1
     assert loaded.tools[0].id == "search"
 
-    token_store = MCPOAuthTokenStore(tmp_path)
+    token_store = MCPOAuthTokenStore(state_dir)
     token_store.set_tokens("docs", {"access_token": "access", "refresh_token": "refresh", "id_token": "id"})
     token_store.set_client_info("docs", {"client_id": "client", "client_secret": "client-secret"})
     assert token_store.secret_values() == ["access", "refresh", "id", "client-secret"]
+    assert not token_store.path.with_suffix(token_store.path.suffix + ".tmp").exists()
+
+    if os.name == "posix":
+        assert (state_dir.stat().st_mode & 0o777) == 0o700
+        assert (status_store.path.stat().st_mode & 0o777) == 0o600
+        assert (token_store.path.stat().st_mode & 0o777) == 0o600
 
     token_store.clear("docs")
     status_store.clear("docs")

--- a/tests/mcp/test_config_state_tools.py
+++ b/tests/mcp/test_config_state_tools.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kolega_code.mcp.config import (
+    MCPConfigFile,
+    MCPServerConfig,
+    global_mcp_config_path,
+    load_mcp_config,
+    mcp_secret_values,
+    server_fingerprint,
+)
+from kolega_code.mcp.service import MCPService, mcp_tool_name
+from kolega_code.mcp.state import MCPServerStatus, MCPStatusStore, MCPToolStatus, MCPOAuthTokenStore
+from kolega_code.mcp.tools import build_mcp_tool_extension
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_load_mcp_config_merges_global_and_trusted_project(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    project = tmp_path / "project"
+    project.mkdir()
+    _write_json(
+        global_mcp_config_path(state_dir),
+        {
+            "schema_version": 1,
+            "servers": [
+                {
+                    "id": "global",
+                    "transport": "streamable_http",
+                    "url": "https://global.example/mcp",
+                    "headers": {"Authorization": "Bearer global-secret"},
+                },
+                {"id": "shared", "transport": "sse", "url": "https://global.example/sse"},
+            ],
+        },
+    )
+    _write_json(
+        project / ".kolega" / "mcp_servers.json",
+        {
+            "schema_version": 1,
+            "servers": [
+                {"id": "project", "transport": "stdio", "command": "python", "args": ["server.py"]},
+                {"id": "shared", "transport": "streamable_http", "url": "https://project.example/mcp"},
+            ],
+        },
+    )
+
+    untrusted = load_mcp_config(project, state_dir, project_trusted=False)
+    assert set(untrusted.servers) == {"global", "shared"}
+    assert untrusted.project_config_present is True
+    assert any("not trusted" in diagnostic for diagnostic in untrusted.diagnostics)
+
+    trusted = load_mcp_config(project, state_dir, project_trusted=True)
+    assert set(trusted.servers) == {"global", "project", "shared"}
+    assert trusted.servers["shared"].source == "project"
+    assert trusted.servers["project"].command == "python"
+    assert mcp_secret_values(trusted) == ["Bearer global-secret"]
+
+
+def test_server_fingerprint_ignores_enabled_and_source_but_not_connection_details() -> None:
+    server = MCPServerConfig(
+        id="docs",
+        transport="streamable_http",
+        url="https://docs.example/mcp",
+        enabled=True,
+        source="global",
+    )
+    same_connection = server.model_copy(update={"enabled": False, "source": "project"})
+    changed_connection = server.model_copy(update={"headers": {"Authorization": "Bearer token"}})
+
+    assert server_fingerprint(server) == server_fingerprint(same_connection)
+    assert server_fingerprint(server) != server_fingerprint(changed_connection)
+
+
+def test_status_and_oauth_token_stores_round_trip_and_redact(tmp_path: Path) -> None:
+    status_store = MCPStatusStore(tmp_path)
+    status = MCPServerStatus.verified(
+        fingerprint="fp",
+        transport="streamable_http",
+        source="global",
+        tools=[MCPToolStatus(id="search", description="Search", input_schema={"type": "object"})],
+        oauth=True,
+    )
+    status_store.update("docs", status)
+
+    loaded = status_store.get("docs")
+    assert loaded is not None
+    assert loaded.status == "verified"
+    assert loaded.tool_count == 1
+    assert loaded.tools[0].id == "search"
+
+    token_store = MCPOAuthTokenStore(tmp_path)
+    token_store.set_tokens("docs", {"access_token": "access", "refresh_token": "refresh", "id_token": "id"})
+    token_store.set_client_info("docs", {"client_id": "client", "client_secret": "client-secret"})
+    assert token_store.secret_values() == ["access", "refresh", "id", "client-secret"]
+
+    token_store.clear("docs")
+    status_store.clear("docs")
+    assert token_store.secret_values() == []
+    assert status_store.get("docs") is None
+
+
+@pytest.mark.asyncio
+async def test_build_mcp_tool_extension_exposes_verified_tools_and_uses_schema(tmp_path: Path, monkeypatch) -> None:
+    state_dir = tmp_path / "state"
+    project = tmp_path / "project"
+    project.mkdir()
+    server = MCPServerConfig(id="docs", transport="streamable_http", url="https://docs.example/mcp")
+    # The extension builder loads from disk, so write the global file after constructing the server.
+    _write_json(global_mcp_config_path(state_dir), MCPConfigFile(servers=[server]).to_file_dict())
+    config = load_mcp_config(project, state_dir, project_trusted=False)
+    tool_status = MCPToolStatus(
+        id="search",
+        description="Search docs",
+        input_schema={"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"]},
+    )
+    MCPStatusStore(state_dir).update(
+        "docs",
+        MCPServerStatus.verified(
+            fingerprint=server_fingerprint(config.servers["docs"]),
+            transport="streamable_http",
+            source="global",
+            tools=[tool_status],
+        ),
+    )
+
+    calls = []
+
+    async def fake_call_tool(self, server_id: str, tool_id: str, arguments: dict):
+        calls.append((server_id, tool_id, arguments))
+        return "ok"
+
+    monkeypatch.setattr(MCPService, "call_tool", fake_call_tool)
+
+    extension = build_mcp_tool_extension(project, state_dir, project_trusted=False)
+    assert extension is not None
+    assert extension.propagate_to_sub_agents is False
+    name = mcp_tool_name("docs", "search")
+    assert set(extension.tools) == {name}
+    assert extension.tool_schemas[name] == tool_status.input_schema
+
+    assert await extension.tools[name](query="kolega") == "ok"
+    assert calls == [("docs", "search", {"query": "kolega"})]

--- a/tests/test_mcp_permissions.py
+++ b/tests/test_mcp_permissions.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from kolega_code.permissions import PermissionKind, PermissionRequest, allow_rule_options, permission_request_for_tool
+
+
+def test_mcp_permission_request_and_allow_rules_are_exact_tool_or_server() -> None:
+    request = permission_request_for_tool("mcp__github__search", {"query": "kolega"})
+    assert request is not None
+    assert request.kind == PermissionKind.MCP
+    assert request.mcp_server == "github"
+    assert request.mcp_tool == "search"
+    assert request.summary == "github/search"
+
+    options = allow_rule_options(request)
+    exact_tool_rule = options[0].rule
+    server_rule = options[1].rule
+
+    assert exact_tool_rule.matches(request)
+    same_tool_other_server = PermissionRequest(
+        kind=PermissionKind.MCP,
+        tool_name="mcp__docs__search",
+        inputs={},
+        mcp_server="docs",
+        mcp_tool="search",
+    )
+    assert not exact_tool_rule.matches(same_tool_other_server)
+
+    other_tool_same_server = PermissionRequest(
+        kind=PermissionKind.MCP,
+        tool_name="mcp__github__issues",
+        inputs={},
+        mcp_server="github",
+        mcp_tool="issues",
+    )
+    assert server_rule.matches(other_tool_same_server)

--- a/tests/test_mcp_transport.py
+++ b/tests/test_mcp_transport.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from contextlib import asynccontextmanager
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from kolega_code.mcp.config import LoadedMCPConfig, MCPOAuthConfig, MCPServerConfig
+from kolega_code.mcp.service import MCPService
+from kolega_code.mcp.state import MCPOAuthTokenStore
+from kolega_code.mcp.transport import open_mcp_session
+
+
+MCP_STDERR_SENTINEL = "raw stdio MCP child stderr should not reach terminal"
+
+
+def _install_fake_stdio_session(monkeypatch: pytest.MonkeyPatch) -> list[object]:
+    import mcp.client.session
+    import mcp.client.stdio
+
+    errlogs: list[object] = []
+
+    @asynccontextmanager
+    async def fake_stdio_client(params, errlog=sys.stderr):
+        errlogs.append(errlog)
+        print(MCP_STDERR_SENTINEL, file=errlog)
+        errlog.flush()
+        yield object(), object()
+
+    class FakeClientSession:
+        def __init__(self, read_stream, write_stream, read_timeout_seconds=None):
+            self.read_stream = read_stream
+            self.write_stream = write_stream
+            self.read_timeout_seconds = read_timeout_seconds
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def initialize(self):
+            return None
+
+        async def list_tools(self, params=None):
+            tool = SimpleNamespace(
+                name="ping",
+                title="Ping",
+                description="Ping test tool",
+                input_schema={"type": "object", "properties": {}},
+            )
+            return SimpleNamespace(tools=[tool], next_cursor=None)
+
+        async def call_tool(self, tool_name, arguments):
+            assert tool_name == "ping"
+            return SimpleNamespace(
+                is_error=False,
+                content=[SimpleNamespace(type="text", text="pong")],
+                structured_content=None,
+            )
+
+    monkeypatch.setattr(mcp.client.stdio, "stdio_client", fake_stdio_client)
+    monkeypatch.setattr(mcp.client.session, "ClientSession", FakeClientSession)
+    return errlogs
+
+
+def _stdio_server() -> MCPServerConfig:
+    return MCPServerConfig(id="local-filesystem", transport="stdio", command="fake-mcp-server")
+
+
+@pytest.mark.asyncio
+async def test_stdio_transport_passes_non_terminal_errlog_by_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    errlogs = _install_fake_stdio_session(monkeypatch)
+
+    async with open_mcp_session(
+        _stdio_server(),
+        project_path=tmp_path,
+        token_store=MCPOAuthTokenStore(tmp_path),
+    ) as session:
+        assert session is not None
+
+    captured = capsys.readouterr()
+    assert MCP_STDERR_SENTINEL not in captured.err
+    assert errlogs
+    assert errlogs[0] is not sys.stderr
+    assert getattr(errlogs[0], "name", None) == os.devnull
+
+
+@pytest.mark.asyncio
+async def test_verify_server_suppresses_stdio_child_stderr(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _install_fake_stdio_session(monkeypatch)
+    server = _stdio_server()
+    service = MCPService(
+        LoadedMCPConfig(servers={server.id: server}),
+        state_dir=tmp_path,
+        project_path=tmp_path,
+    )
+
+    result = await service.verify_server(server.id)
+
+    captured = capsys.readouterr()
+    assert result.ok is True
+    assert result.tool_count == 1
+    assert MCP_STDERR_SENTINEL not in captured.err
+
+
+@pytest.mark.asyncio
+async def test_call_tool_suppresses_stdio_child_stderr(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _install_fake_stdio_session(monkeypatch)
+    server = _stdio_server()
+    service = MCPService(
+        LoadedMCPConfig(servers={server.id: server}),
+        state_dir=tmp_path,
+        project_path=tmp_path,
+    )
+    verified = await service.verify_server(server.id)
+    assert verified.ok is True
+    capsys.readouterr()
+
+    output = await service.call_tool(server.id, "ping", {})
+
+    captured = capsys.readouterr()
+    assert output == "pong"
+    assert MCP_STDERR_SENTINEL not in captured.err
+
+
+@pytest.mark.asyncio
+async def test_verify_server_reports_exception_group_leaf_and_suppresses_sdk_logs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    import kolega_code.mcp.service as service_module
+
+    @asynccontextmanager
+    async def fake_open_mcp_session(*args, **kwargs):
+        try:
+            raise RuntimeError("Registration failed: 404 404 page not found")
+        except RuntimeError as exc:
+            logging.getLogger("mcp.client.auth.oauth2").exception("OAuth flow error")
+            raise ExceptionGroup("unhandled errors in a TaskGroup", [exc]) from exc
+        yield  # pragma: no cover - required to make this an async context manager
+
+    monkeypatch.setattr(service_module, "open_mcp_session", fake_open_mcp_session)
+    caplog.set_level(logging.ERROR, logger="mcp.client.auth.oauth2")
+    server = MCPServerConfig(
+        id="github-copilot",
+        transport="streamable_http",
+        url="https://api.githubcopilot.com/mcp/",
+        oauth=MCPOAuthConfig(enabled=True),
+    )
+    service = MCPService(
+        LoadedMCPConfig(servers={server.id: server}),
+        state_dir=tmp_path,
+        project_path=tmp_path,
+    )
+
+    result = await service.verify_server(server.id, interactive_oauth=True)
+
+    assert result.ok is False
+    assert "GitHub remote MCP OAuth failed" in result.message
+    assert "Registration failed: 404 404 page not found" in result.message
+    assert "TaskGroup" not in result.message
+    assert "OAuth flow error" not in caplog.text

--- a/tests/test_mcp_transport.py
+++ b/tests/test_mcp_transport.py
@@ -9,9 +9,9 @@ from types import SimpleNamespace
 
 import pytest
 
-from kolega_code.mcp.config import LoadedMCPConfig, MCPOAuthConfig, MCPServerConfig
-from kolega_code.mcp.service import MCPService
-from kolega_code.mcp.state import MCPOAuthTokenStore
+from kolega_code.mcp.config import LoadedMCPConfig, MCPOAuthConfig, MCPServerConfig, server_fingerprint
+from kolega_code.mcp.service import MCPService, MCP_FAILURE_MESSAGE_GENERIC, _is_github_copilot_api_url
+from kolega_code.mcp.state import MCPServerStatus, MCPOAuthTokenStore
 from kolega_code.mcp.transport import open_mcp_session
 
 
@@ -70,6 +70,15 @@ def _install_fake_stdio_session(monkeypatch: pytest.MonkeyPatch) -> list[object]
 
 def _stdio_server() -> MCPServerConfig:
     return MCPServerConfig(id="local-filesystem", transport="stdio", command="fake-mcp-server")
+
+
+def test_github_copilot_api_url_matches_hostname_only() -> None:
+    assert _is_github_copilot_api_url("https://api.githubcopilot.com/mcp/")
+    assert _is_github_copilot_api_url("https://api.githubcopilot.com./mcp/")
+    assert not _is_github_copilot_api_url("https://api.githubcopilot.com.evil.example/mcp/")
+    assert not _is_github_copilot_api_url("https://evil.example/mcp/?next=api.githubcopilot.com")
+    assert not _is_github_copilot_api_url("https://api.githubcopilot.com@evil.example/mcp/")
+    assert not _is_github_copilot_api_url("not a url with api.githubcopilot.com")
 
 
 @pytest.mark.asyncio
@@ -145,7 +154,7 @@ async def test_verify_server_reports_exception_group_leaf_and_suppresses_sdk_log
     @asynccontextmanager
     async def fake_open_mcp_session(*args, **kwargs):
         try:
-            raise RuntimeError("Registration failed: 404 404 page not found")
+            raise RuntimeError("Registration failed: 404 404 page not found password=secret-token")
         except RuntimeError as exc:
             logging.getLogger("mcp.client.auth.oauth2").exception("OAuth flow error")
             raise ExceptionGroup("unhandled errors in a TaskGroup", [exc]) from exc
@@ -169,6 +178,39 @@ async def test_verify_server_reports_exception_group_leaf_and_suppresses_sdk_log
 
     assert result.ok is False
     assert "GitHub remote MCP OAuth failed" in result.message
-    assert "Registration failed: 404 404 page not found" in result.message
+    assert "Registration failed" not in result.message
+    assert "secret-token" not in result.message
     assert "TaskGroup" not in result.message
+    assert service.list_status_rows()[0]["message"] == result.message
+    assert "secret-token" not in service.list_status_rows()[0]["message"]
     assert "OAuth flow error" not in caplog.text
+
+
+def test_list_status_rows_replaces_legacy_failed_status_messages(tmp_path: Path) -> None:
+    server = MCPServerConfig(
+        id="docs",
+        transport="streamable_http",
+        url="https://docs.example/mcp/",
+        oauth=MCPOAuthConfig(enabled=True),
+    )
+    service = MCPService(
+        LoadedMCPConfig(servers={server.id: server}),
+        state_dir=tmp_path,
+        project_path=tmp_path,
+    )
+    service.status_store.update(
+        server.id,
+        MCPServerStatus.failed(
+            fingerprint=server_fingerprint(server),
+            transport=server.transport,
+            source=server.source,
+            message="RuntimeError: Registration failed with password=legacy-secret",
+            oauth=True,
+        ),
+    )
+
+    rows = service.list_status_rows()
+
+    assert rows[0]["status"] == "failed"
+    assert rows[0]["message"] == MCP_FAILURE_MESSAGE_GENERIC
+    assert "legacy-secret" not in rows[0]["message"]

--- a/uv.lock
+++ b/uv.lock
@@ -2,13 +2,14 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
-    "python_full_version >= '3.13'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
     "python_full_version < '3.13'",
 ]
 
 [options]
 prerelease-mode = "allow"
-exclude-newer = "2026-06-23T15:22:36.504632Z"
+exclude-newer = "2026-06-24T19:23:15.758172Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1122,6 +1123,15 @@ socks = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "hyperframe"
 version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1329,6 +1339,33 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
 name = "justext"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1372,6 +1409,7 @@ dependencies = [
     { name = "jinja2" },
     { name = "langfuse" },
     { name = "lxml-html-clean" },
+    { name = "mcp" },
     { name = "nest-asyncio" },
     { name = "openai" },
     { name = "packaging" },
@@ -1412,6 +1450,7 @@ requires-dist = [
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "langfuse", specifier = "==3.14.5" },
     { name = "lxml-html-clean", specifier = "==0.4.4" },
+    { name = "mcp", specifier = ">=1.21.2" },
     { name = "nest-asyncio", specifier = "==1.6.0" },
     { name = "openai", specifier = "==1.109.1" },
     { name = "packaging", specifier = "==25.0" },
@@ -1677,6 +1716,32 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "2.0.0a2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "opentelemetry-api" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/dd/b67a1bbcbb6bc4acf7b338ba721f1df9035a8091c3e5db90fc328ac170fd/mcp-2.0.0a2.tar.gz", hash = "sha256:6b1b594c7f714b36e73e8fa01c4e124fd122653d6cd71aae3610438d124d870a", size = 933507, upload-time = "2026-06-16T22:01:37.533Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/85/b1d60d818d46dfc20da642fc95b067c507c6eed59d77ad74b05c098060be/mcp-2.0.0a2-py3-none-any.whl", hash = "sha256:1d8a24e450300b2e671b53b051354c9964fdf0be85f3fdca0fe1733325136b5c", size = 286138, upload-time = "2026-06-16T22:01:35.592Z" },
 ]
 
 [[package]]
@@ -2477,6 +2542,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
+]
+
+[[package]]
 name = "pyee"
 version = "13.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2495,6 +2574,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -2575,12 +2668,43 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2026.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/f5/10a6e845a00fc5e7afd0a988b744f403d4d57162a28d160a093c4d9322f0/pywin32-312-cp311-cp311-win32.whl", hash = "sha256:17948aeadbdb091f0ced6ef0841620794e68327b94ee415571c1203594b7215c", size = 6362659, upload-time = "2026-06-04T07:49:21.349Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c4/dcd2d62b5944b6d5db53413a5899016ccd57ffcb7278f3f81655d25d2027/pywin32-312-cp311-cp311-win_amd64.whl", hash = "sha256:d11417d84412f859b722fad0841b3614459ed0047f7542d8362e77884f6b6e8a", size = 6928825, upload-time = "2026-06-04T07:49:23.934Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/56/3cbb433fe4501cdba2eb9040f56a4e1a8243faa4186b25295564d1a7a79d/pywin32-312-cp311-cp311-win_arm64.whl", hash = "sha256:b2200a054ca6d6625c4842fc56a4976a4b47f96b73dbe5538c3f813a80359f47", size = 6721875, upload-time = "2026-06-04T07:49:26.416Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
 ]
 
 [[package]]
@@ -2659,6 +2783,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/02/51/d3a6ea424652c60f05600d8c2e01a55c913755e7cdad64afabbd1aa16f44/readme_renderer-45.0.tar.gz", hash = "sha256:030a8fac74904f8fba11ad1bb6964e3f76e896dc7e5e71f16af190c9056696d1", size = 36172, upload-time = "2026-06-09T21:05:17.37Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/97/1b/295bf2fa3e740131778065e5ffa2c481f0e7210182d408e9a2c244ff5b0c/readme_renderer-45.0-py3-none-any.whl", hash = "sha256:3385ed220117104a2bceb4a9dac8c5fdf6d1f96890d7ea2a9c7174fd5c84091f", size = 14134, upload-time = "2026-06-09T21:05:15.85Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
 ]
 
 [[package]]
@@ -2815,6 +2953,143 @@ wheels = [
 ]
 
 [[package]]
+name = "rpds-py"
+version = "2026.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd735039a8f0b5b7e3b118232b5eae288c4fd9ab200d41094/rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256", size = 64459, upload-time = "2026-05-28T12:02:13.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/a0/acf8b6fc20bfdcd3a45bd3f57680fb198e157b7e997b9123b10763798bd2/rpds_py-2026.5.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:3397a5ed7174dc2786bb214030232fc36fe8e5584fec43a9952cc542b1a12036", size = 355609, upload-time = "2026-05-28T11:58:50.78Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/95/f8203fd997484b1690a6869cd0e503b6c3c6be55b0ecc36d1a491fe742f0/rpds_py-2026.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:99ab6ba7bfa2cb0f96a04e3652355bf04e3f51aceb1e943b8541dab7ba4828cc", size = 348460, upload-time = "2026-05-28T11:58:52.374Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8c/b47326ad2f0be545a5e5c1a55937a12afaea7d392ba2837bb9680f57e6c9/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0efbe45632665e53e3db8fe1e5692db58fc5cb9bab4459d570b83efefe11164", size = 381031, upload-time = "2026-05-28T11:58:53.775Z" },
+    { url = "https://files.pythonhosted.org/packages/22/0b/e83bbd97ffac6f6389b605cd4e1c8ac5761dc7e977769c9255d8c5adb7bd/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:01d17b29c0c23d82b1f4751147ec49cf451f1fc2554eb9ef5f957e55d2656ead", size = 387121, upload-time = "2026-05-28T11:58:55.243Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/0e/d285d1bc8864245919c61e1ca82263e4a66d337759c3a4cef72766ff9afc/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7559f72b94ae52659086c595dfa017cde03155f7832071d30959049052cb3ece", size = 501026, upload-time = "2026-05-28T11:58:56.788Z" },
+    { url = "https://files.pythonhosted.org/packages/86/06/ccb2109a1e543437b5e43816f2b43b9554cc6783145528a4e3711e05c011/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e25b7088f9ccbfc0dfcaa52bf969300ca229e10ecf758974ebcbb080a4b37bb", size = 391865, upload-time = "2026-05-28T11:58:58.298Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/33/237173db1cfef10105b3839a24de00eb8d2a523711add4632447cdf0aedd/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:613fc4ee9eaef26dc5840666214dd6fbcebcf32f46e76f4abc473059f4e13dda", size = 378012, upload-time = "2026-05-28T11:58:59.589Z" },
+    { url = "https://files.pythonhosted.org/packages/97/64/1eae54e34d5161f9969295e80bd6b62a55f2b6ac5f2a5b60d02c2140e758/rpds_py-2026.5.1-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:85264a90ff4c05c1568dd65f5921c837614b67c60358fb4c17df3b7f2e90690a", size = 391111, upload-time = "2026-05-28T11:59:01.104Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/34/5bb334a5a0f65d77869217c4654f34c78a7d11b93938a3c076a2edeafc52/rpds_py-2026.5.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe71bca7d547acb17027c7fd1624ff8aae623499c498d3e7011182c4de5c25e0", size = 409225, upload-time = "2026-05-28T11:59:02.433Z" },
+    { url = "https://files.pythonhosted.org/packages/16/0f/007ec21283b5b040b4ec3bd95e0402591e22bfa7d5c93dfe01c465c2d2d7/rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05fa4f41f37ec97c9c260441a940450a192f78d774d2b097eee1379f1e1246a", size = 556487, upload-time = "2026-05-28T11:59:04.012Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/10/5437c94508169b6b22d8418fef7a66e9ffb5f3b9e9c94460f2eedafe06ff/rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:df1d2a1996755b24b9ecee92cb4d36c28f86f464a6a173349c26bab41e94b8c2", size = 620798, upload-time = "2026-05-28T11:59:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d5/9937dce4d6bda74157b954e7d1460db05a22f5929dccfeeba1ed27a93df0/rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8895840ac4809e5f60c88fd07617cd71326e73d6e5a8aa783c5c0f7c24985de2", size = 584053, upload-time = "2026-05-28T11:59:06.837Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/31/750617dd0ae1752471bf43f9e41d263398fae7cde7849d23b8574a70e617/rpds_py-2026.5.1-cp311-cp311-win32.whl", hash = "sha256:3684a59b158a7683aaeb8e25352e9a9dd2122cec78f2d8530266e4f91b4c7b3f", size = 214390, upload-time = "2026-05-28T11:59:08.402Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/bb/3dcab0e1d9516303f2eb672a5d6f62eca5a69e2886301e9c8c54b520c39b/rpds_py-2026.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:7bd530e6a530bb3ea892f194fafa455f3516ac25ecf7143fd33c09be62b0470a", size = 231097, upload-time = "2026-05-28T11:59:09.786Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d6/c6bbf5cb1cf12b9732df8074b57f6ef8341ba884c95d40632ae8bddb44e4/rpds_py-2026.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:0a5ae4dbe43c1076983b72616496919872ae7bbe7a1e21cc48336bc3154d130b", size = 226361, upload-time = "2026-05-28T11:59:11.079Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e7/a78582dc57caa592dcc7d4fb69b61390561e908eb3d2f5df5928a8e354c0/rpds_py-2026.5.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3abe24a66e57adcfa645d718063a5fa5103ecc71ddbf26d78af8f9368018ff1d", size = 353040, upload-time = "2026-05-28T11:59:12.531Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/43/35e3f136343aef451e545ce8c38d36c2f93c0ed88703db8b64ba2b205c68/rpds_py-2026.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:58b1d94308ddf0b1982f61f2eb54bf92997c9ece8a8093ef014250f4a517906c", size = 345775, upload-time = "2026-05-28T11:59:13.827Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e1/0f2160c5982d3157734d5cb3ed63d8b2d583a73c9864f77b666449f32cf8/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fa92420128dadce7f54bd73ba1825a273e9268fe9e35dbf7e6362890efa4e08", size = 376329, upload-time = "2026-05-28T11:59:15.271Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/11/ee0ba42aff83bf4effdbc576673c6be64c5e173978c3f6d537e94482f77d/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ca653c6546386227cd9800d1bef6a348099acf8db4250341da6d90f663d6dfcb", size = 383539, upload-time = "2026-05-28T11:59:16.665Z" },
+    { url = "https://files.pythonhosted.org/packages/11/df/d94aa6a499d4ac40afe2d7620f2c597fd3c0f182e854ad7cf3f596a81cb6/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:66c93681c4729e4e3ecba31b8179fae083ff3118841672835140338b4b9867c1", size = 494674, upload-time = "2026-05-28T11:59:17.991Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/75/33d30f43bb2f458de11979486a591b1bf6e5651765ed1704c6197c2dc773/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40ff257542e04796880e011e15cd4dc21c2599975df2aaa8f2c8495ca574e1a5", size = 389268, upload-time = "2026-05-28T11:59:19.434Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/1e/2c9096fc19d5fd084b0184ca2b651e659aa0a37e6fdbecf6ece47f147fe1/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b6825cc329b290e93c5f6a9be2393118a763f6ccf6abd83704e0c102ca583644", size = 376280, upload-time = "2026-05-28T11:59:21Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e5/61ec9f8be8211ea7f48448195549e4aaf02004083475493b0e137702ecb2/rpds_py-2026.5.1-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:de42116e69cb53b911cc34aee5ab98f36c597b822545045d49e938818b99e5e4", size = 387233, upload-time = "2026-05-28T11:59:22.454Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ca/bcec1005c4f4a234f92a29078631fee49206c7265ccae966f18fd332e80e/rpds_py-2026.5.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c0f920015df2a504bebaba6d4c31ccf3fcf942f92655c086da30b671aad19aa6", size = 405009, upload-time = "2026-05-28T11:59:23.845Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e6/4d5718c5cf26c522dc7c9999e238da1e77380b81d0c5d1df11e271ddfeb1/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0408a24e44feb919423dc6d9da677cb5cddb894d2ca9e763967d156d9c60fab4", size = 553113, upload-time = "2026-05-28T11:59:25.184Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/25/2ee807bdb3e1f0b7eddf7782acd5665a8b5205a331a7d7244a52c4812fd9/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cea68bcd53467561ae2f96a6bdad1544299ba97b5b0ddcd5ac3d376e5c781c24", size = 618838, upload-time = "2026-05-28T11:59:26.749Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c1/7d4c26f167f8c41501cc073d30ee22082b16ce358cf5b00ec97cbc7804ea/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4be8b1d2a705cc37d08256004e1d07de143fa0075c8e85a3df020b776f62b732", size = 582436, upload-time = "2026-05-28T11:59:28.11Z" },
+    { url = "https://files.pythonhosted.org/packages/04/1d/9d12b0a337bab46f4769f8857f4007e3b2d639e14f9a44a0efe157696e64/rpds_py-2026.5.1-cp312-cp312-win32.whl", hash = "sha256:6736718bd4fc49cbcb538ba30516fdbef161522acefb739657d48b97bd864fed", size = 212734, upload-time = "2026-05-28T11:59:29.689Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/93/e4116f2de7f56bc7406a76033dc501811ddeb22b7f056b92d632871ebb0c/rpds_py-2026.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:0a7d1eec967df0e9b22614a5e177622e0c89611d03727fa0cb48e45028907870", size = 229045, upload-time = "2026-05-28T11:59:31.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/53/6c3419d85eb2ec5938a37627c585b42d76a63bb731d6e42ed4b079ebf486/rpds_py-2026.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1841d067089e117142d79b98aa0df2f08b52f2ecc1819dd2700636c0db74a473", size = 223967, upload-time = "2026-05-28T11:59:32.318Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/32/14c961ad295f490eb0849ada8b79683e93a59b9de3afdd983eaf55fa6867/rpds_py-2026.5.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:efef4ac29c6ff495531eb17ee705b62841ecaa291b7c7077e848ea03e237164d", size = 352787, upload-time = "2026-05-28T11:59:33.655Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/bb/d1b85117967c11191441a7274ae616c65d93901d082c588f89a50a8da5ae/rpds_py-2026.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c39f5b67a8a2e67179ada2a954227d670fe65fa9098457f698f56ddf248709b3", size = 345179, upload-time = "2026-05-28T11:59:35Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/46/d84105f062e626a1b233f863907288a4708c2d833b8b4c6fb2764bc080c0/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5c30f3f04eef4fbd362226a6f31d7c8895ca4fbb6e0b790f6890a98d8da8559", size = 376173, upload-time = "2026-05-28T11:59:36.43Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/469d7959ce5b1201e1de135dc735b86db3b35dd0d1734f6a44246d5f061c/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:277f6c82f0580848796c7ecc8a7173aa3bfb928e4ff831261c2f60a81dc270db", size = 383162, upload-time = "2026-05-28T11:59:37.995Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/a2/57853d31a1116a561aa072794602ad3f6341e18d70a8523f1bd5b9fc1e5a/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:63c2c4c213f1a4e3f3de28ecab029dbdee976324e729c0d7a55211be72576b02", size = 495093, upload-time = "2026-05-28T11:59:39.453Z" },
+    { url = "https://files.pythonhosted.org/packages/99/63/3a8eabcad9314b7daf5c65f451d2c33d989235cd8a5762186cf2c3f5a4f8/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3350ec808fb538fe71a1f94dfaa0e29c598dfad805ce49f0caec5ae3183c652b", size = 389829, upload-time = "2026-05-28T11:59:40.896Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/25/05678d97fc25e2622df14dc530fb82023174ecfff6733991ed0d78f167bd/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b1b964e3ab599e718dc46c018d104b1ebc007cbc6567d827c94a687fca56d77e", size = 374786, upload-time = "2026-05-28T11:59:42.626Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d1/8c90b6431e80a3b91b284a5c7c8c0c4f9c006444d90477a740d6e0f9c694/rpds_py-2026.5.1-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:19cb09fab7b7fc96b2a6e28f2e34b72a3705ff27b37edb77455316e5d3f3dc9b", size = 386920, upload-time = "2026-05-28T11:59:44.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/99/4638f672ab356682d633ee0da9255f5b67ce6efd0b85eb94ad3e255e65a5/rpds_py-2026.5.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:abe76bcdba31e576cb83eeb8797aa0d882b738fef6dc65d0601fc753806a5b46", size = 405059, upload-time = "2026-05-28T11:59:47.177Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3f/3546524b6eb4cc2e1f363a3d638fa52f6c24faae3500c25fb488b02f1740/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8bff7073db3899158fff55ebf57b113a67030af26f80a18978f9f0aa60250ddf", size = 553030, upload-time = "2026-05-28T11:59:48.603Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/c3/7b3388c796fcf471bd17194242d4dc1a7608567c0fa422bcc1c5e79f9c1e/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8ba264fa49be666cd9cc56bf34ec7002fb3d27a4aee5bcb4d43d0d18feb1bb6f", size = 618975, upload-time = "2026-05-28T11:59:50.314Z" },
+    { url = "https://files.pythonhosted.org/packages/61/1e/a3cb07f2795075d1d88efddae2f541359fde5f08c81ee114c29c2949c90a/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4860b603ddda0475a8885499b3729e90229d480105b42651962a5397d995fa89", size = 581178, upload-time = "2026-05-28T11:59:51.673Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/74/e758c03a5ef46f04c37f2651a2893db846d569ba8a7bca469d4b58939bcd/rpds_py-2026.5.1-cp313-cp313-win32.whl", hash = "sha256:7944270ae71383f6e2657dd7d5ce4eeb4ac2d0059a6738f0510583d462ab4842", size = 212481, upload-time = "2026-05-28T11:59:53.148Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ec/a2aca432db9c7359b40fa393eeeaa0d166c2f70175be956e75fa24197c44/rpds_py-2026.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:88647f43a73c4e01be19b04ceef0c8d3a1958153604d13c773becd8016f2a0cf", size = 228519, upload-time = "2026-05-28T11:59:54.505Z" },
+    { url = "https://files.pythonhosted.org/packages/29/60/a73bfdd45b096574556acf303bbd9fa9eed36ca8a818b514e2a5d5fe2b9d/rpds_py-2026.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:453895624ecf7db7063b1004e44037522bbaef9ff6a945e59bc71662d7a03abd", size = 223446, upload-time = "2026-05-28T11:59:56.081Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e2/408105fd611823f00882aea810f3989a30d26b1bab8b6beb20f98c724e0e/rpds_py-2026.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:b4e4bc98639ec915f512fde3aa7a95e0041d95d9c3cc86eea841fa63cb1e8600", size = 355287, upload-time = "2026-05-28T11:59:57.448Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/58/5c4a43436843c90d0f6d19f82c200c80e3843ca9fa07b237623327f6d384/rpds_py-2026.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cacedb7a6e167680acba45ad5716e89067d225dc80da0d7040cae8c81d4572fa", size = 347033, upload-time = "2026-05-28T11:59:58.881Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c2/1a71acdacaf4e259b10278fb87b039ded3cf80041bcd89dd8a3ea702ded6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68700371c5d7ae1412862ddfa719090925c93ecf351c566d66f09d04b136ea00", size = 376891, upload-time = "2026-05-28T12:00:00.516Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c8/535f3d9b65addd8e28aa87b83c6e526799c3717a88273db8ea795beeef7a/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:296c799becfa849c779c8725494fe9ed94959ed886787df4364b058465bad7f0", size = 385646, upload-time = "2026-05-28T12:00:02.394Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/91/dc033f313345c354ade914dbe73cdb90b615a4409ea02430d5356794f3d8/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d3858b908218ee108d0bbfb2095ccc237648053c9bf98affad7cb079acaf1d97", size = 498830, upload-time = "2026-05-28T12:00:04.189Z" },
+    { url = "https://files.pythonhosted.org/packages/27/fc/90fcbea459dbb8ddc18a2e0fd1de9412b48bc84ffff2db771cf714bacfd6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4fb8d2e7cb2f850b169806d61d1b991738acec96500a75c30f49caf064ce7cef", size = 392830, upload-time = "2026-05-28T12:00:05.797Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/46cd11a228c9750684a798d98f878be6f614aa762438da7378f035e79e35/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27b74c10ed6a8f190f4287f53bcfea348b92a84a9c9f70d30183d1e6172d580d", size = 379613, upload-time = "2026-05-28T12:00:07.433Z" },
+    { url = "https://files.pythonhosted.org/packages/24/4a/d9b0c6af3a1de03eb93741bbe8be2bdce84d8fda8224f3005451d86df389/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:b9a6528956191c48c52294a592dbd4a8386d7048bdb25c0efcb6b966466c6d83", size = 388183, upload-time = "2026-05-28T12:00:09.227Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b4/db7aaabdda6d020afc87d981bcc2f57a434c7dec60ecfc2ab3dd50b20351/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:af03e34e860047bc7a352b842856fcf78798fbb81132cc98bd2f907ab4eb9cd2", size = 408578, upload-time = "2026-05-28T12:00:10.779Z" },
+    { url = "https://files.pythonhosted.org/packages/08/d6/070f6a41cbb343e2ac4171859bf3f3623e0ab002f72619d6d505313ec2de/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fea6e836d10abbe191d557d33bd58bd5987725fe63aa1eefe557d230209855bd", size = 553573, upload-time = "2026-05-28T12:00:12.443Z" },
+    { url = "https://files.pythonhosted.org/packages/75/ab/1a71ea3589c4345dac0a0518f0e6a031cb42689277851b683c46d27463a5/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:fc0c0f878ea770a0a8a462456c5ad36fc9fe6358e6b76fdadc7f17575e0b8bf1", size = 620861, upload-time = "2026-05-28T12:00:14.09Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/22/9bf80a56069c0c443fcfefac639a86a744550a2898817a6dfd3e26654924/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e0b360f316d966b048b085857630b3cc51f3db2f07b06f440eac8f695374d1e3", size = 585633, upload-time = "2026-05-28T12:00:15.66Z" },
+    { url = "https://files.pythonhosted.org/packages/da/68/3b2c0a75c9e04125696f84ebdbbf304acf5a40b58ba4481cdb98a922c3ba/rpds_py-2026.5.1-cp313-cp313t-win32.whl", hash = "sha256:a2999883eedf72fdfb7520b92c7d4ec2572a71ff40239377aa604cc529eecafc", size = 210074, upload-time = "2026-05-28T12:00:17.291Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/8b/609157d5a25d37d4f29f92840ba531f416907c34ae5c5739dd21fc2bef98/rpds_py-2026.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e07be2a9d7122bd6e82dea89814ef8dc893feb1aae97fec1630f3263bbb30e55", size = 228635, upload-time = "2026-05-28T12:00:18.73Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/6f/19c1918a4b590d8de87e712e4abe4b3875771eff60216fb6153cf6665c68/rpds_py-2026.5.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:1f2c391c3059798093b65df23aca2cac150460ae9c630d99dec83d703d9485b9", size = 349756, upload-time = "2026-05-28T12:00:20.217Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/60/a06fe7da34eca79dacbf958a2ba0c6eea85bc2b29de20080bf40f72f66fa/rpds_py-2026.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:413b424f7c4ee65ab5e5be91f5731be0f8b41a1ee2b12dfe810d716312e95a78", size = 343831, upload-time = "2026-05-28T12:00:21.711Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ec/b2333b97b90e2a6ef6ca8ad386ee284968e74bcfe113b3f1a8d9036429a9/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c595a1d9255dce0599e13130d1440ab2506654f2b50294226ee06402f8fef63", size = 375127, upload-time = "2026-05-28T12:00:23.326Z" },
+    { url = "https://files.pythonhosted.org/packages/14/7f/e00aae54067f2b488c4637961d5f58204d470795fc791085fa3f15060d2e/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1c27c5f6102eac8c03e7595a00827a53b271ba40a53b59ff8709170e0855ea4a", size = 379034, upload-time = "2026-05-28T12:00:24.89Z" },
+    { url = "https://files.pythonhosted.org/packages/be/cc/423999bbb8ae8dc93c77fc1d5e984ade5eb89d237d3bb884ccfa72ae2890/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c7fcf61d44cacecaf3aea542b0e053db77972a4573e7ceda16fb2b399161195", size = 490823, upload-time = "2026-05-28T12:00:26.676Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/aa/c671bf660f12e68d3c52ff86c7066ed1372df5a0f4f2ff584e419b8207e7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2c817a189d4ee14290420e5ff051e4dd6baa13f3edf84685071dee07a6d538ee", size = 388144, upload-time = "2026-05-28T12:00:28.577Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c8/d63bb75b68afe77b229e3021c6031bcaf01da5db5b0e69d0d10f9ba679a7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21846aac0ed2e0589f38c12dc44e77bb64e494b771eadbcf169cba00566ba7ba", size = 371959, upload-time = "2026-05-28T12:00:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/c51122014d8274ff37dc606d60049c3db7d83da02b5b282511e5a906a9a6/rpds_py-2026.5.1-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b317c87a13f769a4e787819bd508aaa5d69aa09b0880de9af6d3a8a54571cdec", size = 383558, upload-time = "2026-05-28T12:00:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f9/2790cb99c136a5363acdeacf5c27c56f3de0d4118a1f48fca83404c99c89/rpds_py-2026.5.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ce87129d9f2c14fa6c4a8601fb80eb4488c80d38a20cd13758ef11123e14995d", size = 402789, upload-time = "2026-05-28T12:00:33.247Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1b/e4fb584f8c75d35c38150ff6a332cda949e6f97acba1f4fd123b14ab56fe/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9cdddb6c1207d284d94fd1530adf57fbd797fe7c4b8704ba85f49414f2557e7d", size = 551405, upload-time = "2026-05-28T12:00:34.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f7/a6731b4216cb3793ea1af5391da240f5683dacc0d13e034fe5fc3503f240/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:4e237e139f94d3c036fd28eb9f564c99055476ff4ff05cd42be55ce349b5aa02", size = 616975, upload-time = "2026-05-28T12:00:36.268Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/2e051a81d95d8e63f4b35a1c463a87e8766bc3d083c067c5dfb6bf220747/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ed0954b524873214369184a9c82b0eaa45a3fbb9a798cd95b17e0d98499e7ea0", size = 578701, upload-time = "2026-05-28T12:00:37.82Z" },
+    { url = "https://files.pythonhosted.org/packages/65/56/b5f6fdb2083e32bca8a8993d89e70db114b4756c9e2c38421328126689d2/rpds_py-2026.5.1-cp314-cp314-win32.whl", hash = "sha256:2d88621d6a7d4dfa633d21abe90f280bb205274e16b1d1e61c6ad4640b2453b7", size = 209806, upload-time = "2026-05-28T12:00:39.492Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/80/65a5aa96c155e611d1ed844e4e1f57f3e36b021f396d9f8585d756e6b90d/rpds_py-2026.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:cef8ac28d26f4dda3533060c20fbf80a325458fa9fd23ea72a73cdfa8e978838", size = 225985, upload-time = "2026-05-28T12:00:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/27/7c/ad185212e87b05f196daef92bc5f3caf07298eb47c295b5585c3dd3093ac/rpds_py-2026.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:eaaea962c68cdc68d4a533ba985ab8e9484277910bbfaa2ab3ef7732667bfed8", size = 221219, upload-time = "2026-05-28T12:00:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/23/58/e14ae18759020334646b031e708ab4158d653a938822bfb7b95ef2e93aa3/rpds_py-2026.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:21942f52dbbd5f8758bf021213d28bd45c39e873e65e2407faf5f1846f5761ad", size = 352148, upload-time = "2026-05-28T12:00:44.638Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9b/5f4a1e2f960bca3ac5d052b139dd31eed97b259f9d909173821760d542e8/rpds_py-2026.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f414556f6e3958300ff941e40c9f97e3dc9774ddd1b3434c475d73dd354bbed3", size = 345196, upload-time = "2026-05-28T12:00:46.14Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/71/1d9574d6a2fa20ab60eaa55c7467f5aa20cbc770f341a05f09c0876f59e2/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef1013a8625c74043210190b246f5b1551e09757c1f356c6e4160ef96c5bc081", size = 374981, upload-time = "2026-05-28T12:00:47.531Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/37e99f4915a80aa71670263c1267f7ae0af95f53a3f61e6c3bdc016d4515/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cc68e231a77a5f0d774ae278a1f8e55c0456501820847c1e4efb3829f3441df6", size = 379961, upload-time = "2026-05-28T12:00:49.216Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ff/6e73f74b89d2e0715e0fc86b7dde893f9a61ae2f9b256ff3bdfe41ac4e94/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9baffb505aff33acc69b422a19f77806680f3c8632227d79f48de8a810d1c2c5", size = 495965, upload-time = "2026-05-28T12:00:51.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/e0/425faba25f59d74d4638b267f7c7a80e8649d2ef4db10a19b0c4a71e6e6f/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8d2f912928d426e8cfa396f7f3f8d29a59e6689c86dcca3c420730c1096322b", size = 389526, upload-time = "2026-05-28T12:00:52.77Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/76/7a41960e3fddae47fab43a28684d5da981401dffd88253de0944148654cb/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90f628283be835db980c941767d41c9a27b5239e54ba0a9c1335247e82406964", size = 376190, upload-time = "2026-05-28T12:00:54.215Z" },
+    { url = "https://files.pythonhosted.org/packages/27/60/5f38dc70824fc6951b51d35377e577a3a3a4c81a6769cc5a2de25ebe0ad1/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:1ebb2f0ab7e16132995a72de805170e0203df0c3dd22e1ef1cd1fdd90bd7a131", size = 383921, upload-time = "2026-05-28T12:00:55.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1a/d60a38caa1505f4b9483c3fbbde12c94e1079154f4f401a6da96f7e77621/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f3df3d16ded76f1f8c9cdebd0e1ea55fdf4c23b812de189814da7cf229c22a81", size = 404766, upload-time = "2026-05-28T12:00:57.518Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ff/602fd3f174d6425f0bce05ad0dfbec0e96b38d0f7d08a79af5aa20083885/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9af8905b8f854990e40d5206aa5ac58d9b0fe0b7f351ff2bb086c20f6c8c6a47", size = 551343, upload-time = "2026-05-28T12:00:58.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c1/1be13327acdbead3eca1fde03b6a34dbb011f1e864e217f0d32cc1779a7f/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:036a36a87fb1cd3b214d11c4b3c4f7d2ddad933625dca1c900b56a057c07740a", size = 618502, upload-time = "2026-05-28T12:01:00.656Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d7/afb49b49d7f2be8b7ba1a9f0977fa5168003437b93086726f066544e8351/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:62ae3853454fe9ef283a03c96c2d835d39e84b14643a9d62c82ef0fb87d702ca", size = 581916, upload-time = "2026-05-28T12:01:02.22Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d1/dbef8c1f8a10f07beb62b5f054e20099fd9924b3ec001b8f0b6ac7813a85/rpds_py-2026.5.1-cp314-cp314t-win32.whl", hash = "sha256:6c3d771a46ec18b12af06ce36243a9a80b07a5d0515236332d90863ca8bb326a", size = 207855, upload-time = "2026-05-28T12:01:03.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/72/bfa4e61ab8e7dc1c8adf397e05e6cbdd4239357bd72b248d3de662f23915/rpds_py-2026.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c93c629be4636cf54337bd5f06c104d55e42ced54d681f6fe21ae510a65116f6", size = 225422, upload-time = "2026-05-28T12:01:05.194Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/7b5da92b640f67b6717ccafc83cdd06bfa7ff2395c3685c68922bb54d703/rpds_py-2026.5.1-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:3574b55c604b8f75dacb007136508bbc0db406e626301778096a133327e7f2fb", size = 349576, upload-time = "2026-05-28T12:01:06.722Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8a/2aafd7ad355a1bd48ca76e2262b74b15e6432b5a1efe150efd4d779cd55d/rpds_py-2026.5.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:94068eb3ae6d43f5a786b7db96a406a34e6d5c24489feef32fd6e8946ea7b291", size = 343640, upload-time = "2026-05-28T12:01:08.441Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/7d/6c9523c1abbe840a1b7fba3c516d48e1d3487cc80fea4366c4071cf56784/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3a5b10e8ce894825f380a8f1b6444cf73c294dfea62afbb2d13e3a9e630cec1", size = 375322, upload-time = "2026-05-28T12:01:09.934Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5d/0b7b03fb1dc509321f01de3149784ab773e34c8573022029af8076afcb9c/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fc09f82e63d4bcd58149572f857a431bae851dc747e313c3b5bdf7abb907fda8", size = 379066, upload-time = "2026-05-28T12:01:11.48Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/e2/8ef6012999ebf1cb1c22f876d9ce5e63d960fd4631d2af3202d3f480aa25/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e10464d17df3b582745c25cec695cb9558bca2cb6ddb631aee1787fc72c767b2", size = 494586, upload-time = "2026-05-28T12:01:13.051Z" },
+    { url = "https://files.pythonhosted.org/packages/80/af/1eeb029bec67582c226b7809172207cd005073af4ebd906e65ff494f4983/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ba05adbf15d994c38ec0b7ab32e858e5110c21e9009a00a86545fd220f84e038", size = 388415, upload-time = "2026-05-28T12:01:14.631Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/ffbe10711c4d766c1cab0557d6906c074f795814863c67b351355d29354a/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77c004fdc7b891967106f78ddfd7b076bfe6813c6139c6fff6aed3bcaa960b26", size = 372427, upload-time = "2026-05-28T12:01:16.153Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3a/30ba4a6ad457e5b070c18d742a33fb77d8d922b565cc881f8a5313d63bfe/rpds_py-2026.5.1-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:83bcf894486c9d78dd290d3c0124ff6dd8875d3025e2090a8ec49fcc37c55fdd", size = 383615, upload-time = "2026-05-28T12:01:17.809Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/69/62e242b53ce39c0814bd24e1a6e6eba6c92be716277745f317f9540a2e7b/rpds_py-2026.5.1-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c3df104083952a0e0c6f10de33e440eabe98fb6317d23e1a58c68f6df08d01b9", size = 402786, upload-time = "2026-05-28T12:01:19.419Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c1/a770b9c186928a1ed0f7e6d7ae50e7f3950ed23e3f9e366dbc8e38cb55de/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:980450826cf22e133c57e0835070bdd0dd3f73b9b708c3ce223def2cb9469e14", size = 551583, upload-time = "2026-05-28T12:01:21.013Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7c/68e8579b95375b70d2a963103c42e705856cdb98569258bd807f4423891c/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:205dde846f24332ab0c1188699a043b8d165b79bb84529ce272c45048ff6be01", size = 616941, upload-time = "2026-05-28T12:01:22.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a1/a6135aed5730ff03ab957182259987ac11e55fb392a28dc6f0592048a280/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:3966b82dd563176396df030f3dd52a6e54cb69b718e95e78bd555ed3d1e0185d", size = 578349, upload-time = "2026-05-28T12:01:24.118Z" },
+    { url = "https://files.pythonhosted.org/packages/09/6e/f24201a76a84e6c49d0bdfdfcb735210e21701e9b21c5bfc0ba497dd62f6/rpds_py-2026.5.1-cp315-cp315-win32.whl", hash = "sha256:7818f8d0a415be74d2be3590b0a1c1f463a642f4d0217e7d10602dceef5b79aa", size = 209922, upload-time = "2026-05-28T12:01:25.522Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e4/966bc240bb0485fc265278f6de44d05834bf0b3618886e0b22e33d54c49a/rpds_py-2026.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:b3cc20c0d800af78fd0fac68086e28c1856cec51ea528bb81ea851aa40d39325", size = 226003, upload-time = "2026-05-28T12:01:27.062Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/5c/a15a59269cd5e74472734516c73795c15eccfc841b3d4b0228c3f53f19d0/rpds_py-2026.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:3609e9939a8a76cd904cf98a3f1f13b5dc7e150adeaee89e0ea09652ea213e16", size = 221245, upload-time = "2026-05-28T12:01:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/135ce03804e179a71ceb13be095deda4a279bc88f7a6b8fa161c5ad44e12/rpds_py-2026.5.1-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:5d333a7127d4b307601ac37792bee01bb95c867cbfacf21b6375b804d6bbd723", size = 352015, upload-time = "2026-05-28T12:01:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/f1f6d2652eb9d848f6eb369d8db83a2da6249bb49ad2c2a48f45d54538d3/rpds_py-2026.5.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:b5f077b44a4f7808520f66dae234988d867deb9aed9be5da057ce9ba831b2a41", size = 345016, upload-time = "2026-05-28T12:01:31.656Z" },
+    { url = "https://files.pythonhosted.org/packages/88/66/b74182775691ea2290c99e52ac8d5db844e56fbec90ce421f107658c8314/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55d8f9b7b78c9538fc9e04e82ec0e888ff0c3cffcfad152c77e57cd09351a98a", size = 374775, upload-time = "2026-05-28T12:01:33.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8f/15e5a61d9f0a43902d36561d4f07cae6ae9f4716be825159fd72717f33af/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e3a8ae58895ac107ed934a6bf51e5846f95c53b9b940c2c6d310838fd5846358", size = 380270, upload-time = "2026-05-28T12:01:34.574Z" },
+    { url = "https://files.pythonhosted.org/packages/02/c3/f859b12763a80540cdf2af0f15b19904cf756a71d7bdd3f82ff3e5b1bbf9/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0957cf3c2b8632ec7aaebffebea8005b353cc2a237b6e2ae3c2cac0820704cfb", size = 495285, upload-time = "2026-05-28T12:01:36.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/ff27c2ac8411d30b03b1829fd88cae8dad1a4d0da48dd25e57c4038042e6/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c396c1304de421050b3681ea70f371874b54d41b0151e96109758144c231e30b", size = 389581, upload-time = "2026-05-28T12:01:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/67/fe92ee32a6cc05c77228a2f8b1762e7124f386ec20ff83d0757b762d58d0/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aad1bff7f666b9598e573815affd666aac6a13a585dde336f843e33350c7fadc", size = 376041, upload-time = "2026-05-28T12:01:39.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/b4d6685c27aba55bd82f25b278be8237038117d05f9659a6213ad3408130/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:656a042550878f12d45752452d47094b7cfe5ad1e9d7b87b5a22ad3ae5ff8015", size = 383946, upload-time = "2026-05-28T12:01:41.043Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/79/2c1d832a53c8e0f8e98fc970ec257b950fecd4f62be2ab7182b500a0cbc8/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:73c4bd4f70294737b5206a3e8e30ccadbf8a60301831c8ea23eec5dbeea1ecfa", size = 405526, upload-time = "2026-05-28T12:01:43.032Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c4/c98117b03c6a8581ab2c2dfccfe9a5ad82bd8128a3c28b46a6ad2d97c393/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:43bca78665423cabae77146f2fe7ce55272b6c8d55d82cca83effd42c7e13972", size = 551165, upload-time = "2026-05-28T12:01:44.648Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c1/bc479ca069200af730881b1bd525e3114b2b391a351509fcb1b772f28086/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:42d0f20e85e549c870749d0e247f0c10d318a45b7e9676d575d2dcb04a1b2e66", size = 618778, upload-time = "2026-05-28T12:01:46.337Z" },
+    { url = "https://files.pythonhosted.org/packages/77/65/38ab2f90df44c2febfb63cc10ced40763d9b4bc94d173e734528663fe7f5/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b1be5c35683684d5331b93600c210e8367c254683d8a6df6bd21bd2da3a334fb", size = 581839, upload-time = "2026-05-28T12:01:48.109Z" },
+    { url = "https://files.pythonhosted.org/packages/15/2d/ce1f605fe036aadd460e5822e578c6c7ec3a860936cca37d6e0f299daa77/rpds_py-2026.5.1-cp315-cp315t-win32.whl", hash = "sha256:75808f6c38ce7749bb68cc2770161aae5045e6c6f6781a9782e74b93304399df", size = 207866, upload-time = "2026-05-28T12:01:49.648Z" },
+    { url = "https://files.pythonhosted.org/packages/79/cb/966040123eb102371559746908ef2c9471f4d43e17ec9a645a2258dab64b/rpds_py-2026.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:90bd6630002a1c7f09e7843dd79f0d24f3d2897cc25a753480917865d14f15b3", size = 225441, upload-time = "2026-05-28T12:01:51.408Z" },
+    { url = "https://files.pythonhosted.org/packages/42/56/3fe0fb34820ff667be791b3a3c22b85e8bcba54e9c832f47438c191fa7be/rpds_py-2026.5.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:edf2765d84e42447f112ad877af8fe1db0089aaec5b28e88d6eab45e7fe99cea", size = 357151, upload-time = "2026-05-28T12:01:53.43Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f2/3eb9ccdb9f143b8c9b003978898cb497f942a324c077401e6b8834238e63/rpds_py-2026.5.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ad3773236e95f7f33991eb125224b7da66f206504d032a253a02da7e134519fb", size = 350195, upload-time = "2026-05-28T12:01:54.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/24/dbda232bc4f3ed732120692ab0d2c8402cb020516556d8bee622dcef2413/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a04df86b3f0fade39ec8fd0e0aab089b1da9fbd2b48df778a57ef96f5e7d38df", size = 381850, upload-time = "2026-05-28T12:01:56.601Z" },
+    { url = "https://files.pythonhosted.org/packages/40/30/32e769839a358f78810c234f160f2cc21d1e4e47e1c0e0e0d535be5a0219/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6142dbd80c4df62a5d899f0d616d417f84e0bc8d32526c8e5589019d75d028a7", size = 387899, upload-time = "2026-05-28T12:01:58.212Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/86/ec84d243aadb3b34b71dd26a010d0930b2d284ff5fc9a69fec53810ee6fd/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0b35217adefe87f2fe4db7e9766cabe84744bfe9616d9667be18988928c7f2dc", size = 501618, upload-time = "2026-05-28T12:01:59.888Z" },
+    { url = "https://files.pythonhosted.org/packages/74/25/b60e52686bbff777a64f9e4f4d3dd57980dc846913777177a2c92e4937aa/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b95d5e11fc712b752081183a55a244c03cd00570489edd7014d8899f8ceb8162", size = 394003, upload-time = "2026-05-28T12:02:01.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/c7/b3a6a588cc2219510ef3f42e207483a93950bedd1e3a0fd4015c95cff9e5/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:141c9498daf2ace9eda35d2b0e376f9ea8b058d84f2aef4f96fccfd449a2f251", size = 379778, upload-time = "2026-05-28T12:02:03.197Z" },
+    { url = "https://files.pythonhosted.org/packages/31/00/c7dba3fc8a3da8cb3f6db1eb3386be4d79c2e97c6890d20eb9ac66ae8c43/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:6f249f8b860a200ad35193af961183ebe9132710484e6f6ce0cf89fd83c63a9a", size = 392359, upload-time = "2026-05-28T12:02:04.817Z" },
+    { url = "https://files.pythonhosted.org/packages/93/dd/472ba494c70753f93745992c99855bee0636daf74e6984e5e003f150316f/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e4abbf391a70be864920858bf360f4fb380577c9a0f732438a1996726e2c195b", size = 412820, upload-time = "2026-05-28T12:02:06.401Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/6f/93831a3bfe789542ed0c1d0d74b78b440f055d6dc3ea4640eba2d95e6e23/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:c74005a7bb87752acf351c93897ec63ad77a07a0da7ecad9c050e32e7286ba34", size = 557243, upload-time = "2026-05-28T12:02:08.013Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ff/0b3d604614ffc77522c6b288fdbce68957eb583da1002aa65ba38ac0ee40/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:8213afbe8a3a906fb9acb2014423fe3359ee783d0bf90995f70623a3217bfa6c", size = 623541, upload-time = "2026-05-28T12:02:09.661Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ea/e7b0251441da9adfeaebcf29601d10f2a1455fcf0772fae9e7e19032bd96/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8c43a8a973270fd173bf48cdf80bbe66312421cba68d40845034f174f2389049", size = 586326, upload-time = "2026-05-28T12:02:11.47Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.12"
 source = { registry = "https://pypi.org/simple" }
@@ -2895,6 +3170,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/1b/bc9e3e7a72dcdad7dc7888758f5d00f56f8909ed5cfdff822bd72bb4c520/sse_starlette-3.4.5.tar.gz", hash = "sha256:83072538bc211a2f68b7b0422226c4af3e9b62e106e07034664b832ca019842a", size = 35249, upload-time = "2026-06-20T17:36:58.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/75/c88d3f5dafd59c791da1ce27650d30bf5b70cbf1cbf01cd00e5f9e360915/sse_starlette-3.4.5-py3-none-any.whl", hash = "sha256:e71bad53323f65573c3864a6c3bd0c1eb6e5f092b2e48082b0c35927d19ca296", size = 16518, upload-time = "2026-06-20T17:36:56.729Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]
@@ -3162,6 +3463,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.49.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add first-class MCP configuration, verification/status/token storage, OAuth flow support, and transports for `streamable_http`, `sse`, and `stdio`.
- Wire verified MCP tools into CLI/TUI agents through a non-propagating ToolExtension with MCP-specific permissions and trust gating for project config.
- Add CLI `mcp` management commands, TUI Settings > MCP Servers management, diagnostics redaction, tests, and docs.

## Verification
- `ruff check kolega_code/mcp kolega_code/cli/main.py kolega_code/cli/app.py kolega_code/cli/tui/settings_panel.py kolega_code/cli/tui/agent_runtime.py kolega_code/cli/tui/prompt_flows.py kolega_code/agent/tools.py kolega_code/config.py kolega_code/cli/config.py kolega_code/cli/settings.py kolega_code/permissions.py tests/mcp/test_config_state_tools.py tests/test_mcp_permissions.py tests/cli/test_mcp_cli.py`
- `pytest tests/mcp/test_config_state_tools.py tests/test_mcp_permissions.py tests/cli/test_mcp_cli.py`
- `python -m compileall kolega_code`
- `python -m kolega_code.cli.main mcp --help`
- `python -m kolega_code.cli.main ask --help`
- `npm run build` in `docs/`
- `pytest` (`1651 passed, 15 warnings`)
- pre-commit hooks during `git commit`
