### PR TITLE
Adopt Playwright MCP browser agent shape

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,12 @@ OLLAMA_API_KEY=
 KOLEGA_CODE_THINKING_EFFORT=
 
 BROWSERLESS_API_KEY=
+# Optional Browserless connection overrides. CDP and the SFO region remain the defaults.
+# BROWSERLESS_WS_ENDPOINT=wss://production-sfo.browserless.io
+# BROWSERLESS_REGION=sfo
+# BROWSERLESS_PROTOCOL=cdp
+# BROWSERLESS_TIMEOUT_MS=300000
+# BROWSER_CONNECT_TIMEOUT_MS=30000
 
 LANGFUSE_HOST=https://us.cloud.langfuse.com
 LANGFUSE_PUBLIC_KEY=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
   push:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,10 @@ jobs:
         if: needs.changes.outputs.coverage-badge-only != 'true'
         run: uv sync --extra dev --frozen
 
+      - name: Install Playwright Chromium
+        if: needs.changes.outputs.coverage-badge-only != 'true'
+        run: uv run playwright install --with-deps chromium
+
       - name: Run pre-commit hooks
         if: needs.changes.outputs.coverage-badge-only != 'true'
         run: uv run pre-commit run --all-files --show-diff-on-failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev --frozen
 
+      - name: Install Playwright Chromium
+        run: uv run playwright install --with-deps chromium
+
       - name: Verify release version metadata
         run: |
           uv run python - <<'PY'

--- a/docs/src/content/docs/concepts/tools.md
+++ b/docs/src/content/docs/concepts/tools.md
@@ -31,10 +31,14 @@ Run shell commands in the project and stream their output to the **Terminal** ta
 
 Drive a real browser (Playwright) for web tasks:
 
-- `launch_browser`, `list_browsers`, `close_browser`
-- `get_browser_interactive_elements`, `get_browser_console_logs`
-- `take_browser_screenshot`
-- `interact_with_browser`, `set_browser_select_value`
+- `browser_navigate`, `browser_snapshot`, `browser_find`, `browser_close`
+- `browser_click`, `browser_type`, `browser_fill_form`, `browser_select_option`
+- `browser_tabs`, `browser_wait_for`, `browser_handle_dialog`, `browser_file_upload`
+- `browser_console_messages`, `browser_network_requests`, `browser_take_screenshot`
+
+The browser agent uses accessibility snapshots with element refs such as `e12`.
+Actions return an updated snapshot, so the agent can interact deterministically
+without inventing CSS selectors or relying on screenshots.
 
 Launch visible browser windows (instead of headless) with `--browser-visible` on
 the [TUI](../../cli/overview/) or [`ask`](../../cli/ask/).

--- a/docs/src/content/docs/configuration/environment-variables.md
+++ b/docs/src/content/docs/configuration/environment-variables.md
@@ -86,6 +86,12 @@ section.
 | `KOLEGA_CODE_<ROLE>_MODEL` | Model for that agent |
 | `KOLEGA_CODE_<ROLE>_EFFORT` | Thinking effort for that agent |
 
+The `BROWSER` role requires a vision-capable model. An incompatible explicit or
+inherited model is never replaced automatically; dispatching the browser agent
+fails with a configuration error until `KOLEGA_CODE_BROWSER_PROVIDER` and
+`KOLEGA_CODE_BROWSER_MODEL` (or the equivalent Settings override) select a model
+with vision support.
+
 ## State & environment
 
 | Variable | Purpose |

--- a/docs/src/content/docs/configuration/environment-variables.md
+++ b/docs/src/content/docs/configuration/environment-variables.md
@@ -106,6 +106,24 @@ explicitly when you want a cloud provider or a self-hosted SearXNG instance.
 | `TAVILY_API_KEY` | Tavily API key |
 | `SEARXNG_BASE_URL` | Base URL for a self-hosted SearXNG instance |
 
+## Browser automation
+
+Local browser automation needs no credentials. Hosted sandbox deployments can
+connect the same browser agent to Browserless.
+
+| Variable | Purpose |
+| --- | --- |
+| `BROWSERLESS_API_KEY` | Browserless cloud API token |
+| `BROWSERLESS_WS_ENDPOINT` | Optional cloud or self-hosted WebSocket endpoint |
+| `BROWSERLESS_REGION` | Cloud region used when no endpoint is supplied: `sfo`, `lon`, or `ams` |
+| `BROWSERLESS_PROTOCOL` | Connection protocol: `cdp` (default) or `playwright` |
+| `BROWSERLESS_TIMEOUT_MS` | Optional maximum Browserless session duration; must fit the account plan |
+| `BROWSER_CONNECT_TIMEOUT_MS` | Browser transport connection timeout (default 30000 ms) |
+
+Custom endpoint query parameters are preserved, including Browserless proxy,
+stealth, profile, and recording options. If `BROWSERLESS_TIMEOUT_MS` is unset,
+Browserless applies the account's default session duration.
+
 ## Telemetry (Langfuse)
 
 Optional [Langfuse](https://langfuse.com/) tracing of LLM usage.

--- a/docs/src/content/docs/configuration/providers-and-models.mdx
+++ b/docs/src/content/docs/configuration/providers-and-models.mdx
@@ -149,6 +149,12 @@ In the **Settings tab**, the **Agent Models** section (below the main Model sect
 has a provider/model/effort group per role. Leave a role on **Default** to inherit;
 pick a provider, model, and thinking effort to override it.
 
+The **Browser** role requires a model whose catalog entry supports vision. It does
+not fall back to another model or run in a text-only mode. If **Default** resolves
+to a non-vision model, Settings shows a warning and the browser agent fails with a
+configuration error when dispatched. Select an explicit vision-capable Browser
+model to enable it.
+
 Or use environment variables, named `KOLEGA_CODE_<ROLE>_PROVIDER` / `_MODEL` / `_EFFORT`:
 
 ```bash
@@ -156,6 +162,10 @@ Or use environment variables, named `KOLEGA_CODE_<ROLE>_PROVIDER` / `_MODEL` / `
 export KOLEGA_CODE_INVESTIGATION_PROVIDER=deepseek
 export KOLEGA_CODE_INVESTIGATION_MODEL=deepseek-v4-flash
 export KOLEGA_CODE_INVESTIGATION_EFFORT=high
+
+# Browser overrides must name a vision-capable model.
+export KOLEGA_CODE_BROWSER_PROVIDER=anthropic
+export KOLEGA_CODE_BROWSER_MODEL=claude-sonnet-4-6
 ```
 
 Resolution order for a role (first match wins): **env var → saved Settings → the

--- a/docs/src/content/docs/configuration/settings-and-api-keys.mdx
+++ b/docs/src/content/docs/configuration/settings-and-api-keys.mdx
@@ -32,6 +32,10 @@ agents (planning, building, investigation, general, browser) their own provider,
 model, and effort. Leave a role on **Default** to inherit the active model. See
 [Per-agent models](../providers-and-models/#per-agent-models).
 
+The Browser role only accepts vision-capable model overrides. If it inherits a
+non-vision active model, Settings allows the inheritance but warns that the browser
+agent is unavailable until you choose a compatible Browser model.
+
 The **Web Search** section configures the `web_search` tool. DuckDuckGo is the
 default and needs no key. Firecrawl can also run without a key, with an optional
 key for higher rate limits. Tavily requires a key, and SearXNG requires the base

--- a/kolega_code/agent/browseragent.py
+++ b/kolega_code/agent/browseragent.py
@@ -5,6 +5,7 @@ from .baseagent import BaseAgent
 from kolega_code.config import AgentConfig
 from kolega_code.events import AgentConnectionManager
 from kolega_code.llm.models import Message, TextBlock
+from kolega_code.llm.specs import supports_vision as model_supports_vision
 from .prompt_provider import AgentMode, AgentType, PromptExtension, PromptProvider
 from .tools import ToolCollection
 
@@ -18,6 +19,19 @@ class BrowserAgent(BaseAgent):
     """
 
     agent_name = "browser-agent"
+
+    @classmethod
+    def validate_model_capabilities(cls, config: AgentConfig) -> None:
+        """Require the resolved browser-agent model to accept image input."""
+        model_config = config.model_config_for_agent(cls.agent_name)
+        provider = getattr(model_config.provider, "value", model_config.provider)
+        if model_supports_vision(provider, model_config.model):
+            return
+        raise ValueError(
+            "BrowserAgent requires a vision-capable model, but "
+            f"{provider}/{model_config.model} does not support image input. "
+            "Configure a vision-capable model for the Browser agent."
+        )
 
     def __init__(
         self,
@@ -74,6 +88,7 @@ class BrowserAgent(BaseAgent):
             usage_recorder: Optional callback for recording normalized LLM usage
             sub_agent_recorder: Optional callback for persisting sub-agent conversation state
         """
+        self.validate_model_capabilities(config)
         super().__init__(
             project_path,
             workspace_id,

--- a/kolega_code/agent/prompt_templates/system/agents/browser.md.j2
+++ b/kolega_code/agent/prompt_templates/system/agents/browser.md.j2
@@ -45,6 +45,15 @@ If you are asked for links to assets such as images, do not answer from your mem
 
 1. If a website has a cookie consent popup, avoid it. Try another website if you can.
 2. Your search engine of choice is duckduckgo.com
+3. Navigate with `browser_navigate`; it starts the browser session automatically.
+4. Use `browser_snapshot` to understand the page. Prefer exact element refs such as `e12` from the snapshot
+   over manually invented selectors.
+5. Every state-changing action returns an updated snapshot. Use the new refs from that result because refs can
+   become stale when the page changes.
+6. On large pages, use `browser_find` to locate relevant snapshot nodes without loading the entire tree again.
+7. Use `browser_take_screenshot` only for visual inspection. Do not choose interaction targets from screenshots.
+8. Use explicit waits for visible or disappearing text when an application updates asynchronously.
+9. If an action reports a dialog or file chooser, handle that modal before attempting another browser action.
 
 ## **CRITICAL: URL Navigation Guidelines**
 

--- a/kolega_code/agent/tool_backend/browser_tool.py
+++ b/kolega_code/agent/tool_backend/browser_tool.py
@@ -1,15 +1,201 @@
+import json
 from pathlib import Path
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from kolega_code.config import AgentConfig
 from kolega_code.events import AgentEvent
-from kolega_code.services.browser import PlaywrightBrowserManager
+from kolega_code.services.browser import PlaywrightBrowserManager, file_payload
 from .base_tool import BaseTool
 
 
-class BrowserTool(BaseTool):
-    MAX_HTML_CHARS_FOR_CONTENT_OUTPUT = 100_000
+_TARGET = {
+    "type": "string",
+    "description": "Exact element ref from browser_snapshot (for example e12), or a unique selector.",
+}
 
+
+def _schema(properties: dict[str, Any], required: Optional[list[str]] = None) -> dict[str, Any]:
+    result: dict[str, Any] = {"type": "object", "properties": properties}
+    if required:
+        result["required"] = required
+    return result
+
+
+BROWSER_TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
+    "browser_navigate": _schema(
+        {"url": {"type": "string", "description": "HTTP or HTTPS URL to navigate to."}}, ["url"]
+    ),
+    "browser_navigate_back": _schema({}),
+    "browser_snapshot": _schema(
+        {
+            "target": _TARGET,
+            "depth": {"type": "integer", "description": "Optional maximum accessibility-tree depth."},
+        }
+    ),
+    "browser_find": _schema(
+        {
+            "text": {"type": "string", "description": "Case-insensitive text to find in the snapshot."},
+            "regex": {"type": "string", "description": "Regular expression to find in the snapshot."},
+        }
+    ),
+    "browser_wait_for": _schema(
+        {
+            "time": {"type": "number", "description": "Seconds to wait, capped at 30."},
+            "text": {"type": "string", "description": "Text to wait for until visible."},
+            "text_gone": {"type": "string", "description": "Text to wait for until hidden."},
+        }
+    ),
+    "browser_resize": _schema(
+        {
+            "width": {"type": "integer", "description": "Viewport width in CSS pixels."},
+            "height": {"type": "integer", "description": "Viewport height in CSS pixels."},
+        },
+        ["width", "height"],
+    ),
+    "browser_click": _schema(
+        {
+            "target": _TARGET,
+            "double_click": {"type": "boolean", "description": "Perform a double click."},
+            "button": {"type": "string", "enum": ["left", "right", "middle"]},
+            "modifiers": {
+                "type": "array",
+                "items": {"type": "string", "enum": ["Alt", "Control", "ControlOrMeta", "Meta", "Shift"]},
+            },
+        },
+        ["target"],
+    ),
+    "browser_type": _schema(
+        {
+            "target": _TARGET,
+            "text": {"type": "string", "description": "Text to enter."},
+            "submit": {"type": "boolean", "description": "Press Enter after entering text."},
+            "slowly": {"type": "boolean", "description": "Type character by character instead of filling."},
+        },
+        ["target", "text"],
+    ),
+    "browser_fill_form": _schema(
+        {
+            "fields": {
+                "type": "array",
+                "description": "Form fields to fill.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string", "description": "Human-readable field name."},
+                        "target": _TARGET,
+                        "type": {
+                            "type": "string",
+                            "enum": ["textbox", "checkbox", "radio", "combobox", "slider"],
+                        },
+                        "value": {"type": "string", "description": "Value to set."},
+                    },
+                    "required": ["name", "target", "type", "value"],
+                },
+            }
+        },
+        ["fields"],
+    ),
+    "browser_select_option": _schema(
+        {
+            "target": _TARGET,
+            "values": {"type": "array", "items": {"type": "string"}, "description": "Option values to select."},
+        },
+        ["target", "values"],
+    ),
+    "browser_hover": _schema({"target": _TARGET}, ["target"]),
+    "browser_drag": _schema({"start_target": _TARGET, "end_target": _TARGET}, ["start_target", "end_target"]),
+    "browser_drop": _schema(
+        {
+            "target": _TARGET,
+            "paths": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Workspace file paths to drop.",
+            },
+            "data": {
+                "type": "object",
+                "description": "MIME type to string data, such as text/plain or text/uri-list.",
+                "additionalProperties": {"type": "string"},
+            },
+        },
+        ["target"],
+    ),
+    "browser_press_key": _schema(
+        {"key": {"type": "string", "description": "Key name or character, such as ArrowLeft or a."}}, ["key"]
+    ),
+    "browser_tabs": _schema(
+        {
+            "action": {"type": "string", "enum": ["list", "new", "close", "select"]},
+            "index": {"type": "integer", "description": "Tab index for close or select."},
+            "url": {"type": "string", "description": "Optional URL for a new tab."},
+        },
+        ["action"],
+    ),
+    "browser_handle_dialog": _schema(
+        {
+            "accept": {"type": "boolean", "description": "Accept rather than dismiss the dialog."},
+            "prompt_text": {"type": "string", "description": "Text for a prompt dialog."},
+        },
+        ["accept"],
+    ),
+    "browser_file_upload": _schema(
+        {
+            "paths": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Workspace file paths to upload. Use an empty list to cancel.",
+            }
+        },
+        ["paths"],
+    ),
+    "browser_console_messages": _schema(
+        {
+            "level": {"type": "string", "enum": ["error", "warning", "info", "debug"]},
+            "all_messages": {
+                "type": "boolean",
+                "description": "Include the whole session rather than only messages since navigation.",
+            },
+        }
+    ),
+    "browser_network_requests": _schema(
+        {
+            "include_static": {"type": "boolean", "description": "Include images, fonts, scripts, and styles."},
+            "filter_pattern": {"type": "string", "description": "Regular expression matched against request URLs."},
+        }
+    ),
+    "browser_network_request": _schema(
+        {
+            "index": {"type": "integer", "description": "1-based index from browser_network_requests."},
+            "part": {
+                "type": "string",
+                "enum": ["request_headers", "request_body", "response_headers", "response_body"],
+            },
+        },
+        ["index"],
+    ),
+    "browser_take_screenshot": _schema(
+        {
+            "target": _TARGET,
+            "image_type": {"type": "string", "enum": ["png", "jpeg"]},
+            "full_page": {"type": "boolean", "description": "Capture the full scrollable page."},
+            "scale": {"type": "string", "enum": ["css", "device"]},
+        }
+    ),
+    "browser_evaluate": _schema(
+        {
+            "function": {
+                "type": "string",
+                "description": "JavaScript function evaluated in the page, or with the target element as its argument.",
+            },
+            "target": _TARGET,
+        },
+        ["function"],
+    ),
+    "browser_close": _schema({}),
+}
+
+
+class BrowserTool(BaseTool):
     def __init__(
         self,
         project_path: Union[str, Path],
@@ -20,7 +206,7 @@ class BrowserTool(BaseTool):
         caller,
         filesystem=None,
         browser_manager=None,
-    ):
+    ) -> None:
         super().__init__(
             project_path,
             workspace_id,
@@ -31,241 +217,179 @@ class BrowserTool(BaseTool):
             filesystem,
             browser_manager=browser_manager,
         )
-
-        # Use injected browser_manager if provided, otherwise create local one
         if self.browser_manager is None:
             self.browser_manager = PlaywrightBrowserManager()
 
-    async def launch_browser(self, url: str) -> str:
-        browser_result = await self.browser_manager.launch_browser(url)
-
-        # Check if we got an error dict instead of a browser ID
-        if isinstance(browser_result, dict) and "error" in browser_result:
-            return f"Failed to launch browser. Error: {browser_result['error']}"
-
-        if browser_result:
-            browser_launched_event = AgentEvent(
-                event_type="browser_launched", sender=self.caller.agent_name, content={"browser_id": browser_result}
+    async def _broadcast_launched(self, previous_session_id: Optional[str], result: dict[str, Any]) -> None:
+        session_id = result.get("session_id")
+        if session_id and session_id != previous_session_id:
+            event = AgentEvent(
+                event_type="browser_launched", sender=self.caller.agent_name, content={"browser_id": session_id}
             )
-            await self.connection_manager.broadcast_event(browser_launched_event, self.workspace_id, self.thread_id)
+            await self.connection_manager.broadcast_event(event, self.workspace_id, self.thread_id)
 
-            return f"Launched new browser with browser_id {browser_result}"
-        else:
-            return "Failed to launch browser."
+    @staticmethod
+    def _format_page(result: dict[str, Any]) -> str:
+        parts = ["## Page", f"- URL: {result.get('url', 'about:blank')}", f"- Title: {result.get('title', '')}"]
+        if result.get("modal"):
+            parts.extend(["", "## Modal state", "```json", json.dumps(result["modal"], indent=2), "```"])
+        if "result" in result:
+            parts.extend(["", "## Result", "```json", json.dumps(result["result"], indent=2, default=str), "```"])
+        if result.get("result_truncated"):
+            parts.append("Result truncated by size.")
+        if result.get("snapshot") is not None:
+            parts.extend(["", "## Snapshot", "```yaml", result["snapshot"], "```"])
+        return "\n".join(parts)
 
-    async def list_browsers(self):
-        results = await self.browser_manager.list_browsers()
+    def _file_payloads(self, paths: list[str]) -> list[dict[str, Any]]:
+        payloads = []
+        for path in paths:
+            candidate = Path(path)
+            resolved = candidate.resolve() if candidate.is_absolute() else (self.project_path / candidate).resolve()
+            try:
+                resolved.relative_to(self.project_path.resolve())
+            except ValueError as exc:
+                raise ValueError(f"File path is outside the allowed root: {path}") from exc
+            payloads.append(file_payload(path, self.filesystem.read_bytes(path)))
+        return payloads
 
-        if not results:
-            return "No browsers are currently running."
+    async def browser_navigate(self, url: str) -> str:
+        previous = self.browser_manager.session_id
+        result = await self.browser_manager.navigate(url)
+        await self._broadcast_launched(previous, result)
+        return self._format_page(result)
 
-        markdown_output = "# Running Browsers\n\n"
-        markdown_output += "| Browser ID | URL | Launched At |\n"
-        markdown_output += "|------------|-----|------------|\n"
+    async def browser_navigate_back(self) -> str:
+        return self._format_page(await self.browser_manager.navigate_back())
 
-        for browser_id, browser_info in results.items():
-            url = browser_info.get("url", "N/A")
-            launched_at = browser_info.get("launched_at", "N/A")
-            markdown_output += f"| {browser_id} | {url} | {launched_at} |\n"
+    async def browser_snapshot(self, target: Optional[str] = None, depth: Optional[int] = None) -> str:
+        previous = self.browser_manager.session_id
+        result = await self.browser_manager.snapshot(target=target, depth=depth)
+        await self._broadcast_launched(previous, result)
+        return self._format_page(result)
 
-        return markdown_output
+    async def browser_find(self, text: Optional[str] = None, regex: Optional[str] = None) -> str:
+        result = await self.browser_manager.find(text=text, regex=regex)
+        if not result["matches"]:
+            return f"No matches found for {result['query']!r}."
+        return f"Found {result['match_count']} matches for {result['query']!r}:\n\n" + "\n\n---\n\n".join(
+            result["matches"]
+        )
 
-    async def get_browser_console_logs(
+    async def browser_wait_for(
+        self, time: Optional[float] = None, text: Optional[str] = None, text_gone: Optional[str] = None
+    ) -> str:
+        return self._format_page(await self.browser_manager.wait_for(time=time, text=text, text_gone=text_gone))
+
+    async def browser_resize(self, width: int, height: int) -> str:
+        return self._format_page(await self.browser_manager.resize(width, height))
+
+    async def browser_click(
         self,
-        browser_id: str,
-        max_logs: int = 50,
-        log_types: Optional[list] = None,
-        minutes_back: Optional[int] = None,
-        max_chars: int = 8000,
+        target: str,
+        double_click: bool = False,
+        button: str = "left",
+        modifiers: Optional[list[str]] = None,
     ) -> str:
-        logs = await self.browser_manager.get_browser_console_logs(
-            browser_id, max_logs=max_logs, log_types=log_types, minutes_back=minutes_back, max_chars=max_chars
+        return self._format_page(
+            await self.browser_manager.click(target, double_click=double_click, button=button, modifiers=modifiers)
         )
 
-        if not logs["console_logs"]:
-            return "## Console Logs\n\nNo console logs found."
+    async def browser_type(self, target: str, text: str, submit: bool = False, slowly: bool = False) -> str:
+        return self._format_page(await self.browser_manager.type_text(target, text, submit=submit, slowly=slowly))
 
-        # Add metadata about filtering
-        markdown_output = "## Console Logs\n\n"
-        markdown_output += f"**Showing {logs['returned_count']} of {logs['total_logs_count']} total logs**\n\n"
+    async def browser_fill_form(self, fields: list[dict[str, Any]]) -> str:
+        return self._format_page(await self.browser_manager.fill_form(fields))
 
-        filters_applied = logs["filters_applied"]
-        if filters_applied["log_types"]:
-            markdown_output += f"**Filtered by types:** {', '.join(filters_applied['log_types'])}\n"
-        if filters_applied["minutes_back"]:
-            markdown_output += f"**Time window:** Last {filters_applied['minutes_back']} minutes\n"
-        if filters_applied["max_chars"]:
-            markdown_output += f"**Character limit:** {filters_applied['max_chars']}\n"
-        markdown_output += f"**Max logs:** {filters_applied['max_logs']}\n\n"
+    async def browser_select_option(self, target: str, values: list[str]) -> str:
+        return self._format_page(await self.browser_manager.select_option(target, values))
 
-        markdown_output += "| Type | Timestamp | Message | Location |\n"
-        markdown_output += "|------|-----------|---------|----------|\n"
+    async def browser_hover(self, target: str) -> str:
+        return self._format_page(await self.browser_manager.hover(target))
 
-        for log in logs["console_logs"]:
-            log_type = log.get("type", "unknown")
-            timestamp = log.get("timestamp", "N/A")
-            text = log.get("text", "").replace("|", "\\|")  # Escape pipe characters for markdown tables
-            location = log.get("location", "N/A")
-            if location and location != "N/A":
-                location_str = f"{location.get('url', 'unknown')}:{location.get('lineNumber', '?')}:{location.get('columnNumber', '?')}"
-            else:
-                location_str = "N/A"
-            markdown_output += f"| {log_type} | {timestamp} | {text} | {location_str} |\n"
+    async def browser_drag(self, start_target: str, end_target: str) -> str:
+        return self._format_page(await self.browser_manager.drag(start_target, end_target))
 
-        return markdown_output
+    async def browser_drop(
+        self, target: str, paths: Optional[list[str]] = None, data: Optional[dict[str, str]] = None
+    ) -> str:
+        return self._format_page(
+            await self.browser_manager.drop(target, files=self._file_payloads(paths or []), data=data)
+        )
 
-    async def get_browser_interactive_elements(self, browser_id: str) -> str:
-        result = await self.browser_manager.get_browser_interactive_elements(browser_id)
+    async def browser_press_key(self, key: str) -> str:
+        return self._format_page(await self.browser_manager.press_key(key))
 
-        # Format the interactive elements as markdown
-        markdown_output = f"# Interactive Elements: {result['title']}\n\n"
-        markdown_output += f"**Current URL:** {result['current_url']}\n\n"
+    async def browser_tabs(self, action: str, index: Optional[int] = None, url: Optional[str] = None) -> str:
+        previous = self.browser_manager.session_id
+        result = await self.browser_manager.tabs(action, index=index, url=url)
+        await self._broadcast_launched(previous, result)
+        lines = ["## Open tabs"]
+        for tab in result["tabs"]:
+            marker = " (current)" if tab["current"] else ""
+            lines.append(f"- {tab['index']}: {tab['title']} — {tab['url']}{marker}")
+        if result.get("snapshot") is not None or result.get("modal"):
+            lines.extend(["", self._format_page(result)])
+        return "\n".join(lines)
 
-        if result["interactive_elements"]:
-            markdown_output += "## Elements\n\n"
-            markdown_output += "| Type | Text | Selector | Attributes |\n"
-            markdown_output += "|------|------|----------|------------|\n"
+    async def browser_handle_dialog(self, accept: bool, prompt_text: Optional[str] = None) -> str:
+        return self._format_page(await self.browser_manager.handle_dialog(accept, prompt_text))
 
-            for element in result["interactive_elements"]:
-                element_type = element.get("element_type", "unknown")
-                text = element.get("text", "").replace("|", "\\|")  # Escape pipe characters for markdown tables
-                selector = element.get("selector", "").replace("|", "\\|")
-                attributes = str(element.get("attributes", {})).replace("|", "\\|")
+    async def browser_file_upload(self, paths: list[str]) -> str:
+        return self._format_page(await self.browser_manager.file_upload(self._file_payloads(paths)))
 
-                markdown_output += f"| {element_type} | {text} | `{selector}` | {attributes} |\n"
-        else:
-            markdown_output += "No interactive elements found on the page."
+    async def browser_console_messages(self, level: str = "info", all_messages: bool = False) -> str:
+        result = await self.browser_manager.console_messages(level, all_messages=all_messages)
+        header = f"Total messages: {result['total']} (Errors: {result['errors']}, Warnings: {result['warnings']})"
+        messages = []
+        for message in result["messages"]:
+            location = message.get("location") or {}
+            location_text = f" @ {location.get('url')}:{location.get('lineNumber')}" if location.get("url") else ""
+            messages.append(f"[{message['type'].upper()}] {message['text']}{location_text}")
+        return "\n".join([header, "", *messages])
 
-        return markdown_output
+    async def browser_network_requests(self, include_static: bool = False, filter_pattern: Optional[str] = None) -> str:
+        result = await self.browser_manager.network_requests(
+            include_static=include_static, filter_pattern=filter_pattern
+        )
+        if not result["requests"]:
+            return "No matching network requests."
+        lines = ["## Network requests"]
+        for request in result["requests"]:
+            status = request["status"] if request["status"] is not None else request["failure"] or "pending"
+            lines.append(f"- {request['index']}: {request['method']} {request['url']} => {status}")
+        return "\n".join(lines)
 
-    async def get_browser_content(
+    async def browser_network_request(self, index: int, part: Optional[str] = None) -> str:
+        return (
+            "```json\n"
+            + json.dumps(await self.browser_manager.network_request(index, part), indent=2, default=str)
+            + "\n```"
+        )
+
+    async def browser_take_screenshot(
         self,
-        browser_id: str,
-        max_logs: int = 50,
-        log_types: Optional[list] = None,
-        minutes_back: Optional[int] = None,
-        max_chars: int = 8000,
-    ) -> str:
-        content = await self.browser_manager.get_browser_content(
-            browser_id, max_logs=max_logs, log_types=log_types, minutes_back=minutes_back, max_chars=max_chars
+        target: Optional[str] = None,
+        image_type: str = "png",
+        full_page: bool = False,
+        scale: str = "css",
+    ) -> dict[str, Any]:
+        return await self.browser_manager.screenshot(
+            target=target, image_type=image_type, full_page=full_page, scale=scale
         )
 
-        # Format the browser content as markdown
-        markdown_output = f"# Browser Content: {content['title']}\n\n"
-        markdown_output += f"**Current URL:** {content['current_url']}\n\n"
+    async def browser_evaluate(self, function: str, target: Optional[str] = None) -> str:
+        return self._format_page(await self.browser_manager.evaluate(function, target))
 
-        # Add console logs section if there are any
-        if content["console_logs"]:
-            markdown_output += "## Console Logs\n\n"
-
-            # Add metadata about console log filtering
-            if "console_log_metadata" in content:
-                metadata = content["console_log_metadata"]
-                markdown_output += (
-                    f"**Showing {metadata['returned_count']} of {metadata['total_logs_count']} total logs**\n\n"
-                )
-
-                filters_applied = metadata["filters_applied"]
-                if filters_applied["log_types"]:
-                    markdown_output += f"**Filtered by types:** {', '.join(filters_applied['log_types'])}\n"
-                if filters_applied["minutes_back"]:
-                    markdown_output += f"**Time window:** Last {filters_applied['minutes_back']} minutes\n"
-                if filters_applied["max_chars"]:
-                    markdown_output += f"**Character limit:** {filters_applied['max_chars']}\n"
-                markdown_output += f"**Max logs:** {filters_applied['max_logs']}\n\n"
-
-            markdown_output += "| Type | Timestamp | Message | Location |\n"
-            markdown_output += "|------|-----------|---------|----------|\n"
-
-            for log in content["console_logs"]:
-                log_type = log.get("type", "unknown")
-                timestamp = log.get("timestamp", "N/A")
-                text = log.get("text", "").replace("|", "\\|")  # Escape pipe characters for markdown tables
-                location = log.get("location", "N/A")
-                if location and location != "N/A":
-                    location_str = f"{location.get('url', 'unknown')}:{location.get('lineNumber', '?')}:{location.get('columnNumber', '?')}"
-                else:
-                    location_str = "N/A"
-                markdown_output += f"| {log_type} | {timestamp} | {text} | {location_str} |\n"
-
-        # Add HTML content in a code block
-        html = content["html"]
-        original_html_chars = len(html)
-        html_truncated = original_html_chars > self.MAX_HTML_CHARS_FOR_CONTENT_OUTPUT
-        if html_truncated:
-            html = html[: self.MAX_HTML_CHARS_FOR_CONTENT_OUTPUT]
-
-        markdown_output += "\n## Page HTML\n\n"
-        if html_truncated:
-            markdown_output += (
-                f"**HTML truncated by size: Showing first {self.MAX_HTML_CHARS_FOR_CONTENT_OUTPUT:,} "
-                f"of {original_html_chars:,} characters.**\n\n"
-            )
-        markdown_output += "```html\n"
-        markdown_output += html
-        markdown_output += "\n```\n"
-
-        return markdown_output
-
-    async def take_browser_screenshot(self, browser_id: str) -> dict:
-        return await self.browser_manager.take_browser_screenshot(browser_id)
-
-    async def interact_with_browser(
-        self, browser_id: str, action: str, selector: str, text: str, scroll_px: int
-    ) -> str:
-        result = await self.browser_manager.interact_with_browser(browser_id, action, selector, text, scroll_px)
-
-        # Format the interaction result as markdown
-        markdown_output = "# Browser Interaction Result\n\n"
-        markdown_output += f"**Status:** {result['status']}\n"
-        markdown_output += f"**Current URL:** {result['current_url']}\n\n"
-        markdown_output += f"**Action Performed:** {result['action']}\n"
-
-        if result["selector"]:
-            markdown_output += f"**Selector:** `{result['selector']}`\n"
-
-        if result["text"]:
-            markdown_output += f"**Text/URL:** {result['text']}\n"
-
-        return markdown_output
-
-    async def set_browser_select_value(self, browser_id: str, selector: str, value: str) -> str:
-        result = await self.browser_manager.set_select_value(browser_id, selector, value)
-
-        # Format the select value result as markdown
-        markdown_output = "# Select Value Update Result\n\n"
-        markdown_output += f"**Status:** {result['status']}\n"
-        markdown_output += f"**Current URL:** {result['current_url']}\n"
-        markdown_output += f"**Selector:** `{result['selector']}`\n\n"
-
-        if result["status"] == "success":
-            markdown_output += "## ✅ Success\n\n"
-            markdown_output += f"**Requested Value:** `{result['requested_value']}`\n"
-            markdown_output += f"**Selected Value:** `{result['selected_value']}`\n"
-
-            if result["requested_value"] == result["selected_value"]:
-                markdown_output += "\n✓ The select box value was successfully updated."
-            else:
-                markdown_output += "\n⚠️ Warning: The selected value differs from the requested value."
-        else:
-            markdown_output += "## ❌ Error\n\n"
-            markdown_output += f"**Error Message:** {result.get('error', 'Unknown error')}\n"
-
-        return markdown_output
-
-    async def close_browser(self, browser_id) -> str:
-        await self.browser_manager.close_browser(browser_id)
-
-        browser_closed_event = AgentEvent(
-            event_type="browser_closed", sender=self.caller.agent_name, content={"browser_id": browser_id}
+    async def browser_close(self) -> str:
+        session_id = await self.browser_manager.close()
+        if session_id is None:
+            return "No browser session is running."
+        event = AgentEvent(
+            event_type="browser_closed", sender=self.caller.agent_name, content={"browser_id": session_id}
         )
-        await self.connection_manager.broadcast_event(browser_closed_event, self.workspace_id, self.thread_id)
-
-        return f"Browser with ID {browser_id} closed."
+        await self.connection_manager.broadcast_event(event, self.workspace_id, self.thread_id)
+        return "Browser session closed."
 
     async def cleanup(self) -> None:
-        """
-        Clean up all browser resources.
-        This should be called when the tool is being destroyed.
-        """
         await self.browser_manager.cleanup_all_browsers()

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -13,7 +13,7 @@ from kolega_code.services.base import TerminalManager, BrowserManager
 from kolega_code.services.terminal import LocalTerminalManager
 from kolega_code.services.browser import PlaywrightBrowserManager
 from .tool_backend.agent_tool import AgentTool
-from .tool_backend.browser_tool import BrowserTool
+from .tool_backend.browser_tool import BROWSER_TOOL_SCHEMAS, BrowserTool
 from .tool_backend.edit_tool import EditTool
 from .tool_backend.glob_tool import GlobTool
 from .tool_backend.list_directory_tool import ListDirectoryTool
@@ -287,14 +287,29 @@ class ToolCollection(LogMixin):
     ]
 
     browser_tools = [
-        "launch_browser",
-        "list_browsers",
-        "get_browser_interactive_elements",
-        "get_browser_console_logs",
-        "take_browser_screenshot",
-        "interact_with_browser",
-        "set_browser_select_value",
-        "close_browser",
+        "browser_navigate",
+        "browser_navigate_back",
+        "browser_snapshot",
+        "browser_find",
+        "browser_wait_for",
+        "browser_resize",
+        "browser_click",
+        "browser_type",
+        "browser_fill_form",
+        "browser_select_option",
+        "browser_hover",
+        "browser_drag",
+        "browser_drop",
+        "browser_press_key",
+        "browser_tabs",
+        "browser_handle_dialog",
+        "browser_file_upload",
+        "browser_console_messages",
+        "browser_network_requests",
+        "browser_network_request",
+        "browser_take_screenshot",
+        "browser_evaluate",
+        "browser_close",
     ]
 
     # Agent dispatch tools group - includes all agent dispatch functionality
@@ -630,6 +645,7 @@ class ToolCollection(LogMixin):
         self.extension_schemas["lsp_edit"] = _LSP_EDIT_INPUT_SCHEMA
         self.extension_schemas["snapshot"] = _SNAPSHOT_INPUT_SCHEMA
         self.extension_schemas["resolve"] = _RESOLVE_INPUT_SCHEMA
+        self.extension_schemas.update(BROWSER_TOOL_SCHEMAS)
         self.browser_tool = BrowserTool(
             self.project_path,
             self.workspace_id,
@@ -676,276 +692,242 @@ class ToolCollection(LogMixin):
             snapshot_service=self.snapshot_service,
         )
 
-    async def launch_browser(self, url: str) -> str:
-        """
-        Launch a browser and navigate to a specified URL.
-
-        This tool opens a new browser window, navigates to the provided URL,
-        and returns a unique browser ID that can be used to interact with this browser instance
-        through other browser-related tools.
-
-        When to use this tool:
-        - When you need to visit a website to gather information
-        - When you need to interact with web applications
-        - When you need to test web functionality
-        - When you need to demonstrate web-based features to the user
-
-        Usage notes:
-        1. The browser uses a standard viewport size (1280x720) and Chrome user agent
-        2. The returned browser ID must be saved if you plan to interact with this browser later
-        3. Each call creates a new browser instance - use judiciously to avoid resource consumption
+    async def browser_navigate(self, url: str) -> str:
+        """Navigate the current browser tab to a URL, starting a session when needed.
 
         Args:
-            url: The complete URL to navigate to (must include http:// or https://)
-
-        Returns:
-            A confirmation message with the unique browser ID for future reference
+            url: HTTP or HTTPS URL to navigate to.
         """
+        return await self.browser_tool.browser_navigate(url)
 
-        return await self.browser_tool.launch_browser(url)
+    async def browser_navigate_back(self) -> str:
+        """Go back to the previous page and return the updated page snapshot."""
+        return await self.browser_tool.browser_navigate_back()
 
-    async def list_browsers(self) -> str:
+    async def browser_snapshot(self, target: Optional[str] = None, depth: Optional[int] = None) -> str:
+        """Capture the current page's accessibility snapshot.
+
+        Prefer this over screenshots when deciding what to interact with. Interactive
+        nodes include stable refs such as e12 that can be passed to action tools.
+
+        Args:
+            target: Optional snapshot ref or unique selector for a subtree.
+            depth: Optional maximum accessibility-tree depth.
         """
-        List all currently running browser instances.
+        return await self.browser_tool.browser_snapshot(target, depth)
 
-        This tool provides a formatted overview of all active browser sessions, displaying
-        their unique browser IDs, the URLs they're currently visiting, and when they were launched.
+    async def browser_find(self, text: Optional[str] = None, regex: Optional[str] = None) -> str:
+        """Find text or a regular expression in the accessibility snapshot.
 
-        When to use this tool:
-        - When you need to check which browser instances are currently active
-        - When you need to retrieve a browser ID for use with other browser tools
-        - When you want to see which URLs are currently being accessed
-        - When you need to manage multiple browser sessions
+        Provide exactly one of text or regex. This is cheaper than requesting a
+        full snapshot when locating a specific element.
 
-        Usage notes:
-        1. The output is formatted as a markdown table for easy readability
-        2. If no browsers are running, the tool will indicate this
-        3. Browser IDs can be used with other browser tools like close_browser
-        4. This tool is useful for cleanup to ensure all browser instances are properly closed
-
-        Returns:
-            A markdown-formatted table listing all active browser instances with their details
+        Args:
+            text: Case-insensitive text to find.
+            regex: Regular expression to find.
         """
-        return await self.browser_tool.list_browsers()
+        return await self.browser_tool.browser_find(text, regex)
 
-    async def get_browser_console_logs(
-        self,
-        browser_id: str,
-        max_logs: int = 50,
-        log_types: Optional[list] = None,
-        minutes_back: Optional[int] = None,
-        max_chars: int = 8000,
+    async def browser_wait_for(
+        self, time: Optional[float] = None, text: Optional[str] = None, text_gone: Optional[str] = None
     ) -> str:
-        """
-        Retrieve filtered console logs from a browser instance by its browser ID.
-
-        This tool captures console messages (info, warnings, errors) that have been logged
-        in the browser's JavaScript console and returns them in a formatted markdown document.
-        The logs are filtered to prevent context window overflow while focusing on the most relevant information.
-
-        When to use this tool:
-        - When you need to debug JavaScript errors on a webpage
-        - When you want to see application messages logged to the console
-        - When you need to diagnose network or rendering issues
-        - When you're working with web applications that use console logging
-
-        Usage notes:
-        1. You must provide a valid browser_id from a previous launch_browser call
-        2. Console logs are filtered by default to show only errors, warnings, and assertions
-        3. By default, only the most recent 50 logs are returned with a character limit of 8000
-        4. Each log entry includes its type, timestamp, and message text
-        5. Use this after interacting with a page to see what messages were generated
+        """Wait for time to pass, text to appear, or text to disappear.
 
         Args:
-            browser_id: The unique identifier of the browser instance to get console logs from
-            max_logs: Maximum number of logs to return (default: 50, most recent)
-            log_types: List of log types to include (default: ['error', 'warning', 'assert'])
-            minutes_back: Only return logs from the last N minutes (optional)
-            max_chars: Maximum total character count for all log messages (default: 8000)
-
-        Returns:
-            A markdown-formatted document containing the filtered browser console logs
+            time: Seconds to wait, capped at 30.
+            text: Text to wait for until visible.
+            text_gone: Text to wait for until hidden.
         """
-        return await self.browser_tool.get_browser_console_logs(
-            browser_id, max_logs=max_logs, log_types=log_types, minutes_back=minutes_back, max_chars=max_chars
-        )
+        return await self.browser_tool.browser_wait_for(time, text, text_gone)
 
-    async def get_browser_interactive_elements(self, browser_id: str) -> str:
-        """
-        Identify and extract all interactive elements from a browser page.
-
-        This tool analyzes the current state of a browser page and identifies all interactive elements
-        such as buttons, links, form inputs, and other clickable components, returning them in a
-        structured markdown format with their selectors and attributes.
-
-        When to use this tool:
-        - When you need to discover what actions are possible on a webpage
-        - When you need to find specific interactive elements to interact with
-        - When you're exploring a new website and need to understand its interface
-        - When you need to automate interactions with a webpage
-        - When you need precise selectors for use with the interact_with_browser or set_browser_select_value tools
-
-        Usage notes:
-        1. You must provide a valid browser_id from a previous launch_browser call
-        2. The tool returns a comprehensive list of all interactive elements with their types, text content, and selectors
-        3. The selector column provides CSS selectors that can be used with interact_with_browser or set_browser_select_value
-        4. The attributes column provides additional information about each element
-        5. Use this tool before performing interactions to identify the correct elements to target
+    async def browser_resize(self, width: int, height: int) -> str:
+        """Resize the current browser viewport.
 
         Args:
-            browser_id: The unique identifier of the browser instance to analyze
-
-        Returns:
-            A markdown-formatted document listing all interactive elements on the page with their details
+            width: Viewport width in CSS pixels.
+            height: Viewport height in CSS pixels.
         """
-        return await self.browser_tool.get_browser_interactive_elements(browser_id)
+        return await self.browser_tool.browser_resize(width, height)
 
-    async def take_browser_screenshot(self, browser_id: str) -> List[ImageBlock]:
-        """
-        Take a screenshot of the current browser page.
-
-        This tool captures the current visual state of a browser page and returns it as an image,
-        along with relevant metadata such as the current URL and page title.
-
-        When to use this tool:
-        - When you need to visually inspect the current state of a webpage
-        - When you need to capture visual evidence of a web application's behavior
-        - When text-based content extraction is insufficient to understand the page layout
-        - When you need to verify the visual appearance of a web interface
-
-        Usage notes:
-        1. You must provide a valid browser_id from a previous launch_browser call
-        2. The screenshot captures the entire visible viewport of the browser
-        3. The returned image is in base64-encoded format
-        4. The tool also returns metadata about the page including title and URL
+    async def browser_click(
+        self,
+        target: str,
+        double_click: bool = False,
+        button: str = "left",
+        modifiers: Optional[list[str]] = None,
+    ) -> str:
+        """Click an element identified by a snapshot ref or unique selector.
 
         Args:
-            browser_id: The unique identifier of the browser instance to screenshot
-
-        Returns:
-            A list containing a text description and the screenshot image
+            target: Exact snapshot ref or unique selector.
+            double_click: Perform a double click.
+            button: Mouse button: left, right, or middle.
+            modifiers: Keyboard modifiers held during the click.
         """
-        result = await self.browser_tool.take_browser_screenshot(browser_id)
+        return await self.browser_tool.browser_click(target, double_click, button, modifiers)
 
-        # Create an image block with the screenshot data
-        image_block = ImageBlock(image_type="base64", media_type="image/png", data=result["screenshot"])
+    async def browser_type(self, target: str, text: str, submit: bool = False, slowly: bool = False) -> str:
+        """Enter text into an editable element.
 
-        return [image_block]
+        Args:
+            target: Exact snapshot ref or unique selector.
+            text: Text to enter.
+            submit: Press Enter after entering text.
+            slowly: Type character by character instead of filling.
+        """
+        return await self.browser_tool.browser_type(target, text, submit, slowly)
+
+    async def browser_fill_form(self, fields: list[dict[str, Any]]) -> str:
+        """Fill several textbox, checkbox, radio, combobox, or slider fields.
+
+        Args:
+            fields: Structured field descriptions with name, target, type, and value.
+        """
+        return await self.browser_tool.browser_fill_form(fields)
+
+    async def browser_select_option(self, target: str, values: list[str]) -> str:
+        """Select one or more values in a dropdown.
+
+        Args:
+            target: Exact snapshot ref or unique selector.
+            values: Option values to select.
+        """
+        return await self.browser_tool.browser_select_option(target, values)
+
+    async def browser_hover(self, target: str) -> str:
+        """Hover over an element and return the updated snapshot.
+
+        Args:
+            target: Exact snapshot ref or unique selector.
+        """
+        return await self.browser_tool.browser_hover(target)
+
+    async def browser_drag(self, start_target: str, end_target: str) -> str:
+        """Drag one page element to another.
+
+        Args:
+            start_target: Source snapshot ref or unique selector.
+            end_target: Destination snapshot ref or unique selector.
+        """
+        return await self.browser_tool.browser_drag(start_target, end_target)
+
+    async def browser_drop(
+        self, target: str, paths: Optional[list[str]] = None, data: Optional[dict[str, str]] = None
+    ) -> str:
+        """Drop workspace files or MIME-typed string data onto an element.
+
+        Args:
+            target: Destination snapshot ref or unique selector.
+            paths: Workspace file paths to drop.
+            data: MIME type to string value mapping.
+        """
+        return await self.browser_tool.browser_drop(target, paths, data)
+
+    async def browser_press_key(self, key: str) -> str:
+        """Press a keyboard key in the current tab.
+
+        Args:
+            key: Key name or character, such as ArrowLeft or a.
+        """
+        return await self.browser_tool.browser_press_key(key)
+
+    async def browser_tabs(self, action: str, index: Optional[int] = None, url: Optional[str] = None) -> str:
+        """List, create, close, or select browser tabs.
+
+        Args:
+            action: One of list, new, close, or select.
+            index: Tab index for close or select.
+            url: Optional URL for a new tab.
+        """
+        return await self.browser_tool.browser_tabs(action, index, url)
+
+    async def browser_handle_dialog(self, accept: bool, prompt_text: Optional[str] = None) -> str:
+        """Accept or dismiss the currently waiting JavaScript dialog.
+
+        Args:
+            accept: Accept rather than dismiss the dialog.
+            prompt_text: Text to submit to a prompt dialog.
+        """
+        return await self.browser_tool.browser_handle_dialog(accept, prompt_text)
+
+    async def browser_file_upload(self, paths: list[str]) -> str:
+        """Upload workspace files through the currently waiting file chooser.
+
+        Args:
+            paths: Workspace file paths to upload. Use an empty list to cancel.
+        """
+        return await self.browser_tool.browser_file_upload(paths)
+
+    async def browser_console_messages(self, level: str = "info", all_messages: bool = False) -> str:
+        """Return console messages for the current tab.
+
+        Args:
+            level: Minimum severity: error, warning, info, or debug.
+            all_messages: Include the full session instead of only messages since navigation.
+        """
+        return await self.browser_tool.browser_console_messages(level, all_messages)
+
+    async def browser_network_requests(self, include_static: bool = False, filter_pattern: Optional[str] = None) -> str:
+        """List network requests made by the current tab since navigation.
+
+        Args:
+            include_static: Include images, fonts, scripts, and styles.
+            filter_pattern: Optional URL regular expression.
+        """
+        return await self.browser_tool.browser_network_requests(include_static, filter_pattern)
+
+    async def browser_network_request(self, index: int, part: Optional[str] = None) -> str:
+        """Return headers or body details for one indexed network request.
+
+        Args:
+            index: 1-based index from browser_network_requests.
+            part: Optional request_headers, request_body, response_headers, or response_body.
+        """
+        return await self.browser_tool.browser_network_request(index, part)
+
+    async def browser_take_screenshot(
+        self,
+        target: Optional[str] = None,
+        image_type: str = "png",
+        full_page: bool = False,
+        scale: str = "css",
+    ) -> List[ImageBlock]:
+        """Capture a visual screenshot of the page or one element.
+
+        Use browser_snapshot, not the screenshot, to choose interaction targets.
+
+        Args:
+            target: Optional snapshot ref or unique selector.
+            image_type: png or jpeg.
+            full_page: Capture the full scrollable page.
+            scale: css or device pixel scale.
+        """
+        result = await self.browser_tool.browser_take_screenshot(target, image_type, full_page, scale)
+        return [ImageBlock(image_type="base64", media_type=result["media_type"], data=result["image"])]
 
     async def read_image(self, path: str) -> List[Any]:
-        """
-        Read an image file from the project directory so you can see it. Use when the user references a screenshot, diagram, mockup, or other visual asset, or when visual inspection of a file in the workspace is needed. The image is returned for you to view directly.
+        """Read an image file from the project directory so you can see it.
 
-        When to use: the user asks you to look at an image/screenshot/mockup; you need to inspect a visual asset in the project; text-based reading is insufficient to understand a visual file.
+        Use when the user references a screenshot, diagram, mockup, or other
+        visual asset and text-based inspection is insufficient.
 
         Args:
-            path: Path to the image file. Relative to the project root is preferred; an absolute path is also accepted.
-
-        Returns:
-            The image, viewable directly.
-
-        Supported formats: PNG, JPEG, GIF, WebP, BMP.
+            path: Path relative to the project root, or an allowed absolute path.
         """
         return await self.read_image_tool.read_image(path)
 
-    async def interact_with_browser(
-        self, browser_id: str, action: str, selector: str, text: str, scroll_px: int
-    ) -> str:
-        """
-        Interact with a browser by performing actions on web elements.
-
-        This tool allows you to control a browser programmatically by executing common actions
-        like clicking elements, typing text, or navigating to new URLs. It provides a way to
-        automate web interactions within an existing browser session.
-
-        When to use this tool:
-        - When you need to click buttons, links, or other interactive elements on a webpage
-        - When you need to fill out forms by typing text into input fields
-        - When you need to navigate to a different URL within an existing browser session
-        - When you need to automate a sequence of interactions with a web application
-
-        When NOT to use this tool:
-        - When you need to interact with a dropdown or select input. Use set_browser_select_value for that.
-
-        Usage notes:
-        1. You must provide a valid browser_id from a previous launch_browser call
-        2. The action parameter must be one of: 'click', 'type', 'scroll' or 'navigate'
-        3. For 'click' actions, provide a CSS or XPath selector that identifies the element to click
-        4. For 'type' actions, provide both a selector for the input field and the text to type
-        5. For 'scroll' actions, provide a scroll_px (positive to scroll down the page, negative to scroll up)
-        5. For 'navigate' actions, provide the URL in the text parameter (selector can be empty)
-        6. The tool waits for the page to stabilize after the action before returning
-        7. The return value includes the current URL after the action is performed
+    async def browser_evaluate(self, function: str, target: Optional[str] = None) -> str:
+        """Evaluate JavaScript in the page or against one target element.
 
         Args:
-            browser_id: The unique identifier of the browser instance to interact with
-            action: The type of interaction to perform ('click', 'type', or 'navigate')
-            selector: CSS or XPath selector identifying the element to interact with
-            text: Text to type (for 'type' action) or URL to navigate to (for 'navigate' action)
-
-        Returns:
-            A markdown-formatted report of the interaction result, including the current URL
+            function: JavaScript function to evaluate.
+            target: Optional snapshot ref or unique selector passed as the function argument.
         """
-        return await self.browser_tool.interact_with_browser(browser_id, action, selector, text, scroll_px)
+        return await self.browser_tool.browser_evaluate(function, target)
 
-    async def set_browser_select_value(self, browser_id: str, selector: str, value: str) -> str:
-        """
-        Set the value of a select box (dropdown) in a browser page.
-
-        This tool allows you to programmatically select an option from a dropdown menu (select element)
-        on a webpage. It validates that the element is indeed a select box and that the specified value
-        exists among the available options before making the selection.
-
-        When to use this tool:
-        - When you need to select an option from a dropdown menu on a form
-        - When you need to change the selected value in a select box
-        - When automating form filling that includes dropdown selections
-        - When you need to test different options in a select element
-
-        Usage notes:
-        1. You must provide a valid browser_id from a previous launch_browser call
-        2. The selector must identify a <select> HTML element - the tool will fail if used on other element types
-        3. The value parameter should match the 'value' attribute of the <option> you want to select, not the visible text
-        4. Use get_browser_interactive_elements first to find the correct selector and see available option values
-        5. The tool validates that the specified value exists in the select options before attempting to set it
-        6. The response will confirm whether the selection was successful and show the actual selected value
-
-        Args:
-            browser_id: The unique identifier of the browser instance to interact with
-            selector: CSS selector that uniquely identifies the select element
-            value: The value attribute of the option to select (not the display text)
-
-        Returns:
-            A markdown-formatted report showing the result of the selection, including success/error status
-        """
-        return await self.browser_tool.set_browser_select_value(browser_id, selector, value)
-
-    async def close_browser(self, browser_id: str) -> str:
-        """
-        Close a specific browser instance by its ID.
-
-        This tool terminates a browser session that was previously launched with the launch_browser tool,
-        freeing up system resources and cleaning up the browser process.
-
-        When to use this tool:
-        - When you've completed tasks in a specific browser instance
-        - When you need to clean up resources after web-based operations
-        - When you want to start fresh with a new browser session
-        - When you're managing multiple browser instances and need to close specific ones
-
-        Usage notes:
-        1. You must provide a valid browser ID that was returned from a previous launch_browser call
-        2. Once closed, the browser ID becomes invalid and cannot be used again
-        3. It's good practice to close browsers when you're done with them to free up resources
-        4. If you're unsure which browser IDs are available, use the list_browsers tool first
-
-        Args:
-            browser_id: The unique identifier of the browser instance to close
-
-        Returns:
-            A confirmation message indicating the browser has been closed
-        """
-        return await self.browser_tool.close_browser(browser_id)
+    async def browser_close(self) -> str:
+        """Close the current browser session and release its resources."""
+        return await self.browser_tool.browser_close()
 
     async def build_backend(self) -> str:
         """
@@ -1048,14 +1030,11 @@ class ToolCollection(LogMixin):
         5. The agent's report is not automatically shown to the user - you should summarize key findings
 
         IMPORTANT: The browser agent specializes in these tools:
-            - launch_browser
-            - list_browsers
-            - get_browser_content
-            - get_browser_console_logs
-            - take_browser_screenshot
-            - interact_with_browser
-            - set_browser_select_value
-            - close_browser
+            - browser_navigate, browser_snapshot, and browser_find
+            - browser_click, browser_type, browser_fill_form, and browser_select_option
+            - browser_tabs, browser_wait_for, browser_handle_dialog, and browser_file_upload
+            - browser_console_messages, browser_network_requests, and browser_take_screenshot
+            - browser_close
 
         Args:
             task: A detailed description of the browser task to perform

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -380,6 +380,8 @@ class KolegaCodeApp(
                                         with Horizontal(classes="agent-model-field"):
                                             yield Label("Effort", classes="agent-model-field-label")
                                             yield Select([], id=f"am_effort_{role_value}", allow_blank=True, prompt="—")
+                                        if role_value == "browser":
+                                            yield Static("", id="am_status_browser", classes="settings-hint")
                             with Vertical(classes="settings-section", id="settings_web_search") as web_search_section:
                                 web_search_section.border_title = "Web Search"
                                 yield Static(

--- a/kolega_code/cli/messages.py
+++ b/kolega_code/cli/messages.py
@@ -145,6 +145,18 @@ SETTINGS_ACTIVE_MODEL_UNCONFIGURED = "Active model: not configured"
 SETTINGS_API_KEY_LINE = "API key: {status}"
 SETTINGS_THINKING_EFFORT_LINE = "Thinking effort: {effort}"
 SETTINGS_ACTIVE_THEME = "Active theme: {theme}"
+BROWSER_MODEL_VISION_READY = "Browser agent model supports vision."
+BROWSER_MODEL_INHERIT_VISION_READY = "Browser agent inherits a vision-capable model."
+BROWSER_MODEL_INHERIT_NO_VISION = (
+    "Browser agent is unavailable: inherited model {provider}/{model} does not support vision. "
+    "Choose a vision-capable Browser model."
+)
+BROWSER_MODEL_EXPLICIT_NO_VISION = (
+    "Browser model {provider}/{model} does not support vision. Choose a vision-capable model or Default (inherit)."
+)
+BROWSER_MODEL_PROVIDER_NO_VISION = (
+    "Provider {provider} has no vision-capable Browser models. Choose another provider or Default (inherit)."
+)
 
 # Status dashboard
 STATUS_TOKENS_UNKNOWN = "Token counts unavailable."

--- a/kolega_code/cli/provider_registry.py
+++ b/kolega_code/cli/provider_registry.py
@@ -152,6 +152,7 @@ class ModelOption:
     api_key_env: str
     context_length: int
     max_completion_tokens: int
+    supports_vision: bool
     thinking_efforts: tuple[str, ...]
     default_thinking_effort: str | None
 
@@ -183,6 +184,7 @@ def _model_option(provider: ModelProvider, model: str) -> ModelOption:
         api_key_env=_api_key_env(provider),
         context_length=int(specs["context_length"]),
         max_completion_tokens=int(specs["max_completion_tokens"]),
+        supports_vision=bool(specs.get("supports_vision", False)),
         thinking_efforts=thinking_effort_options(provider, model),
         default_thinking_effort=default_thinking_effort(provider, model),
     )
@@ -217,9 +219,13 @@ def ui_provider_options() -> list[tuple[str, str]]:
     return options
 
 
-def ui_model_options(provider: str) -> list[tuple[str, str]]:
+def ui_model_options(provider: str, *, vision_only: bool = False) -> list[tuple[str, str]]:
     """Return Textual Select options for supported UI models."""
-    return [(option.model_label, option.model) for option in UI_MODEL_OPTIONS if option.provider == provider]
+    return [
+        (option.model_label, option.model)
+        for option in UI_MODEL_OPTIONS
+        if option.provider == provider and (option.supports_vision or not vision_only)
+    ]
 
 
 def ui_thinking_effort_options(provider: str, model: str) -> list[tuple[str, str]]:

--- a/kolega_code/cli/tui/settings_panel.py
+++ b/kolega_code/cli/tui/settings_panel.py
@@ -218,6 +218,7 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         if select_id == "provider_select":
             provider = str(event.value)
             self._repopulate_model_select(provider, "model_select", "thinking_effort_select")
+            self._update_browser_model_hint()
             try:
                 api_key_input = self.query_one("#api_key_input", Input)
                 api_key_input.placeholder = self._api_key_placeholder(provider)
@@ -233,6 +234,7 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             except NoMatches:
                 return
             self._set_effort_select_default(provider, str(event.value))
+            self._update_browser_model_hint()
             return
 
         if select_id == "web_search_backend_select":
@@ -262,6 +264,8 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
                 self._repopulate_model_select(
                     provider, f"am_model_{role}", f"am_effort_{role}", model_value=model_value
                 )
+            if role == "browser":
+                self._update_browser_model_hint()
             return
 
         if select_id.startswith("am_model_"):
@@ -275,6 +279,8 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
                 # model change has none pending and falls back to preserve/default.
                 preferred = self._pending_agent_efforts.pop(f"am_effort_{role}", None)
                 self._set_effort_select_default(provider, str(event.value), f"am_effort_{role}", preferred=preferred)
+            if role == "browser":
+                self._update_browser_model_hint()
             return
 
         if select_id == "theme_select":
@@ -322,6 +328,7 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         api_key_input.placeholder = self._api_key_placeholder(provider)
         api_key_input.disabled = provider == chatgpt_constants.PROVIDER_KEY
         self._populate_agent_model_rows()
+        self._update_browser_model_hint()
         self._populate_web_search_controls()
         self._populate_mcp_controls()
         self._populate_lsp_controls()
@@ -361,6 +368,65 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             self._repopulate_model_select(
                 provider, model_id, effort_id, model_value=model_value, effort_value=effort_value
             )
+
+    def _browser_model_status(self) -> tuple[str, str, bool]:
+        """Return the Browser-role model message, tone, and whether saving must stop."""
+        try:
+            browser_provider = str(self.query_one("#am_provider_browser", Select).value)
+        except NoMatches:
+            return "", "info", False
+
+        inherited = browser_provider == INHERIT_SENTINEL
+        if inherited:
+            try:
+                provider = str(self.query_one("#provider_select", Select).value)
+                model = str(self.query_one("#model_select", Select).value)
+            except NoMatches:
+                return "", "info", False
+        else:
+            provider = browser_provider
+            try:
+                model_value = self.query_one("#am_model_browser", Select).value
+            except NoMatches:
+                return "", "info", False
+            if model_value is Select.NULL:
+                return messages.BROWSER_MODEL_PROVIDER_NO_VISION.format(provider=provider), "error", True
+            model = str(model_value)
+
+        option = get_ui_model(provider, model)
+        supports_vision = bool(option and option.supports_vision)
+        if supports_vision:
+            message = messages.BROWSER_MODEL_INHERIT_VISION_READY if inherited else messages.BROWSER_MODEL_VISION_READY
+            return message, "ok", False
+        if inherited:
+            return (
+                messages.BROWSER_MODEL_INHERIT_NO_VISION.format(provider=provider, model=model),
+                "warning",
+                False,
+            )
+        return (
+            messages.BROWSER_MODEL_EXPLICIT_NO_VISION.format(provider=provider, model=model),
+            "error",
+            True,
+        )
+
+    def _update_browser_model_hint(self) -> None:
+        """Keep the Browser-role capability hint synchronized with its resolved model."""
+        message, tone, _ = self._browser_model_status()
+        if not message:
+            return
+        glyph, style = {
+            "ok": (Glyph.CHECK, Color.SUCCESS),
+            "error": (Glyph.CROSS, Color.ERROR),
+            "warning": (Glyph.STATUS, Color.WARNING),
+        }.get(tone, (Glyph.STATUS, Color.MUTED))
+        content = Text()
+        content.append(theme.g(glyph) + " ", style=style)
+        content.append(message)
+        try:
+            self.query_one("#am_status_browser", Static).update(content)
+        except NoMatches:
+            return
 
     def _update_search_backend_fields(self, backend: str) -> None:
         """Show only the inputs the selected web-search backend needs.
@@ -869,7 +935,13 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         if model_value is None:
             current = model_select.value
             model_value = None if current is Select.NULL else str(current)
-        model_options = ui_model_options(provider)
+        browser_role = model_id == "am_model_browser"
+        model_options = ui_model_options(provider, vision_only=True) if browser_role else ui_model_options(provider)
+        valid_models = {value for _, value in model_options}
+        if browser_role and model_value and model_value not in valid_models:
+            stale_option = get_ui_model(provider, model_value)
+            if stale_option is not None:
+                model_options.append((f"{stale_option.model_label} (vision required)", model_value))
         model_select.set_options(model_options)
         valid_models = {value for _, value in model_options}
         model = model_value if (model_value and model_value in valid_models) else None
@@ -950,6 +1022,12 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
     async def _save_settings_from_ui(self) -> None:
         provider = str(self.query_one("#provider_select", Select).value)
         model = str(self.query_one("#model_select", Select).value)
+        browser_message, browser_tone, browser_blocks_save = self._browser_model_status()
+        if browser_blocks_save:
+            self._update_browser_model_hint()
+            self._set_settings_status(browser_message, "error")
+            self._notify_user(browser_message, severity="error")
+            return
         effort = str(self.query_one("#thinking_effort_select", Select).value)
         valid_efforts = {value for _, value in ui_thinking_effort_options(provider, model)}
         if effort not in valid_efforts:
@@ -980,6 +1058,8 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             )
             if override_message:
                 self._notify_user(f"{messages.SETTINGS_SAVED} {override_message}", severity="warning")
+            elif browser_tone == "warning":
+                self._notify_user(f"{messages.SETTINGS_SAVED} {browser_message}", severity="warning")
             else:
                 self._notify_user(messages.SETTINGS_SAVED)
 
@@ -1050,6 +1130,10 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             if override_message:
                 lines.append(override_message)
                 tone = "warning"
+        browser_message, browser_tone, _ = self._browser_model_status()
+        if browser_message and browser_tone in {"warning", "error"}:
+            lines.append(browser_message)
+            tone = browser_tone
         self._set_settings_status("\n".join(lines), tone)
         self._refresh_status_dashboard()
 

--- a/kolega_code/llm/models.py
+++ b/kolega_code/llm/models.py
@@ -538,6 +538,13 @@ class ToolDefinition(ContentBlock):
             kwargs["items"] = cls._dict_to_google_schema(schema["items"])
         if schema.get("required"):
             kwargs["required"] = schema["required"]
+        if schema.get("enum"):
+            kwargs["enum"] = schema["enum"]
+        if "additionalProperties" in schema:
+            additional = schema["additionalProperties"]
+            kwargs["additional_properties"] = (
+                cls._dict_to_google_schema(additional) if isinstance(additional, dict) else additional
+            )
         return genai_types.Schema(**kwargs)
 
     def to_anthropic(self) -> Dict[str, Any]:

--- a/kolega_code/services/base.py
+++ b/kolega_code/services/base.py
@@ -97,137 +97,103 @@ class TerminalManager(ABC):
 
 
 class BrowserManager(ABC):
-    """
-    Abstract base class for browser management.
-    Defines the interface for browser operations.
-    """
+    """Abstract single-session browser interface used by the browser agent."""
 
     @abstractmethod
-    async def launch_browser(self, url: str) -> str:
-        """
-        Launch a new browser instance and navigate to the specified URL.
-
-        Args:
-            url: The URL to navigate to
-
-        Returns:
-            Browser ID string
-
-        Raises:
-            Exception: If browser launch fails
-        """
+    async def navigate(self, url: str) -> Dict[str, Any]: ...
 
     @abstractmethod
-    async def list_browsers(self) -> dict:
-        """
-        Get information about all active browser instances.
-
-        Returns:
-            Dictionary mapping browser IDs to browser information
-        """
+    async def snapshot(self, target: Optional[str] = None, depth: Optional[int] = None) -> Dict[str, Any]: ...
 
     @abstractmethod
-    async def get_browser_console_logs(
+    async def find(self, *, text: Optional[str] = None, regex: Optional[str] = None) -> Dict[str, Any]: ...
+
+    @abstractmethod
+    async def click(
         self,
-        browser_id: str,
-        max_logs: int = 50,
-        log_types: Optional[List[str]] = None,
-        minutes_back: Optional[int] = None,
-        max_chars: Optional[int] = 8000,
-    ) -> dict:
-        """
-        Get console logs from a specific browser with configurable filtering.
-
-        Args:
-            browser_id: ID of the browser to get logs from
-            max_logs: Maximum number of logs to return (most recent)
-            log_types: List of log types to include (e.g., ['error', 'warning', 'assert'])
-            minutes_back: Only return logs from the last N minutes
-            max_chars: Maximum total character count for all log messages combined
-
-        Returns:
-            Dictionary containing filtered console logs and metadata
-
-        Raises:
-            KeyError: If browser_id doesn't exist
-        """
+        target: str,
+        *,
+        double_click: bool = False,
+        button: str = "left",
+        modifiers: Optional[List[str]] = None,
+    ) -> Dict[str, Any]: ...
 
     @abstractmethod
-    async def get_browser_interactive_elements(self, browser_id: str) -> list:
-        """
-        Get interactive elements from a specific browser.
-
-        Args:
-            browser_id: ID of the browser to get elements from
-
-        Returns:
-            Dictionary containing current URL, title, and interactive elements
-
-        Raises:
-            KeyError: If browser_id doesn't exist
-        """
+    async def type_text(
+        self, target: str, text: str, *, submit: bool = False, slowly: bool = False
+    ) -> Dict[str, Any]: ...
 
     @abstractmethod
-    async def take_browser_screenshot(self, browser_id: str) -> dict:
-        """
-        Take a screenshot of a specific browser.
-
-        Args:
-            browser_id: ID of the browser to take screenshot of
-
-        Returns:
-            Dictionary containing current URL, title, and base64-encoded screenshot
-
-        Raises:
-            KeyError: If browser_id doesn't exist
-        """
+    async def fill_form(self, fields: List[Dict[str, Any]]) -> Dict[str, Any]: ...
 
     @abstractmethod
-    async def interact_with_browser(self, browser_id: str, action: str, selector: str, text: str, scroll_px) -> dict:
-        """
-        Interact with a specific browser.
-
-        Args:
-            browser_id: ID of the browser to interact with
-            action: Type of interaction (click, type, scroll, navigate)
-            selector: CSS selector for the element to interact with
-            text: Text to type or URL to navigate to
-            scroll_px: Number of pixels to scroll
-
-        Returns:
-            Dictionary containing status and interaction details
-
-        Raises:
-            KeyError: If browser_id doesn't exist
-            ValueError: If action is unknown
-        """
+    async def select_option(self, target: str, values: List[str]) -> Dict[str, Any]: ...
 
     @abstractmethod
-    async def set_select_value(self, browser_id: str, selector: str, value: str) -> dict:
-        """
-        Set the value of a select box in a specific browser.
-
-        Args:
-            browser_id: ID of the browser to interact with
-            selector: CSS selector for the select element
-            value: The value to set for the select option
-
-        Returns:
-            Dictionary containing status, current URL, and selected value
-
-        Raises:
-            KeyError: If browser_id doesn't exist
-            ValueError: If the element is not a select box or value doesn't exist
-        """
+    async def hover(self, target: str) -> Dict[str, Any]: ...
 
     @abstractmethod
-    async def close_browser(self, browser_id: str) -> None:
-        """
-        Close a specific browser.
+    async def drag(self, start_target: str, end_target: str) -> Dict[str, Any]: ...
 
-        Args:
-            browser_id: ID of the browser to close
+    @abstractmethod
+    async def drop(
+        self,
+        target: str,
+        *,
+        files: Optional[List[Dict[str, Any]]] = None,
+        data: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]: ...
 
-        Raises:
-            KeyError: If browser_id doesn't exist
-        """
+    @abstractmethod
+    async def press_key(self, key: str) -> Dict[str, Any]: ...
+
+    @abstractmethod
+    async def navigate_back(self) -> Dict[str, Any]: ...
+
+    @abstractmethod
+    async def wait_for(
+        self, *, time: Optional[float] = None, text: Optional[str] = None, text_gone: Optional[str] = None
+    ) -> Dict[str, Any]: ...
+
+    @abstractmethod
+    async def resize(self, width: int, height: int) -> Dict[str, Any]: ...
+
+    @abstractmethod
+    async def tabs(self, action: str, *, index: Optional[int] = None, url: Optional[str] = None) -> Dict[str, Any]: ...
+
+    @abstractmethod
+    async def handle_dialog(self, accept: bool, prompt_text: Optional[str] = None) -> Dict[str, Any]: ...
+
+    @abstractmethod
+    async def file_upload(self, files: List[Dict[str, Any]]) -> Dict[str, Any]: ...
+
+    @abstractmethod
+    async def console_messages(self, level: str = "info", *, all_messages: bool = False) -> Dict[str, Any]: ...
+
+    @abstractmethod
+    async def network_requests(
+        self, *, include_static: bool = False, filter_pattern: Optional[str] = None
+    ) -> Dict[str, Any]: ...
+
+    @abstractmethod
+    async def network_request(self, index: int, part: Optional[str] = None) -> Dict[str, Any]: ...
+
+    @abstractmethod
+    async def screenshot(
+        self,
+        *,
+        target: Optional[str] = None,
+        image_type: str = "png",
+        full_page: bool = False,
+        scale: str = "css",
+    ) -> Dict[str, Any]: ...
+
+    @abstractmethod
+    async def evaluate(self, function: str, target: Optional[str] = None) -> Dict[str, Any]: ...
+
+    @abstractmethod
+    async def close(self) -> Optional[str]: ...
+
+    async def cleanup_all_browsers(self) -> None:
+        """Close the current browser session during agent teardown."""
+        await self.close()

--- a/kolega_code/services/browser.py
+++ b/kolega_code/services/browser.py
@@ -141,7 +141,8 @@ class PlaywrightBrowserManager(BrowserManager):
         endpoint = self.browserless_endpoint or ""
         parsed = urllib.parse.urlsplit(endpoint.replace("{token}", "placeholder"))
         embedded_token = "{token}" in endpoint or "token" in urllib.parse.parse_qs(parsed.query)
-        is_cloud = bool(parsed.hostname and parsed.hostname.endswith("browserless.io"))
+        hostname = parsed.hostname or ""
+        is_cloud = hostname == "browserless.io" or hostname.endswith(".browserless.io")
         if is_cloud and not embedded_token and not self.browserless_api_key:
             raise ValueError(
                 "Browserless credentials not found. Set BROWSERLESS_API_KEY or include token= in "

--- a/kolega_code/services/browser.py
+++ b/kolega_code/services/browser.py
@@ -1,73 +1,172 @@
+import asyncio
 import base64
+import contextlib
 import datetime
 import json
+import mimetypes
 import os
+import re
 import urllib.parse
 import uuid
-from typing import List, Optional
-import asyncio
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Optional
 
-from .html import extract_interactive_elements_from_html
 from .base import BrowserManager
 
 
+_BACKENDS = {"local", "browserless", "browserstack"}
+_BROWSERLESS_REGIONS = {"sfo", "lon", "ams"}
+_REF_PATTERN = re.compile(r"^(?:f\d+)?e\d+$")
+_CONSOLE_LEVELS = {"error": 0, "warning": 1, "info": 2, "debug": 3}
+_STATIC_RESOURCE_TYPES = {"font", "image", "media", "script", "stylesheet"}
+_MAX_CONSOLE_MESSAGES = 200
+_MAX_NETWORK_REQUESTS = 500
+_MAX_NETWORK_BODY_CHARS = 20_000
+
+
+def _positive_int(value: Optional[str | int], *, name: str, default: Optional[int] = None) -> Optional[int]:
+    if value in (None, ""):
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a positive integer.") from exc
+    if parsed <= 0:
+        raise ValueError(f"{name} must be a positive integer.")
+    return parsed
+
+
+@dataclass
+class _PageState:
+    page: Any
+    console_all: deque[dict[str, Any]] = field(default_factory=lambda: deque(maxlen=_MAX_CONSOLE_MESSAGES))
+    console_recent: deque[dict[str, Any]] = field(default_factory=lambda: deque(maxlen=_MAX_CONSOLE_MESSAGES))
+    network: deque[dict[str, Any]] = field(default_factory=lambda: deque(maxlen=_MAX_NETWORK_REQUESTS))
+    last_title: str = ""
+
+
+@dataclass
+class _BrowserSession:
+    session_id: str
+    playwright: Any
+    browser: Any
+    context: Any
+    current_page: Any = None
+    pages: dict[int, _PageState] = field(default_factory=dict)
+    dialog: Any = None
+    file_chooser: Any = None
+    pending_action: Optional[asyncio.Task] = None
+    modal_event: asyncio.Event = field(default_factory=asyncio.Event)
+    keepalive_task: Optional[asyncio.Task] = None
+
+
 class PlaywrightBrowserManager(BrowserManager):
-    def __init__(self, use_browserstack: bool = False, browser_backend: str = "local"):
-        self.browsers = {}
+    """Single-session Playwright manager using accessibility snapshot refs."""
+
+    def __init__(
+        self,
+        browser_backend: str = "local",
+        *,
+        browserless_endpoint: Optional[str] = None,
+        browserless_api_key: Optional[str] = None,
+        browserless_timeout_ms: Optional[int] = None,
+        browserless_protocol: Optional[str] = None,
+    ) -> None:
         self.viewport = {"width": 1280, "height": 720}
-        self.user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+        self.user_agent = (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+        )
         self.headless = False
-        self.interaction_timeout = 5000
-        self.max_console_logs_per_browser = 200  # Maximum logs to keep per browser (circular buffer)
+        self.action_timeout = 5000
+        self.navigation_timeout = 30000
+        self.connection_timeout = _positive_int(
+            os.environ.get("BROWSER_CONNECT_TIMEOUT_MS"), name="BROWSER_CONNECT_TIMEOUT_MS", default=30000
+        )
+        self.keepalive_interval = 30
+        self.browser_backend = browser_backend.lower()
+        self._session: Optional[_BrowserSession] = None
 
-        # Browser backend configuration
-        self.browser_backend = browser_backend
-        if use_browserstack:  # Legacy support
-            self.browser_backend = "browserstack"
+        if self.browser_backend not in _BACKENDS:
+            supported = ", ".join(sorted(_BACKENDS))
+            raise ValueError(f"Unknown browser backend '{browser_backend}'. Expected one of: {supported}.")
 
-        # BrowserStack configuration
         if self.browser_backend == "browserstack":
             self.browserstack_username = os.environ.get("BROWSERSTACK_USERNAME")
             self.browserstack_access_key = os.environ.get("BROWSERSTACK_ACCESS_KEY")
-
             if not self.browserstack_username or not self.browserstack_access_key:
                 raise ValueError(
-                    "BrowserStack credentials not found. Please set BROWSERSTACK_USERNAME and "
-                    "BROWSERSTACK_ACCESS_KEY environment variables."
+                    "BrowserStack credentials not found. Set BROWSERSTACK_USERNAME and BROWSERSTACK_ACCESS_KEY."
                 )
 
-        # Browserless configuration
-        elif self.browser_backend == "browserless":
-            self.browserless_api_key = os.environ.get("BROWSERLESS_API_KEY")
+        if self.browser_backend == "browserless":
+            self.browserless_api_key = browserless_api_key or os.environ.get("BROWSERLESS_API_KEY")
+            self.browserless_endpoint = (
+                browserless_endpoint
+                or os.environ.get("BROWSERLESS_WS_ENDPOINT")
+                or os.environ.get("BROWSERLESS_ENDPOINT")
+            )
+            configured_protocol = browserless_protocol or os.environ.get("BROWSERLESS_PROTOCOL")
+            if configured_protocol is None and self.browserless_endpoint:
+                configured_protocol = (
+                    "playwright" if self.browserless_endpoint.rstrip("/").endswith("/playwright") else "cdp"
+                )
+            self.browserless_protocol = (configured_protocol or "cdp").lower()
+            if self.browserless_protocol not in {"cdp", "playwright"}:
+                raise ValueError("BROWSERLESS_PROTOCOL must be either 'cdp' or 'playwright'.")
+            self.browserless_timeout_ms = _positive_int(
+                browserless_timeout_ms
+                if browserless_timeout_ms is not None
+                else os.environ.get("BROWSERLESS_TIMEOUT_MS"),
+                name="BROWSERLESS_TIMEOUT_MS",
+            )
+            if self.browserless_endpoint is None:
+                self.browserless_endpoint = self._default_browserless_endpoint()
+            self._validate_browserless_auth()
+
+    @property
+    def session_id(self) -> Optional[str]:
+        return self._session.session_id if self._session else None
+
+    def _default_browserless_endpoint(self) -> str:
+        region = os.environ.get("BROWSERLESS_REGION", "sfo").lower()
+        if region not in _BROWSERLESS_REGIONS:
+            supported = ", ".join(sorted(_BROWSERLESS_REGIONS))
+            raise ValueError(f"Unknown BROWSERLESS_REGION '{region}'. Expected one of: {supported}.")
+        path = "/chromium/playwright" if self.browserless_protocol == "playwright" else ""
+        return f"wss://production-{region}.browserless.io{path}"
+
+    def _validate_browserless_auth(self) -> None:
+        endpoint = self.browserless_endpoint or ""
+        parsed = urllib.parse.urlsplit(endpoint.replace("{token}", "placeholder"))
+        embedded_token = "{token}" in endpoint or "token" in urllib.parse.parse_qs(parsed.query)
+        is_cloud = bool(parsed.hostname and parsed.hostname.endswith("browserless.io"))
+        if is_cloud and not embedded_token and not self.browserless_api_key:
+            raise ValueError(
+                "Browserless credentials not found. Set BROWSERLESS_API_KEY or include token= in "
+                "BROWSERLESS_WS_ENDPOINT."
+            )
+
+    def _browserless_url(self) -> str:
+        endpoint = self.browserless_endpoint or ""
+        if "{token}" in endpoint:
             if not self.browserless_api_key:
-                raise ValueError("Browserless API key not found. Please set BROWSERLESS_API_KEY environment variable.")
+                raise ValueError("BROWSERLESS_WS_ENDPOINT uses {token}, but BROWSERLESS_API_KEY is not set.")
+            endpoint = endpoint.replace("{token}", urllib.parse.quote(self.browserless_api_key, safe=""))
+        parsed = urllib.parse.urlsplit(endpoint)
+        if parsed.scheme not in {"ws", "wss"}:
+            raise ValueError("BROWSERLESS_WS_ENDPOINT must use ws:// or wss://.")
+        query = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+        keys = {key for key, _ in query}
+        if self.browserless_api_key and "token" not in keys:
+            query.append(("token", self.browserless_api_key))
+        if self.browserless_timeout_ms is not None and "timeout" not in keys:
+            query.append(("timeout", str(self.browserless_timeout_ms)))
+        return urllib.parse.urlunsplit(parsed._replace(query=urllib.parse.urlencode(query)))
 
-        # Keepalive configuration
-        self.keepalive_interval = 30  # Send keepalive every 30 seconds
-        self.keepalive_tasks = {}  # Store keepalive tasks per browser
-
-    async def _keepalive_loop(self, browser_id: str):
-        """Background task to keep the browser connection alive."""
-        while browser_id in self.browsers:
-            try:
-                browser_info = self.browsers.get(browser_id)
-                if not browser_info:
-                    break
-
-                page = browser_info.get("page")
-                if page:
-                    # Send a simple keepalive command
-                    await page.evaluate("() => { /* keepalive */ }")
-
-                await asyncio.sleep(self.keepalive_interval)
-            except Exception as e:
-                print(f"[Keepalive] Error for browser {browser_id}: {e}")
-                # Sleep shorter on error but continue trying
-                await asyncio.sleep(5)
-
-    def _get_browserstack_cdp_url(self) -> str:
-        """Generate the BrowserStack CDP URL with capabilities."""
-        capability = {
+    def _browserstack_url(self) -> str:
+        capabilities = {
             "browser": "chrome",
             "browser_version": "latest",
             "os": "Windows",
@@ -79,368 +178,733 @@ class PlaywrightBrowserManager(BrowserManager):
             "browserstack.console": "verbose",
             "browserstack.networkLogs": "true",
         }
+        return "wss://cdp.browserstack.com/playwright?caps=" + urllib.parse.quote(json.dumps(capabilities))
 
-        # According to BrowserStack docs, we need to encode the JSON capabilities
-        caps_json = json.dumps(capability)
-        caps_string = urllib.parse.quote(caps_json)
-        cdp_url = f"wss://cdp.browserstack.com/playwright?caps={caps_string}"
+    @staticmethod
+    def _normalize_url(url: str) -> str:
+        normalized = url.strip()
+        if normalized == "about:blank":
+            return normalized
+        if "://" not in normalized:
+            prefix = "http://" if normalized.startswith(("localhost", "127.0.0.1", "[::1]")) else "https://"
+            normalized = prefix + normalized
+        parsed = urllib.parse.urlsplit(normalized)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("Browser navigation only supports http:// and https:// URLs.")
+        return normalized
 
-        return cdp_url
+    async def _connect(self, playwright: Any) -> Any:
+        if self.browser_backend == "browserstack":
+            return await playwright.chromium.connect(endpoint=self._browserstack_url(), timeout=self.connection_timeout)
+        if self.browser_backend == "browserless":
+            endpoint = self._browserless_url()
+            if self.browserless_protocol == "playwright":
+                return await playwright.chromium.connect(endpoint, timeout=self.connection_timeout)
+            return await playwright.chromium.connect_over_cdp(endpoint, timeout=self.connection_timeout)
+        return await playwright.chromium.launch(headless=self.headless)
 
-    def _get_browserless_cdp_url(self) -> str:
-        """Generate the Browserless CDP URL."""
-        # Browserless cloud CDP URL format for connectOverCDP
-        # Format: wss://production-sfo.browserless.io?token=YOUR_TOKEN
-        # Alternative regions available: production-lon, production-ams, etc.
+    def _redact_connection_error(self, error: Exception) -> str:
+        message = str(error)
+        for secret_name in ("browserless_api_key", "browserstack_access_key"):
+            secret = getattr(self, secret_name, None)
+            if secret:
+                message = message.replace(secret, "***")
+        return re.sub(r"([?&]token=)[^&\s]+", r"\1***", message)
 
-        # Use timeout to control maximum session duration
-        # Maximum allowed timeout is 60,000 (units unclear but this value works)
-        # This provides either 60 seconds or 60,000ms depending on interpretation
-        timeout = 1800000  # Maximum allowed timeout value
+    async def _ensure_session(self) -> _BrowserSession:
+        if self._session and self._session.browser.is_connected():
+            return self._session
 
-        return f"wss://production-sfo.browserless.io?token={self.browserless_api_key}&timeout={timeout}"
-
-    async def launch_browser(self, url: str) -> str | dict[str, str]:
-        # Imported here, not at module load: playwright.async_api pulls in ~5-15MB
-        # and most sessions never drive a browser. An import error now surfaces when
-        # the browser tool is first used, which is the right place for it.
         from playwright.async_api import async_playwright
 
+        playwright = browser = context = None
         try:
             playwright = await async_playwright().start()
-
-            # Connect based on backend
-            if self.browser_backend == "browserstack":
-                cdp_url = self._get_browserstack_cdp_url()
-                browser = await playwright.chromium.connect(endpoint=cdp_url)
-            elif self.browser_backend == "browserless":
-                cdp_url = self._get_browserless_cdp_url()
-                # Use connectOverCDP for browserless as recommended in their docs
-                browser = await playwright.chromium.connect_over_cdp(cdp_url)
-            else:  # local
-                browser_factory = playwright.chromium
-                browser = await browser_factory.launch(headless=self.headless)
-
-            context_options = {"viewport": self.viewport, "user_agent": self.user_agent}
-            context = await browser.new_context(**context_options)
+            browser = await self._connect(playwright)
+            context = await browser.new_context(viewport=self.viewport, user_agent=self.user_agent)
+            session = _BrowserSession(str(uuid.uuid4()), playwright, browser, context)
+            self._session = session
+            context.on("page", lambda page: self._attach_page(session, page, make_current=True))
             page = await context.new_page()
+            self._attach_page(session, page, make_current=True)
+            if self.browser_backend in {"browserless", "browserstack"}:
+                session.keepalive_task = asyncio.create_task(self._keepalive_loop(session))
+            return session
+        except Exception as exc:
+            if context is not None:
+                with contextlib.suppress(Exception):
+                    await context.close()
+            if browser is not None:
+                with contextlib.suppress(Exception):
+                    await browser.close()
+            if playwright is not None:
+                with contextlib.suppress(Exception):
+                    await playwright.stop()
+            self._session = None
+            raise RuntimeError(self._redact_connection_error(exc)) from None
 
-            console_logs = []
-            network_requests = []
+    async def _keepalive_loop(self, session: _BrowserSession) -> None:
+        while self._session is session:
+            try:
+                page = self._current_page(session)
+                await page.evaluate("() => undefined")
+                await asyncio.sleep(self.keepalive_interval)
+            except asyncio.CancelledError:
+                return
+            except Exception:
+                await asyncio.sleep(5)
 
-            # Register console log listener BEFORE any navigation
-            def console_log_handler(msg):
-                log_entry = {
-                    "type": msg.type,
-                    "text": msg.text,
-                    "timestamp": datetime.datetime.now().isoformat(),
-                    "location": msg.location if hasattr(msg, "location") else None,
-                }
-                console_logs.append(log_entry)
+    def _attach_page(self, session: _BrowserSession, page: Any, *, make_current: bool) -> _PageState:
+        existing = session.pages.get(id(page))
+        if existing:
+            if make_current:
+                session.current_page = page
+            return existing
 
-                # Implement circular buffer to prevent unlimited growth
-                if len(console_logs) > self.max_console_logs_per_browser:
-                    console_logs.pop(0)  # Remove oldest log
+        state = _PageState(page)
+        session.pages[id(page)] = state
+        if make_current:
+            session.current_page = page
 
-            page.on("console", console_log_handler)
-
-            # Also capture page errors and unhandled exceptions
-            def page_error_handler(error):
-                log_entry = {
-                    "type": "error",
-                    "text": f"Page Error: {str(error)}",
-                    "timestamp": datetime.datetime.now().isoformat(),
-                    "location": None,
-                }
-                console_logs.append(log_entry)
-
-                # Implement circular buffer to prevent unlimited growth
-                if len(console_logs) > self.max_console_logs_per_browser:
-                    console_logs.pop(0)  # Remove oldest log
-
-            page.on("pageerror", page_error_handler)
-
-            # Wait for the listener to be fully registered
-            await page.evaluate("() => console.log('Console listener ready')")
-
-            # Now navigate to the URL with better wait strategy
-            await page.goto(url, wait_until="domcontentloaded")
-
-            browser_id = str(uuid.uuid4())
-
-            browser_info = {
-                "type": "chromium",
-                "url": url,
-                "playwright": playwright,
-                "browser": browser,
-                "context": context,
-                "page": page,
-                "console_logs": console_logs,
-                "network_requests": network_requests,
-                "launched_at": datetime.datetime.now().isoformat(),
-                "browserstack": self.browser_backend == "browserstack",
-                "backend": self.browser_backend,
+        def on_console(message: Any) -> None:
+            entry = {
+                "type": message.type,
+                "text": message.text,
+                "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                "location": message.location,
             }
+            state.console_all.append(entry)
+            state.console_recent.append(entry)
 
-            self.browsers[browser_id] = browser_info
-
-            # Start keepalive task for this browser
-            keepalive_task = asyncio.create_task(self._keepalive_loop(browser_id))
-            self.keepalive_tasks[browser_id] = keepalive_task
-
-            return browser_id
-        except Exception as ex:
-            error_msg = f"[Browser Launch Error] {type(ex).__name__}: {str(ex)}"
-            print(error_msg)
-            # Clean up resources in case of error
-            if "playwright" in locals():
-                await playwright.stop()
-
-            # Return error details instead of None
-            return {"error": error_msg}
-
-    async def list_browsers(self) -> dict:
-        result = {}
-        for browser_id, browser in self.browsers.items():
-            result[browser_id] = {
-                "url": browser["url"],
-                "launched_at": browser["launched_at"],
-                "browserstack": browser.get("browserstack", False),
-                "backend": browser.get("backend", "unknown"),
+        def on_page_error(error: Any) -> None:
+            entry = {
+                "type": "error",
+                "text": f"Page Error: {error}",
+                "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                "location": None,
             }
+            state.console_all.append(entry)
+            state.console_recent.append(entry)
 
-        return result
-
-    async def get_browser_console_logs(
-        self,
-        browser_id: str,
-        max_logs: int = 50,
-        log_types: Optional[List[str]] = None,
-        minutes_back: Optional[int] = None,
-        max_chars: Optional[int] = 8000,
-    ) -> dict:
-        """
-        Get console logs from a browser with configurable filtering to prevent context window overflow.
-
-        Args:
-            browser_id: The unique identifier of the browser instance
-            max_logs: Maximum number of logs to return (most recent)
-            log_types: List of log types to include (e.g., ['error', 'warning', 'assert'])
-                      If None, defaults to important types: ['error', 'warning', 'assert']
-            minutes_back: Only return logs from the last N minutes
-            max_chars: Maximum total character count for all log messages combined
-
-        Returns:
-            Dictionary containing filtered console logs and metadata
-        """
-        if browser_id not in self.browsers:
-            raise KeyError(f"Browser with ID {browser_id} not found.")
-
-        browser_info = self.browsers[browser_id]
-        console_logs = browser_info["console_logs"].copy()  # Work with a copy
-        original_count = len(console_logs)
-
-        # Apply time filter first if specified
-        if minutes_back is not None:
-            cutoff_time = datetime.datetime.now() - datetime.timedelta(minutes=minutes_back)
-            console_logs = [
-                log for log in console_logs if datetime.datetime.fromisoformat(log["timestamp"]) > cutoff_time
-            ]
-
-        # Apply type filter - default to important types if not specified
-        if log_types is None:
-            log_types = ["error", "warning", "assert"]
-
-        if log_types:  # Only filter if log_types is not empty
-            console_logs = [log for log in console_logs if log["type"] in log_types]
-
-        # Apply count limit (most recent)
-        if len(console_logs) > max_logs:
-            console_logs = console_logs[-max_logs:]
-
-        # Apply character limit if specified
-        if max_chars is not None:
-            limited_logs = []
-            char_count = 0
-            for log in reversed(console_logs):
-                log_text = f"{log['type']}: {log['text']}"
-                if char_count + len(log_text) > max_chars and limited_logs:
-                    break
-                limited_logs.insert(0, log)
-                char_count += len(log_text)
-            console_logs = limited_logs
-
-        return {
-            "console_logs": console_logs,
-            "total_logs_count": original_count,
-            "returned_count": len(console_logs),
-            "filters_applied": {
-                "max_logs": max_logs,
-                "log_types": log_types,
-                "minutes_back": minutes_back,
-                "max_chars": max_chars,
-            },
-        }
-
-    async def get_browser_interactive_elements(self, browser_id: str) -> dict:
-        if browser_id not in self.browsers:
-            raise KeyError(f"Browser with ID {browser_id} not found.")
-
-        browser_info = self.browsers[browser_id]
-        page = browser_info["page"]
-        current_url = page.url
-        title = await page.title()
-        html = await page.content()
-
-        interactive_elements = extract_interactive_elements_from_html(html)
-
-        return {"current_url": current_url, "title": title, "interactive_elements": interactive_elements}
-
-    async def get_browser_content(self, browser_id: str, **console_log_filters) -> dict:
-        """
-        Get the current content of a browser page including HTML and filtered console logs.
-
-        Args:
-            browser_id: The unique identifier of the browser instance
-            **console_log_filters: Optional filters for console logs (max_logs, log_types, minutes_back, max_chars)
-
-        Returns:
-            Dictionary containing current URL, title, HTML content, and filtered console logs
-        """
-        if browser_id not in self.browsers:
-            raise KeyError(f"Browser with ID {browser_id} not found.")
-
-        browser_info = self.browsers[browser_id]
-        page = browser_info["page"]
-        current_url = page.url
-        title = await page.title()
-        html = await page.content()
-
-        # Get filtered console logs using the new method
-        console_log_result = await self.get_browser_console_logs(browser_id, **console_log_filters)
-        console_logs = console_log_result["console_logs"]
-
-        return {
-            "current_url": current_url,
-            "title": title,
-            "html": html,
-            "console_logs": console_logs,
-            "console_log_metadata": {
-                "total_logs_count": console_log_result["total_logs_count"],
-                "returned_count": console_log_result["returned_count"],
-                "filters_applied": console_log_result["filters_applied"],
-            },
-        }
-
-    async def take_browser_screenshot(self, browser_id: str) -> dict:
-        if browser_id not in self.browsers:
-            raise KeyError(f"Browser with ID {browser_id} not found.")
-
-        browser_info = self.browsers[browser_id]
-        page = browser_info["page"]
-        current_url = page.url
-        title = await page.title()
-
-        screenshot = base64.b64encode(await page.screenshot()).decode("utf-8")
-
-        return {"current_url": current_url, "title": title, "screenshot": screenshot}
-
-    async def interact_with_browser(self, browser_id: str, action: str, selector: str, text: str, scroll_px) -> dict:
-        if browser_id not in self.browsers:
-            raise KeyError(f"Browser with ID {browser_id} not found.")
-
-        browser_info = self.browsers[browser_id]
-        page = browser_info["page"]
-
-        if action == "click":
-            await page.click(selector, timeout=self.interaction_timeout)
-        elif action == "type":
-            await page.fill(selector, text)
-        elif action == "scroll":
-            await page.evaluate(f"window.scrollBy(0, {scroll_px})")
-        elif action == "navigate":
-            await page.goto(text, wait_until="domcontentloaded")
-        else:
-            raise ValueError(f"Unknown action: {action}")
-
-        await page.wait_for_load_state("networkidle")
-
-        return {"status": "success", "current_url": page.url, "action": action, "selector": selector, "text": text}
-
-    async def set_select_value(self, browser_id: str, selector: str, value: str) -> dict:
-        if browser_id not in self.browsers:
-            raise KeyError(f"Browser with ID {browser_id} not found.")
-
-        browser_info = self.browsers[browser_id]
-        page = browser_info["page"]
-
-        try:
-            # First, check if the element exists and is a select element
-            element = await page.query_selector(selector)
-            if not element:
-                raise ValueError(f"Element with selector '{selector}' not found.")
-
-            # Check if it's actually a select element
-            tag_name = await element.evaluate("el => el.tagName.toLowerCase()")
-            if tag_name != "select":
-                raise ValueError(f"Element with selector '{selector}' is not a select box (found: {tag_name}).")
-
-            # Get all option values to validate the value exists
-            option_values = await element.evaluate(
-                """
-                el => Array.from(el.options).map(option => option.value)
-            """
+        def on_request(request: Any) -> None:
+            state.network.append(
+                {
+                    "request": request,
+                    "response": None,
+                    "url": request.url,
+                    "method": request.method,
+                    "resource_type": request.resource_type,
+                    "status": None,
+                    "status_text": None,
+                    "failure": None,
+                }
             )
 
-            if value not in option_values:
-                raise ValueError(f"Value '{value}' not found in select options. Available values: {option_values}")
+        def on_response(response: Any) -> None:
+            record = self._request_record(state, response.request)
+            if record is not None:
+                record["response"] = response
+                record["status"] = response.status
+                record["status_text"] = response.status_text
 
-            # Set the value using Playwright's select_option method
-            await page.select_option(selector, value, timeout=self.interaction_timeout)
+        def on_request_failed(request: Any) -> None:
+            record = self._request_record(state, request)
+            if record is not None:
+                record["failure"] = request.failure
 
-            # Get the currently selected value to confirm
-            selected_value = await element.evaluate("el => el.value")
+        def on_dialog(dialog: Any) -> None:
+            session.dialog = dialog
+            session.modal_event.set()
 
+        def on_file_chooser(file_chooser: Any) -> None:
+            session.file_chooser = file_chooser
+            session.modal_event.set()
+
+        def on_close() -> None:
+            session.pages.pop(id(page), None)
+            if session.current_page is page:
+                open_pages = self._open_pages(session)
+                session.current_page = open_pages[-1] if open_pages else None
+
+        page.on("console", on_console)
+        page.on("pageerror", on_page_error)
+        page.on("request", on_request)
+        page.on("response", on_response)
+        page.on("requestfailed", on_request_failed)
+        page.on("dialog", on_dialog)
+        page.on("filechooser", on_file_chooser)
+        page.on("close", on_close)
+        return state
+
+    @staticmethod
+    def _request_record(state: _PageState, request: Any) -> Optional[dict[str, Any]]:
+        return next((record for record in reversed(state.network) if record["request"] is request), None)
+
+    @staticmethod
+    def _open_pages(session: _BrowserSession) -> list[Any]:
+        return [state.page for state in session.pages.values() if not state.page.is_closed()]
+
+    def _current_page(self, session: _BrowserSession) -> Any:
+        if session.current_page is not None and not session.current_page.is_closed():
+            return session.current_page
+        pages = self._open_pages(session)
+        if not pages:
+            raise RuntimeError("The browser session has no open tabs.")
+        session.current_page = pages[-1]
+        return session.current_page
+
+    def _page_state(self, session: _BrowserSession, page: Optional[Any] = None) -> _PageState:
+        page = page or self._current_page(session)
+        return session.pages[id(page)]
+
+    @staticmethod
+    def _modal_description(session: _BrowserSession) -> Optional[dict[str, Any]]:
+        if session.dialog is not None:
             return {
-                "status": "success",
-                "current_url": page.url,
-                "selector": selector,
-                "selected_value": selected_value,
-                "requested_value": value,
+                "type": "dialog",
+                "dialog_type": session.dialog.type,
+                "message": session.dialog.message,
             }
+        if session.file_chooser is not None:
+            return {"type": "file_chooser", "multiple": session.file_chooser.is_multiple()}
+        return None
 
-        except Exception as e:
-            return {"status": "error", "current_url": page.url, "selector": selector, "error": str(e)}
+    def _assert_no_modal(self, session: _BrowserSession) -> None:
+        modal = self._modal_description(session)
+        if modal:
+            handler = "browser_handle_dialog" if modal["type"] == "dialog" else "browser_file_upload"
+            raise RuntimeError(f"A {modal['type']} is waiting. Call {handler} before using another browser action.")
 
-    async def close_browser(self, browser_id: str) -> None:
-        if browser_id not in self.browsers:
-            raise KeyError(f"Browser with ID {browser_id} not found.")
+    async def _target_locator(self, page: Any, target: str) -> Any:
+        locator = page.locator(f"aria-ref={target}" if _REF_PATTERN.fullmatch(target) else target)
+        count = await locator.count()
+        if count == 0:
+            if _REF_PATTERN.fullmatch(target):
+                raise ValueError(f"Ref {target} is stale or missing. Capture a fresh browser_snapshot and retry.")
+            raise ValueError(f'"{target}" does not match any elements.')
+        if count > 1:
+            raise ValueError(f'"{target}" matches {count} elements. Use a snapshot ref or a unique selector.')
+        return locator
 
-        # Cancel the keepalive task for this browser
-        if browser_id in self.keepalive_tasks:
-            self.keepalive_tasks[browser_id].cancel()
-            del self.keepalive_tasks[browser_id]
+    async def _snapshot(self, page: Any, *, target: Optional[str] = None, depth: Optional[int] = None) -> str:
+        if target:
+            locator = await self._target_locator(page, target)
+            return await locator.aria_snapshot(mode="ai", depth=depth, timeout=self.action_timeout)
+        return await page.aria_snapshot(mode="ai", depth=depth, timeout=self.action_timeout)
 
-        await self.browsers[browser_id]["browser"].close()
-        await self.browsers[browser_id]["playwright"].stop()
+    async def _state_result(
+        self,
+        session: _BrowserSession,
+        *,
+        include_snapshot: bool = True,
+        target: Optional[str] = None,
+        depth: Optional[int] = None,
+    ) -> dict[str, Any]:
+        page = self._current_page(session)
+        state = self._page_state(session, page)
+        modal = self._modal_description(session)
+        if modal:
+            return {
+                "session_id": session.session_id,
+                "url": page.url,
+                "title": state.last_title,
+                "modal": modal,
+            }
+        state.last_title = await page.title()
+        result: dict[str, Any] = {
+            "session_id": session.session_id,
+            "url": page.url,
+            "title": state.last_title,
+        }
+        if include_snapshot:
+            result["snapshot"] = await self._snapshot(page, target=target, depth=depth)
+        return result
 
-        del self.browsers[browser_id]
+    async def _perform_action(
+        self, session: _BrowserSession, action: Callable[[Any], Awaitable[Any]]
+    ) -> dict[str, Any]:
+        self._assert_no_modal(session)
+        page = self._current_page(session)
+        existing_pages = {id(candidate) for candidate in self._open_pages(session)}
+        session.modal_event.clear()
+        action_task = asyncio.ensure_future(action(page))
+        modal_task = asyncio.create_task(session.modal_event.wait())
+        done, _ = await asyncio.wait({action_task, modal_task}, return_when=asyncio.FIRST_COMPLETED)
+
+        if action_task in done and not session.modal_event.is_set():
+            # Playwright may resolve a click just before dispatching its
+            # filechooser callback. Give modal delivery a short grace period so
+            # the caller reliably receives modal state instead of a snapshot.
+            with contextlib.suppress(asyncio.TimeoutError):
+                await asyncio.wait_for(asyncio.shield(modal_task), timeout=0.05)
+
+        if session.modal_event.is_set():
+            modal_task.cancel()
+            if not action_task.done():
+                session.pending_action = action_task
+            else:
+                await action_task
+            return await self._state_result(session, include_snapshot=False)
+
+        modal_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await modal_task
+        action_result = await action_task
+        new_pages = [candidate for candidate in self._open_pages(session) if id(candidate) not in existing_pages]
+        if new_pages:
+            session.current_page = new_pages[-1]
+            with contextlib.suppress(Exception):
+                await session.current_page.wait_for_load_state("domcontentloaded", timeout=5000)
+        result = await self._state_result(session)
+        if action_result is not None:
+            result["result"] = action_result
+        return result
+
+    async def navigate(self, url: str) -> dict[str, Any]:
+        session = await self._ensure_session()
+        self._assert_no_modal(session)
+        page = self._current_page(session)
+        state = self._page_state(session, page)
+        state.console_recent.clear()
+        state.network.clear()
+        await page.goto(self._normalize_url(url), wait_until="domcontentloaded", timeout=self.navigation_timeout)
+        return await self._state_result(session)
+
+    async def snapshot(self, target: Optional[str] = None, depth: Optional[int] = None) -> dict[str, Any]:
+        session = await self._ensure_session()
+        return await self._state_result(session, target=target, depth=depth)
+
+    async def find(self, *, text: Optional[str] = None, regex: Optional[str] = None) -> dict[str, Any]:
+        if bool(text) == bool(regex):
+            raise ValueError("Provide exactly one of text or regex.")
+        session = await self._ensure_session()
+        page = self._current_page(session)
+        lines = (await self._snapshot(page)).splitlines()
+        if regex:
+            literal = re.fullmatch(r"/(.*)/([a-zA-Z]*)", regex)
+            pattern = literal.group(1) if literal else regex
+            flags = re.IGNORECASE if literal and "i" in literal.group(2) else 0
+            compiled = re.compile(pattern, flags)
+            indexes = [index for index, line in enumerate(lines) if compiled.search(line)]
+            query = regex
+        else:
+            needle = (text or "").lower()
+            indexes = [index for index, line in enumerate(lines) if needle in line.lower()]
+            query = text
+        snippets: list[str] = []
+        for index in indexes:
+            snippet = "\n".join(lines[max(0, index - 3) : min(len(lines), index + 4)])
+            if snippet not in snippets:
+                snippets.append(snippet)
+        return {"query": query, "match_count": len(indexes), "matches": snippets}
+
+    async def click(
+        self,
+        target: str,
+        *,
+        double_click: bool = False,
+        button: str = "left",
+        modifiers: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
+        session = await self._ensure_session()
+
+        async def action(page: Any) -> None:
+            locator = await self._target_locator(page, target)
+            options = {"button": button, "modifiers": modifiers or [], "timeout": self.action_timeout}
+            if double_click:
+                await locator.dblclick(**options)
+            else:
+                await locator.click(**options)
+
+        return await self._perform_action(session, action)
+
+    async def type_text(self, target: str, text: str, *, submit: bool = False, slowly: bool = False) -> dict[str, Any]:
+        session = await self._ensure_session()
+
+        async def action(page: Any) -> None:
+            locator = await self._target_locator(page, target)
+            if slowly:
+                await locator.press_sequentially(text, timeout=self.action_timeout)
+            else:
+                await locator.fill(text, timeout=self.action_timeout)
+            if submit:
+                await locator.press("Enter", timeout=self.action_timeout)
+
+        return await self._perform_action(session, action)
+
+    async def fill_form(self, fields: list[dict[str, Any]]) -> dict[str, Any]:
+        session = await self._ensure_session()
+
+        async def action(page: Any) -> None:
+            for form_field in fields:
+                locator = await self._target_locator(page, str(form_field["target"]))
+                field_type = str(form_field["type"])
+                value = str(form_field["value"])
+                if field_type in {"textbox", "slider"}:
+                    await locator.fill(value, timeout=self.action_timeout)
+                elif field_type in {"checkbox", "radio"}:
+                    if value.lower() not in {"true", "false"}:
+                        raise ValueError(f"{field_type} value must be 'true' or 'false'.")
+                    await locator.set_checked(value.lower() == "true", timeout=self.action_timeout)
+                elif field_type == "combobox":
+                    await locator.select_option(label=value, timeout=self.action_timeout)
+                else:
+                    raise ValueError(f"Unsupported form field type: {field_type}")
+
+        return await self._perform_action(session, action)
+
+    async def select_option(self, target: str, values: list[str]) -> dict[str, Any]:
+        session = await self._ensure_session()
+
+        async def action(page: Any) -> list[str]:
+            return await (await self._target_locator(page, target)).select_option(values, timeout=self.action_timeout)
+
+        return await self._perform_action(session, action)
+
+    async def hover(self, target: str) -> dict[str, Any]:
+        session = await self._ensure_session()
+
+        async def action(page: Any) -> None:
+            await (await self._target_locator(page, target)).hover(timeout=self.action_timeout)
+
+        return await self._perform_action(session, action)
+
+    async def drag(self, start_target: str, end_target: str) -> dict[str, Any]:
+        session = await self._ensure_session()
+
+        async def action(page: Any) -> None:
+            start, end = await asyncio.gather(
+                self._target_locator(page, start_target), self._target_locator(page, end_target)
+            )
+            await start.drag_to(end, timeout=self.action_timeout)
+
+        return await self._perform_action(session, action)
+
+    async def drop(
+        self, target: str, *, files: Optional[list[dict[str, Any]]] = None, data: Optional[dict[str, str]] = None
+    ) -> dict[str, Any]:
+        if not files and not data:
+            raise ValueError("Provide files or data to drop.")
+        session = await self._ensure_session()
+
+        async def action(page: Any) -> None:
+            locator = await self._target_locator(page, target)
+            encoded_files = [
+                {
+                    "name": item["name"],
+                    "mime_type": item["mime_type"],
+                    "base64": base64.b64encode(item["buffer"]).decode("ascii"),
+                }
+                for item in files or []
+            ]
+            await locator.evaluate(
+                """(element, payload) => {
+                    const transfer = new DataTransfer();
+                    for (const [type, value] of Object.entries(payload.data || {}))
+                        transfer.setData(type, value);
+                    for (const file of payload.files || []) {
+                        const binary = atob(file.base64);
+                        const bytes = Uint8Array.from(binary, ch => ch.charCodeAt(0));
+                        transfer.items.add(new File([bytes], file.name, { type: file.mime_type }));
+                    }
+                    for (const type of ['dragenter', 'dragover', 'drop'])
+                        element.dispatchEvent(new DragEvent(type, { bubbles: true, dataTransfer: transfer }));
+                }""",
+                {"files": encoded_files, "data": data or {}},
+            )
+
+        return await self._perform_action(session, action)
+
+    async def press_key(self, key: str) -> dict[str, Any]:
+        session = await self._ensure_session()
+
+        async def action(page: Any) -> None:
+            await page.keyboard.press(key)
+
+        return await self._perform_action(session, action)
+
+    async def navigate_back(self) -> dict[str, Any]:
+        session = await self._ensure_session()
+
+        async def action(page: Any) -> None:
+            await page.go_back(wait_until="domcontentloaded", timeout=self.navigation_timeout)
+
+        return await self._perform_action(session, action)
+
+    async def wait_for(
+        self, *, time: Optional[float] = None, text: Optional[str] = None, text_gone: Optional[str] = None
+    ) -> dict[str, Any]:
+        if time is None and text is None and text_gone is None:
+            raise ValueError("Provide time, text, or text_gone.")
+        session = await self._ensure_session()
+        self._assert_no_modal(session)
+        page = self._current_page(session)
+        if time is not None:
+            await asyncio.sleep(min(max(time, 0), 30))
+        if text_gone is not None:
+            await page.get_by_text(text_gone).first.wait_for(state="hidden", timeout=self.action_timeout)
+        if text is not None:
+            await page.get_by_text(text).first.wait_for(state="visible", timeout=self.action_timeout)
+        return await self._state_result(session)
+
+    async def resize(self, width: int, height: int) -> dict[str, Any]:
+        if width <= 0 or height <= 0:
+            raise ValueError("width and height must be positive.")
+        session = await self._ensure_session()
+
+        async def action(page: Any) -> None:
+            await page.set_viewport_size({"width": width, "height": height})
+
+        return await self._perform_action(session, action)
+
+    async def tabs(self, action: str, *, index: Optional[int] = None, url: Optional[str] = None) -> dict[str, Any]:
+        if action not in {"list", "new", "close", "select"}:
+            raise ValueError("action must be list, new, close, or select.")
+        session = await self._ensure_session()
+        self._assert_no_modal(session)
+        pages = self._open_pages(session)
+        if action == "new":
+            page = await session.context.new_page()
+            self._attach_page(session, page, make_current=True)
+            if url:
+                state = self._page_state(session, page)
+                state.console_recent.clear()
+                state.network.clear()
+                await page.goto(
+                    self._normalize_url(url), wait_until="domcontentloaded", timeout=self.navigation_timeout
+                )
+        elif action in {"close", "select"}:
+            if action == "select" and index is None:
+                raise ValueError("index is required when selecting a tab.")
+            selected_index = index if index is not None else pages.index(self._current_page(session))
+            if selected_index < 0 or selected_index >= len(pages):
+                raise ValueError(f"Tab index {selected_index} is out of range.")
+            if action == "select":
+                session.current_page = pages[selected_index]
+                await session.current_page.bring_to_front()
+            else:
+                await pages[selected_index].close()
+                remaining = self._open_pages(session)
+                if not remaining:
+                    closed_id = session.session_id
+                    await self.close()
+                    return {"session_id": closed_id, "tabs": []}
+                session.current_page = remaining[min(selected_index, len(remaining) - 1)]
+
+        pages = self._open_pages(session)
+        tab_results = []
+        for tab_index, page in enumerate(pages):
+            state = self._page_state(session, page)
+            if not self._modal_description(session) or page is not session.current_page:
+                with contextlib.suppress(Exception):
+                    state.last_title = await page.title()
+            tab_results.append(
+                {
+                    "index": tab_index,
+                    "title": state.last_title,
+                    "url": page.url,
+                    "current": page is session.current_page,
+                }
+            )
+        result: dict[str, Any] = {"session_id": session.session_id, "tabs": tab_results}
+        if action != "list":
+            result.update(await self._state_result(session))
+        return result
+
+    async def handle_dialog(self, accept: bool, prompt_text: Optional[str] = None) -> dict[str, Any]:
+        session = await self._ensure_session()
+        dialog = session.dialog
+        if dialog is None:
+            raise RuntimeError("There is no dialog to handle.")
+        try:
+            if accept:
+                await dialog.accept(prompt_text)
+            else:
+                await dialog.dismiss()
+        finally:
+            session.dialog = None
+            session.modal_event.clear()
+        await self._finish_pending_action(session)
+        return await self._state_result(session)
+
+    async def file_upload(self, files: list[dict[str, Any]]) -> dict[str, Any]:
+        session = await self._ensure_session()
+        chooser = session.file_chooser
+        if chooser is None:
+            raise RuntimeError("There is no file chooser to handle.")
+        payloads = [{"name": item["name"], "mimeType": item["mime_type"], "buffer": item["buffer"]} for item in files]
+        try:
+            await chooser.set_files(payloads)
+        finally:
+            session.file_chooser = None
+            session.modal_event.clear()
+        await self._finish_pending_action(session)
+        return await self._state_result(session)
+
+    async def _finish_pending_action(self, session: _BrowserSession) -> None:
+        task = session.pending_action
+        session.pending_action = None
+        if task is not None:
+            await asyncio.wait_for(task, timeout=self.navigation_timeout / 1000)
+
+    async def console_messages(self, level: str = "info", *, all_messages: bool = False) -> dict[str, Any]:
+        if level not in _CONSOLE_LEVELS:
+            raise ValueError("level must be error, warning, info, or debug.")
+        session = await self._ensure_session()
+        state = self._page_state(session)
+        source = state.console_all if all_messages else state.console_recent
+
+        def severity(entry: dict[str, Any]) -> str:
+            kind = entry["type"]
+            if kind in {"assert", "error"}:
+                return "error"
+            if kind == "warning":
+                return "warning"
+            if kind == "debug":
+                return "debug"
+            return "info"
+
+        messages = [entry for entry in source if _CONSOLE_LEVELS[severity(entry)] <= _CONSOLE_LEVELS[level]]
+        return {
+            "messages": messages,
+            "total": len(source),
+            "errors": sum(severity(entry) == "error" for entry in source),
+            "warnings": sum(severity(entry) == "warning" for entry in source),
+        }
+
+    async def network_requests(
+        self, *, include_static: bool = False, filter_pattern: Optional[str] = None
+    ) -> dict[str, Any]:
+        session = await self._ensure_session()
+        records = list(self._page_state(session).network)
+        compiled = re.compile(filter_pattern) if filter_pattern else None
+        results = []
+        for index, record in enumerate(records, 1):
+            if not include_static and record["resource_type"] in _STATIC_RESOURCE_TYPES:
+                continue
+            if compiled and not compiled.search(record["url"]):
+                continue
+            results.append(
+                {
+                    "index": index,
+                    "method": record["method"],
+                    "url": record["url"],
+                    "resource_type": record["resource_type"],
+                    "status": record["status"],
+                    "status_text": record["status_text"],
+                    "failure": record["failure"],
+                }
+            )
+        return {"requests": results, "total": len(results)}
+
+    async def network_request(self, index: int, part: Optional[str] = None) -> dict[str, Any]:
+        session = await self._ensure_session()
+        records = list(self._page_state(session).network)
+        if index <= 0 or index > len(records):
+            raise ValueError(f"Network request index {index} is out of range.")
+        record = records[index - 1]
+        request = record["request"]
+        response = record["response"]
+        result: dict[str, Any] = {
+            "index": index,
+            "method": record["method"],
+            "url": record["url"],
+            "status": record["status"],
+            "failure": record["failure"],
+        }
+        valid_parts = {"request_headers", "request_body", "response_headers", "response_body"}
+        if part is not None and part not in valid_parts:
+            raise ValueError(f"part must be one of: {', '.join(sorted(valid_parts))}.")
+        if part in {None, "request_headers"}:
+            result["request_headers"] = await request.all_headers()
+        if part in {None, "request_body"}:
+            result["request_body"] = request.post_data
+        if response is not None and part in {None, "response_headers"}:
+            result["response_headers"] = await response.all_headers()
+        if response is not None and part in {None, "response_body"}:
+            try:
+                body = (await response.body()).decode("utf-8", errors="replace")
+                result["response_body"] = body[:_MAX_NETWORK_BODY_CHARS]
+                result["response_body_truncated"] = len(body) > _MAX_NETWORK_BODY_CHARS
+            except Exception as exc:
+                result["response_body_error"] = str(exc)
+        return result
+
+    async def screenshot(
+        self,
+        *,
+        target: Optional[str] = None,
+        image_type: str = "png",
+        full_page: bool = False,
+        scale: str = "css",
+    ) -> dict[str, Any]:
+        if image_type not in {"png", "jpeg"}:
+            raise ValueError("image_type must be png or jpeg.")
+        if scale not in {"css", "device"}:
+            raise ValueError("scale must be css or device.")
+        session = await self._ensure_session()
+        self._assert_no_modal(session)
+        page = self._current_page(session)
+        if target and full_page:
+            raise ValueError("full_page cannot be combined with an element target.")
+        if target:
+            image = await (await self._target_locator(page, target)).screenshot(type=image_type, scale=scale)
+        else:
+            image = await page.screenshot(type=image_type, full_page=full_page, scale=scale)
+        state = self._page_state(session)
+        state.last_title = await page.title()
+        return {
+            "url": page.url,
+            "title": state.last_title,
+            "image": base64.b64encode(image).decode("ascii"),
+            "media_type": f"image/{image_type}",
+        }
+
+    async def evaluate(self, function: str, target: Optional[str] = None) -> dict[str, Any]:
+        session = await self._ensure_session()
+
+        async def action(page: Any) -> Any:
+            if target:
+                return await (await self._target_locator(page, target)).evaluate(function)
+            return await page.evaluate(function)
+
+        result = await self._perform_action(session, action)
+        if "result" in result:
+            serialized = json.dumps(result["result"], ensure_ascii=False, default=str)
+            if len(serialized) > _MAX_NETWORK_BODY_CHARS:
+                result["result"] = serialized[:_MAX_NETWORK_BODY_CHARS]
+                result["result_truncated"] = True
+        return result
+
+    async def close(self) -> Optional[str]:
+        session = self._session
+        if session is None:
+            return None
+        self._session = None
+        if session.pending_action and not session.pending_action.done():
+            session.pending_action.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await session.pending_action
+        if session.keepalive_task:
+            session.keepalive_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await session.keepalive_task
+        with contextlib.suppress(Exception):
+            await session.context.close()
+        with contextlib.suppress(Exception):
+            await session.browser.close()
+        with contextlib.suppress(Exception):
+            await session.playwright.stop()
+        return session.session_id
 
     async def cleanup_all_browsers(self) -> None:
-        """
-        Close all open browser instances and clean up resources.
-        This should be called when the browser manager is being destroyed.
-        """
-        browser_ids = list(self.browsers.keys())  # Create a copy of keys to avoid modification during iteration
+        await self.close()
 
-        for browser_id in browser_ids:
-            try:
-                await self.close_browser(browser_id)
-            except Exception as e:
-                # Log error but continue closing other browsers
-                print(f"Error closing browser {browser_id}: {e}")
 
-        # Cancel any remaining keepalive tasks (cleanup safety)
-        for task_id, task in list(self.keepalive_tasks.items()):
-            task.cancel()
-        self.keepalive_tasks.clear()
+def file_payload(path: str, content: bytes) -> dict[str, Any]:
+    """Build the transport-neutral file payload consumed by upload/drop operations."""
+    return {
+        "name": os.path.basename(path),
+        "mime_type": mimetypes.guess_type(path)[0] or "application/octet-stream",
+        "buffer": content,
+    }

--- a/tests/agent/services/test_browser_console_logs.py
+++ b/tests/agent/services/test_browser_console_logs.py
@@ -1,314 +1,129 @@
-# ruff: noqa: F401,F811,E402
-import datetime
-import os
+import asyncio
+import re
+
 import pytest
-from unittest.mock import AsyncMock
-from kolega_code.services.browser import PlaywrightBrowserManager
+import pytest_asyncio
 
-# Check if running in CI environment
-SKIP_IN_CI = bool(os.getenv("CI")) or bool(os.getenv("GITLAB_CI"))
+from kolega_code.services.browser import PlaywrightBrowserManager, file_payload
 
 
-class TestPlaywrightBrowserManager:
-    @pytest.fixture
-    def browser_manager(self):
-        """Create a browser manager instance for testing."""
-        return PlaywrightBrowserManager()
+@pytest_asyncio.fixture
+async def browser_manager():
+    manager = PlaywrightBrowserManager()
+    manager.headless = True
+    try:
+        yield manager
+    finally:
+        await manager.close()
 
-    @pytest.fixture
-    def mock_browser_info(self):
-        """Create mock browser info with sample console logs."""
-        now = datetime.datetime.now()
-        console_logs = [
-            {
-                "type": "log",
-                "text": "Regular log message 1",
-                "timestamp": (now - datetime.timedelta(minutes=10)).isoformat(),
-                "location": None,
-            },
-            {
-                "type": "error",
-                "text": "JavaScript error occurred",
-                "timestamp": (now - datetime.timedelta(minutes=8)).isoformat(),
-                "location": {"url": "test.js", "lineNumber": 42, "columnNumber": 10},
-            },
-            {
-                "type": "warning",
-                "text": "Deprecated API usage",
-                "timestamp": (now - datetime.timedelta(minutes=6)).isoformat(),
-                "location": None,
-            },
-            {
-                "type": "log",
-                "text": "Regular log message 2",
-                "timestamp": (now - datetime.timedelta(minutes=4)).isoformat(),
-                "location": None,
-            },
-            {
-                "type": "assert",
-                "text": "Assertion failed: condition not met",
-                "timestamp": (now - datetime.timedelta(minutes=2)).isoformat(),
-                "location": None,
-            },
-            {
-                "type": "info",
-                "text": "Information message",
-                "timestamp": now.isoformat(),
-                "location": None,
-            },
-        ]
 
-        return {
-            "type": "chromium",
-            "url": "https://example.com",
-            "console_logs": console_logs,
-            "launched_at": now.isoformat(),
-        }
+@pytest.mark.asyncio
+async def test_console_messages_filter_by_severity(browser_manager):
+    await browser_manager.evaluate("() => { console.log('hello'); console.warn('careful'); console.error('broken'); }")
 
-    @pytest.mark.asyncio
-    async def test_get_browser_console_logs_default_filtering(self, browser_manager, mock_browser_info):
-        """Test default console log filtering (errors, warnings, assertions only)."""
-        browser_id = "test-browser-id"
-        browser_manager.browsers[browser_id] = mock_browser_info
+    warnings = await browser_manager.console_messages("warning")
+    assert warnings["total"] == 3
+    assert warnings["errors"] == 1
+    assert warnings["warnings"] == 1
+    assert [message["text"] for message in warnings["messages"]] == ["careful", "broken"]
 
-        result = await browser_manager.get_browser_console_logs(browser_id)
 
-        assert result["total_logs_count"] == 6
-        assert result["returned_count"] == 3  # Only error, warning, assert
-        assert result["filters_applied"]["log_types"] == ["error", "warning", "assert"]
-        assert result["filters_applied"]["max_logs"] == 50
-        assert result["filters_applied"]["max_chars"] == 8000
+@pytest.mark.asyncio
+async def test_console_recent_is_cleared_by_navigation(browser_manager, unused_tcp_port):
+    await browser_manager.evaluate("() => console.error('before navigation')")
 
-        # Check that only the correct log types are returned
-        returned_types = [log["type"] for log in result["console_logs"]]
-        assert "error" in returned_types
-        assert "warning" in returned_types
-        assert "assert" in returned_types
-        assert "log" not in returned_types
-        assert "info" not in returned_types
+    # A failed navigation still starts a new navigation scope before Playwright reports the connection error.
+    with pytest.raises(Exception):
+        await browser_manager.navigate(f"http://127.0.0.1:{unused_tcp_port}")
 
-    @pytest.mark.asyncio
-    async def test_get_browser_console_logs_custom_log_types(self, browser_manager, mock_browser_info):
-        """Test filtering by custom log types."""
-        browser_id = "test-browser-id"
-        browser_manager.browsers[browser_id] = mock_browser_info
+    recent = await browser_manager.console_messages("debug")
+    assert all(message["text"] != "before navigation" for message in recent["messages"])
 
-        result = await browser_manager.get_browser_console_logs(browser_id, log_types=["log", "info"])
 
-        assert result["total_logs_count"] == 6
-        assert result["returned_count"] == 3  # 2 log + 1 info
-        assert result["filters_applied"]["log_types"] == ["log", "info"]
+@pytest.mark.asyncio
+async def test_dialog_returns_modal_state_and_can_be_handled(browser_manager):
+    await browser_manager.evaluate(
+        "() => { document.body.innerHTML = `<button onclick=\"alert('hello')\">Open</button>`; }"
+    )
+    snapshot = (await browser_manager.snapshot())["snapshot"]
+    match = re.search(r"button.*?\[ref=(e\d+)\]", snapshot)
+    assert match is not None
+    target = match.group(1)
 
-        # Check that only the correct log types are returned
-        returned_types = [log["type"] for log in result["console_logs"]]
-        assert "log" in returned_types
-        assert "info" in returned_types
-        assert "error" not in returned_types
+    modal = await browser_manager.click(target)
+    assert modal["modal"] == {"type": "dialog", "dialog_type": "alert", "message": "hello"}
 
-    @pytest.mark.asyncio
-    async def test_get_browser_console_logs_max_logs_limit(self, browser_manager, mock_browser_info):
-        """Test limiting the number of logs returned."""
-        browser_id = "test-browser-id"
-        browser_manager.browsers[browser_id] = mock_browser_info
+    result = await browser_manager.handle_dialog(True)
+    assert "snapshot" in result
+    assert result.get("modal") is None
 
-        result = await browser_manager.get_browser_console_logs(
-            browser_id,
-            max_logs=2,
-            log_types=[],  # Empty list to include all types
+
+@pytest.mark.asyncio
+async def test_action_is_blocked_until_modal_is_handled(browser_manager):
+    await browser_manager.evaluate(
+        "() => { document.body.innerHTML = `<button onclick=\"confirm('continue?')\">Open</button>`; }"
+    )
+    snapshot = (await browser_manager.snapshot())["snapshot"]
+    match = re.search(r"button.*?\[ref=(e\d+)\]", snapshot)
+    assert match is not None
+    target = match.group(1)
+    await browser_manager.click(target)
+
+    with pytest.raises(RuntimeError, match="browser_handle_dialog"):
+        await browser_manager.press_key("Enter")
+
+    await browser_manager.handle_dialog(False)
+
+
+@pytest.mark.asyncio
+async def test_file_chooser_returns_modal_state_and_accepts_payload(browser_manager):
+    await browser_manager.evaluate("() => { document.body.innerHTML = `<input type=file aria-label='Upload'>`; }")
+    snapshot = (await browser_manager.snapshot())["snapshot"]
+    match = re.search(r"button.*?\[ref=(e\d+)\]", snapshot)
+    assert match is not None
+    target = match.group(1)
+
+    modal = await browser_manager.click(target)
+    assert modal["modal"] == {"type": "file_chooser", "multiple": False}
+
+    result = await browser_manager.file_upload([file_payload("avatar.txt", b"hello")])
+    assert "snapshot" in result
+    uploaded = await browser_manager.evaluate("() => document.querySelector('input').files[0].name")
+    assert uploaded["result"] == "avatar.txt"
+
+
+@pytest.mark.asyncio
+async def test_evaluate_result_is_size_capped(browser_manager):
+    result = await browser_manager.evaluate("() => 'x'.repeat(25000)")
+
+    assert result["result_truncated"] is True
+    assert len(result["result"]) == 20_000
+
+
+@pytest.mark.asyncio
+async def test_network_requests_are_indexed_and_details_are_retrievable(browser_manager):
+    async def handle_request(reader, writer):
+        await reader.readuntil(b"\r\n\r\n")
+        body = b"hello from server"
+        writer.write(
+            b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: "
+            + str(len(body)).encode()
+            + b"\r\nConnection: close\r\n\r\n"
+            + body
         )
+        await writer.drain()
+        writer.close()
 
-        assert result["total_logs_count"] == 6
-        assert result["returned_count"] == 2  # Limited to 2 most recent
-        assert result["filters_applied"]["max_logs"] == 2
+    server = await asyncio.start_server(handle_request, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    try:
+        await browser_manager.navigate(f"http://127.0.0.1:{port}/hello")
+        requests = await browser_manager.network_requests()
+        document = next(request for request in requests["requests"] if request["resource_type"] == "document")
+        details = await browser_manager.network_request(document["index"], "response_body")
+    finally:
+        server.close()
+        await server.wait_closed()
 
-        # Should return the 2 most recent logs
-        returned_logs = result["console_logs"]
-        assert len(returned_logs) == 2
-        assert returned_logs[-1]["type"] == "info"  # Most recent
-        assert returned_logs[-2]["type"] == "assert"  # Second most recent
-
-    @pytest.mark.asyncio
-    async def test_get_browser_console_logs_time_filtering(self, browser_manager, mock_browser_info):
-        """Test filtering logs by time window."""
-        browser_id = "test-browser-id"
-        browser_manager.browsers[browser_id] = mock_browser_info
-
-        result = await browser_manager.get_browser_console_logs(
-            browser_id,
-            minutes_back=5,
-            log_types=[],  # Include all types, filter by time
-        )
-
-        assert result["total_logs_count"] == 6
-        assert result["returned_count"] == 3  # Only logs from last 5 minutes
-        assert result["filters_applied"]["minutes_back"] == 5
-
-        # All returned logs should be within the time window
-        cutoff_time = datetime.datetime.now() - datetime.timedelta(minutes=5)
-        for log in result["console_logs"]:
-            log_time = datetime.datetime.fromisoformat(log["timestamp"])
-            assert log_time > cutoff_time
-
-    @pytest.mark.asyncio
-    async def test_get_browser_console_logs_character_limit(self, browser_manager, mock_browser_info):
-        """Test limiting logs by character count."""
-        browser_id = "test-browser-id"
-        browser_manager.browsers[browser_id] = mock_browser_info
-
-        # Set a very low character limit to test truncation
-        result = await browser_manager.get_browser_console_logs(
-            browser_id,
-            max_chars=50,
-            log_types=[],  # Include all types
-        )
-
-        assert result["total_logs_count"] == 6
-        assert result["returned_count"] <= 6  # Should be limited by character count
-
-        # Calculate total character count of returned logs
-        total_chars = sum(len(f"{log['type']}: {log['text']}") for log in result["console_logs"])
-        assert total_chars <= 50
-
-    @pytest.mark.asyncio
-    async def test_get_browser_console_logs_combined_filters(self, browser_manager, mock_browser_info):
-        """Test applying multiple filters simultaneously."""
-        browser_id = "test-browser-id"
-        browser_manager.browsers[browser_id] = mock_browser_info
-
-        result = await browser_manager.get_browser_console_logs(
-            browser_id, max_logs=10, log_types=["error", "warning"], minutes_back=10, max_chars=1000
-        )
-
-        assert result["total_logs_count"] == 6
-        assert result["filters_applied"]["log_types"] == ["error", "warning"]
-        assert result["filters_applied"]["minutes_back"] == 10
-        assert result["filters_applied"]["max_logs"] == 10
-        assert result["filters_applied"]["max_chars"] == 1000
-
-        # Should only contain error and warning logs
-        returned_types = [log["type"] for log in result["console_logs"]]
-        for log_type in returned_types:
-            assert log_type in ["error", "warning"]
-
-    @pytest.mark.asyncio
-    async def test_get_browser_console_logs_empty_logs(self, browser_manager):
-        """Test behavior when no console logs exist."""
-        browser_id = "test-browser-id"
-        browser_manager.browsers[browser_id] = {
-            "console_logs": [],
-            "launched_at": datetime.datetime.now().isoformat(),
-        }
-
-        result = await browser_manager.get_browser_console_logs(browser_id)
-
-        assert result["total_logs_count"] == 0
-        assert result["returned_count"] == 0
-        assert result["console_logs"] == []
-
-    @pytest.mark.asyncio
-    async def test_get_browser_console_logs_browser_not_found(self, browser_manager):
-        """Test error handling when browser ID doesn't exist."""
-        with pytest.raises(KeyError, match="Browser with ID nonexistent not found"):
-            await browser_manager.get_browser_console_logs("nonexistent")
-
-    def test_circular_buffer_implementation(self, browser_manager):
-        """Test that the circular buffer prevents unlimited log growth."""
-        # Set a small buffer size for testing
-        browser_manager.max_console_logs_per_browser = 3
-
-        console_logs = []
-
-        # Simulate the console log handler behavior
-        def simulate_console_log_handler(msg_text, msg_type="log"):
-            log_entry = {
-                "type": msg_type,
-                "text": msg_text,
-                "timestamp": datetime.datetime.now().isoformat(),
-                "location": None,
-            }
-            console_logs.append(log_entry)
-
-            # Implement circular buffer logic
-            if len(console_logs) > browser_manager.max_console_logs_per_browser:
-                console_logs.pop(0)  # Remove oldest log
-
-        # Add more logs than the buffer size
-        simulate_console_log_handler("Log 1")
-        simulate_console_log_handler("Log 2")
-        simulate_console_log_handler("Log 3")
-        assert len(console_logs) == 3
-
-        simulate_console_log_handler("Log 4")
-        assert len(console_logs) == 3  # Should still be 3
-        assert console_logs[0]["text"] == "Log 2"  # First log should be removed
-        assert console_logs[-1]["text"] == "Log 4"  # Last log should be the newest
-
-        simulate_console_log_handler("Log 5")
-        assert len(console_logs) == 3
-        assert console_logs[0]["text"] == "Log 3"
-        assert console_logs[-1]["text"] == "Log 5"
-
-    @pytest.mark.asyncio
-    async def test_no_log_types_filter_includes_all(self, browser_manager, mock_browser_info):
-        """Test that passing an empty list for log_types includes all log types."""
-        browser_id = "test-browser-id"
-        browser_manager.browsers[browser_id] = mock_browser_info
-
-        result = await browser_manager.get_browser_console_logs(
-            browser_id,
-            log_types=[],  # Empty list should include all types
-        )
-
-        assert result["total_logs_count"] == 6
-        assert result["returned_count"] == 6  # All logs should be included
-        assert result["filters_applied"]["log_types"] == []
-
-        # Should include all log types
-        returned_types = [log["type"] for log in result["console_logs"]]
-        assert "log" in returned_types
-        assert "error" in returned_types
-        assert "warning" in returned_types
-        assert "assert" in returned_types
-        assert "info" in returned_types
-
-    @pytest.mark.asyncio
-    async def test_character_limit_preserves_most_recent(self, browser_manager):
-        """Test that character limit preserves the most recent logs."""
-        browser_id = "test-browser-id"
-
-        # Create logs with known character counts
-        console_logs = [
-            {
-                "type": "log",
-                "text": "A" * 10,  # 10 chars + "log: " = 14 chars
-                "timestamp": datetime.datetime.now().isoformat(),
-                "location": None,
-            },
-            {
-                "type": "log",
-                "text": "B" * 10,  # 10 chars + "log: " = 14 chars
-                "timestamp": datetime.datetime.now().isoformat(),
-                "location": None,
-            },
-            {
-                "type": "log",
-                "text": "C" * 10,  # 10 chars + "log: " = 14 chars (most recent)
-                "timestamp": datetime.datetime.now().isoformat(),
-                "location": None,
-            },
-        ]
-
-        browser_manager.browsers[browser_id] = {
-            "console_logs": console_logs,
-            "launched_at": datetime.datetime.now().isoformat(),
-        }
-
-        # Set character limit to allow only 1 log (14 chars) to test the logic
-        result = await browser_manager.get_browser_console_logs(browser_id, max_chars=14, log_types=[])
-
-        assert result["returned_count"] == 1
-        # Should preserve the most recent log (C)
-        returned_texts = [log["text"] for log in result["console_logs"]]
-        assert "C" * 10 in returned_texts
-        assert "A" * 10 not in returned_texts
-        assert "B" * 10 not in returned_texts
+    assert details["status"] == 200
+    assert details["response_body"] == "hello from server"

--- a/tests/agent/services/test_browser_content.py
+++ b/tests/agent/services/test_browser_content.py
@@ -1,94 +1,130 @@
-# ruff: noqa: F401,F811,E402
-import datetime
-import os
+import re
+import time
+
 import pytest
-from unittest.mock import AsyncMock
+import pytest_asyncio
+
 from kolega_code.services.browser import PlaywrightBrowserManager
 
-# Check if running in CI environment
-SKIP_IN_CI = bool(os.getenv("CI")) or bool(os.getenv("GITLAB_CI"))
+
+@pytest_asyncio.fixture
+async def browser_manager():
+    manager = PlaywrightBrowserManager()
+    manager.headless = True
+    try:
+        yield manager
+    finally:
+        await manager.close()
 
 
-class TestPlaywrightBrowserManager:
-    @pytest.fixture
-    def browser_manager(self):
-        """Create a browser manager instance for testing."""
-        return PlaywrightBrowserManager()
+async def _set_content(manager: PlaywrightBrowserManager, html: str) -> None:
+    await manager.evaluate(f"() => {{ document.body.innerHTML = {html!r}; }}")
 
-    @pytest.fixture
-    def mock_browser_info(self):
-        """Create mock browser info with sample console logs."""
-        now = datetime.datetime.now()
-        console_logs = [
-            {
-                "type": "log",
-                "text": "Regular log message 1",
-                "timestamp": (now - datetime.timedelta(minutes=10)).isoformat(),
-                "location": None,
-            },
-            {
-                "type": "error",
-                "text": "JavaScript error occurred",
-                "timestamp": (now - datetime.timedelta(minutes=8)).isoformat(),
-                "location": {"url": "test.js", "lineNumber": 42, "columnNumber": 10},
-            },
-            {
-                "type": "warning",
-                "text": "Deprecated API usage",
-                "timestamp": (now - datetime.timedelta(minutes=6)).isoformat(),
-                "location": None,
-            },
-            {
-                "type": "log",
-                "text": "Regular log message 2",
-                "timestamp": (now - datetime.timedelta(minutes=4)).isoformat(),
-                "location": None,
-            },
-            {
-                "type": "assert",
-                "text": "Assertion failed: condition not met",
-                "timestamp": (now - datetime.timedelta(minutes=2)).isoformat(),
-                "location": None,
-            },
-            {
-                "type": "info",
-                "text": "Information message",
-                "timestamp": now.isoformat(),
-                "location": None,
-            },
+
+def _ref(snapshot: str, role: str) -> str:
+    match = re.search(rf"{role}.*?\[ref=((?:f\d+)?e\d+)\]", snapshot)
+    assert match, snapshot
+    return match.group(1)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_refs_drive_atomic_actions(browser_manager):
+    await _set_content(
+        browser_manager,
+        """<main><h1>Profile</h1>
+        <button onclick="this.textContent='Saved'">Save</button>
+        <input aria-label="Name">
+        <select aria-label="Color"><option value="red">Red</option><option value="blue">Blue</option></select>
+        </main>""",
+    )
+    snapshot = (await browser_manager.snapshot())["snapshot"]
+
+    clicked = await browser_manager.click(_ref(snapshot, "button"))
+    assert 'button "Saved"' in clicked["snapshot"]
+
+    await browser_manager.type_text(_ref(snapshot, "textbox"), "Ada")
+    selected = await browser_manager.select_option(_ref(snapshot, "combobox"), ["blue"])
+    assert selected["result"] == ["blue"]
+
+
+@pytest.mark.asyncio
+async def test_fill_form_and_data_drop(browser_manager):
+    await _set_content(
+        browser_manager,
+        """<input aria-label="Email"><input type="checkbox" aria-label="Subscribe">
+        <div role="button" aria-label="Drop target"
+             ondragover="event.preventDefault()"
+             ondrop="event.preventDefault(); this.textContent=event.dataTransfer.getData('text/plain')">Drop</div>""",
+    )
+    snapshot = (await browser_manager.snapshot())["snapshot"]
+    textbox = _ref(snapshot, "textbox")
+    checkbox = _ref(snapshot, "checkbox")
+    button = _ref(snapshot, "button")
+
+    filled = await browser_manager.fill_form(
+        [
+            {"name": "Email", "target": textbox, "type": "textbox", "value": "ada@example.com"},
+            {"name": "Subscribe", "target": checkbox, "type": "checkbox", "value": "true"},
         ]
+    )
+    assert 'textbox "Email"' in filled["snapshot"]
+    assert "ada@example.com" in filled["snapshot"]
+    assert "[checked]" in filled["snapshot"]
 
-        return {
-            "type": "chromium",
-            "url": "https://example.com",
-            "console_logs": console_logs,
-            "launched_at": now.isoformat(),
-        }
+    dropped = await browser_manager.drop(button, data={"text/plain": "Dropped value"})
+    assert "Dropped value" in dropped["snapshot"]
 
-    @pytest.mark.asyncio
-    async def test_get_browser_content_with_filtered_logs(self, browser_manager, mock_browser_info):
-        """Test that get_browser_content uses filtered console logs."""
-        browser_id = "test-browser-id"
 
-        # Mock the page object
-        mock_page = AsyncMock()
-        mock_page.url = "https://example.com"
-        mock_page.title.return_value = "Test Page"
-        mock_page.content.return_value = "<html><body>Test</body></html>"
+@pytest.mark.asyncio
+async def test_stale_ref_error_requests_fresh_snapshot(browser_manager):
+    await _set_content(browser_manager, '<button id="old">Old</button>')
+    stale_ref = _ref((await browser_manager.snapshot())["snapshot"], "button")
+    await _set_content(browser_manager, '<button id="new">New</button>')
 
-        mock_browser_info["page"] = mock_page
-        browser_manager.browsers[browser_id] = mock_browser_info
+    with pytest.raises(ValueError, match="fresh browser_snapshot"):
+        await browser_manager.click(stale_ref)
 
-        result = await browser_manager.get_browser_content(browser_id, max_logs=2, log_types=["error"])
 
-        assert "current_url" in result
-        assert "title" in result
-        assert "html" in result
-        assert "console_logs" in result
-        assert "console_log_metadata" in result
+@pytest.mark.asyncio
+async def test_ambiguous_selector_is_rejected(browser_manager):
+    await _set_content(browser_manager, "<button>One</button><button>Two</button>")
 
-        metadata = result["console_log_metadata"]
-        assert metadata["total_logs_count"] == 6
-        assert metadata["returned_count"] == 1  # Only 1 error log
-        assert metadata["filters_applied"]["log_types"] == ["error"]
-        assert metadata["filters_applied"]["max_logs"] == 2
+    with pytest.raises(ValueError, match="matches 2 elements"):
+        await browser_manager.click("button")
+
+
+@pytest.mark.asyncio
+async def test_click_does_not_wait_for_network_idle(browser_manager):
+    await _set_content(
+        browser_manager,
+        """<button onclick="window.timer = setInterval(() => fetch('data:text/plain,ping'), 25); this.textContent='Running'">Start</button>""",
+    )
+    target = _ref((await browser_manager.snapshot())["snapshot"], "button")
+
+    started = time.monotonic()
+    result = await browser_manager.click(target)
+
+    assert time.monotonic() - started < 2
+    assert 'button "Running"' in result["snapshot"]
+
+
+@pytest.mark.asyncio
+async def test_tabs_use_implicit_current_session(browser_manager):
+    initial = await browser_manager.tabs("list")
+    assert initial["tabs"][0]["current"] is True
+
+    created = await browser_manager.tabs("new")
+    assert len(created["tabs"]) == 2
+    assert created["tabs"][1]["current"] is True
+
+    selected = await browser_manager.tabs("select", index=0)
+    assert selected["tabs"][0]["current"] is True
+
+    closed = await browser_manager.tabs("close", index=1)
+    assert len(closed["tabs"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_navigation_rejects_file_urls(browser_manager):
+    with pytest.raises(ValueError, match="only supports http"):
+        await browser_manager.navigate("file:///tmp/secret")

--- a/tests/agent/services/test_browser_integration.py
+++ b/tests/agent/services/test_browser_integration.py
@@ -1,120 +1,31 @@
-# ruff: noqa: F401,F811,E402
-import datetime
 import os
+import re
+
 import pytest
-from unittest.mock import AsyncMock
+
 from kolega_code.services.browser import PlaywrightBrowserManager
 
-# Check if running in CI environment
-SKIP_IN_CI = bool(os.getenv("CI")) or bool(os.getenv("GITLAB_CI"))
 
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_live_browserless_snapshot_action_and_screenshot():
+    if not os.getenv("BROWSERLESS_API_KEY"):
+        pytest.skip("BROWSERLESS_API_KEY is not set")
 
-class TestPlaywrightBrowserManagerIntegration:
-    """Integration tests for PlaywrightBrowserManager that use real browsers."""
+    manager = PlaywrightBrowserManager("browserless")
+    try:
+        state = await manager.navigate("https://example.com")
+        assert state["url"].startswith("https://example.com")
+        assert "Example Domain" in state["snapshot"]
 
-    @pytest.mark.integration
-    @pytest.mark.skipif(SKIP_IN_CI, reason="Skipping network-dependent test in CI environment")
-    @pytest.mark.asyncio
-    async def test_real_browser_google_screenshot(self):
-        """Integration test: Launch real browser, load Google, take screenshot."""
-        # Check if BROWSERLESS_API_KEY is available, skip if not
-        if not os.getenv("BROWSERLESS_API_KEY"):
-            pytest.skip("BROWSERLESS_API_KEY environment variable not set")
+        match = re.search(r"link .*?\[ref=((?:f\d+)?e\d+)\]", state["snapshot"])
+        assert match is not None
+        link_ref = match.group(1)
+        clicked = await manager.click(link_ref)
+        assert clicked["url"].startswith("https://www.iana.org")
 
-        browser_manager = PlaywrightBrowserManager(browser_backend="browserless")
-        browser_id = None
-
-        try:
-            # Launch browser and navigate to Google
-            browser_id = await browser_manager.launch_browser("https://www.google.com")
-
-            # Verify we got a valid browser ID (not an error dict)
-            assert isinstance(browser_id, str)
-            assert browser_id != ""
-
-            # Verify browser is in the manager's registry
-            assert browser_id in browser_manager.browsers
-            browser_info = browser_manager.browsers[browser_id]
-            assert browser_info["url"] == "https://www.google.com"
-            assert browser_info["backend"] == "browserless"
-            assert browser_info["browserstack"] is False
-
-            # Take a screenshot
-            screenshot_result = await browser_manager.take_browser_screenshot(browser_id)
-
-            # Verify screenshot result structure
-            assert "current_url" in screenshot_result
-            assert "title" in screenshot_result
-            assert "screenshot" in screenshot_result
-
-            # Verify we're actually on Google
-            assert "google" in screenshot_result["current_url"].lower()
-            assert "google" in screenshot_result["title"].lower()
-
-            # Verify screenshot is base64 encoded
-            screenshot_data = screenshot_result["screenshot"]
-            assert isinstance(screenshot_data, str)
-            assert len(screenshot_data) > 0
-            # Basic check that it's base64 (starts with image header)
-            import base64
-
-            try:
-                decoded = base64.b64decode(screenshot_data)
-                assert len(decoded) > 0
-            except Exception:
-                pytest.fail("Screenshot is not valid base64 data")
-
-            # Test console logs capture
-            console_logs_result = await browser_manager.get_browser_console_logs(browser_id)
-            assert "console_logs" in console_logs_result
-            assert "total_logs_count" in console_logs_result
-            assert "returned_count" in console_logs_result
-
-            # Test browser content retrieval
-            content_result = await browser_manager.get_browser_content(browser_id)
-            assert "current_url" in content_result
-            assert "title" in content_result
-            assert "html" in content_result
-            assert "console_logs" in content_result
-            assert len(content_result["html"]) > 0
-
-            # Test interactive elements extraction
-            elements_result = await browser_manager.get_browser_interactive_elements(browser_id)
-            assert "current_url" in elements_result
-            assert "title" in elements_result
-            assert "interactive_elements" in elements_result
-
-        finally:
-            # Clean up: close the browser if it was created
-            if isinstance(browser_id, str) and browser_id in browser_manager.browsers:
-                await browser_manager.close_browser(browser_id)
-
-            # Additional cleanup to ensure all browsers are closed
-            await browser_manager.cleanup_all_browsers()
-
-    @pytest.mark.integration
-    @pytest.mark.asyncio
-    @pytest.mark.skipif(SKIP_IN_CI, reason="Skipping slow test in CI environment")
-    async def test_real_browser_error_handling(self):
-        """Integration test: Test error handling with real browser for invalid URLs."""
-        # Check if BROWSERLESS_API_KEY is available, skip if not
-        if not os.getenv("BROWSERLESS_API_KEY"):
-            pytest.skip("BROWSERLESS_API_KEY environment variable not set")
-
-        browser_manager = PlaywrightBrowserManager(browser_backend="browserless")
-
-        try:
-            # Try to launch browser with invalid URL
-            result = await browser_manager.launch_browser("not-a-valid-url")
-
-            # Should return error dict rather than browser ID
-            if isinstance(result, dict) and "error" in result:
-                assert "error" in result
-                assert "Browser Launch Error" in result["error"]
-            else:
-                # If it somehow succeeds (maybe Playwright handles it), clean up
-                if isinstance(result, str) and result in browser_manager.browsers:
-                    await browser_manager.close_browser(result)
-
-        finally:
-            await browser_manager.cleanup_all_browsers()
+        screenshot = await manager.screenshot()
+        assert screenshot["media_type"] == "image/png"
+        assert screenshot["image"]
+    finally:
+        await manager.close()

--- a/tests/agent/services/test_browser_integration.py
+++ b/tests/agent/services/test_browser_integration.py
@@ -1,5 +1,6 @@
 import os
 import re
+import urllib.parse
 
 import pytest
 
@@ -15,14 +16,18 @@ async def test_live_browserless_snapshot_action_and_screenshot():
     manager = PlaywrightBrowserManager("browserless")
     try:
         state = await manager.navigate("https://example.com")
-        assert state["url"].startswith("https://example.com")
+        current_url = urllib.parse.urlsplit(state["url"])
+        assert current_url.scheme == "https"
+        assert current_url.hostname == "example.com"
         assert "Example Domain" in state["snapshot"]
 
         match = re.search(r"link .*?\[ref=((?:f\d+)?e\d+)\]", state["snapshot"])
         assert match is not None
         link_ref = match.group(1)
         clicked = await manager.click(link_ref)
-        assert clicked["url"].startswith("https://www.iana.org")
+        clicked_url = urllib.parse.urlsplit(clicked["url"])
+        assert clicked_url.scheme == "https"
+        assert clicked_url.hostname == "www.iana.org"
 
         screenshot = await manager.screenshot()
         assert screenshot["media_type"] == "image/png"

--- a/tests/agent/services/test_browser_parity.py
+++ b/tests/agent/services/test_browser_parity.py
@@ -1,355 +1,110 @@
-"""Test parity between local and BrowserStack browser managers."""
+import urllib.parse
+from unittest.mock import AsyncMock, MagicMock
 
-import datetime
-import os
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
-from dotenv import load_dotenv
 
-from kolega_code.services.browser import PlaywrightBrowserManager
 from kolega_code.sandbox.browser import SandboxBrowserManager
-
-# Load environment variables from .env file
-load_dotenv()
+from kolega_code.services.browser import PlaywrightBrowserManager
 
 
-class TestBrowserManagerParity:
-    """Test suite to ensure identical behavior between local and BrowserStack browser managers."""
+@pytest.fixture
+def browserless_env(monkeypatch):
+    monkeypatch.setenv("BROWSERLESS_API_KEY", "test-token")
 
-    @pytest.fixture
-    def mock_env_vars(self, monkeypatch):
-        """Mock environment variables for BrowserStack and Browserless."""
-        monkeypatch.setenv("BROWSERSTACK_USERNAME", "test_user")
-        monkeypatch.setenv("BROWSERSTACK_ACCESS_KEY", "test_key")
-        monkeypatch.setenv("BROWSERLESS_API_KEY", "test_browserless_key")
 
-    @pytest.fixture
-    def local_browser_manager(self):
-        """Create a local browser manager instance."""
-        return PlaywrightBrowserManager(browser_backend="local")
+def test_unknown_backend_is_rejected():
+    with pytest.raises(ValueError, match="Unknown browser backend"):
+        PlaywrightBrowserManager("unknown")
 
-    @pytest.fixture
-    def browserstack_browser_manager(self, mock_env_vars):
-        """Create a BrowserStack browser manager instance."""
-        return PlaywrightBrowserManager(browser_backend="browserstack")
 
-    @pytest.fixture
-    def browserless_browser_manager(self, mock_env_vars):
-        """Create a Browserless browser manager instance."""
-        return PlaywrightBrowserManager(browser_backend="browserless")
+def test_browserless_cloud_requires_auth(monkeypatch):
+    monkeypatch.delenv("BROWSERLESS_API_KEY", raising=False)
+    monkeypatch.delenv("BROWSERLESS_WS_ENDPOINT", raising=False)
 
-    @pytest.fixture
-    def sandbox_browser_manager(self, mock_env_vars):
-        """Create a sandbox browser manager instance (uses Browserless)."""
-        return SandboxBrowserManager()
+    with pytest.raises(ValueError, match="Browserless credentials not found"):
+        PlaywrightBrowserManager("browserless")
 
-    def test_initialization(self, local_browser_manager, browserstack_browser_manager, sandbox_browser_manager):
-        """Test that all managers initialize with the same properties."""
-        # Check common properties
-        assert local_browser_manager.viewport == browserstack_browser_manager.viewport
-        assert local_browser_manager.viewport == sandbox_browser_manager.viewport
 
-        assert local_browser_manager.user_agent == browserstack_browser_manager.user_agent
-        assert local_browser_manager.user_agent == sandbox_browser_manager.user_agent
+def test_browserless_self_hosted_endpoint_does_not_require_token(monkeypatch):
+    monkeypatch.delenv("BROWSERLESS_API_KEY", raising=False)
+    manager = PlaywrightBrowserManager("browserless", browserless_endpoint="ws://localhost:3000")
 
-        assert local_browser_manager.headless == browserstack_browser_manager.headless
-        assert local_browser_manager.headless == sandbox_browser_manager.headless
+    assert manager._browserless_url() == "ws://localhost:3000"
 
-        assert local_browser_manager.interaction_timeout == browserstack_browser_manager.interaction_timeout
-        assert local_browser_manager.interaction_timeout == sandbox_browser_manager.interaction_timeout
 
-        assert (
-            local_browser_manager.max_console_logs_per_browser
-            == browserstack_browser_manager.max_console_logs_per_browser
-        )
-        assert (
-            local_browser_manager.max_console_logs_per_browser == sandbox_browser_manager.max_console_logs_per_browser
-        )
+def test_browserless_endpoint_preserves_query_and_adds_configured_values(browserless_env):
+    manager = PlaywrightBrowserManager(
+        "browserless",
+        browserless_endpoint="wss://production-lon.browserless.io/chromium?stealth=true",
+        browserless_timeout_ms=300000,
+    )
 
-        # Check backend-specific properties
-        assert local_browser_manager.browser_backend == "local"
-        assert browserstack_browser_manager.browser_backend == "browserstack"
-        assert sandbox_browser_manager.browser_backend == "browserless"
+    parsed = urllib.parse.urlsplit(manager._browserless_url())
+    query = urllib.parse.parse_qs(parsed.query)
+    assert parsed.hostname == "production-lon.browserless.io"
+    assert query == {"stealth": ["true"], "token": ["test-token"], "timeout": ["300000"]}
 
-    def test_browserstack_credentials_required(self):
-        """Test that BrowserStack and Browserless managers require credentials."""
-        # Clear environment variables
-        os.environ.pop("BROWSERSTACK_USERNAME", None)
-        os.environ.pop("BROWSERSTACK_ACCESS_KEY", None)
-        os.environ.pop("BROWSERLESS_API_KEY", None)
 
-        # Should raise ValueError without BrowserStack credentials
-        with pytest.raises(ValueError, match="BrowserStack credentials not found"):
-            PlaywrightBrowserManager(browser_backend="browserstack")
+def test_browserless_region_and_native_protocol(monkeypatch, browserless_env):
+    monkeypatch.setenv("BROWSERLESS_REGION", "ams")
+    manager = PlaywrightBrowserManager("browserless", browserless_protocol="playwright")
 
-        # Should raise ValueError without Browserless credentials
-        with pytest.raises(ValueError, match="Browserless API key not found"):
-            PlaywrightBrowserManager(browser_backend="browserless")
+    assert manager.browserless_endpoint == "wss://production-ams.browserless.io/chromium/playwright"
 
-        # SandboxBrowserManager uses Browserless, so should fail without Browserless credentials
-        with pytest.raises(ValueError, match="Browserless API key not found"):
-            SandboxBrowserManager()
 
-    def test_backward_compatibility(self, mock_env_vars):
-        """Test backward compatibility with use_browserstack parameter."""
-        # Using use_browserstack=True should set browser_backend to "browserstack"
-        manager = PlaywrightBrowserManager(use_browserstack=True)
-        assert manager.browser_backend == "browserstack"
+def test_browserless_does_not_force_session_timeout(browserless_env):
+    manager = PlaywrightBrowserManager("browserless")
 
-        # Using use_browserstack=False should keep default backend
-        manager = PlaywrightBrowserManager(use_browserstack=False)
-        assert manager.browser_backend == "local"
+    assert "timeout=" not in manager._browserless_url()
 
-    @pytest.mark.asyncio
-    async def test_launch_browser_interface(self, local_browser_manager, browserstack_browser_manager):
-        """Test that launch_browser has the same interface for both managers."""
-        # Mock the playwright async_playwright. launch_browser imports it lazily from
-        # playwright.async_api, so patch it at its source module.
-        with patch("playwright.async_api.async_playwright") as mock_playwright:
-            # Setup mock playwright - fix the async mock issue
-            mock_pw_instance = MagicMock()
-            mock_async_playwright = AsyncMock()
-            mock_async_playwright.start.return_value = mock_pw_instance
-            mock_playwright.return_value = mock_async_playwright
 
-            # Mock browser and page
-            mock_browser = AsyncMock()
-            mock_context = AsyncMock()
-            mock_page = AsyncMock()
+def test_browserless_token_is_redacted_from_connection_errors(browserless_env):
+    manager = PlaywrightBrowserManager("browserless")
 
-            mock_browser.new_context.return_value = mock_context
-            mock_context.new_page.return_value = mock_page
-            mock_page.url = "https://example.com"
-            mock_page.evaluate = AsyncMock()
-            mock_page.goto = AsyncMock()
-            mock_page.on = MagicMock()
+    message = manager._redact_connection_error(
+        RuntimeError("failed wss://production-sfo.browserless.io?token=test-token&timeout=1")
+    )
 
-            # For local browser
-            mock_pw_instance.chromium = MagicMock()
-            mock_pw_instance.chromium.launch = AsyncMock(return_value=mock_browser)
+    assert "test-token" not in message
+    assert "token=***" in message
 
-            # For BrowserStack browser - mock connect() instead of connect_over_cdp()
-            mock_pw_instance.chromium.connect = AsyncMock(return_value=mock_browser)
 
-            # Test local browser
-            local_result = await local_browser_manager.launch_browser("https://example.com")
-            assert local_result is not None
-            assert isinstance(local_result, str)  # Should return browser ID
+@pytest.mark.asyncio
+async def test_browserless_cdp_uses_connect_over_cdp(browserless_env):
+    manager = PlaywrightBrowserManager("browserless")
+    playwright = MagicMock()
+    playwright.chromium.connect_over_cdp = AsyncMock(return_value="browser")
 
-            # Test BrowserStack browser
-            bs_result = await browserstack_browser_manager.launch_browser("https://example.com")
-            assert bs_result is not None
-            assert isinstance(bs_result, str)  # Should return browser ID
+    result = await manager._connect(playwright)
 
-            # Verify different connection methods were used
-            mock_pw_instance.chromium.launch.assert_called_once()
-            mock_pw_instance.chromium.connect.assert_called_once()
+    assert result == "browser"
+    playwright.chromium.connect_over_cdp.assert_awaited_once()
+    playwright.chromium.connect.assert_not_called()
 
-    @pytest.mark.asyncio
-    async def test_browser_info_structure(self, local_browser_manager, browserstack_browser_manager):
-        """Test that browser info structure is identical for both managers."""
-        # Mock the playwright async_playwright. launch_browser imports it lazily from
-        # playwright.async_api, so patch it at its source module.
-        with patch("playwright.async_api.async_playwright") as mock_playwright:
-            # Setup mock playwright - fix the async mock issue
-            mock_pw_instance = MagicMock()
-            mock_async_playwright = AsyncMock()
-            mock_async_playwright.start.return_value = mock_pw_instance
-            mock_playwright.return_value = mock_async_playwright
 
-            # Mock browser and page
-            mock_browser = AsyncMock()
-            mock_context = AsyncMock()
-            mock_page = AsyncMock()
+@pytest.mark.asyncio
+async def test_browserless_native_uses_playwright_connect(browserless_env):
+    manager = PlaywrightBrowserManager("browserless", browserless_protocol="playwright")
+    playwright = MagicMock()
+    playwright.chromium.connect = AsyncMock(return_value="browser")
 
-            mock_browser.new_context.return_value = mock_context
-            mock_context.new_page.return_value = mock_page
-            mock_page.url = "https://example.com"
-            mock_page.evaluate = AsyncMock()
-            mock_page.goto = AsyncMock()
-            mock_page.on = MagicMock()
+    result = await manager._connect(playwright)
 
-            # For both browser types
-            mock_pw_instance.chromium = MagicMock()
-            mock_pw_instance.chromium.launch = AsyncMock(return_value=mock_browser)
-            mock_pw_instance.chromium.connect = AsyncMock(return_value=mock_browser)
+    assert result == "browser"
+    playwright.chromium.connect.assert_awaited_once()
+    playwright.chromium.connect_over_cdp.assert_not_called()
 
-            # Launch browsers
-            local_id = await local_browser_manager.launch_browser("https://example.com")
-            bs_id = await browserstack_browser_manager.launch_browser("https://example.com")
 
-            # Check browser info structure
-            local_info = local_browser_manager.browsers[local_id]
-            bs_info = browserstack_browser_manager.browsers[bs_id]
+def test_sandbox_manager_selects_browserless(browserless_env):
+    manager = SandboxBrowserManager(sandbox=object())
 
-            # Both should have the same keys
-            assert set(local_info.keys()) == set(bs_info.keys())
+    assert manager.browser_backend == "browserless"
+    assert manager.sandbox is not None
 
-            # Check specific fields
-            assert local_info["type"] == bs_info["type"] == "chromium"
-            assert local_info["url"] == bs_info["url"] == "https://example.com"
-            assert "playwright" in local_info and "playwright" in bs_info
-            assert "browser" in local_info and "browser" in bs_info
-            assert "context" in local_info and "context" in bs_info
-            assert "page" in local_info and "page" in bs_info
-            assert "console_logs" in local_info and "console_logs" in bs_info
-            assert "network_requests" in local_info and "network_requests" in bs_info
-            assert "launched_at" in local_info and "launched_at" in bs_info
 
-            # BrowserStack flag should be different
-            assert local_info["browserstack"] is False
-            assert bs_info["browserstack"] is True
+def test_browserstack_capabilities_do_not_leak_into_browserless(monkeypatch):
+    monkeypatch.setenv("BROWSERSTACK_USERNAME", "user")
+    monkeypatch.setenv("BROWSERSTACK_ACCESS_KEY", "key")
+    manager = PlaywrightBrowserManager("browserstack")
 
-            # Backend field should be different
-            assert local_info["backend"] == "local"
-            assert bs_info["backend"] == "browserstack"
-
-    @pytest.mark.asyncio
-    async def test_console_log_handling(self, local_browser_manager, browserstack_browser_manager):
-        """Test that console log handling is identical for both managers."""
-        # Create mock browser info with console logs
-        now = datetime.datetime.now()
-        console_logs = [
-            {
-                "type": "error",
-                "text": "Test error",
-                "timestamp": now.isoformat(),
-                "location": None,
-            }
-        ]
-
-        browser_id = "test-browser-id"
-        mock_browser_info = {
-            "console_logs": console_logs,
-            "launched_at": now.isoformat(),
-        }
-
-        # Add to both managers
-        local_browser_manager.browsers[browser_id] = mock_browser_info.copy()
-        browserstack_browser_manager.browsers[browser_id] = mock_browser_info.copy()
-
-        # Test console log retrieval
-        local_logs = await local_browser_manager.get_browser_console_logs(browser_id)
-        bs_logs = await browserstack_browser_manager.get_browser_console_logs(browser_id)
-
-        # Results should be identical
-        assert local_logs == bs_logs
-        assert local_logs["total_logs_count"] == 1
-        assert local_logs["returned_count"] == 1
-        assert local_logs["console_logs"][0]["type"] == "error"
-        assert local_logs["console_logs"][0]["text"] == "Test error"
-
-    @pytest.mark.asyncio
-    async def test_error_handling(self, local_browser_manager, browserstack_browser_manager):
-        """Test that error handling is consistent across both managers."""
-        # Test browser not found error
-        with pytest.raises(KeyError, match="Browser with ID nonexistent not found"):
-            await local_browser_manager.get_browser_console_logs("nonexistent")
-
-        with pytest.raises(KeyError, match="Browser with ID nonexistent not found"):
-            await browserstack_browser_manager.get_browser_console_logs("nonexistent")
-
-        # Test other methods with non-existent browser
-        with pytest.raises(KeyError):
-            await local_browser_manager.take_browser_screenshot("nonexistent")
-
-        with pytest.raises(KeyError):
-            await browserstack_browser_manager.take_browser_screenshot("nonexistent")
-
-    @pytest.mark.asyncio
-    async def test_sandbox_manager_inheritance(self, browserless_browser_manager, sandbox_browser_manager):
-        """Test that SandboxBrowserManager behaves as a PlaywrightBrowserManager with Browserless backend."""
-        # Check that they both use Browserless backend
-        assert browserless_browser_manager.browser_backend == "browserless"
-        assert sandbox_browser_manager.browser_backend == "browserless"
-
-        # Both managers should have browserless credentials
-        assert hasattr(browserless_browser_manager, "browserless_api_key")
-
-        # Sandbox manager should have browserless credentials
-        assert hasattr(sandbox_browser_manager, "browserless_api_key")
-
-        # SandboxBrowserManager should have its additional sandbox attribute
-        assert hasattr(sandbox_browser_manager, "sandbox")
-        assert not hasattr(browserless_browser_manager, "sandbox")
-
-    def test_cdp_url_generation(
-        self, browserstack_browser_manager, browserless_browser_manager, sandbox_browser_manager
-    ):
-        """Test that managers generate correct CDP URLs for their respective backends."""
-        # BrowserStack manager should generate BrowserStack URL
-        bs_url = browserstack_browser_manager._get_browserstack_cdp_url()
-        assert bs_url.startswith("wss://cdp.browserstack.com/playwright?caps=")
-        assert "browserstack.username" in bs_url
-        assert "browserstack.accessKey" in bs_url
-
-        # Browserless manager should generate Browserless URL
-        browserless_url = browserless_browser_manager._get_browserless_cdp_url()
-        assert browserless_url.startswith("wss://production-sfo.browserless.io?token=")
-        assert "timeout=" in browserless_url
-
-        # Sandbox manager should generate Browserless URL
-        sandbox_browserless_url = sandbox_browser_manager._get_browserless_cdp_url()
-        assert sandbox_browserless_url.startswith("wss://production-sfo.browserless.io?token=")
-        assert "timeout=" in sandbox_browserless_url
-
-    @pytest.mark.asyncio
-    async def test_list_browsers_parity(self, local_browser_manager, browserstack_browser_manager):
-        """Test that list_browsers returns the same structure for both managers."""
-        # Mock browser info
-        browser_info = {
-            "url": "https://example.com",
-            "launched_at": datetime.datetime.now().isoformat(),
-            "browserstack": False,
-            "backend": "local",
-        }
-
-        browser_id = "test-id"
-        local_browser_manager.browsers[browser_id] = {**browser_info, "browserstack": False, "backend": "local"}
-        browserstack_browser_manager.browsers[browser_id] = {
-            **browser_info,
-            "browserstack": True,
-            "backend": "browserstack",
-        }
-
-        local_list = await local_browser_manager.list_browsers()
-        bs_list = await browserstack_browser_manager.list_browsers()
-
-        # Check structure is the same
-        assert set(local_list[browser_id].keys()) == set(bs_list[browser_id].keys())
-        assert local_list[browser_id]["url"] == bs_list[browser_id]["url"]
-        assert local_list[browser_id]["launched_at"] == bs_list[browser_id]["launched_at"]
-
-        # Backend flags should be different
-        assert local_list[browser_id]["browserstack"] is False
-        assert bs_list[browser_id]["browserstack"] is True
-        assert local_list[browser_id]["backend"] == "local"
-        assert bs_list[browser_id]["backend"] == "browserstack"
-
-    @pytest.mark.asyncio
-    async def test_all_methods_available(
-        self, local_browser_manager, browserstack_browser_manager, sandbox_browser_manager
-    ):
-        """Test that all browser manager methods are available on all implementations."""
-        methods = [
-            "launch_browser",
-            "list_browsers",
-            "get_browser_console_logs",
-            "get_browser_interactive_elements",
-            "get_browser_content",
-            "take_browser_screenshot",
-            "interact_with_browser",
-            "set_select_value",
-            "close_browser",
-            "cleanup_all_browsers",
-        ]
-
-        for method in methods:
-            assert hasattr(local_browser_manager, method)
-            assert hasattr(browserstack_browser_manager, method)
-            assert hasattr(sandbox_browser_manager, method)
-
-            # All methods should be callable
-            assert callable(getattr(local_browser_manager, method))
-            assert callable(getattr(browserstack_browser_manager, method))
-            assert callable(getattr(sandbox_browser_manager, method))
+    assert manager._browserstack_url().startswith("wss://cdp.browserstack.com/playwright?caps=")

--- a/tests/agent/services/test_browser_parity.py
+++ b/tests/agent/services/test_browser_parity.py
@@ -32,6 +32,13 @@ def test_browserless_self_hosted_endpoint_does_not_require_token(monkeypatch):
     assert manager._browserless_url() == "ws://localhost:3000"
 
 
+def test_browserless_cloud_hostname_requires_domain_boundary(monkeypatch):
+    monkeypatch.delenv("BROWSERLESS_API_KEY", raising=False)
+    manager = PlaywrightBrowserManager("browserless", browserless_endpoint="wss://notbrowserless.io")
+
+    assert manager._browserless_url() == "wss://notbrowserless.io"
+
+
 def test_browserless_endpoint_preserves_query_and_adds_configured_values(browserless_env):
     manager = PlaywrightBrowserManager(
         "browserless",

--- a/tests/agent/test_agent_tools_inventory.py
+++ b/tests/agent/test_agent_tools_inventory.py
@@ -8,12 +8,14 @@ import pytest
 
 from kolega_code.agent.browseragent import BrowserAgent
 from kolega_code.agent.coder import CoderAgent
-from kolega_code.config import AgentConfig
+from kolega_code.config import AgentConfig, ModelConfig, ModelProvider
 from kolega_code.events import AgentConnectionManager
 from kolega_code.agent.generalagent import GeneralAgent
 from kolega_code.agent.investigationagent import InvestigationAgent
 from kolega_code.agent.planningagent import PlanningAgent
 from kolega_code.agent.prompt_provider import AgentMode, PromptProvider
+from kolega_code.agent.tools import ToolCollection
+from kolega_code.llm.specs import MODEL_SPECS
 
 
 INTERNAL_TOOL_NAMES = {"registry", "has_tool", "call", "cleanup", "initialize"}
@@ -104,6 +106,60 @@ def test_browser_agent_tools(project_path, mock_connection_manager, agent_config
 
     assert len(tools) == len(expected_tools)
     assert set(tool_names) == set(expected_tools)
+
+
+@pytest.mark.parametrize("use_override", [False, True], ids=["inherited", "explicit"])
+def test_browser_agent_rejects_nonvision_model_before_initialization(tmp_path, mock_connection_manager, use_override):
+    long_context = ModelConfig(
+        provider=ModelProvider.ANTHROPIC,
+        model="claude-sonnet-4-5-20250929",
+    )
+    agent_models = {}
+    if use_override:
+        agent_models["browser"] = ModelConfig(provider=ModelProvider.DEEPSEEK, model="deepseek-v4-pro")
+    else:
+        long_context = ModelConfig(provider=ModelProvider.DEEPSEEK, model="deepseek-v4-pro")
+    config = AgentConfig(
+        anthropic_api_key="anthropic-key",
+        deepseek_api_key="deepseek-key",
+        long_context_config=long_context,
+        agent_models=agent_models,
+    )
+
+    missing_project = tmp_path / "not-created"
+    with pytest.raises(
+        ValueError,
+        match=r"BrowserAgent requires a vision-capable model.*deepseek/deepseek-v4-pro",
+    ):
+        BrowserAgent(
+            project_path=missing_project,
+            workspace_id="test_workspace",
+            thread_id=str(uuid.uuid4()),
+            connection_manager=mock_connection_manager,
+            config=config,
+        )
+
+
+def test_browser_agent_treats_missing_vision_metadata_as_unsupported(tmp_path, mock_connection_manager, monkeypatch):
+    model = "test-model-without-vision-metadata"
+    monkeypatch.setitem(
+        MODEL_SPECS,
+        (ModelProvider.ANTHROPIC.value, model),
+        {"context_length": 1_000, "max_completion_tokens": 100},
+    )
+    config = AgentConfig(
+        anthropic_api_key="anthropic-key",
+        agent_models={"browser": ModelConfig(provider=ModelProvider.ANTHROPIC, model=model)},
+    )
+
+    with pytest.raises(ValueError, match=r"does not support image input"):
+        BrowserAgent(
+            project_path=tmp_path,
+            workspace_id="test_workspace",
+            thread_id=str(uuid.uuid4()),
+            connection_manager=mock_connection_manager,
+            config=config,
+        )
 
 
 def test_investigation_agent_tools(project_path, mock_connection_manager, agent_config):
@@ -199,6 +255,7 @@ def test_coder_agent_exposes_dispatch_general_agent(project_path, mock_connectio
     assert "dispatch_general_agent" in tool_names
     assert "dispatch_investigation_agent" in tool_names
     assert "dispatch_coding_agent" not in tool_names
+    assert not tool_names.intersection(ToolCollection.browser_tools)
 
 
 def test_sub_agent_coder_cannot_dispatch_general_agent(project_path, mock_connection_manager, agent_config):
@@ -240,6 +297,7 @@ def test_general_agent_tool_inventory(project_path, mock_connection_manager, age
     assert "write" in tool_names
     assert "lsp_edit" in tool_names
     assert "exec_command" in tool_names
+    assert not tool_names.intersection(ToolCollection.browser_tools)
     # Recursion guard: no dispatch tools at all
     assert not any(name.startswith("dispatch_") for name in tool_names)
 

--- a/tests/agent/test_agent_tools_inventory.py
+++ b/tests/agent/test_agent_tools_inventory.py
@@ -76,15 +76,30 @@ def test_browser_agent_tools(project_path, mock_connection_manager, agent_config
     tool_names = [tool.name for tool in tools]
 
     expected_tools = [
-        "close_browser",
-        "get_browser_console_logs",
-        "get_browser_interactive_elements",
-        "interact_with_browser",
-        "launch_browser",
-        "list_browsers",
+        "browser_click",
+        "browser_close",
+        "browser_console_messages",
+        "browser_drag",
+        "browser_drop",
+        "browser_evaluate",
+        "browser_file_upload",
+        "browser_fill_form",
+        "browser_find",
+        "browser_handle_dialog",
+        "browser_hover",
+        "browser_navigate",
+        "browser_navigate_back",
+        "browser_network_request",
+        "browser_network_requests",
+        "browser_press_key",
+        "browser_resize",
+        "browser_select_option",
+        "browser_snapshot",
+        "browser_tabs",
+        "browser_take_screenshot",
+        "browser_type",
+        "browser_wait_for",
         "read_image",
-        "set_browser_select_value",
-        "take_browser_screenshot",
     ]
 
     assert len(tools) == len(expected_tools)

--- a/tests/agent/tool_backend/test_browser_tool.py
+++ b/tests/agent/tool_backend/test_browser_tool.py
@@ -1,335 +1,159 @@
-import datetime
-import pytest
 import uuid
 from unittest.mock import AsyncMock, MagicMock
-from kolega_code.agent.tool_backend.browser_tool import BrowserTool
+
+import pytest
+
+from kolega_code.agent.tool_backend.browser_tool import BROWSER_TOOL_SCHEMAS, BrowserTool
 from kolega_code.config import AgentConfig
+from kolega_code.llm.models import ToolDefinition
+from kolega_code.services.file_system import LocalFileSystem
 
 
-class TestBrowserTool:
-    """Test suite for BrowserTool console log filtering functionality."""
-
-    @pytest.fixture
-    def mock_config(self):
-        """Create a mock agent config."""
-        return MagicMock(spec=AgentConfig)
-
-    @pytest.fixture
-    def mock_connection_manager(self):
-        """Create a mock connection manager."""
-        return AsyncMock()
-
-    @pytest.fixture
-    def mock_caller(self):
-        """Create a mock caller."""
-        caller = MagicMock()
-        caller.agent_name = "test-agent"
-        return caller
-
-    @pytest.fixture
-    def browser_tool(self, mock_config, mock_connection_manager, mock_caller):
-        """Create a browser tool instance for testing."""
-        return BrowserTool(
-            project_path="/test/path",
-            workspace_id="test-workspace",
-            thread_id=str(uuid.uuid4()),
-            connection_manager=mock_connection_manager,
-            config=mock_config,
-            caller=mock_caller,
-        )
-
-    @pytest.fixture
-    def mock_console_logs_result(self):
-        """Create mock console logs result from browser manager."""
-        return {
-            "console_logs": [
-                {
-                    "type": "error",
-                    "text": "JavaScript error occurred",
-                    "timestamp": datetime.datetime.now().isoformat(),
-                    "location": {"url": "test.js", "lineNumber": 42, "columnNumber": 10},
-                },
-                {
-                    "type": "warning",
-                    "text": "Deprecated API usage",
-                    "timestamp": datetime.datetime.now().isoformat(),
-                    "location": None,
-                },
-            ],
-            "total_logs_count": 10,
-            "returned_count": 2,
-            "filters_applied": {
-                "max_logs": 50,
-                "log_types": ["error", "warning", "assert"],
-                "minutes_back": None,
-                "max_chars": 8000,
-            },
+@pytest.fixture
+def browser_manager():
+    manager = MagicMock()
+    manager.session_id = None
+    manager.navigate = AsyncMock(
+        return_value={
+            "session_id": "session-1",
+            "url": "https://example.com",
+            "title": "Example",
+            "snapshot": '- heading "Example" [ref=e2]',
         }
+    )
+    manager.click = AsyncMock()
+    manager.screenshot = AsyncMock()
+    manager.close = AsyncMock()
+    manager.cleanup_all_browsers = AsyncMock()
+    return manager
 
-    @pytest.mark.asyncio
-    async def test_get_browser_console_logs_default_parameters(self, browser_tool, mock_console_logs_result):
-        """Test get_browser_console_logs with default parameters."""
-        browser_tool.browser_manager.get_browser_console_logs = AsyncMock(return_value=mock_console_logs_result)
 
-        result = await browser_tool.get_browser_console_logs("test-browser-id")
+@pytest.fixture
+def browser_tool(tmp_path, browser_manager):
+    caller = MagicMock()
+    caller.agent_name = "test-agent"
+    return BrowserTool(
+        project_path=tmp_path,
+        workspace_id="workspace",
+        thread_id=str(uuid.uuid4()),
+        connection_manager=AsyncMock(),
+        config=MagicMock(spec=AgentConfig),
+        caller=caller,
+        filesystem=LocalFileSystem(root_path=tmp_path),
+        browser_manager=browser_manager,
+    )
 
-        # Verify the browser manager was called with default parameters
-        browser_tool.browser_manager.get_browser_console_logs.assert_called_once_with(
-            "test-browser-id", max_logs=50, log_types=None, minutes_back=None, max_chars=8000
-        )
 
-        # Check that the result contains expected markdown formatting
-        assert "## Console Logs" in result
-        assert "**Showing 2 of 10 total logs**" in result
-        assert "**Filtered by types:** error, warning, assert" in result
-        assert "**Max logs:** 50" in result
-        assert "| Type | Timestamp | Message | Location |" in result
-        assert "| error |" in result
-        assert "| warning |" in result
-        assert "JavaScript error occurred" in result
-        assert "Deprecated API usage" in result
+@pytest.mark.asyncio
+async def test_navigate_formats_snapshot_and_broadcasts_launch(browser_tool, browser_manager):
+    result = await browser_tool.browser_navigate("https://example.com")
 
-    @pytest.mark.asyncio
-    async def test_get_browser_console_logs_custom_parameters(self, browser_tool, mock_console_logs_result):
-        """Test get_browser_console_logs with custom parameters."""
-        # Update mock result to reflect custom parameters
-        mock_console_logs_result["filters_applied"] = {
-            "max_logs": 10,
-            "log_types": ["error"],
-            "minutes_back": 5,
-            "max_chars": 1000,
+    browser_manager.navigate.assert_awaited_once_with("https://example.com")
+    assert "## Page" in result
+    assert "https://example.com" in result
+    assert "## Snapshot" in result
+    assert 'heading "Example" [ref=e2]' in result
+    browser_tool.connection_manager.broadcast_event.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_click_forwards_snake_case_options(browser_tool, browser_manager):
+    browser_manager.click.return_value = {
+        "session_id": "session-1",
+        "url": "https://example.com",
+        "title": "Example",
+        "snapshot": '- button "Saved" [ref=e3]',
+    }
+
+    await browser_tool.browser_click("e2", double_click=True, button="right", modifiers=["Shift"])
+
+    browser_manager.click.assert_awaited_once_with("e2", double_click=True, button="right", modifiers=["Shift"])
+
+
+@pytest.mark.asyncio
+async def test_file_upload_reads_only_through_workspace_filesystem(browser_tool, browser_manager, tmp_path):
+    upload = tmp_path / "avatar.txt"
+    upload.write_text("hello", encoding="utf-8")
+    browser_manager.file_upload = AsyncMock(
+        return_value={
+            "session_id": "session-1",
+            "url": "about:blank",
+            "title": "",
+            "snapshot": "- document",
         }
+    )
 
-        browser_tool.browser_manager.get_browser_console_logs = AsyncMock(return_value=mock_console_logs_result)
+    await browser_tool.browser_file_upload(["avatar.txt"])
 
-        result = await browser_tool.get_browser_console_logs(
-            "test-browser-id", max_logs=10, log_types=["error"], minutes_back=5, max_chars=1000
-        )
+    call = browser_manager.file_upload.await_args
+    assert call is not None
+    payload = call.args[0][0]
+    assert payload["name"] == "avatar.txt"
+    assert payload["buffer"] == b"hello"
 
-        # Verify the browser manager was called with custom parameters
-        browser_tool.browser_manager.get_browser_console_logs.assert_called_once_with(
-            "test-browser-id", max_logs=10, log_types=["error"], minutes_back=5, max_chars=1000
-        )
 
-        # Check that the result reflects custom filtering
-        assert "**Filtered by types:** error" in result
-        assert "**Time window:** Last 5 minutes" in result
-        assert "**Character limit:** 1000" in result
-        assert "**Max logs:** 10" in result
+@pytest.mark.asyncio
+async def test_file_upload_rejects_path_outside_workspace(browser_tool, browser_manager, tmp_path):
+    outside = tmp_path.parent / "outside.txt"
+    outside.write_text("secret", encoding="utf-8")
 
-    @pytest.mark.asyncio
-    async def test_get_browser_console_logs_no_logs(self, browser_tool):
-        """Test get_browser_console_logs when no logs are found."""
-        mock_empty_result = {
-            "console_logs": [],
-            "total_logs_count": 0,
-            "returned_count": 0,
-            "filters_applied": {
-                "max_logs": 50,
-                "log_types": ["error", "warning", "assert"],
-                "minutes_back": None,
-                "max_chars": 8000,
-            },
-        }
+    with pytest.raises(ValueError, match="outside the allowed root"):
+        await browser_tool.browser_file_upload([str(outside)])
 
-        browser_tool.browser_manager.get_browser_console_logs = AsyncMock(return_value=mock_empty_result)
+    browser_manager.file_upload.assert_not_called()
 
-        result = await browser_tool.get_browser_console_logs("test-browser-id")
 
-        assert result == "## Console Logs\n\nNo console logs found."
+@pytest.mark.asyncio
+async def test_close_is_idempotent_and_broadcasts_only_for_live_session(browser_tool, browser_manager):
+    browser_manager.close.return_value = None
+    assert await browser_tool.browser_close() == "No browser session is running."
+    browser_tool.connection_manager.broadcast_event.assert_not_awaited()
 
-    @pytest.mark.asyncio
-    async def test_get_browser_console_logs_location_formatting(self, browser_tool):
-        """Test that console log locations are formatted correctly."""
-        mock_result = {
-            "console_logs": [
-                {
-                    "type": "error",
-                    "text": "Error with location",
-                    "timestamp": datetime.datetime.now().isoformat(),
-                    "location": {"url": "test.js", "lineNumber": 42, "columnNumber": 10},
-                },
-                {
-                    "type": "warning",
-                    "text": "Warning without location",
-                    "timestamp": datetime.datetime.now().isoformat(),
-                    "location": None,
-                },
-            ],
-            "total_logs_count": 2,
-            "returned_count": 2,
-            "filters_applied": {
-                "max_logs": 50,
-                "log_types": ["error", "warning", "assert"],
-                "minutes_back": None,
-                "max_chars": 8000,
-            },
-        }
+    browser_manager.close.return_value = "session-1"
+    assert await browser_tool.browser_close() == "Browser session closed."
+    browser_tool.connection_manager.broadcast_event.assert_awaited_once()
 
-        browser_tool.browser_manager.get_browser_console_logs = AsyncMock(return_value=mock_result)
 
-        result = await browser_tool.get_browser_console_logs("test-browser-id")
+def test_browser_tool_schemas_use_snake_case_and_exclude_legacy_contract():
+    assert "double_click" in BROWSER_TOOL_SCHEMAS["browser_click"]["properties"]
+    assert "full_page" in BROWSER_TOOL_SCHEMAS["browser_take_screenshot"]["properties"]
+    assert "text_gone" in BROWSER_TOOL_SCHEMAS["browser_wait_for"]["properties"]
+    assert "doubleClick" not in BROWSER_TOOL_SCHEMAS["browser_click"]["properties"]
 
-        # Check location formatting
-        assert "test.js:42:10" in result  # Formatted location
-        assert "N/A" in result  # No location case
+    legacy = {
+        "launch_browser",
+        "list_browsers",
+        "get_browser_content",
+        "get_browser_interactive_elements",
+        "interact_with_browser",
+        "set_browser_select_value",
+        "close_browser",
+    }
+    assert legacy.isdisjoint(BROWSER_TOOL_SCHEMAS)
 
-    @pytest.mark.asyncio
-    async def test_get_browser_console_logs_escapes_pipe_characters(self, browser_tool):
-        """Test that pipe characters in log messages are escaped for markdown tables."""
-        mock_result = {
-            "console_logs": [
-                {
-                    "type": "error",
-                    "text": "Error with | pipe character",
-                    "timestamp": datetime.datetime.now().isoformat(),
-                    "location": None,
-                },
-            ],
-            "total_logs_count": 1,
-            "returned_count": 1,
-            "filters_applied": {
-                "max_logs": 50,
-                "log_types": ["error", "warning", "assert"],
-                "minutes_back": None,
-                "max_chars": 8000,
-            },
-        }
 
-        browser_tool.browser_manager.get_browser_console_logs = AsyncMock(return_value=mock_result)
+def test_browser_schema_enums_serialize_for_google():
+    definition = ToolDefinition(
+        name="browser_click",
+        description="Click",
+        parameters=[],
+        input_schema=BROWSER_TOOL_SCHEMAS["browser_click"],
+    )
 
-        result = await browser_tool.get_browser_console_logs("test-browser-id")
+    declarations = definition.to_google().function_declarations
+    assert declarations is not None
+    parameters = declarations[0].parameters
+    assert parameters is not None
+    assert parameters.properties is not None
+    button = parameters.properties["button"]
+    modifiers = parameters.properties["modifiers"]
+    assert modifiers.items is not None
 
-        # Check that pipe character is escaped
-        assert "Error with \\| pipe character" in result
-
-    @pytest.mark.asyncio
-    async def test_get_browser_content_with_console_log_filtering(self, browser_tool):
-        """Test get_browser_content with console log filtering."""
-        mock_content_result = {
-            "current_url": "https://example.com",
-            "title": "Test Page",
-            "html": "<html><body>Test</body></html>",
-            "console_logs": [
-                {
-                    "type": "error",
-                    "text": "JavaScript error",
-                    "timestamp": datetime.datetime.now().isoformat(),
-                    "location": None,
-                },
-            ],
-            "console_log_metadata": {
-                "total_logs_count": 5,
-                "returned_count": 1,
-                "filters_applied": {"max_logs": 10, "log_types": ["error"], "minutes_back": None, "max_chars": 1000},
-            },
-        }
-
-        browser_tool.browser_manager.get_browser_content = AsyncMock(return_value=mock_content_result)
-
-        result = await browser_tool.get_browser_content(
-            "test-browser-id", max_logs=10, log_types=["error"], max_chars=1000
-        )
-
-        # Verify the browser manager was called with filtering parameters
-        browser_tool.browser_manager.get_browser_content.assert_called_once_with(
-            "test-browser-id", max_logs=10, log_types=["error"], minutes_back=None, max_chars=1000
-        )
-
-        # Check that the result contains expected content
-        assert "# Browser Content: Test Page" in result
-        assert "**Current URL:** https://example.com" in result
-        assert "## Console Logs" in result
-        assert "**Showing 1 of 5 total logs**" in result
-        assert "**Filtered by types:** error" in result
-        assert "**Character limit:** 1000" in result
-        assert "**Max logs:** 10" in result
-        assert "## Page HTML" in result
-        assert "<html><body>Test</body></html>" in result
-
-    @pytest.mark.asyncio
-    async def test_get_browser_content_no_console_logs(self, browser_tool):
-        """Test get_browser_content when there are no console logs."""
-        mock_content_result = {
-            "current_url": "https://example.com",
-            "title": "Test Page",
-            "html": "<html><body>Test</body></html>",
-            "console_logs": [],
-            "console_log_metadata": {
-                "total_logs_count": 0,
-                "returned_count": 0,
-                "filters_applied": {
-                    "max_logs": 50,
-                    "log_types": ["error", "warning", "assert"],
-                    "minutes_back": None,
-                    "max_chars": 8000,
-                },
-            },
-        }
-
-        browser_tool.browser_manager.get_browser_content = AsyncMock(return_value=mock_content_result)
-
-        result = await browser_tool.get_browser_content("test-browser-id")
-
-        # Should not contain console logs section when there are no logs
-        assert "# Browser Content: Test Page" in result
-        assert "**Current URL:** https://example.com" in result
-        assert "## Console Logs" not in result
-        assert "## Page HTML" in result
-
-    @pytest.mark.asyncio
-    async def test_get_browser_content_truncates_large_html(self, browser_tool):
-        mock_content_result = {
-            "current_url": "https://example.com",
-            "title": "Large Page",
-            "html": "a" * 100_050,
-            "console_logs": [],
-            "console_log_metadata": {
-                "total_logs_count": 0,
-                "returned_count": 0,
-                "filters_applied": {
-                    "max_logs": 50,
-                    "log_types": ["error", "warning", "assert"],
-                    "minutes_back": None,
-                    "max_chars": 8000,
-                },
-            },
-        }
-
-        browser_tool.browser_manager.get_browser_content = AsyncMock(return_value=mock_content_result)
-
-        result = await browser_tool.get_browser_content("test-browser-id")
-
-        assert "HTML truncated by size: Showing first 100,000 of 100,050 characters" in result
-        html_content = result.split("```html\n", 1)[1].rsplit("\n```", 1)[0]
-        assert len(html_content) == 100_000
-
-    @pytest.mark.asyncio
-    async def test_get_browser_content_without_metadata(self, browser_tool):
-        """Test get_browser_content when console_log_metadata is missing."""
-        mock_content_result = {
-            "current_url": "https://example.com",
-            "title": "Test Page",
-            "html": "<html><body>Test</body></html>",
-            "console_logs": [
-                {
-                    "type": "error",
-                    "text": "JavaScript error",
-                    "timestamp": datetime.datetime.now().isoformat(),
-                    "location": None,
-                },
-            ],
-            # Missing console_log_metadata
-        }
-
-        browser_tool.browser_manager.get_browser_content = AsyncMock(return_value=mock_content_result)
-
-        result = await browser_tool.get_browser_content("test-browser-id")
-
-        # Should still work without metadata
-        assert "# Browser Content: Test Page" in result
-        assert "## Console Logs" in result
-        assert "JavaScript error" in result
-        # Should not contain metadata information
-        assert "**Showing" not in result
-        assert "**Filtered by types:**" not in result
+    assert button.enum == ["left", "right", "middle"]
+    assert modifiers.items.enum == [
+        "Alt",
+        "Control",
+        "ControlOrMeta",
+        "Meta",
+        "Shift",
+    ]

--- a/tests/agent/tool_backend/test_browser_tool.py
+++ b/tests/agent/tool_backend/test_browser_tool.py
@@ -49,10 +49,18 @@ async def test_navigate_formats_snapshot_and_broadcasts_launch(browser_tool, bro
     result = await browser_tool.browser_navigate("https://example.com")
 
     browser_manager.navigate.assert_awaited_once_with("https://example.com")
-    assert "## Page" in result
-    assert "https://example.com" in result
-    assert "## Snapshot" in result
-    assert 'heading "Example" [ref=e2]' in result
+    assert result == "\n".join(
+        [
+            "## Page",
+            "- URL: https://example.com",
+            "- Title: Example",
+            "",
+            "## Snapshot",
+            "```yaml",
+            '- heading "Example" [ref=e2]',
+            "```",
+        ]
+    )
     browser_tool.connection_manager.broadcast_event.assert_awaited_once()
 
 

--- a/tests/cli/test_app_bootstrap_settings.py
+++ b/tests/cli/test_app_bootstrap_settings.py
@@ -806,3 +806,92 @@ async def test_agent_models_section_populates_and_clears_to_inherit(
         await app._save_settings_from_ui()
 
         assert settings_store.load().get_agent_model("investigation") is None
+
+
+@pytest.mark.asyncio
+async def test_browser_model_settings_preserve_and_reject_nonvision_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.widgets import Select, Static
+
+    from kolega_code.cli.app import KolegaCodeApp
+
+    install_fake_agents(monkeypatch)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    state_dir = tmp_path / "state"
+    store = SessionStore(state_dir)
+    settings_store = SettingsStore(state_dir)
+    settings = CliSettings(active_provider=UI_DEFAULT_PROVIDER, active_model=UI_DEFAULT_MODEL)
+    settings.set_api_key(UI_DEFAULT_PROVIDER, "moonshot-key")
+    settings.set_api_key(ModelProvider.DEEPSEEK.value, "deepseek-key")
+    settings.set_agent_model("browser", ModelProvider.DEEPSEEK.value, DEEPSEEK_DEFAULT_MODEL)
+    settings_store.save(settings)
+    session = store.create(project, "code", {})
+    app = KolegaCodeApp(
+        project_path=project,
+        mode="code",
+        store=store,
+        settings_store=settings_store,
+        session=session,
+    )
+
+    async with app.run_test():
+        assert app.query_one("#am_provider_browser", Select).value == ModelProvider.DEEPSEEK.value
+        assert app.query_one("#am_model_browser", Select).value == DEEPSEEK_DEFAULT_MODEL
+        assert "does not support vision" in str(app.query_one("#am_status_browser", Static).render())
+
+        await app._save_settings_from_ui()
+
+        saved = settings_store.load().get_agent_model("browser")
+        assert saved is not None
+        assert saved["provider"] == ModelProvider.DEEPSEEK.value
+        assert saved["model"] == DEEPSEEK_DEFAULT_MODEL
+        assert "does not support vision" in str(app.query_one("#settings_status", Static).render())
+
+
+@pytest.mark.asyncio
+async def test_browser_model_settings_allow_nonvision_inheritance_with_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.widgets import Select, Static
+
+    from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.cli.provider_registry import INHERIT_SENTINEL
+
+    install_fake_agents(monkeypatch)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    state_dir = tmp_path / "state"
+    store = SessionStore(state_dir)
+    settings_store = SettingsStore(state_dir)
+    settings = CliSettings(
+        active_provider=ModelProvider.DEEPSEEK.value,
+        active_model=DEEPSEEK_DEFAULT_MODEL,
+    )
+    settings.set_api_key(ModelProvider.DEEPSEEK.value, "deepseek-key")
+    settings_store.save(settings)
+    session = store.create(project, "code", {})
+    app = KolegaCodeApp(
+        project_path=project,
+        mode="code",
+        store=store,
+        settings_store=settings_store,
+        session=session,
+    )
+
+    async with app.run_test():
+        assert app.query_one("#am_provider_browser", Select).value == INHERIT_SENTINEL
+        hint = str(app.query_one("#am_status_browser", Static).render())
+        assert "Browser agent is unavailable" in hint
+        assert "does not support vision" in hint
+
+        await app._save_settings_from_ui()
+
+        assert settings_store.load().get_agent_model("browser") is None

--- a/tests/cli/test_provider_registry.py
+++ b/tests/cli/test_provider_registry.py
@@ -20,6 +20,16 @@ def test_fireworks_default_model_is_glm_52():
     assert default_model_for_provider(ModelProvider.FIREWORKS) == "accounts/fireworks/models/glm-5p2"
 
 
+def test_vision_only_model_options_follow_catalog_capabilities():
+    fireworks = dict(ui_model_options("fireworks", vision_only=True))
+
+    assert fireworks == {
+        "Kimi K2.7 Code": "accounts/fireworks/models/kimi-k2p7-code",
+        "MiniMax M3": "accounts/fireworks/models/minimax-m3",
+    }
+    assert ui_model_options("deepseek", vision_only=True) == []
+
+
 def test_ollama_cloud_smoke_model_is_available_without_live_call():
     options = dict(ui_model_options("ollama_cloud"))
 


### PR DESCRIPTION
## Summary

- replace the browser-ID/overloaded interaction API with an implicit browser session and atomic `browser_*` tools
- use Playwright accessibility snapshots and stable element refs for subsequent actions
- add tabs/popups, dialogs, file choosers, forms, drag-and-drop, console/network inspection, screenshots, and evaluation
- support Browserless through CDP or the native Playwright protocol, including cloud regions, custom/self-hosted endpoints, timeouts, and secret-safe errors
- update the browser-agent prompt, provider schema conversion, documentation, and tests for the new hard-cutover API

## Backend selection

Backend selection remains host-driven. Local callers use `PlaywrightBrowserManager()`; sandbox deployments inject `SandboxBrowserManager`, which selects `browser_backend="browserless"`. Direct integrations can use `PlaywrightBrowserManager("browserless")`. Browserless environment variables configure the remote connection but do not silently change a local manager into a remote one.

Browserless uses CDP by default. Set `BROWSERLESS_PROTOCOL=playwright` for the native Playwright endpoint. Cloud region, custom/self-hosted WebSocket endpoint, and session timeout are configurable.

## Migration

This is intentionally a hard cutover. The old browser IDs and overloaded legacy tool shapes are removed; there are no compatibility shims.

## Validation

- `uv run pytest -q` — 2001 passed
- `uv run ruff check` — passed
- `uv run pyright` — passed with zero errors
- docs `npm run build` — passed
- all 23 browser tool schemas serialized successfully for Google
- live Browserless integration exercised snapshot, action, and screenshot behavior
