### PR TITLE
chore: release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.15.0 - 2026-07-07
+
+### Added
+
+- Added Language Server Protocol (LSP) integration with an agent-callable
+  read-only `lsp` tool (diagnostics, go-to-definition, references, hover,
+  document/workspace symbols, and status) and a trusted `lsp_edit` tool for
+  rename, formatting, and code actions. The `edit`, `multi_edit`, and `write`
+  tools now append LSP diagnostics to their results, with a `/lsp` status
+  command, detected-language status in the TUI wordmark, and a Settings toggle.
+- Added bounded skill metadata rendering with a context-aware token budget.
+  The prompt catalog now uses skill name and description only, descriptions are
+  truncated before skills are omitted, and `list_skills` is queryable with
+  `max_results`.
+- Documented composable workflow shapes in the Gigacode orchestration guide.
+
 ## 0.14.0 - 2026-07-03
 
 ### Added

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -44,4 +44,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.14.0"
+version = "0.15.0"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [options]
 prerelease-mode = "allow"
-exclude-newer = "2026-06-26T16:32:26.093892Z"
+exclude-newer = "2026-06-30T08:53:12.397551Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1397,7 +1397,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.14.0"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Release v0.15.0 (minor). Version bump, lockfile refresh, and changelog entry. See CHANGELOG.md.