### PR TITLE
feat(tui): add portable tmux shortcuts for images and newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   `/model` picker, CLI flags, and env vars; now the default `xai` model.
 - Send a stable `x-grok-conv-id` header on xAI Chat Completions requests so
   multi-turn agent loops pin to a cache-warm server (xAI prompt-caching guidance).
+- Improved TUI usability inside tmux/screen when Shift-modified keys never reach
+  the app: `/attach` with no path pastes an image from the system clipboard,
+  `Alt+V` is a portable image-paste binding alongside `Ctrl+Shift+V`, startup
+  help highlights `Ctrl+J` / `/plan` / `/build` fallbacks, and a one-time
+  startup hint appears under tmux. Documented optional tmux extended-keys config
+  under Troubleshooting.
 
 ### Fixed
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -120,6 +120,10 @@ export default defineConfig({
               label: "Diagnostics & Bug Reports",
               slug: "troubleshooting/diagnostics",
             },
+            {
+              label: "Terminal & tmux shortcuts",
+              slug: "troubleshooting/terminal-tmux",
+            },
           ],
         },
         {

--- a/docs/src/content/docs/troubleshooting/terminal-tmux.md
+++ b/docs/src/content/docs/troubleshooting/terminal-tmux.md
@@ -1,0 +1,67 @@
+---
+title: Terminal & tmux shortcuts
+description: Why Shift chords fail in tmux/screen and the portable fallbacks Kolega Code supports.
+---
+
+Kolega Code’s TUI uses some Shift-modified shortcuts (`Shift+Enter`, `Shift+Tab`,
+`Ctrl+Shift+V`). In a modern terminal with the [Kitty keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/),
+those chords reach the app. Inside **tmux** or **GNU screen**, the multiplexer
+often sits between the terminal and the app and either drops modifiers or
+never forwards the extended key sequences — so Shift chords look like plain
+keys, or never arrive at all.
+
+Kolega Code cannot invent modifier information the terminal never sends. Instead
+it provides **portable fallbacks** that work without Shift, plus optional tmux
+config if you want the original chords restored.
+
+## Portable shortcuts
+
+| Action | Preferred (capable terminals) | Portable fallback |
+| --- | --- | --- |
+| Send prompt | `Enter` | — |
+| Insert newline | `Shift+Enter` | `Ctrl+J` or `Ctrl+Enter` |
+| Toggle Plan ⇄ Build | `Shift+Tab` | `/plan` or `/build` |
+| Paste image from system clipboard | `Ctrl+Shift+V` | `Alt+V` (Option+V on macOS when the terminal treats Option as Meta) or `/attach` with no path |
+| Attach image from a file | — | `/attach <path>` or `@image.png` |
+
+On session start inside tmux/screen, the startup block prints a short reminder
+of these fallbacks.
+
+### Image paste notes
+
+- `/attach` with **no path** reads an image from the **system** clipboard (same
+  path as `Ctrl+Shift+V` / `Alt+V`). This is the most reliable option under
+  plain tmux.
+- Clipboard image reading uses host tools independent of tmux:
+  - **macOS:** `osascript` (built-in), or `pngpaste` if installed
+  - **Linux:** `xclip` or `wl-paste`
+  - **Windows / WSL:** PowerShell clipboard APIs
+- If Option+V types a special character (e.g. `√`) instead of pasting an image,
+  your terminal is not sending Alt as a modifier. Prefer `/attach`, or enable
+  “Option as Meta” / “Left Option key acts as +Esc” in the terminal settings.
+
+## Optional: restore Shift+Enter in tmux
+
+With **tmux 3.2+** and an outer terminal that supports extended keys, add to
+`~/.tmux.conf`:
+
+```tmux
+set -g extended-keys always
+set -g extended-keys-format csi-u
+set -as terminal-features 'xterm*:extkeys'
+```
+
+Then reload (`tmux source-file ~/.tmux.conf`) or restart tmux.
+
+Also make sure `default-terminal` / `terminal-overrides` match the outer
+terminal’s `$TERM` family (`xterm-256color`, `xterm-ghostty`, etc.) so the
+`extkeys` feature actually applies.
+
+After that, `Shift+Enter` and similar chords often work again inside Kolega Code.
+If they still do not, keep using the portable fallbacks above.
+
+## Related
+
+- [Chat Composer](../../tui/composer/) — full composer key reference
+- [Interface Tour](../../tui/interface/) — key bindings at a glance
+- [Slash Commands](../../tui/slash-commands/) — `/attach`, `/plan`, `/build`

--- a/docs/src/content/docs/tui/composer.md
+++ b/docs/src/content/docs/tui/composer.md
@@ -13,16 +13,23 @@ multi-line input, and drives the option lists the agent shows you.
 | --- | --- |
 | `Enter` | Send the prompt |
 | `Shift+Enter` | Insert a newline (keep typing) |
-| `Ctrl+J` | Insert a newline (alternative) |
+| `Ctrl+J` / `Ctrl+Enter` | Insert a newline (portable alternatives; prefer these inside tmux) |
 | `Ctrl+L` | Select all composer text |
 | `Cmd+A` / `⌘A` | Select all composer text on macOS, when forwarded by the terminal |
 | `Ctrl+A` | Move to the start of the current line (intentionally not select-all) |
 | `Ctrl+U` | Delete backward to the start of the line; at line start, delete the previous line |
+| `Ctrl+Shift+V` | Paste an image from the system clipboard |
+| `Alt+V` | Paste an image from the system clipboard (portable alternative when Shift chords fail) |
 
 `Ctrl+L` is the portable select-all shortcut because `Ctrl+A` is preserved for
 terminal-style line navigation. Some macOS terminal emulators reserve `Cmd+A` for
 terminal scrollback selection before the TUI can see it; `Ctrl+L` still works in
 the composer.
+
+Inside **tmux** or **screen**, Shift-modified keys often never reach the app.
+Use `Ctrl+J` for newlines and `Alt+V` or `/attach` for images. See
+[Terminal & tmux shortcuts](../../troubleshooting/terminal-tmux/) for optional
+tmux config to restore Shift+Enter.
 
 ## Queuing follow-up prompts
 
@@ -44,6 +51,19 @@ follow-ups can drain.
 If you cancel the active turn with `Ctrl+C` or `Escape`, queued follow-ups are
 restored into the composer instead of being silently sent. To discard pending
 follow-ups without stopping the active turn, run [`/queue-clear`](../slash-commands/).
+
+## Attaching images
+
+You can attach images for vision-capable models in several ways:
+
+| Method | How |
+| --- | --- |
+| System clipboard | `Ctrl+Shift+V` or `Alt+V`, or run `/attach` with no path |
+| File path | `/attach path/to/image.png` |
+| File mention | `@screenshot.png` (supported image extensions only) |
+
+Use `/detach` to clear pending attachments before sending. On a non-vision
+model, Kolega Code warns and blocks the send until you detach or switch models.
 
 ## File mentions with `@`
 

--- a/docs/src/content/docs/tui/interface.md
+++ b/docs/src/content/docs/tui/interface.md
@@ -82,14 +82,16 @@ the turn keeps running while you look around.
 
 | Keys | Action |
 | --- | --- |
-| `Shift+Tab` | Toggle Build ⇄ Plan mode |
+| `Shift+Tab` | Toggle Build ⇄ Plan mode (`/plan` / `/build` if Shift is unavailable) |
 | `Ctrl+P` | Toggle shell/edit permissions between Ask ⇄ Auto |
 | `Ctrl+O` | Show or hide the side panel |
 | `Ctrl+G` | Open the sub-agent inspector |
 | `Enter` | Send the prompt |
 | `Shift+Enter` / `Ctrl+J` | Insert a newline |
+| `Ctrl+Shift+V` / `Alt+V` | Paste an image from the system clipboard (`/attach` also works) |
 | `Ctrl+C` / `Escape` | Cancel the current generation |
 | `Ctrl+Q` | Save the session and quit |
 
 A complete composer-and-completion key reference is in
-[Chat Composer](../composer/).
+[Chat Composer](../composer/). If Shift chords fail inside tmux, see
+[Terminal & tmux shortcuts](../../troubleshooting/terminal-tmux/).

--- a/docs/src/content/docs/tui/slash-commands.md
+++ b/docs/src/content/docs/tui/slash-commands.md
@@ -34,6 +34,8 @@ These control the app and your session.
 | --- | --- |
 | `/skills` | List available Agent Skills |
 | `/init` | Create or update `AGENTS.md` for this repository |
+| `/attach` | Attach an image: clipboard if no path, or `/attach <path>` for a file |
+| `/detach` | Remove pending image attachments |
 | `/plan` | Switch to [Plan mode](../modes/) |
 | `/build` | Switch to [Build mode](../modes/) |
 | `/sidebar` | Show or hide the side panel |

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -1905,6 +1905,7 @@ class KolegaCodeApp(
                     "",
                 ]
             )
+        bullet = theme.g(Glyph.BULLET_SEP)
         startup_lines.extend(
             [
                 f"Project: {self.project_path}",
@@ -1919,11 +1920,29 @@ class KolegaCodeApp(
                 f"Thinking effort: {effort}",
                 f"API key: {api_key}",
                 *self._startup_lsp_lines(),
-                f"Enter send {theme.g(Glyph.BULLET_SEP)} Shift+Enter newline {theme.g(Glyph.BULLET_SEP)} Shift+Tab plan/build {theme.g(Glyph.BULLET_SEP)} Ctrl+P permissions {theme.g(Glyph.BULLET_SEP)} Ctrl+O sidebar",
-                f"Ctrl+C stop turn {theme.g(Glyph.BULLET_SEP)} Cmd+C copy selection {theme.g(Glyph.BULLET_SEP)} / commands",
+                (
+                    f"Enter send {bullet} Shift+Enter/Ctrl+J newline {bullet} "
+                    f"Shift+Tab or /plan /build {bullet} Ctrl+P permissions {bullet} Ctrl+O sidebar"
+                ),
+                (f"Alt+V or /attach image {bullet} Ctrl+C stop turn {bullet} Cmd+C copy selection {bullet} / commands"),
             ]
         )
+        if self._running_under_tmux_or_screen():
+            startup_lines.extend(["", messages.TMUX_SHORTCUT_HINT])
         return "\n".join(startup_lines)
+
+    @staticmethod
+    def _running_under_tmux_or_screen() -> bool:
+        """True when the process is nested under tmux or GNU screen.
+
+        Shift-modified keys often never reach the TUI in those multiplexers
+        unless extended-keys / CSI-u is configured. Used only for a one-time
+        startup hint with portable fallbacks.
+        """
+        if os.environ.get("TMUX"):
+            return True
+        term = os.environ.get("TERM", "").strip().lower()
+        return term.startswith("screen") or term.startswith("tmux")
 
     def _startup_lsp_lines(self) -> list[str]:
         """Plain-text LSP status lines for the startup block (above command summary)."""

--- a/kolega_code/cli/messages.py
+++ b/kolega_code/cli/messages.py
@@ -26,6 +26,17 @@ DISCONNECTED_ACTIVITY = "Open Settings and connect a provider to start chatting.
 DISCONNECTED_MODEL = "not connected"
 TASK_LIST_EMPTY_MESSAGE = "No task list has been set."
 PLAN_EMPTY_MESSAGE = "No plan captured yet."
+# Shown once in the startup block when running inside tmux/screen, where Shift
+# chords often never reach the app.
+TMUX_SHORTCUT_HINT = (
+    "tmux/screen: Shift shortcuts may not reach the app. "
+    "Use Ctrl+J for newline, /plan or /build for mode, Alt+V or /attach for images. "
+    "See docs: Terminal & tmux shortcuts."
+)
+ATTACH_CLIPBOARD_EMPTY = (
+    "No image on the clipboard, or no clipboard tool is available. "
+    "Copy an image first, or use /attach <path> or @image.png."
+)
 
 # Turn progress
 WORKING = "Working…"

--- a/kolega_code/cli/slash_commands.py
+++ b/kolega_code/cli/slash_commands.py
@@ -44,7 +44,11 @@ SKILLS_LIST_COMMAND = "/skills"
 
 TUI_COMMAND_ENTRIES: tuple[SlashCommandEntry, ...] = (
     SlashCommandEntry("skills", "List available Agent Skills", CommandScope.TUI),
-    SlashCommandEntry("attach", "Attach an image file to your next message", CommandScope.TUI),
+    SlashCommandEntry(
+        "attach",
+        "Attach an image (clipboard if no path, or a file path)",
+        CommandScope.TUI,
+    ),
     SlashCommandEntry("detach", "Remove pending image attachments", CommandScope.TUI),
     SlashCommandEntry("init", "Create or update AGENTS.md for this repository", CommandScope.TUI),
     SlashCommandEntry("plan", "Switch to plan mode", CommandScope.TUI),

--- a/kolega_code/cli/tui/command_handlers.py
+++ b/kolega_code/cli/tui/command_handlers.py
@@ -129,7 +129,7 @@ class CommandHandlersMixin(tui_app_base.KolegaAppBase):
         Centralized vision check: when the current model does not support vision,
         shows a combined warning-tone hint (attachment confirmation + vision
         mismatch) and a persistent system message in the transcript. This is the
-        single funnel for clipboard paste (both Ctrl+Shift+V and on_paste) and
+        single funnel for clipboard paste (Ctrl+Shift+V / Alt+V and on_paste) and
         /attach, so the warning is consistent across all three paths.
         """
         self._pending_image_attachments.append(attachment)
@@ -144,9 +144,14 @@ class CommandHandlersMixin(tui_app_base.KolegaAppBase):
             self._show_composer_hint(f"Attached images: {names} (press Enter to send, × to remove)", tone="info")
 
     async def _command_attach(self, args: str) -> None:
+        """Attach an image: clipboard when no path is given, otherwise a file path.
+
+        Empty args is the portable path under tmux / terminals that cannot
+        deliver Ctrl+Shift+V — same system-clipboard reader as the key binding.
+        """
         arg = args.strip()
         if not arg:
-            self._show_composer_hint("Usage: /attach <path-to-image>  (PNG, JPEG, GIF, WebP, BMP)", tone="warning")
+            await self._paste_clipboard_image_worker()
             return
         from pathlib import Path as _Path
 
@@ -158,7 +163,8 @@ class CommandHandlersMixin(tui_app_base.KolegaAppBase):
         attachment = encode_image_file(candidate)
         if attachment is None:
             self._show_composer_hint(
-                f"Could not attach {arg}: not a supported image, missing, or too large (>20MB). Use /attach <path>",
+                f"Could not attach {arg}: not a supported image, missing, or too large (>20MB). "
+                "Use /attach <path> or /attach with an image on the clipboard.",
                 tone="warning",
             )
             return
@@ -185,11 +191,7 @@ class CommandHandlersMixin(tui_app_base.KolegaAppBase):
 
         result = await read_clipboard_image()
         if result is None:
-            self._show_composer_hint(
-                "No image on the clipboard, or your terminal doesn't support image paste. "
-                "Use /attach <path> or @image.png instead.",
-                tone="warning",
-            )
+            self._show_composer_hint(messages.ATTACH_CLIPBOARD_EMPTY, tone="warning")
             return
         data, media_type = result
         attachment = encode_image_attachment(data, media_type, path="clipboard")

--- a/kolega_code/cli/tui/widgets.py
+++ b/kolega_code/cli/tui/widgets.py
@@ -564,7 +564,11 @@ class ChatComposer(TextArea):
         *TextArea.BINDINGS,
         Binding("enter", "submit", "Send", priority=True),
         Binding(
-            "shift+enter,ctrl+enter,ctrl+j", "insert_newline", "New line", key_display="Shift+Enter", priority=True
+            "shift+enter,ctrl+enter,ctrl+j",
+            "insert_newline",
+            "New line",
+            key_display="Shift+Enter / Ctrl+J",
+            priority=True,
         ),
         Binding("ctrl+l", "select_all", "Select all", key_display="Ctrl+L", priority=True),
         Binding("super+a", "select_all", "Select all", show=False, key_display="Cmd+A", priority=True),
@@ -572,7 +576,15 @@ class ChatComposer(TextArea):
         Binding("down", "mention_next", "Next match", show=False, priority=True),
         Binding("tab", "mention_accept", "Complete path", show=False, priority=True),
         Binding("escape", "mention_dismiss", "Dismiss matches", show=False, priority=True),
-        Binding("ctrl+shift+v", "paste_clipboard_image", "Paste image", key_display="Ctrl+Shift+V", priority=True),
+        # Ctrl+Shift+V needs extended key encoding (often missing in plain tmux).
+        # Alt+V is a portable fallback; /attach with no path also reads the clipboard.
+        Binding(
+            "ctrl+shift+v,alt+v",
+            "paste_clipboard_image",
+            "Paste image",
+            key_display="Ctrl+Shift+V / Alt+V",
+            priority=True,
+        ),
     ]
 
     MENTION_QUERY_RE = re.compile(r"(?:^|(?<=\s))@(\S*)$")

--- a/tests/cli/test_app_image_vision_warning.py
+++ b/tests/cli/test_app_image_vision_warning.py
@@ -1,10 +1,10 @@
 # ruff: noqa: F401,F811,E402
 """Tests for vision mismatch warnings when attaching/sending images on non-vision models.
 
-Covers all four image attachment entry points:
-  1. Clipboard paste (Ctrl+Shift+V)  — _paste_clipboard_image_worker
+Covers image attachment entry points:
+  1. Clipboard paste (Ctrl+Shift+V / Alt+V) — _paste_clipboard_image_worker
   2. on_paste event (data-URI / file path) — ChatComposer.on_paste -> add_pending_image_attachment
-  3. /attach <path> slash command      — _command_attach -> add_pending_image_attachment
+  3. /attach (clipboard or path) slash command — _command_attach -> add_pending_image_attachment
   4. @file.png mention + submit        — _build_mention_attachments at submit time
 
 Plus the centralised vision check in ``add_pending_image_attachment`` and the

--- a/tests/cli/test_app_tmux_shortcuts.py
+++ b/tests/cli/test_app_tmux_shortcuts.py
@@ -1,0 +1,193 @@
+# ruff: noqa: F401,F811,E402
+"""Portable shortcuts for tmux / constrained terminals.
+
+Covers:
+- /attach with no path reading the system clipboard
+- ChatComposer bindings for Ctrl+Shift+V and Alt+V
+- Ctrl+J newline fallback
+- startup content tmux hint when TMUX/TERM indicates a multiplexer
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kolega_code.cli import messages
+from kolega_code.cli.config import config_summary
+from kolega_code.cli.session_store import SessionStore
+
+from ._app_test_utils import build_test_config, install_fake_agents
+
+
+def _make_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.app import KolegaCodeApp
+
+    install_fake_agents(monkeypatch)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    return KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+
+def _binding_keys(bindings) -> set[str]:
+    keys: set[str] = set()
+    for binding in bindings:
+        key = getattr(binding, "key", None)
+        if not key:
+            continue
+        for part in str(key).split(","):
+            keys.add(part.strip())
+    return keys
+
+
+@pytest.mark.asyncio
+async def test_attach_no_args_reads_clipboard_image(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    app = _make_app(tmp_path, monkeypatch)
+
+    async def _fake_read():
+        return (b"fake-png-bytes", "image/png")
+
+    monkeypatch.setattr("kolega_code.cli.clipboard_image.read_clipboard_image", _fake_read)
+
+    async with app.run_test():
+        await app._command_attach("")
+        assert len(app._pending_image_attachments) == 1
+        assert app._pending_image_attachments[0]["path"] == "clipboard"
+        assert app._pending_image_attachments[0]["media_type"] == "image/png"
+
+
+@pytest.mark.asyncio
+async def test_attach_no_args_empty_clipboard_shows_warning(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    app = _make_app(tmp_path, monkeypatch)
+
+    async def _fake_read():
+        return None
+
+    monkeypatch.setattr("kolega_code.cli.clipboard_image.read_clipboard_image", _fake_read)
+    hints: list[tuple[str, str]] = []
+
+    async with app.run_test():
+        app._show_composer_hint = lambda text, tone="warning": hints.append((text, tone))
+        await app._command_attach("")
+        assert app._pending_image_attachments == []
+        assert hints
+        assert hints[-1][1] == "warning"
+        assert hints[-1][0] == messages.ATTACH_CLIPBOARD_EMPTY
+
+
+def test_chat_composer_image_paste_bindings_include_portable_alt_v() -> None:
+    from textual.binding import Binding
+
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    keys = _binding_keys(ChatComposer.BINDINGS)
+    assert "ctrl+shift+v" in keys
+    assert "alt+v" in keys
+
+    paste_binding = next(
+        b for b in ChatComposer.BINDINGS if isinstance(b, Binding) and b.action == "paste_clipboard_image"
+    )
+    display = paste_binding.key_display or ""
+    assert "Ctrl+Shift+V" in display
+    assert "Alt+V" in display
+
+    newline_binding = next(b for b in ChatComposer.BINDINGS if isinstance(b, Binding) and b.action == "insert_newline")
+    assert "Ctrl+J" in (newline_binding.key_display or "")
+
+
+@pytest.mark.asyncio
+async def test_textual_app_composer_ctrl_j_inserts_line_break(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    app = _make_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        composer.focus()
+
+        await pilot.press("h", "i")
+        await pilot.press("ctrl+j")
+        await pilot.press("t", "h", "e", "r", "e")
+
+        assert composer.text == "hi\nthere"
+
+
+@pytest.mark.asyncio
+async def test_paste_clipboard_image_action_attaches_via_alt_v_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """action_paste_clipboard_image (shared by Ctrl+Shift+V and Alt+V) attaches a clipboard image."""
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    app = _make_app(tmp_path, monkeypatch)
+
+    async def _fake_read():
+        return (b"fake-png-bytes", "image/png")
+
+    monkeypatch.setattr("kolega_code.cli.clipboard_image.read_clipboard_image", _fake_read)
+
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        composer.focus()
+        composer.action_paste_clipboard_image()
+        # Worker runs the clipboard read asynchronously.
+        for _ in range(20):
+            await pilot.pause()
+            if app._pending_image_attachments:
+                break
+        assert len(app._pending_image_attachments) == 1
+        assert app._pending_image_attachments[0]["path"] == "clipboard"
+
+
+def test_running_under_tmux_or_screen_detection(monkeypatch: pytest.MonkeyPatch) -> None:
+    from kolega_code.cli.app import KolegaCodeApp
+
+    monkeypatch.delenv("TMUX", raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
+    assert KolegaCodeApp._running_under_tmux_or_screen() is False
+
+    monkeypatch.setenv("TMUX", "/tmp/tmux-1000/default,1234,0")
+    assert KolegaCodeApp._running_under_tmux_or_screen() is True
+
+    monkeypatch.delenv("TMUX", raising=False)
+    monkeypatch.setenv("TERM", "screen-256color")
+    assert KolegaCodeApp._running_under_tmux_or_screen() is True
+
+    monkeypatch.setenv("TERM", "tmux-256color")
+    assert KolegaCodeApp._running_under_tmux_or_screen() is True
+
+
+@pytest.mark.asyncio
+async def test_startup_content_includes_tmux_hint_when_nested(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TMUX", "/tmp/tmux-1000/default,1,0")
+    app = _make_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        content = app._startup_content()
+        assert messages.TMUX_SHORTCUT_HINT in content
+        assert "Ctrl+J" in content
+        assert "/attach" in content
+        assert "Alt+V" in content
+
+
+@pytest.mark.asyncio
+async def test_startup_content_omits_tmux_hint_outside_multiplexer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("TMUX", raising=False)
+    monkeypatch.setenv("TERM", "xterm-ghostty")
+    app = _make_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        content = app._startup_content()
+        assert messages.TMUX_SHORTCUT_HINT not in content
+        # Portable fallbacks still appear in the general help lines.
+        assert "Ctrl+J" in content
+        assert "/attach" in content


### PR DESCRIPTION
## Summary
- Make image paste and common TUI actions usable inside tmux/screen when Shift-modified keys never reach the app (`Alt+V`, `/attach` with no path for clipboard, clearer `Ctrl+J` / `/plan` / `/build` fallbacks).
- Detect tmux/screen at startup and show a one-time portable-shortcut hint; update composer bindings and help copy accordingly.
- Document optional tmux extended-keys config and the portable shortcut table under Troubleshooting.

## Test plan
- [ ] Run `pytest tests/cli/test_app_tmux_shortcuts.py`
- [ ] Inside tmux, start the TUI and confirm the startup hint appears
- [ ] Confirm `Ctrl+J` inserts a newline and `Alt+V` / bare `/attach` paste a clipboard image
- [ ] Outside tmux, confirm the startup hint is omitted and existing Shift shortcuts still work when the terminal forwards them
- [ ] Spot-check docs: composer, interface, slash commands, and Terminal & tmux troubleshooting page