### PR TITLE
chore: release v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,37 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.19.0 - 2026-07-16
+
+### Added
+
+- Added private, project-scoped memory outside repositories, with bounded
+  Markdown storage, model tools, startup context, linked-worktree sharing,
+  `/memory` commands, settings controls, and a TUI browser and editor.
+
 ### Changed
 
 - Pinned the MCP SDK to stable `1.28.1` and stopped globally enabling
   prerelease dependency resolution.
+- Added the stable-lock `filelock` dependency required by project memory.
+
+### Removed
+
+- Stopped loading or modifying legacy repository `AGENT_MEMORY.md` files.
+  Existing files are not automatically migrated to private project memory.
 
 ### Fixed
 
+- Preserved separate OpenAI and ChatGPT Responses reasoning-summary parts so
+  thinking summaries render as clean, separated lines.
 - Fixed MCP 1.x stream, timeout, and camelCase result compatibility, and now
   report nested transport failures as credential-safe tool errors instead of
   opaque `TaskGroup` messages.
+
+### Security
+
+- Sanitized terminal-rendered control sequences and unsafe hyperlink metadata
+  while preserving raw model, tool, and session content internally.
 
 ## 0.18.0 - 2026-07-14
 

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.18.0"
+__version__ = "0.19.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -48,4 +48,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.18.0"
+__version__ = "0.19.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.18.0"
+version = "0.19.0"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-09T09:36:05.026623Z"
+exclude-newer = "2026-07-09T10:41:47.286336Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1497,7 +1497,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.18.0"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- bump package and module metadata from `0.18.0` to `0.19.0`
- regenerate `uv.lock` with the matching editable package version and refreshed one-week cutoff
- finalize the `0.19.0` changelog for private project memory, stable MCP resolution, compatibility changes, rendering fixes, and terminal hardening

## Release scope

This minor release adds private, project-scoped memory with `/memory`, TUI/settings controls, and model memory tools. It also removes legacy repository `AGENT_MEMORY.md` loading without automatic migration, pins stable MCP 1.28.1 resolution, fixes reasoning-summary/MCP compatibility, and sanitizes terminal-rendered control content.

## Validation

- `./run_tests.sh` — 2,443 passed, 103 deselected
- release version metadata consistency check
- `uv lock --check`
- `git diff --check`
- commit-time pre-commit hooks (`ruff check`, `ruff format`, YAML/whitespace/key checks, and `pyright`)
