### PR TITLE
fix(tui): sanitize terminal control sequences

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import time
 import traceback
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, Optional
 
@@ -18,6 +19,7 @@ from textual import events
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.filter import LineFilter
 from textual.timer import Timer
 from textual.worker import WorkerState
 from textual.widgets import (
@@ -141,6 +143,7 @@ class KolegaCodeApp(
         startup_config_error: Optional[str] = None,
     ) -> None:
         super().__init__()
+        self._terminal_control_filter = tui_terminal_display.TerminalControlFilter()
         self.project_path = project_path
         self.config = config
         self.mode = CLI_AGENT_MODE
@@ -250,6 +253,10 @@ class KolegaCodeApp(
         self._terminal_display_normalizer = tui_terminal_display.TerminalDisplayNormalizer()
         self._log_output_buffer: list[Any] = []
         self._log_flush_timer: Optional[Timer] = None
+
+    def get_line_filters(self) -> Sequence[LineFilter]:
+        """Apply the terminal-control boundary after Textual's style filters."""
+        return (*super().get_line_filters(), self._terminal_control_filter)
 
     def compose(self) -> ComposeResult:
         with Horizontal(id="body"):

--- a/kolega_code/cli/tui/terminal_display.py
+++ b/kolega_code/cli/tui/terminal_display.py
@@ -1,20 +1,27 @@
-"""Display-only terminal stream normalization for the Textual sidebar.
+"""Display-only terminal control sanitization for the Textual UI.
 
-The sidebar terminal is a readable transcript, not a terminal emulator.  Real PTY
-output may contain cursor movement, erase commands, hyperlinks, carriage-return
-progress redraws, and other control bytes that RichLog/Textual should not receive
-raw.  This module strips terminal controls and keeps stable text suitable for a
-log-style widget while leaving the model-facing command output untouched.
+The UI is a renderer, not a terminal emulator. PTY output and other dynamic text
+may contain cursor movement, mode switches, hyperlinks, resets, and other control
+bytes that must never be forwarded as widget text. The parser in this module is
+shared by the readable terminal transcript and a final Textual line filter; raw
+model, tool, and persisted values remain untouched.
 """
 
 from __future__ import annotations
 
 from enum import Enum, auto
 
+from rich.cells import cell_len
+from rich.segment import Segment
+from rich.style import Style
+from textual.color import Color
+from textual.filter import LineFilter
+
 
 class _State(Enum):
     NORMAL = auto()
     ESC = auto()
+    ESC_INTERMEDIATE = auto()
     CSI = auto()
     OSC = auto()
     STRING = auto()
@@ -22,23 +29,25 @@ class _State(Enum):
     STRING_ESC = auto()
 
 
-class TerminalDisplayNormalizer:
-    """Incrementally sanitize terminal output for a log-style display.
+class _TerminalControlParser:
+    """Incrementally remove terminal controls under a configurable display policy."""
 
-    The normalizer is intentionally conservative: it strips terminal control
-    sequences instead of trying to emulate screen state. Standalone carriage
-    returns become newlines so progress redraws become readable transcript lines
-    rather than raw cursor controls. Backspace/delete remove previous characters
-    only within the currently emitted chunk; earlier RichLog lines are not
-    mutated.
-    """
+    _C1_CSI = 0x9B
+    _C1_OSC = 0x9D
+    _C1_ST = 0x9C
+    _C1_STRING_INTRODUCERS = frozenset({0x90, 0x98, 0x9E, 0x9F})
+    _CANCEL_CONTROLS = frozenset({0x18, 0x1A})
 
-    def __init__(self) -> None:
+    def __init__(self, *, preserve_width: bool, terminal_transcript: bool) -> None:
+        self._preserve_width = preserve_width
+        self._terminal_transcript = terminal_transcript
         self._state = _State.NORMAL
+        self._pending_cr = False
 
     def reset(self) -> None:
         """Drop any pending partial escape/control sequence."""
         self._state = _State.NORMAL
+        self._pending_cr = False
 
     def flush(self) -> str:
         """Finish the stream, discarding incomplete escape/control sequences."""
@@ -46,16 +55,27 @@ class TerminalDisplayNormalizer:
         return ""
 
     def feed(self, text: str) -> str:
-        """Return a display-safe representation of ``text``.
-
-        Args:
-            text: Incremental terminal output text. It may split escape sequences
-                across calls.
-        """
+        """Return display-safe text while retaining partial parser state."""
         if not text:
             return ""
 
         out: list[str] = []
+        suppressed: list[str] = []
+
+        def flush_suppressed() -> None:
+            if self._preserve_width and suppressed:
+                if width := cell_len("".join(suppressed)):
+                    out.append(" " * width)
+            suppressed.clear()
+
+        def suppress(ch: str) -> None:
+            if self._preserve_width:
+                suppressed.append(ch)
+
+        def emit(ch: str) -> None:
+            flush_suppressed()
+            out.append(ch)
+
         index = 0
         length = len(text)
         while index < length:
@@ -63,67 +83,129 @@ class TerminalDisplayNormalizer:
             code = ord(ch)
             state = self._state
 
+            if state is _State.NORMAL and self._terminal_transcript and self._pending_cr:
+                self._pending_cr = False
+                if ch == "\n":
+                    index += 1
+                    continue
+
             if state is _State.NORMAL:
                 if ch == "\x1b":
+                    suppress(ch)
                     self._state = _State.ESC
-                elif ch == "\r":
+                elif code == self._C1_CSI:
+                    suppress(ch)
+                    self._state = _State.CSI
+                elif code == self._C1_OSC:
+                    suppress(ch)
+                    self._state = _State.OSC
+                elif code in self._C1_STRING_INTRODUCERS:
+                    suppress(ch)
+                    self._state = _State.STRING
+                elif ch == "\r" and self._terminal_transcript:
                     # CRLF is a newline; standalone CR progress redraws become
                     # stable transcript line breaks.
-                    if index + 1 < length and text[index + 1] == "\n":
-                        out.append("\n")
-                        index += 1
-                    else:
-                        out.append("\n")
-                elif ch == "\b" or ch == "\x7f":
+                    emit("\n")
+                    self._pending_cr = True
+                elif (ch == "\b" or ch == "\x7f") and self._terminal_transcript:
+                    flush_suppressed()
                     self._erase_previous_output_char(out)
                 elif ch == "\n" or ch == "\t":
-                    out.append(ch)
+                    emit(ch)
                 elif self._is_c0_or_c1_control(code):
-                    # Drop BEL, NUL, form-feed, vertical tab, etc. RichLog is a
-                    # display surface, not a control receiver.
-                    pass
+                    suppress(ch)
                 else:
-                    out.append(ch)
+                    emit(ch)
 
             elif state is _State.ESC:
-                if ch == "[":
+                suppress(ch)
+                if ch == "\x1b":
+                    self._state = _State.ESC
+                elif ch == "[":
                     self._state = _State.CSI
                 elif ch == "]":
                     self._state = _State.OSC
                 elif ch in {"P", "^", "_", "X"}:
                     self._state = _State.STRING
-                elif 0x40 <= code <= 0x5F or 0x60 <= code <= 0x7E:
-                    # Two-byte escape sequence: ESC c, ESC 7, ESC 8, etc.
+                elif code == self._C1_CSI:
+                    self._state = _State.CSI
+                elif code == self._C1_OSC:
+                    self._state = _State.OSC
+                elif code in self._C1_STRING_INTRODUCERS:
+                    self._state = _State.STRING
+                elif code in self._CANCEL_CONTROLS:
                     self._state = _State.NORMAL
-                elif self._is_c0_or_c1_control(code):
-                    # Ignore controls inside escape dispatch.
-                    pass
-                else:
+                elif 0x20 <= code <= 0x2F:
+                    self._state = _State.ESC_INTERMEDIATE
+                elif 0x30 <= code <= 0x7E:
+                    # Complete two-byte sequences include ESC 7/8 and ESC c.
+                    self._state = _State.NORMAL
+                elif code > 0x9F:
+                    # Invalid escape bytes are suppressed, then parsing resumes.
+                    self._state = _State.NORMAL
+
+            elif state is _State.ESC_INTERMEDIATE:
+                suppress(ch)
+                if ch == "\x1b":
+                    self._state = _State.ESC
+                elif code in self._CANCEL_CONTROLS:
+                    self._state = _State.NORMAL
+                elif 0x30 <= code <= 0x7E:
+                    self._state = _State.NORMAL
+                elif not (0x20 <= code <= 0x2F) and code > 0x1F:
                     self._state = _State.NORMAL
 
             elif state is _State.CSI:
-                # CSI final byte range per ECMA-48.
-                if 0x40 <= code <= 0x7E:
+                suppress(ch)
+                if ch == "\x1b":
+                    self._state = _State.ESC
+                elif code == self._C1_CSI:
+                    self._state = _State.CSI
+                elif code == self._C1_OSC:
+                    self._state = _State.OSC
+                elif code in self._C1_STRING_INTRODUCERS:
+                    self._state = _State.STRING
+                elif code in self._CANCEL_CONTROLS:
+                    self._state = _State.NORMAL
+                elif 0x40 <= code <= 0x7E:
+                    # CSI final byte range per ECMA-48.
                     self._state = _State.NORMAL
 
             elif state is _State.OSC:
-                if ch == "\x07":
+                suppress(ch)
+                if ch == "\x07" or code == self._C1_ST:
+                    self._state = _State.NORMAL
+                elif code in self._CANCEL_CONTROLS:
                     self._state = _State.NORMAL
                 elif ch == "\x1b":
                     self._state = _State.OSC_ESC
 
             elif state is _State.OSC_ESC:
-                self._state = _State.NORMAL if ch == "\\" else _State.OSC
+                suppress(ch)
+                if ch == "\\" or ch == "\x07" or code == self._C1_ST:
+                    self._state = _State.NORMAL
+                elif code in self._CANCEL_CONTROLS:
+                    self._state = _State.NORMAL
+                elif ch != "\x1b":
+                    self._state = _State.OSC
 
             elif state is _State.STRING:
-                if ch == "\x1b":
+                suppress(ch)
+                if code == self._C1_ST or code in self._CANCEL_CONTROLS:
+                    self._state = _State.NORMAL
+                elif ch == "\x1b":
                     self._state = _State.STRING_ESC
 
             elif state is _State.STRING_ESC:
-                self._state = _State.NORMAL if ch == "\\" else _State.STRING
+                suppress(ch)
+                if ch == "\\" or code == self._C1_ST or code in self._CANCEL_CONTROLS:
+                    self._state = _State.NORMAL
+                elif ch != "\x1b":
+                    self._state = _State.STRING
 
             index += 1
 
+        flush_suppressed()
         return "".join(out)
 
     @staticmethod
@@ -132,6 +214,56 @@ class TerminalDisplayNormalizer:
 
     @staticmethod
     def _erase_previous_output_char(out: list[str]) -> None:
-        # Do not erase across emitted line boundaries.
+        # Do not erase across emitted line boundaries or parser feed calls.
         if out and out[-1] != "\n":
             out.pop()
+
+
+class TerminalDisplayNormalizer:
+    """Incrementally sanitize PTY output for the readable terminal transcript.
+
+    Standalone carriage returns become newlines so progress redraws remain
+    readable. Backspace/delete remove previous characters only within the current
+    emitted chunk; earlier RichLog lines are not mutated.
+    """
+
+    def __init__(self) -> None:
+        self._parser = _TerminalControlParser(
+            preserve_width=False,
+            terminal_transcript=True,
+        )
+
+    def reset(self) -> None:
+        """Drop any pending partial escape/control sequence."""
+        self._parser.reset()
+
+    def flush(self) -> str:
+        """Finish the stream, discarding incomplete escape/control sequences."""
+        return self._parser.flush()
+
+    def feed(self, text: str) -> str:
+        """Return a display-safe representation of incremental terminal output."""
+        return self._parser.feed(text)
+
+
+class TerminalControlFilter(LineFilter):
+    """Remove untrusted terminal controls from final Textual widget segments."""
+
+    @staticmethod
+    def _safe_style(segment: Segment) -> Style | None:
+        """Drop unsafe link metadata before Rich turns it into an OSC hyperlink."""
+        style = segment.style
+        if style is not None:
+            link = style.link
+            if link is not None and any(_TerminalControlParser._is_c0_or_c1_control(ord(ch)) for ch in link):
+                return style.update_link(None)
+        return style
+
+    def apply(self, segments: list[Segment], background: Color) -> list[Segment]:
+        """Sanitize one independently rendered line while preserving Rich styles."""
+        del background
+        parser = _TerminalControlParser(
+            preserve_width=True,
+            terminal_transcript=False,
+        )
+        return [Segment(parser.feed(segment.text), self._safe_style(segment), segment.control) for segment in segments]

--- a/tests/cli/test_terminal_display.py
+++ b/tests/cli/test_terminal_display.py
@@ -1,9 +1,21 @@
-from kolega_code.cli.tui.terminal_display import TerminalDisplayNormalizer
+import pytest
+from rich.cells import cell_len
+from rich.console import Console
+from rich.segment import Segment
+from rich.style import Style
+from textual.color import Color
+from textual.strip import Strip
+
+from kolega_code.cli.tui.terminal_display import TerminalControlFilter, TerminalDisplayNormalizer
 
 
 def _normalize(*chunks: str) -> str:
     normalizer = TerminalDisplayNormalizer()
     return "".join(normalizer.feed(chunk) for chunk in chunks) + normalizer.flush()
+
+
+def _filter_segments(*segments: Segment) -> list[Segment]:
+    return TerminalControlFilter().apply(list(segments), Color.parse("#000000"))
 
 
 def test_terminal_display_normalizer_strips_ansi_sgr_and_csi_controls() -> None:
@@ -26,6 +38,19 @@ def test_terminal_display_normalizer_converts_carriage_return_progress_to_lines(
     assert _normalize("line\r\nnext\n") == "line\nnext\n"
 
 
+def test_terminal_display_normalizer_handles_crlf_split_across_chunks() -> None:
+    assert _normalize("line\r", "\nnext") == "line\nnext"
+    assert _normalize("line\r", "next") == "line\nnext"
+
+
+def test_terminal_display_normalizer_reset_clears_pending_crlf_state() -> None:
+    normalizer = TerminalDisplayNormalizer()
+
+    assert normalizer.feed("line\r") == "line\n"
+    normalizer.reset()
+    assert normalizer.feed("\nnext") == "\nnext"
+
+
 def test_terminal_display_normalizer_handles_backspace_rewrites_within_chunk() -> None:
     assert _normalize("abc\b\bd\n") == "ad\n"
 
@@ -40,3 +65,200 @@ def test_terminal_display_normalizer_holds_split_escape_sequences() -> None:
     assert normalizer.feed("a\x1b[") == "a"
     assert normalizer.feed("31mred") == "red"
     assert normalizer.flush() == ""
+
+
+@pytest.mark.parametrize(
+    "control",
+    [
+        "\x1b[?1049l",
+        "\x1b[?1000h",
+        "\x1b[?1002h",
+        "\x1b[?1003h",
+        "\x1b[?1004h",
+        "\x1b[?1006h",
+        "\x1b[?2004h",
+        "\x9b?1049l",
+        "\x9b?1006h",
+        "\x1bc",
+        "\x1b7",
+        "\x1b8",
+        "\x1b(0",
+    ],
+)
+def test_terminal_display_normalizer_strips_modes_resets_and_escape_sequences(control: str) -> None:
+    assert _normalize(f"before{control}after") == "beforeafter"
+
+
+@pytest.mark.parametrize(
+    ("control", "payload"),
+    [
+        ("\x1b]2;osc-bel\x07", "osc-bel"),
+        ("\x1b]2;osc-st\x1b\\", "osc-st"),
+        ("\x9d2;osc-c1-st\x9c", "osc-c1-st"),
+        ("\x1bPdcs-payload\x1b\\", "dcs-payload"),
+        ("\x1bXsos-payload\x1b\\", "sos-payload"),
+        ("\x1b^pm-payload\x1b\\", "pm-payload"),
+        ("\x1b_apc-payload\x1b\\", "apc-payload"),
+        ("\x90c1-dcs\x9c", "c1-dcs"),
+        ("\x98c1-sos\x9c", "c1-sos"),
+        ("\x9ec1-pm\x9c", "c1-pm"),
+        ("\x9fc1-apc\x9c", "c1-apc"),
+    ],
+)
+def test_terminal_display_normalizer_strips_string_controls(control: str, payload: str) -> None:
+    text = _normalize(f"before{control}after")
+
+    assert text == "beforeafter"
+    assert payload not in text
+
+
+@pytest.mark.parametrize(
+    "control",
+    [
+        "\x1b[31m",
+        "\x1b]2;split-osc\x1b\\",
+        "\x1bPsplit-dcs\x1b\\",
+        "\x9d2;split-c1-osc\x9c",
+    ],
+)
+def test_terminal_display_normalizer_handles_every_split_point(control: str) -> None:
+    for split_at in range(len(control) + 1):
+        assert _normalize("before", control[:split_at], control[split_at:], "after") == "beforeafter"
+
+
+@pytest.mark.parametrize(
+    "control",
+    [
+        "\x1b[31\x18",
+        "\x1b]2;cancelled\x1a",
+        "\x1bPcancelled\x18",
+    ],
+)
+def test_terminal_display_normalizer_resumes_safely_after_cancel_controls(control: str) -> None:
+    assert _normalize(f"before{control}visible") == "beforevisible"
+
+
+def test_terminal_display_normalizer_strips_malformed_and_intermediate_escapes() -> None:
+    assert _normalize("before\x1b%Gafter\x1b\x00[31mend") == "beforeafterend"
+
+
+def test_terminal_display_normalizer_discards_incomplete_sequences_on_flush() -> None:
+    for incomplete in ("\x1b", "\x1b[?1049", "\x1b]unfinished", "\x1bPunfinished", "\x9b?1000"):
+        assert _normalize(f"before{incomplete}") == "before"
+
+
+def test_terminal_display_normalizer_preserves_unicode_newlines_and_tabs_only() -> None:
+    standalone_controls = "\x00\x01\x07\x0b\x0c\x0e\x18\x1a\x7f\x80\x81\x85\x99\x9a\x9c"
+
+    assert _normalize(f"héllo\t世界\n{standalone_controls}done") == "héllo\t世界\ndone"
+
+
+def test_terminal_control_filter_handles_sequences_split_across_styled_segments() -> None:
+    styles = [
+        Style(color="red", meta={"source": "one"}),
+        Style(bold=True, meta={"source": "two"}),
+        Style(italic=True, meta={"source": "three"}),
+        Style(color="blue", meta={"source": "four"}),
+    ]
+    source = [
+        Segment("before\x1b[?10", styles[0]),
+        Segment("49lmiddle\x1b]2;OSC-", styles[1]),
+        Segment("PAYLOAD\x1b", styles[2]),
+        Segment("\\after\x1bPDCS-PAYLOAD\x1b\\", styles[3]),
+    ]
+
+    filtered = _filter_segments(*source)
+    text = "".join(segment.text for segment in filtered)
+
+    assert "before" in text
+    assert "middle" in text
+    assert "after" in text
+    assert "\x1b" not in text
+    assert "1049" not in text
+    assert "OSC-PAYLOAD" not in text
+    assert "DCS-PAYLOAD" not in text
+    assert [segment.style for segment in filtered] == styles
+    assert [segment.control for segment in filtered] == [segment.control for segment in source]
+    assert cell_len(text) == sum(segment.cell_length for segment in source)
+
+
+def test_terminal_control_filter_preserves_width_for_wide_unicode_control_payloads() -> None:
+    source = [
+        Segment("before\x1b]2;\u6f22"),
+        Segment("\U0001f642e\u0301\x07after", Style(italic=True)),
+    ]
+    filtered = _filter_segments(*source)
+    text = "".join(segment.text for segment in filtered)
+
+    assert "\u6f22" not in text
+    assert "\U0001f642e\u0301" not in text
+    assert text.startswith("before")
+    assert text.endswith("after")
+    assert cell_len(text) == sum(segment.cell_length for segment in source)
+
+
+def test_terminal_control_filter_drops_backspace_delete_and_standalone_c1_without_rewriting_text() -> None:
+    filtered = _filter_segments(Segment("ab\b\x7f\x85\x9ctext"))
+
+    assert "".join(segment.text for segment in filtered) == "abtext"
+
+
+def test_terminal_control_filter_preserves_rich_generated_styling_controls() -> None:
+    filtered = _filter_segments(Segment("safe\x1b[?1049ltext", Style(color="red", bold=True)))
+    rendered = Strip(filtered).render(Console(force_terminal=True, color_system="truecolor"))
+
+    assert "\x1b[?1049l" not in rendered
+    assert "\x1b[" in rendered
+    assert "safe" in rendered
+    assert "text" in rendered
+
+
+@pytest.mark.parametrize(
+    ("unsafe_link", "payload"),
+    [
+        ("https://example.invalid/\x9d2;C1-OSC-LINK\x07", "C1-OSC-LINK"),
+        ("https://example.invalid/\x1bPDCS-LINK\x1b\\", "DCS-LINK"),
+        ("https://example.invalid/\x1b[?1049h", "1049h"),
+    ],
+)
+def test_terminal_control_filter_drops_unsafe_rich_link_controls(unsafe_link: str, payload: str) -> None:
+    style = Style(color="red", bold=True, link=unsafe_link, meta={"source": "untrusted"})
+    filtered = _filter_segments(Segment("linked text", style))
+    filtered_style = filtered[0].style
+    rendered = Strip(filtered).render(Console(force_terminal=True, color_system="truecolor"))
+
+    assert filtered_style is not None
+    assert filtered_style.link is None
+    assert filtered_style.color == style.color
+    assert filtered_style.bold == style.bold
+    assert filtered_style.meta == style.meta
+    assert payload not in rendered
+    assert "linked text" in rendered
+
+
+def test_terminal_control_filter_preserves_safe_rich_hyperlinks() -> None:
+    style = Style(underline=True, link="https://example.com/safe")
+    filtered = _filter_segments(Segment("safe link", style))
+    rendered = Strip(filtered).render(Console(force_terminal=True, color_system="truecolor"))
+
+    assert filtered[0].style is style
+    assert "\x1b]8;" in rendered
+    assert "https://example.com/safe" in rendered
+    assert "safe link" in rendered
+
+
+def test_terminal_control_filter_does_not_share_state_between_rendered_lines() -> None:
+    control_filter = TerminalControlFilter()
+    background = Color.parse("#000000")
+
+    first = control_filter.apply([Segment("safe\x1b[?1049")], background)
+    second = control_filter.apply([Segment("l suffix")], background)
+    full_repaint = control_filter.apply([Segment("safe\x1b[?1049l suffix")], background)
+
+    first_text = "".join(segment.text for segment in first)
+    second_text = "".join(segment.text for segment in second)
+    repaint_text = "".join(segment.text for segment in full_repaint)
+    assert "\x1b" not in first_text
+    assert second_text == "l suffix"
+    assert "1049" not in repaint_text
+    assert repaint_text.endswith(" suffix")

--- a/tests/cli/test_tui_control_sanitization.py
+++ b/tests/cli/test_tui_control_sanitization.py
@@ -1,0 +1,137 @@
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+from textual.widgets import Static
+
+from kolega_code.cli.tui.state import ConversationEntry
+from kolega_code.cli.tui.terminal_display import TerminalControlFilter
+from kolega_code.llm.models import Message, TextBlock, ToolResult
+
+from ._app_test_utils import _build_sub_agent_test_app
+
+
+RESTORED_RAW = "RESTORED_BEFORE\x1b]52;c;OSC_PAYLOAD\x07\x1b[?1049h\x90DCS_PAYLOAD\x9cRESTORED_AFTER"
+TOOL_RAW = "TOOL_BEFORE\x1b^PM_PAYLOAD\x1b\\\x9b?1000hTOOL_AFTER"
+DYNAMIC_RAW = (
+    "DYNAMIC_BEFORE"
+    "\x00\x07"
+    "\x1b]2;TITLE_PAYLOAD\x1b\\"
+    "\x1bPPRIVATE_PAYLOAD\x1b\\"
+    "\x9d8;;C1_OSC_PAYLOAD\x9c"
+    "\x1bc"
+    "DYNAMIC_AFTER"
+)
+
+
+def _terminal_repaint(app) -> str:
+    update = app.screen._compositor.render_full_update()
+    return update.render_segments(app.console)
+
+
+def _assert_untrusted_controls_absent(output: str) -> None:
+    for payload in (
+        "OSC_PAYLOAD",
+        "DCS_PAYLOAD",
+        "PM_PAYLOAD",
+        "TITLE_PAYLOAD",
+        "PRIVATE_PAYLOAD",
+        "C1_OSC_PAYLOAD",
+    ):
+        assert payload not in output
+    for attack in ("\x1b[?1049h", "\x1b[?1000h", "\x1bc"):
+        assert attack not in output
+    assert "\x00" not in output
+    assert "\x07" not in output
+    assert not any("\x80" <= character <= "\x9f" for character in output)
+
+
+def test_app_registers_one_stable_terminal_control_filter_last(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    first = app.get_line_filters()
+    second = app.get_line_filters()
+
+    assert first[-1] is app._terminal_control_filter
+    assert second[-1] is app._terminal_control_filter
+    assert sum(isinstance(line_filter, TerminalControlFilter) for line_filter in first) == 1
+
+
+@pytest.mark.asyncio
+async def test_compositor_filters_untrusted_widget_text_but_keeps_trusted_controls(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test(size=(200, 50)) as pilot:
+        panel = app.query_one("#queued_messages", Static)
+        panel.update(DYNAMIC_RAW)
+        panel.display = True
+        turn_status = app.query_one("#turn_status", Static)
+        turn_status.update('[link="https://example.invalid/\x1b]2;STYLE_LINK_PAYLOAD\x07"]MARKUP_LINK[/link]')
+        turn_status.display = True
+        await pilot.pause()
+
+        output = _terminal_repaint(app)
+
+    _assert_untrusted_controls_absent(output)
+    assert "DYNAMIC_BEFORE" in output
+    assert "DYNAMIC_AFTER" in output
+    assert "MARKUP_LINK" in output
+    assert "STYLE_LINK_PAYLOAD" not in output
+    # Cursor movement and Rich styling are generated after line filtering and
+    # must remain available to Textual's compositor/driver.
+    assert "\x1b[" in output
+
+
+@pytest.mark.asyncio
+async def test_restored_model_tool_state_session_and_clipboard_data_stay_raw(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+    history = [
+        Message(role="assistant", content=[TextBlock(RESTORED_RAW)]).to_dict(),
+        Message(
+            role="user",
+            content=[
+                ToolResult(
+                    tool_use_id="tool-1",
+                    content=TOOL_RAW,
+                    name="untrusted_tool",
+                    is_error=False,
+                )
+            ],
+        ).to_dict(),
+    ]
+    original_history = deepcopy(history)
+    copied: list[str] = []
+
+    async with app.run_test(size=(200, 50)) as pilot:
+        monkeypatch.setattr(app, "copy_to_clipboard", copied.append)
+        app._restore_conversation_history(history)
+        await pilot.pause()
+
+        assistant_entry = next(entry for entry in app.conversation_entries if entry.kind == "assistant")
+        tool_entry = next(entry for entry in app.conversation_entries if entry.kind == "tool_result")
+        assert assistant_entry.content == RESTORED_RAW
+        assert tool_entry.full_content == TOOL_RAW
+        assert history == original_history
+
+        await app._command_copy("")
+        assert copied == [RESTORED_RAW]
+
+        assert app.agent is not None
+        app.agent.history = [Message.from_dict(item) for item in history]
+        await app._save_session_history_async()
+        assert app.session.history == original_history
+
+        live_entry = ConversationEntry(kind="assistant", content=DYNAMIC_RAW)
+        app._add_conversation_entry(live_entry)
+        await pilot.pause()
+        assert live_entry.content == DYNAMIC_RAW
+
+        output = _terminal_repaint(app)
+
+    _assert_untrusted_controls_absent(output)
+    assert "RESTORED_BEFORE" in output
+    assert "RESTORED_AFTER" in output


### PR DESCRIPTION
## Summary

- add a shared incremental parser for 7-bit/8-bit terminal control sequences, retaining the existing terminal transcript behavior
- install a final Textual line filter that preserves display width and trusted Rich/Textual styling while suppressing untrusted controls and unsafe hyperlink metadata
- keep model, tool, conversation, session, history, and clipboard values raw and unchanged
- add parser, compositor, restored-history, raw-state, session, clipboard, and streaming regression coverage

## Validation

- manual TUI smoke test with OSC and alternate-screen payloads
- `uv run pytest tests/cli/test_terminal_display.py tests/cli/test_tui_control_sanitization.py tests/cli/test_transcript_streaming_render.py tests/cli/test_app_rendering_entries.py tests/cli/test_app_rendering_terminal_logs.py -ra` (160 passed)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright` (0 errors)
- `./run_tests.sh` (2306 passed, 30 skipped, 103 deselected)