### PR TITLE
fix(docs): replace lime text selection with themed cyan

### DIFF
--- a/docs/src/styles/brand.css
+++ b/docs/src/styles/brand.css
@@ -3,7 +3,7 @@
  * GitHub-dark terminal aesthetic matching the Kolega Code reskin.
  *   - Primary accent: cyan #39C5CF (links, active states, headings)
  *   - Secondary: purple #9B7DD4 (branding)
- *   - Tertiary: lime #ADDD30 (CTAs, selection, status indicators)
+ *   - Tertiary: lime #ADDD30 (CTAs, status indicators)
  *   - Surfaces: #0D1117 page, #161B22 cards, #010409 nav, #0A0D12 code
  *   - Hairlines: #21262D, visible borders: #30363D
  *   - JetBrains Mono for code/mono, IBM Plex Sans for prose
@@ -137,9 +137,17 @@ html {
   scroll-behavior: smooth;
 }
 
+/* Text selection — cyan accent, themed (was lime #addd30 from the old theme).
+ * Translucent so selected text stays readable; bg differs per theme for contrast.
+ * --sl-color-white is Starlight's foreground-text token in both themes. */
 ::selection {
-  background: #addd30;
-  color: #0d1117;
+  color: var(--sl-color-white);
+}
+:root[data-theme="dark"] ::selection {
+  background: rgba(57, 197, 207, 0.3); /* #39c5cf, the dark accent */
+}
+:root[data-theme="light"] ::selection {
+  background: rgba(26, 122, 133, 0.22); /* #1a7a85, the light accent */
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## Summary

Selecting text on the docs site (Starlight) painted it **lime green** — a remnant of the old lime-primary theme. The docs have since been reskinned to a **cyan-primary** palette, and every other highlight was deliberately moved off lime (e.g. the active sidebar page uses a "subtle cyan highlight (not lime fill)"). The `::selection` rule was the one leftover.

## Root cause

`docs/src/styles/brand.css` (the only Starlight custom stylesheet, wired in via `docs/astro.config.mjs:28`) hardcoded lime for both themes:

```css
::selection {
  background: #addd30;
  color: #0d1117;
}
```

## Fix

Replaced with a translucent, theme-aware cyan selection:

```css
::selection { color: var(--sl-color-white); }
:root[data-theme="dark"] ::selection  { background: rgba(57, 197, 207, 0.3);  /* #39c5cf */ }
:root[data-theme="light"] ::selection { background: rgba(26, 122, 133, 0.22); /* #1a7a85 */ }
```

- Matches the established accent system (`--sl-color-text-accent`).
- Translucent background keeps selected prose/code readable instead of a flat fill.
- `--sl-color-white` is Starlight's foreground-text token in both themes, so contrast is correct in dark and light.
- Lime is **retained** where it's intentional: CTA buttons and the `--sl-color-green` success hue.
- Also updated the stale brand header comment that still listed `selection` under lime.

## Verification

- `npm run build` → passes (31 pages, no CSS errors).
- Compiled CSS (`dist/_astro/*.css`) contains the cyan selection rules and **no lime on `::selection`**:
  - `::selection{background:#39c5cf4d}` (dark) and `::selection{background:#1a7a8538}` (light).
- Pre-commit hooks (ruff, pyright) passed.

### Manual check (reviewer)
`cd docs && npm run dev` → select text on a page and in a code block, toggle dark/light — highlight should be cyan in both themes with readable text.