### PR TITLE
fix(tui): keep turn worker alive during goal verifier

### DIFF
--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -108,7 +108,6 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
             self._flush_conversation_render()
             self._active_progress_entry = None
             self._turn_active = False
-            self.agent_worker = None
             if self._plan_decision_active:
                 self._set_composer_status(messages.PLAN_READY_PLACEHOLDER)
             else:
@@ -119,21 +118,29 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
         return cancelled_by_user
 
     async def _process_message(self, message: str, attachments: list[dict] | None = None) -> None:
-        if self.agent is None:
-            return
-        cancelled_by_user = await self._run_turn_stream(lambda: self._agent_turn_stream(message, attachments))
-        if cancelled_by_user:
-            self._schedule_maybe_start_queued_message()
-            return
-        # Un-pause a paused goal on any user-initiated turn so the loop resumes.
-        if self._goal is not None and self._goal.paused and not self._goal.met:
-            self._goal.paused = False
-            self._goal.status_note = ""
-            self._sync_goal_to_session()
-        if self._goal is not None and self._goal.is_active:
-            await self._run_goal_loop()
-        else:
-            self._schedule_maybe_start_queued_message()
+        try:
+            if self.agent is None:
+                return
+            cancelled_by_user = await self._run_turn_stream(lambda: self._agent_turn_stream(message, attachments))
+            if cancelled_by_user:
+                self._schedule_maybe_start_queued_message()
+                return
+            # Un-pause a paused goal on any user-initiated turn so the loop resumes.
+            if self._goal is not None and self._goal.paused and not self._goal.met:
+                self._goal.paused = False
+                self._goal.status_note = ""
+                self._sync_goal_to_session()
+            if self._goal is not None and self._goal.is_active:
+                await self._run_goal_loop()
+            else:
+                self._schedule_maybe_start_queued_message()
+        finally:
+            # The turn worker owns ``agent_worker`` for its whole lifetime — including
+            # the goal loop's verifier phase, which runs between work turns. Clear it
+            # only here so the app stays "busy" during goal evaluation: submissions
+            # queue instead of running immediately (which would cancel the verifier
+            # via the exclusive ``turns`` worker group) and Esc can interrupt the loop.
+            self.agent_worker = None
 
     # ------------------------------------------------------------------
     # Autonomous goal loop
@@ -202,31 +209,37 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
 
     async def _run_goal_loop(self) -> None:
         """Evaluate → continue loop, run after a successful (non-cancelled) turn."""
-        while self._goal is not None and self._goal.is_active:
-            self._accumulate_goal_tokens()
-            verdict = await self._evaluate_active_goal()
-            if verdict.met:
-                await self._complete_goal(verdict)
-                break
-            self._goal.turns_evaluated += 1
-            self._sync_goal_to_session()
-            if self._goal.turns_evaluated >= self._goal.max_turns:
-                await self._abort_goal()
-                break
-            turns_remaining = self._goal.max_turns - self._goal.turns_evaluated
-            nudge = build_goal_nudge(self._goal.condition, verdict, turns_remaining)
-            self._add_conversation_entry(
-                tui_state.ConversationEntry(
-                    kind="system",
-                    content=messages.GOAL_NOT_MET_CONTINUE.format(
-                        reason=verdict.reason or "see the verifier's assessment"
-                    ),
+        try:
+            while self._goal is not None and self._goal.is_active:
+                self._accumulate_goal_tokens()
+                verdict = await self._evaluate_active_goal()
+                if verdict.met:
+                    await self._complete_goal(verdict)
+                    break
+                self._goal.turns_evaluated += 1
+                self._sync_goal_to_session()
+                if self._goal.turns_evaluated >= self._goal.max_turns:
+                    await self._abort_goal()
+                    break
+                turns_remaining = self._goal.max_turns - self._goal.turns_evaluated
+                nudge = build_goal_nudge(self._goal.condition, verdict, turns_remaining)
+                self._add_conversation_entry(
+                    tui_state.ConversationEntry(
+                        kind="system",
+                        content=messages.GOAL_NOT_MET_CONTINUE.format(
+                            reason=verdict.reason or "see the verifier's assessment"
+                        ),
+                    )
                 )
-            )
-            cancelled = await self._run_turn_stream(lambda: self._agent_turn_stream(nudge))
-            if cancelled:
+                cancelled = await self._run_turn_stream(lambda: self._agent_turn_stream(nudge))
+                if cancelled:
+                    await self._pause_goal(messages.GOAL_PAUSED.format(reason="Stopped by user. "))
+                    break
+        except asyncio.CancelledError:
+            # Cancelled between work turns (e.g. Esc while the verifier was running).
+            # Pause so the goal survives and can be resumed, like the nudge-turn cancel.
+            if self._goal is not None and not self._goal.met and not self._goal.paused:
                 await self._pause_goal(messages.GOAL_PAUSED.format(reason="Stopped by user. "))
-                break
         self._schedule_maybe_start_queued_message()
 
     async def _complete_goal(self, verdict) -> None:

--- a/tests/cli/test_app_goal_command.py
+++ b/tests/cli/test_app_goal_command.py
@@ -49,6 +49,11 @@ class GoalFakeAgent:
         # raise asyncio.CancelledError instead of yielding.
         self._stream_call_count = 0
         self._cancel_on_calls: set[int] = set()
+        # Optional verifier gate: when set, evaluate_goal_condition signals
+        # ``_verifier_started`` then blocks on ``_release_verifier`` so tests can
+        # act *during* the verifier phase (e.g. submit a message or cancel).
+        self._verifier_started: asyncio.Event | None = None
+        self._release_verifier: asyncio.Event | None = None
         GoalFakeAgent.instances.append(self)
 
     # -- goal plumbing ----------------------------------------------------- #
@@ -62,6 +67,10 @@ class GoalFakeAgent:
 
     async def evaluate_goal_condition(self, condition):
         self._evaluate_calls.append(condition)
+        if self._verifier_started is not None:
+            self._verifier_started.set()
+        if self._release_verifier is not None:
+            await self._release_verifier.wait()  # CancelledError propagates here on cancel
         if self._goal_evaluate_results:
             return self._goal_evaluate_results.pop(0)
         return GoalVerdict(met=True, reason="done")
@@ -473,6 +482,86 @@ async def test_goal_blocked_while_turn_active(tmp_path: Path, monkeypatch: pytes
         # Goal is untouched and a stop-first warning was surfaced.
         assert app._goal is not None
         assert app._goal.condition == "make all tests pass"
+
+
+@pytest.mark.asyncio
+async def test_submission_during_verifier_is_queued(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A message submitted while the verifier runs is queued, not processed
+    immediately (which would cancel the verifier via the exclusive worker group)."""
+    app = _build_goal_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        await _wait_for(app, pilot, lambda: app.agent is not None)
+        agent = GoalFakeAgent.instances[-1]
+
+        # First evaluation: not met (blocks on the gate); second: met.
+        agent._goal_evaluate_results = [
+            GoalVerdict(met=False, reason="not yet"),
+            GoalVerdict(met=True, reason="done"),
+        ]
+        verifier_started = asyncio.Event()
+        release_verifier = asyncio.Event()
+        agent._verifier_started = verifier_started
+        agent._release_verifier = release_verifier
+
+        await _submit(app, pilot, "/goal make all tests pass")
+        await _wait_for(app, pilot, lambda: verifier_started.is_set())
+
+        # The worker is alive during the verifier (the fix). Without it,
+        # agent_worker is None and a submission would start a new turn worker
+        # that cancels the verifier via the exclusive ``turns`` group.
+        assert app.agent_worker is not None
+        assert app._turn_active is False
+
+        # Submit a steering message mid-verifier → it must queue, not run.
+        await _submit(app, pilot, "steer: do X")
+        assert any(item.text == "steer: do X" for item in app._queued_messages)
+        assert "steer: do X" not in agent.messages
+
+        # Release the verifier so the loop can proceed to completion, and clear
+        # the gate so the second evaluation doesn't block.
+        release_verifier.set()
+        agent._release_verifier = None
+        agent._verifier_started = None
+
+        await _wait_goal_terminal(app, pilot)
+        # The queued message is drained and processed after the goal loop ends.
+        await _wait_for(app, pilot, lambda: "steer: do X" in agent.messages, timeout=8.0)
+        await _wait_turn_idle(app, pilot)
+
+        assert "steer: do X" in agent.messages
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_verifier_pauses_goal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Esc while the verifier is running pauses the goal instead of doing nothing."""
+    app = _build_goal_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        await _wait_for(app, pilot, lambda: app.agent is not None)
+        agent = GoalFakeAgent.instances[-1]
+
+        # First evaluation: not met → blocks on the gate so we can cancel mid-verifier.
+        agent._goal_evaluate_results = [GoalVerdict(met=False, reason="keep going")]
+        verifier_started = asyncio.Event()
+        release_verifier = asyncio.Event()
+        agent._verifier_started = verifier_started
+        agent._release_verifier = release_verifier
+
+        await _submit(app, pilot, "/goal make all tests pass")
+        await _wait_for(app, pilot, lambda: verifier_started.is_set())
+
+        # The worker is alive during the verifier (the fix). Without it,
+        # agent_worker is None and action_cancel_generation is a no-op.
+        assert app.agent_worker is not None
+
+        app.action_cancel_generation()
+        await _wait_goal_terminal(app, pilot)
+
+        assert app._goal is not None
+        assert app._goal.paused is True
+        assert app._goal.met is False
+        assert any(e.kind == "system" and "Goal paused" in e.content for e in app.conversation_entries)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Problem

When an autonomous `/goal` loop runs its read-only verifier (`_evaluate_active_goal`), the TUI incorrectly reported itself as **idle**. `_run_turn_stream`'s `finally` block cleared `agent_worker = None` after each work turn, but the goal loop (including the verifier) continued running inside the same `_process_message` worker. During that window:

- **Submitting a message started a new turn immediately** — and since both workers use Textual's exclusive `turns` worker group, the new worker **cancelled the in-flight verifier**.
- **Esc/cancel did nothing** during the verifier (and during nudge turns) because `action_cancel_generation` only acts when `agent_worker is not None`.
- **Slash commands** (`/model`, `/goal clear`, etc.) were unguarded mid-verifier.

## Fix

All changes in `kolega_code/cli/tui/agent_runtime.py`:

1. **`_run_turn_stream`** — removed `self.agent_worker = None` from the `finally` block. The per-turn UI teardown (`_turn_active = False`, composer restore, etc.) is unchanged.

2. **`_process_message`** — wrapped the body in `try / finally`; the `finally` sets `agent_worker = None` once, when the entire worker (including the goal loop) is truly done. Existing `_schedule_maybe_start_queued_message()` calls stay exactly where they were.

3. **`_run_goal_loop`** — wrapped the `while` loop in `try / except asyncio.CancelledError`. If cancelled during the verifier (where no `_run_turn_stream` is on the stack to catch it), the goal is **paused** — mirroring the existing nudge-turn cancel behavior.

No new state flags were needed — the existing `agent_worker` guards everywhere (submission, queued-message drain, cancel, all slash commands) now work uniformly during the goal loop.

## Tests

Added a verifier gate to `GoalFakeAgent` (`_verifier_started` / `_release_verifier` events) so tests can act *during* the verifier phase:

- **`test_submission_during_verifier_is_queued`** — submits a message while the verifier is blocked, asserts it's queued (not processed), then releases the verifier and confirms the queued message drains after the loop completes.
- **`test_cancel_during_verifier_pauses_goal`** — calls `action_cancel_generation()` mid-verifier, asserts the goal pauses.

## Checks

- `pytest tests/cli/test_app_goal_command.py` (20 tests, incl. 2 new) — ✅
- `pytest tests/cli/test_app_rendering_errors.py test_app_composer_input.py test_app_plan_lifecycle.py test_app_permission_prompts.py test_app_sub_agents_workflows.py` (90 tests) — ✅
- `pytest tests/cli/test_ask_goal.py tests/agent/test_goal.py` (27 tests) — ✅
- `pytest tests/cli/` full suite (583 tests) — ✅ 582 pass, 1 pre-existing flaky failure (`test_changes_inspector_opens_and_renders_git_shell_changes`, passes in isolation, unrelated)
- `ruff check` + `ruff format --check` — ✅
- `pyright` — ✅ 0 errors
- pre-commit hooks (ruff, pyright, trailing-whitespace, etc.) — ✅ all passed