### PR TITLE
fix(tools): avoid dispatcher input name collisions

### DIFF
--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -242,12 +242,17 @@ class ToolCollection(LogMixin):
         self.read_only = tool_config.read_only
         self.browser_only = tool_config.browser_only
 
-        # Build tool exclusions list from config
+        # Build tool exclusions list from config. These are internal
+        # management/logging APIs, not model-facing tools.
         self.tool_exclusions = [
             "read_memory",
             "write_memory",
             "execute_terminal_command",
             "get_tool_list",
+            "registry",
+            "has_tool",
+            "call",
+            "cleanup",
             "log_error",
             "log_warning",
             "log_info",

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -1480,9 +1480,9 @@ class ToolCollection(LogMixin):
         """True if the named tool is currently enabled."""
         return name in self.registry()
 
-    async def call(self, name: str, **inputs: Any) -> Any:
+    async def call(self, tool_name: str, /, **inputs: Any) -> Any:
         """Dispatch an enabled tool by name."""
-        return await self.registry().call(name, **inputs)
+        return await self.registry().call(tool_name, **inputs)
 
     def get_tool_list(self) -> List[ToolDefinition]:
         """

--- a/kolega_code/tools/registry.py
+++ b/kolega_code/tools/registry.py
@@ -55,9 +55,9 @@ class ToolRegistry:
     def select(self, policy: ToolPolicy) -> "ToolRegistry":
         return ToolRegistry([tool for tool in self if policy.allows(tool.name)])
 
-    async def call(self, name: str, **inputs: Any) -> Any:
+    async def call(self, tool_name: str, /, **inputs: Any) -> Any:
         """Dispatch a tool by name. Raises KeyError for unknown tools."""
-        return await self.get(name).call(**inputs)
+        return await self.get(tool_name).call(**inputs)
 
     def definitions(self) -> List[ToolDefinition]:
         """

--- a/tests/agent/test_agent_tools_inventory.py
+++ b/tests/agent/test_agent_tools_inventory.py
@@ -16,6 +16,13 @@ from kolega_code.agent.planningagent import PlanningAgent
 from kolega_code.agent.prompt_provider import AgentMode, PromptProvider
 
 
+INTERNAL_TOOL_NAMES = {"registry", "has_tool", "call", "cleanup"}
+
+
+def assert_internal_tools_not_exposed(tool_names):
+    assert INTERNAL_TOOL_NAMES.isdisjoint(tool_names)
+
+
 @pytest.fixture
 def mock_connection_manager():
     """Create a mock connection manager."""
@@ -169,6 +176,7 @@ def test_coder_agent_exposes_dispatch_general_agent(project_path, mock_connectio
 
     tool_names = {tool.name for tool in agent.tool_collection.get_tool_list()}
 
+    assert_internal_tools_not_exposed(tool_names)
     assert "dispatch_general_agent" in tool_names
     assert "dispatch_investigation_agent" in tool_names
     assert "dispatch_coding_agent" not in tool_names
@@ -203,6 +211,7 @@ def test_general_agent_tool_inventory(project_path, mock_connection_manager, age
 
     tool_names = {tool.name for tool in agent.tool_collection.get_tool_list()}
 
+    assert_internal_tools_not_exposed(tool_names)
     # Full read/write/terminal access
     assert "read_entire_file" in tool_names
     assert "search_codebase" in tool_names

--- a/tests/agent/test_tool_collection_config.py
+++ b/tests/agent/test_tool_collection_config.py
@@ -12,6 +12,18 @@ from kolega_code.agent.tool_backend.memory_tool import MemoryTool
 from kolega_code.agent.tools import ToolCollection, ToolDefinition, ToolCollectionConfig
 
 
+INTERNAL_TOOL_NAMES = {
+    "registry",
+    "has_tool",
+    "call",
+    "cleanup",
+    "get_tool_list",
+    "log_error",
+    "log_warning",
+    "log_info",
+}
+
+
 @pytest.fixture
 def mock_connection_manager() -> AsyncMock:
     return AsyncMock()
@@ -100,11 +112,12 @@ class TestToolCollection:
                 assert hasattr(param, "description")
                 assert hasattr(param, "required")
 
-        # Check that excluded tools are not in the list
+        # Check that excluded/internal tools are not in the list
         excluded_tools = tool_collection.tool_exclusions
         tool_names = [tool.name for tool in tool_list]
         assert "exec_command" in tool_names
         assert "write_stdin" in tool_names
+        assert INTERNAL_TOOL_NAMES.isdisjoint(tool_names)
         for excluded_tool in excluded_tools:
             assert excluded_tool not in tool_names
 

--- a/tests/agent/test_tool_registry.py
+++ b/tests/agent/test_tool_registry.py
@@ -37,6 +37,36 @@ class TestToolRegistry:
         assert await registry.call("read", arg="x") == "contents:x"
 
     @pytest.mark.asyncio
+    async def test_call_allows_tool_input_named_name(self):
+        async def handler(name: str):
+            return f"activated:{name}"
+
+        registry = ToolRegistry().add(
+            Tool(
+                name="activate_skill",
+                definition=ToolDefinition(name="activate_skill", description="Activate a skill", parameters=[]),
+                handler=handler,
+            )
+        )
+
+        assert await registry.call("activate_skill", name="some-skill") == "activated:some-skill"
+
+    @pytest.mark.asyncio
+    async def test_call_allows_tool_input_named_tool_name(self):
+        async def handler(tool_name: str):
+            return f"echo:{tool_name}"
+
+        registry = ToolRegistry().add(
+            Tool(
+                name="echo",
+                definition=ToolDefinition(name="echo", description="Echo a tool_name input", parameters=[]),
+                handler=handler,
+            )
+        )
+
+        assert await registry.call("echo", tool_name="payload") == "echo:payload"
+
+    @pytest.mark.asyncio
     async def test_call_unknown_tool_raises(self):
         with pytest.raises(KeyError):
             await ToolRegistry().call("nope")
@@ -105,3 +135,32 @@ class TestToolCollectionRegistry:
         names_from_list = [d.name for d in collection.get_tool_list()]
         registry_names = [tool.name for tool in collection.registry()]
         assert names_from_list == registry_names
+
+    @pytest.mark.asyncio
+    async def test_collection_call_allows_conflicting_tool_input_names(self, tmp_path):
+        from unittest.mock import Mock
+
+        from kolega_code.agent.tools import ToolCollection, ToolExtension
+
+        async def echo_conflicting_inputs(name: str, tool_name: str):
+            return f"{name}:{tool_name}"
+
+        collection = ToolCollection(
+            tmp_path,
+            "ws",
+            "thread",
+            Mock(),
+            Mock(),
+            Mock(agent_name="test"),
+            tool_extensions=[
+                ToolExtension(
+                    name="test-extension",
+                    tools={"echo_conflicting_inputs": echo_conflicting_inputs},
+                )
+            ],
+        )
+
+        assert (
+            await collection.call("echo_conflicting_inputs", name="some-skill", tool_name="payload")
+            == "some-skill:payload"
+        )


### PR DESCRIPTION
## Summary
- make internal tool dispatcher arguments positional-only to avoid collisions with tool inputs like `name`
- keep public tool schemas unchanged, including `activate_skill(name=...)`
- add regression coverage for tool inputs named `name` and `tool_name`, including `ToolCollection.call`

## Tests
- `pytest tests/agent/test_tool_registry.py tests/cli/test_skills.py`
- `pytest tests/agent/test_base_agent_tool_execution.py tests/agent/test_tool_collection_extensions.py`

## Notes
- This branch was created from `fix/exclude-internal-tool-methods` and targets `main`, per request.