### PR TITLE
Deliver queued messages into the running turn at tool boundaries

### DIFF
--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextvars
+from dataclasses import dataclass
 import logging
 import os
 import random
@@ -10,7 +11,7 @@ import uuid
 from email.utils import parsedate_to_datetime
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, List, Optional, cast
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable, Dict, List, Optional, cast
 from contextlib import AbstractAsyncContextManager
 from collections.abc import Coroutine
 
@@ -77,6 +78,12 @@ HOOK_DECISION_SYSTEM_PROMPT = (
     '{"ok": false, "reason": "<short explanation>"} to block it. The reason is shown to the '
     "agent. Output nothing other than the JSON object."
 )
+
+
+@dataclass
+class QueuedUserInput:
+    text: str
+    attachments: Optional[List[Dict[str, Any]]] = None
 
 
 class BaseAgent(LogMixin):
@@ -340,6 +347,7 @@ class BaseAgent(LogMixin):
         self.sub_agent_context = None  # Dispatch metadata (agent_id, task) set by AgentTool
         # Set by a blocking PostToolUse hook to end the turn after the current tool batch.
         self._hook_end_turn = False
+        self.queued_input_provider: Optional[Callable[[], Awaitable[List[QueuedUserInput]]]] = None
 
     # ------------------------------------------------------------------
     # Conversation delegation
@@ -835,6 +843,14 @@ class BaseAgent(LogMixin):
         """Update the host callback used when permission mode is ask."""
         self.permission_callback = permission_callback or auto_allow_permission_callback
         self.context.permission_callback = self.permission_callback
+
+    def set_queued_input_provider(self, provider: Callable[[], Awaitable[List[QueuedUserInput]]]) -> None:
+        """Set the host-supplied async callable that drains queued UI messages.
+
+        It drains user messages queued while a turn runs and is wired on the
+        main agent only, never on sub-agents.
+        """
+        self.queued_input_provider = provider
 
     @property
     def current_tool_call_id(self):
@@ -1500,6 +1516,29 @@ class BaseAgent(LogMixin):
         """Return the agent's final report: the text of the last message in history."""
         return self.history[-1].get_text_content()
 
+    async def _deliver_queued_user_inputs(self) -> None:
+        """Append user inputs drained from the host while the current turn is running."""
+        if self.queued_input_provider is None:
+            return
+
+        inputs = await self.queued_input_provider()
+        if not inputs:
+            return
+
+        for item in inputs:
+            blocks = await self.build_user_content(item.text, item.attachments)
+            if self.session_recorder is not None:
+                await asyncio.to_thread(
+                    self.session_recorder.record_context_message,
+                    Message(role="user", content=blocks),
+                )
+            self.append_user_message(blocks)
+
+        await self.log_info(
+            f"Delivered {len(inputs)} queued user message(s)",
+            sender=self.agent_name,
+        )
+
     async def process_message_stream(
         self, message: str, attachments: Optional[List[Dict[str, Any]]] = None
     ) -> AsyncGenerator[Dict[str, Any], None]:
@@ -1760,6 +1799,10 @@ class BaseAgent(LogMixin):
                         # A blocking PostToolUse hook asked to end the turn.
                         self._hook_end_turn = False
                         break
+
+                    # The loop will continue — deliver any user messages queued in the
+                    # host UI so the next model request sees them.
+                    await self._deliver_queued_user_inputs()
 
                 # Stop hooks (main agent only). On a natural turn end, a hook may
                 # keep the agent working by blocking the stop and returning a reason.

--- a/kolega_code/cli/messages.py
+++ b/kolega_code/cli/messages.py
@@ -50,11 +50,12 @@ STOPPED_WITH_ERROR = "Stopped due to an error: {error}"
 CANCEL_REQUESTED = "Cancellation requested."
 WAITING_FOR_ANSWER = "Waiting for your answer…"
 WAITING_FOR_PERMISSION = "Waiting for permission…"
-QUEUED_MESSAGE = "Queued. It will be sent when the current turn finishes."
+QUEUED_MESSAGE = "Queued. It will be delivered to the agent at the next tool boundary, or when this turn finishes."
 QUEUE_PLACEHOLDER = "Queue a follow-up…"
 QUEUE_EMPTY = "No queued messages."
 QUEUE_CLEARED = "Cleared {count} queued message(s)."
 QUEUE_LIST_TITLE = "Queued messages:"
+QUEUE_DELIVERED_MID_TURN = "Delivered {count} queued message(s) to the current turn."
 
 # Turn status strip finals
 DONE_IN = "Done in {duration}"

--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 
 from kolega_code.agent import AgentConfig, AgentEvent, CoderAgent, PlanningAgent, PromptExtension, ToolExtension
+from kolega_code.agent.baseagent import QueuedUserInput
 from kolega_code.agent.prompt_provider import AgentMode
 from kolega_code.agent.custom_agents import discover_custom_agents, validate_custom_agent_models
 from kolega_code.agent.prompts import build_current_plan_artifact_prompt
@@ -404,6 +405,38 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
         )
         return True
 
+    async def _provide_queued_user_inputs(self) -> list[QueuedUserInput]:
+        """Agent-driven mid-turn drain: the running turn pulls queued messages
+        at a tool boundary instead of waiting for the turn to finish.
+
+        Runs on the TUI event loop inside the turn worker, so mutating the
+        queue here is race-free with the composer.
+        """
+        if not self._queued_messages:
+            return []
+        # Render tool events already emitted so tool output stays above the
+        # interjected user entries in the transcript.
+        await self._drain_pending_events()
+        # Snapshot after the await: an Esc during the drain restores whatever
+        # is still in the list, so anything taken here is genuinely delivered.
+        taken = list(self._queued_messages)
+        if not taken:
+            return []
+        self._queued_messages.clear()
+        inputs: list[QueuedUserInput] = []
+        for queued in taken:
+            queued.entry.kind = "user"
+            queued.entry.tone = None
+            if queued.entry not in self.conversation_entries:
+                self._add_conversation_entry(queued.entry)
+            else:
+                self._invalidate_conversation(queued.entry)
+            inputs.append(QueuedUserInput(text=queued.text, attachments=queued.attachments))
+        self._refresh_queued_messages_panel()
+        self._clear_composer_hint()
+        self._log_status(messages.QUEUE_DELIVERED_MID_TURN.format(count=len(inputs)), "info")
+        return inputs
+
     async def _consume_events(self) -> None:
         while True:
             event = await self.connection_manager.next_event()
@@ -734,6 +767,9 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
             custom_agent_catalog=self.custom_agent_catalog,
         )
         assert self.agent is not None
+        # Mid-turn queue delivery: the running turn drains composer messages
+        # queued while it works (main agent only; sub-agents never get this).
+        self.agent.set_queued_input_provider(self._provide_queued_user_inputs)
         # Initialize LSP (language detection + server resolution)
         agent = self.agent
         assert agent.tool_collection is not None

--- a/tests/agent/compaction_helpers.py
+++ b/tests/agent/compaction_helpers.py
@@ -43,16 +43,24 @@ class FakeLLM:
       counts a chars/4 proxy of the messages, which lets a test prove that the
       effective token count drops after compaction.
     - ``generate`` returns a scripted summary message.
-    - ``stream`` returns a ``FakeStream`` that ends the agent loop after one pass.
+    - ``stream`` returns one scripted message per call when ``message_script`` is
+      supplied, then falls back to the existing final-message behavior.
     """
 
     def __init__(
-        self, token_script=None, *, summary_text="SUMMARY: condensed older turns.", proxy=False, final_message=None
+        self,
+        token_script=None,
+        *,
+        summary_text="SUMMARY: condensed older turns.",
+        proxy=False,
+        final_message=None,
+        message_script: list[Message] | None = None,
     ):
         self._token_script = list(token_script) if token_script else None
         self._summary_text = summary_text
         self._proxy = proxy
         self._final_message = final_message
+        self._message_script = list(message_script) if message_script else None
         # Mirror the LLMClient surface: a provider object exposing base_url, which
         # the diagnostics layer reads (agent.llm.provider.base_url).
         self.provider = MagicMock(base_url="https://api.test.example/v1")
@@ -78,9 +86,12 @@ class FakeLLM:
     async def _stream(self, *args, **kwargs):
         # The summary is produced by streaming (compaction) and the turn loop also
         # streams; a single end_turn message carrying the summary text serves both.
-        final = self._final_message or Message(
-            role="assistant", content=[TextBlock(text=self._summary_text)], stop_reason="end_turn"
-        )
+        if self._message_script:
+            final = self._message_script.pop(0)
+        else:
+            final = self._final_message or Message(
+                role="assistant", content=[TextBlock(text=self._summary_text)], stop_reason="end_turn"
+            )
         return FakeStream(final)
 
 

--- a/tests/agent/test_base_agent_queued_injection.py
+++ b/tests/agent/test_base_agent_queued_injection.py
@@ -1,0 +1,180 @@
+import base64
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kolega_code.agent.baseagent import QueuedUserInput
+from kolega_code.cli.session_store import SessionStore
+from kolega_code.llm.models import ImageBlock, Message, TextBlock, ToolCall, ToolResult
+
+from .compaction_helpers import FakeLLM
+
+
+def _tool_call_message(tool_call: ToolCall) -> Message:
+    return Message(
+        role="assistant",
+        content=[tool_call],
+        stop_reason="tool_use",
+        tool_calls=[tool_call],
+    )
+
+
+def _end_turn_message(text: str = "done") -> Message:
+    return Message(role="assistant", content=[TextBlock(text=text)], stop_reason="end_turn")
+
+
+def _tool_result(tool_call: ToolCall) -> ToolResult:
+    return ToolResult(
+        tool_use_id=tool_call.id,
+        name=tool_call.name,
+        content="ok",
+        is_error=False,
+    )
+
+
+def _configure_agent(base_agent, message_script: list[Message]) -> None:
+    base_agent.system_prompt = Message(role="system", content=[TextBlock(text="sys")])
+    base_agent.tool_collection = MagicMock()
+    base_agent.tool_collection.get_tool_list = MagicMock(return_value=[])
+    base_agent.llm = FakeLLM(token_script=[100], message_script=message_script)
+    base_agent.log_info = AsyncMock()
+    base_agent.log_error = AsyncMock()
+
+
+@pytest.mark.asyncio
+async def test_queued_input_injected_after_tool_batch(base_agent) -> None:
+    tool_call = ToolCall(id="tool-1", name="read_file", input={})
+    _configure_agent(base_agent, [_tool_call_message(tool_call), _end_turn_message()])
+    base_agent.process_tool_calls = AsyncMock(return_value=[_tool_result(tool_call)])
+    provider = AsyncMock(side_effect=[[QueuedUserInput("also do Y")], []])
+    base_agent.set_queued_input_provider(provider)
+
+    _ = [chunk async for chunk in base_agent.process_message_stream("do X")]
+
+    assert [message.role for message in base_agent.history] == [
+        "user",
+        "assistant",
+        "user",
+        "user",
+        "assistant",
+    ]
+    assert isinstance(base_agent.history[1].content[0], ToolCall)
+    assert all(isinstance(block, ToolResult) for block in base_agent.history[2].content)
+    assert len(base_agent.history[3].content) == 1
+    assert isinstance(base_agent.history[3].content[0], TextBlock)
+    assert base_agent.history[3].content[0].text == "also do Y"
+    assert base_agent.history[4].stop_reason == "end_turn"
+    assert base_agent.conversation.is_valid_for_anthropic() is True
+    provider.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_no_injection_when_should_stop_after_tools(base_agent, monkeypatch) -> None:
+    tool_call = ToolCall(id="tool-1", name="read_file", input={})
+    _configure_agent(base_agent, [_tool_call_message(tool_call)])
+    base_agent.process_tool_calls = AsyncMock(return_value=[_tool_result(tool_call)])
+    provider = AsyncMock(return_value=[QueuedUserInput("also do Y")])
+    base_agent.set_queued_input_provider(provider)
+    monkeypatch.setattr(base_agent, "should_stop_after_tools", lambda: True)
+
+    _ = [chunk async for chunk in base_agent.process_message_stream("do X")]
+
+    provider.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_injection_when_hook_end_turn(base_agent) -> None:
+    tool_call = ToolCall(id="tool-1", name="read_file", input={})
+    _configure_agent(base_agent, [_tool_call_message(tool_call)])
+
+    def end_turn_after_tools(_tool_calls):
+        base_agent._hook_end_turn = True
+        return [_tool_result(tool_call)]
+
+    base_agent.process_tool_calls = AsyncMock(side_effect=end_turn_after_tools)
+    provider = AsyncMock(return_value=[QueuedUserInput("also do Y")])
+    base_agent.set_queued_input_provider(provider)
+
+    _ = [chunk async for chunk in base_agent.process_message_stream("do X")]
+
+    provider.assert_not_awaited()
+    assert base_agent._hook_end_turn is False
+
+
+@pytest.mark.asyncio
+async def test_no_injection_when_no_tool_calls(base_agent) -> None:
+    _configure_agent(base_agent, [_end_turn_message()])
+    provider = AsyncMock(return_value=[QueuedUserInput("also do Y")])
+    base_agent.set_queued_input_provider(provider)
+
+    _ = [chunk async for chunk in base_agent.process_message_stream("do X")]
+
+    provider.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_injection_journal_ordering_and_replay(base_agent, tmp_path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", {})
+    base_agent.session_recorder = store.recorder(session.session_id)
+
+    tool_call = ToolCall(id="tool-1", name="read_file", input={})
+    _configure_agent(base_agent, [_tool_call_message(tool_call), _end_turn_message()])
+    base_agent.process_tool_calls = AsyncMock(return_value=[_tool_result(tool_call)])
+    provider = AsyncMock(return_value=[QueuedUserInput("also do Y")])
+    base_agent.set_queued_input_provider(provider)
+
+    _ = [chunk async for chunk in base_agent.process_message_stream("do X")]
+
+    event_types = [event.event_type for event in store.journal(session.session_id).read_events()]
+    assert event_types[-6:] == [
+        "turn.started",
+        "assistant.message",
+        "tool.results",
+        "context.message",
+        "assistant.message",
+        "turn.completed",
+    ]
+
+    replayed = [Message.from_dict(item) for item in store.load(session.session_id).history]
+    assert [message.role for message in replayed] == ["user", "assistant", "user", "user", "assistant"]
+    assert all(isinstance(block, ToolResult) for block in replayed[2].content)
+    assert len(replayed[3].content) == 1
+    assert isinstance(replayed[3].content[0], TextBlock)
+    assert replayed[3].content[0].text == "also do Y"
+
+
+@pytest.mark.asyncio
+async def test_injection_with_attachments(base_agent) -> None:
+    tool_call = ToolCall(id="tool-1", name="read_file", input={})
+    _configure_agent(base_agent, [_tool_call_message(tool_call), _end_turn_message()])
+    base_agent.process_tool_calls = AsyncMock(return_value=[_tool_result(tool_call)])
+    image_data = base64.b64encode(b"fake-image-data").decode("utf-8")
+    provider = AsyncMock(
+        return_value=[
+            QueuedUserInput(
+                "look at this too",
+                attachments=[
+                    {
+                        "type": "image",
+                        "media_type": "image/png",
+                        "data": image_data,
+                        "filename": "queued.png",
+                    }
+                ],
+            )
+        ]
+    )
+    base_agent.set_queued_input_provider(provider)
+
+    _ = [chunk async for chunk in base_agent.process_message_stream("do X")]
+
+    injected = base_agent.history[3]
+    assert len(injected.content) == 2
+    assert isinstance(injected.content[0], TextBlock)
+    assert injected.content[0].text == "look at this too"
+    assert isinstance(injected.content[1], ImageBlock)
+    assert injected.content[1].media_type == "image/png"
+    assert injected.content[1].data == image_data

--- a/tests/cli/_app_test_utils.py
+++ b/tests/cli/_app_test_utils.py
@@ -42,9 +42,13 @@ class FakeCoderAgent:
         self.attachments: list = []
         self.active_goal_condition = None
         self.session_recorder = kwargs.get("session_recorder")
+        self.queued_input_provider = None
 
     def apply_goal(self, condition, prompt_extension=None):
         self.active_goal_condition = condition
+
+    def set_queued_input_provider(self, provider):
+        self.queued_input_provider = provider
 
     def append_user_message(self, content):
         self.history.append(Message(role="user", content=content))

--- a/tests/cli/test_app_composer_input.py
+++ b/tests/cli/test_app_composer_input.py
@@ -729,3 +729,156 @@ async def test_textual_app_cancel_restores_queued_followups_to_composer(
         assert app.query_one("#queued_messages").display is False
         assert composer.text == expected_text
         assert not [entry for entry in app.conversation_entries if entry.content in {"second", "third"}]
+
+
+@pytest.mark.asyncio
+async def test_textual_app_queued_message_delivered_mid_turn(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    turn_started = asyncio.Event()
+    reach_boundary = asyncio.Event()
+    delivered_ready = asyncio.Event()
+    release_finish = asyncio.Event()
+
+    class _ToolBoundaryCoderAgent(FakeCoderAgent):
+        """Simulates a turn that hits a tool boundary and pulls queued input."""
+
+        async def process_message_stream(self, message, attachments=None):
+            self.messages.append(message)
+            turn_started.set()
+            await reach_boundary.wait()
+            provider = self.queued_input_provider
+            assert provider is not None
+            inputs = await provider()
+            self.delivered = [(item.text, item.attachments) for item in inputs]
+            delivered_ready.set()
+            await release_finish.wait()
+            yield {"type": "response", "content": "done", "complete": True, "uuid": "response-1"}
+
+    install_fake_agents(monkeypatch, coder_cls=_ToolBoundaryCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        composer.focus()
+
+        composer.load_text("first")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+        worker = app.agent_worker
+        assert worker is not None
+        await asyncio.wait_for(turn_started.wait(), timeout=2)
+
+        composer.load_text("second")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+        await pilot.pause()
+        assert [item.text for item in app._queued_messages] == ["second"]
+        assert app.query_one("#queued_messages").display is True
+
+        reach_boundary.set()
+        await asyncio.wait_for(delivered_ready.wait(), timeout=2)
+        await pilot.pause()
+
+        # Mid-turn: the message was handed to the running turn, not a new one.
+        assert app.agent_worker is not None
+        assert app.agent is not None
+        assert getattr(app.agent, "delivered") == [("second", None)]
+        assert app._queued_messages == []
+        assert app.query_one("#queued_messages").display is False
+        second_entries = [entry for entry in app.conversation_entries if entry.content == "second"]
+        assert [entry.kind for entry in second_entries] == ["user"]
+
+        release_finish.set()
+        await worker.wait()
+        for _ in range(10):
+            await pilot.pause()
+            if app.agent_worker is None:
+                break
+
+        # No second turn started for the delivered message.
+        assert app.agent_worker is None
+        assert getattr(app.agent, "messages") == ["first"]
+        user_contents = [entry.content for entry in app.conversation_entries if entry.kind == "user"]
+        assert user_contents.count("second") == 1
+        assert not [entry for entry in app.conversation_entries if entry.kind == "queued"]
+
+
+@pytest.mark.asyncio
+async def test_textual_app_cancel_restores_only_undelivered(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    turn_started = asyncio.Event()
+    reach_boundary = asyncio.Event()
+    delivered_ready = asyncio.Event()
+
+    class _ToolBoundaryCoderAgent(FakeCoderAgent):
+        """Delivers queued input at one boundary, then blocks until cancelled."""
+
+        async def process_message_stream(self, message, attachments=None):
+            self.messages.append(message)
+            turn_started.set()
+            await reach_boundary.wait()
+            provider = self.queued_input_provider
+            assert provider is not None
+            inputs = await provider()
+            self.delivered = [item.text for item in inputs]
+            delivered_ready.set()
+            await asyncio.Event().wait()
+            yield {"type": "response", "content": "unreachable", "complete": True, "uuid": "response-1"}
+
+    install_fake_agents(monkeypatch, coder_cls=_ToolBoundaryCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        composer.focus()
+
+        composer.load_text("first")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+        assert app.agent_worker is not None
+        await asyncio.wait_for(turn_started.wait(), timeout=2)
+
+        composer.load_text("second")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+        reach_boundary.set()
+        await asyncio.wait_for(delivered_ready.wait(), timeout=2)
+        await pilot.pause()
+        assert app.agent is not None
+        assert getattr(app.agent, "delivered") == ["second"]
+
+        composer.load_text("third")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+        assert [item.text for item in app._queued_messages] == ["third"]
+
+        composer.load_text("")
+        app.action_cancel_generation()
+        for _ in range(10):
+            await pilot.pause()
+            if app.agent_worker is None:
+                break
+
+        # Only the undelivered follow-up returns to the composer; the delivered
+        # one stays in the transcript as a user message.
+        assert app.agent_worker is None
+        assert app._queued_messages == []
+        assert composer.text == "third"
+        second_entries = [entry for entry in app.conversation_entries if entry.content == "second"]
+        assert [entry.kind for entry in second_entries] == ["user"]
+        assert not [entry for entry in app.conversation_entries if entry.content == "third"]

--- a/tests/cli/test_session_store.py
+++ b/tests/cli/test_session_store.py
@@ -349,6 +349,43 @@ def test_interrupted_tool_call_gets_synthetic_error_and_is_not_rerun(tmp_path: P
     assert store.journal(record.session_id).read_events()[-1].event_type == "turn.failed"
 
 
+def test_interrupted_turn_after_injected_context_message_is_recovered(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    store = SessionStore(tmp_path / "state")
+    record = store.create(project, "code", {})
+    interrupted = SessionRecorder(store.journal(record.session_id), recover=False)
+    tool_call = ToolCall(id="read-1", name="read_file", input={"path": "a.txt"})
+    interrupted.start_turn(Message(role="user", content=[TextBlock("read it")]))
+    interrupted.record_assistant(
+        Message(
+            role="assistant",
+            content=[tool_call],
+            stop_reason="tool_use",
+            tool_calls=[tool_call],
+        )
+    )
+    interrupted.record_tool_results(
+        [ToolResult(tool_use_id="read-1", name="read_file", content="contents", is_error=False)]
+    )
+    interrupted.record_context_message(Message(role="user", content=[TextBlock("also do Y")]))
+
+    event_types = [event.event_type for event in store.journal(record.session_id).read_events()]
+    assert event_types[-2:] == ["tool.results", "context.message"]
+
+    recovery = SessionRecorder(store.journal(record.session_id), recover=False)
+    assert recovery.recover_interrupted_turn() is True
+    assert recovery.current_turn_id is None
+    assert store.journal(record.session_id).read_events()[-1].event_type == "turn.failed"
+
+    replayed = [Message.from_dict(item) for item in store.load(record.session_id).history]
+    assert [message.role for message in replayed] == ["user", "assistant", "user", "user"]
+    assert isinstance(replayed[2].content[0], ToolResult)
+    assert replayed[2].content[0].content == "contents"
+    assert isinstance(replayed[3].content[0], TextBlock)
+    assert replayed[3].content[0].text == "also do Y"
+
+
 def test_terminal_assistant_message_is_recovered_when_only_marker_is_missing(tmp_path: Path) -> None:
     project = tmp_path / "project"
     project.mkdir()


### PR DESCRIPTION
## Problem

Messages typed while the agent is busy are queued and only drained after the whole turn completes — each queued message then starts a brand-new turn. That's too slow for steering: a queued "actually, also check X" should reach the model at the next tool boundary of the *running* turn.

## Design

After a tool batch's results are appended and the loop has decided to continue (past the `should_stop_after_tools` / `_hook_end_turn` breaks), `BaseAgent` drains a host-supplied async provider and appends each queued message as its **own `role="user"` message** right after the tool-results message:

- **Valid everywhere.** `is_valid_for_anthropic` only requires tool_results in the message immediately after the assistant's tool_use message; consecutive user messages are an established shape here (the compaction summary is a user-role message emitted back-to-back with the tail).
- **Same pattern as the Stop-hook "keep working" injection**: journaled persistence-first as a `context.message` event, so live history and journal-replayed history are identical, and `recover_interrupted_turn` is unaffected.
- **TUI side**: `_provide_queued_user_inputs` runs on the same event loop inside the turn worker (race-free), promotes queued entries to user entries in the transcript, clears the panel, and hands the drained inputs to the loop. Wired via `set_queued_input_provider` on the main agent only — sub-agents never get it.

Behavior at the edges is unchanged: messages queued during the final text stream (no further tool boundary) still drain through the existing post-turn path as new turns; Esc restores only undelivered messages to the composer; `/queue-clear` still discards the pending remainder. Injected messages skip the `UserPromptSubmit` hook (matching the Stop-hook precedent) — hook parity is a deliberate non-goal for this PR.

## Testing

- 6 new agent-loop tests (`tests/agent/test_base_agent_queued_injection.py`): injection position + Anthropic validity, no-injection on all about-to-stop paths, journal ordering + round-trip replay, attachment handling.
- Journal-recovery test: crash right after an injection recovers the turn with the injected message intact.
- 2 new TUI tests: mid-turn delivery (entry promoted, panel hidden, no second turn spawned) and Esc restoring only undelivered messages.
- Full suite: 2283 passed, 0 failures.
- End-to-end run with the real app, real `CoderAgent` loop, real `read_entire_file` execution, and real journal (scripted LLM only): verified the second model request contains the queued message, journal reads `turn.started → assistant.message → tool.results → context.message → assistant.message → turn.completed`, exactly one turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158V7UdbaurAPbGsSSWHnKa