### PR TITLE
feat(models): add Anthropic Claude Fable 5 and Sonnet 5 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ### Added
 
+- Added support for Anthropic Claude Fable 5 (`claude-fable-5`) and Claude Sonnet 5
+  (`claude-sonnet-5`): 1M-token context, 128K max output, vision input, and
+  adaptive thinking with `low`/`medium`/`high`/`xhigh`/`max` effort levels. Both
+  are selectable in the Settings UI, `/model` picker, CLI flags, and env vars.
 - Added a `/goal` slash command that sets an autonomous completion condition the
   agent works toward. After each turn, a read-only investigation sub-agent
   verifies whether the goal is met; if not, the agent is nudged to continue

--- a/docs/src/content/docs/configuration/providers-and-models.mdx
+++ b/docs/src/content/docs/configuration/providers-and-models.mdx
@@ -171,6 +171,8 @@ models in the TUI.
 
 | Provider/model | Values | Kolega Code default |
 | --- | --- | --- |
+| Anthropic `claude-fable-5` | `low`, `medium`, `high`, `xhigh`, `max` | `medium` |
+| Anthropic `claude-sonnet-5` | `low`, `medium`, `high`, `xhigh`, `max` | `medium` |
 | Anthropic `claude-opus-4-7` | `low`, `medium`, `high`, `xhigh`, `max` | `medium` |
 | DeepSeek `deepseek-v4-pro` | `none`, `high`, `max` | `high` |
 | Moonshot `kimi-k2.7-code` | `auto` | `auto` |

--- a/kolega_code/cli/provider_registry.py
+++ b/kolega_code/cli/provider_registry.py
@@ -53,9 +53,11 @@ MODEL_LABELS: dict[str, str] = {
     "glm-5.2": "GLM-5.2",
     "glm-5.1": "GLM-5.1",
     # Anthropic
+    "claude-fable-5": "Claude Fable 5",
     "claude-opus-4-8": "Claude Opus 4.8",
     "claude-opus-4-7": "Claude Opus 4.7",
     "claude-opus-4-6": "Claude Opus 4.6",
+    "claude-sonnet-5": "Claude Sonnet 5",
     "claude-sonnet-4-6": "Claude Sonnet 4.6",
     "claude-sonnet-4-5-20250929": "Claude Sonnet 4.5",
     "claude-opus-4-5-20251101": "Claude Opus 4.5",

--- a/kolega_code/llm/specs/catalog/anthropic.py
+++ b/kolega_code/llm/specs/catalog/anthropic.py
@@ -2,6 +2,18 @@ from kolega_code.llm.specs.types import ThinkingEffortSpec
 
 # Anthropic models
 ANTHROPIC_SPECS = {
+    ("anthropic", "claude-fable-5"): {
+        "context_length": 1000000,
+        "max_completion_tokens": 128000,
+        "default_temperature": 1.0,
+        "supports_temperature": False,
+        "supports_vision": True,
+        "thinking_effort": ThinkingEffortSpec(
+            options=("low", "medium", "high", "xhigh", "max"),
+            default="medium",
+            mode="anthropic_adaptive_effort",
+        ),
+    },
     ("anthropic", "claude-opus-4-8"): {
         "context_length": 1000000,
         "max_completion_tokens": 128000,
@@ -33,6 +45,18 @@ ANTHROPIC_SPECS = {
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
             options=("low", "medium", "high", "max"),
+            default="medium",
+            mode="anthropic_adaptive_effort",
+        ),
+    },
+    ("anthropic", "claude-sonnet-5"): {
+        "context_length": 1000000,
+        "max_completion_tokens": 128000,
+        "default_temperature": 1.0,
+        "supports_temperature": False,
+        "supports_vision": True,
+        "thinking_effort": ThinkingEffortSpec(
+            options=("low", "medium", "high", "xhigh", "max"),
             default="medium",
             mode="anthropic_adaptive_effort",
         ),

--- a/tests/agent/llm/test_model_specs.py
+++ b/tests/agent/llm/test_model_specs.py
@@ -59,3 +59,29 @@ def test_fireworks_serverless_model_specs():
         assert specs["default_temperature"] == 1.0
         assert thinking_effort_options("fireworks", model) == ("none", "low", "medium", "high", "max")
         assert specs["thinking_effort"].default == "medium"
+
+
+def test_claude_fable_5_model_specs():
+    specs = get_model_specs("anthropic", "claude-fable-5")
+
+    assert specs["context_length"] == 1000000
+    assert specs["max_completion_tokens"] == 128000
+    assert specs["default_temperature"] == 1.0
+    assert specs["supports_temperature"] is False
+    assert specs["supports_vision"] is True
+    assert specs["thinking_effort"].options == ("low", "medium", "high", "xhigh", "max")
+    assert specs["thinking_effort"].default == "medium"
+    assert specs["thinking_effort"].mode == "anthropic_adaptive_effort"
+
+
+def test_claude_sonnet_5_model_specs():
+    specs = get_model_specs("anthropic", "claude-sonnet-5")
+
+    assert specs["context_length"] == 1000000
+    assert specs["max_completion_tokens"] == 128000
+    assert specs["default_temperature"] == 1.0
+    assert specs["supports_temperature"] is False
+    assert specs["supports_vision"] is True
+    assert specs["thinking_effort"].options == ("low", "medium", "high", "xhigh", "max")
+    assert specs["thinking_effort"].default == "medium"
+    assert specs["thinking_effort"].mode == "anthropic_adaptive_effort"

--- a/tests/agent/llm/test_supports_vision.py
+++ b/tests/agent/llm/test_supports_vision.py
@@ -13,6 +13,8 @@ def test_supports_vision_flag_present_on_every_entry():
 @pytest.mark.parametrize(
     "provider,model,expected",
     [
+        ("anthropic", "claude-fable-5", True),
+        ("anthropic", "claude-sonnet-5", True),
         ("anthropic", "claude-opus-4-8", True),
         ("anthropic", "claude-haiku-4-5-20251001", True),
         ("openai", "gpt-5.5", True),

--- a/tests/agent/llm/test_thinking_effort.py
+++ b/tests/agent/llm/test_thinking_effort.py
@@ -9,6 +9,10 @@ from kolega_code.llm.specs import default_thinking_effort, thinking_effort_optio
 
 
 def test_model_specs_expose_provider_specific_thinking_efforts() -> None:
+    assert thinking_effort_options("anthropic", "claude-fable-5") == ("low", "medium", "high", "xhigh", "max")
+    assert default_thinking_effort("anthropic", "claude-fable-5") == "medium"
+    assert thinking_effort_options("anthropic", "claude-sonnet-5") == ("low", "medium", "high", "xhigh", "max")
+    assert default_thinking_effort("anthropic", "claude-sonnet-5") == "medium"
     assert thinking_effort_options("moonshot", "kimi-k2.7-code") == ("auto",)
     assert default_thinking_effort("moonshot", "kimi-k2.7-code") == "auto"
     assert thinking_effort_options("moonshot", "kimi-k2.6") == ("auto", "none")


### PR DESCRIPTION
## Summary

Add first-class support for two newly released Anthropic models — **Claude Fable 5** (`claude-fable-5`) and **Claude Sonnet 5** (`claude-sonnet-5`) — so they appear in the Settings UI, `/model` picker, CLI flags, and env-var configuration, and serialize requests correctly.

Both models share the same API shape as the newest already-supported model (`claude-opus-4-8`):

| Spec | Fable 5 | Sonnet 5 |
| --- | --- | --- |
| API model ID | `claude-fable-5` | `claude-sonnet-5` |
| Context window | 1,000,000 | 1,000,000 |
| Max output tokens | 128,000 | 128,000 |
| Vision input | Yes | Yes |
| Thinking | Adaptive only (`thinking: {"type": "adaptive"}`) | Adaptive only |
| Effort levels | `low`, `medium`, `high`, `xhigh`, `max` | `low`, `medium`, `high`, `xhigh`, `max` |
| `temperature`/`top_p`/`top_k` | Removed | Removed |

**No provider code changes were needed.** The `anthropic_adaptive_effort` thinking mode and the `supports_temperature=False` sanitization already existed in the codebase and handle these models exactly. Registration in `MODEL_SPECS` is sufficient — the Settings UI, `/model` picker, and CLI validation are all auto-derived from the catalog.

## Changes

- `kolega_code/llm/specs/catalog/anthropic.py` — register `claude-fable-5` (top of dict) and `claude-sonnet-5` (before `claude-sonnet-4-6`, newest-first grouping). Insertion order drives UI display order.
- `kolega_code/cli/provider_registry.py` — friendly display labels ("Claude Fable 5" / "Claude Sonnet 5"). Default Anthropic model unchanged (`claude-opus-4-8`).
- `tests/agent/llm/test_model_specs.py` — two tests asserting the full spec for each model.
- `tests/agent/llm/test_supports_vision.py` — two parametrized vision cases.
- `tests/agent/llm/test_thinking_effort.py` — effort-options/default assertions.
- `docs/src/content/docs/configuration/providers-and-models.mdx` — two rows in the thinking-effort table.
- `CHANGELOG.md` — Unreleased → Added entry.

## Checks

- Targeted unit tests (`test_model_specs`, `test_supports_vision`, `test_thinking_effort`, `test_provider_registry`, `test_settings`, `test_cli_config`): **115 passed**.
- Full fast suite (`./run_tests.sh`): **1705 passed, 2 skipped, 50 deselected**. The 2 skips are live Anthropic API 429 quota exhaustion — unrelated to these changes.