### PR TITLE
Fix thinking summary formatting

### DIFF
--- a/kolega_code/llm/providers/responses_common.py
+++ b/kolega_code/llm/providers/responses_common.py
@@ -307,6 +307,19 @@ class ResponsesStreamWrapper:
         self._closed = False
         self._text = ""
         self._reasoning = ""
+        # Responses reasoning summaries are a list of independently streamed
+        # ``summary_text`` parts. Keep their display state separate from the raw
+        # accumulator so the TUI can preserve part boundaries and discard redundant
+        # whole-line Markdown bold markers without changing the provider payload we
+        # retain for reasoning continuity.
+        self._summary_part_key: Optional[tuple[str, int]] = None
+        self._summary_part_has_output = False
+        self._summary_display_started = False
+        self._summary_display_ends_newline = False
+        self._summary_line_mode: Optional[bool] = None  # None=undecided, True=bold candidate, False=plain
+        self._summary_line_buffer: List[str] = []
+        self._summary_seen_delta_parts: set[tuple[str, int]] = set()
+        self._summary_finished_parts: set[tuple[str, int]] = set()
         # Completed reasoning items (with encrypted_content), in stream order, so
         # they can be resent next turn for chain-of-thought continuity.
         self._reasoning_items: List[Dict[str, Any]] = []
@@ -338,8 +351,159 @@ class ResponsesStreamWrapper:
         if iterator is None:
             iterator = self._stream.__aiter__()
             self._iterator = iterator
-        event = await iterator.__anext__()  # propagates StopAsyncIteration
+        try:
+            event = await iterator.__anext__()
+        except StopAsyncIteration:
+            # Defensive fallback for Responses-compatible backends that omit the
+            # summary ``done`` lifecycle events.
+            trailing = self._finish_active_summary_part()
+            if trailing:
+                return MessageChunk(type="thinking", thinking=trailing)
+            raise
         return self._handle_event(event)
+
+    @staticmethod
+    def _summary_key(event: Any) -> tuple[str, int]:
+        item_id = str(getattr(event, "item_id", "") or "")
+        raw_index = getattr(event, "summary_index", 0)
+        try:
+            summary_index = int(raw_index)
+        except (TypeError, ValueError):
+            summary_index = 0
+        return item_id, summary_index
+
+    @staticmethod
+    def _plain_summary_line(line: str) -> str:
+        """Remove one redundant whole-line ``**...**`` wrapper.
+
+        Inline emphasis, multiple bold spans, triple-star emphasis, and code-like
+        uses of ``**`` remain literal. Thinking already has a uniform dim-italic
+        transcript style, so a whole-line bold wrapper adds only visible markup.
+        """
+        stripped = line.strip()
+        if (
+            len(stripped) > 4
+            and stripped.startswith("**")
+            and stripped.endswith("**")
+            and not stripped.startswith("***")
+            and not stripped.endswith("***")
+            and stripped.count("**") == 2
+        ):
+            start = line.find(stripped)
+            return line[:start] + stripped[2:-2] + line[start + len(stripped) :]
+        return line
+
+    def _finish_summary_line(self) -> str:
+        """Flush the only line type we buffer: a possible ``**...**`` title."""
+        if self._summary_line_mode is False:
+            self._summary_line_mode = None
+            return ""
+        line = "".join(self._summary_line_buffer)
+        self._summary_line_buffer.clear()
+        was_bold_candidate = self._summary_line_mode is True
+        self._summary_line_mode = None
+        return self._plain_summary_line(line) if was_bold_candidate else line
+
+    def _normalize_summary_delta(self, delta: str) -> str:
+        """Normalize summary titles incrementally without delaying ordinary prose.
+
+        At the start of each line, at most two significant characters are held to
+        decide whether the line begins with ``**``. Plain lines then pass through
+        immediately; only a possible bold title waits for its line/part boundary so
+        delimiters split across transport chunks are handled correctly.
+        """
+        output: List[str] = []
+        for char in delta:
+            if self._summary_line_mode is False:
+                output.append(char)
+                if char == "\n":
+                    self._summary_line_mode = None
+                continue
+
+            if char == "\n":
+                output.append(self._finish_summary_line())
+                output.append("\n")
+                continue
+
+            self._summary_line_buffer.append(char)
+            if self._summary_line_mode is not None:
+                continue
+
+            prefix = "".join(self._summary_line_buffer).lstrip(" \t")
+            if not prefix or prefix == "*":
+                continue
+            if prefix.startswith("**"):
+                self._summary_line_mode = True
+                continue
+
+            output.extend(self._summary_line_buffer)
+            self._summary_line_buffer.clear()
+            self._summary_line_mode = False
+
+        return "".join(output)
+
+    def _emit_summary_text(self, text: str) -> str:
+        if not text:
+            return ""
+        prefix = ""
+        if (
+            not self._summary_part_has_output
+            and self._summary_display_started
+            and not self._summary_display_ends_newline
+            and not text.startswith("\n")
+        ):
+            prefix = "\n"
+        self._summary_part_has_output = True
+        rendered = prefix + text
+        self._summary_display_started = True
+        self._summary_display_ends_newline = rendered.endswith("\n")
+        return rendered
+
+    def _finish_active_summary_part(self) -> str:
+        return self._emit_summary_text(self._finish_summary_line())
+
+    def _switch_summary_part(self, key: tuple[str, int]) -> str:
+        if key == self._summary_part_key:
+            return ""
+        trailing = self._finish_active_summary_part()
+        self._summary_part_key = key
+        self._summary_part_has_output = False
+        return trailing
+
+    @staticmethod
+    def _thinking_chunk(text: str) -> MessageChunk:
+        if text:
+            return MessageChunk(type="thinking", thinking=text)
+        return MessageChunk(type="ignore", text="")
+
+    def _handle_summary_delta(self, event: Any) -> MessageChunk:
+        key = self._summary_key(event)
+        display = self._switch_summary_part(key)
+        delta = getattr(event, "delta", "") or ""
+        self._reasoning += delta
+        self._summary_seen_delta_parts.add(key)
+        display += self._emit_summary_text(self._normalize_summary_delta(delta))
+        return self._thinking_chunk(display)
+
+    def _handle_summary_done(self, event: Any) -> MessageChunk:
+        key = self._summary_key(event)
+        display = self._switch_summary_part(key)
+        if key in self._summary_finished_parts:
+            return self._thinking_chunk(display)
+
+        # Official streams send deltas before the done event. If a compatible
+        # backend sends only the completed text, still surface it once.
+        if key not in self._summary_seen_delta_parts:
+            text = getattr(event, "text", None)
+            if text is None:
+                text = getattr(getattr(event, "part", None), "text", "")
+            text = text or ""
+            self._reasoning += text
+            display += self._emit_summary_text(self._normalize_summary_delta(text))
+
+        display += self._finish_active_summary_part()
+        self._summary_finished_parts.add(key)
+        return self._thinking_chunk(display)
 
     def _handle_event(self, event: Any) -> MessageChunk:
         event_type = getattr(event, "type", "")
@@ -347,7 +511,13 @@ class ResponsesStreamWrapper:
             delta = getattr(event, "delta", "") or ""
             self._text += delta
             return MessageChunk(type="text", text=delta)
-        if event_type in ("response.reasoning_summary_text.delta", "response.reasoning_text.delta"):
+        if event_type == "response.reasoning_summary_text.delta":
+            return self._handle_summary_delta(event)
+        if event_type in ("response.reasoning_summary_text.done", "response.reasoning_summary_part.done"):
+            return self._handle_summary_done(event)
+        if event_type == "response.reasoning_summary_part.added":
+            return self._thinking_chunk(self._switch_summary_part(self._summary_key(event)))
+        if event_type == "response.reasoning_text.delta":
             delta = getattr(event, "delta", "") or ""
             self._reasoning += delta
             return MessageChunk(type="thinking", thinking=delta)
@@ -438,6 +608,7 @@ class ResponsesStreamWrapper:
                     record["arguments"] = arguments
         elif event_type == "response.completed":
             self._final_response = getattr(event, "response", None)
+            return self._thinking_chunk(self._finish_active_summary_part())
         elif event_type in ("response.failed", "error"):
             message = getattr(event, "message", None) or "Responses stream failed."
             raise RuntimeError(message)

--- a/tests/agent/llm/test_chatgpt_oauth_streaming.py
+++ b/tests/agent/llm/test_chatgpt_oauth_streaming.py
@@ -139,6 +139,160 @@ async def test_responses_stream_wrapper_uses_deltas_when_completed_output_empty(
 
 
 @pytest.mark.asyncio
+async def test_responses_stream_wrapper_separates_and_cleans_summary_parts():
+    completed = _ns(output=[], usage=None, status="completed", incomplete_details=None)
+    summaries = [
+        "**Identifying LSP snapshot handling issue**",
+        "**Classifying active target implementation status**",
+        "**Confirming rank1 and rank2 completeness**",
+    ]
+    events = []
+    for index, summary in enumerate(summaries):
+        events.append(
+            _ns(
+                type="response.reasoning_summary_part.added",
+                item_id="rs_1",
+                summary_index=index,
+                part=_ns(type="summary_text", text=""),
+            )
+        )
+        # Split both opening and closing delimiters across transport events to
+        # prove cleanup follows logical lines, not individual delta boundaries.
+        for delta in (summary[:1], summary[1:-1], summary[-1:]):
+            events.append(
+                _ns(
+                    type="response.reasoning_summary_text.delta",
+                    item_id="rs_1",
+                    summary_index=index,
+                    delta=delta,
+                )
+            )
+        events.extend(
+            [
+                _ns(
+                    type="response.reasoning_summary_text.done",
+                    item_id="rs_1",
+                    summary_index=index,
+                    text=summary,
+                ),
+                _ns(
+                    type="response.reasoning_summary_part.done",
+                    item_id="rs_1",
+                    summary_index=index,
+                    part=_ns(type="summary_text", text=summary),
+                ),
+            ]
+        )
+    events.extend(
+        [
+            _ns(
+                type="response.output_item.done",
+                item=_ns(
+                    type="reasoning",
+                    id="rs_1",
+                    encrypted_content="ENC",
+                    summary=[_ns(type="summary_text", text=summary) for summary in summaries],
+                ),
+            ),
+            _ns(type="response.completed", response=completed),
+        ]
+    )
+
+    wrapper = ResponsesStreamWrapper(_FakeStream(events))
+    thinking_chunks = []
+    async with wrapper as stream:
+        async for chunk in stream:
+            if chunk.type == "thinking" and chunk.thinking:
+                thinking_chunks.append(chunk.thinking)
+
+    assert "".join(thinking_chunks) == "\n".join(summary[2:-2] for summary in summaries)
+    assert "**" not in "".join(thinking_chunks)
+
+    # Display cleanup must not alter the authoritative summary preserved for
+    # encrypted reasoning replay.
+    message = await wrapper.get_final_message()
+    reasoning = [block for block in message.content if isinstance(block, ResponsesReasoningBlock)]
+    assert reasoning and reasoning[0].summary == summaries
+
+
+@pytest.mark.asyncio
+async def test_responses_stream_wrapper_only_strips_whole_line_summary_bold():
+    completed = _ns(output=[], usage=None, status="completed", incomplete_details=None)
+    summary = "**Whole title**\nplain 2 ** 3\n**first** and **second**"
+    events = [
+        _ns(
+            type="response.reasoning_summary_text.delta",
+            item_id="rs_1",
+            summary_index=0,
+            delta=summary,
+        ),
+        _ns(
+            type="response.reasoning_summary_text.done",
+            item_id="rs_1",
+            summary_index=0,
+            text=summary,
+        ),
+        _ns(type="response.completed", response=completed),
+    ]
+
+    wrapper = ResponsesStreamWrapper(_FakeStream(events))
+    thinking_chunks = []
+    async with wrapper as stream:
+        async for chunk in stream:
+            if chunk.type == "thinking" and chunk.thinking:
+                thinking_chunks.append(chunk.thinking)
+
+    assert "".join(thinking_chunks) == "Whole title\nplain 2 ** 3\n**first** and **second**"
+
+
+@pytest.mark.asyncio
+async def test_responses_stream_wrapper_uses_delta_keys_and_stream_end_as_summary_boundaries():
+    # Compatible Responses backends may omit part-added/done events. Changes in
+    # (item_id, summary_index) and stream exhaustion must still flush clean lines.
+    events = [
+        _ns(
+            type="response.reasoning_summary_text.delta",
+            item_id="rs_1",
+            summary_index=0,
+            delta="**First part**",
+        ),
+        _ns(
+            type="response.reasoning_summary_text.delta",
+            item_id="rs_1",
+            summary_index=1,
+            delta="",  # an empty part must not introduce a blank line
+        ),
+        _ns(
+            type="response.reasoning_summary_text.delta",
+            item_id="rs_2",
+            summary_index=0,
+            delta="**Second item**",
+        ),
+    ]
+    wrapper = ResponsesStreamWrapper(_FakeStream(events))
+
+    thinking_chunks = []
+    async with wrapper as stream:
+        async for chunk in stream:
+            if chunk.type == "thinking" and chunk.thinking:
+                thinking_chunks.append(chunk.thinking)
+
+    assert "".join(thinking_chunks) == "First part\nSecond item"
+
+
+@pytest.mark.asyncio
+async def test_responses_stream_wrapper_leaves_raw_reasoning_text_unchanged():
+    wrapper = ResponsesStreamWrapper(
+        _FakeStream([_ns(type="response.reasoning_text.delta", delta="raw **reasoning**")])
+    )
+
+    async with wrapper as stream:
+        chunks = [chunk async for chunk in stream]
+
+    assert [(chunk.type, chunk.thinking) for chunk in chunks] == [("thinking", "raw **reasoning**")]
+
+
+@pytest.mark.asyncio
 async def test_responses_stream_wrapper_tool_call_from_output_item_done():
     # Tool calls must survive even when args arrive only via output_item.done
     # (and the completed output is empty, as on the ChatGPT backend).

--- a/tests/cli/test_app_rendering_streaming.py
+++ b/tests/cli/test_app_rendering_streaming.py
@@ -121,6 +121,54 @@ async def test_textual_app_merges_streamed_thinking_chunks(tmp_path: Path, monke
 
 
 @pytest.mark.asyncio
+async def test_textual_app_renders_clean_summary_parts_as_one_italic_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.app import KolegaCodeApp
+
+    lines = [
+        "Identifying LSP snapshot handling issue",
+        "Classifying active target implementation status",
+        "Confirming rank1 and rank2 completeness",
+    ]
+    chunks = [
+        {"type": "thinking", "content": lines[0], "complete": False, "uuid": "thinking-1"},
+        {"type": "thinking", "content": f"\n{lines[1]}", "complete": False, "uuid": "thinking-1"},
+        {"type": "thinking", "content": f"\n{lines[2]}", "complete": False, "uuid": "thinking-1"},
+        {"type": "thinking", "content": "", "complete": True, "uuid": "thinking-1"},
+        {"type": "response", "content": "done", "complete": True, "uuid": "response-1"},
+    ]
+
+    class SummaryChunkCoderAgent(FakeCoderAgent):
+        async def process_message_stream(self, message, attachments=None):
+            for chunk in chunks:
+                yield chunk
+
+    monkeypatch.setattr(agent_runtime_module, "CoderAgent", SummaryChunkCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test():
+        await app._process_message("hi")
+
+        thinking_entries = [entry for entry in app.conversation_entries if entry.kind == "thinking"]
+        assert len(thinking_entries) == 1
+        assert thinking_entries[0].content == "\n".join(lines)
+
+        formatted = app._format_conversation_entry(thinking_entries[0])
+        assert renderable_text(formatted).splitlines() == [f"  {line}" for line in lines]
+        assert "**" not in renderable_text(formatted)
+        assert any("italic" in style and "dim" in style for style in first_text_styles(formatted))
+
+
+@pytest.mark.asyncio
 async def test_textual_app_formats_thinking_as_italic_chat_entry(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## What changed

- preserve OpenAI Responses reasoning-summary part boundaries in the streamed thinking transcript
- remove redundant whole-line `**...**` wrappers while retaining inline/code uses of `**`
- keep raw reasoning and persisted encrypted-replay summaries unchanged
- add provider and TUI regressions for split delimiters, missing lifecycle events, empty parts, and final italic rendering

## Why

Responses reasoning summaries arrive as separate `(item_id, summary_index)` parts. The adapter previously concatenated only their text deltas, so adjacent Markdown-bold titles rendered as strings such as `**first****second**`. The transcript already applies dim-italic styling and treats thinking as literal text, making those markers both redundant and visually broken.

## Impact

Thinking summaries from the API-key OpenAI and ChatGPT OAuth Responses providers now appear as clean newline-separated italic lines. Raw reasoning from other event types and stored reasoning continuity data are not changed.

## Validation

- `ruff check` passed
- `pyright` passed
- focused provider/transcript suite: 105 passed
- `./run_tests.sh`: 2,288 passed, 103 deselected