### PR TITLE
chore: release v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.21.0 - 2026-07-17
+
+### Added
+
+- Added `/rewind [turns-back]` to restore workspace files and conversation to
+  their state before an earlier turn, with a pre-rewind snapshot captured for
+  recovery.
+
+### Fixed
+
+- Replaced the leftover lime text-selection color in the docs with a
+  theme-aware cyan.
+- Hardened diagnostics file writes to avoid a CodeQL clear-text-storage false
+  positive, creating log and sidecar files owner-only from the outset.
+
 ## 0.20.0 - 2026-07-17
 
 ### Added

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.20.0"
+__version__ = "0.21.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -48,4 +48,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.20.0"
+__version__ = "0.21.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.20.0"
+version = "0.21.0"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-10T08:04:15.056492Z"
+exclude-newer = "2026-07-10T12:04:02.291161Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1497,7 +1497,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Release bump to **0.21.0**.

## Changes
- Bump version to `0.21.0` in `pyproject.toml`, `kolega_code/__init__.py`, and `kolega_code/agent/__init__.py`
- Refresh `uv.lock` (version + `exclude-newer` cutoff)
- Update `CHANGELOG.md` with the 0.21.0 entry

## Release notes
### Added
- `/rewind [turns-back]` to restore workspace files and conversation to an earlier turn

### Fixed
- Docs text-selection color moved to theme-aware cyan
- Hardened diagnostics file writes (owner-only from the outset) to clear a CodeQL false positive

Fast test suite (`./run_tests.sh`): 2479 passed, 2 skipped, 103 deselected.