### PR TITLE
feat: bounded skill metadata rendering with context-aware budget

### DIFF
--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -76,6 +76,7 @@ from .skills import (
     activated_skill_names,
     build_skill_prompt_extension,
     build_skill_tool_extension,
+    context_window_tokens_for_skill_budget,
     discover_skills,
 )
 from .updater import check_for_update, run_self_update, update_status_message
@@ -759,7 +760,10 @@ async def _run_ask(args: argparse.Namespace) -> int:
     agent_ref: dict[str, CoderAgent] = {}
     prompt_extensions = []
     tool_extensions = []
-    skill_prompt_extension = build_skill_prompt_extension(skill_catalog)
+    skill_prompt_extension = build_skill_prompt_extension(
+        skill_catalog,
+        context_window_tokens=context_window_tokens_for_skill_budget(config, CoderAgent.agent_name),
+    )
     skill_tool_extension = build_skill_tool_extension(
         skill_catalog,
         lambda: agent_ref["agent"].history if "agent" in agent_ref else [],

--- a/kolega_code/cli/skills.py
+++ b/kolega_code/cli/skills.py
@@ -5,22 +5,67 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Iterable, Optional
+from typing import Callable, Iterable, Optional, Sequence
 
 import yaml
 
 from kolega_code.agent import PromptExtension, ToolExtension
 from kolega_code.agent.prompts import build_skill_catalog_prompt
-from kolega_code.llm.models import Message
 from kolega_code.agent.prompt_provider import AgentMode
+from kolega_code.llm.models import Message
+from kolega_code.llm.specs import get_model_specs
 
 
 PROJECT_SKILLS_DIR = Path(".agents") / "skills"
 USER_SKILLS_DIR = Path(".agents") / "skills"
 MAX_RESOURCE_FILES = 100
 MAX_RESOURCE_READ_CHARS = 100_000
+DEFAULT_SKILL_METADATA_CHAR_BUDGET = 8_000
+MAX_SKILL_METADATA_CHAR_BUDGET = 48_000
+SKILL_METADATA_CONTEXT_WINDOW_PERCENT = 2
+APPROX_CHARS_PER_TOKEN = 4
+SKILL_DESCRIPTION_TRUNCATION_SUFFIX = "..."
+LIST_SKILLS_DEFAULT_MAX_RESULTS = 50
+LIST_SKILLS_MAX_RESULTS = 100
 SKILL_NAME_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$")
 SKILL_CONTENT_RE = re.compile(r'<skill_content name="([^"]+)">')
+
+
+@dataclass(frozen=True)
+class SkillCatalogBudget:
+    max_chars: int
+    source: str = "explicit"
+
+    @classmethod
+    def for_context_window(cls, context_window_tokens: Optional[int]) -> "SkillCatalogBudget":
+        if context_window_tokens and context_window_tokens > 0:
+            budget_tokens = max(1, context_window_tokens * SKILL_METADATA_CONTEXT_WINDOW_PERCENT // 100)
+            return cls(
+                max_chars=min(
+                    MAX_SKILL_METADATA_CHAR_BUDGET,
+                    budget_tokens * APPROX_CHARS_PER_TOKEN,
+                ),
+                source=f"{SKILL_METADATA_CONTEXT_WINDOW_PERCENT}% of context window",
+            )
+        return cls(max_chars=DEFAULT_SKILL_METADATA_CHAR_BUDGET, source="default")
+
+    def normalized(self) -> "SkillCatalogBudget":
+        return SkillCatalogBudget(max_chars=max(1, int(self.max_chars)), source=self.source)
+
+
+@dataclass(frozen=True)
+class SkillCatalogRenderReport:
+    total_count: int
+    included_count: int
+    omitted_count: int
+    truncated_description_count: int = 0
+    truncated_description_chars: int = 0
+
+
+@dataclass(frozen=True)
+class SkillCatalogRenderResult:
+    markdown: str
+    report: SkillCatalogRenderReport
 
 
 @dataclass(frozen=True)
@@ -71,9 +116,68 @@ class SkillCatalog:
 
         return "\n".join(lines)
 
-    def prompt_catalog(self) -> str:
-        catalog_lines = [f"- `{record.name}` ({record.scope}): {record.description}" for record in self.skills.values()]
-        return build_skill_catalog_prompt("\n".join(catalog_lines))
+    def render_prompt_catalog(self, budget: Optional[SkillCatalogBudget] = None) -> SkillCatalogRenderResult:
+        render = _render_skill_metadata_records(
+            list(self.skills.values()),
+            budget or SkillCatalogBudget.for_context_window(None),
+        )
+        markdown = _append_skill_metadata_notes(render.markdown, render.report)
+        return SkillCatalogRenderResult(markdown=markdown, report=render.report)
+
+    def prompt_catalog(
+        self,
+        *,
+        context_window_tokens: Optional[int] = None,
+        budget: Optional[SkillCatalogBudget] = None,
+    ) -> str:
+        effective_budget = budget or SkillCatalogBudget.for_context_window(context_window_tokens)
+        return build_skill_catalog_prompt(self.render_prompt_catalog(effective_budget).markdown)
+
+    def format_model_catalog(
+        self,
+        *,
+        query: str = "",
+        max_results: int = LIST_SKILLS_DEFAULT_MAX_RESULTS,
+        budget: Optional[SkillCatalogBudget] = None,
+    ) -> str:
+        """Return a bounded model-facing skill list with names and descriptions only."""
+        records = _filter_skill_records(list(self.skills.values()), query)
+        clean_query = query.strip()
+        if not records:
+            if clean_query:
+                return f"No Agent Skills matched query `{clean_query}`."
+            return "No Agent Skills found."
+
+        max_results = _clamp_max_results(max_results)
+        visible_records = records[:max_results]
+        render = _render_skill_metadata_records(
+            visible_records,
+            budget or SkillCatalogBudget.for_context_window(None),
+        )
+
+        if clean_query:
+            lines = [f"Available Agent Skills matching `{clean_query}` ({len(records)} total):"]
+        else:
+            lines = [f"Available Agent Skills ({len(records)} total):"]
+        if render.markdown:
+            lines.extend(["", render.markdown])
+
+        if render.report.truncated_description_count:
+            lines.extend(["", "Skill descriptions were shortened to fit the skill metadata budget."])
+
+        omitted_count = len(records) - render.report.included_count
+        if omitted_count > 0:
+            lines.extend(
+                [
+                    "",
+                    (
+                        f"{omitted_count} matching skills were not shown. "
+                        "Call `list_skills(query=...)` with a narrower query to inspect more."
+                    ),
+                ]
+            )
+
+        return "\n".join(lines)
 
     def activation_content(self, name: str, *, active_names: Optional[set[str]] = None) -> str:
         record = self._require_skill(name)
@@ -158,6 +262,161 @@ class SkillCatalog:
         return record
 
 
+def _render_skill_metadata_records(
+    records: Sequence[SkillRecord],
+    budget: SkillCatalogBudget,
+) -> SkillCatalogRenderResult:
+    budget = budget.normalized()
+    records = list(records)
+    total_count = len(records)
+    if not records:
+        return SkillCatalogRenderResult(
+            markdown="",
+            report=SkillCatalogRenderReport(total_count=0, included_count=0, omitted_count=0),
+        )
+
+    full_lines = [_skill_metadata_line(record, _clean_description(record.description)) for record in records]
+    if _joined_len(full_lines) <= budget.max_chars:
+        return SkillCatalogRenderResult(
+            markdown="\n".join(full_lines),
+            report=SkillCatalogRenderReport(total_count=total_count, included_count=total_count, omitted_count=0),
+        )
+
+    minimum_lines = [_skill_metadata_line(record, "") for record in records]
+    if _joined_len(minimum_lines) <= budget.max_chars:
+        lines, truncated_count, truncated_chars = _largest_description_limited_lines(records, budget.max_chars)
+        return SkillCatalogRenderResult(
+            markdown="\n".join(lines),
+            report=SkillCatalogRenderReport(
+                total_count=total_count,
+                included_count=total_count,
+                omitted_count=0,
+                truncated_description_count=truncated_count,
+                truncated_description_chars=truncated_chars,
+            ),
+        )
+
+    included_lines: list[str] = []
+    included_records: list[SkillRecord] = []
+    for record in records:
+        line = _skill_metadata_line(record, "")
+        if not _line_fits(included_lines, line, budget.max_chars):
+            break
+        included_lines.append(line)
+        included_records.append(record)
+
+    return SkillCatalogRenderResult(
+        markdown="\n".join(included_lines),
+        report=SkillCatalogRenderReport(
+            total_count=total_count,
+            included_count=len(included_lines),
+            omitted_count=total_count - len(included_lines),
+            truncated_description_count=sum(1 for record in included_records if _clean_description(record.description)),
+            truncated_description_chars=sum(len(_clean_description(record.description)) for record in included_records),
+        ),
+    )
+
+
+def _largest_description_limited_lines(records: Sequence[SkillRecord], max_chars: int) -> tuple[list[str], int, int]:
+    max_description_len = max((len(_clean_description(record.description)) for record in records), default=0)
+    best_lines = [_skill_metadata_line(record, "") for record in records]
+    best_truncated_count = sum(1 for record in records if _clean_description(record.description))
+    best_truncated_chars = sum(len(_clean_description(record.description)) for record in records)
+    low = 0
+    high = max_description_len
+
+    while low <= high:
+        mid = (low + high) // 2
+        lines, truncated_count, truncated_chars = _description_limited_lines(records, mid)
+        if _joined_len(lines) <= max_chars:
+            best_lines = lines
+            best_truncated_count = truncated_count
+            best_truncated_chars = truncated_chars
+            low = mid + 1
+        else:
+            high = mid - 1
+
+    return best_lines, best_truncated_count, best_truncated_chars
+
+
+def _description_limited_lines(records: Sequence[SkillRecord], description_limit: int) -> tuple[list[str], int, int]:
+    lines: list[str] = []
+    truncated_count = 0
+    truncated_chars = 0
+    for record in records:
+        description = _clean_description(record.description)
+        rendered_description = _truncate_description(description, description_limit)
+        if rendered_description != description:
+            truncated_count += 1
+            truncated_chars += max(0, len(description) - len(rendered_description))
+        lines.append(_skill_metadata_line(record, rendered_description))
+    return lines, truncated_count, truncated_chars
+
+
+def _truncate_description(description: str, limit: int) -> str:
+    if limit <= 0:
+        return ""
+    if len(description) <= limit:
+        return description
+    if limit <= len(SKILL_DESCRIPTION_TRUNCATION_SUFFIX):
+        return description[:limit].rstrip()
+    body_limit = max(0, limit - len(SKILL_DESCRIPTION_TRUNCATION_SUFFIX))
+    return f"{description[:body_limit].rstrip()}{SKILL_DESCRIPTION_TRUNCATION_SUFFIX}"
+
+
+def _skill_metadata_line(record: SkillRecord, description: str) -> str:
+    if description:
+        return f"- `{record.name}`: {description}"
+    return f"- `{record.name}`:"
+
+
+def _clean_description(description: str) -> str:
+    return " ".join(description.split())
+
+
+def _joined_len(lines: Sequence[str]) -> int:
+    return len("\n".join(lines))
+
+
+def _line_fits(existing_lines: Sequence[str], new_line: str, max_chars: int) -> bool:
+    if not existing_lines:
+        return len(new_line) <= max_chars
+    return _joined_len([*existing_lines, new_line]) <= max_chars
+
+
+def _append_skill_metadata_notes(markdown: str, report: SkillCatalogRenderReport) -> str:
+    notes: list[str] = []
+    if report.truncated_description_count:
+        notes.append("Skill descriptions were shortened to fit the skill metadata budget.")
+    if report.omitted_count:
+        notes.append(f"{report.omitted_count} additional skills were omitted to fit the skill metadata budget.")
+    if not notes:
+        return markdown
+    note_block = "\n".join(f"- {note}" for note in notes)
+    if markdown:
+        return f"{markdown}\n\n{note_block}"
+    return note_block
+
+
+def _filter_skill_records(records: Sequence[SkillRecord], query: str) -> list[SkillRecord]:
+    clean_query = query.strip().lower()
+    if not clean_query:
+        return list(records)
+    return [
+        record
+        for record in records
+        if clean_query in record.name.lower() or clean_query in _clean_description(record.description).lower()
+    ]
+
+
+def _clamp_max_results(max_results: int) -> int:
+    try:
+        value = int(max_results)
+    except (TypeError, ValueError):
+        value = LIST_SKILLS_DEFAULT_MAX_RESULTS
+    return max(1, min(value, LIST_SKILLS_MAX_RESULTS))
+
+
 def discover_skills(project_path: Path, *, user_home: Optional[Path] = None) -> SkillCatalog:
     """Discover project and user Agent Skills."""
     user_home = user_home or Path.home()
@@ -202,13 +461,27 @@ def discover_skills(project_path: Path, *, user_home: Optional[Path] = None) -> 
     return catalog
 
 
-def build_skill_prompt_extension(catalog: SkillCatalog) -> Optional[PromptExtension]:
+def context_window_tokens_for_skill_budget(config: object, agent_name: Optional[str]) -> Optional[int]:
+    try:
+        model_config = config.model_config_for_agent(agent_name)  # type: ignore[attr-defined]
+        specs = get_model_specs(model_config.provider, model_config.model)
+        context_length = int(specs.get("context_length") or 0)
+    except Exception:
+        return None
+    return context_length if context_length > 0 else None
+
+
+def build_skill_prompt_extension(
+    catalog: SkillCatalog,
+    *,
+    context_window_tokens: Optional[int] = None,
+) -> Optional[PromptExtension]:
     if not catalog.has_skills():
         return None
     return PromptExtension(
         id="cli-agent-skills",
         title="Agent Skills",
-        markdown=catalog.prompt_catalog(),
+        markdown=catalog.prompt_catalog(context_window_tokens=context_window_tokens),
         modes=[AgentMode.CLI],
     )
 
@@ -220,16 +493,21 @@ def build_skill_tool_extension(
     if not catalog.has_skills():
         return None
 
-    async def list_skills() -> str:
+    async def list_skills(query: str = "", max_results: int = LIST_SKILLS_DEFAULT_MAX_RESULTS) -> str:
         """
         Return Agent Skills available in this CLI session.
 
-        Use this when choosing whether a specialized workflow is available.
+        Use this when choosing whether a specialized workflow is available. Pass a query to search by skill name or
+        description when the default result set is too broad.
+
+        Args:
+            query: Optional case-insensitive search text matched against skill names and descriptions.
+            max_results: Maximum number of matching skills to inspect. Values are clamped to a safe limit.
 
         Returns:
-            A Markdown list of skill names, scopes, and descriptions.
+            A bounded Markdown list of skill names and descriptions.
         """
-        return catalog.format_catalog()
+        return catalog.format_model_catalog(query=query, max_results=max_results)
 
     async def activate_skill(name: str) -> str:
         """

--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -22,7 +22,12 @@ from ..goal import (
     now_iso,
 )
 from ..plan_artifacts import write_current_plan_artifact
-from ..skills import build_skill_prompt_extension, build_skill_tool_extension, discover_skills
+from ..skills import (
+    build_skill_prompt_extension,
+    build_skill_tool_extension,
+    context_window_tokens_for_skill_budget,
+    discover_skills,
+)
 from . import app_base as tui_app_base
 from . import constants as tui_constants
 from . import state as tui_state
@@ -663,7 +668,13 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
             plan_artifact_extension = self._current_plan_artifact_prompt_extension()
             if plan_artifact_extension is not None:
                 prompt_extensions.append(plan_artifact_extension)
-        skill_prompt_extension = build_skill_prompt_extension(self.skill_catalog)
+        skill_prompt_extension = build_skill_prompt_extension(
+            self.skill_catalog,
+            context_window_tokens=context_window_tokens_for_skill_budget(
+                config,
+                getattr(agent_class, "agent_name", None),
+            ),
+        )
         skill_tool_extension = build_skill_tool_extension(
             self.skill_catalog,
             lambda: self.agent.history if self.agent is not None else [],

--- a/tests/cli/test_ask_goal.py
+++ b/tests/cli/test_ask_goal.py
@@ -11,6 +11,7 @@ from kolega_code.llm.models import Message
 class GoalAskFakeAgent:
     """Fake CoderAgent supporting the goal loop contract."""
 
+    agent_name = "coder"
     instances: list["GoalAskFakeAgent"] = []
     # Class-level verdict queue so tests can pre-populate before ``main`` creates
     # the agent instance internally.

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -331,6 +331,7 @@ def test_ask_skill_with_prompt_activates_before_dispatch(
     from kolega_code.cli import main as main_module
 
     class FakeCoderAgent:
+        agent_name = "coder"
         instances = []
 
         def __init__(self, **kwargs):
@@ -380,6 +381,7 @@ def test_ask_plain_handles_billing_error_without_traceback(
     from kolega_code.cli import main as main_module
 
     class FakeCoderAgent:
+        agent_name = "coder"
         instances = []
 
         def __init__(self, **kwargs):
@@ -432,6 +434,8 @@ def test_ask_json_handles_billing_error_without_traceback(
     from kolega_code.cli import main as main_module
 
     class FakeCoderAgent:
+        agent_name = "coder"
+
         def __init__(self, **kwargs):
             self.kwargs = kwargs
 
@@ -711,6 +715,7 @@ def _sub_agent_test_event():
 class _SubAgentEventCoderAgent:
     """Fake CoderAgent that broadcasts a sub-agent event mid-stream."""
 
+    agent_name = "coder"
     instances = []
 
     def __init__(self, **kwargs):
@@ -794,6 +799,7 @@ def test_ask_prompt_with_file_mention_attaches_content(
     from kolega_code.cli import main as main_module
 
     class FakeCoderAgent:
+        agent_name = "coder"
         instances = []
 
         def __init__(self, **kwargs):
@@ -846,6 +852,7 @@ def test_ask_prompt_with_unresolved_mention_warns_on_stderr(
     from kolega_code.cli import main as main_module
 
     class FakeCoderAgent:
+        agent_name = "coder"
         instances = []
 
         def __init__(self, **kwargs):

--- a/tests/cli/test_skills.py
+++ b/tests/cli/test_skills.py
@@ -2,7 +2,14 @@ from pathlib import Path
 
 import pytest
 
-from kolega_code.cli.skills import activated_skill_names, discover_skills
+from kolega_code.cli.skills import (
+    MAX_SKILL_METADATA_CHAR_BUDGET,
+    SkillCatalogBudget,
+    activated_skill_names,
+    build_skill_prompt_extension,
+    build_skill_tool_extension,
+    discover_skills,
+)
 from kolega_code.llm.models import Message, TextBlock, ToolResult
 
 
@@ -83,6 +90,132 @@ Follow folded instructions.
     catalog = discover_skills(project, user_home=user_home)
 
     assert catalog.skills["folded-skill"].description == "Use this folded skill when testing YAML descriptions."
+
+
+def test_prompt_catalog_uses_only_names_and_descriptions(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    user_home = tmp_path / "home"
+    project.mkdir()
+    write_skill(project / ".agents" / "skills", "plain-skill", "Use this plain skill.")
+
+    catalog = discover_skills(project, user_home=user_home)
+    prompt = catalog.prompt_catalog(budget=SkillCatalogBudget(max_chars=1_000))
+
+    assert "- `plain-skill`: Use this plain skill." in prompt
+    assert "/plain-skill" not in prompt
+    assert "(project)" not in prompt
+
+
+def test_prompt_catalog_truncates_descriptions_before_omitting_skills(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    user_home = tmp_path / "home"
+    project.mkdir()
+    skills_root = project / ".agents" / "skills"
+    long_description = "Use this skill " + ("for a very long specialized workflow " * 8)
+    for name in ("alpha-skill", "beta-skill", "gamma-skill"):
+        write_skill(skills_root, name, long_description)
+
+    catalog = discover_skills(project, user_home=user_home)
+    render = catalog.render_prompt_catalog(SkillCatalogBudget(max_chars=95))
+
+    assert render.report.included_count == 3
+    assert render.report.omitted_count == 0
+    assert render.report.truncated_description_count == 3
+    assert "`alpha-skill`" in render.markdown
+    assert "`beta-skill`" in render.markdown
+    assert "`gamma-skill`" in render.markdown
+    assert "Skill descriptions were shortened" in render.markdown
+    assert long_description not in render.markdown
+
+
+def test_prompt_catalog_omits_overflow_when_names_exceed_budget(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    user_home = tmp_path / "home"
+    project.mkdir()
+    skills_root = project / ".agents" / "skills"
+    for index in range(10):
+        write_skill(skills_root, f"skill-{index:02d}", f"Use skill {index}.")
+
+    catalog = discover_skills(project, user_home=user_home)
+    render = catalog.render_prompt_catalog(SkillCatalogBudget(max_chars=30))
+
+    assert render.report.included_count == 2
+    assert render.report.omitted_count == 8
+    assert "`skill-00`" in render.markdown
+    assert "`skill-01`" in render.markdown
+    assert "`skill-02`" not in render.markdown
+    assert "8 additional skills were omitted" in render.markdown
+
+
+def test_build_skill_prompt_extension_uses_context_window_budget(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    user_home = tmp_path / "home"
+    project.mkdir()
+    write_skill(
+        project / ".agents" / "skills",
+        "budgeted-skill",
+        "Use this skill " + ("when the model needs a long detailed workflow " * 12),
+    )
+
+    catalog = discover_skills(project, user_home=user_home)
+    extension = build_skill_prompt_extension(catalog, context_window_tokens=1_000)
+
+    assert extension is not None
+    assert "`budgeted-skill`" in extension.markdown
+    assert "Skill descriptions were shortened" in extension.markdown
+    assert "(project)" not in extension.markdown
+
+
+def test_context_window_budget_has_hard_cap() -> None:
+    budget = SkillCatalogBudget.for_context_window(1_000_000)
+
+    assert budget.max_chars == MAX_SKILL_METADATA_CHAR_BUDGET
+
+
+def test_large_context_skill_prompt_extension_stays_bounded(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    user_home = tmp_path / "home"
+    project.mkdir()
+    skills_root = project / ".agents" / "skills"
+    long_description = "Use this skill " + ("when the model needs a long detailed stress workflow " * 10)
+    for index in range(200):
+        write_skill(skills_root, f"stress-skill-{index:03d}", long_description)
+
+    catalog = discover_skills(project, user_home=user_home)
+    extension = build_skill_prompt_extension(catalog, context_window_tokens=1_000_000)
+
+    assert extension is not None
+    assert len(extension.markdown) <= MAX_SKILL_METADATA_CHAR_BUDGET + 500
+    assert "`stress-skill-000`" in extension.markdown
+    assert "`stress-skill-199`" in extension.markdown
+    assert "Skill descriptions were shortened" in extension.markdown
+
+
+@pytest.mark.asyncio
+async def test_list_skills_tool_is_bounded_and_queryable(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    user_home = tmp_path / "home"
+    project.mkdir()
+    skills_root = project / ".agents" / "skills"
+    for index in range(60):
+        write_skill(skills_root, f"alpha-{index:02d}", f"Use alpha skill {index}.")
+
+    catalog = discover_skills(project, user_home=user_home)
+    extension = build_skill_tool_extension(catalog, lambda: [])
+    assert extension is not None
+    list_skills = extension.tools["list_skills"]
+
+    default_output = await list_skills()
+    assert "`alpha-00`" in default_output
+    assert "`alpha-49`" in default_output
+    assert "`alpha-59`" not in default_output
+    assert "10 matching skills were not shown" in default_output
+    assert "/alpha-00" not in default_output
+    assert "(project)" not in default_output
+
+    queried_output = await list_skills(query="alpha-59")
+    assert "`alpha-59`" in queried_output
+    assert "Use alpha skill 59." in queried_output
 
 
 def test_discover_skills_skips_missing_description_and_malformed_yaml(tmp_path: Path) -> None:


### PR DESCRIPTION
- Prompt catalog now uses only skill name + description (no scope, no path).
- Default metadata budget is 8,000 chars; large-context budget is 2% of
  context window, hard-capped at 48,000 chars.
- Descriptions are truncated before skills are omitted from the prompt.
- Full SKILL.md content is still only loaded on activation.
- list_skills tool is now bounded/queryable with query and max_results.
- CLI ask and TUI agent startup both pass the active model's context
  window into the skill prompt budget.
- Regression tests for name/description-only rendering, truncation,
  omission, large-context hard cap, and bounded/queryable list_skills.
