### PR TITLE
chore: release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.13.0 - 2026-07-02
+
+### Added
+
+- Added first-class MCP (Model Context Protocol) support in the CLI and TUI,
+  including server settings management.
+- Persisted plan artifacts so they survive across CLI invocations.
+
+### Changed
+
+- Made session diff refreshes incremental and asynchronous for smoother TUI
+  performance.
+
+### Fixed
+
+- Hid queued follow-up messages from the transcript view.
+- Polished status card spacing and made the context-full note generic.
+- Avoided tool dispatcher input name collisions and excluded internal tool
+  collection methods from dispatch.
+- Hardened MCP credential handling, status logging, config output, and server
+  settings reliability.
+- Preserved gigacode enabled state across session resume.
+- Corrected the GPT-5.5 context window to 272K on the Codex backend.
+
 ## 0.12.0 - 2026-06-30
 
 ### Added

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.12.0"
+__version__ = "0.13.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -44,4 +44,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.12.0"
+__version__ = "0.13.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.12.0"
+version = "0.13.0"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [options]
 prerelease-mode = "allow"
-exclude-newer = "2026-06-24T19:23:15.758172Z"
+exclude-newer = "2026-06-25T14:08:37.658749Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1397,7 +1397,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Release v0.13.0

### Added
- First-class MCP (Model Context Protocol) support in the CLI and TUI, including server settings management.
- Persisted plan artifacts so they survive across CLI invocations.

### Changed
- Made session diff refreshes incremental and asynchronous for smoother TUI performance.

### Fixed
- Hid queued follow-up messages from the transcript view.
- Polished status card spacing and made the context-full note generic.
- Avoided tool dispatcher input name collisions and excluded internal tool collection methods from dispatch.
- Hardened MCP credential handling, status logging, config output, and server settings reliability.
- Preserved gigacode enabled state across session resume.
- Corrected the GPT-5.5 context window to 272K on the Codex backend.