### PR TITLE
chore: release v0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.21.1 - 2026-07-20
+
+### Changed
+
+- Kept the terminal UI responsive in large sessions by bounding mounted
+  transcript and subagent rows while preserving scrollback and navigation.
+
+### Fixed
+
+- Preserved the active model and reasoning effort when opening settings instead
+  of allowing stale selector events to reset them.
+
 ## 0.21.0 - 2026-07-17
 
 ### Added

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.21.0"
+__version__ = "0.21.1"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -48,4 +48,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.21.0"
+__version__ = "0.21.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.21.0"
+version = "0.21.1"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/tests/cli/test_app_rendering_selection.py
+++ b/tests/cli/test_app_rendering_selection.py
@@ -282,6 +282,23 @@ async def test_conversation_selection_can_start_in_blank_separator(
         await pilot.pause()
 
         first, second = list(app.query(ConversationEntryWidget))[-2:]
+
+        def selection_targets_are_ready() -> bool:
+            if app._conversation_anchor_pending:
+                return False
+            separator_y = first.region.height - 1
+            for widget, (x, y) in ((first, (0, separator_y)), (second, (20, 1))):
+                hit_widget, select_offset = app.screen.get_widget_and_offset_at(
+                    widget.region.x + x, widget.region.y + y
+                )
+                if hit_widget is not widget or select_offset is None:
+                    return False
+            return True
+
+        # The widgets can be queryable before the compositor's hit map reflects
+        # their post-anchor regions. Mouse selection requires both to agree.
+        await _wait_for_layout(pilot, selection_targets_are_ready)
+
         separator_y = first.region.height - 1
 
         await pilot.mouse_down(first, offset=(0, separator_y))

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-10T12:04:02.291161Z"
+exclude-newer = "2026-07-13T10:24:09.350077Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1497,7 +1497,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.21.0"
+version = "0.21.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- bump package and module versions to `0.21.1`
- document the large-session TUI performance improvements and settings retention fix
- refresh the lockfile release metadata and dependency cutoff

## Checks
- `BROWSERLESS_API_KEY= ./run_tests.sh` — 2494 passed, 1 skipped, 103 deselected
- pre-commit hooks — ruff, formatting, YAML, private-key scan, and pyright passed

## Note
The configured live Browserless integration timed out twice against the external service; the required fast suite passes with that credential-dependent integration skipped, matching CI where the credential is unavailable.