### PR TITLE
chore: release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,40 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.18.0 - 2026-07-14
+
 ### Added
 
+- Added custom Markdown subagents with project and user discovery, YAML
+  frontmatter configuration, safe tool and mode restrictions, and CLI/TUI
+  commands for listing and validating definitions.
 - Added GPT-5.6 Sol, Terra, and Luna to the OpenAI API-key and ChatGPT-subscription
-  model catalogs, with vision and `none` through `max` reasoning effort. GPT-5.6
-  Sol is now the default for both OpenAI providers.
+  model catalogs, with vision and `none` through `max` reasoning effort.
+- Added model-specific editing surfaces, including Codex-style `apply_patch`,
+  Claude-style editing, and a reproducible multi-language benchmark corpus.
+- Replaced mutable session snapshots with an append-only event journal that
+  preserves more context across crashes, repairs incomplete tails, and lazily
+  migrates existing saved sessions.
+- Added guided first-run onboarding and a full-screen settings editor with
+  staged validation, connection testing, and safe apply/discard controls.
+- Queued messages can now steer an active agent turn at the next tool boundary
+  instead of always waiting to start a separate turn.
+
+### Changed
+
+- GPT-5.6 Sol is now the default for the OpenAI API-key and
+  ChatGPT-subscription providers.
+- OpenAI and ChatGPT models now prefer `apply_patch`, while direct DeepSeek
+  models prefer Claude-style edits; explicit edit-protocol choices remain
+  respected.
+- Corrected the reasoning-effort choices exposed for GPT-5.4 Mini.
+- Refreshed the TUI settings, onboarding, and transcript presentation with
+  clearer summaries, compact controls, and inline role glyphs.
+
+### Fixed
+
+- Prevented empty completed responses from creating blank subagent trajectory
+  steps rendered as orphan role glyphs.
 
 ## 0.17.0 - 2026-07-10
 

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.17.0"
+__version__ = "0.18.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -48,4 +48,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.17.0"
+__version__ = "0.18.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.17.0"
+version = "0.18.0"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -14,7 +14,7 @@ resolution-markers = [
 
 [options]
 prerelease-mode = "allow"
-exclude-newer = "2026-07-06T17:39:54.796514Z"
+exclude-newer = "2026-07-07T17:34:58.527258Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1498,7 +1498,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.17.0"
+version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- release cutoff: `9fe279336b6044fc790b5b96bc1ccc8a5a86ac47` (PR #255)
- bump package and module metadata from `0.17.0` to `0.18.0`
- regenerate `uv.lock`, retaining the expected rolling `exclude-newer` cutoff
- compile the complete user-facing changelog since `v0.17.0`

## Changelog highlights

- **Added:** custom Markdown subagents and management commands, GPT-5.6 models, model-specific edit tools and benchmark corpus, durable session journals, onboarding/settings editor, and mid-turn queued-message delivery
- **Changed:** GPT-5.6 Sol defaults, OpenAI/ChatGPT `apply_patch`, DeepSeek Claude-style edits, GPT-5.4 Mini effort metadata, and refreshed TUI presentation
- **Fixed:** empty subagent trajectory steps and orphan role glyphs

## Validation

- `./run_tests.sh` — 2,283 passed, 103 deselected
- release version metadata check — passed (`0.18.0` across project and modules)
- `uv build` — wheel and sdist built
- `uv run twine check dist/*` — passed
- pre-commit hooks — Ruff, formatting, hygiene checks, and Pyright passed
- `git diff --check` — passed

## Release checklist

- [x] Version metadata is consistent
- [x] Lockfile is regenerated
- [x] Changelog is complete and dated
- [x] Local fast tests and package checks pass
- [ ] Required PR checks pass
- [ ] Merge commit is tagged `v0.18.0`
- [ ] Release workflow publishes to PyPI and creates the GitHub Release
- [ ] Published package and CLI version are verified
