### PR TITLE
Prefer Claude Code edits for DeepSeek models

### DIFF
--- a/benchmarks/edit_tools/README.md
+++ b/benchmarks/edit_tools/README.md
@@ -33,8 +33,9 @@ uv run python -m benchmarks.edit_tools run \
   --confirm-live
 ```
 
-For the full DeepSeek V4 Pro/Flash comparison, the checked-in matrix plans 800
-trials (100 tasks × 4 protocols × 2 models):
+For the full DeepSeek V4 Pro/Flash comparison, the checked-in matrix plans 600
+trials (100 tasks × 3 protocols × 2 models). Codex apply-patch is deliberately
+excluded because it is not a viable default for these models:
 
 ```bash
 uv run python -m benchmarks.edit_tools run \
@@ -193,10 +194,12 @@ task/repetition outcomes and bootstrap over tasks with a fixed seed. The report
 names a leader only when the paired 95% interval excludes zero.
 
 Reports keep task success and exact workspace matching separate. They also
-record first-edit-attempt success as both a count and a rate: the number of
-trials whose first edit-tool call applied successfully divided by the number of
-trials that made an edit-tool call. Trials that never attempt an edit are
-reported separately by `no_edit_rate` rather than included in that denominator.
+record first-edit-attempt success per changed file as a primary outcome: the
+earliest edit call targeting each file must parse and apply. A failed call that
+is fixed on a later attempt remains a first-attempt failure for that file, and a
+target file with no edit call is unsuccessful. Reports separately show the
+share of trials where every changed file succeeded on its first attempt, a
+conditional first-call rate, and `no_edit_rate` as diagnostics.
 
 ## Complete provider smoke
 

--- a/benchmarks/edit_tools/matrices/deepseek-v4.yaml
+++ b/benchmarks/edit_tools/matrices/deepseek-v4.yaml
@@ -7,13 +7,13 @@ max_iterations: 30
 models:
   - provider: deepseek
     model: deepseek-v4-pro
-    protocols: [search_replace, codex_apply_patch, claude_code, hashline_v2]
+    protocols: [search_replace, claude_code, hashline_v2]
     temperature: 1.0
     thinking_effort: high
     max_output_tokens: 8192
   - provider: deepseek
     model: deepseek-v4-flash
-    protocols: [search_replace, codex_apply_patch, claude_code, hashline_v2]
+    protocols: [search_replace, claude_code, hashline_v2]
     temperature: 1.0
     thinking_effort: high
     max_output_tokens: 8192

--- a/benchmarks/edit_tools/models.py
+++ b/benchmarks/edit_tools/models.py
@@ -405,6 +405,8 @@ class TrialRecord(BaseModel):
     operation_success_rate: float = Field(default=0.0, ge=0.0, le=1.0)
     completed_operations: int = Field(default=0, ge=0)
     total_operations: int = Field(default=0, ge=0)
+    first_attempt_file_successes: int = Field(default=0, ge=0)
+    first_attempt_files: int = Field(default=0, ge=0)
     first_attempt_success: bool = False
     oracle_success: bool = False
     terminal_stop: bool = False

--- a/benchmarks/edit_tools/protocols.py
+++ b/benchmarks/edit_tools/protocols.py
@@ -9,6 +9,7 @@ from typing import Any, Callable
 
 from kolega_code.agent.prompt_provider import AgentMode
 from kolega_code.agent.tools import ToolCollection, ToolCollectionConfig, ToolExtension
+from kolega_code.agent.tool_backend.codex_patch import CodexPatchParseError
 from kolega_code.config import AgentConfig, EditProtocol
 from kolega_code.events import AgentConnectionManager, AgentEvent
 from kolega_code.llm.models import ToolCall, ToolDefinition, ToolResult
@@ -215,6 +216,8 @@ async def execute_call(
                 raise ValueError(f"tool {call.name!r} requires object input")
             output = str(await registry.call(call.name, **inputs))
         except Exception as exc:  # noqa: BLE001 - the model may recover on its next iteration
+            if isinstance(exc, CodexPatchParseError):
+                parse_ok = False
             is_error = True
             error = str(exc)
             output = f"Tool error: {error}"

--- a/benchmarks/edit_tools/report.py
+++ b/benchmarks/edit_tools/report.py
@@ -34,6 +34,21 @@ def _percentile(values: list[int], fraction: float) -> float:
     return float(ordered[index])
 
 
+def _first_attempt_file_totals(records: Iterable[TrialRecord]) -> tuple[int, int]:
+    successes = 0
+    files = 0
+    for record in records:
+        if record.first_attempt_files:
+            successes += record.first_attempt_file_successes
+            files += record.first_attempt_files
+        else:
+            # Historical records predate file-level counters. Preserve their
+            # old one-outcome-per-trial interpretation when rebuilding reports.
+            successes += int(record.first_attempt_success)
+            files += 1
+    return successes, files
+
+
 def aggregate(records: Iterable[TrialRecord]) -> list[dict[str, Any]]:
     groups: dict[tuple[str, str, str, str], list[TrialRecord]] = defaultdict(list)
     for record in records:
@@ -51,6 +66,8 @@ def aggregate(records: Iterable[TrialRecord]) -> list[dict[str, Any]]:
             if (attempts := [attempt for attempt in item.tool_attempts if attempt.name in edit_names])
         ]
         first_edit_attempt_successes = sum(attempt.apply_ok for attempt in first_edit_attempts)
+        first_attempt_file_successes, first_attempt_files = _first_attempt_file_totals(scored)
+        all_files_first_attempt_successes = sum(item.first_attempt_success for item in scored)
         latency = [item.elapsed_ms for item in scored]
         family_groups: dict[str, list[TrialRecord]] = defaultdict(list)
         for item in scored:
@@ -89,12 +106,22 @@ def aggregate(records: Iterable[TrialRecord]) -> list[dict[str, Any]]:
                 ),
                 "success_ci_low": low if scored else None,
                 "success_ci_high": high if scored else None,
-                # Retained for report consumers created before the metric was
-                # given an explicit edit-tool name. Its denominator is all
-                # scored trials, so no-edit trials count as unsuccessful.
+                # Legacy names remain aliases for the primary per-file metric.
                 "first_attempt_rate": (
-                    sum(item.first_attempt_success for item in scored) / len(scored) if scored else None
+                    first_attempt_file_successes / first_attempt_files if first_attempt_files else None
                 ),
+                "first_attempt_successes": first_attempt_file_successes,
+                "first_attempt_trials": first_attempt_files,
+                "first_attempt_file_success_rate": (
+                    first_attempt_file_successes / first_attempt_files if first_attempt_files else None
+                ),
+                "first_attempt_file_successes": first_attempt_file_successes,
+                "first_attempt_files": first_attempt_files,
+                "all_files_first_attempt_success_rate": (
+                    all_files_first_attempt_successes / len(scored) if scored else None
+                ),
+                "all_files_first_attempt_successes": all_files_first_attempt_successes,
+                "all_files_first_attempt_trials": len(scored),
                 "first_edit_attempt_successes": first_edit_attempt_successes,
                 "first_edit_attempts": len(first_edit_attempts),
                 "first_edit_attempt_success_rate": (
@@ -161,6 +188,8 @@ def breakdown(records: Iterable[TrialRecord], dimension: str) -> list[dict[str, 
             if (attempts := [attempt for attempt in item.tool_attempts if attempt.name in edit_names])
         ]
         first_edit_attempt_successes = sum(attempt.apply_ok for attempt in first_edit_attempts)
+        first_attempt_file_successes, first_attempt_files = _first_attempt_file_totals(scored)
+        all_files_first_attempt_successes = sum(item.first_attempt_success for item in scored)
         rows.append(
             {
                 "provider": provider,
@@ -174,6 +203,21 @@ def breakdown(records: Iterable[TrialRecord], dimension: str) -> list[dict[str, 
                     sum(item.functional_success for item in scored) / len(scored) if scored else None
                 ),
                 "exact_match_rate": sum(item.exact_match for item in scored) / len(scored) if scored else None,
+                "first_attempt_successes": first_attempt_file_successes,
+                "first_attempt_trials": first_attempt_files,
+                "first_attempt_rate": (
+                    first_attempt_file_successes / first_attempt_files if first_attempt_files else None
+                ),
+                "first_attempt_file_success_rate": (
+                    first_attempt_file_successes / first_attempt_files if first_attempt_files else None
+                ),
+                "first_attempt_file_successes": first_attempt_file_successes,
+                "first_attempt_files": first_attempt_files,
+                "all_files_first_attempt_success_rate": (
+                    all_files_first_attempt_successes / len(scored) if scored else None
+                ),
+                "all_files_first_attempt_successes": all_files_first_attempt_successes,
+                "all_files_first_attempt_trials": len(scored),
                 "first_edit_attempt_successes": first_edit_attempt_successes,
                 "first_edit_attempts": len(first_edit_attempts),
                 "first_edit_attempt_success_rate": (
@@ -274,11 +318,12 @@ def markdown_report(
         "",
         "Provider and harness failures are not included in scored success-rate denominators.",
         "Task success means all configured oracle checks passed; exact match means the resulting workspace "
-        "matched the expected workspace exactly. First edit attempt measures successful first edit-tool "
-        "applications among trials that made an edit attempt.",
+        "matched the expected workspace exactly. First attempt/file scores the earliest edit call targeting each "
+        "changed file; it must parse and apply, and a missing call is unsuccessful. All files first try requires "
+        "that outcome for every changed file in a trial. Conditional first call excludes no-edit trials.",
         "",
-        "| Provider/model | Lane | Protocol | Scored | Task success | Exact match | Operations | Family macro | 95% CI | First edit attempt | Apply | Infra/not run |",
-        "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: |",
+        "| Provider/model | Lane | Protocol | Scored | Task success | Exact match | Operations | Family macro | 95% CI | First attempt/file | All files first try | Conditional first call | Apply | No edit | Infra/not run |",
+        "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: |",
     ]
     for row in rows:
         ci = (
@@ -292,8 +337,10 @@ def markdown_report(
             f"{_format_rate(row['success_rate'])} | {_format_rate(row['exact_match_rate'])} | "
             f"{_format_rate(row['operation_success_rate'])} | "
             f"{_format_rate(row['macro_family_success_rate'])} | {ci} | "
+            f"{_format_counted_rate(row['first_attempt_rate'], row['first_attempt_successes'], row['first_attempt_trials'])} | "
+            f"{_format_counted_rate(row['all_files_first_attempt_success_rate'], row['all_files_first_attempt_successes'], row['all_files_first_attempt_trials'])} | "
             f"{_format_counted_rate(row['first_edit_attempt_success_rate'], row['first_edit_attempt_successes'], row['first_edit_attempts'])} | "
-            f"{_format_rate(row['apply_success_rate'])} | {infra} |"
+            f"{_format_rate(row['apply_success_rate'])} | {_format_rate(row['no_edit_rate'])} | {infra} |"
         )
     for dimension in ("language", "family", "target_length", "payload_size", "target_file_count"):
         lines.extend(
@@ -301,8 +348,8 @@ def markdown_report(
                 "",
                 f"## By {dimension}",
                 "",
-                f"| Provider/model | Lane | Protocol | {dimension.replace('_', ' ').title()} | Scored | Task success | Exact match | First edit attempt | Operations |",
-                "| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: |",
+                f"| Provider/model | Lane | Protocol | {dimension.replace('_', ' ').title()} | Scored | Task success | Exact match | First attempt/file | All files first try | Conditional first call | Operations |",
+                "| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
             ]
         )
         for item in breakdowns[dimension]:
@@ -310,6 +357,8 @@ def markdown_report(
                 f"| {item['provider']}/{item['model']} | {item['lane']} | {item['protocol']} | "
                 f"{item[dimension]} | {item['scored']} | {_format_rate(item['success_rate'])} | "
                 f"{_format_rate(item['exact_match_rate'])} | "
+                f"{_format_counted_rate(item['first_attempt_rate'], item['first_attempt_successes'], item['first_attempt_trials'])} | "
+                f"{_format_counted_rate(item['all_files_first_attempt_success_rate'], item['all_files_first_attempt_successes'], item['all_files_first_attempt_trials'])} | "
                 f"{_format_counted_rate(item['first_edit_attempt_success_rate'], item['first_edit_attempt_successes'], item['first_edit_attempts'])} | "
                 f"{_format_rate(item['operation_success_rate'])} |"
             )

--- a/benchmarks/edit_tools/runner.py
+++ b/benchmarks/edit_tools/runner.py
@@ -16,7 +16,7 @@ from kolega_code.agent.errors import MaxAgentIterationsExceeded
 from kolega_code.agent.prompt_provider import AgentMode
 from kolega_code.cli.config import CliConfigError, CliConfigOverrides, build_agent_config
 from kolega_code.cli.settings import SettingsStore
-from kolega_code.config import AgentConfig, ModelProvider
+from kolega_code.config import AgentConfig, EditProtocol, ModelProvider
 from kolega_code.llm.client import LLMClient
 from kolega_code.llm.exceptions import LLMError
 from kolega_code.llm.models import (
@@ -51,6 +51,7 @@ from .protocols import (
     execute_call,
     get_protocol,
 )
+from .scoring import score_first_attempts_by_file
 from .usage import add_usage
 from .workspace import collateral_paths, materialize_task, oracle_to_dict, verify_task, workspace_diff
 
@@ -140,15 +141,15 @@ def plan_trials(
             continue
         model_parameters = _model_parameters(model)
         model_parameters["max_iterations"] = matrix.max_iterations
-        for protocol_id in model.protocols:
-            if protocols and protocol_id not in protocols:
+        for lane in matrix.lanes:
+            if lanes and lane not in lanes:
                 continue
-            adapter = get_protocol(protocol_id)
-            for lane in matrix.lanes:
-                if lanes and lane not in lanes:
-                    continue
-                for task in selected_tasks:
-                    for repetition in range(1, repetitions + 1):
+            for task in selected_tasks:
+                for repetition in range(1, repetitions + 1):
+                    for protocol_id in model.protocols:
+                        if protocols and protocol_id not in protocols:
+                            continue
+                        adapter = get_protocol(protocol_id)
                         seed = (task.seed or 0) + repetition
                         identifier = trial_id(
                             suite=suite,
@@ -179,6 +180,7 @@ def plan_trials(
 
 
 def _build_config(project_path: Path, spec: PlannedTrial) -> AgentConfig:
+    adapter = get_protocol(spec.protocol)
     settings_store = SettingsStore()
     settings = settings_store.load()
     override = CliConfigOverrides(
@@ -190,7 +192,7 @@ def _build_config(project_path: Path, spec: PlannedTrial) -> AgentConfig:
         thinking_model=spec.model.model,
         thinking_effort=spec.model_parameters["thinking_effort"],
         environment="benchmark",
-        edit_protocol=spec.protocol,
+        edit_protocol=(adapter.production_protocol or EditProtocol.SEARCH_REPLACE).value,
     )
     config = build_agent_config(
         project_path,
@@ -546,7 +548,13 @@ async def run_trial(
                 tool_attempts=execution.attempts,
             )
         edit_attempts = [attempt for attempt in execution.attempts if attempt.name in adapter.tool_names]
-        first_attempt_success = bool(edit_attempts and edit_attempts[0].apply_ok)
+        first_attempt_file_successes, first_attempt_files = score_first_attempts_by_file(
+            trial.task,
+            execution.attempts,
+            set(adapter.tool_names),
+            workspace=workspace,
+        )
+        first_attempt_success = bool(first_attempt_files and first_attempt_file_successes == first_attempt_files)
         status = "passed" if oracle.success else "failed"
         failure_stage = None
         if not oracle.success:
@@ -573,6 +581,8 @@ async def run_trial(
             suite_id=suite.id,
             status=status,
             task_success=oracle.success,
+            first_attempt_file_successes=first_attempt_file_successes,
+            first_attempt_files=first_attempt_files,
             first_attempt_success=first_attempt_success,
             oracle_success=oracle.success,
             functional_success=oracle.functional_success,
@@ -592,9 +602,10 @@ async def run_trial(
                 "iteration_exhausted": execution.iteration_exhausted,
                 "transport_kind": (
                     "native_freeform"
-                    if trial.protocol == "codex_apply_patch" and trial.model.provider in {"openai", "openai_chatgpt"}
+                    if adapter.production_protocol == EditProtocol.CODEX_APPLY_PATCH
+                    and trial.model.provider in {"openai", "openai_chatgpt"}
                     else "json_envelope"
-                    if trial.protocol == "codex_apply_patch"
+                    if adapter.production_protocol == EditProtocol.CODEX_APPLY_PATCH
                     else "json"
                 ),
             },

--- a/benchmarks/edit_tools/scoring.py
+++ b/benchmarks/edit_tools/scoring.py
@@ -1,0 +1,80 @@
+"""Edit-attempt scoring shared by benchmark execution and tests."""
+
+from __future__ import annotations
+
+from pathlib import Path, PurePosixPath
+import re
+from typing import Iterable
+
+from .models import TaskSpec, ToolAttempt
+
+
+_PATCH_FILE = re.compile(r"^\*\*\* (?:Add|Update|Delete) File: (.+?)\s*$", re.MULTILINE)
+_PATCH_MOVE = re.compile(r"^\*\*\* Move to: (.+?)\s*$", re.MULTILINE)
+
+
+def changed_file_paths(task: TaskSpec) -> frozenset[str]:
+    """Return every file whose expected content or presence differs."""
+
+    paths = set(task.before_files) | set(task.expected_files)
+    return frozenset(path for path in paths if task.before_files.get(path) != task.expected_files.get(path))
+
+
+def _normalize_path(value: object, workspace: Path | None) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    raw = value.strip()
+    if workspace is not None:
+        root = workspace.resolve()
+        candidate = Path(raw)
+        resolved = (
+            candidate.resolve(strict=False) if candidate.is_absolute() else (root / candidate).resolve(strict=False)
+        )
+        try:
+            return resolved.relative_to(root).as_posix()
+        except ValueError:
+            return None
+    candidate = PurePosixPath(raw)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        return None
+    normalized = candidate.as_posix()
+    return None if normalized in {"", "."} else normalized.removeprefix("./")
+
+
+def attempt_file_paths(attempt: ToolAttempt, workspace: Path | None = None) -> frozenset[str]:
+    """Extract files targeted by one edit call, including multi-file patches."""
+
+    raw = attempt.raw_input
+    values: list[object] = []
+    if isinstance(raw, dict):
+        values.extend(raw.get(key) for key in ("path", "file_path", "rename") if raw.get(key) is not None)
+        if isinstance(raw.get("input"), str):
+            raw = raw["input"]
+    if isinstance(raw, str):
+        values.extend(_PATCH_FILE.findall(raw))
+        values.extend(_PATCH_MOVE.findall(raw))
+    return frozenset(path for value in values if (path := _normalize_path(value, workspace)) is not None)
+
+
+def score_first_attempts_by_file(
+    task: TaskSpec,
+    attempts: Iterable[ToolAttempt],
+    edit_tool_names: set[str] | frozenset[str],
+    *,
+    workspace: Path | None = None,
+) -> tuple[int, int]:
+    """Score the earliest edit call for every file the task must change.
+
+    A later recovery cannot erase an earlier failure for the same file. A
+    target file that is never named by an edit call also counts as a failure.
+    """
+
+    targets = changed_file_paths(task)
+    first_outcomes: dict[str, bool] = {}
+    for attempt in attempts:
+        if attempt.name not in edit_tool_names:
+            continue
+        outcome = attempt.parse_ok and attempt.apply_ok
+        for path in attempt_file_paths(attempt, workspace):
+            first_outcomes.setdefault(path, outcome)
+    return sum(first_outcomes.get(path, False) for path in targets), len(targets)

--- a/kolega_code/agent/tool_backend/codex_patch.py
+++ b/kolega_code/agent/tool_backend/codex_patch.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal, Optional
 
-
 CODEX_APPLY_PATCH_GRAMMAR = r"""start: begin_patch hunk+ end_patch
 begin_patch: "*** Begin Patch" LF
 end_patch: "*** End Patch" LF?
@@ -50,14 +49,22 @@ class CodexPatchError(ValueError):
     """The patch is malformed or cannot be applied."""
 
 
+class CodexPatchParseError(CodexPatchError):
+    """The patch payload is not valid Codex patch syntax."""
+
+
+class CodexPatchApplyError(CodexPatchError):
+    """A valid patch cannot be matched against the current file contents."""
+
+
 def parse_codex_patch(raw: str) -> list[PatchOperation]:
     """Parse Codex patch text without requiring Lark at runtime."""
     text = raw.replace("\r\n", "\n").replace("\r", "\n")
     lines = text.splitlines()
     if not lines or lines[0].strip() != "*** Begin Patch":
-        raise CodexPatchError("Patch must start with '*** Begin Patch'.")
+        raise CodexPatchParseError("Patch must start with '*** Begin Patch'.")
     if len(lines) < 2 or lines[-1].strip() != "*** End Patch":
-        raise CodexPatchError("Patch must end with '*** End Patch'.")
+        raise CodexPatchParseError("Patch must end with '*** End Patch'.")
 
     operations: list[PatchOperation] = []
     index = 1
@@ -71,11 +78,11 @@ def parse_codex_patch(raw: str) -> list[PatchOperation]:
             while index < end and not lines[index].startswith("*** "):
                 line = lines[index]
                 if not line.startswith("+"):
-                    raise CodexPatchError(f"Add File lines must start with '+': {line!r}")
+                    raise CodexPatchParseError(f"Add File lines must start with '+': {line!r}")
                 added.append(line[1:])
                 index += 1
             if not added:
-                raise CodexPatchError(f"Add File requires at least one '+' line: {path}")
+                raise CodexPatchParseError(f"Add File requires at least one '+' line: {path}")
             operations.append(PatchOperation(kind="add", path=path, add_lines=tuple(added)))
             continue
 
@@ -109,30 +116,30 @@ def parse_codex_patch(raw: str) -> list[PatchOperation]:
                 line = lines[index]
                 if line == "@@" or line.startswith("@@ "):
                     if eof:
-                        raise CodexPatchError("'*** End of File' must be the final line of an update.")
+                        raise CodexPatchParseError("'*** End of File' must be the final line of an update.")
                     finish_chunk()
                     context = line[3:] if line.startswith("@@ ") else None
                 elif line == "*** End of File":
                     if eof:
-                        raise CodexPatchError("An update may contain only one '*** End of File' marker.")
+                        raise CodexPatchParseError("An update may contain only one '*** End of File' marker.")
                     eof = True
                 elif line[:1] in {"+", "-", " "}:
                     if eof:
-                        raise CodexPatchError("'*** End of File' must be the final line of an update.")
+                        raise CodexPatchParseError("'*** End of File' must be the final line of an update.")
                     change_lines.append((line[0], line[1:]))
                 else:
-                    raise CodexPatchError(f"Invalid Update File line: {line!r}")
+                    raise CodexPatchParseError(f"Invalid Update File line: {line!r}")
                 index += 1
             finish_chunk()
             if not chunks and move_to is None:
-                raise CodexPatchError(f"Update File has no changes: {path}")
+                raise CodexPatchParseError(f"Update File has no changes: {path}")
             operations.append(PatchOperation(kind="update", path=path, move_to=move_to, chunks=tuple(chunks)))
             continue
 
-        raise CodexPatchError(f"Invalid patch operation marker: {marker!r}")
+        raise CodexPatchParseError(f"Invalid patch operation marker: {marker!r}")
 
     if not operations:
-        raise CodexPatchError("Patch must contain at least one file operation.")
+        raise CodexPatchParseError("Patch must contain at least one file operation.")
     return operations
 
 
@@ -151,7 +158,7 @@ def apply_update_chunks(content: str, chunks: tuple[PatchChunk, ...], path: str)
         if chunk.context is not None:
             context_index = _find_line(lines, chunk.context, cursor)
             if context_index is None:
-                raise CodexPatchError(f"Update chunk #{number} context does not match {path}: {chunk.context!r}")
+                raise CodexPatchApplyError(f"Update chunk #{number} context does not match {path}: {chunk.context!r}")
             hint = context_index + 1
 
         old_lines = [text for prefix, text in chunk.lines if prefix in {" ", "-"}]
@@ -163,7 +170,7 @@ def apply_update_chunks(content: str, chunks: tuple[PatchChunk, ...], path: str)
             match = _find_sequence(lines, old_lines, hint, at_end=chunk.end_of_file)
             if match is None:
                 preview = "\n".join(old_lines[:5])
-                raise CodexPatchError(f"Update chunk #{number} does not match {path}:\n{preview}")
+                raise CodexPatchApplyError(f"Update chunk #{number} does not match {path}:\n{preview}")
             start, end = match
         lines[start:end] = new_lines
         cursor = start + len(new_lines)
@@ -179,7 +186,7 @@ def apply_update_chunks(content: str, chunks: tuple[PatchChunk, ...], path: str)
 def _path_after(line: str, prefix: str) -> str:
     path = line[len(prefix) :].strip()
     if not path:
-        raise CodexPatchError(f"Missing path after {prefix.strip()!r}.")
+        raise CodexPatchParseError(f"Missing path after {prefix.strip()!r}.")
     return path
 
 
@@ -214,7 +221,13 @@ def _find_line(lines: list[str], needle: str, start: int) -> Optional[int]:
     return None
 
 
-def _find_sequence(lines: list[str], needle: list[str], start: int, *, at_end: bool) -> Optional[tuple[int, int]]:
+def _find_sequence(
+    lines: list[str],
+    needle: list[str],
+    start: int,
+    *,
+    at_end: bool,
+) -> Optional[tuple[int, int]]:
     if len(needle) > len(lines):
         return None
     candidates = [len(lines) - len(needle)] if at_end else range(start, len(lines) - len(needle) + 1)

--- a/kolega_code/llm/specs/catalog/deepseek.py
+++ b/kolega_code/llm/specs/catalog/deepseek.py
@@ -7,6 +7,7 @@ DEEPSEEK_SPECS = {
         "max_completion_tokens": 384000,
         "default_temperature": 1.0,
         "supports_vision": False,
+        "preferred_edit_protocol": "claude_code",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "high", "max"),
             default="high",
@@ -18,6 +19,7 @@ DEEPSEEK_SPECS = {
         "max_completion_tokens": 384000,
         "default_temperature": 1.0,
         "supports_vision": False,
+        "preferred_edit_protocol": "claude_code",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "high", "max"),
             default="high",

--- a/tests/agent/llm/test_edit_protocol_resolution.py
+++ b/tests/agent/llm/test_edit_protocol_resolution.py
@@ -77,3 +77,14 @@ def test_all_openai_catalog_models_prefer_codex_apply_patch() -> None:
 
     assert openai_models
     assert set(openai_models.values()) == {EditProtocol.CODEX_APPLY_PATCH.value}
+
+
+def test_direct_deepseek_models_prefer_claude_code() -> None:
+    deepseek_models = {
+        key: specs.get("preferred_edit_protocol") for key, specs in MODEL_SPECS.items() if key[0] == "deepseek"
+    }
+
+    assert deepseek_models == {
+        ("deepseek", "deepseek-v4-pro"): EditProtocol.CLAUDE_CODE.value,
+        ("deepseek", "deepseek-v4-flash"): EditProtocol.CLAUDE_CODE.value,
+    }

--- a/tests/benchmarks/test_edit_benchmark_protocols.py
+++ b/tests/benchmarks/test_edit_benchmark_protocols.py
@@ -137,6 +137,24 @@ async def test_malformed_freeform_envelope_is_a_parse_failure(tmp_path: Path) ->
 
 
 @pytest.mark.asyncio
+async def test_malformed_patch_payload_is_a_parse_failure(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    adapter = get_protocol("codex_apply_patch")
+    collection, _, caller = create_tool_collection(workspace, config(EditProtocol.CODEX_APPLY_PATCH), adapter, tmp_path)
+    definitions = {item.name: item for item in adapter.definitions(collection)}
+    call = ToolCall(id="call-1", name="apply_patch", input="not a patch", input_kind="freeform")
+    try:
+        result, attempt = await execute_call(collection, caller, call, definitions, 1)
+    finally:
+        await collection.cleanup()
+
+    assert result.is_error
+    assert not attempt.parse_ok
+    assert not attempt.apply_ok
+
+
+@pytest.mark.asyncio
 async def test_research_adapter_can_run_without_production_edit_enum(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()

--- a/tests/benchmarks/test_edit_benchmark_report.py
+++ b/tests/benchmarks/test_edit_benchmark_report.py
@@ -128,5 +128,53 @@ def test_report_distinguishes_task_exact_and_first_edit_success() -> None:
     markdown = markdown_report(rows, [], breakdowns)
     assert "| Scored | Task success | Exact match |" in markdown
     assert "| 2 | 100.0% | 50.0% |" in markdown
-    assert "First edit attempt" in markdown
+    assert "First attempt" in markdown
     assert "50.0% (1/2)" in markdown
+
+
+def test_end_to_end_first_attempt_counts_no_edit_as_failure() -> None:
+    no_edit = record("codex_apply_patch", 1, False)
+    first_try = record("codex_apply_patch", 2, True).model_copy(
+        update={
+            "first_attempt_success": True,
+            "tool_attempts": [
+                ToolAttempt(
+                    iteration=1,
+                    name="apply_patch",
+                    input_kind="freeform",
+                    raw_input="*** Begin Patch\n*** Add File: a\n+x\n*** End Patch",
+                    apply_ok=True,
+                )
+            ],
+        }
+    )
+
+    row = aggregate([no_edit, first_try])[0]
+
+    assert row["first_attempt_rate"] == 0.5
+    assert row["first_edit_attempt_success_rate"] == 1.0
+    assert row["no_edit_rate"] == 0.5
+
+
+def test_first_attempt_rate_is_weighted_per_target_file() -> None:
+    partial = record("claude_code", 1, True).model_copy(
+        update={
+            "first_attempt_file_successes": 1,
+            "first_attempt_files": 2,
+            "first_attempt_success": False,
+        }
+    )
+    complete = record("claude_code", 2, True).model_copy(
+        update={
+            "first_attempt_file_successes": 2,
+            "first_attempt_files": 2,
+            "first_attempt_success": True,
+        }
+    )
+
+    row = aggregate([partial, complete])[0]
+
+    assert row["first_attempt_file_success_rate"] == 0.75
+    assert row["first_attempt_file_successes"] == 3
+    assert row["first_attempt_files"] == 4
+    assert row["all_files_first_attempt_success_rate"] == 0.5

--- a/tests/benchmarks/test_edit_benchmark_scoring.py
+++ b/tests/benchmarks/test_edit_benchmark_scoring.py
@@ -1,0 +1,92 @@
+from pathlib import Path
+
+from benchmarks.edit_tools.models import FileContent, TaskSpec, ToolAttempt
+from benchmarks.edit_tools.scoring import attempt_file_paths, score_first_attempts_by_file
+
+
+def task() -> TaskSpec:
+    return TaskSpec(
+        id="two-files",
+        prompt="Update both files.",
+        before_files={
+            "a.py": FileContent(text="old a\n"),
+            "nested/b.py": FileContent(text="old b\n"),
+        },
+        expected_files={
+            "a.py": FileContent(text="new a\n"),
+            "nested/b.py": FileContent(text="new b\n"),
+        },
+    )
+
+
+def attempt(path: str, *, apply_ok: bool) -> ToolAttempt:
+    return ToolAttempt(
+        iteration=1,
+        name="edit",
+        input_kind="json",
+        raw_input={"path": path},
+        parse_ok=True,
+        apply_ok=apply_ok,
+        is_error=not apply_ok,
+    )
+
+
+def test_first_failure_for_a_file_is_not_erased_by_recovery() -> None:
+    attempts = [
+        attempt("a.py", apply_ok=False),
+        attempt("a.py", apply_ok=True),
+        attempt("nested/b.py", apply_ok=True),
+    ]
+
+    assert score_first_attempts_by_file(task(), attempts, {"edit"}) == (1, 2)
+
+
+def test_target_file_without_an_edit_call_counts_as_a_failure() -> None:
+    assert score_first_attempts_by_file(task(), [attempt("a.py", apply_ok=True)], {"edit"}) == (1, 2)
+
+
+def test_apply_patch_call_attributes_outcome_to_every_file() -> None:
+    patch = """*** Begin Patch
+*** Update File: a.py
+@@
+-old a
++new a
+*** Update File: nested/b.py
+@@
+-old b
++new b
+*** End Patch"""
+    patch_attempt = ToolAttempt(
+        iteration=1,
+        name="apply_patch",
+        input_kind="freeform",
+        raw_input=patch,
+        apply_ok=True,
+    )
+
+    assert attempt_file_paths(patch_attempt) == {"a.py", "nested/b.py"}
+    assert score_first_attempts_by_file(task(), [patch_attempt], {"apply_patch"}) == (2, 2)
+
+
+def test_rename_call_targets_source_and_destination() -> None:
+    rename_attempt = ToolAttempt(
+        iteration=1,
+        name="edit",
+        input_kind="json",
+        raw_input={"path": "old.py", "rename": "new.py", "edits": []},
+        apply_ok=True,
+    )
+
+    assert attempt_file_paths(rename_attempt) == {"old.py", "new.py"}
+
+
+def test_absolute_workspace_path_maps_to_target_file(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    assert score_first_attempts_by_file(
+        task(),
+        [attempt(str(workspace / "a.py"), apply_ok=True)],
+        {"edit"},
+        workspace=workspace,
+    ) == (1, 2)

--- a/uv.lock
+++ b/uv.lock
@@ -3689,11 +3689,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

- prefer the Claude Code-style edit protocol for direct `deepseek-v4-pro` and `deepseek-v4-flash`
- exclude Apply Patch from the DeepSeek comparison matrix
- score first-edit success per changed file, locking the earliest edit outcome so a successful retry cannot erase a first-attempt failure
- expose per-file and all-files-first-try metrics in benchmark reports
- distinguish malformed Codex patches from valid patches that fail to apply
- add coverage for model defaults, path attribution, retries, renames, multi-file patches, and weighted reporting

## Why

The direct DeepSeek models needed a model-specific edit default. Across 320 live trajectories with zero infrastructure retries, Claude Code-style was the strongest overall protocol and had the best holdout result on both models:

- Pro holdout: 18/20 task success and 38/39 first attempts per target file
- Flash holdout: 20/20 task success and 39/39 first attempts per target file

The previous benchmark's first-attempt diagnostic represented the first edit call in a trajectory. That hid failures when a model retried a failed edit or edited multiple files. The primary metric now records the first attempt separately for each file the task must change.

No experimental Hashline implementation change is included.

## Impact

Direct DeepSeek users get Claude Code-style edits by default unless they explicitly override the protocol. Benchmark reports now reflect the practical first-edit behavior we care about: whether each file succeeded on the model's first attempt.

## Validation

- post-change live CoderAgent smoke: 8/8 tasks passed; 10/10 target files succeeded on first attempt
- focused tests: 24 passed
- benchmark tests: 78 passed, 52 skipped
- `ruff check .`
- `pyright`: 0 errors
- all pre-commit hooks passed
- full suite: 2,236 passed and 52 skipped; sandbox-blocked browser tests and the loaded timing test passed on isolated rerun, while one unrelated live Browserless integration timed out
