### PR TITLE
fix(tools): exclude internal tool collection methods

### DIFF
--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -242,12 +242,17 @@ class ToolCollection(LogMixin):
         self.read_only = tool_config.read_only
         self.browser_only = tool_config.browser_only
 
-        # Build tool exclusions list from config
+        # Build tool exclusions list from config. These are internal
+        # management/logging APIs, not model-facing tools.
         self.tool_exclusions = [
             "read_memory",
             "write_memory",
             "execute_terminal_command",
             "get_tool_list",
+            "registry",
+            "has_tool",
+            "call",
+            "cleanup",
             "log_error",
             "log_warning",
             "log_info",

--- a/tests/agent/test_agent_tools_inventory.py
+++ b/tests/agent/test_agent_tools_inventory.py
@@ -16,6 +16,13 @@ from kolega_code.agent.planningagent import PlanningAgent
 from kolega_code.agent.prompt_provider import AgentMode, PromptProvider
 
 
+INTERNAL_TOOL_NAMES = {"registry", "has_tool", "call", "cleanup"}
+
+
+def assert_internal_tools_not_exposed(tool_names):
+    assert INTERNAL_TOOL_NAMES.isdisjoint(tool_names)
+
+
 @pytest.fixture
 def mock_connection_manager():
     """Create a mock connection manager."""
@@ -169,6 +176,7 @@ def test_coder_agent_exposes_dispatch_general_agent(project_path, mock_connectio
 
     tool_names = {tool.name for tool in agent.tool_collection.get_tool_list()}
 
+    assert_internal_tools_not_exposed(tool_names)
     assert "dispatch_general_agent" in tool_names
     assert "dispatch_investigation_agent" in tool_names
     assert "dispatch_coding_agent" not in tool_names
@@ -203,6 +211,7 @@ def test_general_agent_tool_inventory(project_path, mock_connection_manager, age
 
     tool_names = {tool.name for tool in agent.tool_collection.get_tool_list()}
 
+    assert_internal_tools_not_exposed(tool_names)
     # Full read/write/terminal access
     assert "read_entire_file" in tool_names
     assert "search_codebase" in tool_names

--- a/tests/agent/test_tool_collection_config.py
+++ b/tests/agent/test_tool_collection_config.py
@@ -12,6 +12,18 @@ from kolega_code.agent.tool_backend.memory_tool import MemoryTool
 from kolega_code.agent.tools import ToolCollection, ToolDefinition, ToolCollectionConfig
 
 
+INTERNAL_TOOL_NAMES = {
+    "registry",
+    "has_tool",
+    "call",
+    "cleanup",
+    "get_tool_list",
+    "log_error",
+    "log_warning",
+    "log_info",
+}
+
+
 @pytest.fixture
 def mock_connection_manager() -> AsyncMock:
     return AsyncMock()
@@ -100,11 +112,12 @@ class TestToolCollection:
                 assert hasattr(param, "description")
                 assert hasattr(param, "required")
 
-        # Check that excluded tools are not in the list
+        # Check that excluded/internal tools are not in the list
         excluded_tools = tool_collection.tool_exclusions
         tool_names = [tool.name for tool in tool_list]
         assert "exec_command" in tool_names
         assert "write_stdin" in tool_names
+        assert INTERNAL_TOOL_NAMES.isdisjoint(tool_names)
         for excluded_tool in excluded_tools:
             assert excluded_tool not in tool_names
 


### PR DESCRIPTION
## Summary
- exclude internal ToolCollection management APIs from model-facing tool discovery
- add regression coverage for default/full ToolCollection inventories
- strengthen CoderAgent and GeneralAgent inventory assertions

## Tests
- pytest tests/agent/test_tool_collection_config.py tests/agent/test_agent_tools_inventory.py tests/agent/test_tool_collection_extensions.py