### PR TITLE
fix(tui): polish status card spacing

### DIFF
--- a/kolega_code/cli/tui/status_dashboard.py
+++ b/kolega_code/cli/tui/status_dashboard.py
@@ -75,13 +75,11 @@ class StatusDashboardMixin:
             indicator = escape(state.compaction_message or messages.COMPACTING)
             context_lines += f"\n[{Color.ACCENT}]{theme.g(Glyph.RUNNING)} {indicator}[/{Color.ACCENT}]"
 
-        title = theme.role_header(Glyph.STATUS, "Status", Color.ACCENT)
         turn_line = (
             f"{label('Turn')} [{turn_style}]{theme.g(Glyph.STATUS)}[/{turn_style}] "
             f"[bold]{escape(state.turn_state.value)}[/bold]"
         )
         return (
-            f"{title}\n\n"
             f"{label('Model')}\n[bold]{escape(provider_model)}[/bold]\n\n"
             f"{label('Thinking effort')} [bold]{escape(effort)}[/bold]\n"
             f"{label('Mode')} [bold]{mode}[/bold]\n"

--- a/kolega_code/cli/tui/styles.tcss
+++ b/kolega_code/cli/tui/styles.tcss
@@ -129,7 +129,11 @@ ToolEntryWidget .tool-body {
     border: none;
     background: $background;
     color: $text;
-    padding: 0;
+    padding: 1 0 1 1;
+}
+
+#status_task_list_markdown {
+    padding: 0 0 1 0;
 }
 
 .status-section,

--- a/tests/cli/test_app_bootstrap_settings.py
+++ b/tests/cli/test_app_bootstrap_settings.py
@@ -211,7 +211,7 @@ async def test_textual_app_status_tab_is_default_dashboard(tmp_path: Path, monke
         dashboard_widget = app.query_one("#status_dashboard", Static)
         dashboard = str(dashboard_widget.render())
 
-        assert "Status" in dashboard
+        assert dashboard.lstrip().startswith("Model")
         assert f"{config.long_context_config.provider.value}/{config.long_context_config.model}" in dashboard
         assert "Build" in dashboard
         assert "Idle" in dashboard

--- a/tests/cli/test_tui_stylesheet.py
+++ b/tests/cli/test_tui_stylesheet.py
@@ -251,8 +251,11 @@ def test_tui_stylesheet_keeps_sidebar_tabs_consistent_and_restores_card_contrast
     assert "background: $background" in status_dashboard_block
     assert "background: $surface" not in status_dashboard_block
     assert "color: $text" in status_dashboard_block
-    assert "padding: 0" in status_dashboard_block
+    assert "padding: 1 0 1 1" in status_dashboard_block
     assert "border: round" not in status_dashboard_block
+
+    task_list_block = css.split("#status_task_list_markdown {", 1)[1].split("}", 1)[0]
+    assert "padding: 0 0 1 0" in task_list_block
 
     section_block = css.split(".status-section,", 1)[1].split("}", 1)[0]
     assert ".planning-section" in section_block
@@ -362,8 +365,11 @@ async def test_sidebar_tab_and_settings_planning_computed_styles_keep_contrast(
         assert app.query_one("#planning_form").styles.padding.left == 1
         assert str(app.query_one("#status_dashboard").styles.border) == "Edges()"
         assert app.query_one("#status_dashboard").styles.background == app.query_one("#status_form").styles.background
-        assert app.query_one("#status_dashboard").styles.padding.left == 0
-        assert app.query_one("#status_task_list_markdown") is not None
+        assert app.query_one("#status_dashboard").styles.padding.left == 1
+        assert app.query_one("#status_dashboard").styles.padding.top == 1
+        assert app.query_one("#status_dashboard").styles.padding.bottom == 1
+        task_list_markdown = app.query_one("#status_task_list_markdown")
+        assert task_list_markdown.styles.padding.bottom == 1
 
         settings_background = app.query_one("#settings_form").styles.background
         select_current_widgets = list(app.query("#settings_form SelectCurrent"))


### PR DESCRIPTION
## Summary
- Remove the redundant inner Status header so the card begins with Model
- Add top/left/bottom padding to the Status card content
- Add bottom breathing room to the Task List card content

## Tests
- pytest tests/cli/test_tui_stylesheet.py tests/cli/test_app_bootstrap_settings.py::test_textual_app_status_tab_is_default_dashboard
- pytest tests/cli/test_app_status_modes.py tests/cli/test_app_rendering_status.py