### PR TITLE
fix(tui): hide queued messages from transcript

### DIFF
--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -124,8 +124,9 @@ class AgentRuntimeMixin:
             attachments=[dict(item) for item in attachments] if attachments else None,
             entry=entry,
         )
+        # Keep the future transcript entry unmounted while pending; the queue
+        # widget is the only waiting-message preview until this item starts.
         self._queued_messages.append(queued)
-        self._add_conversation_entry(entry)
         self._refresh_queued_messages_panel()
         self._log_status(messages.QUEUED_MESSAGE, "info")
 
@@ -217,9 +218,9 @@ class AgentRuntimeMixin:
         if queued.entry not in self.conversation_entries:
             self._add_conversation_entry(queued.entry)
         else:
-            # The entry is already mounted (added when queued); just re-render that one
-            # widget for the queued->user transition instead of rebuilding the whole
-            # transcript, which on a long thread is a synchronous O(entries) hitch.
+            # Defensive compatibility for any already-mounted queued entry (for
+            # example from older in-memory behavior): re-render just that widget
+            # for the queued->user transition instead of rebuilding the transcript.
             self._invalidate_conversation(queued.entry)
         self._refresh_queued_messages_panel()
         self._clear_composer_hint()

--- a/kolega_code/cli/tui/state.py
+++ b/kolega_code/cli/tui/state.py
@@ -98,7 +98,11 @@ class ConversationEntry:
 
 @dataclass
 class QueuedMessage:
-    """One UI-local follow-up queued while the current turn is running."""
+    """One UI-local follow-up queued while the current turn is running.
+
+    ``entry`` is the future transcript entry and stays out of
+    ``conversation_entries`` until the queued message begins processing.
+    """
 
     queue_id: str
     text: str

--- a/tests/cli/test_app_composer_input.py
+++ b/tests/cli/test_app_composer_input.py
@@ -559,10 +559,8 @@ async def test_textual_app_queues_multiple_active_turn_messages_fifo(
         await pilot.pause()
 
         assert [item.text for item in app._queued_messages] == ["second", "third"]
-        assert [entry.kind for entry in app.conversation_entries if entry.content in {"second", "third"}] == [
-            "queued",
-            "queued",
-        ]
+        assert not [entry for entry in app.conversation_entries if entry.content in {"second", "third"}]
+        assert not [entry for entry in app.conversation_entries if entry.kind == "queued"]
         queued_panel = app.query_one("#queued_messages")
         assert queued_panel.display is True
         queued_text = renderable_text(queued_panel.render())
@@ -655,6 +653,8 @@ async def test_textual_app_queue_clear_command_discards_active_turn_followups(
             composer.load_text(text)
             await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
         assert len(app._queued_messages) == 2
+        assert not [entry for entry in app.conversation_entries if entry.content in {"second", "third"}]
+        assert not [entry for entry in app.conversation_entries if entry.kind == "queued"]
 
         composer.load_text("/queue-clear")
         await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
@@ -737,6 +737,8 @@ async def test_textual_app_cancel_restores_queued_followups_to_composer(
             await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
         assert [item.text for item in app._queued_messages] == ["second", "third"]
         assert app.query_one("#queued_messages").display is True
+        assert not [entry for entry in app.conversation_entries if entry.content in {"second", "third"}]
+        assert not [entry for entry in app.conversation_entries if entry.kind == "queued"]
 
         composer.load_text(draft)
         app.action_cancel_generation()


### PR DESCRIPTION
## Summary
- keep queued follow-up messages out of the main transcript while pending
- show queued messages only in the queue widget until they begin processing
- add/update TUI coverage for queue drain, clear, and cancel behavior

## Tests
- pytest tests/cli/test_app_composer_input.py tests/cli/test_app_permission_prompts.py