### PR TITLE
fix(cli): clarify session list output

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Resume a previous conversation:
 
 ```bash
 kolega-code . --resume            # latest session
-kolega-code . --resume <id>       # a specific thread or session
+kolega-code . --resume <id>       # a specific Resume ID from `sessions list`
 ```
 
 ## Two ways to use it

--- a/docs/src/content/docs/cli/overview.md
+++ b/docs/src/content/docs/cli/overview.md
@@ -39,11 +39,11 @@ kolega-code [PROJECT_PATH]
 | --- | --- |
 | `PROJECT_PATH` | Project directory to work in (default `.`) |
 | `--new` | Start a new session (this is the default) |
-| `--resume [THREAD_ID]` | Resume the latest saved thread, or a specific thread/session ID |
+| `--resume [SESSION_ID]` | Resume the latest saved session, or a specific Resume ID from `sessions list`. Legacy thread IDs are also accepted |
 | `--browser-visible` | Launch visible Playwright browser windows instead of headless |
 | `--show-logs` | Show the optional diagnostic Logs side-panel tab. Hidden by default to avoid unnecessary log rendering work |
 | `--permission-mode <auto\|ask>` | Shell/edit permission mode. TUI sessions default to `ask` |
-| `--session <ID>` | Legacy alias for `--resume THREAD_ID` |
+| `--session <ID>` | Legacy alias for `--resume SESSION_ID` |
 
 See [Sessions & Resuming](../../tui/sessions-and-resume/) for the full session
 workflow.

--- a/docs/src/content/docs/cli/sessions.md
+++ b/docs/src/content/docs/cli/sessions.md
@@ -28,11 +28,19 @@ kolega-code sessions list --project .
 | `--project <PATH>` | Only show sessions for this project |
 | `--state-dir <PATH>` | Directory for CLI session state |
 
-Each row is tab-separated:
+Each saved session is shown as a labeled block:
 
 ```text
-<session_id>  <thread_id>  <updated_at>  <mode>  <project_path>  <title>
+Updated:   2026-07-19T10:00:00+00:00
+Title:     Improve session listing
+Mode:      code
+Project:   /path/to/project
+Resume ID: 0123456789abcdef0123456789abcdef
 ```
+
+Sessions are ordered from oldest to newest, so the most recently updated
+session and its Resume ID appear nearest the shell prompt. Pass that Resume ID
+to `--resume`, `sessions delete`, or `sessions export`.
 
 ## `sessions delete`
 
@@ -44,7 +52,7 @@ kolega-code sessions delete <session_id>
 
 | Argument / option | Description |
 | --- | --- |
-| `session_id` | The session to delete (required) |
+| `session_id` | The Resume ID shown by `sessions list` (required) |
 | `--state-dir <PATH>` | Directory for CLI session state |
 
 ## `sessions export`
@@ -58,7 +66,7 @@ kolega-code sessions export <session_id> --output run.json
 
 | Argument / option | Description |
 | --- | --- |
-| `session_id` | The session to export (required) |
+| `session_id` | The Resume ID shown by `sessions list` (required) |
 | `--output <PATH>` | Write JSON to a file instead of stdout |
 | `--state-dir <PATH>` | Directory for CLI session state |
 

--- a/docs/src/content/docs/tui/sessions-and-resume.md
+++ b/docs/src/content/docs/tui/sessions-and-resume.md
@@ -24,14 +24,16 @@ location and the `KOLEGA_CODE_STATE_DIR` override.
 # Resume the most recent session for this project
 kolega-code . --resume
 
-# Resume a specific thread or session ID
-kolega-code . --resume <thread-or-session-id>
+# Resume a specific session using the Resume ID from `sessions list`
+kolega-code . --resume <session-id>
 ```
 
 A few rules:
 
 - `--resume` with no ID resumes the **latest** session for the project. If there
   are none, the CLI reports that.
+- `sessions list` labels the session ID to copy as **Resume ID**. Previously
+  saved commands that use a thread ID remain supported for compatibility.
 - A session belongs to the project it was created in — resuming it from a
   different project directory is rejected.
 - `--new` forces a fresh session (this is the default behavior).

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -206,8 +206,8 @@ def _add_tui_args(parser: argparse.ArgumentParser) -> None:
         "--resume",
         nargs="?",
         const=RESUME_LATEST,
-        metavar="THREAD_ID",
-        help="Resume the latest saved thread, or resume the given thread/session ID.",
+        metavar="SESSION_ID",
+        help="Resume the latest saved session, or resume the given session ID (legacy thread IDs are also accepted).",
     )
     parser.add_argument("--browser-visible", action="store_true", help="Launch visible Playwright browser windows.")
     parser.add_argument("--show-logs", action="store_true", help="Show the diagnostic Logs sidebar tab.")
@@ -231,7 +231,7 @@ def _add_tui_args(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Trust and enable this project's .kolega/lsp.json (persisted for future runs).",
     )
-    _add_session_args(parser, session_help="Legacy alias for --resume THREAD_ID.")
+    _add_session_args(parser, session_help="Legacy alias for --resume SESSION_ID.")
     _add_common_model_args(parser)
 
 
@@ -1107,11 +1107,23 @@ def _run_sessions(args: argparse.Namespace) -> int:
     if args.sessions_command == "list":
         project = args.project.expanduser().resolve() if args.project else None
         records = store.list(project_path=project)
-        for record in records:
-            print(
-                f"{record.session_id}\t{record.thread_id}\t{record.updated_at}\t"
-                f"{record.mode}\t{record.project_path}\t{record.title}"
+        if not records:
+            print("No saved sessions.")
+            return 0
+        entries = []
+        for record in reversed(records):
+            entries.append(
+                "\n".join(
+                    (
+                        f"Updated:   {record.updated_at}",
+                        f"Title:     {record.title}",
+                        f"Mode:      {record.mode}",
+                        f"Project:   {record.project_path}",
+                        f"Resume ID: {record.session_id}",
+                    )
+                )
             )
+        print("\n\n".join(entries))
         return 0
     if args.sessions_command == "delete":
         store.delete(args.session_id)

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -15,7 +15,7 @@ from kolega_code.cli.main import (
     parse_args,
 )
 from kolega_code.cli.provider_registry import DEEPSEEK_DEFAULT_MODEL, UI_DEFAULT_MODEL, UI_DEFAULT_PROVIDER
-from kolega_code.cli.session_store import SessionStore, SessionStoreError
+from kolega_code.cli.session_store import SessionRecord, SessionStore, SessionStoreError
 from kolega_code.cli.settings import CliSettings, SettingsStore
 from kolega_code.cli.updater import UpdateCheckResult, UpdateRunResult
 from kolega_code.agent.prompt_overrides import PROMPT_OVERRIDE_DIR
@@ -78,6 +78,8 @@ def test_explicit_tui_help_shows_tui_arguments(capsys) -> None:
     assert "usage: kolega-code tui" in output
     assert "project_path" in output
     assert "--resume" in output
+    assert "SESSION_ID" in output
+    assert "legacy thread IDs are also accepted" in output
     assert "--permission-mode" in output
 
 
@@ -175,6 +177,78 @@ def test_parse_sessions_list_subcommand() -> None:
     assert args.command == "sessions"
     assert args.sessions_command == "list"
     assert args.project == Path("/tmp/project")
+
+
+def test_sessions_list_shows_resume_ids_oldest_to_newest(
+    tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from kolega_code.cli import main as main_module
+
+    project = tmp_path / "project"
+    project.mkdir()
+    records = [
+        SessionRecord(
+            session_id="newest-session",
+            thread_id="newest-thread",
+            workspace_id="newest-workspace",
+            project_path=str(project),
+            mode="code",
+            title="Newest work",
+            created_at="2026-07-20T12:00:00+00:00",
+            updated_at="2026-07-20T13:00:00+00:00",
+        ),
+        SessionRecord(
+            session_id="oldest-session",
+            thread_id="oldest-thread",
+            workspace_id="oldest-workspace",
+            project_path=str(project),
+            mode="code",
+            title="Older work",
+            created_at="2026-07-19T09:00:00+00:00",
+            updated_at="2026-07-19T10:00:00+00:00",
+        ),
+    ]
+    projects: list[Path | None] = []
+
+    class FakeStore:
+        def list(self, project_path: Path | None = None) -> list[SessionRecord]:
+            projects.append(project_path)
+            return records
+
+    monkeypatch.setattr(main_module, "_store_from_args", lambda args: FakeStore())
+
+    exit_code = main_module.main(["sessions", "list", "--project", str(project)])
+
+    assert exit_code == 0
+    assert projects == [project.resolve()]
+    output = capsys.readouterr().out
+    assert "Resume ID: oldest-session" in output
+    assert "Resume ID: newest-session" in output
+    assert "oldest-thread" not in output
+    assert "newest-thread" not in output
+    assert "Older work" in output
+    assert "Newest work" in output
+    assert str(project) in output
+    assert "Mode:      code" in output
+    assert "2026-07-19T10:00:00+00:00" in output
+    assert "2026-07-20T13:00:00+00:00" in output
+    assert output.index("oldest-session") < output.index("newest-session")
+    assert output.rstrip().endswith("Resume ID: newest-session")
+
+
+def test_sessions_list_prints_empty_state(capsys, monkeypatch: pytest.MonkeyPatch) -> None:
+    from kolega_code.cli import main as main_module
+
+    class EmptyStore:
+        def list(self, project_path: Path | None = None) -> list[SessionRecord]:
+            return []
+
+    monkeypatch.setattr(main_module, "_store_from_args", lambda args: EmptyStore())
+
+    exit_code = main_module.main(["sessions", "list"])
+
+    assert exit_code == 0
+    assert capsys.readouterr().out == "No saved sessions.\n"
 
 
 def test_parse_update_subcommand() -> None:


### PR DESCRIPTION
## Summary
- show one clearly labeled Resume ID per saved session
- order session listings oldest-to-newest so the latest ID is nearest the prompt
- add an empty state and document legacy thread-ID resume compatibility

## Testing
- `python -m pytest tests/cli/test_main.py tests/cli/test_session_store.py -q`
- `python -m ruff check kolega_code/cli/main.py tests/cli/test_main.py`
- `python -m pyright kolega_code/cli/main.py tests/cli/test_main.py`
- `npm run build --prefix docs`