### PR TITLE
fix(tui): prevent OSError crash on long multi-line paste

### DIFF
--- a/kolega_code/cli/tui/widgets.py
+++ b/kolega_code/cli/tui/widgets.py
@@ -757,14 +757,25 @@ class ChatComposer(TextArea):
             event.prevent_default()
             event.stop()
             return
-        if stripped and "\n" not in stripped and _Path(stripped).exists() and image_media_type(stripped) is not None:
-            att = encode_image_file(_Path(stripped))
-            if att is not None:
-                att["path"] = stripped
-                self.app.add_pending_image_attachment(att)
-                event.prevent_default()
-                event.stop()
-                return
+        # Treat pasted text as an image file path only when it is a single line
+        # (CR or LF) and has a supported image extension. The cheap extension
+        # check runs before the filesystem probe so ordinary pasted text never
+        # reaches os.stat(), which raises OSError [Errno 63] (ENAMETOOLONG) on
+        # long inputs. See GitHub #218.
+        if stripped and "\n" not in stripped and "\r" not in stripped and image_media_type(stripped) is not None:
+            try:
+                path_exists = _Path(stripped).exists()
+            except OSError:
+                # e.g. path too long or otherwise inaccessible — not a usable image path.
+                path_exists = False
+            if path_exists:
+                att = encode_image_file(_Path(stripped))
+                if att is not None:
+                    att["path"] = stripped
+                    self.app.add_pending_image_attachment(att)
+                    event.prevent_default()
+                    event.stop()
+                    return
         # No image detected — let TextArea's default _on_paste insert the text.
         return
 

--- a/tests/cli/test_app_composer_input.py
+++ b/tests/cli/test_app_composer_input.py
@@ -307,6 +307,105 @@ async def test_textual_app_composer_preserves_multiline_paste(tmp_path: Path, mo
 
 
 @pytest.mark.asyncio
+async def test_textual_app_composer_long_cr_separated_paste_does_not_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual import events
+
+    from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    install_fake_agents(monkeypatch)
+
+    # macOS Terminal delivers pasted line breaks as carriage returns, not LF.
+    # A few thousand chars reproduces the OSError [Errno 63] from GitHub #218.
+    pasted = "\r".join("line of text " * 50 for _ in range(30))
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test():
+        composer = app.query_one("#composer", ChatComposer)
+        composer.focus()
+
+        # The custom handler must not raise and must not queue an image attachment.
+        await composer.on_paste(events.Paste(pasted))
+        assert app._pending_image_attachments == []
+
+        # Text is inserted by the default TextArea handler. TextArea normalizes
+        # CR line breaks to LF on insertion, so compare against the normalized form.
+        await composer._on_paste(events.Paste(pasted))
+        assert composer.text == pasted.replace("\r", "\n")
+
+
+@pytest.mark.asyncio
+async def test_textual_app_composer_long_single_line_paste_does_not_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual import events
+
+    from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    install_fake_agents(monkeypatch)
+
+    # A single very long line with no line breaks and no image extension.
+    pasted = "x" * 5000
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test():
+        composer = app.query_one("#composer", ChatComposer)
+        composer.focus()
+
+        await composer.on_paste(events.Paste(pasted))
+        assert app._pending_image_attachments == []
+
+
+@pytest.mark.asyncio
+async def test_textual_app_composer_paste_image_file_path_still_attaches(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual import events
+
+    from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    install_fake_agents(monkeypatch)
+
+    png = tmp_path / "shot.png"
+    png.write_bytes(b"\x89PNG\r\n\x1a\nfake-image-bytes")
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test():
+        composer = app.query_one("#composer", ChatComposer)
+        composer.focus()
+
+        await composer.on_paste(events.Paste(str(png)))
+        assert len(app._pending_image_attachments) == 1
+        assert app._pending_image_attachments[0]["path"] == str(png)
+
+
+@pytest.mark.asyncio
 async def test_textual_app_composer_auto_grows_caps_and_shrinks(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Pasting a long, multi-line block of text into the chat composer crashed the TUI with an uncaught `OSError: [Errno 63] File name too long` (#218). The `ChatComposer.on_paste` handler probed pasted text as a possible image file path via `os.stat()`, which raised `ENAMETOOLONG` on long inputs.

Three compounding defects are fixed in `ChatComposer.on_paste`:

1. **CR line breaks** — the multi-line guard only checked `\n`, not `\r`. macOS Terminal delivers pasted line breaks as carriage returns, so multi-line pastes slipped past the guard. Now `\r` is treated as a line break too.
2. **Check order** — the expensive, crash-prone `_Path(stripped).exists()` ran *before* the cheap `image_media_type()` extension check, so ordinary pasted prose reached `os.stat()`. The extension check now runs first, so non-image text never touches the filesystem.
3. **Guard `OSError`** — `_Path(stripped).exists()` is now wrapped in `try/except OSError` as defense-in-depth.

## Behavior

- Long pastes (CR, LF, CRLF, or no line breaks at all) are inserted as text and never crash.
- Pasting a single-line path to a real image file on disk still attaches it as an image (unchanged).

## Tests

Added three regression tests in `tests/cli/test_app_composer_input.py`:
- long CR-separated multi-line paste → no crash, no spurious attachment, text inserted
- long single-line paste (`"x" * 5000`) → no crash, no attachment
- real `.png` path paste → still attaches as image

## Checks

- `pytest tests/cli/test_app_composer_input.py tests/cli/test_app_image_vision_warning.py` → 34 passed
- `ruff check` + `ruff format` → clean (pre-commit hooks pass)

Fixes #218.