### PR TITLE
chore: release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.16.0 - 2026-07-09
+
 ### Added
 
 - Added support for xAI Grok 4.5 (`grok-4.5`): 500K-token context, vision input,
@@ -13,6 +15,10 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   `/model` picker, CLI flags, and env vars; now the default `xai` model.
 - Send a stable `x-grok-conv-id` header on xAI Chat Completions requests so
   multi-turn agent loops pin to a cache-warm server (xAI prompt-caching guidance).
+- Added session-scoped workspace snapshots for agent file mutations: `snapshot`
+  (list/show/create/restore, including `snapshot_id='latest'` undo) and `resolve`
+  for applying or discarding pending `lsp_edit` preview actions. Restore refuses
+  on post-snapshot drift unless `force=true`.
 - Improved TUI usability inside tmux/screen when Shift-modified keys never reach
   the app: `/attach` with no path pastes an image from the system clipboard,
   `Alt+V` is a portable image-paste binding alongside `Ctrl+Shift+V`, startup
@@ -22,6 +28,10 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ### Fixed
 
+- Prevented a TUI crash when pasting long multi-line text into the composer
+  (`OSError: File name too long` from treating paste content as a path).
+- Stopped advertising host lifecycle `initialize` as a model-callable tool while
+  keeping it available for CLI/TUI startup (LSP setup).
 - Bumped `lxml-html-clean` to 0.4.5 (and transitive `lxml` to 6.1.1) to clear
   GHSA-4jhm-jv67-739f from the dependency audit.
 

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.15.0"
+__version__ = "0.16.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -44,4 +44,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.15.0"
+__version__ = "0.16.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.15.0"
+version = "0.16.0"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [options]
 prerelease-mode = "allow"
-exclude-newer = "2026-07-02T08:47:45.93029Z"
+exclude-newer = "2026-07-02T11:56:37.365489Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1397,7 +1397,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.15.0"
+version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Release **kolega-code 0.16.0** from current `main` after `v0.15.0`.

### User-facing changes

- **xAI Grok 4.5** (`grok-4.5`): 500K context, vision, reasoning effort; default xAI model; `x-grok-conv-id` prompt-cache header
- **Workspace snapshots**: session-scoped `snapshot` (list/show/create/restore, including `latest` undo) and `resolve` for pending `lsp_edit` previews
- **tmux/screen TUI UX**: `/attach` clipboard paste, `Alt+V`, startup help/hint, troubleshooting docs
- **Fixes**: long multi-line paste crash in composer; hide host-only `initialize` from model-facing tools
- **Security/deps**: `lxml-html-clean` 0.4.5 (GHSA-4jhm-jv67-739f)

### Release process

Per `RELEASING.md`:

1. Review + merge this PR
2. Tag the merge commit: `git tag v0.16.0 && git push origin v0.16.0`
3. Confirm Release workflow (build → smoke → PyPI → GitHub Release)
4. Verify: `uv tool install --force kolega-code && kolega-code --version`

Do **not** tag before this PR is merged.

## Test plan

- [x] Version parity: `pyproject.toml` + both `__version__`s = `0.16.0`
- [x] `uv lock` refreshed (expected `exclude-newer` window update)
- [x] `CHANGELOG.md` finalized for 0.16.0 with empty Unreleased
- [x] `./run_tests.sh` — 1932 passed, 50 deselected
- [x] Pre-commit hooks on commit (ruff, pyright, etc.)
- [ ] CI green on this PR
- [ ] After merge: tag `v0.16.0`, Release workflow, PyPI + `gh release view v0.16.0`