### PR TITLE
fix(edit): allow paths outside project

### DIFF
--- a/docs/src/content/docs/concepts/tools.md
+++ b/docs/src/content/docs/concepts/tools.md
@@ -23,6 +23,12 @@ Read, search, and edit your project:
   [configured language servers](../../configuration/lsp/).
 - Create and edit files — create new files and apply precise edits.
 
+File-edit paths may be project-relative, use `../` traversal, or be absolute;
+local LSP server edits may likewise target external files. Permissions and the
+Vibe edit policy still apply. Any external or mixed mutation is not snapshotted
+or undoable, and an external or mixed LSP preview cannot create a resolvable
+pending action—rerun it with `apply: true`.
+
 ### Terminal
 
 Run shell commands in the project and stream their output to the **Terminal** tab.

--- a/docs/src/content/docs/configuration/lsp.md
+++ b/docs/src/content/docs/configuration/lsp.md
@@ -44,6 +44,19 @@ does not advertise or return an edit for an operation, Kolega Code reports that
 the operation is unsupported instead of constructing a manual fallback edit.
 Pass `apply: false` to preview the LSP edit without writing files.
 
+### External paths, permissions, and undo
+
+Local `file:` URIs returned by a language server may target files outside the
+project. Initiating paths can likewise be project-relative, use `../` traversal,
+or be absolute. The existing edit permission gate still applies to the request,
+and the Vibe edit policy checks every touched path before mutation.
+
+A mutation that touches any external path—including a mix of project and
+external files—is not snapshotted and cannot be undone through snapshot restore.
+With `apply: false`, such an external or mixed edit can be previewed but cannot
+create a snapshot-backed, resolvable pending action. To perform it, rerun the
+operation with `apply: true`.
+
 ## Project configuration
 
 Create `<project>/.kolega/lsp.json` to override LSP behavior for a repository.

--- a/kolega_code/agent/tool_backend/base_tool.py
+++ b/kolega_code/agent/tool_backend/base_tool.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Union, Optional, Set
+from typing import TYPE_CHECKING, Callable, Optional, Set, TypeVar, Union
 
 from ..common import LogMixin
 from kolega_code.config import AgentConfig
@@ -8,6 +8,12 @@ from kolega_code.events import AgentConnectionManager, AgentEvent
 from kolega_code.services.file_system import FileSystem, LocalFileSystem
 from kolega_code.services.base import TerminalManager, BrowserManager
 from ..prompt_provider import AgentMode
+
+if TYPE_CHECKING:
+    from kolega_code.services.snapshots import SnapshotService
+
+
+T = TypeVar("T")
 
 
 class BaseTool(LogMixin):
@@ -218,6 +224,28 @@ class BaseTool(LogMixin):
         if os.path.basename(path) in self._get_vibe_blacklist_basenames():
             return f"You are not allowed to edit this file: {path}"
         return None
+
+    def _mutate_with_optional_snapshot(
+        self,
+        *,
+        tool_name: str,
+        reason: str,
+        paths: list[str],
+        mutate: Callable[[], T],
+    ) -> T:
+        """Run one mutation, recording it only when every path can be snapshotted."""
+
+        snapshot_service: Optional["SnapshotService"] = getattr(self, "_snapshot_service", None)
+        if snapshot_service is None or not snapshot_service.can_snapshot_paths(paths):
+            return mutate()
+        mutation = snapshot_service.record_mutation(
+            tool_name=tool_name,
+            tool_call_id=getattr(self.caller, "current_tool_execution_id", None),
+            reason=reason,
+            paths=paths,
+            mutate=mutate,
+        )
+        return mutation.result
 
     async def send_edit_preview(self, preview: Optional[dict], *, tool_call_id: Optional[str], tool_name: str) -> None:
         """Broadcast a UI-only diff/head preview for inline rendering in the chat.

--- a/kolega_code/agent/tool_backend/edit_tool.py
+++ b/kolega_code/agent/tool_backend/edit_tool.py
@@ -124,7 +124,7 @@ class EditTool(BaseTool):
                 self.filesystem.create_directory(parent)
             self.filesystem.write_text(path, updated_content)
 
-        self._record_snapshot_mutation(
+        self._mutate_with_optional_snapshot(
             tool_name="edit",
             reason=f"claude edit {path}",
             paths=self._snapshot_paths_for_write(path),
@@ -174,7 +174,7 @@ class EditTool(BaseTool):
                 self.filesystem.create_directory(parent)
             self.filesystem.write_text(path, content)
 
-        self._record_snapshot_mutation(
+        self._mutate_with_optional_snapshot(
             tool_name="write",
             reason=f"claude write {path}",
             paths=self._snapshot_paths_for_write(path),
@@ -275,7 +275,7 @@ class EditTool(BaseTool):
                     self.filesystem.create_directory(parent_dir)
                 self.filesystem.write_text(path, content)
 
-            self._record_snapshot_mutation(
+            self._mutate_with_optional_snapshot(
                 tool_name="write",
                 reason=f"write {path}",
                 paths=self._snapshot_paths_for_write(path),
@@ -345,7 +345,7 @@ class EditTool(BaseTool):
                 if self.filesystem.exists(source):
                     self.filesystem.remove(source, missing_ok=True)
 
-            self._record_snapshot_mutation(
+            self._mutate_with_optional_snapshot(
                 tool_name="edit",
                 reason=f"hashline delete {source}",
                 paths=[source],
@@ -411,7 +411,7 @@ class EditTool(BaseTool):
             if destination is not None and self.filesystem.exists(source):
                 self.filesystem.remove(source, missing_ok=True)
 
-        self._record_snapshot_mutation(
+        self._mutate_with_optional_snapshot(
             tool_name="edit",
             reason=(f"hashline move {source} -> {destination}" if destination else f"hashline edit {source}"),
             paths=snapshot_paths,
@@ -545,7 +545,7 @@ class EditTool(BaseTool):
                     self.filesystem.create_directory(parent)
                 self.filesystem.write_text(path, working[path] or "")
 
-        self._record_snapshot_mutation(
+        self._mutate_with_optional_snapshot(
             tool_name="apply_patch",
             reason=f"apply_patch ({len(normalized_operations)} operations)",
             paths=snapshot_paths,
@@ -599,36 +599,16 @@ class EditTool(BaseTool):
         )
 
     def _normalize_patch_path(self, path: str) -> str:
-        candidate = Path(path)
-        if candidate.is_absolute():
-            raise ValueError(f"Patch paths must be relative to the project: {path}")
-        try:
-            relative = (self.project_path / candidate).resolve(strict=False).relative_to(self.project_path.resolve())
-        except ValueError as exc:
-            raise ValueError(f"Patch path is outside the project: {path}") from exc
-        normalized = relative.as_posix()
-        if normalized in {"", "."}:
-            raise ValueError("Patch path must not be the project root.")
-        return normalized
+        if not path or not path.strip():
+            raise ValueError("Patch path is required.")
+        return path
 
     def _normalize_claude_path(self, path: str) -> str:
-        """Return a project-relative path and reject workspace escapes."""
+        """Validate a model-provided path without changing its filesystem semantics."""
 
         if not path or not path.strip():
             raise ValueError("file_path is required")
-        root = self.project_path.resolve()
-        candidate = Path(path)
-        resolved = (
-            candidate.resolve(strict=False) if candidate.is_absolute() else (root / candidate).resolve(strict=False)
-        )
-        try:
-            relative = resolved.relative_to(root)
-        except ValueError as exc:
-            raise ValueError(f"File path is outside the project: {path}") from exc
-        normalized = relative.as_posix()
-        if normalized in {"", "."}:
-            raise ValueError("file_path must identify a file inside the project")
-        return normalized
+        return path
 
     @staticmethod
     def _content_digest(content: str) -> str:
@@ -646,7 +626,10 @@ class EditTool(BaseTool):
         while parent and parent != ".":
             if self.filesystem.exists(parent) and not self.filesystem.is_dir(parent):
                 raise NotADirectoryError(f"Patch parent is not a directory: {parent}")
-            parent = self.filesystem.get_parent(parent)
+            next_parent = self.filesystem.get_parent(parent)
+            if next_parent == parent:
+                break
+            parent = next_parent
 
     async def _edit_blocks(self, path: str, blocks: list[SearchReplaceBlock], *, tool_name: str) -> str:
         if not self.filesystem.exists(path):
@@ -678,7 +661,7 @@ class EditTool(BaseTool):
             blocked_msg = self._enforce_vibe_edit_policy(path)
             if blocked_msg:
                 return blocked_msg
-            self._record_snapshot_mutation(
+            self._mutate_with_optional_snapshot(
                 tool_name=tool_name,
                 reason=f"{tool_name} {path}",
                 paths=[path],
@@ -726,31 +709,15 @@ class EditTool(BaseTool):
             )
         return parsed_blocks
 
-    def _record_snapshot_mutation(
-        self,
-        *,
-        tool_name: str,
-        reason: str,
-        paths: list[str],
-        mutate: Callable[[], None],
-    ) -> None:
-        if self._snapshot_service is None or not self._snapshot_service.can_snapshot_paths(paths):
-            mutate()
-            return
-        self._snapshot_service.record_mutation(
-            tool_name=tool_name,
-            tool_call_id=getattr(self.caller, "current_tool_execution_id", None),
-            reason=reason,
-            paths=paths,
-            mutate=mutate,
-        )
-
     def _snapshot_paths_for_write(self, path: str) -> list[str]:
         paths = [path]
         parent = self.filesystem.get_parent(path)
         while parent and parent != "." and not self.filesystem.exists(parent):
             paths.append(parent)
-            parent = self.filesystem.get_parent(parent)
+            next_parent = self.filesystem.get_parent(parent)
+            if next_parent == parent:
+                break
+            parent = next_parent
         return paths
 
     def _resolve_replacement(self, content: str, block: SearchReplaceBlock) -> ResolvedReplacement:

--- a/kolega_code/agent/tool_backend/lsp_tool.py
+++ b/kolega_code/agent/tool_backend/lsp_tool.py
@@ -917,32 +917,33 @@ class LspEditTool(BaseTool):
             return blocked
 
         if should_apply:
-            if self._snapshot_service is not None:
-                mutation = self._snapshot_service.record_mutation(
-                    tool_name="lsp_edit",
-                    tool_call_id=getattr(self.caller, "current_tool_execution_id", None),
-                    reason=f"lsp_edit {operation}",
-                    paths=preview.touched_paths,
-                    mutate=lambda: applier.apply(edit),
-                )
-                result = mutation.result
-            else:
-                result = applier.apply(edit)
+            result = self._mutate_with_optional_snapshot(
+                tool_name="lsp_edit",
+                reason=f"lsp_edit {operation}",
+                paths=list(preview.touched_paths),
+                mutate=lambda: applier.apply(edit),
+            )
         else:
             result = preview
         await self._send_previews(result, operation)
         lines = [self._format_workspace_edit_result(operation, result)]
         if not should_apply and self._snapshot_service is not None:
-            pending = self._snapshot_service.create_pending_workspace_edit(
-                tool_name="lsp_edit",
-                tool_call_id=getattr(self.caller, "current_tool_execution_id", None),
-                operation=operation,
-                workspace_edit=edit,
-                touched_paths=preview.touched_paths,
-                summaries=preview.summaries,
-                previews=self._preview_payloads(preview),
-            )
-            lines.append(f'Pending action: `{pending.action_id}`. Use resolve(decision="apply") to apply it.')
+            if self._snapshot_service.can_snapshot_paths(preview.touched_paths):
+                pending = self._snapshot_service.create_pending_workspace_edit(
+                    tool_name="lsp_edit",
+                    tool_call_id=getattr(self.caller, "current_tool_execution_id", None),
+                    operation=operation,
+                    workspace_edit=edit,
+                    touched_paths=preview.touched_paths,
+                    summaries=preview.summaries,
+                    previews=self._preview_payloads(preview),
+                )
+                lines.append(f'Pending action: `{pending.action_id}`. Use resolve(decision="apply") to apply it.')
+            else:
+                lines.append(
+                    "Snapshot-backed pending preview is unavailable because this edit includes paths outside "
+                    "the project. No pending action was created; rerun with `apply=True` to apply the edit."
+                )
         if should_apply and include_diagnostics:
             diagnostics = await self._diagnostics_for_paths(result.touched_paths)
             if diagnostics:
@@ -1007,7 +1008,8 @@ class LspEditTool(BaseTool):
 
     def _file_uri(self, path: str) -> str:
         path_obj = Path(path)
-        absolute = path_obj.resolve() if path_obj.is_absolute() else (self.project_path / path_obj).resolve()
+        project_path = self.project_path if self.project_path.is_absolute() else Path.cwd() / self.project_path
+        absolute = path_obj if path_obj.is_absolute() else project_path / path_obj
         return absolute.as_uri()
 
     def _line_end_character(self, path: str, line_1based: int) -> int:

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -71,7 +71,9 @@ _LSP_INPUT_SCHEMA: dict[str, Any] = {
         },
         "path": {
             "type": "string",
-            "description": "File path (relative to project root preferred). Required for most operations.",
+            "description": (
+                "File path: project-relative, using ../ traversal, or absolute. Required for most operations."
+            ),
         },
         "line": {
             "type": "integer",
@@ -116,7 +118,7 @@ _LSP_EDIT_INPUT_SCHEMA: dict[str, Any] = {
         },
         "path": {
             "type": "string",
-            "description": "File path (relative to project root preferred).",
+            "description": "File path: project-relative, using ../ traversal, or absolute.",
         },
         "line": {
             "type": "integer",
@@ -132,7 +134,7 @@ _LSP_EDIT_INPUT_SCHEMA: dict[str, Any] = {
         },
         "new_path": {
             "type": "string",
-            "description": "Destination path for rename_file.",
+            "description": ("Destination path for rename_file: project-relative, using ../ traversal, or absolute."),
         },
         "query": {
             "type": "string",
@@ -249,7 +251,10 @@ def _hashline_operation_schema(
 _HASHLINE_V2_INPUT_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
-        "path": {"type": "string", "description": "Project-relative path to edit."},
+        "path": {
+            "type": "string",
+            "description": "Path to edit: project-relative, using ../ traversal, or absolute.",
+        },
         "edits": {
             "type": "array",
             "description": (
@@ -304,7 +309,10 @@ _HASHLINE_V2_INPUT_SCHEMA: dict[str, Any] = {
             },
         },
         "delete": {"type": "boolean", "description": "Delete path; requires edits=[] and no rename."},
-        "rename": {"type": "string", "description": "Move the edited result to this project-relative path."},
+        "rename": {
+            "type": "string",
+            "description": ("Move the edited result to this path: project-relative, using ../ traversal, or absolute."),
+        },
     },
     "required": ["path", "edits"],
     "additionalProperties": False,
@@ -1411,7 +1419,7 @@ class ToolCollection(LogMixin):
         If you want to create or overwrite a file, use the write tool.
 
         Args:
-            path: Path to the file to edit. Relative to the project root is preferred; an absolute path is also accepted.
+            path: Path to edit: project-relative, using ../ traversal, or absolute.
             block: A single search and replace block formatted as shown above
 
         Returns:
@@ -1439,7 +1447,7 @@ class ToolCollection(LogMixin):
         be unique unless ``replace_all`` is true.
 
         Args:
-            file_path: Absolute or project-relative path to the file to modify.
+            file_path: Path to modify: project-relative, using ../ traversal, or absolute.
             old_string: Exact text to replace.
             new_string: Replacement text, which must differ from old_string.
             replace_all: Replace every exact occurrence instead of requiring a unique match.
@@ -1456,6 +1464,7 @@ class ToolCollection(LogMixin):
         This is a FREEFORM tool, so do not wrap the patch in JSON. Supply one
         complete patch beginning with `*** Begin Patch` and ending with
         `*** End Patch`. A patch may add, update, move, or delete multiple files.
+        Patch paths may be project-relative, use ``../`` traversal, or be absolute.
 
         Args:
             input: The raw Codex apply_patch payload.
@@ -1493,10 +1502,10 @@ class ToolCollection(LogMixin):
         or ``rename`` to move the edited result.
 
         Args:
-            path: Project-relative file path.
+            path: File path: project-relative, using ../ traversal, or absolute.
             edits: Hashline v2 operations for this file.
             delete: Delete the file; cannot be combined with edits or rename.
-            rename: Optional project-relative destination path.
+            rename: Optional destination path: project-relative, using ../ traversal, or absolute.
 
         Returns:
             A short summary, or fresh tagged context when an anchor is stale.
@@ -1511,7 +1520,7 @@ class ToolCollection(LogMixin):
         this tool for deliberate complete-file writes.
 
         Args:
-            path: Project-relative path to create or replace.
+            path: Path to create or replace: project-relative, using ../ traversal, or absolute.
             content: Complete file content.
 
         Returns:
@@ -1545,7 +1554,7 @@ class ToolCollection(LogMixin):
         4. Normalized smart quotes.
 
         Args:
-            path: Path to the file to edit. Relative to the project root is preferred; an absolute path is also accepted.
+            path: Path to edit: project-relative, using ../ traversal, or absolute.
             blocks: One or more search and replace blocks formatted as shown above
 
         Returns:
@@ -1567,7 +1576,7 @@ class ToolCollection(LogMixin):
         Existing files must be read first. Prefer edit for partial changes.
 
         Args:
-            file_path: Absolute or project-relative path to create or overwrite.
+            file_path: Path to create or overwrite: project-relative, using ../ traversal, or absolute.
             content: Complete content to write to the file.
 
         Returns:
@@ -1753,7 +1762,7 @@ class ToolCollection(LogMixin):
         For small edits to existing files, prefer edit or multi_edit.
 
         Args:
-            path: Path to the file to write. Relative to the project root is preferred; an absolute path is also accepted.
+            path: Path to write: project-relative, using ../ traversal, or absolute.
             content: Content to write to the file
 
         Returns:
@@ -1984,7 +1993,7 @@ class ToolCollection(LogMixin):
 
         Args:
             operation: One of the operations listed above.
-            path: File path (relative to project root preferred).
+            path: File path: project-relative, using ../ traversal, or absolute.
             line: 1-based line number for position operations.
             symbol: Symbol name to resolve on the line (supports ``name#N``).
             query: Search query for ``workspace_symbols``.
@@ -2016,7 +2025,9 @@ class ToolCollection(LogMixin):
 
         This is the mutating companion to the read-only ``lsp`` tool. Use
         ``apply=False`` to preview the server-provided WorkspaceEdit without
-        writing files.
+        writing files. ``path`` and ``new_path`` may be project-relative, use
+        ``../`` traversal, or be absolute; local file URIs returned by the
+        server may also target files outside the project.
         """
         return await self.lsp_edit_tool.lsp_edit(
             operation,
@@ -2079,7 +2090,8 @@ class ToolCollection(LogMixin):
         definition = tool_definition_from_callable(method_name, method)
         if method_name == "apply_patch":
             definition.description = (
-                "Use the `apply_patch` tool to edit files. This is a FREEFORM tool, so do not wrap the patch in JSON."
+                "Use the `apply_patch` tool to edit files. This is a FREEFORM tool, so do not wrap the patch in JSON. "
+                "Patch paths may be project-relative, use ../ traversal, or be absolute."
             )
             definition.input_kind = "freeform"
             definition.freeform_format = {

--- a/kolega_code/services/lsp/edits.py
+++ b/kolega_code/services/lsp/edits.py
@@ -325,11 +325,14 @@ class WorkspaceEditApplier:
             raise WorkspaceEditError(f"Unsupported URI scheme for edit: {parsed.scheme!r}.")
         if parsed.netloc not in ("", "localhost"):
             raise WorkspaceEditError(f"Unsupported file URI host: {parsed.netloc!r}.")
-        absolute_path = Path(unquote(parsed.path)).resolve()
+        decoded_path = unquote(parsed.path)
+        if not decoded_path:
+            raise WorkspaceEditError("WorkspaceEdit file URI path must not be empty.")
+        absolute_path = Path(decoded_path)
         try:
             relative = absolute_path.relative_to(self.project_path)
-        except ValueError as exc:
-            raise WorkspaceEditError(f"WorkspaceEdit path is outside the project: {uri}") from exc
+        except ValueError:
+            return str(absolute_path)
         relative_text = relative.as_posix()
         if not relative_text or relative_text == ".":
             raise WorkspaceEditError("WorkspaceEdit path must not be the project root.")

--- a/tests/agent/test_edit_protocol_tools.py
+++ b/tests/agent/test_edit_protocol_tools.py
@@ -5,6 +5,18 @@ import pytest
 
 from kolega_code.agent.tools import ToolCollection, ToolCollectionConfig
 from kolega_code.config import AgentConfig, EditProtocol, ModelConfig, ModelProvider
+from kolega_code.tools import ToolRegistry
+
+
+def assert_external_path_description(description: str) -> None:
+    assert "project-relative" in description.lower()
+    assert "../" in description
+    assert "absolute" in description.lower()
+
+
+def parameter_description(registry: ToolRegistry, tool_name: str, parameter_name: str) -> str:
+    parameters = registry.get(tool_name).definition.parameters
+    return next(parameter.description for parameter in parameters if parameter.name == parameter_name)
 
 
 def collection(
@@ -43,6 +55,8 @@ def test_default_protocol_keeps_search_replace_tools(tmp_path: Path) -> None:
 
     assert {"edit", "multi_edit", "write"}.issubset(registry.names())
     assert "apply_patch" not in registry
+    for tool_name in ("edit", "multi_edit", "write"):
+        assert_external_path_description(parameter_description(registry, tool_name, "path"))
 
 
 def test_codex_protocol_replaces_ordinary_write_tools(tmp_path: Path) -> None:
@@ -55,6 +69,7 @@ def test_codex_protocol_replaces_ordinary_write_tools(tmp_path: Path) -> None:
     assert definition.input_kind == "freeform"
     assert definition.freeform_format is not None
     assert definition.freeform_format["syntax"] == "lark"
+    assert_external_path_description(definition.description)
 
 
 def test_read_only_agent_never_gets_apply_patch(tmp_path: Path) -> None:
@@ -84,6 +99,12 @@ def test_claude_protocol_reuses_lowercase_names_with_exact_string_schema(tmp_pat
     }
     assert {parameter.name for parameter in write_parameters} == {"file_path", "content"}
     assert all(parameter.required for parameter in write_parameters)
+    assert_external_path_description(
+        next(parameter.description for parameter in edit_parameters if parameter.name == "file_path")
+    )
+    assert_external_path_description(
+        next(parameter.description for parameter in write_parameters if parameter.name == "file_path")
+    )
 
 
 def test_read_only_agent_never_gets_claude_edit_tools(tmp_path: Path) -> None:
@@ -107,9 +128,21 @@ def test_hashline_protocol_exposes_edit_write_and_nested_schema(tmp_path: Path) 
     assert schema["required"] == ["path", "edits"]
     assert len(schema["properties"]["edits"]["items"]["anyOf"]) == 5
     assert "only CONTENT to content fields" in schema["properties"]["edits"]["description"]
+    assert_external_path_description(schema["properties"]["path"]["description"])
+    assert_external_path_description(schema["properties"]["rename"]["description"])
+    assert_external_path_description(parameter_description(registry, "write", "path"))
     declarations = registry.get("edit").definition.to_google().function_declarations
     assert declarations is not None
     assert declarations[0].parameters is not None
+
+
+def test_lsp_edit_schema_supports_external_source_and_destination_paths(tmp_path: Path) -> None:
+    registry = collection(tmp_path, EditProtocol.SEARCH_REPLACE).registry()
+    schema = registry.get("lsp_edit").definition.input_schema
+
+    assert schema is not None
+    assert_external_path_description(schema["properties"]["path"]["description"])
+    assert_external_path_description(schema["properties"]["new_path"]["description"])
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_permissions.py
+++ b/tests/agent/test_permissions.py
@@ -112,6 +112,81 @@ def test_edit_permission_rule_can_scope_to_path():
     assert rule.matches(request)
 
 
+@pytest.mark.parametrize(
+    ("tool_name", "inputs", "expected_path"),
+    [
+        (
+            "edit",
+            {"file_path": "/outside/claude.py", "old_string": "old", "new_string": "new"},
+            "/outside/claude.py",
+        ),
+        (
+            "edit",
+            {"file_path": "../outside/claude.py", "old_string": "old", "new_string": "new"},
+            "../outside/claude.py",
+        ),
+        ("edit", {"path": "/outside/hashline.py", "edits": []}, "/outside/hashline.py"),
+        ("edit", {"path": "../outside/hashline.py", "edits": []}, "../outside/hashline.py"),
+        ("write", {"path": "/outside/write.py", "content": ""}, "/outside/write.py"),
+        ("write", {"file_path": "../outside/write.py", "content": ""}, "../outside/write.py"),
+        ("multi_edit", {"path": "/outside/multi.py", "blocks": ""}, "/outside/multi.py"),
+        ("multi_edit", {"path": "../outside/multi.py", "blocks": ""}, "../outside/multi.py"),
+        (
+            "apply_patch",
+            {"input": "*** Begin Patch\n*** Add File: /outside/patch.py\n+x = 1\n*** End Patch\n"},
+            "/outside/patch.py",
+        ),
+        (
+            "apply_patch",
+            {"input": "*** Begin Patch\n*** Add File: ../outside/patch.py\n+x = 1\n*** End Patch\n"},
+            "../outside/patch.py",
+        ),
+        (
+            "lsp_edit",
+            {"operation": "format_document", "path": "/outside/lsp.py"},
+            "/outside/lsp.py",
+        ),
+        (
+            "lsp_edit",
+            {"operation": "format_document", "path": "../outside/lsp.py"},
+            "../outside/lsp.py",
+        ),
+    ],
+)
+def test_edit_permissions_retain_external_path_spelling(
+    tool_name: str,
+    inputs: dict[str, object],
+    expected_path: str,
+) -> None:
+    request = permission_request_for_tool(tool_name, inputs)
+
+    assert request is not None
+    assert request.kind == PermissionKind.EDIT
+    assert request.path == expected_path
+    rule = PermissionRule.create(
+        kind=PermissionKind.EDIT,
+        tool=tool_name,
+        match_type="path",
+        pattern=expected_path,
+    )
+    assert rule.matches(request)
+
+
+def test_edit_permission_does_not_canonicalize_path() -> None:
+    raw_path = "/outside/dir/../target.py"
+    request = permission_request_for_tool("write", {"path": raw_path, "content": ""})
+
+    assert request is not None
+    assert request.path == raw_path
+    canonicalized_rule = PermissionRule.create(
+        kind=PermissionKind.EDIT,
+        tool="write",
+        match_type="path",
+        pattern="/outside/target.py",
+    )
+    assert not canonicalized_rule.matches(request)
+
+
 def test_claude_edit_permission_uses_file_path():
     request = permission_request_for_tool(
         "edit",
@@ -131,6 +206,25 @@ def test_hashline_rename_permission_includes_source_and_destination():
     assert request is not None
     assert request.path == "src/old.py -> src/new.py"
     assert request.summary == "edit src/old.py -> src/new.py"
+
+
+@pytest.mark.parametrize(
+    ("source", "destination"),
+    [
+        ("../outside/old.py", "/outside/new.py"),
+        ("/outside/old.py", "../outside/new.py"),
+    ],
+)
+def test_hashline_rename_permission_retains_external_source_and_destination(source: str, destination: str) -> None:
+    request = permission_request_for_tool(
+        "edit",
+        {"path": source, "edits": [], "rename": destination},
+    )
+
+    assert request is not None
+    assert request.kind == PermissionKind.EDIT
+    assert request.path == f"{source} -> {destination}"
+    assert request.summary == f"edit {source} -> {destination}"
 
 
 def test_single_file_apply_patch_permission_can_scope_to_path():
@@ -195,6 +289,25 @@ def test_lsp_edit_rename_file_permission_summary_includes_destination():
     assert request is not None
     assert request.kind == PermissionKind.EDIT
     assert request.summary == "lsp_edit src/old.py -> src/new.py"
+
+
+@pytest.mark.parametrize(
+    ("source", "destination"),
+    [
+        ("../outside/old.py", "/outside/new.py"),
+        ("/outside/old.py", "../outside/new.py"),
+    ],
+)
+def test_lsp_edit_rename_file_permission_retains_external_source_and_destination(source: str, destination: str) -> None:
+    request = permission_request_for_tool(
+        "lsp_edit",
+        {"operation": "rename_file", "path": source, "new_path": destination},
+    )
+
+    assert request is not None
+    assert request.kind == PermissionKind.EDIT
+    assert request.path == f"{source} -> {destination}"
+    assert request.summary == f"lsp_edit {source} -> {destination}"
 
 
 @pytest.mark.asyncio

--- a/tests/agent/tool_backend/test_claude_edit.py
+++ b/tests/agent/tool_backend/test_claude_edit.py
@@ -26,6 +26,15 @@ def edit_tool(tmp_path: Path) -> EditTool:
     return EditTool(tmp_path, "workspace", "thread", AsyncMock(), config, caller)
 
 
+def nested_edit_tool(tmp_path: Path, template: EditTool) -> tuple[EditTool, Path]:
+    project = tmp_path / "project"
+    project.mkdir()
+    return (
+        EditTool(project, "workspace", "thread", AsyncMock(), template.config, template.caller),
+        project,
+    )
+
+
 @pytest.mark.asyncio
 async def test_claude_edit_requires_read_and_replaces_unique_match(edit_tool: EditTool, tmp_path: Path) -> None:
     target = tmp_path / "a.txt"
@@ -110,9 +119,41 @@ async def test_claude_write_preserves_existing_bom_and_line_endings(edit_tool: E
 
 
 @pytest.mark.asyncio
-async def test_claude_edit_rejects_paths_outside_workspace(edit_tool: EditTool, tmp_path: Path) -> None:
-    with pytest.raises(ValueError, match="outside the project"):
-        await edit_tool.claude_write(str(tmp_path.parent / "escape.txt"), "no\n")
+async def test_claude_external_absolute_and_parent_paths_support_full_write_and_update(
+    edit_tool: EditTool, tmp_path: Path
+) -> None:
+    tool, _project = nested_edit_tool(tmp_path, edit_tool)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    absolute = outside / "absolute.txt"
+    absolute.write_text("before\n")
+
+    tool.observe_read(str(absolute))
+    assert await tool.claude_write(str(absolute), "full write\n") == f"Wrote {absolute}"
+    tool.observe_read(str(absolute))
+    assert await tool.claude_edit(str(absolute), "full write", "updated") == f"Edited {absolute}"
+
+    relative = "../outside/relative.txt"
+    assert await tool.claude_write(relative, "created\n") == f"Wrote {relative}"
+    tool.observe_read(relative)
+    assert await tool.claude_edit(relative, "created", "changed") == f"Edited {relative}"
+
+    assert absolute.read_text() == "updated\n"
+    assert (outside / "relative.txt").read_text() == "changed\n"
+
+
+@pytest.mark.asyncio
+async def test_claude_write_preserves_dotdot_after_symlink_component(edit_tool: EditTool, tmp_path: Path) -> None:
+    tool, project = nested_edit_tool(tmp_path, edit_tool)
+    symlink_target = tmp_path / "real" / "child"
+    symlink_target.mkdir(parents=True)
+    (project / "link").symlink_to(symlink_target, target_is_directory=True)
+    raw_path = "link/../symlink-sensitive.txt"
+
+    assert await tool.claude_write(raw_path, "through symlink\n") == f"Wrote {raw_path}"
+
+    assert (tmp_path / "real" / "symlink-sensitive.txt").read_text() == "through symlink\n"
+    assert not (project / "symlink-sensitive.txt").exists()
 
 
 @pytest.mark.asyncio

--- a/tests/agent/tool_backend/test_codex_apply_patch.py
+++ b/tests/agent/tool_backend/test_codex_apply_patch.py
@@ -37,6 +37,10 @@ def edit_tool(tmp_path: Path, caller: Mock, config: AgentConfig) -> EditTool:
     return EditTool(tmp_path, "workspace", str(uuid.uuid4()), AsyncMock(), config, caller)
 
 
+def make_edit_tool(project_path: Path, caller: Mock, config: AgentConfig) -> EditTool:
+    return EditTool(project_path, "workspace", str(uuid.uuid4()), AsyncMock(), config, caller)
+
+
 def patch(*lines: str) -> str:
     return "\n".join(("*** Begin Patch", *lines, "*** End Patch")) + "\n"
 
@@ -154,25 +158,76 @@ async def test_apply_patch_validation_failure_writes_nothing(edit_tool: EditTool
 
 
 @pytest.mark.asyncio
-async def test_apply_patch_rejects_escape_and_directories(edit_tool: EditTool, tmp_path: Path) -> None:
-    with pytest.raises(ValueError, match="outside the project"):
-        await edit_tool.apply_patch(patch("*** Add File: ../escape.txt", "+no"))
+async def test_apply_patch_supports_absolute_parent_traversal_and_external_moves(
+    tmp_path: Path, caller: Mock, config: AgentConfig
+) -> None:
+    project = tmp_path / "project"
+    outside = tmp_path / "outside"
+    project.mkdir()
+    outside.mkdir()
+    (project / "entry").mkdir()
+    absolute_update = outside / "absolute-update.txt"
+    absolute_delete = outside / "absolute-delete.txt"
+    absolute_destination = outside / "absolute-moved.txt"
+    absolute_update.write_text("before\n")
+    absolute_delete.write_text("delete me\n")
+    (outside / "move-source.txt").write_text("move me\n")
+    tool = make_edit_tool(project, caller, config)
 
+    result = await tool.apply_patch(
+        patch(
+            "*** Add File: ../outside/created.txt",
+            "+created",
+            "*** Add File: entry/../../outside/repeated-parent.txt",
+            "+repeated",
+            f"*** Update File: {absolute_update}",
+            "@@",
+            "-before",
+            "+after",
+            f"*** Delete File: {absolute_delete}",
+            "*** Update File: ../outside/move-source.txt",
+            f"*** Move to: {absolute_destination}",
+            "@@",
+            "-move me",
+            "+moved",
+        )
+    )
+
+    assert (outside / "created.txt").read_text() == "created\n"
+    assert (outside / "repeated-parent.txt").read_text() == "repeated\n"
+    assert absolute_update.read_text() == "after\n"
+    assert not absolute_delete.exists()
+    assert not (outside / "move-source.txt").exists()
+    assert absolute_destination.read_text() == "moved\n"
+    assert f"M ../outside/move-source.txt -> {absolute_destination}" in result
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_rejects_directories(edit_tool: EditTool, tmp_path: Path) -> None:
     (tmp_path / "folder").mkdir()
     with pytest.raises(IsADirectoryError):
         await edit_tool.apply_patch(patch("*** Add File: folder", "+no"))
 
 
 @pytest.mark.asyncio
-async def test_apply_patch_checks_all_vibe_protected_paths(edit_tool: EditTool, tmp_path: Path, caller: Mock) -> None:
+async def test_apply_patch_checks_external_vibe_protected_path_before_mixed_mutation(
+    tmp_path: Path, caller: Mock, config: AgentConfig
+) -> None:
+    project = tmp_path / "project"
+    outside = tmp_path / "outside"
+    project.mkdir()
+    outside.mkdir()
+    edit_tool = make_edit_tool(project, caller, config)
     caller.agent_mode = AgentMode.VIBE.value
     caller.protected_files = {"package.json"}
 
-    result = await edit_tool.apply_patch(patch("*** Add File: safe.txt", "+safe", "*** Add File: package.json", "+{}"))
+    result = await edit_tool.apply_patch(
+        patch("*** Add File: safe.txt", "+safe", "*** Add File: ../outside/package.json", "+{}")
+    )
 
     assert "not allowed" in result
-    assert not (tmp_path / "safe.txt").exists()
-    assert not (tmp_path / "package.json").exists()
+    assert not (project / "safe.txt").exists()
+    assert not (outside / "package.json").exists()
 
 
 @pytest.mark.asyncio

--- a/tests/agent/tool_backend/test_edit_tool.py
+++ b/tests/agent/tool_backend/test_edit_tool.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -5,6 +6,7 @@ import uuid
 
 from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
 from kolega_code.agent.tool_backend.edit_tool import EditTool
+from kolega_code.sandbox.filesystem import SandboxFileSystem
 from kolega_code.services.file_system import LocalFileSystem
 
 
@@ -250,6 +252,47 @@ class TestEditTool:
         assert "overlaps" in str(exc_info.value)
         assert file_path.read_text() == "alpha beta gamma\n"
 
+    async def test_legacy_edit_multi_edit_and_write_support_external_paths(
+        self,
+        project_path: Path,
+        mock_connection_manager: AsyncMock,
+        agent_config: AgentConfig,
+        mock_base_agent: Mock,
+    ) -> None:
+        project = project_path / "project"
+        outside = project_path / "outside"
+        project.mkdir()
+        outside.mkdir()
+        tool = EditTool(
+            project,
+            "test_workspace",
+            str(uuid.uuid4()),
+            mock_connection_manager,
+            agent_config,
+            mock_base_agent,
+        )
+        absolute_edit = outside / "absolute-edit.txt"
+        relative_multi_edit = outside / "relative-multi-edit.txt"
+        absolute_edit.write_text("before\n")
+        relative_multi_edit.write_text("alpha\nbeta\n")
+
+        assert await tool.edit(str(absolute_edit), block("before", "after")) == f"Edited {absolute_edit}"
+        assert (
+            await tool.multi_edit(
+                "../outside/relative-multi-edit.txt",
+                block("alpha", "ALPHA") + "\n" + block("beta", "BETA"),
+            )
+            == "Edited ../outside/relative-multi-edit.txt with 2 replacements"
+        )
+        assert await tool.write("../outside/relative-write.txt", "relative\n") == "Wrote ../outside/relative-write.txt"
+        absolute_write = outside / "absolute-write.txt"
+        assert await tool.write(str(absolute_write), "absolute\n") == f"Wrote {absolute_write}"
+
+        assert absolute_edit.read_text() == "after\n"
+        assert relative_multi_edit.read_text() == "ALPHA\nBETA\n"
+        assert (outside / "relative-write.txt").read_text() == "relative\n"
+        assert absolute_write.read_text() == "absolute\n"
+
     # --- line-ending handling: parse tolerance (the reported failure) ---
 
     async def test_edit_parses_block_with_crlf_markers(self, edit_tool, project_path):
@@ -448,6 +491,54 @@ class TestWriteTool:
 
         assert "Permission denied" in str(exc_info.value)
         assert not (project_path / "test.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_external_paths_use_sandbox_root_semantics(
+    project_path: Path,
+    mock_connection_manager: AsyncMock,
+    agent_config: AgentConfig,
+    mock_base_agent: Mock,
+) -> None:
+    sandbox = Mock()
+
+    def run(command: str) -> Mock:
+        result = Mock()
+        result.exit_code = 1 if command.startswith("test -") else 0
+        result.stdout = ""
+        result.stderr = ""
+        return result
+
+    sandbox.commands.run.side_effect = run
+    sandbox.files.write = Mock()
+    filesystem = SandboxFileSystem(sandbox, "/sandbox/project")
+    tool = EditTool(
+        project_path,
+        "test_workspace",
+        str(uuid.uuid4()),
+        mock_connection_manager,
+        agent_config,
+        mock_base_agent,
+        filesystem,
+    )
+    patch_text = (
+        "*** Begin Patch\n"
+        "*** Add File: /external/absolute.txt\n"
+        "+absolute\n"
+        "*** Add File: ../../../outside/repeated-parent.txt\n"
+        "+relative\n"
+        "*** End Patch\n"
+    )
+
+    result = await tool.apply_patch(patch_text)
+
+    assert "A /external/absolute.txt" in result
+    assert "A ../../../outside/repeated-parent.txt" in result
+    sandbox.files.write.assert_any_call("/external/absolute.txt", "absolute\n")
+    sandbox.files.write.assert_any_call(
+        "/sandbox/project/../../../outside/repeated-parent.txt",
+        "relative\n",
+    )
 
 
 def _make_mock_lsp_manager(*, auto_diagnostics_on_edit: bool, diagnostics=None) -> Mock:

--- a/tests/agent/tool_backend/test_hashline_v2.py
+++ b/tests/agent/tool_backend/test_hashline_v2.py
@@ -34,6 +34,12 @@ def edit_tool(tmp_path: Path) -> EditTool:
     return EditTool(tmp_path, "workspace", str(uuid.uuid4()), AsyncMock(), config, caller)
 
 
+def nested_edit_tool(tmp_path: Path, template: EditTool) -> EditTool:
+    project = tmp_path / "project"
+    project.mkdir()
+    return EditTool(project, "workspace", str(uuid.uuid4()), AsyncMock(), template.config, template.caller)
+
+
 @pytest.mark.parametrize(
     ("content", "expected"),
     [
@@ -176,7 +182,7 @@ async def test_backend_creates_moves_and_deletes(edit_tool: EditTool, tmp_path: 
 
 
 @pytest.mark.asyncio
-async def test_backend_stale_failure_and_bad_path_write_nothing(edit_tool: EditTool, tmp_path: Path) -> None:
+async def test_backend_stale_failure_writes_nothing(edit_tool: EditTool, tmp_path: Path) -> None:
     target = tmp_path / "file.txt"
     target.write_text("one\ntwo\n")
 
@@ -184,12 +190,33 @@ async def test_backend_stale_failure_and_bad_path_write_nothing(edit_tool: EditT
         await edit_tool.hashline_edit("file.txt", [{"op": "set", "tag": "2#ZZ", "content": ["TWO"]}])
     assert target.read_text() == "one\ntwo\n"
 
-    with pytest.raises(ValueError, match="outside the project"):
-        await edit_tool.hashline_edit("../escape.txt", [{"op": "append", "content": ["bad"]}])
-    assert not (tmp_path.parent / "escape.txt").exists()
 
-    with pytest.raises(ValueError, match="outside the project"):
-        await edit_tool.hashline_write("../escape.txt", "bad")
+@pytest.mark.asyncio
+async def test_backend_external_create_write_update_rename_and_delete(edit_tool: EditTool, tmp_path: Path) -> None:
+    tool = nested_edit_tool(tmp_path, edit_tool)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    absolute = outside / "absolute.txt"
+
+    assert await tool.hashline_write(str(absolute), "one\ntwo") == f"Wrote {absolute}"
+    moved = await tool.hashline_edit(
+        str(absolute),
+        [{"op": "set", "tag": format_line_tag(2, "two"), "content": ["TWO"]}],
+        rename="../outside/moved.txt",
+    )
+    assert moved == f"Updated and moved {absolute} to ../outside/moved.txt"
+    assert not absolute.exists()
+    assert (outside / "moved.txt").read_text() == "one\nTWO"
+
+    created = await tool.hashline_edit(
+        "../outside/created.txt",
+        [{"op": "append", "content": ["created"]}],
+    )
+    assert created == "Created ../outside/created.txt"
+    assert (outside / "created.txt").read_text() == "created"
+
+    assert await tool.hashline_edit("../outside/moved.txt", [], delete=True) == "Deleted ../outside/moved.txt"
+    assert not (outside / "moved.txt").exists()
 
 
 @pytest.mark.asyncio

--- a/tests/agent/tool_backend/test_lsp_tool.py
+++ b/tests/agent/tool_backend/test_lsp_tool.py
@@ -28,7 +28,9 @@ def mock_connection_manager():
 
 @pytest.fixture
 def project_path(tmp_path):
-    return tmp_path
+    project = tmp_path / "project"
+    project.mkdir()
+    return project
 
 
 @pytest.fixture
@@ -459,6 +461,11 @@ class TestLspNewReadOnlyOperations:
 
 @pytest.mark.asyncio
 class TestLspEditTool:
+    async def test_file_uri_preserves_parent_segments(self, lsp_edit_tool, project_path):
+        uri = lsp_edit_tool._file_uri("link/../target.py")
+
+        assert f"{project_path.as_uri()}/link/../target.py" == uri
+
     async def test_rename_preview_does_not_write_file(self, lsp_edit_tool, mock_lsp_manager, project_path):
         path = project_path / "foo.py"
         path.write_text("old = 1\nprint(old)\n", encoding="utf-8")
@@ -540,6 +547,79 @@ class TestLspEditTool:
 
         assert result.startswith("Applied LSP edit `apply_code_action`.")
         assert path.read_text(encoding="utf-8") == "value = defined_var\n"
+
+    async def test_external_workspace_edit_applies_without_snapshot_service(
+        self, lsp_edit_tool, mock_lsp_manager, project_path
+    ):
+        outside_dir = project_path.parent / "outside"
+        outside_dir.mkdir()
+        outside = outside_dir / "external.py"
+        outside.write_text("old = 1\n", encoding="utf-8")
+        mock_lsp_manager._resolve_position.return_value = (0, 0)
+        mock_lsp_manager.get_rename.return_value = {
+            "changes": {
+                outside.as_uri(): [
+                    {
+                        "range": {
+                            "start": {"line": 0, "character": 0},
+                            "end": {"line": 0, "character": 3},
+                        },
+                        "newText": "new",
+                    }
+                ]
+            }
+        }
+
+        result = await lsp_edit_tool.lsp_edit(
+            operation="rename",
+            path=str(outside),
+            line=1,
+            symbol="old",
+            new_name="new",
+            apply=True,
+        )
+
+        assert result.startswith("Applied LSP edit `rename`.")
+        assert outside.read_text(encoding="utf-8") == "new = 1\n"
+
+    async def test_mixed_internal_external_workspace_edit_applies_every_change(
+        self, lsp_edit_tool, mock_lsp_manager, project_path
+    ):
+        internal = project_path / "internal.py"
+        outside_dir = project_path.parent / "outside"
+        outside_dir.mkdir()
+        external = outside_dir / "external.py"
+        internal.write_text("old = 1\n", encoding="utf-8")
+        external.write_text("old = 2\n", encoding="utf-8")
+        replacement = [
+            {
+                "range": {
+                    "start": {"line": 0, "character": 0},
+                    "end": {"line": 0, "character": 3},
+                },
+                "newText": "new",
+            }
+        ]
+        mock_lsp_manager._resolve_position.return_value = (0, 0)
+        mock_lsp_manager.get_rename.return_value = {
+            "changes": {
+                internal.as_uri(): replacement,
+                external.as_uri(): replacement,
+            }
+        }
+
+        result = await lsp_edit_tool.lsp_edit(
+            operation="rename",
+            path="internal.py",
+            line=1,
+            symbol="old",
+            new_name="new",
+            apply=True,
+        )
+
+        assert result.startswith("Applied LSP edit `rename`.")
+        assert internal.read_text(encoding="utf-8") == "new = 1\n"
+        assert external.read_text(encoding="utf-8") == "new = 2\n"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/tool_backend/test_snapshot_tool.py
+++ b/tests/agent/tool_backend/test_snapshot_tool.py
@@ -36,6 +36,17 @@ def _snapshot_service(project_path, filesystem) -> SnapshotService:
     )
 
 
+def _manager_with_rename_edit(workspace_edit) -> Mock:
+    manager = Mock()
+    manager.enabled = True
+    manager._initialized = True
+    manager.server_for_path.return_value = "pyright"
+    manager._resolve_position.return_value = (0, 0)
+    manager.get_rename = AsyncMock(return_value=workspace_edit)
+    manager._config = Mock(auto_diagnostics_on_edit=False)
+    return manager
+
+
 @pytest.mark.asyncio
 async def test_edit_snapshot_can_be_restored(tmp_path):
     project = tmp_path / "project"
@@ -83,8 +94,10 @@ async def test_edit_snapshot_can_be_restored(tmp_path):
 @pytest.mark.asyncio
 async def test_out_of_project_write_skips_snapshot_and_succeeds(tmp_path):
     project = tmp_path / "project"
+    outside_dir = tmp_path / "outside"
     project.mkdir()
-    outside = tmp_path / "outside.txt"
+    outside_dir.mkdir()
+    outside = outside_dir / "outside.txt"
     filesystem = LocalFileSystem(project)
     service = _snapshot_service(project, filesystem)
     tool = EditTool(
@@ -108,8 +121,10 @@ async def test_out_of_project_write_skips_snapshot_and_succeeds(tmp_path):
 @pytest.mark.asyncio
 async def test_out_of_project_edit_skips_snapshot_and_succeeds(tmp_path):
     project = tmp_path / "project"
+    outside_dir = tmp_path / "outside"
     project.mkdir()
-    outside = tmp_path / "outside.txt"
+    outside_dir.mkdir()
+    outside = outside_dir / "outside.txt"
     outside.write_text("alpha\n", encoding="utf-8")
     filesystem = LocalFileSystem(project)
     service = _snapshot_service(project, filesystem)
@@ -129,6 +144,226 @@ async def test_out_of_project_edit_skips_snapshot_and_succeeds(tmp_path):
     assert result == f"Edited {outside}"
     assert outside.read_text(encoding="utf-8") == "beta\n"
     assert service.list_snapshots() == []
+
+
+@pytest.mark.asyncio
+async def test_external_lsp_apply_succeeds_without_snapshot(tmp_path):
+    project = tmp_path / "project"
+    outside_dir = tmp_path / "outside"
+    project.mkdir()
+    outside_dir.mkdir()
+    outside = outside_dir / "external.py"
+    outside.write_text("old = 1\n", encoding="utf-8")
+    filesystem = LocalFileSystem(project)
+    service = _snapshot_service(project, filesystem)
+    manager = _manager_with_rename_edit(
+        {
+            "changes": {
+                outside.as_uri(): [
+                    {
+                        "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 3}},
+                        "newText": "new",
+                    }
+                ]
+            }
+        }
+    )
+    tool = LspEditTool(
+        project,
+        "workspace",
+        "thread",
+        AsyncMock(),
+        Mock(),
+        _caller(),
+        filesystem,
+        lsp_manager=manager,
+        snapshot_service=service,
+    )
+
+    result = await tool.lsp_edit(
+        operation="rename",
+        path=str(outside),
+        line=1,
+        symbol="old",
+        new_name="new",
+        apply=True,
+    )
+
+    assert result.startswith("Applied LSP edit `rename`.")
+    assert outside.read_text(encoding="utf-8") == "new = 1\n"
+    assert service.list_snapshots() == []
+
+
+@pytest.mark.asyncio
+async def test_mixed_lsp_apply_changes_every_file_without_snapshot(tmp_path):
+    project = tmp_path / "project"
+    outside_dir = tmp_path / "outside"
+    project.mkdir()
+    outside_dir.mkdir()
+    internal = project / "internal.py"
+    external = outside_dir / "external.py"
+    internal.write_text("old = 1\n", encoding="utf-8")
+    external.write_text("old = 2\n", encoding="utf-8")
+    replacement = [
+        {
+            "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 3}},
+            "newText": "new",
+        }
+    ]
+    filesystem = LocalFileSystem(project)
+    service = _snapshot_service(project, filesystem)
+    manager = _manager_with_rename_edit(
+        {
+            "changes": {
+                internal.as_uri(): replacement,
+                external.as_uri(): replacement,
+            }
+        }
+    )
+    tool = LspEditTool(
+        project,
+        "workspace",
+        "thread",
+        AsyncMock(),
+        Mock(),
+        _caller(),
+        filesystem,
+        lsp_manager=manager,
+        snapshot_service=service,
+    )
+
+    result = await tool.lsp_edit(
+        operation="rename",
+        path="internal.py",
+        line=1,
+        symbol="old",
+        new_name="new",
+        apply=True,
+    )
+
+    assert result.startswith("Applied LSP edit `rename`.")
+    assert internal.read_text(encoding="utf-8") == "new = 1\n"
+    assert external.read_text(encoding="utf-8") == "new = 2\n"
+    assert service.list_snapshots() == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mixed", [False, True], ids=["external", "mixed"])
+async def test_external_lsp_preview_writes_nothing_and_creates_no_pending_action(tmp_path, mixed):
+    project = tmp_path / "project"
+    outside_dir = tmp_path / "outside"
+    project.mkdir()
+    outside_dir.mkdir()
+    internal = project / "internal.py"
+    external = outside_dir / "external.py"
+    internal.write_text("old = 1\n", encoding="utf-8")
+    external.write_text("old = 2\n", encoding="utf-8")
+    replacement = [
+        {
+            "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 3}},
+            "newText": "new",
+        }
+    ]
+    changes = {external.as_uri(): replacement}
+    if mixed:
+        changes[internal.as_uri()] = replacement
+    filesystem = LocalFileSystem(project)
+    service = _snapshot_service(project, filesystem)
+    manager = _manager_with_rename_edit({"changes": changes})
+    tool = LspEditTool(
+        project,
+        "workspace",
+        "thread",
+        AsyncMock(),
+        Mock(),
+        _caller(),
+        filesystem,
+        lsp_manager=manager,
+        snapshot_service=service,
+    )
+
+    result = await tool.lsp_edit(
+        operation="rename",
+        path="internal.py" if mixed else str(external),
+        line=1,
+        symbol="old",
+        new_name="new",
+        apply=False,
+    )
+
+    assert result.startswith("Preview LSP edit `rename`.")
+    assert "No pending action was created; rerun with `apply=True`" in result
+    assert internal.read_text(encoding="utf-8") == "old = 1\n"
+    assert external.read_text(encoding="utf-8") == "old = 2\n"
+    assert service.list_pending_actions() == []
+    assert service.list_snapshots() == []
+
+
+@pytest.mark.asyncio
+async def test_mixed_apply_patch_bypasses_snapshot_and_external_is_never_restored(tmp_path):
+    project = tmp_path / "project"
+    outside_dir = tmp_path / "outside"
+    project.mkdir()
+    outside_dir.mkdir()
+    internal = project / "internal.txt"
+    external = outside_dir / "external.txt"
+    internal.write_text("one\n", encoding="utf-8")
+    external.write_text("alpha\n", encoding="utf-8")
+    filesystem = LocalFileSystem(project)
+    service = _snapshot_service(project, filesystem)
+    caller = _caller()
+    connection = AsyncMock()
+    edit_tool = EditTool(
+        project,
+        "workspace",
+        "thread",
+        connection,
+        Mock(),
+        caller,
+        filesystem,
+        snapshot_service=service,
+    )
+    snapshot_tool = SnapshotTool(
+        project,
+        "workspace",
+        "thread",
+        connection,
+        Mock(),
+        caller,
+        filesystem,
+        snapshot_service=service,
+    )
+    patch = (
+        "*** Begin Patch\n"
+        "*** Update File: internal.txt\n"
+        "@@\n"
+        "-one\n"
+        "+two\n"
+        f"*** Update File: {external}\n"
+        "@@\n"
+        "-alpha\n"
+        "+beta\n"
+        "*** End Patch\n"
+    )
+
+    await edit_tool.apply_patch(patch)
+
+    assert internal.read_text(encoding="utf-8") == "two\n"
+    assert external.read_text(encoding="utf-8") == "beta\n"
+    assert service.list_snapshots() == []
+
+    await edit_tool.edit("internal.txt", _block("two", "three"))
+    record = service.latest_snapshot()
+    assert record is not None
+    external_text = str(external)
+    assert external_text not in record.touched_paths
+    assert external_text not in record.before
+    assert external_text not in record.after
+
+    await snapshot_tool.snapshot(action="restore", snapshot_id=record.snapshot_id)
+
+    assert internal.read_text(encoding="utf-8") == "two\n"
+    assert external.read_text(encoding="utf-8") == "beta\n"
 
 
 @pytest.mark.asyncio
@@ -292,7 +527,7 @@ async def test_resolve_discards_pending_workspace_edit(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_lsp_preview_creates_pending_action_without_writing(tmp_path):
+async def test_internal_lsp_preview_creates_and_resolves_pending_action(tmp_path):
     project = tmp_path / "project"
     project.mkdir()
     path = project / "a.py"
@@ -343,3 +578,20 @@ async def test_lsp_preview_creates_pending_action_without_writing(tmp_path):
     pending = service.list_pending_actions()
     assert len(pending) == 1
     assert pending[0].operation == "rename"
+
+    snapshot_tool = SnapshotTool(
+        project,
+        "workspace",
+        "thread",
+        AsyncMock(),
+        Mock(),
+        _caller(),
+        filesystem,
+        snapshot_service=service,
+    )
+    resolve_result = await snapshot_tool.resolve(pending[0].action_id, decision="apply")
+
+    assert f"Applied pending action `{pending[0].action_id}`" in resolve_result
+    assert path.read_text(encoding="utf-8") == "new = 1\n"
+    assert service.load_pending_action(pending[0].action_id).status == "applied"
+    assert len(service.list_snapshots()) == 1

--- a/tests/services/lsp/test_edits.py
+++ b/tests/services/lsp/test_edits.py
@@ -114,10 +114,12 @@ def test_preserves_crlf_line_endings(tmp_path):
     assert path.read_bytes() == b"name = new\r\n"
 
 
-def test_rejects_outside_project_uri(tmp_path):
-    path = tmp_path / "main.py"
-    path.write_text("x\n", encoding="utf-8")
-    outside = tmp_path.parent / "outside.py"
+def test_applies_text_edit_outside_project(tmp_path):
+    project = tmp_path / "project"
+    outside_dir = tmp_path / "outside"
+    project.mkdir()
+    outside_dir.mkdir()
+    outside = outside_dir / "outside.py"
     outside.write_text("x\n", encoding="utf-8")
     edit = {
         "changes": {
@@ -133,10 +135,68 @@ def test_rejects_outside_project_uri(tmp_path):
         }
     }
 
-    with pytest.raises(WorkspaceEditError, match="outside the project"):
-        _applier(tmp_path).apply(edit)
+    result = _applier(project).apply(edit)
 
-    assert outside.read_text(encoding="utf-8") == "x\n"
+    assert result.applied is True
+    assert result.touched_paths == (str(outside),)
+    assert outside.read_text(encoding="utf-8") == "y\n"
+
+
+def test_applies_external_create_rename_and_delete_resource_operations(tmp_path):
+    project = tmp_path / "project"
+    outside = tmp_path / "outside"
+    project.mkdir()
+    outside.mkdir()
+    source = outside / "rename-source.py"
+    renamed = outside / "renamed" / "rename-destination.py"
+    created = outside / "created.py"
+    deleted = outside / "deleted.py"
+    source.write_text("source\n", encoding="utf-8")
+    deleted.write_text("delete me\n", encoding="utf-8")
+    edit = {
+        "documentChanges": [
+            {"kind": "create", "uri": created.as_uri()},
+            {"kind": "rename", "oldUri": source.as_uri(), "newUri": renamed.as_uri()},
+            {"kind": "delete", "uri": deleted.as_uri()},
+        ]
+    }
+
+    result = _applier(project).apply(edit)
+
+    assert result.applied is True
+    assert created.read_text(encoding="utf-8") == ""
+    assert not source.exists()
+    assert renamed.read_text(encoding="utf-8") == "source\n"
+    assert not deleted.exists()
+    assert set(result.touched_paths) == {str(created), str(source), str(renamed), str(deleted)}
+
+
+@pytest.mark.parametrize(
+    ("uri", "message"),
+    [
+        ("https://example.com/outside.py", "Unsupported URI scheme"),
+        ("file://remote.example/outside.py", "Unsupported file URI host"),
+    ],
+)
+def test_rejects_non_file_and_non_local_file_uris(tmp_path, uri, message):
+    project = tmp_path / "project"
+    project.mkdir()
+    edit = {
+        "changes": {
+            uri: [
+                {
+                    "range": {
+                        "start": {"line": 0, "character": 0},
+                        "end": {"line": 0, "character": 0},
+                    },
+                    "newText": "x",
+                }
+            ]
+        }
+    }
+
+    with pytest.raises(WorkspaceEditError, match=message):
+        _applier(project).apply(edit)
 
 
 def test_document_changes_rename_file(tmp_path):

--- a/tests/services/lsp/test_lsp_edit_tool_integration.py
+++ b/tests/services/lsp/test_lsp_edit_tool_integration.py
@@ -62,6 +62,26 @@ async def test_lsp_edit_rename_file_applies_will_rename_and_resource_rename(fake
 
 
 @pytest.mark.asyncio
+async def test_lsp_edit_rename_file_can_move_file_outside_project(fake_lsp_manager):
+    manager = fake_lsp_manager
+    old_path = manager._project_path / "old_external.py"
+    outside_dir = manager._project_path.parent / "outside"
+    new_path = outside_dir / "new_external.py"
+    outside_dir.mkdir()
+    old_path.write_text("value = 1\n", encoding="utf-8")
+
+    result = await _make_tool(manager).lsp_edit(
+        operation="rename_file",
+        path="old_external.py",
+        new_path=str(new_path),
+    )
+
+    assert "Applied LSP edit `rename_file`." in result
+    assert not old_path.exists()
+    assert new_path.read_text(encoding="utf-8") == "value = 1\n"
+
+
+@pytest.mark.asyncio
 async def test_lsp_edit_apply_code_action_allows_scoped_workspace_apply_edit(fake_lsp_manager):
     manager = fake_lsp_manager
     path = manager._project_path / "imports_tool.py"


### PR DESCRIPTION
## Summary

- allow Codex apply-patch, Claude-style, Hashline v2, and LSP WorkspaceEdits to modify absolute and `../` paths without edit-layer project containment
- preserve raw path and symlink semantics while keeping existing permission and Vibe-policy gates
- bypass snapshots atomically for external or mixed mutations, and prevent unresolvable pending LSP previews
- document external-path behavior and add regression coverage across local and sandbox filesystems

## Validation

- `./run_tests.sh` — 2532 passed, 103 deselected
- focused edit/LSP/snapshot/permission suites — 190 passed
- `uv run ruff check kolega_code tests`
- `uv run pyright`
- `cd docs && npm run build`
- pre-commit hooks on commit
