### PR TITLE
fix(tools): handle CRLF line endings in edit/multi_edit/write

### DIFF
--- a/kolega_code/agent/tool_backend/edit_tool.py
+++ b/kolega_code/agent/tool_backend/edit_tool.py
@@ -6,7 +6,7 @@ from .base_tool import BaseTool
 from .edit_preview import build_diff_preview, build_head_preview
 
 
-_BLOCK_PATTERN = re.compile(r"<<<<<<< SEARCH\n(.*?)\n=======\n(.*?)\n>>>>>>> REPLACE", re.DOTALL)
+_BLOCK_PATTERN = re.compile(r"<<<<<<< SEARCH\r?\n(.*?)\r?\n=======\r?\n(.*?)\r?\n>>>>>>> REPLACE", re.DOTALL)
 _SMART_PUNCTUATION_TRANSLATION = str.maketrans(
     {
         "\u2018": "'",
@@ -101,6 +101,12 @@ class EditTool(BaseTool):
             if parent_dir and parent_dir != "." and not self.filesystem.exists(parent_dir):
                 self.filesystem.create_directory(parent_dir)
 
+            # Preserve the file's dominant line ending on overwrite; new files
+            # keep the line endings the caller provided (typically LF).
+            if exists and old_content is not None:
+                line_ending = self._detect_dominant_line_ending(path, old_content)
+                content = self._normalize_line_endings(content, line_ending)
+
             self.filesystem.write_text(path, content)
 
             preview = (
@@ -135,20 +141,28 @@ class EditTool(BaseTool):
             self._validate_non_overlapping(resolved)
             updated_content = self._apply_replacements(original_content, resolved)
 
-            if updated_content == original_content:
+            # Preserve the file's dominant line ending. ``read_text`` may normalize
+            # CRLF -> LF (Python universal newlines), so detect the true on-disk
+            # ending and rewrite the result in that ending to keep unchanged
+            # regions byte-identical and avoid mixed line endings.
+            line_ending = self._detect_dominant_line_ending(path, original_content)
+            normalized_original = self._normalize_line_endings(original_content, line_ending)
+            normalized_updated = self._normalize_line_endings(updated_content, line_ending)
+
+            if normalized_updated == normalized_original:
                 await self.log_warning(
                     f"No changes made to {path}. All replacements were identical to original text.",
                     sender=self.caller.agent_name,
                 )
-                return f"# {path} (No changes made)\n\n```\n{original_content}\n```"
+                return f"# {path} (No changes made)\n\n```\n{normalized_original}\n```"
 
             blocked_msg = self._enforce_vibe_edit_policy(path)
             if blocked_msg:
                 return blocked_msg
-            self.filesystem.write_text(path, updated_content)
+            self.filesystem.write_text(path, normalized_updated)
 
             await self.send_edit_preview(
-                build_diff_preview(original_content, updated_content, path),
+                build_diff_preview(original_content, normalized_updated, path),
                 tool_call_id=getattr(self.caller, "current_tool_execution_id", None),
                 tool_name=tool_name,
             )
@@ -328,3 +342,40 @@ class EditTool(BaseTool):
 
     def _normalize_unicode_punctuation(self, text: str) -> str:
         return text.translate(_SMART_PUNCTUATION_TRANSLATION)
+
+    def _detect_dominant_line_ending(self, path: str, content: str) -> str:
+        """Return the dominant line ending (``\\r\\n``, ``\\r``, or ``\\n``) on disk.
+
+        ``read_text`` performs universal-newline translation (``\\r\\n`` -> ``\\n``)
+        on local filesystems, so when the read content has no carriage returns we
+        inspect the raw bytes to recover the true ending. Sandbox/MCP filesystems
+        that return raw text with carriage returns are detected directly from
+        ``content``.
+        """
+        if "\r" in content:
+            return self._dominant_line_ending_from_text(content)
+        try:
+            raw = self.filesystem.read_bytes(path)
+            raw_text = raw if isinstance(raw, str) else raw.decode("utf-8", errors="replace")
+            return self._dominant_line_ending_from_text(raw_text)
+        except Exception:
+            return "\n"
+
+    @staticmethod
+    def _dominant_line_ending_from_text(text: str) -> str:
+        n_crlf = text.count("\r\n")
+        n_lf = text.count("\n") - n_crlf
+        n_cr = text.count("\r") - n_crlf
+        if n_crlf > 0 and n_crlf >= n_lf and n_crlf >= n_cr:
+            return "\r\n"
+        if n_cr > 0 and n_cr > n_lf:
+            return "\r"
+        return "\n"
+
+    @staticmethod
+    def _normalize_line_endings(text: str, target: str) -> str:
+        """Normalize all line endings in ``text`` to ``target``."""
+        text = text.replace("\r\n", "\n").replace("\r", "\n")
+        if target == "\n":
+            return text
+        return text.replace("\n", target)

--- a/kolega_code/services/file_system.py
+++ b/kolega_code/services/file_system.py
@@ -553,7 +553,10 @@ class LocalFileSystem(FileSystem):
 
     def write_text(self, path: str, content: str, encoding: str = "utf-8") -> None:
         resolved_path = self._resolve_path(path)
-        resolved_path.write_text(content, encoding=encoding)
+        # newline="" disables platform newline translation so we write exactly
+        # the bytes the caller normalized (prevents \r\r\n on Windows and
+        # CRLF->LF round-trip surprises on macOS/Linux).
+        resolved_path.write_text(content, encoding=encoding, newline="")
 
     def write_bytes(self, path: str, content: bytes) -> None:
         resolved_path = self._resolve_path(path)

--- a/tests/agent/services/test_local_file_system.py
+++ b/tests/agent/services/test_local_file_system.py
@@ -69,6 +69,16 @@ class TestLocalFileSystem:
         read_content = filesystem.read_text("test_utf8.txt", encoding="utf-8")
         assert read_content == content
 
+    def test_write_text_is_verbatim_crlf(self, filesystem, temp_dir):
+        """write_text writes CRLF content verbatim (no platform translation)."""
+        filesystem.write_text("crlf.txt", "a\r\nb\r\n")
+        assert (temp_dir / "crlf.txt").read_bytes() == b"a\r\nb\r\n"
+
+    def test_write_text_is_verbatim_lf(self, filesystem, temp_dir):
+        """write_text writes LF content verbatim (no platform translation)."""
+        filesystem.write_text("lf.txt", "a\nb\n")
+        assert (temp_dir / "lf.txt").read_bytes() == b"a\nb\n"
+
     def test_write_and_read_bytes(self, filesystem):
         """Test writing and reading binary files."""
         content = b"\x00\x01\x02\x03\xff\xfe\xfd"

--- a/tests/agent/tool_backend/test_edit_tool.py
+++ b/tests/agent/tool_backend/test_edit_tool.py
@@ -52,6 +52,8 @@ def edit_tool(project_path, mock_connection_manager, agent_config, mock_base_age
 
 
 class MemoryFileSystem:
+    """CRLF-preserving in-memory filesystem (mimics sandbox/E2B reads)."""
+
     def __init__(self, content: str):
         self.content = content
 
@@ -60,6 +62,9 @@ class MemoryFileSystem:
 
     def read_text(self, path: str) -> str:
         return self.content
+
+    def read_bytes(self, path: str) -> bytes:
+        return self.content.encode("utf-8")
 
     def write_text(self, path: str, content: str) -> None:
         self.content = content
@@ -244,6 +249,123 @@ class TestEditTool:
         assert "overlaps" in str(exc_info.value)
         assert file_path.read_text() == "alpha beta gamma\n"
 
+    # --- line-ending handling: parse tolerance (the reported failure) ---
+
+    async def test_edit_parses_block_with_crlf_markers(self, edit_tool, project_path):
+        """CRLF at the SEARCH/=======/REPLACE marker lines parses and applies."""
+        file_path = project_path / "src.py"
+        file_path.write_bytes(b"def foo():\r\n    return 1\r\n\r\ndef bar():\r\n    return 2\r\n")
+        crlf_block = (
+            "<<<<<<< SEARCH\r\ndef foo():\r\n    return 1\r\n=======\r\ndef foo():\r\n    return 99\r\n>>>>>>> REPLACE"
+        )
+
+        result = await edit_tool.edit("src.py", crlf_block)
+
+        assert result == "Edited src.py"
+        after = file_path.read_bytes()
+        assert b"def foo():\r\n    return 99\r\n" in after
+        # unchanged lines keep CRLF; no bare LF introduced
+        assert b"\n" not in after.replace(b"\r\n", b"")
+
+    async def test_multi_edit_parses_block_with_crlf_markers(self, edit_tool, project_path):
+        """multi_edit tolerates CRLF marker lines across multiple blocks."""
+        file_path = project_path / "src.py"
+        file_path.write_bytes(b"alpha\r\nbeta\r\ngamma\r\n")
+        crlf_blocks = (
+            "<<<<<<< SEARCH\r\nalpha\r\n=======\r\nALPHA\r\n>>>>>>> REPLACE\r\n"
+            "<<<<<<< SEARCH\r\ngamma\r\n=======\r\nGAMMA\r\n>>>>>>> REPLACE"
+        )
+
+        result = await edit_tool.multi_edit("src.py", crlf_blocks)
+
+        assert result == "Edited src.py with 2 replacements"
+        assert file_path.read_bytes() == b"ALPHA\r\nbeta\r\nGAMMA\r\n"
+
+    async def test_edit_crlf_markers_lf_content_parses(self, edit_tool, project_path):
+        """CRLF marker lines with LF content parses and edits an LF file."""
+        file_path = project_path / "src.py"
+        file_path.write_text("def foo():\n    return 1\n\ndef bar():\n    return 2\n")
+        crlf_markers_lf_content = (
+            "<<<<<<< SEARCH\r\ndef foo():\n    return 1\n=======\r\ndef foo():\n    return 99\n>>>>>>> REPLACE"
+        )
+
+        result = await edit_tool.edit("src.py", crlf_markers_lf_content)
+
+        assert result == "Edited src.py"
+        assert file_path.read_text() == "def foo():\n    return 99\n\ndef bar():\n    return 2\n"
+
+    # --- line-ending handling: preservation ---
+
+    async def test_edit_preserves_crlf_line_endings(self, edit_tool, project_path):
+        """Editing a CRLF file preserves CRLF on unchanged and changed lines."""
+        file_path = project_path / "src.py"
+        file_path.write_bytes(b"def foo():\r\n    return 1\r\n\r\ndef bar():\r\n    return 2\r\n")
+
+        result = await edit_tool.edit("src.py", block("def foo():\n    return 1", "def foo():\n    return 99"))
+
+        assert result == "Edited src.py"
+        after = file_path.read_bytes()
+        assert b"def foo():\r\n    return 99\r\n" in after
+        assert b"def bar():\r\n    return 2\r\n" in after
+        assert b"\n" not in after.replace(b"\r\n", b"")
+
+    async def test_edit_preserves_lf_line_endings(self, edit_tool, project_path):
+        """Editing an LF file introduces no carriage returns."""
+        file_path = project_path / "lf.py"
+        file_path.write_bytes(b"def foo():\n    return 1\n\ndef bar():\n    return 2\n")
+
+        result = await edit_tool.edit("lf.py", block("def foo():\n    return 1", "def foo():\n    return 99"))
+
+        assert result == "Edited lf.py"
+        after = file_path.read_bytes()
+        assert b"\r" not in after
+        assert after == b"def foo():\n    return 99\n\ndef bar():\n    return 2\n"
+
+    async def test_edit_normalizes_mixed_line_endings_to_dominant(self, edit_tool, project_path):
+        """A file with mixed endings is normalized to the dominant ending after edit."""
+        file_path = project_path / "mix.py"
+        # two CRLF lines, one bare-LF line -> dominant is CRLF
+        file_path.write_bytes(b"line one\r\nline two\nline three\r\n")
+
+        result = await edit_tool.edit("mix.py", block("line one", "LINE ONE"))
+
+        assert result == "Edited mix.py"
+        after = file_path.read_bytes()
+        assert after == b"LINE ONE\r\nline two\r\nline three\r\n"
+        assert b"\n" not in after.replace(b"\r\n", b"")
+
+    async def test_edit_crlf_content_no_mixed_endings(
+        self, project_path, mock_connection_manager, agent_config, mock_base_agent
+    ):
+        """A CRLF-preserving (sandbox-like) filesystem edit yields no mixed endings."""
+        filesystem = MemoryFileSystem("def foo():\r\n    return 1\r\n\r\ndef bar():\r\n    return 2\r\n")
+        tool = EditTool(
+            project_path,
+            "test_workspace",
+            str(uuid.uuid4()),
+            mock_connection_manager,
+            agent_config,
+            mock_base_agent,
+            filesystem,
+        )
+
+        result = await tool.edit("crlf.txt", block("def foo():\n    return 1", "def foo():\n    return 99"))
+
+        assert result == "Edited crlf.txt"
+        assert "\n" not in filesystem.content.replace("\r\n", "")
+        assert filesystem.content == "def foo():\r\n    return 99\r\n\r\ndef bar():\r\n    return 2\r\n"
+
+    async def test_edit_no_change_does_not_write_crlf_file(self, edit_tool, project_path):
+        """A no-op edit on a CRLF file leaves disk bytes unchanged (no write, no LE flip)."""
+        file_path = project_path / "nc.py"
+        original = b"foo\r\nbar\r\n"
+        file_path.write_bytes(original)
+
+        result = await edit_tool.edit("nc.py", block("foo", "foo"))
+
+        assert "No changes made" in result
+        assert file_path.read_bytes() == original
+
 
 @pytest.mark.asyncio
 class TestWriteTool:
@@ -300,6 +422,23 @@ class TestWriteTool:
         assert content["tool_name"] == "write"
         assert content["kind"] == "diff"
         assert content["path"] == "m.py"
+
+    async def test_write_overwrite_preserves_dominant_line_endings(self, edit_tool, project_path):
+        """write overwrite adopts the file's dominant line ending; new files stay LF."""
+        crlf_file = project_path / "crlf.py"
+        crlf_file.write_bytes(b"old\r\ncontent\r\n")
+
+        result = await edit_tool.write("crlf.py", "new\ncontent\n")
+
+        assert result == "Wrote crlf.py"
+        after = crlf_file.read_bytes()
+        assert after == b"new\r\ncontent\r\n"
+        assert b"\n" not in after.replace(b"\r\n", b"")
+
+        # a brand-new file keeps the LF content the caller provided
+        result = await edit_tool.write("new.py", "brand\nnew\n")
+        assert result == "Wrote new.py"
+        assert (project_path / "new.py").read_bytes() == b"brand\nnew\n"
 
     async def test_write_permission_error(self, edit_tool, project_path):
         with patch("pathlib.Path.write_text", side_effect=PermissionError("Permission denied")):


### PR DESCRIPTION
## Problem

The `edit`/`multi_edit`/`write` tools mishandle CRLF line endings in two ways:

### 1. Parse failure (the reported bug)

The block parser regex uses literal `\n` at the `<<<<<<< SEARCH` / `=======` / `>>>>>>> REPLACE` marker delimiters. When the model sends a block argument with `\r\n` at those marker lines (which happens when it copies text from a CRLF-preserving read such as `cat` or an MCP local-filesystem), `_parse_blocks` rejects the whole block with `"No valid search and replace blocks found"` **before** the "Normalized line endings" content fallback can run. This is why the agent saw "the tool claims a normalized-line-endings fallback, but it's still failing."

### 2. Line-ending corruption on successful edits

Even when an edit matches, the result corrupts line endings:

- **Local silent CRLF→LF:** `LocalFileSystem.read_text` (Python universal newlines) translates `\r\n`→`\n`, and `write_text` writes `\n`, so editing a CRLF file rewrites the **entire** file as LF — unchanged lines lose their CRLF, producing huge spurious diffs.
- **Mixed endings (sandbox):** Sandbox/MCP filesystems return raw CRLF; an LF replace block is spliced in, yielding mixed `\n`/`\r\n`.
- **Windows:** `Path.write_text` with default `newline=None` translates `\n`→`os.linesep` (`\r\n`), so writing CRLF content yields `\r\r\n`.

## Fix

- **`edit_tool.py`**: `_BLOCK_PATTERN` now uses `\r?\n` at marker delimiters (parse tolerance). Added `_detect_dominant_line_ending` and `_normalize_line_endings` — `_edit_blocks` and `write` now normalize the result to the file's dominant line ending, keeping unchanged regions byte-identical.
- **`file_system.py`**: `LocalFileSystem.write_text` passes `newline=""` for verbatim writes on all platforms.

## Tests

11 new tests covering: CRLF-marker parse tolerance for `edit`/`multi_edit`, CRLF/LF/mixed-ending preservation, sandbox-like no-mixed-endings, write overwrite preservation, and no-op no-write. Added `read_bytes` to the test `MemoryFileSystem`.

Existing suites: 353 agent tests + 70 edit/fs tests pass (was 59).