### PR TITLE
feat(agent): bound Gigacode recursive delegation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 - Bundled the `docx`, `pdf`, `pptx`, `review`, `skill-authoring`, and `xlsx`
   workflows from `kolega-skills` v0.1.0 so they are available out of the box.
 
+### Fixed
+
+- Bounded Gigacode delegation depth so direct workflow workers are leaves by
+  default, with an explicit one-hop nested-agent opt-in.
+
 ## 0.21.1 - 2026-07-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,16 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 ### Fixed
 
 - Bounded Gigacode delegation depth so direct workflow workers are leaves by
-  default, with an explicit one-hop nested-agent opt-in.
+  default, with an explicit one-hop nested-agent opt-in. Built-in nested workers
+  share the workflow lifetime-agent count and output-token budget; concurrency
+  caps active execution chains and serializes nested dispatch within each direct
+  worker. Completed spend blocks later launches while in-flight calls may produce
+  bounded overshoot. Depth-2 recursion supports only built-in dispatch tools until
+  opaque host `ToolExtension` callbacks have a workflow-aware accounting and depth
+  protocol. Run totals and failed-agent artifacts now retain finalized nested or
+  pre-failure output usage. Ordinary non-workflow extension and delegation behavior
+  is unchanged, and no supported API, metadata schema, cache-key field, or artifact
+  field was removed or renamed.
 
 ## 0.21.1 - 2026-07-20
 

--- a/docs/src/content/docs/gigacode.mdx
+++ b/docs/src/content/docs/gigacode.mdx
@@ -127,6 +127,11 @@ type already supports. It never grants unsupported dispatch tools, and workers
 can never call `run_workflow`; the setting permits nested agent dispatch, not a
 nested workflow.
 
+Depth-2 recursion supports built-in agent-dispatch tools only. Opaque
+host-provided `ToolExtension` dispatch callbacks are unavailable inside workflows
+until a workflow-aware accounting and depth protocol exists. This restriction
+does not change ordinary non-workflow extension or agent-delegation behavior.
+
 <Aside type="note">
 Workflows are deterministic and **resumable**. Each run is saved under Kolega
 Code's state directory (`workflows/<run-id>/`) with its script, full result files,
@@ -162,8 +167,17 @@ A few more guarantees:
   delegate further or run another workflow.
 - Workflow sub-agents don't touch your [task list](../tui/modes/) — only the main
   agent manages it, so agents running in parallel can't clobber it.
-- Concurrency is capped, and there's a hard ceiling on the total number of agents a
-  single workflow can spawn, as a runaway-loop backstop.
+- Concurrency caps active workflow execution chains rather than retained parent
+  and child objects. Nested dispatch within one direct worker is serialized, so
+  it cannot multiply that worker's active chain.
+- There's a hard ceiling on the lifetime number of agents a single workflow can
+  spawn, as a runaway-loop backstop. Built-in nested workers count against that
+  same workflow-wide total and its output-token budget.
+- Output-token budget admission uses completed spend. Once completed spend reaches
+  the limit, later direct or nested launches are blocked; calls already in flight
+  can still finish, producing bounded overshoot.
+- Run totals and failed-agent artifacts retain finalized output usage from direct
+  and built-in nested workers, even when a later step fails.
 
 ## See also
 

--- a/docs/src/content/docs/gigacode.mdx
+++ b/docs/src/content/docs/gigacode.mdx
@@ -109,6 +109,24 @@ unknowns through research and option comparison; a debugging task might cluster
 failures, investigate root causes, test targeted fixes, and run a regression
 review. All of those shapes are built from the same primitives above.
 
+### Delegation depth
+
+Workflow metadata has an optional `max_agent_depth` setting. It defaults to `1`,
+which makes agents launched directly by workflow `agent()` calls leaf workers:
+they cannot dispatch child agents. The only other accepted value, and the hard
+maximum, is `2`, which allows one worker-to-child hop; those nested children are
+always leaves.
+
+Strongly prefer the default of `1` and represent fan-out visibly in the workflow
+with `agent()`, `parallel()`, and `pipeline()`. Depth `2` is an exceptional opt-in
+for a worker that genuinely needs to consult a specialist. Nested calls are less
+visible to workflow-level orchestration and can multiply token use.
+
+Setting depth `2` only preserves dispatch tools that the direct worker's agent
+type already supports. It never grants unsupported dispatch tools, and workers
+can never call `run_workflow`; the setting permits nested agent dispatch, not a
+nested workflow.
+
 <Aside type="note">
 Workflows are deterministic and **resumable**. Each run is saved under Kolega
 Code's state directory (`workflows/<run-id>/`) with its script, full result files,
@@ -139,6 +157,9 @@ running a workflow for risky changes.
 
 A few more guarantees:
 
+- By default, direct workflow workers are leaves. The optional delegation-depth
+  policy is capped at one nested worker-to-child hop, and nested children cannot
+  delegate further or run another workflow.
 - Workflow sub-agents don't touch your [task list](../tui/modes/) — only the main
   agent manages it, so agents running in parallel can't clobber it.
 - Concurrency is capped, and there's a hard ceiling on the total number of agents a

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -40,6 +40,7 @@ from kolega_code.llm.exceptions import (
     llm_error_message,
     map_to_llm_error,
 )
+from kolega_code.llm.instrumented_client import get_output_tokens
 from kolega_code.llm.models import ImageBlock, Message, MessageHistory, TextBlock, ToolCall, ToolResult
 from kolega_code.llm.providers.models import TokenCount
 from kolega_code.llm.specs import get_model_specs, supports_vision as model_supports_vision
@@ -62,6 +63,7 @@ if TYPE_CHECKING:
     # Type hints only — langfuse is a heavy optional dependency kept off the
     # startup import path. Agents receive a Langfuse *instance* via the context.
     from langfuse import Langfuse
+    from .orchestration.accounting import AgentReservation, WorkflowRunAccounting
 
 
 logger = logging.getLogger(__name__)
@@ -363,6 +365,11 @@ class BaseAgent(LogMixin):
         self.parent_tool_call_id = None  # Parent tool call ID when running as sub-agent
         self.conversation_id = None  # Sub-agent conversation ID
         self.sub_agent_context = None  # Dispatch metadata (agent_id, task) set by AgentTool
+        # Private workflow lifecycle state. These references never enter
+        # sub_agent_context or any serialized agent metadata.
+        self._workflow_accounting: Optional["WorkflowRunAccounting"] = None
+        self._accounting_reservation: Optional["AgentReservation"] = None
+        self.total_tokens_used: int = 0
         # Set by a blocking PostToolUse hook to end the turn after the current tool batch.
         self._hook_end_turn = False
         self.queued_input_provider: Optional[Callable[[], Awaitable[List[QueuedUserInput]]]] = None
@@ -1761,6 +1768,12 @@ class BaseAgent(LogMixin):
                 assistant_message = await stream.get_final_message()
                 self._normalize_freeform_tool_calls(assistant_message)
                 assistant_message.usage_metadata["edit_protocol"] = self.edit_protocol.value
+                self.total_tokens_used += get_output_tokens(
+                    assistant_message.usage_metadata,
+                    self.primary_model_config.provider.value,
+                )
+                if self._accounting_reservation is not None:
+                    self._accounting_reservation.report_total(self.total_tokens_used)
                 stop_reason = assistant_message.stop_reason
                 await self.emitter.llm_request(
                     "end",

--- a/kolega_code/agent/orchestration/__init__.py
+++ b/kolega_code/agent/orchestration/__init__.py
@@ -18,7 +18,7 @@ from .errors import (
     WorkflowError,
     WorkflowScriptError,
 )
-from .executor import extract_meta, run_script, safe_builtins
+from .executor import DEFAULT_MAX_AGENT_DEPTH, MAX_AGENT_DEPTH, extract_meta, run_script, safe_builtins
 from .journal import RunJournal, saved_workflows_dir, workflows_root
 from .runtime import DEFAULT_AGENT_CAP, MAX_FANOUT, WorkflowRuntime, default_concurrency
 from .types import AgentRunResult, AgentRunSpec, DispatchFn, EmitFn
@@ -32,6 +32,8 @@ __all__ = [
     "extract_meta",
     "run_script",
     "safe_builtins",
+    "DEFAULT_MAX_AGENT_DEPTH",
+    "MAX_AGENT_DEPTH",
     "RunJournal",
     "workflows_root",
     "saved_workflows_dir",

--- a/kolega_code/agent/orchestration/accounting.py
+++ b/kolega_code/agent/orchestration/accounting.py
@@ -1,0 +1,89 @@
+"""Internal lifetime-agent and token accounting for one workflow run."""
+
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+from typing import Optional
+
+from .budget import Budget
+from .errors import WorkflowAgentCapExceeded
+
+
+class AgentReservation:
+    """Lifetime launch ticket that settles one agent's cumulative token usage."""
+
+    def __init__(self, budget: Budget) -> None:
+        self._budget = budget
+        self._reported_tokens = 0
+
+    @property
+    def reported_tokens(self) -> int:
+        """Largest valid cumulative token total reported for this agent."""
+        return self._reported_tokens
+
+    def report_total(self, tokens: Optional[int]) -> None:
+        """Add only newly reported cumulative tokens to the shared budget."""
+        if type(tokens) is not int:
+            return
+        total = tokens
+
+        delta = total - self._reported_tokens
+        if delta <= 0:
+            return
+
+        self._budget.add(delta)
+        self._reported_tokens = total
+
+
+class WorkflowRunAccounting:
+    """Shared admission and usage state for a single workflow invocation."""
+
+    def __init__(self, budget: Budget, agent_cap: int) -> None:
+        self._budget = budget
+        self._agent_cap = agent_cap
+        self._agent_count = 0
+
+    @property
+    def budget(self) -> Budget:
+        """The exact budget exposed to and shared by the workflow."""
+        return self._budget
+
+    @property
+    def agent_cap(self) -> int:
+        """Maximum number of lifetime agent attempts admitted for the run."""
+        return self._agent_cap
+
+    @property
+    def agent_count(self) -> int:
+        """Number of agent launches accepted for the lifetime of the run."""
+        return self._agent_count
+
+    def reserve_agent(self) -> AgentReservation:
+        """Admit one lifetime agent attempt and return its usage ticket."""
+        self._budget.check()
+        if self._agent_count >= self._agent_cap:
+            raise WorkflowAgentCapExceeded(
+                f"workflow exceeded the lifetime agent cap ({self._agent_cap}); likely a runaway loop"
+            )
+
+        self._agent_count += 1
+        return AgentReservation(self._budget)
+
+
+_current_agent_reservation: ContextVar[Optional[AgentReservation]] = ContextVar(
+    "current_workflow_agent_reservation",
+    default=None,
+)
+
+
+def set_current_agent_reservation(reservation: AgentReservation) -> Token[Optional[AgentReservation]]:
+    """Expose a live reservation to the internal dispatch adapter without serializing it."""
+    return _current_agent_reservation.set(reservation)
+
+
+def reset_current_agent_reservation(token: Token[Optional[AgentReservation]]) -> None:
+    _current_agent_reservation.reset(token)
+
+
+def get_current_agent_reservation() -> Optional[AgentReservation]:
+    return _current_agent_reservation.get()

--- a/kolega_code/agent/orchestration/context.py
+++ b/kolega_code/agent/orchestration/context.py
@@ -1,0 +1,25 @@
+"""Strict validation for private workflow delegation context."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from .executor import MAX_AGENT_DEPTH
+
+
+def validated_workflow_depth(context: object) -> Optional[tuple[int, int]]:
+    """Return a strict workflow ``(depth, maximum)`` pair, or ``None``."""
+    if not isinstance(context, dict) or not isinstance(context.get("workflow_run_id"), str):
+        return None
+    depth = context.get("depth")
+    maximum = context.get("max_agent_depth")
+    if type(depth) is not int or type(maximum) is not int:
+        return None
+    if not 1 <= depth <= maximum <= MAX_AGENT_DEPTH:
+        return None
+    return depth, maximum
+
+
+def has_workflow_context_marker(context: object) -> bool:
+    """Whether a context claims to belong to a workflow, valid or malformed."""
+    return isinstance(context, dict) and "workflow_run_id" in context

--- a/kolega_code/agent/orchestration/executor.py
+++ b/kolega_code/agent/orchestration/executor.py
@@ -20,6 +20,8 @@ from typing import Any, Dict
 from .errors import WorkflowScriptError
 
 WRAPPER_NAME = "__workflow_main__"
+DEFAULT_MAX_AGENT_DEPTH = 1
+MAX_AGENT_DEPTH = 2
 
 # Builtins the script may use. Deliberately omits __import__, open, eval, exec,
 # compile, input, and the time/random surface. __build_class__ is included so a
@@ -125,6 +127,17 @@ def extract_meta(source: str) -> Dict[str, Any]:
                         raise WorkflowScriptError("`meta` must be a dict literal.")
                     if not value.get("name") or not value.get("description"):
                         raise WorkflowScriptError("`meta` must include non-empty `name` and `description`.")
+                    max_agent_depth = value.get("max_agent_depth", DEFAULT_MAX_AGENT_DEPTH)
+                    if (
+                        isinstance(max_agent_depth, bool)
+                        or not isinstance(max_agent_depth, int)
+                        or not DEFAULT_MAX_AGENT_DEPTH <= max_agent_depth <= MAX_AGENT_DEPTH
+                    ):
+                        raise WorkflowScriptError(
+                            f"`meta.max_agent_depth` must be an integer from "
+                            f"{DEFAULT_MAX_AGENT_DEPTH} to {MAX_AGENT_DEPTH}."
+                        )
+                    value["max_agent_depth"] = max_agent_depth
                     return value
 
     raise WorkflowScriptError(

--- a/kolega_code/agent/orchestration/guide.py
+++ b/kolega_code/agent/orchestration/guide.py
@@ -62,6 +62,11 @@ workflow with `agent()`, `parallel()`, and `pipeline()`. Depth `2` is an excepti
 opt-in for a worker that genuinely must consult a specialist; nested calls are
 less visible to workflow-level orchestration and can multiply token use.
 
+At depth `2`, recursive delegation supports built-in agent-dispatch tools only.
+Opaque host-provided `ToolExtension` dispatch callbacks are unavailable in
+workflows until there is a workflow-aware accounting and depth protocol. Ordinary
+non-workflow extension and agent-delegation behavior is unchanged.
+
 ### Primitives (all available as globals in the script)
 
 - `await agent(prompt, *, label=None, phase=None, schema=None, model=None, effort=None, agent_type=None)`
@@ -95,8 +100,15 @@ less visible to workflow-level orchestration and can multiply token use.
   (this is what makes resume work). Pass any timestamps/seeds in via `args`. Vary agents
   by index/prompt, not by randomness.
 - Concurrency is capped automatically; you may pass large lists to `parallel`/`pipeline`
-  (up to 4096) and they all complete — only a handful run at once. A lifetime cap of
-  1000 agents is a runaway-loop backstop.
+  (up to 4096) and they all complete — only a handful active execution chains run
+  at once. Nested dispatch within one direct worker is serialized. A lifetime cap
+  of 1000 agents is a runaway-loop backstop, and built-in nested workers count
+  against both that workflow-wide count and the output-token budget.
+- Budget admission uses completed output-token spend: reaching the limit blocks
+  later direct or nested launches, but calls already in flight can finish and
+  produce bounded overshoot.
+- Run totals and failed-agent artifacts include finalized output from direct and
+  built-in nested workers, including usage recorded before a later failure.
 - Use `schema` for anything you'll compute over (counts, filtering, merging). The
   sub-agent is forced to return data matching the schema instead of prose.
 

--- a/kolega_code/agent/orchestration/guide.py
+++ b/kolega_code/agent/orchestration/guide.py
@@ -46,7 +46,21 @@ return {"confirmed": confirmed}
 ```
 
 `meta` must be a pure literal (no variables, calls, or f-strings) — it is read
-without running the script. Required keys: `name`, `description`. Optional `phases`.
+without running the script. Required keys: `name`, `description`. Optional keys:
+`phases` and `max_agent_depth`.
+
+`max_agent_depth` controls nested agent delegation for the whole workflow. It
+defaults to `1`, so agents dispatched directly by workflow `agent()` calls are
+leaves and receive no agent-dispatch tools. The only other accepted value, and
+the hard maximum, is `2`: direct workers may then retain only the dispatch tools
+their agent type already supports, and any children they dispatch are leaves.
+This never enables unsupported dispatch tools and never permits a worker to call
+`run_workflow`.
+
+Strongly prefer the default of `1`. Express fan-out and stages visibly in the
+workflow with `agent()`, `parallel()`, and `pipeline()`. Depth `2` is an exceptional
+opt-in for a worker that genuinely must consult a specialist; nested calls are
+less visible to workflow-level orchestration and can multiply token use.
 
 ### Primitives (all available as globals in the script)
 

--- a/kolega_code/agent/orchestration/runtime.py
+++ b/kolega_code/agent/orchestration/runtime.py
@@ -19,7 +19,7 @@ from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional
 
 from .budget import Budget
 from .errors import WorkflowAgentCapExceeded, WorkflowScriptError
-from .executor import run_script, safe_builtins
+from .executor import DEFAULT_MAX_AGENT_DEPTH, run_script, safe_builtins
 from .journal import RunJournal
 from .types import AgentRunSpec, DispatchFn, EmitFn, WorkflowResolver
 
@@ -72,6 +72,7 @@ class WorkflowRuntime:
         budget: Budget,
         concurrency: Optional[int] = None,
         agent_cap: int = DEFAULT_AGENT_CAP,
+        max_agent_depth: int = DEFAULT_MAX_AGENT_DEPTH,
         resume_cache: Optional[Dict[int, Any]] = None,
         workflow_resolver: Optional[WorkflowResolver] = None,
     ) -> None:
@@ -81,6 +82,7 @@ class WorkflowRuntime:
         self.budget = budget
         self._sem = asyncio.Semaphore(concurrency or default_concurrency())
         self._agent_cap = agent_cap
+        self._max_agent_depth = max_agent_depth
         self._resolver = workflow_resolver
 
         self._agent_count = 0
@@ -144,6 +146,7 @@ class WorkflowRuntime:
             model=model,
             effort=effort,
             agent_type=agent_type,
+            max_agent_depth=self._max_agent_depth,
             call_index=index,
         )
         key = spec.cache_key()
@@ -188,6 +191,7 @@ class WorkflowRuntime:
             status=result.status,
             phase=spec.phase,
             agent_type=spec.agent_type,
+            max_agent_depth=spec.max_agent_depth,
             tokens=result.tokens,
             error=result.error,
             transcript_path=result.transcript_path,
@@ -200,6 +204,7 @@ class WorkflowRuntime:
                 "label": spec.label,
                 "phase": spec.phase,
                 "agent_type": spec.agent_type,
+                "max_agent_depth": spec.max_agent_depth,
                 "status": result.status,
                 "tokens": result.tokens,
                 "error": result.error,

--- a/kolega_code/agent/orchestration/runtime.py
+++ b/kolega_code/agent/orchestration/runtime.py
@@ -17,8 +17,13 @@ import os
 import random
 from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional
 
+from .accounting import (
+    WorkflowRunAccounting,
+    reset_current_agent_reservation,
+    set_current_agent_reservation,
+)
 from .budget import Budget
-from .errors import WorkflowAgentCapExceeded, WorkflowScriptError
+from .errors import WorkflowScriptError
 from .executor import DEFAULT_MAX_AGENT_DEPTH, run_script, safe_builtins
 from .journal import RunJournal
 from .types import AgentRunSpec, DispatchFn, EmitFn, WorkflowResolver
@@ -72,6 +77,7 @@ class WorkflowRuntime:
         budget: Budget,
         concurrency: Optional[int] = None,
         agent_cap: int = DEFAULT_AGENT_CAP,
+        accounting: Optional[WorkflowRunAccounting] = None,
         max_agent_depth: int = DEFAULT_MAX_AGENT_DEPTH,
         resume_cache: Optional[Dict[int, Any]] = None,
         workflow_resolver: Optional[WorkflowResolver] = None,
@@ -79,13 +85,14 @@ class WorkflowRuntime:
         self._dispatch = dispatch
         self._emit = emit
         self._journal = journal
-        self.budget = budget
+        self._accounting = accounting or WorkflowRunAccounting(budget, agent_cap)
+        if self._accounting.budget is not budget:
+            raise ValueError("workflow accounting must own the runtime budget")
+        self.budget = self._accounting.budget
         self._sem = asyncio.Semaphore(concurrency or default_concurrency())
-        self._agent_cap = agent_cap
         self._max_agent_depth = max_agent_depth
         self._resolver = workflow_resolver
 
-        self._agent_count = 0
         self._call_index = 0
         self._current_phase: Optional[str] = None
         self._nested_depth = 0
@@ -167,21 +174,20 @@ class WorkflowRuntime:
             self._emit_soon("workflow_agent_cached", {"label": label, "phase": spec.phase})
             return cached_value
 
-        self._agent_count += 1
-        if self._agent_count > self._agent_cap:
-            raise WorkflowAgentCapExceeded(
-                f"workflow exceeded the lifetime agent cap ({self._agent_cap}); likely a runaway loop"
-            )
-
-        self.budget.check()
-
         async with self._sem:
             # Stagger starts within the admitted batch so they don't hit the API in lockstep.
             if START_STAGGER_SECONDS:
                 await asyncio.sleep(random.uniform(0, START_STAGGER_SECONDS))
-            result = await self._dispatch(spec)
+            reservation = self._accounting.reserve_agent()
+            result = None
+            reservation_token = set_current_agent_reservation(reservation)
+            try:
+                result = await self._dispatch(spec)
+            finally:
+                reset_current_agent_reservation(reservation_token)
+                reservation.report_total(result.tokens if result is not None else None)
 
-        self.budget.add(result.tokens)
+        assert result is not None
         value = result.value
         self._journal.record(
             index,

--- a/kolega_code/agent/orchestration/types.py
+++ b/kolega_code/agent/orchestration/types.py
@@ -25,6 +25,8 @@ class AgentRunSpec:
     model: Optional[str] = None
     effort: Optional[str] = None
     agent_type: Optional[str] = None
+    # Workflow-wide delegation ceiling. Direct workflow workers are depth 1.
+    max_agent_depth: int = 1
     # Position of this call in the run, assigned by the runtime in invocation
     # order. Combined with ``cache_key`` it drives resume.
     call_index: int = 0
@@ -41,6 +43,7 @@ class AgentRunSpec:
             "model": self.model,
             "effort": self.effort,
             "agent_type": self.agent_type,
+            "max_agent_depth": self.max_agent_depth,
         }
         encoded = json.dumps(payload, sort_keys=True, default=str)
         return hashlib.sha1(encoded.encode("utf-8")).hexdigest()

--- a/kolega_code/agent/tool_backend/agent_tool.py
+++ b/kolega_code/agent/tool_backend/agent_tool.py
@@ -10,6 +10,8 @@ from kolega_code.config import AgentConfig
 from kolega_code.events import AgentEvent
 from kolega_code.hooks import HookDispatcher, HookEvent
 from kolega_code.permissions import PermissionMode, auto_allow_permission_callback
+from ..orchestration.accounting import AgentReservation, WorkflowRunAccounting
+from ..orchestration.context import has_workflow_context_marker, validated_workflow_depth
 from .base_tool import BaseTool
 
 
@@ -172,6 +174,25 @@ class AgentTool(BaseTool):
         Returns:
             The agent's recap of its work
         """
+        parent_context = getattr(self.caller, "sub_agent_context", None)
+        workflow_depth: Optional[tuple[int, int]] = None
+        workflow_accounting: Optional[WorkflowRunAccounting] = None
+        reservation: Optional[AgentReservation] = None
+
+        if has_workflow_context_marker(parent_context):
+            workflow_depth = validated_workflow_depth(parent_context)
+            if workflow_depth is None:
+                raise RuntimeError("invalid workflow delegation context")
+            parent_depth, max_agent_depth = workflow_depth
+            if parent_depth >= max_agent_depth:
+                raise RuntimeError(f"workflow agent depth limit reached ({max_agent_depth})")
+            workflow_accounting = getattr(self.caller, "_workflow_accounting", None)
+            if not isinstance(workflow_accounting, WorkflowRunAccounting):
+                raise RuntimeError("workflow delegation accounting is unavailable")
+            # Event-loop-confined admission happens before imports, conversation
+            # creation, events, or child construction.
+            reservation = workflow_accounting.reserve_agent()
+
         # Extract the agent name from the class
         module_path, class_name = agent_class_import.rsplit(".", 1)
 
@@ -202,14 +223,16 @@ class AgentTool(BaseTool):
                 task=task,
             )
 
-        parent_context = getattr(self.caller, "sub_agent_context", None)
         if not isinstance(parent_context, dict):
             parent_context = {}
-        context_depth = parent_context.get("depth")
-        if isinstance(context_depth, int) and not isinstance(context_depth, bool):
-            parent_depth = context_depth
+        if workflow_depth is not None:
+            parent_depth = workflow_depth[0]
         else:
-            parent_depth = 1 if getattr(self.caller, "sub_agent", False) else 0
+            context_depth = parent_context.get("depth")
+            if isinstance(context_depth, int) and not isinstance(context_depth, bool):
+                parent_depth = context_depth
+            else:
+                parent_depth = 1 if getattr(self.caller, "sub_agent", False) else 0
 
         # Attached to every event from this dispatch so the UI can group and
         # disambiguate concurrently running sub-agents.
@@ -225,12 +248,10 @@ class AgentTool(BaseTool):
         # A nested dispatch from a workflow worker inherits the workflow's
         # delegation policy and grouping metadata. Cosmetic call labels/indexes
         # belong only to the direct workflow call and are deliberately not copied.
-        workflow_run_id = parent_context.get("workflow_run_id")
-        max_agent_depth = parent_context.get("max_agent_depth")
-        if isinstance(workflow_run_id, str) and isinstance(max_agent_depth, int):
+        if workflow_depth is not None:
             sub_agent_info.update(
-                workflow_run_id=workflow_run_id,
-                max_agent_depth=max_agent_depth,
+                workflow_run_id=parent_context["workflow_run_id"],
+                max_agent_depth=workflow_depth[1],
                 phase=parent_context.get("phase"),
                 parent_agent_id=parent_context.get("agent_id"),
             )
@@ -240,6 +261,7 @@ class AgentTool(BaseTool):
         # Send start status
         await self._send_status_event("GENERATING", f"Starting {agent_name} task", sub_agent_info=sub_agent_info)
         conversation_finished = False
+        agent = None
 
         try:
             # Create the agent instance
@@ -287,6 +309,9 @@ class AgentTool(BaseTool):
             agent.parent_tool_call_id = tool_call_id
             agent.conversation_id = conversation_id
             agent.sub_agent_context = sub_agent_info
+            if workflow_accounting is not None:
+                agent._workflow_accounting = workflow_accounting
+                agent._accounting_reservation = reservation
 
             # Track messages and their sequence
             last_saved_index = -1  # Track what we've already saved
@@ -429,6 +454,9 @@ class AgentTool(BaseTool):
             raise
 
         finally:
+            if reservation is not None:
+                total_tokens = getattr(agent, "total_tokens_used", None)
+                reservation.report_total(total_tokens if type(total_tokens) is int else None)
             # Handle interrupted conversations
             if conversation_id and not conversation_finished:
                 execution_time = time.time() - start_time
@@ -512,10 +540,8 @@ class AgentTool(BaseTool):
             raise RuntimeError("Custom agents require an initialized parent tool collection.")
 
         eligible = set(collection.registry().names())
-        from ..tools import ToolCollection  # lazy import: tools.py imports AgentTool
-
-        eligible.difference_update(ToolCollection.agent_dispatch_tools)
-        eligible.difference_update(ToolCollection.orchestration_tools)
+        eligible.difference_update(getattr(collection, "agent_dispatch_tools", ()))
+        eligible.difference_update(getattr(collection, "orchestration_tools", ()))
 
         for extension in getattr(self.caller, "tool_extensions", None) or []:
             if not getattr(extension, "propagate_to_sub_agents", True):
@@ -611,6 +637,7 @@ class AgentTool(BaseTool):
             # read-only-safe; otherwise read-only sub-agents would have it filtered
             # out and could never return structured output.
             tool_groups={"read_only_tools": ["submit_result"]},
+            propagate_to_sub_agents=False,
         )
 
     def _construct_workflow_sub_agent(self, agent_class, config, extra_tool_extensions):
@@ -761,6 +788,8 @@ class AgentTool(BaseTool):
         agent_class,
         task: str,
         *,
+        workflow_accounting: WorkflowRunAccounting,
+        reservation: AgentReservation,
         config=None,
         schema: Optional[dict] = None,
         sub_agent_info_extra: Optional[dict] = None,
@@ -833,6 +862,8 @@ class AgentTool(BaseTool):
             agent.parent_tool_call_id = tool_call_id
             agent.conversation_id = conversation_id
             agent.sub_agent_context = sub_agent_info
+            agent._workflow_accounting = workflow_accounting
+            agent._accounting_reservation = reservation
 
             last_saved_index = await self._stream_workflow_agent(
                 agent,
@@ -897,6 +928,8 @@ class AgentTool(BaseTool):
             return result, (total_tokens if isinstance(total_tokens, int) else 0), structured
 
         except Exception as e:
+            failed_tokens = getattr(agent, "total_tokens_used", None)
+            reservation.report_total(failed_tokens if type(failed_tokens) is int else None)
             if conversation_id:
                 await self._fail_conversation(
                     conversation_id,
@@ -919,6 +952,7 @@ class AgentTool(BaseTool):
                 metadata=artifact_metadata,
                 prompt=task,
                 status="failed",
+                tokens=reservation.reported_tokens,
                 error=str(e),
                 history=final_history,
             )
@@ -927,6 +961,8 @@ class AgentTool(BaseTool):
             raise
 
         finally:
+            total_tokens = getattr(agent, "total_tokens_used", None)
+            reservation.report_total(total_tokens if type(total_tokens) is int else None)
             if conversation_id and not conversation_finished:
                 await self._interrupt_conversation(
                     conversation_id,

--- a/kolega_code/agent/tool_backend/agent_tool.py
+++ b/kolega_code/agent/tool_backend/agent_tool.py
@@ -202,12 +202,14 @@ class AgentTool(BaseTool):
                 task=task,
             )
 
-        # Calculate depth based on whether the caller is also a sub-agent
-        parent_depth = 0
-        if hasattr(self.caller, "sub_agent") and self.caller.sub_agent:
-            # If the caller is a sub-agent, get its depth
-            # For now, we'll increment from 1, but ideally we'd track this
-            parent_depth = 1
+        parent_context = getattr(self.caller, "sub_agent_context", None)
+        if not isinstance(parent_context, dict):
+            parent_context = {}
+        context_depth = parent_context.get("depth")
+        if isinstance(context_depth, int) and not isinstance(context_depth, bool):
+            parent_depth = context_depth
+        else:
+            parent_depth = 1 if getattr(self.caller, "sub_agent", False) else 0
 
         # Attached to every event from this dispatch so the UI can group and
         # disambiguate concurrently running sub-agents.
@@ -220,6 +222,18 @@ class AgentTool(BaseTool):
             "parent_tool_call_id": tool_call_id,
             "depth": parent_depth + 1,
         }
+        # A nested dispatch from a workflow worker inherits the workflow's
+        # delegation policy and grouping metadata. Cosmetic call labels/indexes
+        # belong only to the direct workflow call and are deliberately not copied.
+        workflow_run_id = parent_context.get("workflow_run_id")
+        max_agent_depth = parent_context.get("max_agent_depth")
+        if isinstance(workflow_run_id, str) and isinstance(max_agent_depth, int):
+            sub_agent_info.update(
+                workflow_run_id=workflow_run_id,
+                max_agent_depth=max_agent_depth,
+                phase=parent_context.get("phase"),
+                parent_agent_id=parent_context.get("agent_id"),
+            )
         if sub_agent_info_extra:
             sub_agent_info.update(sub_agent_info_extra)
 
@@ -722,6 +736,7 @@ class AgentTool(BaseTool):
             f"- Label: {metadata.get('label') or ''}",
             f"- Phase: {metadata.get('phase') or ''}",
             f"- Agent type: {metadata.get('agent_type') or metadata.get('agent_name') or ''}",
+            f"- Max agent depth: {metadata.get('max_agent_depth', '')}",
             f"- Status: {status}",
             f"- Tokens: {tokens}",
         ]

--- a/kolega_code/agent/tool_backend/workflow_tool.py
+++ b/kolega_code/agent/tool_backend/workflow_tool.py
@@ -149,6 +149,7 @@ class WorkflowTool(BaseTool):
                 "run_id": run_id,
                 "name": meta.get("name"),
                 "description": meta.get("description"),
+                "max_agent_depth": meta["max_agent_depth"],
                 "status": "running",
                 "args": args,
                 "resumed_from": resume_from_run_id or None,
@@ -165,6 +166,7 @@ class WorkflowTool(BaseTool):
                 "name": meta.get("name"),
                 "description": meta.get("description"),
                 "phases": meta.get("phases") or [],
+                "max_agent_depth": meta["max_agent_depth"],
             },
         )
 
@@ -173,6 +175,7 @@ class WorkflowTool(BaseTool):
             emit=emit,
             journal=journal,
             budget=budget,
+            max_agent_depth=meta["max_agent_depth"],
             resume_cache=resume_cache,
             workflow_resolver=self._make_resolver(state_dir),
         )
@@ -252,6 +255,8 @@ class WorkflowTool(BaseTool):
                 "phase": spec.phase,
                 "label": spec.label,
                 "call_index": spec.call_index,
+                "depth": 1,
+                "max_agent_depth": spec.max_agent_depth,
             }
             label_for_path = spec.label or spec.agent_type or agent_class.__name__
             artifact_paths = journal.agent_artifact_paths(spec.call_index, label_for_path)
@@ -261,6 +266,7 @@ class WorkflowTool(BaseTool):
                 "phase": spec.phase,
                 "agent_type": spec.agent_type or agent_class.__name__,
                 "agent_name": getattr(agent_class, "agent_name", agent_class.__name__),
+                "max_agent_depth": spec.max_agent_depth,
             }
             try:
                 recap, tokens, structured = await self._agent_tool.dispatch_workflow_agent(
@@ -309,6 +315,7 @@ class WorkflowTool(BaseTool):
                     name=content.get("name"),
                     description=content.get("description"),
                     phases=content.get("phases") or [],
+                    max_agent_depth=content.get("max_agent_depth"),
                 )
             elif kind == "workflow_end":
                 payload.update(
@@ -418,6 +425,7 @@ class WorkflowTool(BaseTool):
             f"- Status: {status}",
             f"- Duration: {duration_seconds}s",
             f"- Tokens: {budget.spent()}",
+            f"- Max agent depth: {meta['max_agent_depth']}",
             f"- Script: `{journal.script_path}`",
             f"- Result: `{journal.result_md_path}`",
             "",

--- a/kolega_code/agent/tool_backend/workflow_tool.py
+++ b/kolega_code/agent/tool_backend/workflow_tool.py
@@ -21,12 +21,16 @@ from ..orchestration import (
     AgentRunResult,
     AgentRunSpec,
     Budget,
+    DEFAULT_AGENT_CAP,
+    DispatchFn,
+    EmitFn,
     RunJournal,
     WorkflowRuntime,
     WorkflowScriptError,
     extract_meta,
     saved_workflows_dir,
 )
+from ..orchestration.accounting import WorkflowRunAccounting, get_current_agent_reservation
 from .agent_tool import AgentTool
 from .base_tool import BaseTool
 
@@ -72,7 +76,7 @@ RUN_WORKFLOW_INPUT_SCHEMA = {
 }
 
 
-def _import_agent_class(import_path: str):
+def _import_agent_class(import_path: str) -> type[Any]:
     module_path, class_name = import_path.rsplit(".", 1)
     module = __import__(module_path, fromlist=[class_name])
     return getattr(module, class_name)
@@ -143,6 +147,7 @@ class WorkflowTool(BaseTool):
             resume_cache = RunJournal.for_run(state_dir, resume_from_run_id).load_cache()
 
         budget = Budget(total=token_budget or None)
+        accounting = WorkflowRunAccounting(budget, DEFAULT_AGENT_CAP)
         started = time.time()
         journal.write_meta(
             {
@@ -171,10 +176,11 @@ class WorkflowTool(BaseTool):
         )
 
         runtime = WorkflowRuntime(
-            dispatch=self._make_dispatch(run_id, journal),
+            dispatch=self._make_dispatch(run_id, journal, accounting),
             emit=emit,
             journal=journal,
             budget=budget,
+            accounting=accounting,
             max_agent_depth=meta["max_agent_depth"],
             resume_cache=resume_cache,
             workflow_resolver=self._make_resolver(state_dir),
@@ -217,7 +223,7 @@ class WorkflowTool(BaseTool):
         return self._summarize(meta, run_id, journal, budget, status, error, result)
 
     # -------------------------------------------------------------- internals
-    def _resolve_source(self, script: str, script_path: str, resume_from_run_id: str, state_dir) -> str:
+    def _resolve_source(self, script: str, script_path: str, resume_from_run_id: str, state_dir: Path) -> str:
         if script_path:
             try:
                 return open(script_path, encoding="utf-8").read()
@@ -234,7 +240,12 @@ class WorkflowTool(BaseTool):
                 ) from exc
         raise WorkflowScriptError("run_workflow requires one of: script, script_path, or resume_from_run_id")
 
-    def _make_dispatch(self, run_id: str, journal: RunJournal):
+    def _make_dispatch(
+        self,
+        run_id: str,
+        journal: RunJournal,
+        accounting: WorkflowRunAccounting,
+    ) -> DispatchFn:
         # When the orchestrating agent is itself read-only (e.g. plan mode's
         # PlanningAgent), every workflow sub-agent is forced to a read-only
         # investigation agent so the read-only contract is preserved — the
@@ -244,6 +255,9 @@ class WorkflowTool(BaseTool):
         read_only = bool(getattr(getattr(self.caller, "tool_collection", None), "read_only", False))
 
         async def dispatch(spec: AgentRunSpec) -> AgentRunResult:
+            reservation = get_current_agent_reservation()
+            if reservation is None:
+                raise RuntimeError("workflow dispatch requires an agent reservation")
             if read_only:
                 import_path = _AGENT_TYPE_IMPORTS["investigation"]
             else:
@@ -272,6 +286,8 @@ class WorkflowTool(BaseTool):
                 recap, tokens, structured = await self._agent_tool.dispatch_workflow_agent(
                     agent_class,
                     spec.prompt,
+                    workflow_accounting=accounting,
+                    reservation=reservation,
                     config=config,
                     schema=spec.schema,
                     sub_agent_info_extra=sub_info_extra,
@@ -280,6 +296,7 @@ class WorkflowTool(BaseTool):
                 )
             except Exception as exc:  # noqa: BLE001 - a dead agent becomes a None result, not a crash
                 return AgentRunResult(
+                    tokens=reservation.reported_tokens,
                     status="failed",
                     error=str(exc),
                     transcript_path=str(artifact_paths["jsonl"]),
@@ -296,7 +313,7 @@ class WorkflowTool(BaseTool):
 
         return dispatch
 
-    def _make_emit(self, run_id: str, journal: RunJournal):
+    def _make_emit(self, run_id: str, journal: RunJournal) -> EmitFn:
         sender = getattr(self.caller, "agent_name", None) or "gigacode"
 
         async def emit(kind: str, content: dict) -> None:

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -31,6 +31,7 @@ from .tool_backend.terminal_tool import TerminalTool
 from .tool_backend.think_hard_tool import ThinkHardTool
 from .tool_backend.workflow_tool import RUN_WORKFLOW_INPUT_SCHEMA, WorkflowTool
 from .edit_protocols import EDIT_HANDLER_NAMES, edit_protocol_spec
+from .orchestration.context import has_workflow_context_marker, validated_workflow_depth
 
 # Import additional tools for consolidated functionality
 from .tool_backend.build_tool import BuildTool
@@ -572,6 +573,12 @@ class ToolCollection(LogMixin):
         self.extension_callbacks = {}
         self.extension_schemas = {}
         self._extension_group_names = set()
+        self._extension_dispatch_tools: set[str] = set()
+        self._legacy_only_extension_dispatch_tools: set[str] = set()
+        # Extension declarations are per collection. Never mutate the shared
+        # class inventories, and keep the legacy alias as the same list object.
+        self.agent_dispatch_tools = list(type(self).agent_dispatch_tools)
+        self.investigation_agent_tools = self.agent_dispatch_tools
 
         # Set legacy attributes for backward compatibility
         self.read_only = tool_config.read_only
@@ -606,7 +613,7 @@ class ToolCollection(LogMixin):
         self._initialize_tools()
         self._register_tool_extensions()
 
-    def _register_tool_extensions(self):
+    def _register_tool_extensions(self) -> None:
         """Bind host-provided extension callbacks onto this collection."""
         for extension in self.tool_extensions:
             for tool_name, callback in extension.tools.items():
@@ -618,7 +625,30 @@ class ToolCollection(LogMixin):
             for tool_name, schema in extension.tool_schemas.items():
                 self.extension_schemas[tool_name] = schema
 
+        canonical_declarations = {
+            tool_name
+            for extension in self.tool_extensions
+            for tool_name in extension.tool_groups.get("agent_dispatch_tools", [])
+        }
+        legacy_declarations = {
+            tool_name
+            for extension in self.tool_extensions
+            for tool_name in extension.tool_groups.get("investigation_agent_tools", [])
+        }
+        self._legacy_only_extension_dispatch_tools = (
+            legacy_declarations - canonical_declarations
+        ) & self.extension_callbacks.keys()
+
+        for extension in self.tool_extensions:
             for group_name, tool_names in extension.tool_groups.items():
+                if group_name in {"agent_dispatch_tools", "investigation_agent_tools"}:
+                    for tool_name in tool_names:
+                        if tool_name not in self.agent_dispatch_tools:
+                            self.agent_dispatch_tools.append(tool_name)
+                        if tool_name in self.extension_callbacks:
+                            self._extension_dispatch_tools.add(tool_name)
+                    self._extension_group_names.update({"agent_dispatch_tools", "investigation_agent_tools"})
+                    continue
                 existing_group = list(getattr(self, group_name, []))
                 merged_group = list(dict.fromkeys(existing_group + list(tool_names)))
                 setattr(self, group_name, merged_group)
@@ -2228,16 +2258,22 @@ class ToolCollection(LogMixin):
         explicit_schema = self.extension_schemas.get(method_name)
         if explicit_schema is not None:
             definition.input_schema = explicit_schema
+        context = getattr(self.caller, "sub_agent_context", None)
+        workflow_dispatch = method_name in self.agent_dispatch_tools and (
+            validated_workflow_depth(context) is not None or has_workflow_context_marker(context)
+        )
+        ordinary_parallel_dispatch = (
+            method_name in self.agent_dispatch_tools and method_name not in self._legacy_only_extension_dispatch_tools
+        )
         return Tool(
             name=method_name,
             definition=definition,
             handler=method,
             groups=self._groups_for(method_name),
-            # Read-only tools have no side effects and agent dispatches operate
-            # on independent sub-agents, so these may run concurrently.
-            parallel_safe=(
-                method_name in (self.read_only_tools or []) or method_name in (self.agent_dispatch_tools or [])
-            ),
+            # Workflow parents lend their admitted execution-chain slot to one
+            # child at a time. Ordinary delegation remains parallel-safe.
+            parallel_safe=(method_name in (self.read_only_tools or []) or ordinary_parallel_dispatch)
+            and not workflow_dispatch,
         )
 
     def has_tool(self, name: str) -> bool:
@@ -2272,16 +2308,12 @@ class ToolCollection(LogMixin):
         # workflow context retain their normal behavior.
         if method_name in self.agent_dispatch_tools:
             sub_agent_context = getattr(self.caller, "sub_agent_context", None)
-            if isinstance(sub_agent_context, dict):
-                depth = sub_agent_context.get("depth")
-                max_agent_depth = sub_agent_context.get("max_agent_depth")
-                if (
-                    isinstance(depth, int)
-                    and not isinstance(depth, bool)
-                    and isinstance(max_agent_depth, int)
-                    and not isinstance(max_agent_depth, bool)
-                    and depth >= max_agent_depth
-                ):
+            workflow_depth = validated_workflow_depth(sub_agent_context)
+            if has_workflow_context_marker(sub_agent_context):
+                if workflow_depth is None:
+                    return False
+                depth, maximum = workflow_depth
+                if method_name in self._extension_dispatch_tools or depth >= maximum:
                     return False
 
         if method_name == "dispatch_custom_agent":
@@ -2316,7 +2348,11 @@ class ToolCollection(LogMixin):
         # If restrict_to_tool_groups is True, only include tools from explicitly enabled groups
         if self.tool_config.restrict_to_tool_groups:
             # Check if tool belongs to any enabled group
-            if method_name in self.agent_dispatch_tools and self.tool_config.include_agent_dispatch_tools:
+            if (
+                method_name in self.agent_dispatch_tools
+                and method_name not in self._legacy_only_extension_dispatch_tools
+                and self.tool_config.include_agent_dispatch_tools
+            ):
                 return True
             if method_name in self.memory_tools and self.tool_config.include_memory_tools:
                 return method_name not in self.tool_exclusions
@@ -2346,6 +2382,8 @@ class ToolCollection(LogMixin):
 
         # Check investigation agent tools
         if method_name in self.agent_dispatch_tools:
+            if method_name in self._legacy_only_extension_dispatch_tools:
+                return True
             return self.tool_config.include_agent_dispatch_tools
 
         # Check memory tools

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -2267,6 +2267,23 @@ class ToolCollection(LogMixin):
         Returns:
             True if the tool should be included, False otherwise
         """
+        # Gigacode delegation depth is scoped through sub_agent_context. It only
+        # narrows a workflow worker's existing dispatch inventory; callers with no
+        # workflow context retain their normal behavior.
+        if method_name in self.agent_dispatch_tools:
+            sub_agent_context = getattr(self.caller, "sub_agent_context", None)
+            if isinstance(sub_agent_context, dict):
+                depth = sub_agent_context.get("depth")
+                max_agent_depth = sub_agent_context.get("max_agent_depth")
+                if (
+                    isinstance(depth, int)
+                    and not isinstance(depth, bool)
+                    and isinstance(max_agent_depth, int)
+                    and not isinstance(max_agent_depth, bool)
+                    and depth >= max_agent_depth
+                ):
+                    return False
+
         if method_name == "dispatch_custom_agent":
             catalog = getattr(self.caller, "custom_agent_catalog", None)
             if getattr(self.caller, "sub_agent", False) or catalog is None or not catalog.has_agents():

--- a/kolega_code/llm/instrumented_client.py
+++ b/kolega_code/llm/instrumented_client.py
@@ -3,6 +3,7 @@ Instrumented LLM client that adds Langfuse tracing to all LLM operations.
 """
 
 import os
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Optional, List, Dict, Union, AsyncContextManager, Coroutine
 from datetime import datetime, timezone
 import logging
@@ -17,6 +18,46 @@ from .models import Message, MessageHistory, ToolDefinition
 from .providers.models import GenerationParams
 
 logger = logging.getLogger(__name__)
+
+_ANTHROPIC_USAGE_PROVIDERS = frozenset({"anthropic", "moonshot", "zai", "kimi_coding"})
+_OPENAI_USAGE_PROVIDERS = frozenset(
+    {
+        "openai",
+        "openai_chatgpt",
+        "together",
+        "groq",
+        "fireworks",
+        "llama",
+        "xai",
+        "dashscope",
+        "deepseek",
+        "ollama_cloud",
+    }
+)
+
+
+def _usage_token_fields(provider: object) -> Optional[tuple[str, str]]:
+    """Return the normalized input/output field names for a known provider."""
+    if not isinstance(provider, str):
+        return None
+    if provider in _ANTHROPIC_USAGE_PROVIDERS:
+        return "input_tokens", "output_tokens"
+    if provider in _OPENAI_USAGE_PROVIDERS:
+        return "prompt_tokens", "completion_tokens"
+    if provider == "google":
+        return "prompt_token_count", "candidates_token_count"
+    return None
+
+
+def get_output_tokens(usage_metadata: Optional[Mapping[str, Any]], provider: Optional[str] = None) -> int:
+    """Extract a provider-shaped, non-negative output-token count."""
+    if not usage_metadata:
+        return 0
+    fields = _usage_token_fields(usage_metadata.get("provider", provider))
+    if fields is None:
+        return 0
+    value = usage_metadata.get(fields[1], 0)
+    return value if type(value) is int and value >= 0 else 0
 
 
 class InstrumentedLLMClient(LLMClient):
@@ -92,34 +133,14 @@ class InstrumentedLLMClient(LLMClient):
 
         provider = usage_metadata.get("provider", self.provider_name)
 
-        if provider in ["anthropic", "moonshot", "kimi_coding"]:
-            input_tokens = usage_metadata.get("input_tokens", 0)
-            output_tokens = usage_metadata.get("output_tokens", 0)
-            cache_read_tokens = usage_metadata.get("cache_read_input_tokens", 0)
-            cache_write_tokens = usage_metadata.get("cache_write_input_tokens", 0)
-        elif provider in [
-            "openai",
-            "openai_chatgpt",
-            "together",
-            "groq",
-            "fireworks",
-            "llama",
-            "xai",
-            "dashscope",
-            "deepseek",
-        ]:
-            input_tokens = usage_metadata.get("prompt_tokens", 0)
-            output_tokens = usage_metadata.get("completion_tokens", 0)
-            cache_read_tokens = usage_metadata.get("cache_read_input_tokens", 0)
-            cache_write_tokens = usage_metadata.get("cache_write_input_tokens", 0)
-        elif provider == "google":
-            input_tokens = usage_metadata.get("prompt_token_count", 0)
-            output_tokens = usage_metadata.get("candidates_token_count", 0)
-            cache_read_tokens = usage_metadata.get("cache_read_input_tokens", 0)
-            cache_write_tokens = usage_metadata.get("cache_write_input_tokens", 0)
-        else:
+        fields = _usage_token_fields(provider)
+        if fields is None:
             logger.warning(f"Unknown provider for usage recording: {provider}")
             return None
+        input_tokens = usage_metadata.get(fields[0], 0)
+        output_tokens = usage_metadata.get(fields[1], 0)
+        cache_read_tokens = usage_metadata.get("cache_read_input_tokens", 0)
+        cache_write_tokens = usage_metadata.get("cache_write_input_tokens", 0)
 
         return {
             "user_id": self.user_id,

--- a/kolega_code/llm/providers/google.py
+++ b/kolega_code/llm/providers/google.py
@@ -20,6 +20,7 @@ class GoogleStreamWrapper:
         self._tool_call_index = 0
         self.stop_reason = None
         self.tool_execution_ids = ToolExecutionIdRegistry()
+        self.usage_metadata: dict[str, Any] = {}
 
         self._closed = False
 
@@ -45,6 +46,13 @@ class GoogleStreamWrapper:
 
             content = chunk.text or ""
             self.final_content += content
+            usage = getattr(chunk, "usage_metadata", None)
+            if usage is not None:
+                self.usage_metadata = {
+                    "prompt_token_count": getattr(usage, "prompt_token_count", 0),
+                    "candidates_token_count": getattr(usage, "candidates_token_count", 0),
+                    "total_token_count": getattr(usage, "total_token_count", 0),
+                }
 
             # Read function calls off the parts so we also capture each part's thought_signature
             # (Gemini 3.x requires it echoed back). Accumulate across chunks with a running index.
@@ -70,6 +78,7 @@ class GoogleStreamWrapper:
             stop_reason=self.stop_reason,
             tool_execution_ids=self.tool_execution_ids,
         )
+        message.usage_metadata.update(self.usage_metadata)
         message.usage_metadata["provider"] = "google"
         return message
 

--- a/tests/agent/llm/test_google_thought_signature.py
+++ b/tests/agent/llm/test_google_thought_signature.py
@@ -6,11 +6,14 @@ on the way in, emitted on the way out, and survives session persistence.
 """
 
 import json
+from collections.abc import AsyncGenerator
 
+import pytest
 from google.genai import types as genai_types
 
 from kolega_code.agent.conversation import Conversation
 from kolega_code.llm.models import Message, ToolCall
+from kolega_code.llm.providers.google import GoogleStreamWrapper
 
 
 def _fake_google_response(signature: bytes) -> genai_types.GenerateContentResponse:
@@ -64,6 +67,23 @@ def test_from_google_captures_signature() -> None:
     assert tool_calls[0].thought_signature == b"GSIG"
     # Also exposed via the dedicated tool_calls field.
     assert msg.tool_calls[0].thought_signature == b"GSIG"
+
+
+@pytest.mark.asyncio
+async def test_google_stream_preserves_final_usage_metadata() -> None:
+    async def stream() -> AsyncGenerator[genai_types.GenerateContentResponse, None]:
+        yield _fake_google_response(b"GSIG")
+
+    async with GoogleStreamWrapper(stream()) as wrapper:
+        await anext(wrapper)
+        message = await wrapper.get_final_message()
+
+    assert message.usage_metadata == {
+        "prompt_token_count": 1,
+        "candidates_token_count": 1,
+        "total_token_count": 2,
+        "provider": "google",
+    }
 
 
 def test_persisted_session_preserves_signature() -> None:

--- a/tests/agent/llm/test_instrumented_client.py
+++ b/tests/agent/llm/test_instrumented_client.py
@@ -4,6 +4,7 @@ Tests for the InstrumentedLLMClient class.
 """
 
 import os
+from typing import Any, Optional
 import pytest
 from unittest.mock import Mock, AsyncMock, patch, MagicMock
 
@@ -11,10 +12,37 @@ from kolega_code.llm.models import Message, MessageHistory, TextBlock
 from kolega_code.llm.instrumented_client import (
     InstrumentedLLMClient,
     MinimalLangfuseStreamWrapper,
+    get_output_tokens,
 )
 
 # Check if running in CI environment
 SKIP_IN_CI = bool(os.getenv("CI")) or bool(os.getenv("GITLAB_CI"))
+
+
+@pytest.mark.parametrize(
+    ("metadata", "provider", "expected"),
+    [
+        ({"provider": "anthropic", "output_tokens": 11}, None, 11),
+        ({"provider": "zai", "output_tokens": 12}, None, 12),
+        ({"provider": "openai", "completion_tokens": 13}, None, 13),
+        ({"provider": "ollama_cloud", "completion_tokens": 14}, None, 14),
+        ({"provider": "google", "candidates_token_count": 15}, None, 15),
+        ({"output_tokens": 16}, "moonshot", 16),
+        ({"provider": "unknown", "output_tokens": 17}, None, 0),
+        ({"provider": "anthropic", "output_tokens": -1}, None, 0),
+        ({"provider": "anthropic", "output_tokens": True}, None, 0),
+        ({"provider": "anthropic", "output_tokens": "18"}, None, 0),
+        ({"provider": [], "output_tokens": 18}, None, 0),
+        ({"provider": {}, "output_tokens": 18}, None, 0),
+        ({}, "anthropic", 0),
+    ],
+)
+def test_get_output_tokens(
+    metadata: dict[str, Any],
+    provider: Optional[str],
+    expected: int,
+) -> None:
+    assert get_output_tokens(metadata, provider) == expected
 
 
 class TestInstrumentedLLMClient:

--- a/tests/agent/orchestration/test_accounting.py
+++ b/tests/agent/orchestration/test_accounting.py
@@ -1,0 +1,85 @@
+"""Focused tests for private workflow-run accounting."""
+
+from typing import Any, cast
+
+import pytest
+
+from kolega_code.agent.orchestration.accounting import WorkflowRunAccounting
+from kolega_code.agent.orchestration.budget import Budget
+from kolega_code.agent.orchestration.errors import WorkflowAgentCapExceeded, WorkflowBudgetExceeded
+
+
+def test_reservations_share_exact_budget_and_lifetime_count() -> None:
+    budget = Budget()
+    accounting = WorkflowRunAccounting(budget, agent_cap=3)
+
+    first = accounting.reserve_agent()
+    second = accounting.reserve_agent()
+    first.report_total(4)
+    second.report_total(6)
+
+    assert accounting.budget is budget
+    assert accounting.agent_cap == 3
+    assert accounting.agent_count == 2
+    assert budget.spent() == 10
+
+
+def test_cap_rejection_is_prospective_and_does_not_increment_count() -> None:
+    accounting = WorkflowRunAccounting(Budget(), agent_cap=1)
+
+    accounting.reserve_agent()
+
+    with pytest.raises(WorkflowAgentCapExceeded, match="lifetime agent cap \\(1\\)"):
+        accounting.reserve_agent()
+    assert accounting.agent_count == 1
+
+
+def test_budget_rejection_does_not_increment_count() -> None:
+    budget = Budget(total=5)
+    budget.add(5)
+    accounting = WorkflowRunAccounting(budget, agent_cap=2)
+
+    with pytest.raises(WorkflowBudgetExceeded, match="budget exhausted"):
+        accounting.reserve_agent()
+    assert accounting.agent_count == 0
+
+
+def test_cumulative_reports_add_only_positive_deltas_and_are_idempotent() -> None:
+    budget = Budget()
+    reservation = WorkflowRunAccounting(budget, agent_cap=1).reserve_agent()
+
+    reservation.report_total(7)
+    reservation.report_total(12)
+    reservation.report_total(12)
+
+    assert reservation.reported_tokens == 12
+    assert budget.spent() == 12
+
+
+def test_invalid_negative_and_regressing_reports_are_ignored() -> None:
+    budget = Budget()
+    reservation = WorkflowRunAccounting(budget, agent_cap=1).reserve_agent()
+    reservation.report_total(9)
+
+    invalid_totals: tuple[Any, ...] = (None, -4, 3, True, 2.9, "9", "invalid", object(), float("inf"))
+    for total in invalid_totals:
+        reservation.report_total(cast(Any, total))
+
+    assert reservation.reported_tokens == 9
+    assert budget.spent() == 9
+
+
+def test_reservations_track_independent_cumulative_totals() -> None:
+    budget = Budget()
+    accounting = WorkflowRunAccounting(budget, agent_cap=2)
+    first = accounting.reserve_agent()
+    second = accounting.reserve_agent()
+
+    first.report_total(10)
+    second.report_total(7)
+    first.report_total(15)
+    second.report_total(9)
+
+    assert first.reported_tokens == 15
+    assert second.reported_tokens == 9
+    assert budget.spent() == 24

--- a/tests/agent/orchestration/test_orchestration.py
+++ b/tests/agent/orchestration/test_orchestration.py
@@ -4,6 +4,11 @@ These exercise the orchestration package in isolation with a stub ``dispatch``,
 so they need none of the agent/LLM stack.
 """
 
+import asyncio
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Optional
+
 import pytest
 
 from kolega_code.agent.orchestration import (
@@ -15,22 +20,25 @@ from kolega_code.agent.orchestration import (
     WorkflowBudgetExceeded,
     WorkflowRuntime,
     WorkflowScriptError,
+    DispatchFn,
     extract_meta,
 )
+from kolega_code.agent.orchestration.accounting import WorkflowRunAccounting
 
 META = 'meta = {"name": "t", "description": "d"}\n'
 
 
 def make_runtime(
-    tmp_path,
+    tmp_path: Path,
     *,
-    dispatch=None,
-    budget=None,
-    resume_cache=None,
-    concurrency=4,
-    agent_cap=1000,
-    max_agent_depth=1,
-):
+    dispatch: Optional[DispatchFn] = None,
+    budget: Optional[Budget] = None,
+    accounting: Optional[WorkflowRunAccounting] = None,
+    resume_cache: Optional[dict[int, Any]] = None,
+    concurrency: int = 4,
+    agent_cap: int = 1000,
+    max_agent_depth: int = 1,
+) -> tuple[WorkflowRuntime, list[AgentRunSpec], list[tuple[str, dict[str, Any]]], RunJournal]:
     """Build a runtime backed by a recording stub dispatch."""
     calls = []
 
@@ -42,7 +50,7 @@ def make_runtime(
 
     events = []
 
-    async def emit(kind, content):
+    async def emit(kind: str, content: dict[str, Any]) -> None:
         events.append((kind, content))
 
     journal = RunJournal.for_run(tmp_path, "run")
@@ -51,6 +59,7 @@ def make_runtime(
         emit=emit,
         journal=journal,
         budget=budget if budget is not None else Budget(),
+        accounting=accounting,
         resume_cache=resume_cache,
         concurrency=concurrency,
         agent_cap=agent_cap,
@@ -67,13 +76,13 @@ def test_extract_meta_valid():
 
 
 @pytest.mark.parametrize("max_agent_depth", [1, 2])
-def test_extract_meta_accepts_supported_agent_depths(max_agent_depth):
+def test_extract_meta_accepts_supported_agent_depths(max_agent_depth: int) -> None:
     source = f'meta = {{"name": "t", "description": "d", "max_agent_depth": {max_agent_depth}}}\nreturn 1'
     assert extract_meta(source)["max_agent_depth"] == max_agent_depth
 
 
 @pytest.mark.parametrize("max_agent_depth", [0, 3, True, "2", 1.5, None])
-def test_extract_meta_rejects_invalid_agent_depths(max_agent_depth):
+def test_extract_meta_rejects_invalid_agent_depths(max_agent_depth: Any) -> None:
     source = f'meta = {{"name": "t", "description": "d", "max_agent_depth": {max_agent_depth!r}}}\nreturn 1'
     with pytest.raises(WorkflowScriptError, match="max_agent_depth"):
         extract_meta(source)
@@ -124,10 +133,23 @@ async def test_agent_returns_text_and_structured(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_agent_spec_carries_explicit_max_agent_depth(tmp_path):
+async def test_agent_spec_carries_explicit_max_agent_depth(tmp_path: Path) -> None:
     runtime, calls, _, _ = make_runtime(tmp_path, max_agent_depth=2)
     await runtime.execute(META + "return await agent('hello')", args=None)
     assert calls[0].max_agent_depth == 2
+
+
+@pytest.mark.asyncio
+async def test_agent_reservation_is_absent_from_spec_serialization(tmp_path: Path) -> None:
+    serialized_specs: list[dict[str, Any]] = []
+
+    async def dispatch(spec: AgentRunSpec) -> AgentRunResult:
+        serialized_specs.append(asdict(spec))
+        return AgentRunResult(text="ok", tokens=3)
+
+    runtime, _, _, _ = make_runtime(tmp_path, dispatch=dispatch)
+    assert await runtime.execute(META + "return await agent('hello')", args=None) == "ok"
+    assert "reservation" not in serialized_specs[0]
 
 
 @pytest.mark.asyncio
@@ -228,6 +250,62 @@ async def test_agent_cap_raises(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_cached_agent_does_not_reserve_or_spend(tmp_path: Path) -> None:
+    budget = Budget(total=5)
+    accounting = WorkflowRunAccounting(budget, agent_cap=1)
+    cached_spec = AgentRunSpec(prompt="cached")
+    runtime, calls, _, _ = make_runtime(
+        tmp_path,
+        budget=budget,
+        accounting=accounting,
+        resume_cache={0: (cached_spec.cache_key(), "from-cache")},
+    )
+
+    assert await runtime.agent("cached") == "from-cache"
+    assert calls == []
+    assert accounting.agent_count == 0
+    assert budget.spent() == 0
+
+
+@pytest.mark.asyncio
+async def test_queued_cancellation_does_not_reserve_agent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from kolega_code.agent.orchestration import runtime as runtime_module
+
+    monkeypatch.setattr(runtime_module, "START_STAGGER_SECONDS", 0)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def dispatch(spec: AgentRunSpec) -> AgentRunResult:
+        if spec.prompt == "first":
+            started.set()
+            await release.wait()
+        return AgentRunResult(text=spec.prompt, tokens=1)
+
+    budget = Budget()
+    accounting = WorkflowRunAccounting(budget, agent_cap=2)
+    runtime, _, _, _ = make_runtime(
+        tmp_path,
+        dispatch=dispatch,
+        budget=budget,
+        accounting=accounting,
+        concurrency=1,
+    )
+
+    first = asyncio.create_task(runtime.agent("first"))
+    await started.wait()
+    queued = asyncio.create_task(runtime.agent("queued"))
+    await asyncio.sleep(0)
+    queued.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await queued
+
+    assert accounting.agent_count == 1
+    release.set()
+    assert await first == "first"
+    assert budget.spent() == 1
+
+
+@pytest.mark.asyncio
 async def test_parallel_fanout_cap(tmp_path):
     runtime, _, _, _ = make_runtime(tmp_path)
     script = META + "return await parallel([(lambda: agent('x'))] * 5000)"
@@ -277,7 +355,7 @@ async def test_resume_reruns_after_change(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_resume_reruns_when_max_agent_depth_changes(tmp_path):
+async def test_resume_reruns_when_max_agent_depth_changes(tmp_path: Path) -> None:
     runtime, _, _, journal = make_runtime(tmp_path, max_agent_depth=1)
     await runtime.execute(META + "return await agent('one')", args=None)
 

--- a/tests/agent/orchestration/test_orchestration.py
+++ b/tests/agent/orchestration/test_orchestration.py
@@ -21,7 +21,16 @@ from kolega_code.agent.orchestration import (
 META = 'meta = {"name": "t", "description": "d"}\n'
 
 
-def make_runtime(tmp_path, *, dispatch=None, budget=None, resume_cache=None, concurrency=4, agent_cap=1000):
+def make_runtime(
+    tmp_path,
+    *,
+    dispatch=None,
+    budget=None,
+    resume_cache=None,
+    concurrency=4,
+    agent_cap=1000,
+    max_agent_depth=1,
+):
     """Build a runtime backed by a recording stub dispatch."""
     calls = []
 
@@ -45,6 +54,7 @@ def make_runtime(tmp_path, *, dispatch=None, budget=None, resume_cache=None, con
         resume_cache=resume_cache,
         concurrency=concurrency,
         agent_cap=agent_cap,
+        max_agent_depth=max_agent_depth,
     )
     return runtime, calls, events, journal
 
@@ -53,6 +63,20 @@ def make_runtime(tmp_path, *, dispatch=None, budget=None, resume_cache=None, con
 def test_extract_meta_valid():
     meta = extract_meta(META + "return 1")
     assert meta["name"] == "t" and meta["description"] == "d"
+    assert meta["max_agent_depth"] == 1
+
+
+@pytest.mark.parametrize("max_agent_depth", [1, 2])
+def test_extract_meta_accepts_supported_agent_depths(max_agent_depth):
+    source = f'meta = {{"name": "t", "description": "d", "max_agent_depth": {max_agent_depth}}}\nreturn 1'
+    assert extract_meta(source)["max_agent_depth"] == max_agent_depth
+
+
+@pytest.mark.parametrize("max_agent_depth", [0, 3, True, "2", 1.5, None])
+def test_extract_meta_rejects_invalid_agent_depths(max_agent_depth):
+    source = f'meta = {{"name": "t", "description": "d", "max_agent_depth": {max_agent_depth!r}}}\nreturn 1'
+    with pytest.raises(WorkflowScriptError, match="max_agent_depth"):
+        extract_meta(source)
 
 
 @pytest.mark.parametrize(
@@ -96,6 +120,14 @@ async def test_agent_returns_text_and_structured(tmp_path):
     assert out[0] == "recap:hello"
     assert out[1] == {"prompt": "world", "idx": 1}
     assert len(calls) == 2
+    assert all(call.max_agent_depth == 1 for call in calls)
+
+
+@pytest.mark.asyncio
+async def test_agent_spec_carries_explicit_max_agent_depth(tmp_path):
+    runtime, calls, _, _ = make_runtime(tmp_path, max_agent_depth=2)
+    await runtime.execute(META + "return await agent('hello')", args=None)
+    assert calls[0].max_agent_depth == 2
 
 
 @pytest.mark.asyncio
@@ -242,3 +274,15 @@ async def test_resume_reruns_after_change(tmp_path):
     runtime2, calls2, _, _ = make_runtime(tmp_path, resume_cache=cache)
     await runtime2.execute(META + "await agent('one')\nawait agent('CHANGED')\nreturn 1", args=None)
     assert [c.prompt for c in calls2] == ["CHANGED"]
+
+
+@pytest.mark.asyncio
+async def test_resume_reruns_when_max_agent_depth_changes(tmp_path):
+    runtime, _, _, journal = make_runtime(tmp_path, max_agent_depth=1)
+    await runtime.execute(META + "return await agent('one')", args=None)
+
+    runtime2, calls2, _, _ = make_runtime(tmp_path, resume_cache=journal.load_cache(), max_agent_depth=2)
+    await runtime2.execute(META + "return await agent('one')", args=None)
+
+    assert [call.prompt for call in calls2] == ["one"]
+    assert calls2[0].max_agent_depth == 2

--- a/tests/agent/test_base_agent_runtime.py
+++ b/tests/agent/test_base_agent_runtime.py
@@ -2,6 +2,7 @@
 import os
 import uuid
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -9,6 +10,8 @@ from dotenv import load_dotenv
 
 from kolega_code.agent.baseagent import BaseAgent
 from kolega_code.agent.errors import MaxAgentIterationsExceeded
+from kolega_code.agent.orchestration.accounting import WorkflowRunAccounting
+from kolega_code.agent.orchestration.budget import Budget
 from kolega_code.cli.session_store import SessionStore
 from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
 from kolega_code.events import AgentConnectionManager
@@ -113,6 +116,42 @@ class TestBaseAgent:
 
         assert chunks[-1]["complete"] is True
         assert base_agent.history[-1].stop_reason == "end_turn"
+
+    @pytest.mark.asyncio
+    async def test_finalized_usage_is_reported_before_tool_dispatch(self, base_agent: BaseAgent) -> None:
+        tool_call = ToolCall(id="tool_1", name="read_file", input={})
+        message = Message(
+            role="assistant",
+            content=[tool_call],
+            stop_reason="tool_use",
+            tool_calls=[tool_call],
+            usage_metadata={"provider": "anthropic", "output_tokens": 7},
+        )
+        budget = Budget()
+        accounting = WorkflowRunAccounting(budget, agent_cap=1)
+        reservation = accounting.reserve_agent()
+        base_agent._workflow_accounting = accounting
+        base_agent._accounting_reservation = reservation
+        base_agent.system_prompt = Message(role="system", content=[TextBlock(text="sys")])
+        base_agent.tool_collection = MagicMock()
+        base_agent.tool_collection.get_tool_list = MagicMock(return_value=[])
+        base_agent.llm = cast(Any, FakeLLM(token_script=[100], final_message=message))
+
+        async def process_tools(tool_use_blocks: list[ToolCall]) -> list[ToolResult]:
+            assert tool_use_blocks == [tool_call]
+            assert budget.spent() == 7
+            assert reservation.reported_tokens == 7
+            return [ToolResult(tool_use_id="tool_1", name="read_file", content="ok", is_error=False)]
+
+        base_agent.process_tool_calls = process_tools
+        base_agent.should_stop_after_tools = MagicMock(return_value=True)
+        base_agent.log_info = AsyncMock()
+
+        _chunks = [chunk async for chunk in base_agent.process_message_stream("run")]
+
+        assert base_agent.total_tokens_used == 7
+        reservation.report_total(base_agent.total_tokens_used)
+        assert budget.spent() == 7
 
     @pytest.mark.asyncio
     async def test_memory_refresh_failure_keeps_last_prompt_and_continues_turn(self, base_agent):

--- a/tests/agent/test_gigacode_gating.py
+++ b/tests/agent/test_gigacode_gating.py
@@ -11,6 +11,7 @@ from kolega_code.agent.planningagent import PlanningAgent
 from kolega_code.agent.prompt_provider import AgentMode, PromptExtension
 from kolega_code.agent.tool_backend.agent_tool import AgentTool
 from kolega_code.agent.tools import ToolExtension
+from kolega_code.agent.tools import ToolCollection
 from kolega_code.config import AgentConfig
 from kolega_code.events import AgentConnectionManager
 from kolega_code.permissions import PermissionMode
@@ -83,6 +84,53 @@ def test_sub_agent_never_gets_run_workflow(project_path, mock_connection_manager
     agent = _coder(project_path, mock_connection_manager, agent_config, sub_agent=True)
     agent.gigacode_enabled = True
     names = {tool.name for tool in agent.tool_collection.get_tool_list()}
+    assert "run_workflow" not in names
+
+
+def test_default_workflow_coder_is_a_leaf(project_path, mock_connection_manager, agent_config):
+    agent = _coder(project_path, mock_connection_manager, agent_config, sub_agent=True)
+    agent.sub_agent_context = {
+        "workflow_run_id": "run-1",
+        "depth": 1,
+        "max_agent_depth": 1,
+    }
+
+    names = {tool.name for tool in agent.tool_collection.get_tool_list()}
+
+    assert not names.intersection(ToolCollection.agent_dispatch_tools)
+    assert "run_workflow" not in names
+
+
+def test_workflow_coder_at_depth_one_can_use_existing_dispatch_tools_when_max_is_two(
+    project_path, mock_connection_manager, agent_config
+):
+    agent = _coder(project_path, mock_connection_manager, agent_config, sub_agent=True)
+    agent.sub_agent_context = {
+        "workflow_run_id": "run-1",
+        "depth": 1,
+        "max_agent_depth": 2,
+    }
+
+    names = {tool.name for tool in agent.tool_collection.get_tool_list()}
+
+    assert "dispatch_investigation_agent" in names
+    assert "dispatch_browser_agent" in names
+    # The depth policy cannot add capabilities excluded by the CoderAgent itself.
+    assert "dispatch_general_agent" not in names
+    assert "run_workflow" not in names
+
+
+def test_nested_workflow_agent_at_max_depth_is_a_leaf(project_path, mock_connection_manager, agent_config):
+    agent = _coder(project_path, mock_connection_manager, agent_config, sub_agent=True)
+    agent.sub_agent_context = {
+        "workflow_run_id": "run-1",
+        "depth": 2,
+        "max_agent_depth": 2,
+    }
+
+    names = {tool.name for tool in agent.tool_collection.get_tool_list()}
+
+    assert not names.intersection(ToolCollection.agent_dispatch_tools)
     assert "run_workflow" not in names
 
 

--- a/tests/agent/test_gigacode_gating.py
+++ b/tests/agent/test_gigacode_gating.py
@@ -87,7 +87,11 @@ def test_sub_agent_never_gets_run_workflow(project_path, mock_connection_manager
     assert "run_workflow" not in names
 
 
-def test_default_workflow_coder_is_a_leaf(project_path, mock_connection_manager, agent_config):
+def test_default_workflow_coder_is_a_leaf(
+    project_path: str,
+    mock_connection_manager: AgentConnectionManager,
+    agent_config: AgentConfig,
+) -> None:
     agent = _coder(project_path, mock_connection_manager, agent_config, sub_agent=True)
     agent.sub_agent_context = {
         "workflow_run_id": "run-1",
@@ -102,8 +106,10 @@ def test_default_workflow_coder_is_a_leaf(project_path, mock_connection_manager,
 
 
 def test_workflow_coder_at_depth_one_can_use_existing_dispatch_tools_when_max_is_two(
-    project_path, mock_connection_manager, agent_config
-):
+    project_path: str,
+    mock_connection_manager: AgentConnectionManager,
+    agent_config: AgentConfig,
+) -> None:
     agent = _coder(project_path, mock_connection_manager, agent_config, sub_agent=True)
     agent.sub_agent_context = {
         "workflow_run_id": "run-1",
@@ -115,12 +121,17 @@ def test_workflow_coder_at_depth_one_can_use_existing_dispatch_tools_when_max_is
 
     assert "dispatch_investigation_agent" in names
     assert "dispatch_browser_agent" in names
+    assert agent.tool_collection.registry().get("dispatch_investigation_agent").parallel_safe is False
     # The depth policy cannot add capabilities excluded by the CoderAgent itself.
     assert "dispatch_general_agent" not in names
     assert "run_workflow" not in names
 
 
-def test_nested_workflow_agent_at_max_depth_is_a_leaf(project_path, mock_connection_manager, agent_config):
+def test_nested_workflow_agent_at_max_depth_is_a_leaf(
+    project_path: str,
+    mock_connection_manager: AgentConnectionManager,
+    agent_config: AgentConfig,
+) -> None:
     agent = _coder(project_path, mock_connection_manager, agent_config, sub_agent=True)
     agent.sub_agent_context = {
         "workflow_run_id": "run-1",

--- a/tests/agent/test_parallel_tool_calls.py
+++ b/tests/agent/test_parallel_tool_calls.py
@@ -4,6 +4,7 @@ import asyncio
 import os
 import uuid
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
@@ -88,6 +89,8 @@ class ConcurrencyTracker:
 class FakeToolCollection:
     """Test stand-in for ToolCollection: builds a registry from get_tool_list + methods."""
 
+    workflow_context = False
+
     def get_tool_list(self) -> list[SimpleNamespace]:
         raise NotImplementedError
 
@@ -104,13 +107,47 @@ class FakeToolCollection:
                     name=spec.name,
                     definition=ToolDefinition(name=spec.name, description="", parameters=[]),
                     handler=getattr(self, spec.name),
-                    parallel_safe=spec.name in parallel,
+                    parallel_safe=spec.name in parallel
+                    and not (self.workflow_context and spec.name in ToolCollection.agent_dispatch_tools),
                 )
             )
         return registry
 
 
 class TestParallelToolCalls:
+    @pytest.mark.asyncio
+    async def test_workflow_dispatch_batches_run_sequentially(self, base_agent: BaseAgent) -> None:
+        tracker = ConcurrencyTracker()
+
+        class Tools(FakeToolCollection):
+            workflow_context = True
+
+            def get_tool_list(self) -> list[SimpleNamespace]:
+                return [
+                    SimpleNamespace(name="dispatch_general_agent"),
+                    SimpleNamespace(name="read_entire_file"),
+                ]
+
+            async def dispatch_general_agent(self, task: str) -> str:
+                await tracker.run()
+                return task
+
+            async def read_entire_file(self, task: str) -> str:
+                await tracker.run()
+                return task
+
+        base_agent.tool_collection = cast(Any, Tools())
+        blocks = [
+            make_tool_call("dispatch_general_agent", 0),
+            make_tool_call("read_entire_file", 1),
+            make_tool_call("dispatch_general_agent", 2),
+        ]
+
+        results = await base_agent.process_tool_calls(blocks)
+
+        assert len(results) == 3
+        assert tracker.max_active == 1
+
     @pytest.mark.asyncio
     async def test_dispatch_tools_run_concurrently(self, base_agent):
         first_started = asyncio.Event()

--- a/tests/agent/test_prompts.py
+++ b/tests/agent/test_prompts.py
@@ -85,6 +85,15 @@ def test_gigacode_guide_includes_workflow_shape_vocabulary() -> None:
     assert "Synthesis gate" in GIGACODE_AUTHORING_GUIDE
 
 
+def test_gigacode_guide_recommends_leaf_workers_by_default() -> None:
+    assert "max_agent_depth" in GIGACODE_AUTHORING_GUIDE
+    assert "defaults to `1`" in GIGACODE_AUTHORING_GUIDE
+    assert "hard maximum" in GIGACODE_AUTHORING_GUIDE
+    assert "is `2`" in GIGACODE_AUTHORING_GUIDE
+    assert "parallel()" in GIGACODE_AUTHORING_GUIDE
+    assert "pipeline()" in GIGACODE_AUTHORING_GUIDE
+
+
 def test_init_agents_prompt_renders_arguments() -> None:
     rendered = prompts.build_init_agents_prompt("focus on Python packaging")
 

--- a/tests/agent/test_tool_collection_config.py
+++ b/tests/agent/test_tool_collection_config.py
@@ -9,7 +9,7 @@ from kolega_code.agent.baseagent import BaseAgent
 from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
 from kolega_code.events import AgentConnectionManager
 from kolega_code.agent.tool_backend.memory_tool import MemoryTool
-from kolega_code.agent.tools import ToolCollection, ToolDefinition, ToolCollectionConfig
+from kolega_code.agent.tools import ToolCollection, ToolDefinition, ToolCollectionConfig, ToolExtension
 
 
 INTERNAL_TOOL_NAMES = {
@@ -214,6 +214,43 @@ class TestToolCollection:
         # Should include investigation tools
         assert "dispatch_investigation_agent" in tool_names
         assert "dispatch_browser_agent" in tool_names
+
+    async def test_workflow_depth_gate_cannot_be_bypassed_by_dispatch_extension_group(
+        self,
+        project_path: Path,
+        mock_connection_manager: AgentConnectionManager,
+        agent_config: AgentConfig,
+        mock_base_agent: BaseAgent,
+    ) -> None:
+        async def dispatch_host_agent(task: str) -> str:
+            return task
+
+        extension = ToolExtension(
+            name="host-agent-dispatch",
+            tools={"dispatch_host_agent": dispatch_host_agent},
+            tool_groups={"agent_dispatch_tools": ["dispatch_host_agent"]},
+        )
+        config = ToolCollectionConfig(include_agent_dispatch_tools=True)
+        tool_collection = ToolCollection(
+            project_path,
+            "test_workspace",
+            str(uuid.uuid4()),
+            mock_connection_manager,
+            agent_config,
+            mock_base_agent,
+            tool_config=config,
+            tool_extensions=[extension],
+        )
+
+        assert "dispatch_host_agent" in tool_collection.registry()
+
+        setattr(
+            mock_base_agent,
+            "sub_agent_context",
+            {"workflow_run_id": "run-1", "depth": 1, "max_agent_depth": 1},
+        )
+        names_at_limit = set(tool_collection.registry().names())
+        assert not names_at_limit.intersection(ToolCollection.agent_dispatch_tools)
 
     async def test_backward_compatibility_legacy_parameters(
         self,

--- a/tests/agent/test_tool_collection_extensions.py
+++ b/tests/agent/test_tool_collection_extensions.py
@@ -82,6 +82,89 @@ def tool_collection(
 
 @pytest.mark.asyncio
 class TestToolCollection:
+    async def test_dispatch_extension_aliases_are_normalized_and_hidden_in_workflows(
+        self,
+        project_path: Path,
+        mock_connection_manager: AgentConnectionManager,
+        agent_config: AgentConfig,
+        mock_base_agent: BaseAgent,
+    ) -> None:
+        from kolega_code.agent.tools import ToolExtension
+
+        async def dispatch_host_agent(task: str) -> str:
+            return task
+
+        extension = ToolExtension(
+            name="host-dispatch",
+            tools={"dispatch_host_agent": dispatch_host_agent},
+            tool_groups={
+                "investigation_agent_tools": ["dispatch_host_agent"],
+                "agent_dispatch_tools": ["dispatch_host_agent"],
+            },
+        )
+        config = ToolCollectionConfig(include_agent_dispatch_tools=True)
+        collection = ToolCollection(
+            project_path,
+            "test_workspace",
+            str(uuid.uuid4()),
+            mock_connection_manager,
+            agent_config,
+            mock_base_agent,
+            tool_config=config,
+            tool_extensions=[extension],
+        )
+
+        assert collection.investigation_agent_tools is collection.agent_dispatch_tools
+        assert collection.agent_dispatch_tools.count("dispatch_host_agent") == 1
+        assert "dispatch_host_agent" not in ToolCollection.agent_dispatch_tools
+        ordinary_tool = collection.registry().get("dispatch_host_agent")
+        assert ordinary_tool.groups >= {"agent_dispatch_tools", "investigation_agent_tools"}
+        assert ordinary_tool.parallel_safe is True
+
+        setattr(
+            mock_base_agent,
+            "sub_agent_context",
+            {"workflow_run_id": "run", "depth": 1, "max_agent_depth": 2},
+        )
+        assert "dispatch_host_agent" not in collection.registry()
+
+    async def test_legacy_only_dispatch_extension_keeps_ordinary_policy(
+        self,
+        project_path: Path,
+        mock_connection_manager: AgentConnectionManager,
+        agent_config: AgentConfig,
+        mock_base_agent: BaseAgent,
+    ) -> None:
+        from kolega_code.agent.tools import ToolExtension
+
+        async def dispatch_host_agent(task: str) -> str:
+            return task
+
+        extension = ToolExtension(
+            name="legacy-host-dispatch",
+            tools={"dispatch_host_agent": dispatch_host_agent},
+            tool_groups={"investigation_agent_tools": ["dispatch_host_agent"]},
+        )
+        collection = ToolCollection(
+            project_path,
+            "test_workspace",
+            str(uuid.uuid4()),
+            mock_connection_manager,
+            agent_config,
+            mock_base_agent,
+            tool_extensions=[extension],
+        )
+
+        ordinary_tool = collection.registry().get("dispatch_host_agent")
+        assert ordinary_tool.parallel_safe is False
+
+        setattr(
+            mock_base_agent,
+            "sub_agent_context",
+            {"workflow_run_id": "run", "depth": 1, "max_agent_depth": 2},
+        )
+        assert "dispatch_host_agent" not in collection.registry()
+
     async def test_tool_collection_extension_tools(
         self,
         project_path: Path,

--- a/tests/agent/tool_backend/test_agent_tool.py
+++ b/tests/agent/tool_backend/test_agent_tool.py
@@ -239,6 +239,53 @@ class TestAgentTool:
         assert MockAgent.last_instance.init_kwargs["max_iterations"] == 3
         MockAgent.configure_streaming([])
 
+    async def test_nested_dispatch_inherits_workflow_depth_and_grouping(
+        self, agent_tool, mock_connection_manager, mock_caller
+    ):
+        original_import = builtins.__import__
+        mock_caller.sub_agent = True
+        mock_caller.sub_agent_context = {
+            "agent_id": "parent-agent",
+            "workflow_run_id": "workflow-run",
+            "phase": "Verify",
+            "depth": 1,
+            "max_agent_depth": 2,
+        }
+
+        with patch.object(builtins, "__import__") as mock_import:
+            mock_module = MagicMock()
+            mock_module.MockAgent = MockAgent
+
+            def mock_import_func(name, *args, **kwargs):
+                if name == "test.module":
+                    return mock_module
+                return original_import(name, *args, **kwargs)
+
+            mock_import.side_effect = mock_import_func
+            MockAgent.configure_streaming(
+                [{"content": "Done.", "complete": True, "uuid": str(uuid.uuid4()), "type": "response"}]
+            )
+            MockAgent.last_instance = None
+
+            await agent_tool._dispatch_agent(agent_class_import="test.module.MockAgent", task="Nested task")
+
+        assert MockAgent.last_instance is not None
+        context = MockAgent.last_instance.sub_agent_context
+        assert context["workflow_run_id"] == "workflow-run"
+        assert context["phase"] == "Verify"
+        assert context["parent_agent_id"] == "parent-agent"
+        assert context["depth"] == 2
+        assert context["max_agent_depth"] == 2
+
+        start_event = next(
+            call.args[0]
+            for call in mock_connection_manager.broadcast_event.call_args_list
+            if call.args[0].content.get("status") == "GENERATING"
+        )
+        assert start_event.sub_agent_info["depth"] == 2
+        assert start_event.sub_agent_info["workflow_run_id"] == "workflow-run"
+        MockAgent.configure_streaming([])
+
     async def test_dispatch_agent_uses_execution_id_for_sub_agent_conversation(
         self, agent_tool, mock_connection_manager, mock_caller
     ):

--- a/tests/agent/tool_backend/test_agent_tool.py
+++ b/tests/agent/tool_backend/test_agent_tool.py
@@ -1,12 +1,14 @@
 """Tests for the unified AgentTool dispatch mechanism."""
 
 import pytest
-from typing import ClassVar, Optional
+from typing import Any, ClassVar, Optional
 from unittest.mock import AsyncMock, Mock, MagicMock, patch
 import uuid
 import builtins
 
 from kolega_code.agent.tool_backend.agent_tool import AgentTool
+from kolega_code.agent.orchestration.accounting import WorkflowRunAccounting
+from kolega_code.agent.orchestration.budget import Budget
 from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
 
 
@@ -240,8 +242,11 @@ class TestAgentTool:
         MockAgent.configure_streaming([])
 
     async def test_nested_dispatch_inherits_workflow_depth_and_grouping(
-        self, agent_tool, mock_connection_manager, mock_caller
-    ):
+        self,
+        agent_tool: AgentTool,
+        mock_connection_manager: AsyncMock,
+        mock_caller: Mock,
+    ) -> None:
         original_import = builtins.__import__
         mock_caller.sub_agent = True
         mock_caller.sub_agent_context = {
@@ -251,12 +256,16 @@ class TestAgentTool:
             "depth": 1,
             "max_agent_depth": 2,
         }
+        accounting = WorkflowRunAccounting(Budget(), agent_cap=2)
+        parent_reservation = accounting.reserve_agent()
+        mock_caller._workflow_accounting = accounting
+        mock_caller._accounting_reservation = parent_reservation
 
         with patch.object(builtins, "__import__") as mock_import:
             mock_module = MagicMock()
             mock_module.MockAgent = MockAgent
 
-            def mock_import_func(name, *args, **kwargs):
+            def mock_import_func(name: str, *args: Any, **kwargs: Any) -> Any:
                 if name == "test.module":
                     return mock_module
                 return original_import(name, *args, **kwargs)
@@ -276,6 +285,9 @@ class TestAgentTool:
         assert context["parent_agent_id"] == "parent-agent"
         assert context["depth"] == 2
         assert context["max_agent_depth"] == 2
+        assert MockAgent.last_instance._workflow_accounting is accounting
+        assert MockAgent.last_instance._accounting_reservation is not parent_reservation
+        assert accounting.agent_count == 2
 
         start_event = next(
             call.args[0]
@@ -285,6 +297,61 @@ class TestAgentTool:
         assert start_event.sub_agent_info["depth"] == 2
         assert start_event.sub_agent_info["workflow_run_id"] == "workflow-run"
         MockAgent.configure_streaming([])
+
+    async def test_nested_dispatch_rejects_cap_before_import_or_events(
+        self,
+        agent_tool: AgentTool,
+        mock_connection_manager: AsyncMock,
+        mock_caller: Mock,
+    ) -> None:
+        accounting = WorkflowRunAccounting(Budget(), agent_cap=1)
+        accounting.reserve_agent()
+        mock_caller.sub_agent = True
+        mock_caller.sub_agent_context = {
+            "workflow_run_id": "workflow-run",
+            "depth": 1,
+            "max_agent_depth": 2,
+        }
+        mock_caller._workflow_accounting = accounting
+
+        with patch.object(builtins, "__import__") as mock_import:
+            with pytest.raises(Exception, match="lifetime agent cap"):
+                await agent_tool._dispatch_agent(agent_class_import="test.module.MockAgent", task="Nested task")
+
+        mock_import.assert_not_called()
+        assert accounting.agent_count == 1
+        assert not any(
+            call.args[0].content.get("status") == "GENERATING"
+            for call in mock_connection_manager.broadcast_event.call_args_list
+        )
+
+    @pytest.mark.parametrize(
+        "context",
+        [
+            {"workflow_run_id": "run", "depth": True, "max_agent_depth": 2},
+            {"workflow_run_id": "run", "depth": 1, "max_agent_depth": "2"},
+            {"workflow_run_id": "run", "depth": 0, "max_agent_depth": 2},
+            {"workflow_run_id": "run", "depth": 1, "max_agent_depth": 3},
+            {"workflow_run_id": "run", "depth": 2, "max_agent_depth": 2},
+        ],
+    )
+    async def test_nested_dispatch_rejects_invalid_or_over_depth_context_before_import(
+        self,
+        context: dict[str, Any],
+        agent_tool: AgentTool,
+        mock_caller: Mock,
+    ) -> None:
+        accounting = WorkflowRunAccounting(Budget(), agent_cap=3)
+        mock_caller.sub_agent = True
+        mock_caller.sub_agent_context = context
+        mock_caller._workflow_accounting = accounting
+
+        with patch.object(builtins, "__import__") as mock_import:
+            with pytest.raises(RuntimeError, match="workflow"):
+                await agent_tool._dispatch_agent(agent_class_import="test.module.MockAgent", task="Nested task")
+
+        mock_import.assert_not_called()
+        assert accounting.agent_count == 0
 
     async def test_dispatch_agent_uses_execution_id_for_sub_agent_conversation(
         self, agent_tool, mock_connection_manager, mock_caller

--- a/tests/agent/tool_backend/test_workflow_tool.py
+++ b/tests/agent/tool_backend/test_workflow_tool.py
@@ -6,11 +6,13 @@ the real run_workflow code path (state-dir resolution, journal, emit, summary).
 
 import json
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from kolega_code.agent.tool_backend.workflow_tool import WorkflowTool
+from kolega_code.agent.orchestration.accounting import AgentReservation, WorkflowRunAccounting
 from kolega_code.config import AgentConfig, ModelConfig, ModelProvider
 from kolega_code.events import AgentConnectionManager
 
@@ -53,20 +55,22 @@ def workflow_tool(tmp_path, connection_manager, caller, monkeypatch):
     return tool, tmp_path
 
 
-def _stub_dispatch():
+def _stub_dispatch() -> tuple[Any, list[tuple[Any, ...]]]:
     """A dispatch_workflow_agent stub returning (recap, tokens, structured)."""
     calls = []
 
     async def dispatch_workflow_agent(
-        agent_class,
-        task,
+        agent_class: type[Any],
+        task: str,
         *,
-        config=None,
-        schema=None,
-        sub_agent_info_extra=None,
-        artifact_paths=None,
-        artifact_metadata=None,
-    ):
+        workflow_accounting: WorkflowRunAccounting,
+        reservation: AgentReservation,
+        config: Any = None,
+        schema: Any = None,
+        sub_agent_info_extra: Any = None,
+        artifact_paths: Any = None,
+        artifact_metadata: Any = None,
+    ) -> tuple[str, int, Any]:
         calls.append((task, schema, sub_agent_info_extra, artifact_paths, artifact_metadata))
         if artifact_paths:
             artifact_paths["jsonl"].write_text(json.dumps({"role": "assistant", "content": task}) + "\n")
@@ -203,10 +207,21 @@ async def test_readable_transcript_indexes_agent_calls(workflow_tool):
 
 
 @pytest.mark.asyncio
-async def test_failed_agent_call_is_recorded_in_transcript(workflow_tool):
+async def test_failed_agent_call_is_recorded_in_transcript(
+    workflow_tool: tuple[WorkflowTool, Path],
+) -> None:
     tool, state_dir = workflow_tool
 
-    async def failing_dispatch(*args, **kwargs):
+    async def failing_dispatch(
+        agent_class: type[Any],
+        task: str,
+        *,
+        reservation: AgentReservation,
+        **kwargs: Any,
+    ) -> tuple[str, int, Any]:
+        assert agent_class is not None
+        assert task == "boom"
+        reservation.report_total(9)
         raise RuntimeError("agent exploded")
 
     tool._agent_tool.dispatch_workflow_agent = failing_dispatch
@@ -219,6 +234,8 @@ async def test_failed_agent_call_is_recorded_in_transcript(workflow_tool):
     transcript = (Path(state_dir) / "workflows" / run_id / "transcript.md").read_text()
     assert "failed" in transcript
     assert "agent exploded" in transcript
+    assert "- tokens: `9`" in transcript
+    assert json.loads((Path(state_dir) / "workflows" / run_id / "run.json").read_text())["total_tokens"] == 9
 
 
 @pytest.mark.asyncio
@@ -238,7 +255,9 @@ async def test_run_workflow_carries_phase_and_label_to_dispatch(workflow_tool):
 
 
 @pytest.mark.asyncio
-async def test_run_workflow_propagates_explicit_max_agent_depth(workflow_tool):
+async def test_run_workflow_propagates_explicit_max_agent_depth(
+    workflow_tool: tuple[WorkflowTool, Path],
+) -> None:
     tool, _ = workflow_tool
     stub, calls = _stub_dispatch()
     tool._agent_tool.dispatch_workflow_agent = stub
@@ -293,7 +312,9 @@ async def test_per_agent_markdown_and_jsonl_are_written(workflow_tool):
     markdown_text = markdown.read_text()
     assert "artifact task" in markdown_text
     assert "final artifact recap" in markdown_text
+    assert "Tokens: 11" in markdown_text
     assert "artifact answer" in raw.read_text()
+    assert json.loads((Path(state_dir) / "workflows" / run_id / "run.json").read_text())["total_tokens"] == 11
 
 
 @pytest.mark.asyncio

--- a/tests/agent/tool_backend/test_workflow_tool.py
+++ b/tests/agent/tool_backend/test_workflow_tool.py
@@ -114,6 +114,7 @@ async def test_run_workflow_writes_artifacts_and_summary(workflow_tool):
     meta = json.loads((run_dir / "run.json").read_text())
     assert meta["status"] == "completed"
     assert meta["name"] == "demo"
+    assert meta["max_agent_depth"] == 1
     assert meta["artifacts"]["resultPath"] == str(run_dir / "result.md")
     # token total = 3*3 (parallel) + 7 (schema) = 16
     assert meta["total_tokens"] == 16
@@ -142,6 +143,7 @@ async def test_run_workflow_writes_artifacts_and_summary(workflow_tool):
     assert start["name"] == "demo"
     assert start["description"] == "demo workflow"
     assert start["phases"] == [{"title": "Find"}]
+    assert start["max_agent_depth"] == 1
     end = next(e for e in workflow_events if e["message_type"] == "workflow_end")
     assert end["status"] == "completed"
 
@@ -188,6 +190,7 @@ async def test_readable_transcript_indexes_agent_calls(workflow_tool):
     run_dir = Path(state_dir) / "workflows" / run_id
     transcript = (run_dir / "transcript.md").read_text()
     assert "# Workflow transcript: transcript" in transcript
+    assert "Max agent depth: 1" in transcript
     assert "alpha-label" in transcript
     assert "beta-label" in transcript
     assert "Find" in transcript
@@ -230,6 +233,27 @@ async def test_run_workflow_carries_phase_and_label_to_dispatch(workflow_tool):
     assert extra["phase"] == "Build"
     assert extra["label"] == "my-label"
     assert "workflow_run_id" in extra
+    assert extra["depth"] == 1
+    assert extra["max_agent_depth"] == 1
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_propagates_explicit_max_agent_depth(workflow_tool):
+    tool, _ = workflow_tool
+    stub, calls = _stub_dispatch()
+    tool._agent_tool.dispatch_workflow_agent = stub
+
+    script = (
+        'meta = {"name": "nested", "description": "d", "max_agent_depth": 2}\n'
+        'await agent("go", label="coordinator")\n'
+        "return 1\n"
+    )
+    await tool.run_workflow(script=script)
+
+    _task, _schema, extra, _artifact_paths, artifact_metadata = calls[0]
+    assert extra["depth"] == 1
+    assert extra["max_agent_depth"] == 2
+    assert artifact_metadata["max_agent_depth"] == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add workflow-wide `meta["max_agent_depth"]` with a default of `1` and a hard maximum of `2`
- propagate workflow identity and real nesting depth through direct and recursive agent dispatch
- enforce the limit in the model-facing tool registry while preserving ordinary non-workflow delegation and keeping `run_workflow` top-level-only
- include the depth policy in resume cache keys, workflow artifacts, authoring guidance, user docs, and the changelog
- cover metadata validation, cache invalidation, propagation, built-in/extension tool gating, artifacts, and guide wording

## Testing

- `./run_tests.sh tests/agent/orchestration/test_orchestration.py tests/agent/tool_backend/test_workflow_tool.py tests/agent/tool_backend/test_agent_tool.py tests/agent/test_gigacode_gating.py tests/agent/test_tool_collection_config.py tests/agent/test_prompts.py -q` — 83 passed
- `./run_tests.sh` — 2549 passed, 2 skipped, 1 unrelated local failure because bundled-skill manifest validation found ignored `__pycache__/*.pyc` files
- `uv run ruff check .`
- `uv run pyright`
- `cd docs && npm run build`
- `git diff --check`
