### PR TITLE
chore: release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.14.0 - 2026-07-03
+
 ### Added
 
 - Adopted Pyright static type checking (basic mode) across the codebase.
@@ -22,6 +24,14 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   automatically until the goal is met, a turn cap is hit, or the user
   pauses/cancels. Also available as `kolega-code ask --goal <condition>` for
   run-to-completion from the CLI. Goal state persists with the session.
+
+### Fixed
+
+- Handled CRLF line endings in the edit, multi_edit, and write tools so diffs
+  and patches apply correctly on Windows-originated files.
+- Showed full diffs on the session changes screen instead of a capped preview.
+- Kept the turn worker alive during goal verification so the agent does not
+  stall while checking autonomous goal conditions.
 
 ## 0.13.0 - 2026-07-02
 

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.13.0"
+__version__ = "0.14.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -44,4 +44,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.13.0"
+__version__ = "0.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.13.0"
+version = "0.14.0"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [options]
 prerelease-mode = "allow"
-exclude-newer = "2026-06-26T13:23:34.200128Z"
+exclude-newer = "2026-06-26T16:32:26.093892Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1397,7 +1397,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Release v0.14.0 — see CHANGELOG.md for details.