### PR TITLE
feat: add workspace snapshot/undo and pending-action resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ build/
 coverage.xml
 htmlcov/
 docs/kolega_reskin_project/
+docs/agent-harness-frontier-roadmap.md

--- a/kolega_code/agent/tool_backend/edit_tool.py
+++ b/kolega_code/agent/tool_backend/edit_tool.py
@@ -9,6 +9,7 @@ from .edit_preview import build_diff_preview, build_head_preview
 
 if TYPE_CHECKING:
     from kolega_code.services.lsp import LspManager
+    from kolega_code.services.snapshots import SnapshotService
 
 
 _BLOCK_PATTERN = re.compile(r"<<<<<<< SEARCH\r?\n(.*?)\r?\n=======\r?\n(.*?)\r?\n>>>>>>> REPLACE", re.DOTALL)
@@ -43,9 +44,16 @@ class ResolvedReplacement:
 
 
 class EditTool(BaseTool):
-    def __init__(self, *args, lsp_manager: Optional["LspManager"] = None, **kwargs) -> None:
+    def __init__(
+        self,
+        *args,
+        lsp_manager: Optional["LspManager"] = None,
+        snapshot_service: Optional["SnapshotService"] = None,
+        **kwargs,
+    ) -> None:
         super().__init__(*args, **kwargs)
         self._lsp_manager = lsp_manager
+        self._snapshot_service = snapshot_service
 
     async def edit(self, path: str, block: str) -> str:
         """
@@ -115,8 +123,6 @@ class EditTool(BaseTool):
                     old_content = None
 
             parent_dir = self.filesystem.get_parent(path)
-            if parent_dir and parent_dir != "." and not self.filesystem.exists(parent_dir):
-                self.filesystem.create_directory(parent_dir)
 
             # Preserve the file's dominant line ending on overwrite; new files
             # keep the line endings the caller provided (typically LF).
@@ -124,7 +130,17 @@ class EditTool(BaseTool):
                 line_ending = self._detect_dominant_line_ending(path, old_content)
                 content = self._normalize_line_endings(content, line_ending)
 
-            self.filesystem.write_text(path, content)
+            def _write() -> None:
+                if parent_dir and parent_dir != "." and not self.filesystem.exists(parent_dir):
+                    self.filesystem.create_directory(parent_dir)
+                self.filesystem.write_text(path, content)
+
+            self._record_snapshot_mutation(
+                tool_name="write",
+                reason=f"write {path}",
+                paths=self._snapshot_paths_for_write(path),
+                mutate=_write,
+            )
 
             preview = (
                 build_diff_preview(old_content, content, path)
@@ -180,7 +196,12 @@ class EditTool(BaseTool):
             blocked_msg = self._enforce_vibe_edit_policy(path)
             if blocked_msg:
                 return blocked_msg
-            self.filesystem.write_text(path, normalized_updated)
+            self._record_snapshot_mutation(
+                tool_name=tool_name,
+                reason=f"{tool_name} {path}",
+                paths=[path],
+                mutate=lambda: self.filesystem.write_text(path, normalized_updated),
+            )
 
             await self.send_edit_preview(
                 build_diff_preview(original_content, normalized_updated, path),
@@ -222,6 +243,33 @@ class EditTool(BaseTool):
                 )
             )
         return parsed_blocks
+
+    def _record_snapshot_mutation(
+        self,
+        *,
+        tool_name: str,
+        reason: str,
+        paths: list[str],
+        mutate: Callable[[], None],
+    ) -> None:
+        if self._snapshot_service is None or not self._snapshot_service.can_snapshot_paths(paths):
+            mutate()
+            return
+        self._snapshot_service.record_mutation(
+            tool_name=tool_name,
+            tool_call_id=getattr(self.caller, "current_tool_execution_id", None),
+            reason=reason,
+            paths=paths,
+            mutate=mutate,
+        )
+
+    def _snapshot_paths_for_write(self, path: str) -> list[str]:
+        paths = [path]
+        parent = self.filesystem.get_parent(path)
+        while parent and parent != "." and not self.filesystem.exists(parent):
+            paths.append(parent)
+            parent = self.filesystem.get_parent(parent)
+        return paths
 
     def _resolve_replacement(self, content: str, block: SearchReplaceBlock) -> ResolvedReplacement:
         passes: list[tuple[str, Callable[[str, str], list[tuple[int, int]]]]] = [

--- a/kolega_code/agent/tool_backend/lsp_tool.py
+++ b/kolega_code/agent/tool_backend/lsp_tool.py
@@ -5,13 +5,16 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
-from typing import Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 from urllib.parse import unquote, urlparse
 
 from .base_tool import BaseTool
 from .edit_preview import build_diff_preview
 from kolega_code.services.lsp import LspManager, format_diagnostics, format_no_diagnostics
 from kolega_code.services.lsp.edits import WorkspaceEditApplier, WorkspaceEditError, WorkspaceEditResult
+
+if TYPE_CHECKING:
+    from kolega_code.services.snapshots import SnapshotService
 
 
 class LspTool(BaseTool):
@@ -563,9 +566,16 @@ class LspEditTool(BaseTool):
 
     _ALL_OPS = {"rename", "rename_file", "format_document", "format_range", "apply_code_action"}
 
-    def __init__(self, *args, lsp_manager: Optional[LspManager] = None, **kwargs) -> None:
+    def __init__(
+        self,
+        *args,
+        lsp_manager: Optional[LspManager] = None,
+        snapshot_service: Optional["SnapshotService"] = None,
+        **kwargs,
+    ) -> None:
         super().__init__(*args, **kwargs)
         self._lsp_manager = lsp_manager
+        self._snapshot_service = snapshot_service
 
     async def lsp_edit(
         self,
@@ -842,7 +852,17 @@ class LspEditTool(BaseTool):
                         blocked = self._first_blocked_path(preview.touched_paths)
                         if blocked:
                             return {"applied": False, "failureReason": blocked}
-                        applied = applier.apply(workspace_edit)
+                        if self._snapshot_service is not None:
+                            mutation = self._snapshot_service.record_mutation(
+                                tool_name="lsp_edit",
+                                tool_call_id=getattr(self.caller, "current_tool_execution_id", None),
+                                reason="lsp apply_code_action workspace/applyEdit",
+                                paths=preview.touched_paths,
+                                mutate=lambda: applier.apply(workspace_edit),
+                            )
+                            applied = mutation.result
+                        else:
+                            applied = applier.apply(workspace_edit)
                         server_results.append(applied)
                         return {"applied": True}
                     except WorkspaceEditError as exc:
@@ -896,9 +916,33 @@ class LspEditTool(BaseTool):
         if should_apply and blocked:
             return blocked
 
-        result = applier.apply(edit) if should_apply else preview
+        if should_apply:
+            if self._snapshot_service is not None:
+                mutation = self._snapshot_service.record_mutation(
+                    tool_name="lsp_edit",
+                    tool_call_id=getattr(self.caller, "current_tool_execution_id", None),
+                    reason=f"lsp_edit {operation}",
+                    paths=preview.touched_paths,
+                    mutate=lambda: applier.apply(edit),
+                )
+                result = mutation.result
+            else:
+                result = applier.apply(edit)
+        else:
+            result = preview
         await self._send_previews(result, operation)
         lines = [self._format_workspace_edit_result(operation, result)]
+        if not should_apply and self._snapshot_service is not None:
+            pending = self._snapshot_service.create_pending_workspace_edit(
+                tool_name="lsp_edit",
+                tool_call_id=getattr(self.caller, "current_tool_execution_id", None),
+                operation=operation,
+                workspace_edit=edit,
+                touched_paths=preview.touched_paths,
+                summaries=preview.summaries,
+                previews=self._preview_payloads(preview),
+            )
+            lines.append(f'Pending action: `{pending.action_id}`. Use resolve(decision="apply") to apply it.')
         if should_apply and include_diagnostics:
             diagnostics = await self._diagnostics_for_paths(result.touched_paths)
             if diagnostics:
@@ -909,14 +953,22 @@ class LspEditTool(BaseTool):
         return WorkspaceEditApplier(self.project_path, self.filesystem).preview(edit)
 
     async def _send_previews(self, result: WorkspaceEditResult, operation: str) -> None:
-        for change in result.text_changes:
-            if change.old_text == change.new_text:
-                continue
+        for preview in self._preview_payloads(result):
             await self.send_edit_preview(
-                build_diff_preview(change.old_text, change.new_text, change.path),
+                preview,
                 tool_call_id=getattr(self.caller, "current_tool_execution_id", None),
                 tool_name="lsp_edit",
             )
+
+    def _preview_payloads(self, result: WorkspaceEditResult) -> list[dict[str, Any]]:
+        previews: list[dict[str, Any]] = []
+        for change in result.text_changes:
+            if change.old_text == change.new_text:
+                continue
+            preview = build_diff_preview(change.old_text, change.new_text, change.path)
+            if preview:
+                previews.append(preview)
+        return previews
 
     def _format_workspace_edit_result(self, operation: str, result: WorkspaceEditResult) -> str:
         label = "Applied" if result.applied else "Preview"

--- a/kolega_code/agent/tool_backend/snapshot_tool.py
+++ b/kolega_code/agent/tool_backend/snapshot_tool.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional
+
+from kolega_code.services.lsp.edits import WorkspaceEditApplier
+from kolega_code.services.snapshots import PendingAction, SnapshotError, SnapshotRecord, SnapshotService
+from kolega_code.tools import ToolError
+
+from .base_tool import BaseTool
+from .edit_preview import build_diff_preview
+
+if TYPE_CHECKING:
+    from kolega_code.services.lsp.edits import WorkspaceEditResult
+
+
+class SnapshotTool(BaseTool):
+    def __init__(self, *args, snapshot_service: SnapshotService, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.snapshot_service = snapshot_service
+
+    async def snapshot(
+        self,
+        action: str = "list",
+        snapshot_id: str = "",
+        paths: Optional[list[str]] = None,
+        force: bool = False,
+        limit: int = 20,
+    ) -> str:
+        """Manage file snapshots for undo, inspection, and manual checkpoints.
+
+        Actions:
+        - list: show recent snapshots for this session.
+        - show: show one snapshot's metadata and touched paths.
+        - create: create a manual checkpoint for the provided paths.
+        - restore: restore a snapshot's before-state. Use snapshot_id="latest" for undo.
+
+        Args:
+            action: One of list, show, create, or restore.
+            snapshot_id: Snapshot id to show or restore. Use latest for the newest snapshot.
+            paths: Project-relative paths for create.
+            force: Restore even when tracked files changed after the snapshot.
+            limit: Maximum number of snapshots to list.
+
+        Returns:
+            Markdown summary of the requested snapshot operation.
+        """
+        try:
+            normalized_action = action.strip().lower()
+            if normalized_action == "list":
+                return self._format_snapshot_list(self.snapshot_service.list_snapshots(limit=limit))
+            if normalized_action == "show":
+                if not snapshot_id:
+                    raise SnapshotError("snapshot_id is required for action=show.")
+                return self._format_snapshot_detail(self.snapshot_service.load_snapshot(snapshot_id))
+            if normalized_action == "create":
+                record = self.snapshot_service.create_manual_snapshot(
+                    paths=paths or (),
+                    reason="manual snapshot",
+                    tool_call_id=getattr(self.caller, "current_tool_execution_id", None),
+                )
+                return f"Created manual snapshot `{record.snapshot_id}` for {', '.join(record.touched_paths)}."
+            if normalized_action == "restore":
+                target_id = snapshot_id or "latest"
+                result = self.snapshot_service.restore_snapshot(target_id, force=force)
+                forced = " with force=true" if result.forced else ""
+                return (
+                    f"Restored snapshot `{result.snapshot_id}`{forced}.\n\n"
+                    f"Touched paths: {', '.join(result.restored_paths) or '(none)'}"
+                )
+            raise SnapshotError("action must be one of: list, show, create, restore.")
+        except SnapshotError as exc:
+            raise ToolError(str(exc)) from exc
+
+    async def resolve(self, action_id: str, decision: str, force: bool = False) -> str:
+        """Apply or discard a pending preview action.
+
+        Pending actions are created by preview-only tools such as lsp_edit(apply=false).
+        Applying a pending action checks that the source files still match the preview
+        inputs before writing, unless force=true is explicitly provided.
+
+        Args:
+            action_id: Pending action id returned by a preview-only tool.
+            decision: apply or discard.
+            force: Apply even if source hashes no longer match.
+
+        Returns:
+            Markdown summary of the resolve decision.
+        """
+        try:
+            action = self.snapshot_service.load_pending_action(action_id)
+            normalized_decision = decision.strip().lower()
+            if normalized_decision == "discard":
+                updated = self.snapshot_service.update_pending_action(action, status="discarded", message="discarded")
+                return f"Discarded pending action `{updated.action_id}`."
+            if normalized_decision != "apply":
+                raise SnapshotError("decision must be apply or discard.")
+            if action.status != "pending":
+                raise SnapshotError(f"Pending action `{action.action_id}` is already {action.status}.")
+
+            mismatches = self.snapshot_service.diff_expected_current(action.source)
+            if mismatches and not force:
+                message = self.snapshot_service._format_mismatch_error(action.action_id, mismatches)
+                self.snapshot_service.update_pending_action(action, status="stale", message=message)
+                raise SnapshotError(message)
+
+            applier = WorkspaceEditApplier(self.project_path, self.filesystem)
+            preview = applier.preview(action.workspace_edit)
+
+            def _apply() -> "WorkspaceEditResult":
+                return applier.apply(action.workspace_edit)
+
+            mutation = self.snapshot_service.record_mutation(
+                tool_name=action.tool_name or "resolve",
+                tool_call_id=getattr(self.caller, "current_tool_execution_id", None) or action.tool_call_id,
+                reason=f"resolve {action.action_id} ({action.operation})",
+                paths=preview.touched_paths,
+                mutate=_apply,
+            )
+            result = mutation.result
+            await self._send_previews(result, action)
+            updated = self.snapshot_service.update_pending_action(
+                action,
+                status="applied",
+                snapshot_id=mutation.snapshot.snapshot_id if mutation.snapshot else None,
+                message="applied",
+            )
+            snapshot_line = f"\nSnapshot: `{updated.snapshot_id}`" if updated.snapshot_id else ""
+            forced = " with force=true" if force else ""
+            return (
+                f"Applied pending action `{updated.action_id}`{forced}.\n\n"
+                + self._format_workspace_edit_result(action.operation, result)
+                + snapshot_line
+            )
+        except SnapshotError as exc:
+            raise ToolError(str(exc)) from exc
+
+    async def _send_previews(self, result: "WorkspaceEditResult", action: PendingAction) -> None:
+        for change in result.text_changes:
+            if change.old_text == change.new_text:
+                continue
+            await self.send_edit_preview(
+                build_diff_preview(change.old_text, change.new_text, change.path),
+                tool_call_id=getattr(self.caller, "current_tool_execution_id", None) or action.tool_call_id,
+                tool_name="resolve",
+            )
+
+    @staticmethod
+    def _format_snapshot_list(records: list[SnapshotRecord]) -> str:
+        if not records:
+            return "No snapshots recorded for this session."
+        lines = ["# Snapshots", ""]
+        for record in records:
+            marker = " manual" if record.manual else ""
+            lines.append(
+                f"- `{record.snapshot_id}`{marker} - {record.tool_name} - "
+                f"{record.created_at} - {', '.join(record.touched_paths) or '(none)'}"
+            )
+        return "\n".join(lines)
+
+    @staticmethod
+    def _format_snapshot_detail(record: SnapshotRecord) -> str:
+        lines = [
+            f"# Snapshot `{record.snapshot_id}`",
+            "",
+            f"- Tool: `{record.tool_name}`",
+            f"- Tool call: `{record.tool_call_id or '-'}`",
+            f"- Created: {record.created_at}",
+            f"- Reason: {record.reason or '-'}",
+            f"- Manual: {str(record.manual).lower()}",
+            "",
+            "## Paths",
+        ]
+        for path in record.touched_paths:
+            before = record.before.get(path)
+            after = record.after.get(path)
+            lines.append(f"- `{path}`: {SnapshotTool._state_label(before)} -> {SnapshotTool._state_label(after)}")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _format_workspace_edit_result(operation: str, result: Any) -> str:
+        lines = [f"Applied LSP edit `{operation}`."]
+        for summary in result.summaries:
+            lines.append(f"- {summary}")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _state_label(state: Any) -> str:
+        if state is None:
+            return "missing"
+        suffix = f":{state.sha256[:12]}" if getattr(state, "sha256", None) else ""
+        return f"{state.kind}{suffix}"

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -21,6 +21,7 @@ from .tool_backend.memory_tool import MemoryTool
 from .tool_backend.read_file_tool import ReadFileTool
 from .tool_backend.read_image_tool import ReadImageTool
 from .tool_backend.search_codebase_tool import SearchCodebaseTool
+from .tool_backend.snapshot_tool import SnapshotTool
 from .tool_backend.web_fetch_tool import WebFetchTool
 from .tool_backend.web_search_tool import WebSearchTool
 from .tool_backend.terminal_tool import TerminalTool
@@ -31,6 +32,7 @@ from .tool_backend.workflow_tool import RUN_WORKFLOW_INPUT_SCHEMA, WorkflowTool
 from .tool_backend.build_tool import BuildTool
 from .tool_backend.lsp_tool import LspEditTool, LspTool
 from kolega_code.services.lsp import LspManager
+from kolega_code.services.snapshots import SnapshotService
 
 # Explicit input schema for the generic ``lsp`` tool.  The ``operation`` parameter
 # is an enum that signature introspection cannot express.
@@ -154,6 +156,54 @@ _LSP_EDIT_INPUT_SCHEMA: dict[str, Any] = {
         },
     },
     "required": ["operation"],
+}
+
+_SNAPSHOT_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "action": {
+            "type": "string",
+            "enum": ["list", "show", "create", "restore"],
+            "description": "Snapshot operation. Use restore with snapshot_id='latest' to undo the latest snapshot.",
+        },
+        "snapshot_id": {
+            "type": "string",
+            "description": "Snapshot id for show/restore. Use 'latest' to restore the newest snapshot.",
+        },
+        "paths": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Project-relative paths for action=create.",
+        },
+        "force": {
+            "type": "boolean",
+            "description": "Restore even when tracked files changed after the snapshot.",
+        },
+        "limit": {
+            "type": "integer",
+            "description": "Maximum number of snapshots to list.",
+        },
+    },
+}
+
+_RESOLVE_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "action_id": {
+            "type": "string",
+            "description": "Pending action id returned by a preview-only tool.",
+        },
+        "decision": {
+            "type": "string",
+            "enum": ["apply", "discard"],
+            "description": "Apply or discard the pending preview action.",
+        },
+        "force": {
+            "type": "boolean",
+            "description": "Apply even if source hashes no longer match.",
+        },
+    },
+    "required": ["action_id", "decision"],
 }
 
 
@@ -425,6 +475,15 @@ class ToolCollection(LogMixin):
         else:
             self.lsp_manager = None
 
+        snapshot_session_id = str(getattr(self.caller, "session_id", None) or self.thread_id)
+        self.snapshot_service = SnapshotService(
+            self.project_path,
+            self.workspace_id,
+            self.thread_id,
+            snapshot_session_id,
+            self.filesystem,
+        )
+
         self.think_hard_tool = ThinkHardTool(
             self.project_path,
             self.workspace_id,
@@ -443,6 +502,17 @@ class ToolCollection(LogMixin):
             self.caller,
             self.filesystem,
             lsp_manager=self.lsp_manager,
+            snapshot_service=self.snapshot_service,
+        )
+        self.snapshot_tool = SnapshotTool(
+            self.project_path,
+            self.workspace_id,
+            self.thread_id,
+            self.connection_manager,
+            self.config,
+            self.caller,
+            self.filesystem,
+            snapshot_service=self.snapshot_service,
         )
         self.list_directory_tool = ListDirectoryTool(
             self.project_path,
@@ -557,6 +627,8 @@ class ToolCollection(LogMixin):
         # can't express, so register an explicit input schema.
         self.extension_schemas["lsp"] = _LSP_INPUT_SCHEMA
         self.extension_schemas["lsp_edit"] = _LSP_EDIT_INPUT_SCHEMA
+        self.extension_schemas["snapshot"] = _SNAPSHOT_INPUT_SCHEMA
+        self.extension_schemas["resolve"] = _RESOLVE_INPUT_SCHEMA
         self.browser_tool = BrowserTool(
             self.project_path,
             self.workspace_id,
@@ -600,6 +672,7 @@ class ToolCollection(LogMixin):
             self.caller,
             self.filesystem,
             lsp_manager=self.lsp_manager,
+            snapshot_service=self.snapshot_service,
         )
 
     async def launch_browser(self, url: str) -> str:
@@ -1427,6 +1500,56 @@ class ToolCollection(LogMixin):
             PermissionError: If the file cannot be written to
         """
         return await self.edit_tool.write(path, content)
+
+    async def snapshot(
+        self,
+        action: str = "list",
+        snapshot_id: str = "",
+        paths: Optional[list[str]] = None,
+        force: bool = False,
+        limit: int = 20,
+    ) -> str:
+        """Manage file snapshots for undo, inspection, and manual checkpoints.
+
+        Use action="list" to see recent snapshots, action="show" with a snapshot_id
+        to inspect one, action="create" with paths to make a manual checkpoint, and
+        action="restore" to restore a snapshot's before-state. Use snapshot_id="latest"
+        with restore as an undo for the newest snapshot.
+
+        Args:
+            action: One of list, show, create, or restore.
+            snapshot_id: Snapshot id for show/restore; use latest for newest.
+            paths: Project-relative paths for create.
+            force: Restore even when tracked files changed after the snapshot.
+            limit: Maximum number of snapshots to list.
+
+        Returns:
+            Markdown summary of the snapshot operation.
+        """
+        return await self.snapshot_tool.snapshot(
+            action=action,
+            snapshot_id=snapshot_id,
+            paths=paths,
+            force=force,
+            limit=limit,
+        )
+
+    async def resolve(self, action_id: str, decision: str, force: bool = False) -> str:
+        """Apply or discard a pending preview action.
+
+        Pending actions are created by preview-only tools such as lsp_edit(apply=false).
+        Applying a pending action checks that the source files still match the preview
+        inputs before writing, unless force=true is explicitly provided.
+
+        Args:
+            action_id: Pending action id returned by a preview-only tool.
+            decision: apply or discard.
+            force: Apply even if source hashes no longer match.
+
+        Returns:
+            Markdown summary of the resolve operation.
+        """
+        return await self.snapshot_tool.resolve(action_id=action_id, decision=decision, force=force)
 
     async def read_memory(self) -> str:
         """

--- a/kolega_code/services/snapshots.py
+++ b/kolega_code/services/snapshots.py
@@ -1,0 +1,600 @@
+"""Private workspace snapshots and pending preview actions.
+
+The snapshot store is deliberately outside the user's project tree. It records
+pre/post file states for trusted mutating tools so an agent edit can be undone
+without creating commits, refs, or repo-local metadata.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from hashlib import sha256
+from pathlib import Path, PurePosixPath
+from typing import Any, Callable, Generic, Iterable, Literal, TypeVar
+
+from kolega_code.cli.session_store import default_state_dir
+from kolega_code.local_state import PRIVATE_FILE_MODE, ensure_private_dir, write_private_text
+from kolega_code.services.file_system import FileSystem
+
+
+SnapshotKind = Literal["missing", "file", "directory"]
+PendingStatus = Literal["pending", "applied", "discarded", "stale"]
+
+T = TypeVar("T")
+
+
+class SnapshotError(RuntimeError):
+    """Raised when snapshot, pending-action, or restore operations fail."""
+
+
+@dataclass(frozen=True)
+class FileState:
+    path: str
+    kind: SnapshotKind
+    sha256: str | None = None
+    size: int = 0
+    blob_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "kind": self.kind,
+            "sha256": self.sha256,
+            "size": self.size,
+            "blob_id": self.blob_id,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "FileState":
+        return cls(
+            path=str(data["path"]),
+            kind=data["kind"],
+            sha256=data.get("sha256"),
+            size=int(data.get("size") or 0),
+            blob_id=data.get("blob_id"),
+        )
+
+
+@dataclass(frozen=True)
+class SnapshotRecord:
+    snapshot_id: str
+    session_id: str
+    workspace_id: str
+    thread_id: str
+    project_path: str
+    tool_name: str
+    tool_call_id: str | None
+    reason: str
+    created_at: str
+    touched_paths: tuple[str, ...]
+    before: dict[str, FileState]
+    after: dict[str, FileState]
+    manual: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": 1,
+            "snapshot_id": self.snapshot_id,
+            "session_id": self.session_id,
+            "workspace_id": self.workspace_id,
+            "thread_id": self.thread_id,
+            "project_path": self.project_path,
+            "tool_name": self.tool_name,
+            "tool_call_id": self.tool_call_id,
+            "reason": self.reason,
+            "created_at": self.created_at,
+            "touched_paths": list(self.touched_paths),
+            "before": {path: state.to_dict() for path, state in self.before.items()},
+            "after": {path: state.to_dict() for path, state in self.after.items()},
+            "manual": self.manual,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "SnapshotRecord":
+        if data.get("schema_version") != 1:
+            raise SnapshotError(f"Unsupported snapshot schema version: {data.get('schema_version')}")
+        return cls(
+            snapshot_id=str(data["snapshot_id"]),
+            session_id=str(data["session_id"]),
+            workspace_id=str(data.get("workspace_id") or ""),
+            thread_id=str(data.get("thread_id") or ""),
+            project_path=str(data.get("project_path") or ""),
+            tool_name=str(data.get("tool_name") or ""),
+            tool_call_id=data.get("tool_call_id"),
+            reason=str(data.get("reason") or ""),
+            created_at=str(data["created_at"]),
+            touched_paths=tuple(str(path) for path in data.get("touched_paths") or ()),
+            before={path: FileState.from_dict(state) for path, state in (data.get("before") or {}).items()},
+            after={path: FileState.from_dict(state) for path, state in (data.get("after") or {}).items()},
+            manual=bool(data.get("manual", False)),
+        )
+
+
+@dataclass(frozen=True)
+class PendingAction:
+    action_id: str
+    session_id: str
+    workspace_id: str
+    thread_id: str
+    project_path: str
+    tool_name: str
+    tool_call_id: str | None
+    operation: str
+    created_at: str
+    updated_at: str
+    status: PendingStatus
+    touched_paths: tuple[str, ...]
+    source: dict[str, FileState]
+    workspace_edit: dict[str, Any]
+    summaries: tuple[str, ...] = ()
+    previews: tuple[dict[str, Any], ...] = ()
+    snapshot_id: str | None = None
+    message: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": 1,
+            "action_id": self.action_id,
+            "session_id": self.session_id,
+            "workspace_id": self.workspace_id,
+            "thread_id": self.thread_id,
+            "project_path": self.project_path,
+            "tool_name": self.tool_name,
+            "tool_call_id": self.tool_call_id,
+            "operation": self.operation,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "status": self.status,
+            "touched_paths": list(self.touched_paths),
+            "source": {path: state.to_dict() for path, state in self.source.items()},
+            "workspace_edit": self.workspace_edit,
+            "summaries": list(self.summaries),
+            "previews": list(self.previews),
+            "snapshot_id": self.snapshot_id,
+            "message": self.message,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "PendingAction":
+        if data.get("schema_version") != 1:
+            raise SnapshotError(f"Unsupported pending action schema version: {data.get('schema_version')}")
+        return cls(
+            action_id=str(data["action_id"]),
+            session_id=str(data["session_id"]),
+            workspace_id=str(data.get("workspace_id") or ""),
+            thread_id=str(data.get("thread_id") or ""),
+            project_path=str(data.get("project_path") or ""),
+            tool_name=str(data.get("tool_name") or ""),
+            tool_call_id=data.get("tool_call_id"),
+            operation=str(data.get("operation") or ""),
+            created_at=str(data["created_at"]),
+            updated_at=str(data.get("updated_at") or data["created_at"]),
+            status=data.get("status") or "pending",
+            touched_paths=tuple(str(path) for path in data.get("touched_paths") or ()),
+            source={path: FileState.from_dict(state) for path, state in (data.get("source") or {}).items()},
+            workspace_edit=data.get("workspace_edit") or {},
+            summaries=tuple(str(item) for item in data.get("summaries") or ()),
+            previews=tuple(dict(item) for item in data.get("previews") or ()),
+            snapshot_id=data.get("snapshot_id"),
+            message=str(data.get("message") or ""),
+        )
+
+
+@dataclass(frozen=True)
+class RestoreResult:
+    snapshot_id: str
+    restored_paths: tuple[str, ...]
+    forced: bool
+
+
+@dataclass(frozen=True)
+class MutationRecordResult(Generic[T]):
+    result: T
+    snapshot: SnapshotRecord | None
+
+
+@dataclass(frozen=True)
+class StateMismatch:
+    path: str
+    expected: FileState
+    actual: FileState
+
+
+class SnapshotService:
+    """Session-scoped snapshot and pending-action store."""
+
+    def __init__(
+        self,
+        project_path: Path,
+        workspace_id: str,
+        thread_id: str,
+        session_id: str,
+        filesystem: FileSystem,
+        *,
+        root: Path | None = None,
+    ) -> None:
+        self.project_path = project_path.resolve()
+        self.workspace_id = workspace_id
+        self.thread_id = thread_id
+        self.session_id = session_id
+        self.filesystem = filesystem
+        self.root = (root or default_state_dir()).expanduser() / "snapshots" / session_id
+        self.blobs_dir = self.root / "blobs"
+        self.snapshots_dir = self.root / "records"
+        self.pending_dir = self.root / "pending"
+
+    def ensure_dirs(self) -> None:
+        ensure_private_dir(self.root)
+        ensure_private_dir(self.blobs_dir)
+        ensure_private_dir(self.snapshots_dir)
+        ensure_private_dir(self.pending_dir)
+
+    def capture_paths(self, paths: Iterable[str]) -> dict[str, FileState]:
+        states: dict[str, FileState] = {}
+        for raw_path in paths:
+            path = self.normalize_path(raw_path)
+            self._capture_path(path, states)
+        return dict(sorted(states.items()))
+
+    def can_snapshot_paths(self, paths: Iterable[str]) -> bool:
+        try:
+            for path in paths:
+                self.normalize_path(path)
+        except SnapshotError:
+            return False
+        return True
+
+    def record_mutation(
+        self,
+        *,
+        tool_name: str,
+        tool_call_id: str | None,
+        reason: str,
+        paths: Iterable[str],
+        mutate: Callable[[], T],
+    ) -> MutationRecordResult[T]:
+        touched_paths = tuple(dict.fromkeys(self.normalize_path(path) for path in paths))
+        before = self.capture_paths(touched_paths)
+        result = mutate()
+        after = self.capture_paths(touched_paths)
+        snapshot = None
+        if not self._states_equal(before, after):
+            snapshot = self._write_snapshot(
+                tool_name=tool_name,
+                tool_call_id=tool_call_id,
+                reason=reason,
+                touched_paths=touched_paths,
+                before=before,
+                after=after,
+                manual=False,
+            )
+        return MutationRecordResult(result=result, snapshot=snapshot)
+
+    def create_manual_snapshot(
+        self,
+        *,
+        paths: Iterable[str],
+        reason: str = "manual snapshot",
+        tool_call_id: str | None = None,
+    ) -> SnapshotRecord:
+        touched_paths = tuple(dict.fromkeys(self.normalize_path(path) for path in paths))
+        if not touched_paths:
+            raise SnapshotError("At least one path is required to create a manual snapshot.")
+        current = self.capture_paths(touched_paths)
+        return self._write_snapshot(
+            tool_name="snapshot",
+            tool_call_id=tool_call_id,
+            reason=reason,
+            touched_paths=touched_paths,
+            before=current,
+            after=current,
+            manual=True,
+        )
+
+    def restore_snapshot(self, snapshot_id: str, *, force: bool = False) -> RestoreResult:
+        record = self.load_snapshot(snapshot_id)
+        expected = record.after
+        if not force and not record.manual:
+            mismatches = self.diff_expected_current(expected)
+            if mismatches:
+                raise SnapshotError(self._format_mismatch_error(record.snapshot_id, mismatches))
+        self._apply_states(record.before)
+        return RestoreResult(
+            snapshot_id=record.snapshot_id,
+            restored_paths=record.touched_paths,
+            forced=force,
+        )
+
+    def diff_expected_current(self, expected: dict[str, FileState]) -> list[StateMismatch]:
+        if not expected:
+            return []
+        current = self.capture_paths(expected.keys())
+        mismatches: list[StateMismatch] = []
+        for path in sorted(set(expected) | set(current)):
+            expected_state = expected.get(path) or FileState(path=path, kind="missing")
+            actual_state = current.get(path) or FileState(path=path, kind="missing")
+            if expected_state != actual_state:
+                mismatches.append(StateMismatch(path=path, expected=expected_state, actual=actual_state))
+        return mismatches
+
+    def list_snapshots(self, *, limit: int = 20) -> list[SnapshotRecord]:
+        self.ensure_dirs()
+        records: list[SnapshotRecord] = []
+        for path in self.snapshots_dir.glob("*.json"):
+            try:
+                records.append(SnapshotRecord.from_dict(json.loads(path.read_text(encoding="utf-8"))))
+            except Exception:
+                continue
+        records.sort(key=lambda item: item.created_at, reverse=True)
+        return records[: max(1, limit)]
+
+    def latest_snapshot(self) -> SnapshotRecord | None:
+        records = self.list_snapshots(limit=1)
+        return records[0] if records else None
+
+    def load_snapshot(self, snapshot_id: str) -> SnapshotRecord:
+        if snapshot_id == "latest":
+            latest = self.latest_snapshot()
+            if latest is None:
+                raise SnapshotError("No snapshots exist for this session.")
+            return latest
+        path = self.snapshots_dir / f"{snapshot_id}.json"
+        if not path.exists():
+            raise SnapshotError(f"Snapshot not found: {snapshot_id}")
+        return SnapshotRecord.from_dict(json.loads(path.read_text(encoding="utf-8")))
+
+    def create_pending_workspace_edit(
+        self,
+        *,
+        tool_name: str,
+        tool_call_id: str | None,
+        operation: str,
+        workspace_edit: dict[str, Any],
+        touched_paths: Iterable[str],
+        summaries: Iterable[str] = (),
+        previews: Iterable[dict[str, Any]] = (),
+    ) -> PendingAction:
+        normalized_paths = tuple(dict.fromkeys(self.normalize_path(path) for path in touched_paths))
+        source = self.capture_paths(normalized_paths)
+        now = _now()
+        action = PendingAction(
+            action_id=_new_id("act"),
+            session_id=self.session_id,
+            workspace_id=self.workspace_id,
+            thread_id=self.thread_id,
+            project_path=str(self.project_path),
+            tool_name=tool_name,
+            tool_call_id=tool_call_id,
+            operation=operation,
+            created_at=now,
+            updated_at=now,
+            status="pending",
+            touched_paths=normalized_paths,
+            source=source,
+            workspace_edit=workspace_edit,
+            summaries=tuple(summaries),
+            previews=tuple(previews),
+        )
+        self._write_pending(action)
+        return action
+
+    def list_pending_actions(self, *, include_resolved: bool = False, limit: int = 20) -> list[PendingAction]:
+        self.ensure_dirs()
+        actions: list[PendingAction] = []
+        for path in self.pending_dir.glob("*.json"):
+            try:
+                action = PendingAction.from_dict(json.loads(path.read_text(encoding="utf-8")))
+            except Exception:
+                continue
+            if include_resolved or action.status == "pending":
+                actions.append(action)
+        actions.sort(key=lambda item: item.updated_at, reverse=True)
+        return actions[: max(1, limit)]
+
+    def load_pending_action(self, action_id: str) -> PendingAction:
+        path = self.pending_dir / f"{action_id}.json"
+        if not path.exists():
+            raise SnapshotError(f"Pending action not found: {action_id}")
+        return PendingAction.from_dict(json.loads(path.read_text(encoding="utf-8")))
+
+    def update_pending_action(
+        self,
+        action: PendingAction,
+        *,
+        status: PendingStatus,
+        snapshot_id: str | None = None,
+        message: str = "",
+    ) -> PendingAction:
+        updated = PendingAction(
+            action_id=action.action_id,
+            session_id=action.session_id,
+            workspace_id=action.workspace_id,
+            thread_id=action.thread_id,
+            project_path=action.project_path,
+            tool_name=action.tool_name,
+            tool_call_id=action.tool_call_id,
+            operation=action.operation,
+            created_at=action.created_at,
+            updated_at=_now(),
+            status=status,
+            touched_paths=action.touched_paths,
+            source=action.source,
+            workspace_edit=action.workspace_edit,
+            summaries=action.summaries,
+            previews=action.previews,
+            snapshot_id=snapshot_id if snapshot_id is not None else action.snapshot_id,
+            message=message,
+        )
+        self._write_pending(updated)
+        return updated
+
+    def normalize_path(self, path: str) -> str:
+        if not path:
+            raise SnapshotError("Snapshot path must not be empty.")
+        candidate = Path(path)
+        if candidate.is_absolute():
+            try:
+                rel = candidate.resolve(strict=False).relative_to(self.project_path)
+            except ValueError as exc:
+                raise SnapshotError(f"Snapshot path is outside the project: {path}") from exc
+        else:
+            try:
+                rel = (self.project_path / candidate).resolve(strict=False).relative_to(self.project_path)
+            except ValueError as exc:
+                raise SnapshotError(f"Snapshot path is outside the project: {path}") from exc
+        normalized = PurePosixPath(rel.as_posix()).as_posix()
+        if not normalized or normalized == ".":
+            raise SnapshotError("Snapshot path must not be the project root.")
+        return normalized
+
+    def _capture_path(self, path: str, states: dict[str, FileState]) -> None:
+        if path in states:
+            return
+        if not self.filesystem.exists(path):
+            states[path] = FileState(path=path, kind="missing")
+            return
+        if self.filesystem.is_file(path):
+            data = self.filesystem.read_bytes(path)
+            digest = sha256(data).hexdigest()
+            blob_id = self._write_blob(digest, data)
+            states[path] = FileState(path=path, kind="file", sha256=digest, size=len(data), blob_id=blob_id)
+            return
+        if self.filesystem.is_dir(path):
+            states[path] = FileState(path=path, kind="directory")
+            for name in sorted(self.filesystem.listdir(path)):
+                child = f"{path.rstrip('/')}/{name}"
+                self._capture_path(child, states)
+            return
+        raise SnapshotError(f"Cannot snapshot unsupported filesystem entry: {path}")
+
+    def _apply_states(self, states: dict[str, FileState]) -> None:
+        for state in sorted(
+            (s for s in states.values() if s.kind == "missing"), key=lambda item: _depth(item.path), reverse=True
+        ):
+            self._remove_existing(state.path)
+        for state in sorted((s for s in states.values() if s.kind == "directory"), key=lambda item: _depth(item.path)):
+            if self.filesystem.exists(state.path) and not self.filesystem.is_dir(state.path):
+                self._remove_existing(state.path)
+            if not self.filesystem.exists(state.path):
+                self.filesystem.mkdir(state.path, parents=True, exist_ok=True)
+        for state in sorted((s for s in states.values() if s.kind == "file"), key=lambda item: _depth(item.path)):
+            parent = self.filesystem.get_parent(state.path)
+            if parent and parent != "." and not self.filesystem.exists(parent):
+                self.filesystem.mkdir(parent, parents=True, exist_ok=True)
+            if self.filesystem.exists(state.path) and self.filesystem.is_dir(state.path):
+                self.filesystem.rmtree(state.path)
+            self.filesystem.write_bytes(state.path, self._read_blob(state))
+
+    def _remove_existing(self, path: str) -> None:
+        if not self.filesystem.exists(path):
+            return
+        if self.filesystem.is_dir(path):
+            self.filesystem.rmtree(path)
+        else:
+            self.filesystem.remove(path, missing_ok=True)
+
+    def _write_snapshot(
+        self,
+        *,
+        tool_name: str,
+        tool_call_id: str | None,
+        reason: str,
+        touched_paths: tuple[str, ...],
+        before: dict[str, FileState],
+        after: dict[str, FileState],
+        manual: bool,
+    ) -> SnapshotRecord:
+        record = SnapshotRecord(
+            snapshot_id=_new_id("snap"),
+            session_id=self.session_id,
+            workspace_id=self.workspace_id,
+            thread_id=self.thread_id,
+            project_path=str(self.project_path),
+            tool_name=tool_name,
+            tool_call_id=tool_call_id,
+            reason=reason,
+            created_at=_now(),
+            touched_paths=touched_paths,
+            before=before,
+            after=after,
+            manual=manual,
+        )
+        self.ensure_dirs()
+        write_private_text(
+            self.snapshots_dir / f"{record.snapshot_id}.json", json.dumps(record.to_dict(), indent=2) + "\n"
+        )
+        return record
+
+    def _write_pending(self, action: PendingAction) -> None:
+        self.ensure_dirs()
+        write_private_text(self.pending_dir / f"{action.action_id}.json", json.dumps(action.to_dict(), indent=2) + "\n")
+
+    def _write_blob(self, digest: str, data: bytes) -> str:
+        self.ensure_dirs()
+        path = self.blobs_dir / digest
+        if not path.exists():
+            fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, PRIVATE_FILE_MODE)
+            try:
+                with os.fdopen(fd, "wb", closefd=False) as handle:
+                    handle.write(data)
+            except Exception:
+                try:
+                    path.unlink(missing_ok=True)
+                finally:
+                    raise
+            finally:
+                os.close(fd)
+            try:
+                os.chmod(path, PRIVATE_FILE_MODE)
+            except OSError:
+                pass
+        return digest
+
+    def _read_blob(self, state: FileState) -> bytes:
+        if not state.blob_id:
+            raise SnapshotError(f"Missing blob id for file state: {state.path}")
+        path = self.blobs_dir / state.blob_id
+        if not path.exists():
+            raise SnapshotError(f"Snapshot blob is missing for {state.path}: {state.blob_id}")
+        data = path.read_bytes()
+        digest = sha256(data).hexdigest()
+        if digest != state.sha256:
+            raise SnapshotError(f"Snapshot blob hash mismatch for {state.path}")
+        return data
+
+    @staticmethod
+    def _states_equal(left: dict[str, FileState], right: dict[str, FileState]) -> bool:
+        return left == right
+
+    @staticmethod
+    def _format_mismatch_error(snapshot_id: str, mismatches: list[StateMismatch]) -> str:
+        lines = [
+            f"Snapshot {snapshot_id} cannot be restored because tracked files changed after the snapshot.",
+            "Use force=true only if you intentionally want to overwrite current changes.",
+        ]
+        for mismatch in mismatches[:8]:
+            lines.append(
+                "- "
+                + mismatch.path
+                + f": expected {mismatch.expected.kind}:{mismatch.expected.sha256 or '-'}"
+                + f", found {mismatch.actual.kind}:{mismatch.actual.sha256 or '-'}"
+            )
+        if len(mismatches) > 8:
+            lines.append(f"- ... {len(mismatches) - 8} more mismatch(es)")
+        return "\n".join(lines)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _new_id(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:12]}"
+
+
+def _depth(path: str) -> int:
+    return len(PurePosixPath(path).parts)

--- a/tests/agent/tool_backend/test_snapshot_tool.py
+++ b/tests/agent/tool_backend/test_snapshot_tool.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from kolega_code.agent.tool_backend.edit_tool import EditTool
+from kolega_code.agent.tool_backend.lsp_tool import LspEditTool
+from kolega_code.agent.tool_backend.snapshot_tool import SnapshotTool
+from kolega_code.services.file_system import LocalFileSystem
+from kolega_code.services.snapshots import SnapshotService
+from kolega_code.tools import ToolError
+
+
+def _block(search: str, replace: str) -> str:
+    return f"<<<<<<< SEARCH\n{search}\n=======\n{replace}\n>>>>>>> REPLACE"
+
+
+def _caller() -> Mock:
+    caller = Mock()
+    caller.agent_name = "test_agent"
+    caller.sub_agent = False
+    caller.current_tool_execution_id = "tool-call-1"
+    return caller
+
+
+def _snapshot_service(project_path, filesystem) -> SnapshotService:
+    return SnapshotService(
+        project_path,
+        "workspace",
+        "thread",
+        f"session-{uuid.uuid4().hex}",
+        filesystem,
+        root=project_path.parent / "state",
+    )
+
+
+@pytest.mark.asyncio
+async def test_edit_snapshot_can_be_restored(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    path = project / "a.txt"
+    path.write_text("one\ntwo\n", encoding="utf-8")
+    filesystem = LocalFileSystem(project)
+    service = _snapshot_service(project, filesystem)
+    caller = _caller()
+    connection = AsyncMock()
+    edit_tool = EditTool(
+        project,
+        "workspace",
+        "thread",
+        connection,
+        Mock(),
+        caller,
+        filesystem,
+        snapshot_service=service,
+    )
+    snapshot_tool = SnapshotTool(
+        project,
+        "workspace",
+        "thread",
+        connection,
+        Mock(),
+        caller,
+        filesystem,
+        snapshot_service=service,
+    )
+
+    result = await edit_tool.edit("a.txt", _block("two", "three"))
+
+    assert result == "Edited a.txt"
+    assert path.read_text(encoding="utf-8") == "one\nthree\n"
+    records = service.list_snapshots()
+    assert len(records) == 1
+
+    restore_result = await snapshot_tool.snapshot(action="restore", snapshot_id="latest")
+
+    assert "Restored snapshot" in restore_result
+    assert path.read_text(encoding="utf-8") == "one\ntwo\n"
+
+
+@pytest.mark.asyncio
+async def test_out_of_project_write_skips_snapshot_and_succeeds(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    outside = tmp_path / "outside.txt"
+    filesystem = LocalFileSystem(project)
+    service = _snapshot_service(project, filesystem)
+    tool = EditTool(
+        project,
+        "workspace",
+        "thread",
+        AsyncMock(),
+        Mock(),
+        _caller(),
+        filesystem,
+        snapshot_service=service,
+    )
+
+    result = await tool.write(str(outside), "outside\n")
+
+    assert result == f"Wrote {outside}"
+    assert outside.read_text(encoding="utf-8") == "outside\n"
+    assert service.list_snapshots() == []
+
+
+@pytest.mark.asyncio
+async def test_out_of_project_edit_skips_snapshot_and_succeeds(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("alpha\n", encoding="utf-8")
+    filesystem = LocalFileSystem(project)
+    service = _snapshot_service(project, filesystem)
+    tool = EditTool(
+        project,
+        "workspace",
+        "thread",
+        AsyncMock(),
+        Mock(),
+        _caller(),
+        filesystem,
+        snapshot_service=service,
+    )
+
+    result = await tool.edit(str(outside), _block("alpha", "beta"))
+
+    assert result == f"Edited {outside}"
+    assert outside.read_text(encoding="utf-8") == "beta\n"
+    assert service.list_snapshots() == []
+
+
+@pytest.mark.asyncio
+async def test_manual_checkpoint_restores_after_change_without_force(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    path = project / "a.txt"
+    path.write_text("checkpoint\n", encoding="utf-8")
+    filesystem = LocalFileSystem(project)
+    service = _snapshot_service(project, filesystem)
+    tool = SnapshotTool(
+        project,
+        "workspace",
+        "thread",
+        AsyncMock(),
+        Mock(),
+        _caller(),
+        filesystem,
+        snapshot_service=service,
+    )
+    await tool.snapshot(action="create", paths=["a.txt"])
+    record = service.latest_snapshot()
+    assert record is not None
+    path.write_text("changed\n", encoding="utf-8")
+
+    result = await tool.snapshot(action="restore", snapshot_id=record.snapshot_id)
+
+    assert "Restored snapshot" in result
+    assert path.read_text(encoding="utf-8") == "checkpoint\n"
+
+
+@pytest.mark.asyncio
+async def test_snapshot_expected_failures_raise_tool_error(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    filesystem = LocalFileSystem(project)
+    service = _snapshot_service(project, filesystem)
+    tool = SnapshotTool(
+        project,
+        "workspace",
+        "thread",
+        AsyncMock(),
+        Mock(),
+        _caller(),
+        filesystem,
+        snapshot_service=service,
+    )
+
+    with pytest.raises(ToolError, match="Snapshot not found"):
+        await tool.snapshot(action="show", snapshot_id="snap_missing")
+
+
+@pytest.mark.asyncio
+async def test_resolve_expected_failures_raise_tool_error(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    path = project / "a.txt"
+    path.write_text("one\n", encoding="utf-8")
+    filesystem = LocalFileSystem(project)
+    service = _snapshot_service(project, filesystem)
+    tool = SnapshotTool(
+        project,
+        "workspace",
+        "thread",
+        AsyncMock(),
+        Mock(),
+        _caller(),
+        filesystem,
+        snapshot_service=service,
+    )
+    action = service.create_pending_workspace_edit(
+        tool_name="lsp_edit",
+        tool_call_id="tool-call-1",
+        operation="format_document",
+        workspace_edit={"changes": {}},
+        touched_paths=["a.txt"],
+    )
+
+    with pytest.raises(ToolError, match="decision must be apply or discard"):
+        await tool.resolve(action.action_id, decision="wait")
+
+
+@pytest.mark.asyncio
+async def test_resolve_applies_pending_workspace_edit(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    path = project / "a.txt"
+    path.write_text("one\n", encoding="utf-8")
+    filesystem = LocalFileSystem(project)
+    service = _snapshot_service(project, filesystem)
+    caller = _caller()
+    tool = SnapshotTool(
+        project,
+        "workspace",
+        "thread",
+        AsyncMock(),
+        Mock(),
+        caller,
+        filesystem,
+        snapshot_service=service,
+    )
+    workspace_edit = {
+        "changes": {
+            path.resolve().as_uri(): [
+                {
+                    "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 3}},
+                    "newText": "two",
+                }
+            ]
+        }
+    }
+    action = service.create_pending_workspace_edit(
+        tool_name="lsp_edit",
+        tool_call_id="tool-call-1",
+        operation="format_document",
+        workspace_edit=workspace_edit,
+        touched_paths=["a.txt"],
+        summaries=["updated a.txt"],
+    )
+
+    result = await tool.resolve(action.action_id, decision="apply")
+
+    assert f"Applied pending action `{action.action_id}`" in result
+    assert path.read_text(encoding="utf-8") == "two\n"
+    assert service.load_pending_action(action.action_id).status == "applied"
+    assert len(service.list_snapshots()) == 1
+
+
+@pytest.mark.asyncio
+async def test_resolve_discards_pending_workspace_edit(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    path = project / "a.txt"
+    path.write_text("one\n", encoding="utf-8")
+    filesystem = LocalFileSystem(project)
+    service = _snapshot_service(project, filesystem)
+    caller = _caller()
+    tool = SnapshotTool(
+        project,
+        "workspace",
+        "thread",
+        AsyncMock(),
+        Mock(),
+        caller,
+        filesystem,
+        snapshot_service=service,
+    )
+    action = service.create_pending_workspace_edit(
+        tool_name="lsp_edit",
+        tool_call_id="tool-call-1",
+        operation="format_document",
+        workspace_edit={"changes": {}},
+        touched_paths=["a.txt"],
+    )
+
+    result = await tool.resolve(action.action_id, decision="discard")
+
+    assert f"Discarded pending action `{action.action_id}`" in result
+    assert path.read_text(encoding="utf-8") == "one\n"
+    assert service.load_pending_action(action.action_id).status == "discarded"
+
+
+@pytest.mark.asyncio
+async def test_lsp_preview_creates_pending_action_without_writing(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    path = project / "a.py"
+    path.write_text("old = 1\n", encoding="utf-8")
+    filesystem = LocalFileSystem(project)
+    service = _snapshot_service(project, filesystem)
+    manager = Mock()
+    manager.enabled = True
+    manager._initialized = True
+    manager.server_for_path.return_value = "pyright"
+    manager._resolve_position.return_value = (0, 0)
+    manager.get_rename = AsyncMock(
+        return_value={
+            "changes": {
+                path.resolve().as_uri(): [
+                    {
+                        "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 3}},
+                        "newText": "new",
+                    }
+                ]
+            }
+        }
+    )
+    tool = LspEditTool(
+        project,
+        "workspace",
+        "thread",
+        AsyncMock(),
+        Mock(),
+        _caller(),
+        filesystem,
+        lsp_manager=manager,
+        snapshot_service=service,
+    )
+
+    result = await tool.lsp_edit(
+        operation="rename",
+        path="a.py",
+        line=1,
+        symbol="old",
+        new_name="new",
+        apply=False,
+    )
+
+    assert result.startswith("Preview LSP edit `rename`.")
+    assert "Pending action:" in result
+    assert path.read_text(encoding="utf-8") == "old = 1\n"
+    pending = service.list_pending_actions()
+    assert len(pending) == 1
+    assert pending[0].operation == "rename"

--- a/tests/services/test_snapshots.py
+++ b/tests/services/test_snapshots.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import pytest
+
+from kolega_code.services.file_system import LocalFileSystem
+from kolega_code.services.snapshots import SnapshotError, SnapshotService
+
+
+@pytest.fixture
+def snapshot_service(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    state = tmp_path / "state"
+    return SnapshotService(
+        project,
+        "workspace",
+        "thread",
+        "session",
+        LocalFileSystem(project),
+        root=state,
+    )
+
+
+def test_record_mutation_and_restore(snapshot_service, tmp_path):
+    project = tmp_path / "project"
+    path = project / "a.txt"
+    path.write_text("before\n", encoding="utf-8")
+
+    result = snapshot_service.record_mutation(
+        tool_name="edit",
+        tool_call_id="call-1",
+        reason="test edit",
+        paths=["a.txt"],
+        mutate=lambda: path.write_text("after\n", encoding="utf-8"),
+    )
+
+    assert result.snapshot is not None
+    assert path.read_text(encoding="utf-8") == "after\n"
+
+    restored = snapshot_service.restore_snapshot(result.snapshot.snapshot_id)
+
+    assert restored.snapshot_id == result.snapshot.snapshot_id
+    assert path.read_text(encoding="utf-8") == "before\n"
+
+
+def test_restore_refuses_when_current_state_changed(snapshot_service, tmp_path):
+    project = tmp_path / "project"
+    path = project / "a.txt"
+    path.write_text("before\n", encoding="utf-8")
+    result = snapshot_service.record_mutation(
+        tool_name="edit",
+        tool_call_id="call-1",
+        reason="test edit",
+        paths=["a.txt"],
+        mutate=lambda: path.write_text("after\n", encoding="utf-8"),
+    )
+    assert result.snapshot is not None
+    path.write_text("user change\n", encoding="utf-8")
+
+    with pytest.raises(SnapshotError) as exc_info:
+        snapshot_service.restore_snapshot(result.snapshot.snapshot_id)
+
+    assert "tracked files changed" in str(exc_info.value)
+    assert path.read_text(encoding="utf-8") == "user change\n"
+
+
+def test_force_restore_overwrites_changed_current_state(snapshot_service, tmp_path):
+    project = tmp_path / "project"
+    path = project / "a.txt"
+    path.write_text("before\n", encoding="utf-8")
+    result = snapshot_service.record_mutation(
+        tool_name="edit",
+        tool_call_id="call-1",
+        reason="test edit",
+        paths=["a.txt"],
+        mutate=lambda: path.write_text("after\n", encoding="utf-8"),
+    )
+    assert result.snapshot is not None
+    path.write_text("user change\n", encoding="utf-8")
+
+    snapshot_service.restore_snapshot(result.snapshot.snapshot_id, force=True)
+
+    assert path.read_text(encoding="utf-8") == "before\n"
+
+
+def test_manual_snapshot_restores_after_change_without_force(snapshot_service, tmp_path):
+    project = tmp_path / "project"
+    path = project / "a.txt"
+    path.write_text("checkpoint\n", encoding="utf-8")
+    record = snapshot_service.create_manual_snapshot(paths=["a.txt"])
+    path.write_text("changed\n", encoding="utf-8")
+
+    snapshot_service.restore_snapshot(record.snapshot_id)
+
+    assert path.read_text(encoding="utf-8") == "checkpoint\n"
+
+
+def test_write_snapshot_restores_new_file_and_created_parent(snapshot_service, tmp_path):
+    project = tmp_path / "project"
+    filesystem = LocalFileSystem(project)
+
+    result = snapshot_service.record_mutation(
+        tool_name="write",
+        tool_call_id="call-1",
+        reason="create nested file",
+        paths=["new/child.txt", "new"],
+        mutate=lambda: (project / "new").mkdir() or (project / "new" / "child.txt").write_text("created\n"),
+    )
+    assert result.snapshot is not None
+    assert (project / "new" / "child.txt").exists()
+
+    snapshot_service.restore_snapshot(result.snapshot.snapshot_id)
+
+    assert not filesystem.exists("new")
+
+
+def test_create_and_update_pending_workspace_edit(snapshot_service, tmp_path):
+    project = tmp_path / "project"
+    (project / "a.txt").write_text("one\n", encoding="utf-8")
+    edit = {"changes": {"file:///tmp/unused": []}}
+
+    action = snapshot_service.create_pending_workspace_edit(
+        tool_name="lsp_edit",
+        tool_call_id="call-1",
+        operation="format_document",
+        workspace_edit=edit,
+        touched_paths=["a.txt"],
+        summaries=["updated a.txt"],
+        previews=[{"kind": "diff", "path": "a.txt", "lines": [], "more": 0, "adds": 0, "dels": 0}],
+    )
+
+    loaded = snapshot_service.load_pending_action(action.action_id)
+    assert loaded.status == "pending"
+    assert loaded.source["a.txt"].kind == "file"
+
+    updated = snapshot_service.update_pending_action(loaded, status="discarded", message="discarded")
+    assert snapshot_service.load_pending_action(action.action_id).status == "discarded"
+    assert updated.message == "discarded"


### PR DESCRIPTION
## Summary

Adds a private, session-scoped snapshot store so agent edits can be **undone without commits or repo-local metadata**, plus a deferred-apply mechanism for preview-only operations.

### New tools

- **`snapshot`** — `list` / `show` / `create` (manual checkpoint) / `restore`. `restore` with `snapshot_id="latest"` undoes the most recent change. Restore refuses on post-snapshot drift unless `force=true`; **manual checkpoints bypass the drift guard** (so the normal create→change→revert flow works).
- **`resolve`** — `apply` / `discard` a pending preview action created by `lsp_edit(apply=false)`. Apply re-checks source hashes (marks `stale` on drift) and records its own snapshot so the apply stays undoable.

### Wiring

- `SnapshotService` (`kolega_code/services/snapshots.py`) — content-addressed blobs (sha256), permission-hardened (`0600`), stored under private state outside the project tree.
- `edit` / `multi_edit` / `write` / `lsp_edit` now route writes through `record_mutation`. **Out-of-project paths skip snapshotting and write normally** (no regression for absolute/out-of-tree paths).
- `lsp_edit(apply=false)` now creates a pending action and returns its id for `resolve`.
- Expected failures raise `ToolError` (not `RuntimeError`) so the executor treats them as tool errors rather than internal faults.
- `MutationRecordResult` is `Generic[T]` for correct typing.

### Test plan

- [x] New unit tests: `tests/services/test_snapshots.py`, `tests/agent/tool_backend/test_snapshot_tool.py`
- [x] Existing inventory/registry tests still pass (snapshot/resolve exposed to full agents; excluded from read-only investigation agent)
- [x] End-to-end exercise via the real `ToolCollection.call()` dispatch path: edit→undo, manual checkpoint restore, drift refusal + force, nested-write cleanup, resolve apply/discard, out-of-project write/edit, and in-project edits still snapshotted
- [x] `pyright` clean; `pre-commit` all hooks pass