### PR TITLE
chore: release v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
-### Added
+## 0.16.1 - 2026-07-10
+
+### Changed
 
 - Rebuilt `web_fetch` as a fully local, content-type-aware pipeline with bounded
   HTTP retries, automatic quality-gated Trafilatura/Readability/DOM extraction,
   JSON/text/feed handling, and local PDF/Office conversion.
-- Added grounded fast-model answers with verified page excerpts, long-content
-  chunking, and bounded extracted-content fallback when answering fails.
+- `web_fetch` now returns grounded fast-model answers with verified page excerpts,
+  long-content chunking, and a bounded extracted-content fallback when answering fails.
 
 ### Fixed
 

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.16.0"
+__version__ = "0.16.1"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -44,4 +44,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.16.0"
+__version__ = "0.16.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.16.0"
+version = "0.16.1"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -14,7 +14,7 @@ resolution-markers = [
 
 [options]
 prerelease-mode = "allow"
-exclude-newer = "2026-07-03T07:55:34.428466Z"
+exclude-newer = "2026-07-03T09:48:46.816566Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1498,7 +1498,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.16.0"
+version = "0.16.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Patch release bumping `0.16.0` → `0.16.1`.

Ships the rebuilt, local-first `web_fetch` pipeline (#229) as an improvement to the
existing tool. Since `web_fetch` already existed, this is a patch bump rather than a
minor one.

## Changes

- Bump version to `0.16.1` in `pyproject.toml`, `kolega_code/__init__.py`,
  `kolega_code/agent/__init__.py`, and `uv.lock`.
- Reframe the `CHANGELOG.md` `Unreleased` entry into a `0.16.1` section, moving the
  pipeline/answering bullets to `Changed` (improvement, not new feature) and keeping
  the failure-reporting/truncation items under `Fixed`.

## Verification

- `./run_tests.sh` — 1953 passed, 50 deselected (slow).
- Pre-commit hooks (ruff, pyright) passed.

Post-merge: tag `v0.16.1` from the merge commit and confirm the `Release` workflow
publishes to PyPI and creates the GitHub Release.