### PR TITLE
feat(cli): persist plan artifacts

### DIFF
--- a/kolega_code/agent/prompt_templates/extensions/cli/current_plan_artifact.md.j2
+++ b/kolega_code/agent/prompt_templates/extensions/cli/current_plan_artifact.md.j2
@@ -1,0 +1,7 @@
+The current approved implementation plan is persisted as a private Markdown artifact at:
+
+`{{ plan_artifact_path }}`
+
+If the conversation has been compacted, context seems incomplete, or you need exact acceptance criteria, read the artifact with `read_entire_file` (or `read_file_section` if the file is large) before continuing.
+
+Treat this artifact as read-only. Do not edit or overwrite it.

--- a/kolega_code/agent/prompt_templates/user_tasks/cli/implement_plan.md.j2
+++ b/kolega_code/agent/prompt_templates/user_tasks/cli/implement_plan.md.j2
@@ -1,4 +1,8 @@
 Implement the approved plan below. Follow it as the source of truth, but still inspect the code before editing and run appropriate checks.
+{% if plan_artifact_path %}
+
+The approved plan is also persisted at `{{ plan_artifact_path }}`. If the conversation is compacted or you need the exact plan again later, read that file with `read_entire_file` (or `read_file_section` if needed). Treat it as read-only.
+{% endif %}
 {% if gigacode_enabled %}
 
 gigacode is enabled. If this plan splits into independent, non-overlapping workstreams (parts that don't edit the same files or depend on each other's output), implement them in parallel by authoring a workflow and calling `run_workflow` — fan out one coder sub-agent per workstream, then verify. Keep tightly-coupled or ordering-dependent changes sequential and do them directly yourself. If the plan is small or its parts are coupled, just implement it directly.

--- a/kolega_code/agent/prompts.py
+++ b/kolega_code/agent/prompts.py
@@ -50,6 +50,9 @@ COMPRESSION_SUMMARY_USER_PROMPT_TEMPLATE = prompt_template_source("auxiliary/com
 IMPLEMENT_PLAN_PROMPT_TEMPLATE = prompt_template_source("user_tasks/cli/implement_plan.md.j2").replace(
     "{{ plan }}", "{plan}"
 )
+CURRENT_PLAN_ARTIFACT_PROMPT_TEMPLATE = prompt_template_source("extensions/cli/current_plan_artifact.md.j2").replace(
+    "{{ plan_artifact_path }}", "{plan_artifact_path}"
+)
 SKILL_CATALOG_PROMPT_TEMPLATE = prompt_template_source("extensions/skills/catalog.md.j2").replace(
     "{{ catalog }}", "{catalog}"
 )
@@ -64,8 +67,24 @@ def build_compression_summary_user_prompt(history: str, previous_summary: Option
     )
 
 
-def build_implement_plan_prompt(plan: str, gigacode_enabled: bool = False) -> str:
-    return render_prompt_template("user_tasks/cli/implement_plan.md.j2", plan=plan, gigacode_enabled=gigacode_enabled)
+def build_implement_plan_prompt(
+    plan: str,
+    gigacode_enabled: bool = False,
+    plan_artifact_path: Optional[str | Path] = None,
+) -> str:
+    return render_prompt_template(
+        "user_tasks/cli/implement_plan.md.j2",
+        plan=plan,
+        gigacode_enabled=gigacode_enabled,
+        plan_artifact_path=str(plan_artifact_path) if plan_artifact_path else "",
+    )
+
+
+def build_current_plan_artifact_prompt(plan_artifact_path: str | Path) -> str:
+    return render_prompt_template(
+        "extensions/cli/current_plan_artifact.md.j2",
+        plan_artifact_path=str(plan_artifact_path),
+    )
 
 
 def build_init_agents_prompt(arguments: str) -> str:

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -1247,10 +1247,12 @@ class KolegaCodeApp(
         if plan:
             self._latest_plan = plan
             self._plan_reofferable = True
+            self._ensure_current_plan_artifact(plan)
             await self._show_plan_for_decision(plan, notification=messages.PLAN_CAPTURED)
             return
 
         if self._latest_plan and self._plan_reofferable and not self._plan_pending:
+            self._ensure_current_plan_artifact(self._latest_plan)
             await self._show_plan_for_decision(self._latest_plan, notification=messages.PLAN_REOFFERED)
 
     async def _show_plan_for_decision(self, plan: str, *, notification: str) -> None:
@@ -1274,6 +1276,7 @@ class KolegaCodeApp(
         # plan as a read-only reference while it is being built; clearing
         # _plan_pending is what hides the "Implement plan" action so it does not
         # reappear when the user re-enters plan mode.
+        plan_artifact_path = self._ensure_current_plan_artifact(plan)
         self._plan_pending = False
         self._plan_reofferable = False
         self._plan_decision_active = False
@@ -1285,7 +1288,11 @@ class KolegaCodeApp(
         self._set_plan_actions_visible(False)
         self._refresh_input_area_visibility()
 
-        prompt = build_implement_plan_prompt(plan, gigacode_enabled=self._gigacode_enabled)
+        prompt = build_implement_plan_prompt(
+            plan,
+            gigacode_enabled=self._gigacode_enabled,
+            plan_artifact_path=str(plan_artifact_path) if plan_artifact_path is not None else None,
+        )
         self._add_conversation_entry(tui_state.ConversationEntry(kind="user", content="Implement the approved plan."))
         self.agent_worker = self.run_worker(
             self._process_message(prompt), name="kolega-turn", group="turns", exclusive=True

--- a/kolega_code/cli/plan_artifacts.py
+++ b/kolega_code/cli/plan_artifacts.py
@@ -1,0 +1,49 @@
+"""Private CLI plan artifacts for preserving approved plans across compaction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kolega_code.local_state import ensure_private_dir, ensure_private_file, write_private_text
+
+PLAN_ARTIFACTS_DIR = "plans"
+CURRENT_PLAN_FILENAME = "current-plan.md"
+
+
+def current_plan_artifact_path(state_root: Path, session_id: str) -> Path:
+    """Return the deterministic artifact path for a session's current approved plan."""
+    return Path(state_root).expanduser() / PLAN_ARTIFACTS_DIR / session_id / CURRENT_PLAN_FILENAME
+
+
+def normalize_plan_artifact_content(plan_markdown: str) -> str:
+    """Normalize plan Markdown before persisting it as an artifact."""
+    stripped = plan_markdown.strip()
+    return f"{stripped}\n" if stripped else ""
+
+
+def write_current_plan_artifact(state_root: Path, session_id: str, plan_markdown: str) -> Path:
+    """Persist ``plan_markdown`` to the session's private current-plan artifact.
+
+    The session store remains the canonical source of the latest plan. This file is
+    a readable, stable artifact that agents can re-open after conversation
+    compaction has summarized away the original implementation prompt.
+    """
+    root = Path(state_root).expanduser()
+    path = current_plan_artifact_path(root, session_id)
+    content = normalize_plan_artifact_content(plan_markdown)
+    ensure_private_dir(root)
+    ensure_private_dir(root / PLAN_ARTIFACTS_DIR)
+    ensure_private_dir(path.parent)
+
+    if path.exists():
+        try:
+            if path.read_text(encoding="utf-8") == content:
+                ensure_private_file(path)
+                return path
+        except OSError:
+            # Fall through and rewrite atomically; write_private_text will surface
+            # any real write failure to the caller.
+            pass
+
+    write_private_text(path, content)
+    return path

--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -6,12 +6,14 @@ import asyncio
 
 from kolega_code.agent import AgentConfig, AgentEvent, CoderAgent, PlanningAgent, PromptExtension, ToolExtension
 from kolega_code.agent.prompt_provider import AgentMode
+from kolega_code.agent.prompts import build_current_plan_artifact_prompt
 from kolega_code.hooks import HookDispatcher, HookEvent, load_hook_config, project_hooks_present
 from kolega_code.llm.exceptions import LLMError, llm_error_message
 from kolega_code.services.browser import PlaywrightBrowserManager
 
 from .. import messages
 from ..config import CliConfigError, build_agent_config, config_summary
+from ..plan_artifacts import write_current_plan_artifact
 from ..skills import build_skill_prompt_extension, build_skill_tool_extension, discover_skills
 from . import constants as tui_constants
 from . import state as tui_state
@@ -424,6 +426,40 @@ class AgentRuntimeMixin:
         self._ensure_startup_entry()
         self._schedule_primary_focus_restore()
 
+    def _ensure_current_plan_artifact(self, plan: str | None = None):
+        """Persist the latest plan to the session artifact path, returning the path if available."""
+        plan_markdown = plan if plan is not None else getattr(self, "_latest_plan", None)
+        if not plan_markdown:
+            return None
+        try:
+            return write_current_plan_artifact(self.store.root, self.session.session_id, plan_markdown)
+        except Exception as exc:  # noqa: BLE001 - artifact persistence is best-effort for continuity
+            try:
+                self._notify_user(
+                    f"Could not persist current plan artifact: {exc}",
+                    severity="warning",
+                )
+            except Exception:
+                pass
+            return None
+
+    def _current_plan_artifact_prompt_extension(self) -> PromptExtension | None:
+        """Return prompt context that points the build agent at the persisted plan artifact."""
+        if self.interaction_mode != tui_constants.BUILD_INTERACTION_MODE or not getattr(self, "_latest_plan", None):
+            return None
+        artifact_path = self._ensure_current_plan_artifact()
+        if artifact_path is None:
+            return None
+        return PromptExtension(
+            id="cli-current-plan-artifact",
+            title="Current Plan Artifact",
+            markdown=build_current_plan_artifact_prompt(artifact_path),
+            modes=[AgentMode.CLI],
+            # Read-only continuity context is safe and useful for delegated agents,
+            # especially if their own histories compact while implementing the plan.
+            propagate_to_sub_agents=True,
+        )
+
     async def _build_agent(
         self,
         config: AgentConfig,
@@ -453,6 +489,9 @@ class AgentRuntimeMixin:
         if self.interaction_mode == tui_constants.BUILD_INTERACTION_MODE:
             prompt_extensions.append(self._shared_task_list_prompt_extension())
             tool_extensions.append(self._shared_task_list_tool_extension())
+            plan_artifact_extension = self._current_plan_artifact_prompt_extension()
+            if plan_artifact_extension is not None:
+                prompt_extensions.append(plan_artifact_extension)
         skill_prompt_extension = build_skill_prompt_extension(self.skill_catalog)
         skill_tool_extension = build_skill_tool_extension(
             self.skill_catalog,

--- a/tests/agent/test_prompts.py
+++ b/tests/agent/test_prompts.py
@@ -11,6 +11,7 @@ def test_static_prompt_templates_load() -> None:
     assert "analyzing shell command output" in prompts.SHELL_COMPRESSION_SYSTEM_PROMPT
     assert "get_task_list" in prompts.SHARED_TASK_LIST_PROMPT
     assert "ask_user_choice" in prompts.PLANNING_QUESTION_PROMPT
+    assert "read-only" in prompts.CURRENT_PLAN_ARTIFACT_PROMPT_TEMPLATE
 
 
 def test_compression_summary_user_prompt_renders_history() -> None:
@@ -27,6 +28,28 @@ def test_implement_plan_prompt_renders_plan() -> None:
     assert "Implement the approved plan below." in rendered
     assert "- [ ] update docs" in rendered
     assert "{plan}" in prompts.IMPLEMENT_PLAN_PROMPT_TEMPLATE
+
+
+def test_implement_plan_prompt_renders_plan_artifact_path_when_provided() -> None:
+    rendered = prompts.build_implement_plan_prompt(
+        "- [ ] update docs",
+        plan_artifact_path="/tmp/kolega/plans/session/current-plan.md",
+    )
+
+    assert "/tmp/kolega/plans/session/current-plan.md" in rendered
+    assert "conversation is compacted" in rendered
+    assert "read_entire_file" in rendered
+    assert "read-only" in rendered
+    assert "- [ ] update docs" in rendered
+
+
+def test_current_plan_artifact_prompt_renders_path() -> None:
+    rendered = prompts.build_current_plan_artifact_prompt("/tmp/kolega/plans/session/current-plan.md")
+
+    assert "/tmp/kolega/plans/session/current-plan.md" in rendered
+    assert "read_entire_file" in rendered
+    assert "read_file_section" in rendered
+    assert "read-only" in rendered
 
 
 def test_implement_plan_prompt_omits_gigacode_nudge_by_default() -> None:

--- a/tests/cli/test_app_plan_lifecycle.py
+++ b/tests/cli/test_app_plan_lifecycle.py
@@ -20,6 +20,7 @@ from kolega_code.llm.models import Message, TextBlock, ToolCall, ToolResult
 from kolega_code.events import AgentEvent
 from kolega_code.agent.prompt_provider import AgentMode
 from kolega_code.cli.config import build_agent_config, config_summary
+from kolega_code.cli.plan_artifacts import current_plan_artifact_path
 from kolega_code.cli.provider_registry import (
     DEEPSEEK_DEFAULT_MODEL,
     MOONSHOT_K26_MODEL,
@@ -127,6 +128,8 @@ async def test_textual_app_shows_plan_decision_when_planning_agent_writes_plan(
         assert loaded.latest_plan_markdown == initial_plan
         assert loaded.plan_reofferable is True
         assert loaded.interaction_mode == "plan"
+        plan_artifact = current_plan_artifact_path(store.root, session.session_id)
+        assert plan_artifact.read_text(encoding="utf-8") == initial_plan + "\n"
 
         await app._discuss_pending_plan()
 
@@ -184,6 +187,8 @@ async def test_textual_app_shows_plan_decision_when_planning_agent_writes_plan(
         loaded = store.load(session.session_id)
         assert loaded.latest_plan_markdown == "# Revised plan\n\nBuild planning mode carefully."
         assert loaded.plan_reofferable is True
+        assert plan_artifact.read_text(encoding="utf-8") == "# Revised plan\n\nBuild planning mode carefully.\n"
+        assert initial_plan not in plan_artifact.read_text(encoding="utf-8")
 
 
 @pytest.mark.asyncio
@@ -248,7 +253,13 @@ async def test_textual_app_implement_plan_switches_to_build_and_sends_plan(
         assert app.interaction_mode == "build"
         assert isinstance(app.agent, FakeCoderAgent)
         assert app.agent.messages
+        plan_artifact = current_plan_artifact_path(store.root, session.session_id)
+        assert plan_artifact.read_text(encoding="utf-8") == "# Plan\n\nBuild it.\n"
         assert "# Plan\n\nBuild it." in app.agent.messages[-1]
+        assert str(plan_artifact) in app.agent.messages[-1]
+        artifact_extension = extension_by_name(app.agent.kwargs["prompt_extensions"], "cli-current-plan-artifact")
+        assert str(plan_artifact) in artifact_extension.markdown
+        assert artifact_extension.propagate_to_sub_agents is True
         assert app._plan_decision_active is False
         # The plan is kept as a read-only sidebar reference, but it is no longer
         # pending a decision so the action must not be re-offered.
@@ -518,8 +529,11 @@ async def test_textual_app_discuss_plan_preserves_old_plan_until_new_plan_is_wri
 
         assert app.interaction_mode == "build"
         assert isinstance(app.agent, FakeCoderAgent)
+        plan_artifact = current_plan_artifact_path(store.root, session.session_id)
+        assert plan_artifact.read_text(encoding="utf-8") == "# New plan\n\nBuild this instead.\n"
         assert "# New plan\n\nBuild this instead." in app.agent.messages[-1]
         assert "# Plan\n\nBuild it after discussing." not in app.agent.messages[-1]
+        assert "# Plan\n\nBuild it after discussing." not in plan_artifact.read_text(encoding="utf-8")
         assert app._latest_plan == "# New plan\n\nBuild this instead."
         assert app._plan_reofferable is False
         assert app.query_one("#planning_plan_markdown", PlanningMarkdown).source == "# New plan\n\nBuild this instead."

--- a/tests/cli/test_app_planning_restore.py
+++ b/tests/cli/test_app_planning_restore.py
@@ -20,6 +20,7 @@ from kolega_code.llm.models import Message, TextBlock, ToolCall, ToolResult
 from kolega_code.events import AgentEvent
 from kolega_code.agent.prompt_provider import AgentMode
 from kolega_code.cli.config import build_agent_config, config_summary
+from kolega_code.cli.plan_artifacts import current_plan_artifact_path
 from kolega_code.cli.provider_registry import (
     DEEPSEEK_DEFAULT_MODEL,
     MOONSHOT_K26_MODEL,
@@ -153,6 +154,8 @@ async def test_textual_app_restores_saved_plan_in_build_mode_without_plan_action
     session.plan_pending = True
     session.interaction_mode = "build"
     store.save(session)
+    plan_artifact = current_plan_artifact_path(store.root, session.session_id)
+    assert not plan_artifact.exists()
 
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
 
@@ -161,6 +164,10 @@ async def test_textual_app_restores_saved_plan_in_build_mode_without_plan_action
         assert isinstance(app.agent, FakeCoderAgent)
         assert app._latest_plan == saved_plan
         assert app.query_one("#planning_plan_markdown", PlanningMarkdown).source == saved_plan
+        assert plan_artifact.read_text(encoding="utf-8") == saved_plan + "\n"
+        artifact_extension = extension_by_name(app.agent.kwargs["prompt_extensions"], "cli-current-plan-artifact")
+        assert str(plan_artifact) in artifact_extension.markdown
+        assert artifact_extension.propagate_to_sub_agents is True
         # Even with a pending plan, the action stays hidden outside plan mode.
         assert app.query_one("#plan_actions").display is False
 

--- a/tests/cli/test_plan_artifacts.py
+++ b/tests/cli/test_plan_artifacts.py
@@ -1,0 +1,48 @@
+import os
+import stat
+from pathlib import Path
+
+from kolega_code.cli.plan_artifacts import (
+    CURRENT_PLAN_FILENAME,
+    current_plan_artifact_path,
+    normalize_plan_artifact_content,
+    write_current_plan_artifact,
+)
+
+
+def test_current_plan_artifact_path_is_under_state_dir(tmp_path: Path) -> None:
+    path = current_plan_artifact_path(tmp_path / "state", "session-123")
+
+    assert path == tmp_path / "state" / "plans" / "session-123" / CURRENT_PLAN_FILENAME
+
+
+def test_normalize_plan_artifact_content_strips_and_adds_trailing_newline() -> None:
+    assert normalize_plan_artifact_content("\n# Plan\n\nBuild it.  \n") == "# Plan\n\nBuild it.\n"
+
+
+def test_write_current_plan_artifact_writes_private_markdown(tmp_path: Path) -> None:
+    state_root = tmp_path / "state"
+
+    old_umask = os.umask(0)
+    try:
+        path = write_current_plan_artifact(state_root, "session-123", "\n# Plan\n\nBuild it.\n")
+    finally:
+        os.umask(old_umask)
+
+    assert path == current_plan_artifact_path(state_root, "session-123")
+    assert path.read_text(encoding="utf-8") == "# Plan\n\nBuild it.\n"
+
+    if os.name != "nt":
+        assert stat.S_IMODE(state_root.stat().st_mode) == 0o700
+        assert stat.S_IMODE((state_root / "plans").stat().st_mode) == 0o700
+        assert stat.S_IMODE((state_root / "plans" / "session-123").stat().st_mode) == 0o700
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_write_current_plan_artifact_rewrites_when_plan_changes(tmp_path: Path) -> None:
+    state_root = tmp_path / "state"
+    path = write_current_plan_artifact(state_root, "session-123", "# Plan\n\nFirst.")
+
+    write_current_plan_artifact(state_root, "session-123", "# Plan\n\nSecond.")
+
+    assert path.read_text(encoding="utf-8") == "# Plan\n\nSecond.\n"


### PR DESCRIPTION
## Summary
- persist planning-mode plans as private session artifacts under the CLI state directory
- include artifact path guidance in implement-plan prompts and build-mode prompt extensions
- recreate missing build-mode plan artifacts from canonical session plan markdown

## Tests
- uv run pytest tests/agent/test_prompts.py tests/cli/test_plan_artifacts.py tests/cli/test_app_plan_lifecycle.py tests/cli/test_app_planning_restore.py tests/cli/test_session_store.py
- uv run ruff check kolega_code/cli/plan_artifacts.py kolega_code/agent/prompts.py kolega_code/cli/tui/agent_runtime.py kolega_code/cli/app.py tests/agent/test_prompts.py tests/cli/test_plan_artifacts.py tests/cli/test_app_plan_lifecycle.py tests/cli/test_app_planning_restore.py