### PR TITLE
Prevent filesystem scan hangs

### DIFF
--- a/kolega_code/agent/tool_backend/glob_tool.py
+++ b/kolega_code/agent/tool_backend/glob_tool.py
@@ -1,12 +1,61 @@
+import asyncio
+import os
+import shutil
+import time
+from dataclasses import dataclass
 from datetime import datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import List, Tuple, Literal
 import shlex
+
+from kolega_code.services.workspace_scan import ScanLimits, compile_workspace_glob, scan_workspace
 
 from .base_tool import BaseTool
 
 FileType = Literal["f", "d"]
 FileRow = Tuple[str, FileType, int, int]  # (path, type, size_bytes, mtime_epoch)
+
+_BROAD_ROOT_EXCLUDE_DIRS = {
+    ".Trash",
+    ".cache",
+    ".cargo",
+    ".conda",
+    ".docker",
+    ".dropbox",
+    ".gem",
+    ".local",
+    ".npm",
+    ".nuget",
+    ".nvm",
+    ".pyenv",
+    ".rustup",
+    ".wine",
+    "Applications",
+    "Applications (Parallels)",
+    "Caches",
+    "CloudStorage",
+    "Containers",
+    "Developer",
+    "Group Containers",
+    "Metadata",
+    "Mobile Documents",
+    "Movies",
+    "Music",
+    "Parallels",
+    "Pictures",
+    "calibre_library",
+    "models",
+}
+
+
+@dataclass
+class GlobSearchResult:
+    rows: List[FileRow]
+    observed_items: int
+    complete: bool
+    stop_reason: str | None = None
+    visited_entries: int = 0
+    elapsed_seconds: float = 0.0
 
 
 class GlobTool(BaseTool):
@@ -93,18 +142,22 @@ class GlobTool(BaseTool):
             normalized_pattern = self._normalize_pattern(pattern)
 
             if hasattr(self.filesystem, "sandbox"):
-                rows, total_items, reached_limit = await self._search_files_sandbox(
-                    normalized_pattern, include_directories, self.MAX_RESULTS
-                )
+                search = await self._search_files_sandbox(normalized_pattern, include_directories, self.MAX_RESULTS)
             else:
-                rows, total_items, reached_limit = await self._search_files_local(
-                    normalized_pattern, include_directories, self.MAX_RESULTS
+                search = await self._search_files_local(normalized_pattern, include_directories, self.MAX_RESULTS)
+
+            if not search.complete:
+                await self.log_warning(
+                    "File scan stopped before completion "
+                    f"(reason={search.stop_reason}, visited={search.visited_entries}, "
+                    f"elapsed={search.elapsed_seconds:.2f}s)",
+                    sender=self.caller.agent_name,
                 )
 
-            if total_items == 0:
+            if search.observed_items == 0 and search.complete:
                 return f"No files found matching pattern: '{normalized_pattern}'"
 
-            return self._format_results(rows, total_items, reached_limit, show_details, normalized_pattern)
+            return self._format_results(search, show_details, normalized_pattern)
 
         except Exception as e:
             error_msg = f"Error finding files: {str(e)}"
@@ -120,63 +173,189 @@ class GlobTool(BaseTool):
             p = f"**/{p}"
         return p
 
-    async def _search_files_local(
+    @staticmethod
+    def _is_broad_local_root(root: Path) -> bool:
+        resolved = root.expanduser().resolve()
+        return resolved == Path.home().resolve() or resolved == Path(resolved.anchor)
+
+    def _search_exclude_dirs(self, root: Path) -> set[str]:
+        excluded = set(self.EXCLUDE_DIRS)
+        if self._is_broad_local_root(root):
+            excluded.update(_BROAD_ROOT_EXCLUDE_DIRS)
+        return excluded
+
+    @staticmethod
+    def _find_scope(pattern: str) -> tuple[str, bool]:
+        """Return the fixed start directory and whether traversal is recursive."""
+        parts = PurePosixPath(pattern.replace("\\", "/").lstrip("/")).parts
+        fixed: list[str] = []
+        for part in parts:
+            if any(character in part for character in ("*", "?", "[")):
+                break
+            fixed.append(part)
+        if len(fixed) == len(parts) and fixed:
+            fixed.pop()
+        start = "./" + "/".join(fixed) if fixed else "."
+        return start, "**" in parts
+
+    async def _search_files_local(self, pattern: str, include_directories: bool, limit: int) -> GlobSearchResult:
+        if os.name != "nt" and shutil.which("find") is not None:
+            return await self._search_files_local_process(pattern, include_directories, limit)
+
+        # Windows/no-find fallback: still off-loop and cancellable, with generous
+        # emergency bounds rather than an ordinary-result correctness cutoff.
+        root = Path(getattr(self.filesystem, "root_path", self.project_path))
+        outcome = await scan_workspace(
+            root,
+            pattern=pattern,
+            include_files=True,
+            include_directories=include_directories,
+            exclude_directories=frozenset(self.EXCLUDE_DIRS),
+            binary_extensions=frozenset(self.BINARY_EXTENSIONS),
+            max_file_size=self.MAX_FILE_SIZE_BYTES,
+            limits=ScanLimits(
+                timeout_seconds=300.0,
+                max_entries=5_000_000,
+                max_results=limit + 1,
+            ),
+        )
+        rows: List[FileRow] = [
+            (path.path, "d" if path.is_dir else "f", path.size, path.modified_time) for path in outcome.paths[:limit]
+        ]
+        return GlobSearchResult(
+            rows=rows,
+            observed_items=len(outcome.paths),
+            complete=outcome.complete,
+            stop_reason=outcome.stop_reason,
+            visited_entries=outcome.visited_entries,
+            elapsed_seconds=outcome.elapsed_seconds,
+        )
+
+    async def _search_files_local_process(
         self, pattern: str, include_directories: bool, limit: int
-    ) -> Tuple[List[FileRow], int, bool]:
-        matched_paths = self.filesystem.glob(pattern)
+    ) -> GlobSearchResult:
+        """Search with a cancellable subprocess so traversal never blocks Textual."""
+        root = Path(getattr(self.filesystem, "root_path", self.project_path))
+        excluded = sorted(self._search_exclude_dirs(root))
+        start_path, recursive = self._find_scope(pattern)
+        if not (root / start_path).exists():
+            return GlobSearchResult([], 0, True)
+        args = ["find", start_path]
+        if not recursive:
+            args.extend(["-maxdepth", "1"])
+        if excluded:
+            args.append("(")
+            for index, directory in enumerate(excluded):
+                if index:
+                    args.append("-o")
+                args.extend(["-name", directory])
+            args.extend([")", "-type", "d", "-prune", "-o"])
+        basename_pattern = pattern.replace("\\", "/").rsplit("/", 1)[-1] or "*"
+        args.extend(["-name", basename_pattern, "-print0"])
 
-        filtered: List[FileRow] = []
-        total_items = 0
-
-        for rel_path in sorted(matched_paths):
-            is_file = self.filesystem.is_file(rel_path)
-            is_dir = self.filesystem.is_directory(rel_path)
-
-            if not include_directories and not is_file:
-                continue
-
-            # Exclude by directory names
-            parts = Path(rel_path).parts
-            if any(part in self.EXCLUDE_DIRS for part in parts):
-                continue
-
-            if is_file:
-                # Exclude by extension
-                if Path(rel_path).suffix.lower() in self.BINARY_EXTENSIONS:
+        matcher = compile_workspace_glob(pattern)
+        started = time.monotonic()
+        proc = await asyncio.create_subprocess_exec(
+            *args,
+            cwd=root,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        assert proc.stdout is not None
+        rows: List[FileRow] = []
+        observed = 0
+        try:
+            while True:
+                try:
+                    raw_path = await proc.stdout.readuntil(b"\0")
+                except asyncio.IncompleteReadError:
+                    break
+                relative = raw_path[:-1].decode("utf-8", "surrogateescape")
+                if relative.startswith("./"):
+                    relative = relative[2:]
+                if not relative:
                     continue
 
-                # Exclude by size and collect size/mtime
-                try:
-                    stat_info = self.filesystem.stat(rel_path)
-                    size = int(stat_info.get("size", 0))
-                    if size > self.MAX_FILE_SIZE_BYTES:
-                        continue
-                    mtime = int(stat_info.get("modified_time", 0))
-                except Exception:
-                    # If stat fails, skip file
+                row = self._local_file_row(root, relative, include_directories, matcher)
+                if row is None:
                     continue
 
-                row: FileRow = (rel_path, "f", size, mtime)
-            elif is_dir and include_directories:
+                observed += 1
+                if len(rows) < limit:
+                    rows.append(row)
+                if observed > limit:
+                    await self._stop_local_find_process(proc)
+                    return GlobSearchResult(
+                        rows,
+                        observed,
+                        False,
+                        "result_limit",
+                        elapsed_seconds=time.monotonic() - started,
+                    )
+
+            return_code = await proc.wait()
+        except asyncio.CancelledError:
+            await self._stop_local_find_process(proc)
+            raise
+
+        return GlobSearchResult(
+            rows,
+            observed,
+            return_code == 0,
+            None if return_code == 0 else "command_error",
+            elapsed_seconds=time.monotonic() - started,
+        )
+
+    def _local_file_row(self, root: Path, relative: str, include_directories: bool, matcher) -> FileRow | None:
+        full_path = root / relative
+        try:
+            is_directory = full_path.is_dir()
+            is_file = full_path.is_file()
+        except OSError:
+            return None
+        candidate = relative + "/" if is_directory else relative
+        if not matcher.match_file(candidate):
+            return None
+        if is_directory:
+            if not include_directories:
+                return None
+            try:
+                modified_time = int(full_path.stat().st_mtime)
+            except OSError:
+                modified_time = 0
+            return (relative, "d", 0, modified_time)
+        if is_file:
+            if full_path.suffix.lower() in self.BINARY_EXTENSIONS:
+                return None
+            try:
+                stat_result = full_path.stat()
+            except OSError:
+                return None
+            if stat_result.st_size > self.MAX_FILE_SIZE_BYTES:
+                return None
+            return (relative, "f", int(stat_result.st_size), int(stat_result.st_mtime))
+        return None
+
+    @staticmethod
+    async def _stop_local_find_process(proc: asyncio.subprocess.Process) -> None:
+        if proc.returncode is not None:
+            return
+        try:
+            proc.terminate()
+            await asyncio.wait_for(proc.wait(), timeout=1.0)
+        except (ProcessLookupError, asyncio.TimeoutError):
+            if proc.returncode is None:
                 try:
-                    stat_info = self.filesystem.stat(rel_path)
-                    mtime = int(stat_info.get("modified_time", 0))
-                except Exception:
-                    mtime = 0
-                row = (rel_path, "d", 0, mtime)
-            else:
-                continue
+                    proc.kill()
+                except ProcessLookupError:
+                    return
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=1.0)
+                except asyncio.TimeoutError:
+                    pass
 
-            total_items += 1
-            if len(filtered) < limit:
-                filtered.append(row)
-
-        reached_limit = total_items > limit
-        return filtered, total_items, reached_limit
-
-    async def _search_files_sandbox(
-        self, pattern: str, include_directories: bool, limit: int
-    ) -> Tuple[List[FileRow], int, bool]:
+    async def _search_files_sandbox(self, pattern: str, include_directories: bool, limit: int) -> GlobSearchResult:
         root = shlex.quote(getattr(self.filesystem, "root_path", "."))
         include_flag = "1" if include_directories else "0"
 
@@ -190,6 +369,7 @@ cd {root}
 
 pattern={shlex.quote(pattern)}
 max_results={limit}
+scan_limit=$((max_results + 1))
 include_dirs={include_flag}
 
 run_find() {{
@@ -211,35 +391,47 @@ run_find() {{
   esac
 }}
 
-matches=$(run_find | sed "s#^\\./##" | sort)
-total_items=$(printf "%s\\n" "$matches" | sed "/^$/d" | wc -l | tr -d " ")
-limited=$(printf "%s\\n" "$matches" | sed "/^$/d" | head -n "$max_results")
-
 # Emit TSV: path \t type(f|d) \t size(bytes) \t mtime(epoch)
+total_items=0
 while IFS= read -r p; do
   [[ -z "$p" ]] && continue
   if [[ -f "$p" ]]; then
     sz=$(stat -c %s "$p" 2>/dev/null || echo 0)
+    [[ "$sz" -gt {self.MAX_FILE_SIZE_BYTES} ]] && continue
+    case "${{p##*.}}" in
+      pyc|so|dll|exe|bin|jar|war|jpg|jpeg|png|gif|bmp|ico|svg|pdf|zip|tar|gz|tgz|rar|7z|mp3|mp4|avi|mov|mkv|wav|o|obj|class|binary|wasm|node) continue;;
+    esac
     mt=$(stat -c %Y "$p" 2>/dev/null || echo 0)
     printf "%s\tf\t%s\t%s\n" "$p" "$sz" "$mt"
   elif [[ -d "$p" ]] && [[ "$include_dirs" == "1" ]]; then
     mt=$(stat -c %Y "$p" 2>/dev/null || echo 0)
     printf "%s\td\t0\t%s\n" "$p" "$mt"
+  else
+    continue
   fi
-done <<< "$limited"
+  total_items=$((total_items + 1))
+  [[ "$total_items" -ge "$scan_limit" ]] && break
+done < <(run_find | sed "s#^\\./##")
 
 echo "__TOTAL__ $total_items"
+if [[ "$total_items" -ge "$scan_limit" ]]; then
+  echo "__COMPLETE__ 0 result_limit"
+else
+  echo "__COMPLETE__ 1"
+fi
 '"""
 
         sandbox = getattr(self.filesystem, "sandbox", None)
         assert sandbox is not None, "sandbox filesystem required for _search_files_sandbox"
-        result = await sandbox.commands.run(script)
+        result = await sandbox.commands.run(script, timeout=0)
         if result.exit_code != 0:
-            return [], 0, False
+            return GlobSearchResult([], 0, False, "command_error")
 
         lines = [ln for ln in (result.stdout or "").splitlines() if ln.strip()]
         rows: List[FileRow] = []
         total_items = 0
+        complete = True
+        stop_reason = None
 
         for ln in lines:
             if ln.startswith("__TOTAL__ "):
@@ -247,6 +439,11 @@ echo "__TOTAL__ $total_items"
                     total_items = int(ln.split()[-1])
                 except Exception:
                     total_items = len(rows)
+                continue
+            if ln.startswith("__COMPLETE__ "):
+                fields = ln.split()
+                complete = len(fields) >= 2 and fields[1] == "1"
+                stop_reason = fields[2] if len(fields) >= 3 else None
                 continue
             parts = ln.split("\t")
             if len(parts) != 4:
@@ -264,21 +461,32 @@ echo "__TOTAL__ $total_items"
                     continue
             rows.append((path_str, "f" if type_str == "f" else "d", int(size_str or "0"), int(float(mtime_str or "0"))))
 
-        reached_limit = total_items > limit
-        return rows, total_items, reached_limit
+        return GlobSearchResult(
+            rows=rows[:limit],
+            observed_items=total_items,
+            complete=complete,
+            stop_reason=stop_reason,
+            elapsed_seconds=0.0,
+        )
 
-    def _format_results(
-        self, rows: List[FileRow], total_items: int, reached_limit: bool, show_details: bool, pattern: str
-    ) -> str:
+    def _format_results(self, search: GlobSearchResult, show_details: bool, pattern: str) -> str:
         results: List[str] = [f"# Files Matching '{pattern}'"]
-        if reached_limit:
-            results.append(f"\nFound {total_items} matching items (showing first {self.MAX_RESULTS})\n")
-            results.append(f"⚠️ **Note:** Displaying only the first {self.MAX_RESULTS} of {total_items} results.\n")
+        if search.stop_reason == "result_limit":
+            results.append(
+                f"\nFound at least {search.observed_items} matching items (showing first {self.MAX_RESULTS})\n"
+            )
+            results.append(f"⚠️ **Note:** Search stopped after collecting the first {self.MAX_RESULTS} results.\n")
+        elif not search.complete:
+            results.append(f"\nFound {search.observed_items} matching items before the search stopped\n")
+            results.append(
+                f"⚠️ **Incomplete search:** stopped because of {search.stop_reason or 'a scan limit'}. "
+                "Narrow the pattern or project root for exhaustive results.\n"
+            )
         else:
-            results.append(f"\nFound {total_items} matching items\n")
+            results.append(f"\nFound {search.observed_items} matching items\n")
 
         by_directory: dict[str, List[FileRow]] = {}
-        for path_str, ftype, size_bytes, mtime_epoch in rows:
+        for path_str, ftype, size_bytes, mtime_epoch in search.rows:
             parent = self.filesystem.get_parent(path_str) or ""
             by_directory.setdefault(parent, []).append((path_str, ftype, size_bytes, mtime_epoch))
 

--- a/kolega_code/agent/tool_backend/search_codebase_tool.py
+++ b/kolega_code/agent/tool_backend/search_codebase_tool.py
@@ -4,9 +4,14 @@ import os
 import re
 import shlex
 import shutil
+import threading
+import time
 from base64 import b64decode
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, List, Optional, Tuple, cast
+
+from kolega_code.services.workspace_scan import ScanLimits, ScanOutcome, scan_workspace
 
 from .base_tool import BaseTool
 
@@ -20,6 +25,20 @@ _MAX_FILES = 128
 _MAX_LINES_PER_FILE = 5
 _MAX_LINE_LENGTH = 200
 _MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
+_SEARCH_TIMEOUT_SECONDS = 60.0
+_SCAN_TIMEOUT_SECONDS = 30.0
+_SCAN_MAX_ENTRIES = 500_000
+_BROAD_ROOT_EXCLUDE_DIRS = {
+    "Applications",
+    "Applications (Parallels)",
+    "Library",
+    "Movies",
+    "Music",
+    "Parallels",
+    "Pictures",
+    "calibre_library",
+    "models",
+}
 
 
 class _EngineUnavailable(Exception):
@@ -27,9 +46,22 @@ class _EngineUnavailable(Exception):
     flag, non-regex error) so the caller falls back to the next engine tier."""
 
 
+class _SearchTimedOut(Exception):
+    """Raised when an otherwise valid search exceeds its execution budget."""
+
+
 # One normalized match line, shared currency between every engine and the formatter.
 # (relative_path, line_number, raw_line_text)
 Record = Tuple[str, int, str]
+
+
+@dataclass
+class SearchRun:
+    records: List[Record]
+    complete: bool = True
+    stop_reason: Optional[str] = None
+    visited_entries: int = 0
+    elapsed_seconds: float = 0.0
 
 
 class SearchCodebaseTool(BaseTool):
@@ -103,6 +135,18 @@ class SearchCodebaseTool(BaseTool):
         """The sandbox handle (only present on sandbox filesystems)."""
         return cast(Any, self.filesystem).sandbox
 
+    def _is_broad_local_root(self) -> bool:
+        if hasattr(self.filesystem, "sandbox"):
+            return False
+        root = Path(self._fs_root).expanduser().resolve()
+        return root == Path.home().resolve() or root == Path(root.anchor)
+
+    def _search_exclude_dirs(self) -> set[str]:
+        excluded = set(self.EXCLUDE_DIRS)
+        if self._is_broad_local_root():
+            excluded.update(_BROAD_ROOT_EXCLUDE_DIRS)
+        return excluded
+
     async def search_codebase(
         self, pattern: str, file_pattern: str = "*", case_sensitive: bool = False, literal: bool = False
     ) -> str:
@@ -151,10 +195,19 @@ class SearchCodebaseTool(BaseTool):
             # Run the first available engine; fall back down the tiers on failure.
             for runner in await self._engine_chain():
                 try:
-                    records = await runner(pattern, file_pattern, case_sensitive, literal, regex)
+                    run = await runner(pattern, file_pattern, case_sensitive, literal, regex)
                 except _EngineUnavailable:
                     continue
-                return self._format_results(records, pattern)
+                except _SearchTimedOut:
+                    run = SearchRun([], complete=False, stop_reason="deadline", elapsed_seconds=_SEARCH_TIMEOUT_SECONDS)
+                if not run.complete:
+                    await self.log_warning(
+                        "Code search stopped before completion "
+                        f"(reason={run.stop_reason}, visited={run.visited_entries}, "
+                        f"elapsed={run.elapsed_seconds:.2f}s)",
+                        sender=self.caller.agent_name,
+                    )
+                return self._format_results(run, pattern)
 
             # The Python tier never raises _EngineUnavailable, so this is unreachable.
             return f"No matches found for pattern '{pattern}'"
@@ -210,7 +263,6 @@ class SearchCodebaseTool(BaseTool):
     def _rg_args(self, pattern: str, file_pattern: str, case_sensitive: bool, literal: bool) -> List[str]:
         args = [
             "--json",
-            "--hidden",
             "--no-config",
             "--no-ignore-parent",
             "--no-ignore-global",
@@ -218,12 +270,18 @@ class SearchCodebaseTool(BaseTool):
             "--max-filesize",
             "10M",
         ]
+        # Hidden project files matter for a normal repository. At a home/filesystem
+        # root, however, --hidden expands the search into package caches and tool
+        # state that dwarf the user's source trees. Keep broad-root search useful by
+        # searching visible workspaces and pruning platform data directories.
+        if not self._is_broad_local_root():
+            args.append("--hidden")
         if not case_sensitive:
             args.append("-i")
         if literal:
             args.append("-F")
         # --hidden re-includes .git etc., so explicitly re-exclude the dirs.
-        for exclude_dir in sorted(self.EXCLUDE_DIRS):
+        for exclude_dir in sorted(self._search_exclude_dirs()):
             args += ["-g", f"!{exclude_dir}/"]
         # Also drop a *file* literally named .env (the glob above only excludes dirs).
         args += ["-g", "!.env"]
@@ -240,7 +298,7 @@ class SearchCodebaseTool(BaseTool):
 
     async def _run_rg_local(
         self, pattern: str, file_pattern: str, case_sensitive: bool, literal: bool, regex
-    ) -> List[Record]:
+    ) -> SearchRun:
         if shutil.which("rg") is None:
             raise _EngineUnavailable()
         args = self._rg_args(pattern, file_pattern, case_sensitive, literal)
@@ -255,29 +313,36 @@ class SearchCodebaseTool(BaseTool):
                 stderr=asyncio.subprocess.PIPE,
                 env=env,
             )
-            stdout, _stderr = await proc.communicate()
+            stdout, _stderr = await self._communicate_local_process(proc)
         except (OSError, ValueError):
             raise _EngineUnavailable()
         # 0 = matches, 1 = no matches; anything else (2 = usage/regex error on an
         # old rg, etc.) falls back to the next tier.
         if proc.returncode not in (0, 1):
             raise _EngineUnavailable()
-        return self._parse_rg_json(stdout.decode("utf-8", "replace"))
+        return SearchRun(self._parse_rg_json(stdout.decode("utf-8", "replace")))
 
     async def _run_rg_sandbox(
         self, pattern: str, file_pattern: str, case_sensitive: bool, literal: bool, regex
-    ) -> List[Record]:
+    ) -> SearchRun:
         args = self._rg_args(pattern, file_pattern, case_sensitive, literal)
         cmd = "RIPGREP_CONFIG_FILE= rg " + " ".join(shlex.quote(a) for a in args)
         full_cmd = f"cd {shlex.quote(self._fs_root)} && {cmd} ; echo {_RC_MARKER}=$?"
         try:
-            result = await self._fs_sandbox.commands.run(full_cmd)
+            result = await asyncio.wait_for(
+                self._fs_sandbox.commands.run(full_cmd, timeout=_SEARCH_TIMEOUT_SECONDS),
+                timeout=_SEARCH_TIMEOUT_SECONDS + 1.0,
+            )
+        except asyncio.CancelledError:
+            raise
+        except (asyncio.TimeoutError, TimeoutError):
+            raise _SearchTimedOut()
         except Exception:
             raise _EngineUnavailable()
         rc, out = self._split_rc(result.stdout or "")
         if rc not in (0, 1):
             raise _EngineUnavailable()
-        return self._parse_rg_json(out)
+        return SearchRun(self._parse_rg_json(out))
 
     def _parse_rg_json(self, stdout_text: str) -> List[Record]:
         records: List[Record] = []
@@ -326,8 +391,10 @@ class SearchCodebaseTool(BaseTool):
         argv.append("-F" if literal else "-E")
         if file_pattern != "*":
             argv.append(f"--include={file_pattern}")
-        for exclude_dir in sorted(self.EXCLUDE_DIRS):
+        for exclude_dir in sorted(self._search_exclude_dirs()):
             argv.append(f"--exclude-dir={exclude_dir}")
+        if self._is_broad_local_root():
+            argv.append("--exclude-dir=.*")
         for ext in sorted(self.BINARY_EXTENSIONS):
             argv.append(f"--exclude=*{ext}")
         # -e guards a pattern that starts with '-'; '.' is the search root.
@@ -336,7 +403,7 @@ class SearchCodebaseTool(BaseTool):
 
     async def _run_grep_local(
         self, pattern: str, file_pattern: str, case_sensitive: bool, literal: bool, regex
-    ) -> List[Record]:
+    ) -> SearchRun:
         if shutil.which("grep") is None:
             raise _EngineUnavailable()
         argv = self._grep_argv(pattern, file_pattern, case_sensitive, literal)
@@ -348,29 +415,36 @@ class SearchCodebaseTool(BaseTool):
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
-            stdout, _stderr = await proc.communicate()
+            stdout, _stderr = await self._communicate_local_process(proc)
         except (OSError, ValueError):
             raise _EngineUnavailable()
         if proc.returncode not in (0, 1):
             raise _EngineUnavailable()
         records = self._parse_grep(stdout.decode("utf-8", "replace"))
         # grep has no --max-filesize; reproduce the 10MB skip via stat (local only).
-        return self._drop_oversize_local(records)
+        return SearchRun(self._drop_oversize_local(records))
 
     async def _run_grep_sandbox(
         self, pattern: str, file_pattern: str, case_sensitive: bool, literal: bool, regex
-    ) -> List[Record]:
+    ) -> SearchRun:
         argv = self._grep_argv(pattern, file_pattern, case_sensitive, literal)
         cmd = " ".join(shlex.quote(a) for a in argv)
         full_cmd = f"cd {shlex.quote(self._fs_root)} && {cmd} ; echo {_RC_MARKER}=$?"
         try:
-            result = await self._fs_sandbox.commands.run(full_cmd)
+            result = await asyncio.wait_for(
+                self._fs_sandbox.commands.run(full_cmd, timeout=_SEARCH_TIMEOUT_SECONDS),
+                timeout=_SEARCH_TIMEOUT_SECONDS + 1.0,
+            )
+        except asyncio.CancelledError:
+            raise
+        except (asyncio.TimeoutError, TimeoutError):
+            raise _SearchTimedOut()
         except Exception:
             raise _EngineUnavailable()
         rc, out = self._split_rc(result.stdout or "")
         if rc not in (0, 1):
             raise _EngineUnavailable()
-        return self._parse_grep(out)
+        return SearchRun(self._parse_grep(out))
 
     def _parse_grep(self, stdout_text: str) -> List[Record]:
         """Parse `grep -rn` output lines of the form `<path>:<lineno>:<content>`.
@@ -395,6 +469,37 @@ class SearchCodebaseTool(BaseTool):
             records.append((self._normalize_path(path), int(num_str), content))
         return records
 
+    async def _communicate_local_process(self, proc: asyncio.subprocess.Process) -> tuple[bytes, bytes]:
+        """Wait asynchronously and never leave a child behind on cancellation.
+
+        Local ripgrep/grep work does not block the event loop, so imposing a short
+        wall-clock timeout only creates false negatives on broad workspaces. The
+        user can cancel the turn at any time; cancellation terminates the child.
+        """
+        try:
+            return await proc.communicate()
+        except asyncio.CancelledError:
+            await self._stop_local_process(proc)
+            raise
+
+    @staticmethod
+    async def _stop_local_process(proc: asyncio.subprocess.Process) -> None:
+        if proc.returncode is not None:
+            return
+        try:
+            proc.terminate()
+            await asyncio.wait_for(proc.wait(), timeout=1.0)
+        except (ProcessLookupError, asyncio.TimeoutError):
+            if proc.returncode is None:
+                try:
+                    proc.kill()
+                except ProcessLookupError:
+                    return
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=1.0)
+                except asyncio.TimeoutError:
+                    pass
+
     def _drop_oversize_local(self, records: List[Record]) -> List[Record]:
         sizes: dict = {}
         kept: List[Record] = []
@@ -414,36 +519,125 @@ class SearchCodebaseTool(BaseTool):
 
     async def _run_python(
         self, pattern: str, file_pattern: str, case_sensitive: bool, literal: bool, regex
-    ) -> List[Record]:
-        files_with_info = await self._get_files_batch_local(file_pattern)
-        records: List[Record] = []
-        for file_path, file_size in files_with_info:
-            if file_size > _MAX_FILE_SIZE:
-                continue
-            if self._is_likely_binary_by_extension(file_path):
-                continue
-            try:
-                content = self.filesystem.read_text(file_path)
-                if "\x00" in content[:1024]:
+    ) -> SearchRun:
+        if hasattr(self.filesystem, "sandbox"):
+            return await self._run_python_sandbox_fallback(file_pattern, regex)
+
+        normalized_pattern = "**/*" if file_pattern == "*" else f"**/{file_pattern}"
+        self._load_gitignore_patterns()
+        scan = await scan_workspace(
+            Path(self._fs_root),
+            pattern=normalized_pattern,
+            include_files=True,
+            include_directories=False,
+            exclude_directories=frozenset(self._search_exclude_dirs()),
+            skip_hidden_directories=self._is_broad_local_root(),
+            binary_extensions=frozenset(self.BINARY_EXTENSIONS),
+            max_file_size=_MAX_FILE_SIZE,
+            ignore_spec=getattr(self, "_gitignore_spec", None),
+            limits=ScanLimits(timeout_seconds=_SCAN_TIMEOUT_SECONDS, max_entries=_SCAN_MAX_ENTRIES),
+        )
+        return await self._search_scanned_files(scan, regex)
+
+    async def _search_scanned_files(self, scan: ScanOutcome, regex) -> SearchRun:
+        cancel_event = threading.Event()
+        started = time.monotonic()
+        remaining = max(0.01, _SEARCH_TIMEOUT_SECONDS - scan.elapsed_seconds)
+        deadline = started + remaining
+
+        def search() -> SearchRun:
+            records: List[Record] = []
+            matched_files: set[str] = set()
+            for scanned in scan.paths:
+                if cancel_event.is_set():
+                    return SearchRun(records, False, "cancelled", scan.visited_entries, time.monotonic() - started)
+                if time.monotonic() >= deadline:
+                    return SearchRun(records, False, "deadline", scan.visited_entries, time.monotonic() - started)
+                try:
+                    content = self.filesystem.read_text(scanned.path)
+                    if "\x00" in content[:1024]:
+                        continue
+                except Exception:
                     continue
-            except Exception:
-                continue
-            norm = self._normalize_path(file_path)
-            for line_num, line in enumerate(content.splitlines(), start=1):
-                if regex.search(line):
-                    records.append((norm, line_num, line))
-        return records
+                norm = self._normalize_path(scanned.path)
+                for line_num, line in enumerate(content.splitlines(), start=1):
+                    if regex.search(line):
+                        records.append((norm, line_num, line))
+                        matched_files.add(norm)
+                if len(matched_files) > _MAX_FILES:
+                    return SearchRun(
+                        records,
+                        False,
+                        "result_limit",
+                        scan.visited_entries,
+                        scan.elapsed_seconds + time.monotonic() - started,
+                    )
+            return SearchRun(
+                records,
+                scan.complete,
+                scan.stop_reason,
+                scan.visited_entries,
+                scan.elapsed_seconds + time.monotonic() - started,
+            )
+
+        task = asyncio.create_task(asyncio.to_thread(search))
+        try:
+            return await asyncio.wait_for(asyncio.shield(task), timeout=remaining + 1.0)
+        except asyncio.CancelledError:
+            cancel_event.set()
+            task.cancel()
+            raise
+        except asyncio.TimeoutError:
+            cancel_event.set()
+            task.cancel()
+            return SearchRun([], False, "deadline", scan.visited_entries, _SEARCH_TIMEOUT_SECONDS)
+
+    async def _run_python_sandbox_fallback(self, file_pattern: str, regex) -> SearchRun:
+        """Keep the legacy remote-files fallback off-loop and time bounded."""
+        cancel_event = threading.Event()
+        started = time.monotonic()
+
+        def search() -> SearchRun:
+            records: List[Record] = []
+            for file_path, file_size in self._get_files_batch_sync(file_pattern):
+                if cancel_event.is_set() or time.monotonic() - started >= _SEARCH_TIMEOUT_SECONDS:
+                    return SearchRun(records, False, "deadline", elapsed_seconds=time.monotonic() - started)
+                if file_size > _MAX_FILE_SIZE or self._is_likely_binary_by_extension(file_path):
+                    continue
+                try:
+                    content = self.filesystem.read_text(file_path)
+                    if "\x00" in content[:1024]:
+                        continue
+                except Exception:
+                    continue
+                norm = self._normalize_path(file_path)
+                for line_num, line in enumerate(content.splitlines(), start=1):
+                    if regex.search(line):
+                        records.append((norm, line_num, line))
+            return SearchRun(records, elapsed_seconds=time.monotonic() - started)
+
+        task = asyncio.create_task(asyncio.to_thread(search))
+        try:
+            return await asyncio.wait_for(asyncio.shield(task), timeout=_SEARCH_TIMEOUT_SECONDS + 1.0)
+        except asyncio.CancelledError:
+            cancel_event.set()
+            task.cancel()
+            raise
+        except asyncio.TimeoutError:
+            cancel_event.set()
+            task.cancel()
+            return SearchRun([], False, "deadline", elapsed_seconds=_SEARCH_TIMEOUT_SECONDS)
 
     # ------------------------------------------------------------------
     # Shared output formatting
     # ------------------------------------------------------------------
 
-    def _format_results(self, records: List[Record], original_pattern: str) -> str:
+    def _format_results(self, run: SearchRun, original_pattern: str) -> str:
         """Group records by file (first-seen order), apply the display caps, and
         render the markdown output. `(N matches)` is the matching-line count."""
         files: dict = {}
         limit_hit = False
-        for path, line_num, raw in records:
+        for path, line_num, raw in run.records:
             if path in files:
                 files[path].append((line_num, raw))
             elif len(files) < _MAX_FILES:
@@ -451,8 +645,14 @@ class SearchCodebaseTool(BaseTool):
             else:
                 limit_hit = True
 
-        if not files:
+        if not files and run.complete:
             return f"No matches found for pattern '{original_pattern}'"
+        if not files:
+            return (
+                f"Search for pattern '{original_pattern}' stopped before completion because of "
+                f"{run.stop_reason or 'a search limit'}. No matches were observed; narrow the query "
+                "or project root for exhaustive results."
+            )
 
         blocks = []
         for path, hits in files.items():
@@ -469,9 +669,14 @@ class SearchCodebaseTool(BaseTool):
             blocks.append(block)
 
         output = f"# Search Results for '{original_pattern}'\n\n"
-        if limit_hit:
+        if limit_hit or run.stop_reason == "result_limit":
             output += (
                 f"⚠️ **Note:** Showing only the first {_MAX_FILES} results. There are more matches in the codebase.\n\n"
+            )
+        elif not run.complete:
+            output += (
+                f"⚠️ **Incomplete search:** stopped because of {run.stop_reason or 'a search limit'}. "
+                "Narrow the query or project root for exhaustive results.\n\n"
             )
         output += "\n\n".join(blocks)
         return output
@@ -503,7 +708,7 @@ class SearchCodebaseTool(BaseTool):
             path = path[2:]
         return path
 
-    async def _get_files_batch_local(self, file_pattern: str) -> List[Tuple[str, int]]:
+    def _get_files_batch_sync(self, file_pattern: str) -> List[Tuple[str, int]]:
         """
         Get files for local filesystem with minimal stat calls.
         """

--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -765,6 +765,13 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
         resolved = {r["language_id"]: r for r in status.get("resolved", [])}
         missing = status.get("missing", [])
 
+        if not status.get("scan_complete", True):
+            lines.append(
+                "\n**⚠️ Detection incomplete:** filesystem scan stopped because of "
+                f"{status.get('scan_stop_reason') or 'a scan limit'} after "
+                f"{status.get('scanned_entries', 0)} entries."
+            )
+
         if detected:
             lines.append(f"\n**Detected {len(detected)} language(s):**")
             for d in detected:

--- a/kolega_code/cli/tui/settings_panel.py
+++ b/kolega_code/cli/tui/settings_panel.py
@@ -993,8 +993,16 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             return
         detected_names = [d["display_name"] for d in lsp_status.get("detected", [])]
         missing_names = [m["display_name"] for m in lsp_status.get("missing", [])]
+        incomplete = not lsp_status.get("scan_complete", True)
+        incomplete_text = (
+            "Detection incomplete "
+            f"({lsp_status.get('scan_stop_reason') or 'scan limit'}, "
+            f"{lsp_status.get('scanned_entries', 0)} entries)."
+        )
         if detected_names:
             parts = [f"Detected: {', '.join(detected_names)}"]
+            if incomplete:
+                parts.append(incomplete_text)
             if missing_names:
                 parts.append(f"Missing servers: {', '.join(missing_names)}")
             # Show active sessions with live state
@@ -1008,6 +1016,8 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             if active:
                 parts.append(f"Active: {', '.join(active)}")
             status.update(" ".join(parts))
+        elif incomplete:
+            status.update(incomplete_text)
         else:
             status.update("No supported languages detected in this project.")
 

--- a/kolega_code/services/lsp/detector.py
+++ b/kolega_code/services/lsp/detector.py
@@ -7,10 +7,13 @@ language servers via the ``LspRegistry``.
 from __future__ import annotations
 
 import logging
-import os
+import asyncio
+import fnmatch
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
+
+from kolega_code.services.workspace_scan import ScanLimits, scan_workspace
 
 from .registry import LspRegistry
 
@@ -92,6 +95,10 @@ class DetectionReport:
     detected: list[DetectionResult] = field(default_factory=list)
     resolved: list[ResolvedLanguage] = field(default_factory=list)
     missing: list[ResolvedLanguage] = field(default_factory=list)
+    scan_complete: bool = True
+    scan_stop_reason: Optional[str] = None
+    scanned_entries: int = 0
+    scan_elapsed_seconds: float = 0.0
 
 
 async def detect_languages(project_path: str | Path, registry: LspRegistry) -> DetectionReport:
@@ -110,43 +117,31 @@ async def detect_languages(project_path: str | Path, registry: LspRegistry) -> D
     root = Path(project_path).resolve()
     all_languages = registry.languages
 
-    # Phase A: config file scan (root + one level deep for monorepos)
-    config_hits: dict[str, list[str]] = {}  # language_id → [config file paths]
-    for lang_id, spec in all_languages.items():
-        found: list[str] = []
-        for pattern in spec.config_files:
-            # Check root
-            if _matches_config(root, pattern):
-                found.append(pattern)
-            # Check one level deep (monorepo support)
-            try:
-                for child in root.iterdir():
-                    if child.is_dir() and child.name not in _SKIP_DIRS and not child.name.startswith("."):
-                        if _matches_config(child, pattern):
-                            found.append(f"{child.name}/{pattern}")
-            except PermissionError:
-                pass
-        if found:
-            config_hits[lang_id] = found
-
-    # Phase A.5: exact filename scan (e.g. Dockerfile)
-    filename_hits: dict[str, list[str]] = {}
-    for lang_id, spec in all_languages.items():
-        found: list[str] = []
-        for fname in spec.filename_map:
-            if (root / fname).exists():
-                found.append(fname)
-        if found:
-            filename_hits[lang_id] = found
+    # A single bounded traversal supplies both shallow config signals and the
+    # recursive extension survey. This avoids a separate unbounded root probe.
+    scan = await scan_workspace(
+        root,
+        pattern="**/*",
+        include_files=True,
+        include_directories=False,
+        exclude_directories=frozenset(_SKIP_DIRS),
+        skip_hidden_directories=True,
+        collect_metadata=False,
+        limits=ScanLimits(timeout_seconds=5.0, max_entries=50_000),
+    )
+    scanned_paths = [scanned.path for scanned in scan.paths]
+    config_hits, filename_hits = await asyncio.to_thread(
+        _detect_config_signals,
+        scanned_paths,
+        all_languages,
+    )
 
     # Phase B: extension survey
     ext_counts: dict[str, int] = {}
-    ext_to_lang: dict[str, str] = {}
-    for lang_id, spec in all_languages.items():
-        for ext in spec.extensions:
-            ext_to_lang[ext.lower()] = lang_id
-
-    _count_extensions(root, ext_counts)
+    for scanned in scan.paths:
+        suffix = Path(scanned.path).suffix.lower()
+        if suffix:
+            ext_counts[suffix] = ext_counts.get(suffix, 0) + 1
 
     # Phase C: merge signals
     detected: list[DetectionResult] = []
@@ -227,7 +222,15 @@ async def detect_languages(project_path: str | Path, registry: LspRegistry) -> D
         else:
             missing.append(rl)
 
-    return DetectionReport(detected=detected, resolved=resolved, missing=missing)
+    return DetectionReport(
+        detected=detected,
+        resolved=resolved,
+        missing=missing,
+        scan_complete=scan.complete,
+        scan_stop_reason=scan.stop_reason,
+        scanned_entries=scan.visited_entries,
+        scan_elapsed_seconds=scan.elapsed_seconds,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -235,38 +238,29 @@ async def detect_languages(project_path: str | Path, registry: LspRegistry) -> D
 # ---------------------------------------------------------------------------
 
 
-def _matches_config(directory: Path, pattern: str) -> bool:
-    """Check whether *pattern* (a filename or glob) exists in *directory*."""
-    if "*" in pattern or "?" in pattern:
-        return any(True for _ in directory.glob(pattern))
-    return (directory / pattern).exists()
+def _detect_config_signals(
+    scanned_paths: list[str], all_languages: dict[str, Any]
+) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
+    """Derive root/one-level signals from the already bounded path snapshot."""
+    shallow = [path for path in (Path(raw_path) for raw_path in scanned_paths) if len(path.parts) <= 2]
+    root_names = {path.name for path in shallow if len(path.parts) == 1}
 
+    config_hits: dict[str, list[str]] = {}
+    filename_hits: dict[str, list[str]] = {}
+    for lang_id, spec in all_languages.items():
+        configs: list[str] = []
+        for pattern in spec.config_files:
+            for path in shallow:
+                if fnmatch.fnmatchcase(path.name, pattern):
+                    configs.append(path.as_posix())
+        if configs:
+            config_hits[lang_id] = sorted(dict.fromkeys(configs))
 
-def _count_extensions(root: Path, counts: dict[str, int]) -> None:
-    """Walk *root* and increment *counts* keyed by lowercase file extension.
+        filenames = [fname for fname in spec.filename_map if fname in root_names]
+        if filenames:
+            filename_hits[lang_id] = filenames
 
-    Skips directories and files matching common ignore patterns.
-    """
-    try:
-        for entry in os.scandir(root):
-            name = entry.name
-            # Skip hidden and ignored directories
-            if entry.is_dir(follow_symlinks=False):
-                if name in _SKIP_DIRS or name.startswith("."):
-                    continue
-                try:
-                    _count_extensions(Path(entry.path), counts)
-                except PermissionError:
-                    pass
-            elif entry.is_file(follow_symlinks=False):
-                _, ext = os.path.splitext(name)
-                if ext:
-                    counts[ext.lower()] = counts.get(ext.lower(), 0) + 1
-                else:
-                    # No extension — count under empty string key
-                    pass
-    except PermissionError:
-        pass
+    return config_hits, filename_hits
 
 
 def _relative(root: Path, path: Path) -> str:

--- a/kolega_code/services/lsp/manager.py
+++ b/kolega_code/services/lsp/manager.py
@@ -198,6 +198,16 @@ class LspManager:
 
             messages: list[str] = []
 
+            if not self.report.scan_complete:
+                scan_warning = (
+                    "LSP language detection used partial filesystem results "
+                    f"(reason={self.report.scan_stop_reason or 'scan limit'}, "
+                    f"visited={self.report.scanned_entries}, "
+                    f"elapsed={self.report.scan_elapsed_seconds:.2f}s)."
+                )
+                logger.warning(scan_warning)
+                messages.append(scan_warning)
+
             # Summary of detected languages
             detected_lines = []
             for dr in self.report.detected:
@@ -887,6 +897,10 @@ class LspManager:
         return {
             "enabled": self._config.enabled,
             "initialized": self._initialized,
+            "scan_complete": self.report.scan_complete if self.report is not None else True,
+            "scan_stop_reason": self.report.scan_stop_reason if self.report is not None else None,
+            "scanned_entries": self.report.scanned_entries if self.report is not None else 0,
+            "scan_elapsed_seconds": self.report.scan_elapsed_seconds if self.report is not None else 0.0,
             "detected": detected,
             "resolved": resolved,
             "missing": missing,

--- a/kolega_code/services/workspace_scan.py
+++ b/kolega_code/services/workspace_scan.py
@@ -1,0 +1,244 @@
+"""Bounded, cancellable local workspace traversal.
+
+Agent tools must not call recursive ``pathlib``/``os`` scans on the asyncio event
+loop.  This module keeps the synchronous walk small and cooperative so callers can
+run it in a worker thread without losing cancellation or allowing an accidentally
+broad project root to consume unbounded time and memory.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Optional
+
+import pathspec
+
+
+DEFAULT_SCAN_TIMEOUT_SECONDS = 5.0
+DEFAULT_SCAN_MAX_ENTRIES = 50_000
+_OUTER_TIMEOUT_GRACE_SECONDS = 1.0
+
+
+@dataclass(frozen=True)
+class ScanLimits:
+    timeout_seconds: float = DEFAULT_SCAN_TIMEOUT_SECONDS
+    max_entries: int = DEFAULT_SCAN_MAX_ENTRIES
+    max_results: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class ScannedPath:
+    path: str
+    is_dir: bool
+    size: int = 0
+    modified_time: int = 0
+
+
+@dataclass
+class ScanOutcome:
+    paths: list[ScannedPath] = field(default_factory=list)
+    visited_entries: int = 0
+    elapsed_seconds: float = 0.0
+    complete: bool = True
+    stop_reason: Optional[str] = None
+
+
+def compile_workspace_glob(pattern: str) -> pathspec.GitIgnoreSpec:
+    normalized = pattern.replace("\\", "/").lstrip("/") or "*"
+    # Leading slash anchors patterns without ``**`` to the workspace root,
+    # matching Path.glob rather than gitignore's basename-at-any-depth behavior.
+    return pathspec.GitIgnoreSpec.from_lines([f"/{normalized}"])
+
+
+def _fixed_prefix(pattern: str) -> PurePosixPath:
+    """Return the directory prefix before the first wildcard component."""
+    normalized = pattern.replace("\\", "/").lstrip("/")
+    parts = PurePosixPath(normalized).parts
+    fixed: list[str] = []
+    for part in parts:
+        if any(char in part for char in ("*", "?", "[")):
+            break
+        fixed.append(part)
+    if len(fixed) == len(parts) and fixed:
+        fixed.pop()  # exact path: scan its parent so the path itself is tested
+    return PurePosixPath(*fixed) if fixed else PurePosixPath(".")
+
+
+def scan_workspace_sync(
+    root: Path,
+    *,
+    pattern: str = "**/*",
+    include_files: bool = True,
+    include_directories: bool = False,
+    exclude_directories: frozenset[str] = frozenset(),
+    skip_hidden_directories: bool = False,
+    binary_extensions: frozenset[str] = frozenset(),
+    max_file_size: Optional[int] = None,
+    collect_metadata: bool = True,
+    ignore_spec: Optional[pathspec.PathSpec] = None,
+    limits: ScanLimits = ScanLimits(),
+    cancel_event: Optional[threading.Event] = None,
+) -> ScanOutcome:
+    """Walk *root* within explicit time/entry/result limits.
+
+    The function is intentionally synchronous.  Async callers should use
+    :func:`scan_workspace`, which runs it in a worker thread.
+    """
+    started = time.monotonic()
+    deadline = started + max(0.0, limits.timeout_seconds)
+    root = Path(root).resolve()
+    matcher = compile_workspace_glob(pattern)
+    outcome = ScanOutcome()
+
+    def stop(reason: str) -> bool:
+        outcome.complete = False
+        outcome.stop_reason = reason
+        outcome.elapsed_seconds = time.monotonic() - started
+        return True
+
+    def should_stop() -> bool:
+        if cancel_event is not None and cancel_event.is_set():
+            return stop("cancelled")
+        if time.monotonic() >= deadline:
+            return stop("deadline")
+        if outcome.visited_entries >= limits.max_entries:
+            return stop("entry_limit")
+        return False
+
+    prefix = _fixed_prefix(pattern)
+    if any(part in exclude_directories for part in prefix.parts):
+        outcome.elapsed_seconds = time.monotonic() - started
+        return outcome
+    if skip_hidden_directories and any(part.startswith(".") for part in prefix.parts):
+        outcome.elapsed_seconds = time.monotonic() - started
+        return outcome
+    start_dir = root if str(prefix) == "." else root.joinpath(*prefix.parts)
+    if not start_dir.exists():
+        outcome.elapsed_seconds = time.monotonic() - started
+        return outcome
+
+    if start_dir.is_file():
+        scan_stack: list[tuple[Path, PurePosixPath]] = [(start_dir.parent, prefix.parent)]
+    else:
+        scan_stack = [(start_dir, prefix)]
+
+    while scan_stack:
+        if should_stop():
+            return outcome
+        directory, relative_directory = scan_stack.pop()
+        pending_stop_reason: Optional[str] = None
+        try:
+            discovered = []
+            with os.scandir(directory) as iterator:
+                for entry in iterator:
+                    if cancel_event is not None and cancel_event.is_set():
+                        pending_stop_reason = "cancelled"
+                        break
+                    if time.monotonic() >= deadline:
+                        pending_stop_reason = "deadline"
+                        break
+                    if outcome.visited_entries >= limits.max_entries:
+                        pending_stop_reason = "entry_limit"
+                        break
+                    outcome.visited_entries += 1
+                    discovered.append(entry)
+        except (FileNotFoundError, NotADirectoryError, PermissionError, OSError):
+            continue
+
+        child_directories: list[tuple[Path, PurePosixPath]] = []
+        for entry in sorted(discovered, key=lambda item: item.name.casefold()):
+            if cancel_event is not None and cancel_event.is_set():
+                stop("cancelled")
+                return outcome
+            if time.monotonic() >= deadline:
+                stop("deadline")
+                return outcome
+            relative = relative_directory / entry.name if str(relative_directory) != "." else PurePosixPath(entry.name)
+            relative_text = relative.as_posix()
+            try:
+                is_directory = entry.is_dir(follow_symlinks=False)
+                is_file = entry.is_file(follow_symlinks=False)
+            except OSError:
+                continue
+
+            if is_directory:
+                if entry.name in exclude_directories or (skip_hidden_directories and entry.name.startswith(".")):
+                    continue
+                if ignore_spec is not None and ignore_spec.match_file(relative_text + "/"):
+                    continue
+                child_directories.append((Path(entry.path), relative))
+                if not include_directories or not matcher.match_file(relative_text + "/"):
+                    continue
+                scanned = ScannedPath(path=relative_text, is_dir=True)
+            elif is_file:
+                if not include_files or not matcher.match_file(relative_text):
+                    continue
+                if ignore_spec is not None and ignore_spec.match_file(relative_text):
+                    continue
+                if Path(entry.name).suffix.lower() in binary_extensions:
+                    continue
+                if collect_metadata or max_file_size is not None:
+                    try:
+                        stat_result = entry.stat(follow_symlinks=False)
+                    except OSError:
+                        continue
+                    if max_file_size is not None and stat_result.st_size > max_file_size:
+                        continue
+                    scanned = ScannedPath(
+                        path=relative_text,
+                        is_dir=False,
+                        size=int(stat_result.st_size) if collect_metadata else 0,
+                        modified_time=int(stat_result.st_mtime) if collect_metadata else 0,
+                    )
+                else:
+                    scanned = ScannedPath(path=relative_text, is_dir=False)
+            else:
+                continue
+
+            outcome.paths.append(scanned)
+            if limits.max_results is not None and len(outcome.paths) >= limits.max_results:
+                stop("result_limit")
+                return outcome
+
+        if pending_stop_reason is not None:
+            stop(pending_stop_reason)
+            return outcome
+
+        # Stack is LIFO; reverse to visit alphabetically first.
+        scan_stack.extend(reversed(child_directories))
+
+    outcome.elapsed_seconds = time.monotonic() - started
+    return outcome
+
+
+async def scan_workspace(root: Path, **kwargs) -> ScanOutcome:
+    """Run :func:`scan_workspace_sync` off-loop with prompt cancellation."""
+    limits = kwargs.get("limits")
+    if not isinstance(limits, ScanLimits):
+        limits = ScanLimits()
+        kwargs["limits"] = limits
+    cancel_event = threading.Event()
+    kwargs["cancel_event"] = cancel_event
+    task = asyncio.create_task(asyncio.to_thread(scan_workspace_sync, root, **kwargs))
+    try:
+        return await asyncio.wait_for(
+            asyncio.shield(task),
+            timeout=limits.timeout_seconds + _OUTER_TIMEOUT_GRACE_SECONDS,
+        )
+    except asyncio.CancelledError:
+        cancel_event.set()
+        task.cancel()
+        raise
+    except asyncio.TimeoutError:
+        cancel_event.set()
+        task.cancel()
+        return ScanOutcome(
+            elapsed_seconds=limits.timeout_seconds + _OUTER_TIMEOUT_GRACE_SECONDS,
+            complete=False,
+            stop_reason="deadline",
+        )

--- a/tests/agent/tool_backend/test_glob_tool.py
+++ b/tests/agent/tool_backend/test_glob_tool.py
@@ -1,10 +1,12 @@
+import asyncio
 from unittest.mock import AsyncMock, Mock
 
 import pytest
 import uuid
 
 from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
-from kolega_code.agent.tool_backend.glob_tool import GlobTool
+from kolega_code.agent.tool_backend.glob_tool import GlobSearchResult, GlobTool
+from kolega_code.services.workspace_scan import ScanOutcome, ScannedPath
 
 
 @pytest.fixture
@@ -159,7 +161,7 @@ class TestGlobTool:
 
         result = await glob_tool.find_files_by_pattern("*.txt")
 
-        assert "Found 150 matching items" in result
+        assert "Found at least 129 matching items" in result
         assert "showing first 128" in result
 
     @pytest.mark.asyncio
@@ -197,3 +199,78 @@ class TestGlobTool:
 
         assert "**main.py**" in result
         assert "**utils.py**" in result
+
+    @pytest.mark.asyncio
+    async def test_local_search_does_not_use_unbounded_filesystem_glob(self, glob_tool, sample_files, monkeypatch):
+        monkeypatch.setattr(
+            glob_tool.filesystem,
+            "glob",
+            Mock(side_effect=AssertionError("unbounded glob should not be called")),
+        )
+
+        result = await glob_tool.find_files_by_pattern("**/*.py")
+
+        assert "**main.py**" in result
+
+    @pytest.mark.asyncio
+    async def test_incomplete_empty_search_does_not_claim_no_files(self, glob_tool, monkeypatch):
+        async def incomplete(*args, **kwargs):
+            return GlobSearchResult([], 0, False, "deadline", visited_entries=100, elapsed_seconds=5.0)
+
+        monkeypatch.setattr(glob_tool, "_search_files_local", incomplete)
+        result = await glob_tool.find_files_by_pattern("**/missing.txt")
+
+        assert "No files found" not in result
+        assert "Incomplete search" in result
+        assert "deadline" in result
+
+    @pytest.mark.asyncio
+    async def test_no_find_falls_back_to_off_thread_scanner(self, glob_tool, monkeypatch):
+        async def fallback_scan(*args, **kwargs):
+            return ScanOutcome(paths=[ScannedPath("main.py", False, 4, 1)], visited_entries=1)
+
+        monkeypatch.setattr("kolega_code.agent.tool_backend.glob_tool.shutil.which", lambda name: None)
+        monkeypatch.setattr("kolega_code.agent.tool_backend.glob_tool.scan_workspace", fallback_scan)
+
+        result = await glob_tool.find_files_by_pattern("**/*.py")
+
+        assert "**main.py**" in result
+
+    @pytest.mark.asyncio
+    async def test_cancelling_native_find_terminates_child(self, glob_tool, monkeypatch):
+        class BlockingStdout:
+            async def readuntil(self, separator):
+                await asyncio.Event().wait()
+
+        class BlockingProcess:
+            def __init__(self):
+                self.stdout = BlockingStdout()
+                self.returncode = None
+                self.terminated = False
+
+            def terminate(self):
+                self.terminated = True
+                self.returncode = -15
+
+            def kill(self):
+                self.returncode = -9
+
+            async def wait(self):
+                return self.returncode
+
+        proc = BlockingProcess()
+
+        async def create_process(*args, **kwargs):
+            return proc
+
+        monkeypatch.setattr(
+            "kolega_code.agent.tool_backend.glob_tool.asyncio.create_subprocess_exec",
+            create_process,
+        )
+        task = asyncio.create_task(glob_tool._search_files_local_process("**/*.py", True, 128))
+        await asyncio.sleep(0)
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert proc.terminated is True

--- a/tests/agent/tool_backend/test_glob_tool_sandbox_parity.py
+++ b/tests/agent/tool_backend/test_glob_tool_sandbox_parity.py
@@ -98,7 +98,7 @@ def _make_mock_sandbox_for_glob(tmp_path: Path) -> Any:
     exclude_dirs = GlobTool.EXCLUDE_DIRS
     bin_exts = GlobTool.BINARY_EXTENSIONS
 
-    def run_side_effect(cmd: str):
+    def run_side_effect(cmd: str, **kwargs):
         result = Mock()
         result.exit_code = 0
         result.stderr = ""

--- a/tests/agent/tool_backend/test_search_codebase_tool.py
+++ b/tests/agent/tool_backend/test_search_codebase_tool.py
@@ -1,4 +1,6 @@
 import shutil
+import asyncio
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
@@ -7,6 +9,7 @@ import uuid
 
 from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
 from kolega_code.agent.tool_backend.search_codebase_tool import SearchCodebaseTool
+from kolega_code.services.file_system import LocalFileSystem
 
 _WHICH_PATH = "kolega_code.agent.tool_backend.search_codebase_tool.shutil.which"
 
@@ -308,6 +311,81 @@ def func():
         alt = await search_codebase_tool.search_codebase("def|return")
         assert "src/main.py" in alt
         assert "src/utils.py" in alt
+
+    async def test_python_fallback_does_not_use_unbounded_filesystem_glob(
+        self, search_codebase_tool, sample_files, monkeypatch
+    ):
+        monkeypatch.setattr(_WHICH_PATH, _which_factory(set()))
+        monkeypatch.setattr(
+            search_codebase_tool.filesystem,
+            "glob",
+            Mock(side_effect=AssertionError("unbounded glob should not be called")),
+        )
+
+        result = await search_codebase_tool.search_codebase("print")
+
+        assert "src/main.py" in result
+
+    async def test_cancelling_local_search_terminates_child(self, search_codebase_tool):
+        class BlockingProcess:
+            def __init__(self):
+                self.returncode = None
+                self.terminated = False
+                self.killed = False
+                self._never = asyncio.Event()
+
+            async def communicate(self):
+                await self._never.wait()
+                return b"", b""
+
+            def terminate(self):
+                self.terminated = True
+                self.returncode = -15
+
+            def kill(self):
+                self.killed = True
+                self.returncode = -9
+
+            async def wait(self):
+                return self.returncode
+
+        proc = BlockingProcess()
+        task = asyncio.create_task(search_codebase_tool._communicate_local_process(proc))
+        await asyncio.sleep(0)
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert proc.terminated is True
+        assert proc.killed is False
+
+    async def test_local_search_is_not_cut_off_by_fallback_deadline(self, search_codebase_tool, monkeypatch):
+        monkeypatch.setattr(
+            "kolega_code.agent.tool_backend.search_codebase_tool._SEARCH_TIMEOUT_SECONDS",
+            0.001,
+        )
+
+        class CompletingProcess:
+            returncode = 0
+
+            async def communicate(self):
+                await asyncio.sleep(0.02)
+                return b"complete", b""
+
+        stdout, stderr = await search_codebase_tool._communicate_local_process(CompletingProcess())
+
+        assert stdout == b"complete"
+        assert stderr == b""
+
+    async def test_home_root_search_prunes_platform_data_without_hiding_visible_workspaces(self):
+        tool = object.__new__(SearchCodebaseTool)
+        tool.filesystem = LocalFileSystem(root_path=Path.home())
+
+        args = tool._rg_args("needle", "*", case_sensitive=False, literal=False)
+
+        assert "--hidden" not in args
+        assert "!Library/" in args
+        assert args[-1] == "."
 
     async def test_search_codebase_sandbox_ripgrep(self, search_codebase_tool):
         """Sandbox path: probe finds rg, parse rg --json, format identically."""

--- a/tests/cli/test_app_lsp_settings_status.py
+++ b/tests/cli/test_app_lsp_settings_status.py
@@ -68,6 +68,7 @@ class _LspEnabledFakeAgent(FakeCoderAgent):
         manager.status = lambda: {
             "enabled": True,
             "initialized": True,
+            "scan_complete": True,
             "detected": [
                 {
                     "language_id": "python",
@@ -94,6 +95,30 @@ async def test_lsp_status_shows_detected_languages_after_build(tmp_path: Path, m
         text = _static_text(status)
         assert "not active" not in text
         assert "Python" in text
+
+
+@pytest.mark.asyncio
+async def test_lsp_status_warns_when_detection_is_incomplete(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from textual.widgets import Static
+
+    class _PartialLspAgent(_LspEnabledFakeAgent):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            manager = self.tool_collection.lsp_manager
+            assert manager is not None
+            original_status = manager.status
+            manager.status = lambda: {
+                **original_status(),
+                "scan_complete": False,
+                "scan_stop_reason": "entry_limit",
+                "scanned_entries": 50_000,
+            }
+
+    app = _make_app(tmp_path, monkeypatch, coder_cls=_PartialLspAgent)
+    async with app.run_test():
+        text = _static_text(app.query_one("#lsp_status", Static))
+        assert "Detection incomplete" in text
+        assert "entry_limit" in text
 
 
 @pytest.mark.asyncio

--- a/tests/services/lsp/test_detector.py
+++ b/tests/services/lsp/test_detector.py
@@ -6,6 +6,7 @@ import pytest
 
 from kolega_code.services.lsp import LspRegistry
 from kolega_code.services.lsp.detector import DetectionReport, detect_languages
+from kolega_code.services.workspace_scan import ScanOutcome, ScannedPath
 
 
 @pytest.mark.asyncio
@@ -74,3 +75,23 @@ async def test_detect_empty_project(tmp_path: Path):
     assert report.detected == []
     assert report.resolved == []
     assert report.missing == []
+
+
+@pytest.mark.asyncio
+async def test_detect_languages_retains_partial_scan_status(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    async def partial_scan(*args, **kwargs):
+        return ScanOutcome(
+            paths=[ScannedPath("main.py", is_dir=False)],
+            visited_entries=50_000,
+            elapsed_seconds=5.0,
+            complete=False,
+            stop_reason="entry_limit",
+        )
+
+    monkeypatch.setattr("kolega_code.services.lsp.detector.scan_workspace", partial_scan)
+    report = await detect_languages(tmp_path, LspRegistry())
+
+    assert report.scan_complete is False
+    assert report.scan_stop_reason == "entry_limit"
+    assert report.scanned_entries == 50_000
+    assert any(language.language_id == "python" for language in report.detected)

--- a/tests/services/lsp/test_manager.py
+++ b/tests/services/lsp/test_manager.py
@@ -135,6 +135,20 @@ def test_status_returns_expected_fields(manager: LspManager):
     assert status["diagnostic_counts"] == {}
 
 
+def test_status_exposes_incomplete_detection(manager: LspManager):
+    assert manager.report is not None
+    manager.report.scan_complete = False
+    manager.report.scan_stop_reason = "deadline"
+    manager.report.scanned_entries = 50_000
+    manager.report.scan_elapsed_seconds = 5.0
+
+    status = manager.status()
+
+    assert status["scan_complete"] is False
+    assert status["scan_stop_reason"] == "deadline"
+    assert status["scanned_entries"] == 50_000
+
+
 def test_status_includes_session_info(manager: LspManager):
     """status() includes active session details."""
     fake_client = MagicMock()

--- a/tests/services/test_workspace_scan.py
+++ b/tests/services/test_workspace_scan.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from kolega_code.services import workspace_scan
+from kolega_code.services.workspace_scan import ScanLimits, ScanOutcome, scan_workspace, scan_workspace_sync
+
+
+def _paths(outcome: ScanOutcome) -> list[str]:
+    return [entry.path for entry in outcome.paths]
+
+
+def test_scan_preserves_rooted_pathlib_glob_semantics(tmp_path: Path) -> None:
+    (tmp_path / "main.py").write_text("", encoding="utf-8")
+    (tmp_path / "src" / "pkg").mkdir(parents=True)
+    (tmp_path / "src" / "app.py").write_text("", encoding="utf-8")
+    (tmp_path / "src" / "pkg" / "nested.py").write_text("", encoding="utf-8")
+
+    root_only = scan_workspace_sync(tmp_path, pattern="*.py")
+    recursive = scan_workspace_sync(tmp_path, pattern="**/*.py")
+    under_src = scan_workspace_sync(tmp_path, pattern="src/**/*.py")
+
+    assert _paths(root_only) == ["main.py"]
+    assert _paths(recursive) == ["main.py", "src/app.py", "src/pkg/nested.py"]
+    assert _paths(under_src) == ["src/app.py", "src/pkg/nested.py"]
+
+
+def test_scan_prunes_excluded_directory_before_descent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / "node_modules" / "pkg").mkdir(parents=True)
+    (tmp_path / "node_modules" / "pkg" / "index.js").write_text("", encoding="utf-8")
+    (tmp_path / "app.js").write_text("", encoding="utf-8")
+    real_scandir = workspace_scan.os.scandir
+
+    def guarded_scandir(path):
+        if Path(path).name == "node_modules":
+            raise AssertionError("excluded directory was traversed")
+        return real_scandir(path)
+
+    monkeypatch.setattr(workspace_scan.os, "scandir", guarded_scandir)
+    outcome = scan_workspace_sync(
+        tmp_path,
+        exclude_directories=frozenset({"node_modules"}),
+    )
+
+    assert _paths(outcome) == ["app.js"]
+    assert outcome.complete is True
+
+
+def test_scan_stops_after_extra_result_proves_truncation(tmp_path: Path) -> None:
+    for index in range(10):
+        (tmp_path / f"f{index:02}.txt").write_text("", encoding="utf-8")
+
+    outcome = scan_workspace_sync(tmp_path, limits=ScanLimits(max_results=4))
+
+    assert _paths(outcome) == ["f00.txt", "f01.txt", "f02.txt", "f03.txt"]
+    assert outcome.complete is False
+    assert outcome.stop_reason == "result_limit"
+
+
+def test_scan_entry_budget_returns_observed_partial_results(tmp_path: Path) -> None:
+    for index in range(10):
+        (tmp_path / f"f{index:02}.txt").write_text("", encoding="utf-8")
+
+    outcome = scan_workspace_sync(tmp_path, limits=ScanLimits(max_entries=3))
+
+    assert len(outcome.paths) == 3
+    assert set(_paths(outcome)).issubset({f"f{index:02}.txt" for index in range(10)})
+    assert outcome.visited_entries == 3
+    assert outcome.complete is False
+    assert outcome.stop_reason == "entry_limit"
+
+
+@pytest.mark.asyncio
+async def test_async_scan_does_not_block_event_loop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    started = threading.Event()
+    release = threading.Event()
+
+    def slow_scan(*args, **kwargs):
+        started.set()
+        release.wait(timeout=2)
+        return ScanOutcome()
+
+    monkeypatch.setattr(workspace_scan, "scan_workspace_sync", slow_scan)
+    scan_task = asyncio.create_task(scan_workspace(tmp_path))
+    assert await asyncio.to_thread(started.wait, 1)
+
+    marker = asyncio.create_task(asyncio.sleep(0.01, result="responsive"))
+    assert await asyncio.wait_for(marker, timeout=0.2) == "responsive"
+    release.set()
+    await scan_task
+
+
+@pytest.mark.asyncio
+async def test_async_scan_cancellation_signals_worker(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    started = threading.Event()
+    stopped = threading.Event()
+
+    def cancellable_scan(*args, cancel_event: threading.Event, **kwargs):
+        started.set()
+        while not cancel_event.is_set():
+            time.sleep(0.005)
+        stopped.set()
+        return ScanOutcome(complete=False, stop_reason="cancelled")
+
+    monkeypatch.setattr(workspace_scan, "scan_workspace_sync", cancellable_scan)
+    task = asyncio.create_task(scan_workspace(tmp_path))
+    assert await asyncio.to_thread(started.wait, 1)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert await asyncio.to_thread(stopped.wait, 0.5)


### PR DESCRIPTION
## Summary

- move recursive local filename discovery to an asynchronous, cancellable native `find` subprocess, with an off-thread Python fallback when `find` is unavailable
- keep local ripgrep/grep content searches exhaustive and cancellable instead of imposing premature deadlines
- bound LSP startup discovery off the UI event loop and expose partial-scan status in the TUI
- add broad-root pruning for cache and platform-data directories while retaining useful source/config locations
- add regression coverage for responsiveness, pruning, result limits, cancellation, fallbacks, and LSP status

## Root cause

`find_files_by_pattern` called `Path.glob()` synchronously from the Textual event loop and materialized the entire result set before applying exclusions or the 128-result display limit. With a broad root such as `$HOME`, the UI, cancellation, diagnostics event handling, and turn completion all stopped while the recursive scan ran. LSP detection used the same synchronous recursive pattern during startup.

The first bounded implementation also applied short deadlines to asynchronous filename/content searches. That prevented UI hangs but produced false-negative partial results for sparse broad-root queries. This revision keeps those searches exhaustive while making their process/thread work cancellable and non-blocking.

## Impact

- the TUI remains responsive during recursive filesystem work
- Escape terminates local `find`, ripgrep, and grep children promptly
- `find_files_by_pattern("**/claude_desktop_config.json")` completes against the home root without an entry-limit false negative
- `search_codebase("mcpServers|mcp_servers")` completes against the home root without a deadline false negative
- LSP discovery cannot block the event loop and reports when its startup survey is partial

## Validation

- `./run_tests.sh`: 1,980 passed, 50 deselected
- focused filesystem/LSP regression suite: 91 passed
- `ruff check .`
- `ruff format --check .`
- `pyright`
- live broad-root reproductions for both reported queries
