### PR TITLE
fix(cli): retain active model and effort when opening settings

### DIFF
--- a/kolega_code/cli/tui/settings_panel.py
+++ b/kolega_code/cli/tui/settings_panel.py
@@ -238,6 +238,11 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
 
         if select_id == "provider_select":
             provider = str(event.value)
+            if str(event.select.value) != provider:
+                # Stale event: the select already holds a newer value (e.g. a
+                # mount-time Changed posted with the compose-time default, delivered
+                # after _populate_settings_controls restored the real provider).
+                return
             self._repopulate_model_select(provider, "model_select", "thinking_effort_select")
             self._update_browser_model_hint()
             try:
@@ -251,6 +256,9 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             return
 
         if select_id == "model_select":
+            if str(event.select.value) != str(event.value):
+                # Stale event: a newer model was set after this event was posted.
+                return
             try:
                 provider = str(self._settings_query_one("#provider_select", Select).value)
             except NoMatches:

--- a/tests/cli/test_tui_settings_screens.py
+++ b/tests/cli/test_tui_settings_screens.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -12,7 +13,14 @@ from kolega_code.cli.settings import CliSettings, SettingsStore
 from ._app_test_utils import install_fake_agents, wait_for_onboarding_screen
 
 
-def _configured_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+def _configured_app(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    provider: str = UI_DEFAULT_PROVIDER,
+    model: str = UI_DEFAULT_MODEL,
+    effort: str | None = None,
+):
     from kolega_code.cli.app import KolegaCodeApp
 
     install_fake_agents(monkeypatch)
@@ -20,8 +28,8 @@ def _configured_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     project.mkdir()
     state_dir = tmp_path / "state"
     settings_store = SettingsStore(state_dir)
-    settings = CliSettings(active_provider=UI_DEFAULT_PROVIDER, active_model=UI_DEFAULT_MODEL)
-    settings.set_api_key(UI_DEFAULT_PROVIDER, "stored-key")
+    settings = CliSettings(active_provider=provider, active_model=model, active_thinking_effort=effort)
+    settings.set_api_key(provider, "stored-key")
     settings_store.save(settings)
     config = build_agent_config(project, env={}, settings=settings, settings_store=settings_store)
     store = SessionStore(state_dir)
@@ -96,6 +104,73 @@ async def test_settings_screen_is_categorized_and_stages_credentials_atomically(
         screen.query_one("#provider_select", Select).value = "deepseek"
         await pilot.pause()
         assert screen.query_one("#api_key_input", Input).value == ""
+
+
+async def _wait_for_select_values(pilot, screen, expected: dict[str, str], *, attempts: int = 50) -> None:
+    """Poll until the given Select widgets hold the expected values (or give up).
+
+    The provider→model→effort cascade settles over several message passes, so a
+    single ``pilot.pause()`` can race on loaded runners.
+    """
+    from textual.widgets import Select
+
+    for _ in range(attempts):
+        await pilot.pause()
+        await asyncio.sleep(0.01)
+        if all(str(screen.query_one(f"#{widget_id}", Select).value) == value for widget_id, value in expected.items()):
+            return
+
+
+@pytest.mark.asyncio
+async def test_settings_screen_retains_active_model_and_effort(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_cli_env: None,
+) -> None:
+    """Regression: stale mount-time Select.Changed events must not clobber the draft."""
+    pytest.importorskip("textual")
+    from textual.widgets import Select
+
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+
+    app, _ = _configured_app(
+        tmp_path,
+        monkeypatch,
+        provider="ollama_cloud",
+        model="gemma4:31b",
+        effort="high",
+    )
+
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.action_open_settings()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+        await _wait_for_select_values(
+            pilot,
+            screen,
+            {
+                "provider_select": "ollama_cloud",
+                "model_select": "gemma4:31b",
+                "thinking_effort_select": "high",
+            },
+        )
+        provider = screen.query_one("#provider_select", Select)
+        model = screen.query_one("#model_select", Select)
+        effort = screen.query_one("#thinking_effort_select", Select)
+        assert str(provider.value) == "ollama_cloud"
+        assert str(model.value) == "gemma4:31b"
+        assert str(effort.value) == "high"
+        assert screen.dirty is False
+
+        # A genuine provider change still cascades: model falls back to the new
+        # provider's first model, then a manual model pick is retained.
+        provider.value = "deepseek"
+        await _wait_for_select_values(pilot, screen, {"model_select": "deepseek-v4-pro"})
+        assert str(model.value) == "deepseek-v4-pro"
+
+        model.value = "deepseek-v4-flash"
+        await _wait_for_select_values(pilot, screen, {"model_select": "deepseek-v4-flash"})
+        assert str(model.value) == "deepseek-v4-flash"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes a settings-screen bug where the **Model** and **Thinking effort** selects fell back to catalog defaults instead of showing the active configuration (Provider was unaffected). Worse, since Apply persists the displayed draft, saving any unrelated change could silently overwrite the saved model.

## Root cause

`SettingsScreen` composes the Provider/Model/Effort selects with hardcoded defaults (`UI_DEFAULT_PROVIDER`/`UI_DEFAULT_MODEL`). On mount, each `Select` posts an initial `Changed` event carrying that default value. `_populate_settings_controls()` then synchronously restores the real values — but the stale mount-time events are delivered **afterwards** to `SettingsPanelMixin.on_select_changed`, which trusted `event.value` and re-ran the provider→model→effort cascade, resetting the model to the provider's first catalog entry and the effort to the model default.

The `am_provider_*` and `theme_select` branches of the same handler already guard against this by comparing the event payload against the select's current value; the `provider_select` and `model_select` branches lacked the guard.

## Fix

Add the same stale-event guard (`if str(event.select.value) != ...: return`) to the `provider_select` and `model_select` branches. Genuine user changes always have `event.value == event.select.value` at processing time; stale initialization events don't.

## Tests

- New regression test `test_settings_screen_retains_active_model_and_effort`: opens settings with `ollama_cloud/gemma4:31b` + effort `high`, asserts all three selects show the active values and the screen is not dirty; also asserts a manual provider change still cascades (model falls back to the new provider's first model) and a manual model pick is retained. Verified the test **fails without the fix**.
- Full `tests/cli` suite: 793 passed. ruff + pyright clean (pre-commit hooks).