### PR TITLE
Add TUI custom agent commands

### DIFF
--- a/docs/src/content/docs/concepts/agents.md
+++ b/docs/src/content/docs/concepts/agents.md
@@ -93,6 +93,11 @@ kolega-code agents list --project .
 kolega-code agents validate --project .
 ```
 
+Inside the TUI, use `/agents` (or `/agents list`) to inspect all effective
+definitions and `/agents validate` to rescan and report invalid files. Definitions
+changed while the TUI is running become dispatchable after the active agent is
+rebuilt, such as when switching modes, or after restarting the TUI.
+
 The Build or Plan agent sees the names and descriptions enabled for its mode and
 can select one through `dispatch_custom_agent`. Build is the safe default; an
 agent must explicitly declare `mode: plan` or `mode: all` before Plan can use it.

--- a/docs/src/content/docs/tui/slash-commands.md
+++ b/docs/src/content/docs/tui/slash-commands.md
@@ -33,6 +33,7 @@ These control the app and your session.
 | Command | Description |
 | --- | --- |
 | `/skills` | List available Agent Skills |
+| `/agents` | List or validate custom agents (`/agents validate`) |
 | `/init` | Create or update `AGENTS.md` for this repository |
 | `/attach` | Attach an image: clipboard if no path, or `/attach <path>` for a file |
 | `/detach` | Remove pending image attachments |
@@ -75,6 +76,12 @@ without an API key; `/logout chatgpt` removes the stored credentials. See
 Run `/queue-clear` to discard follow-up prompts that you queued while the current
 turn is running. It removes their `Queued` transcript entries, but it does not
 cancel or otherwise stop the active agent turn.
+
+Run `/agents` or `/agents list` to inspect all effective user and project custom-agent
+definitions, including agents configured for the other interaction mode. Run
+`/agents validate` to rescan the files and report invalid definitions. File changes
+become dispatchable after the active agent is rebuilt (for example, by switching
+modes) or the TUI is restarted.
 
 Run `/diagnostics` to print a snapshot of this session — version, platform and
 terminal, active model and endpoint, which providers have keys, and how many

--- a/kolega_code/cli/slash_commands.py
+++ b/kolega_code/cli/slash_commands.py
@@ -44,6 +44,7 @@ SKILLS_LIST_COMMAND = "/skills"
 
 TUI_COMMAND_ENTRIES: tuple[SlashCommandEntry, ...] = (
     SlashCommandEntry("skills", "List available Agent Skills", CommandScope.TUI),
+    SlashCommandEntry("agents", "List and validate custom agents", CommandScope.TUI),
     SlashCommandEntry(
         "attach",
         "Attach an image (clipboard if no path, or a file path)",

--- a/kolega_code/cli/tui/command_handlers.py
+++ b/kolega_code/cli/tui/command_handlers.py
@@ -7,6 +7,7 @@ from typing import Awaitable, Callable, Optional
 
 
 from kolega_code.agent import PromptExtension
+from kolega_code.agent.custom_agents import discover_custom_agents, validate_custom_agent_models
 from kolega_code.agent.prompt_dump import (
     dump_prompt_overrides,
     format_prompt_dump_result,
@@ -48,6 +49,7 @@ class CommandHandlersMixin(tui_app_base.KolegaAppBase):
     def _tui_command_handlers(self) -> dict[str, Callable[[str], Awaitable[None]]]:
         return {
             "/attach": self._command_attach,
+            "/agents": self._command_agents,
             "/detach": self._command_detach,
             "/init": self._command_init,
             "/plan": self._command_plan,
@@ -408,6 +410,26 @@ class CommandHandlersMixin(tui_app_base.KolegaAppBase):
             return
 
         self._add_conversation_entry(tui_state.ConversationEntry(kind="system", content=usage))
+
+    async def _command_agents(self, args: str) -> None:
+        command = args.strip().lower()
+        usage = "Usage: /agents [list|validate]"
+        if command not in {"", "list", "validate"}:
+            self._add_conversation_entry(tui_state.ConversationEntry(kind="system", content=usage))
+            return
+
+        catalog = discover_custom_agents(self.project_path, self.settings_store.root)
+        if self.config is not None:
+            catalog = validate_custom_agent_models(catalog, self.config)
+
+        content = catalog.format_catalog()
+        content += (
+            "\n\nCustom-agent file changes become dispatchable after the active agent is rebuilt "
+            "(for example, by switching modes) or the TUI is restarted."
+        )
+        self._add_conversation_entry(tui_state.ConversationEntry(kind="system", content=content))
+        if command == "validate" and catalog.has_errors():
+            self._notify_user("Some custom-agent definitions are invalid.", severity="error")
 
     async def _command_sidebar(self, args: str) -> None:
         await self.action_toggle_sidebar()

--- a/tests/cli/test_custom_agents_cli.py
+++ b/tests/cli/test_custom_agents_cli.py
@@ -92,3 +92,113 @@ async def test_tui_filters_custom_agents_when_switching_build_and_plan_modes(
         await pilot.press("shift+tab")
         assert isinstance(app.agent, FakePlanningAgent)
         assert app.agent.kwargs["custom_agent_catalog"].names() == ["planner", "shared"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("command", ["/agents", "/agents list"])
+async def test_tui_agents_command_lists_definitions_for_all_modes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+) -> None:
+    pytest.importorskip("textual")
+    from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    install_fake_agents(monkeypatch)
+    project = tmp_path / "project"
+    project.mkdir()
+    agent_dir = project / ".kolega" / "agents"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "builder.md").write_text(
+        "---\nname: builder\ndescription: Build specialist\n---\nBuild.\n",
+        encoding="utf-8",
+    )
+    (agent_dir / "planner.md").write_text(
+        "---\nname: planner\ndescription: Plan specialist\nmode: plan\n---\nPlan.\n",
+        encoding="utf-8",
+    )
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test():
+        composer = app.query_one("#composer", ChatComposer)
+        assert "/agents" in app._tui_command_handlers()
+        composer.load_text(command)
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+
+        entry = app.conversation_entries[-1]
+        assert entry.kind == "system"
+        assert "`builder` (project, build): Build specialist" in entry.content
+        assert "`planner` (project, plan): Plan specialist" in entry.content
+        assert "become dispatchable after the active agent is rebuilt" in entry.content
+        assert isinstance(app.agent, FakeCoderAgent)
+        assert app.agent.messages == []
+
+
+@pytest.mark.asyncio
+async def test_tui_agents_validate_reports_errors_and_notifies(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("textual")
+    from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    install_fake_agents(monkeypatch)
+    project = tmp_path / "project"
+    project.mkdir()
+    _write_agent(project, "---\nname: reviewer\ndescription: Reviews code\ntyop: true\n---\nReview.\n")
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+    notifications: list[tuple[str, str]] = []
+
+    async with app.run_test():
+        monkeypatch.setattr(
+            app,
+            "_notify_user",
+            lambda message, *, severity="information", title=None: notifications.append((message, severity)),
+        )
+        composer = app.query_one("#composer", ChatComposer)
+        composer.load_text("/agents validate")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+
+        entry = app.conversation_entries[-1]
+        assert entry.kind == "system"
+        assert "unknown frontmatter field(s): tyop" in entry.content
+        assert notifications == [("Some custom-agent definitions are invalid.", "error")]
+        assert isinstance(app.agent, FakeCoderAgent)
+        assert app.agent.messages == []
+
+
+@pytest.mark.asyncio
+async def test_tui_agents_command_rejects_invalid_syntax_without_starting_turn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("textual")
+    from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    install_fake_agents(monkeypatch)
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test():
+        composer = app.query_one("#composer", ChatComposer)
+        composer.load_text("/agents reload")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+
+        entry = app.conversation_entries[-1]
+        assert entry.kind == "system"
+        assert entry.content == "Usage: /agents [list|validate]"
+        assert isinstance(app.agent, FakeCoderAgent)
+        assert app.agent.messages == []

--- a/tests/cli/test_slash_commands.py
+++ b/tests/cli/test_slash_commands.py
@@ -32,6 +32,7 @@ def test_agent_command_names_match_command_processor():
     assert agent_command_names() == {spec.name for spec in CommandProcessor.SPECS}
     assert THREAD_RESET_COMMANDS <= agent_command_names()
     assert SKILLS_LIST_COMMAND in TUI_COMMAND_NAMES
+    assert "/agents" in TUI_COMMAND_NAMES
     assert "/init" in TUI_COMMAND_NAMES
     assert "/sidebar" in TUI_COMMAND_NAMES
     assert "/prompts" in TUI_COMMAND_NAMES
@@ -52,6 +53,7 @@ def test_all_command_entries_include_each_scope():
     entries = all_command_entries(_catalog("demo-skill"))
     by_name = {entry.name: entry for entry in entries}
     assert by_name["help"].scope is CommandScope.AGENT
+    assert by_name["agents"].scope is CommandScope.TUI
     assert by_name["init"].scope is CommandScope.TUI
     assert by_name["plan"].scope is CommandScope.TUI
     assert by_name["effort"].scope is CommandScope.TUI
@@ -64,10 +66,11 @@ def test_all_command_entries_include_each_scope():
 
 
 def test_builtin_command_shadows_skill_with_same_name():
-    entries = all_command_entries(_catalog("init"))
-    matches = [entry for entry in entries if entry.name == "init"]
-    assert len(matches) == 1
-    assert matches[0].scope is CommandScope.TUI
+    entries = all_command_entries(_catalog("agents", "init"))
+    for name in ("agents", "init"):
+        matches = [entry for entry in entries if entry.name == name]
+        assert len(matches) == 1
+        assert matches[0].scope is CommandScope.TUI
 
 
 def test_search_commands_prefix_matches_first():


### PR DESCRIPTION
## Summary

- add `/agents` and `/agents list` to show all effective user and project custom-agent definitions
- add `/agents validate` to rescan definitions, report diagnostics, and notify on validation errors
- register the command in slash autocomplete, keep it out of the agent loop, and document reload semantics
- add TUI, command-registry, validation, and skill-collision coverage

This is a follow-up to #240, which merged before this TUI command commit was pushed.

## Validation

- 50 custom-agent and neighboring TUI/command tests passed
- full pre-commit suite passed: Ruff, formatting, YAML, Pyright, and repository hygiene
- documentation build passed (29 pages)
- `git diff --check` passed