### PR TITLE
chore(skills): update bundled skills to v0.2.0

### DIFF
--- a/kolega_code/_bundled_skills/manifest.json
+++ b/kolega_code/_bundled_skills/manifest.json
@@ -10,31 +10,35 @@
     },
     {
       "path": "skills/docx/SKILL.md",
-      "sha256": "d869b9260fbce004f4d005ed28411c1467bc70a0818094be8137b6bd24aaafca"
+      "sha256": "e254a04fcba5443d94ca717288c1610624694c6f0fbc1d7901a904af6dbff84d"
     },
     {
       "path": "skills/docx/references/examples.md",
-      "sha256": "ce766f36cb456666e4966ba58201b18d994e589f896e88699bd413bd56b25046"
+      "sha256": "783ae00cd90109acd9c47538d41675a258b07c28fca9bbfa235b2552e980fbe1"
     },
     {
       "path": "skills/docx/references/limitations.md",
-      "sha256": "54f2571813b4e1ef12bfe76ca688ee2ec27661139d2d7957a932fe862990be98"
+      "sha256": "285d0bdaee53504e63818cf96732fc2bee65dda5af70807863cf741409889ef7"
     },
     {
       "path": "skills/docx/references/operations.md",
-      "sha256": "7d234d99aa77354e5c3b0cce80b697253452488ba6ae1ad121ad084227170789"
+      "sha256": "a0c429c5ce9ae742af21151597445b673aacd44fb268ab708ca2238c849bbd59"
+    },
+    {
+      "path": "skills/docx/references/quality.md",
+      "sha256": "58a1118ff96cdedeb0e4292a870e5a07d97e68bb024b53a96c0bca6a148c3e59"
     },
     {
       "path": "skills/docx/requirements.txt",
-      "sha256": "73d47ee7a49833e483956358d9aab8bdb1eb13fcbe43ec58b256dd419a63c418"
+      "sha256": "7f74b1020539ae33adb3a243bef2e8ca5da993e5968b576653c2947b5c8b40c9"
     },
     {
       "path": "skills/docx/scripts/docx_tool.py",
-      "sha256": "2797778b2d7434a4a5fde19c441939b6bf3e4f714d028ace67851dfd12a9fe52"
+      "sha256": "36038c85860a1f927b8b25ae4e53ca270c49354c13adccf25f20392c8496eaba"
     },
     {
       "path": "skills/docx/scripts/smoke_test.py",
-      "sha256": "af2f7fd09227288a3ccfb09857a8797b68482b294f1fa7f24fc203c63d870862"
+      "sha256": "1cb265f9b129032a09586132a4bfb4924bbd0aefa6dfa6c641576e1e159b3ece"
     },
     {
       "path": "skills/pdf/LICENSE",
@@ -42,43 +46,51 @@
     },
     {
       "path": "skills/pdf/SKILL.md",
-      "sha256": "e00018920e406805cae3b7ba90dc5eb1bb888a8ac57c99155c3f9a1125f4a035"
+      "sha256": "f6e91ead73aa54dce474ab0a0da7730ea791b2c7eb80da5c3a9813074f0198a6"
     },
     {
       "path": "skills/pdf/references/examples.md",
-      "sha256": "edb2340f20bdfe982c6fe7f85dbf0434ea1ee5343ff618f6e0b4face2bebadf3"
+      "sha256": "994b7c5ea5e14d7dd54649c5ba394ec9617f6416315496948e9e1c217486355b"
     },
     {
       "path": "skills/pdf/references/limitations.md",
-      "sha256": "6ce0758f30fa34e98723741cc63631f4766d4191acd0c282962a00234f55cac1"
+      "sha256": "5ef055f536e00747f68776a4eb3421bc21ea2cf79b50677acc7b12f8bd574b90"
     },
     {
       "path": "skills/pdf/references/ocr.md",
-      "sha256": "1d333f699d45497af9ef51f26223a2d02fc175ac48cdb99d80b5325d5e60ebf2"
+      "sha256": "80cff207593ec6d084051333d8e7b38a70f8f1c19f05d4f1135046a3c5c64685"
     },
     {
       "path": "skills/pdf/references/operations.md",
-      "sha256": "9270383770551240e6b42222283734da6f5b5bfe4093a19c9222365cb0e43ccc"
+      "sha256": "d679bf188f131a546711c731e368a9d7047dfd52c1b7d3ac46e7f593cb5c52f8"
+    },
+    {
+      "path": "skills/pdf/references/quality.md",
+      "sha256": "e862113d24540e1a483d242a3786fcacd036177876d11de189ebfdae122d4c8d"
+    },
+    {
+      "path": "skills/pdf/references/redaction.md",
+      "sha256": "c4e92364050e3197c1678b25827e644f8f35fd4fa92de5a644b9a11d607ddad5"
     },
     {
       "path": "skills/pdf/requirements-ocr-paddle.txt",
-      "sha256": "16408356d75582877e60be769e934a9ab26bf4a59b86d6a7a7b1449f72beac65"
+      "sha256": "ef7f565b3e898a776ccaef119f40ae2130ba511b2fec870255c204ba33250de7"
     },
     {
       "path": "skills/pdf/requirements-ocr-surya.txt",
-      "sha256": "5f65ed6d42e5574279198a4f570e4f385e6bd9ed348cd61719a960f0c18dfed9"
+      "sha256": "db287e7843cd45fdc752e18ce18f8eecd7d246504be4141f8434c553cf3007d0"
     },
     {
       "path": "skills/pdf/requirements.txt",
-      "sha256": "5fee90fe08771e06d0ef90076e81e8fa93844f7d286a0a0f742195bca1ac56ab"
+      "sha256": "f77e1972999da050970cb3ea8c82162453f3b948fe12888558bd6047ae173535"
     },
     {
       "path": "skills/pdf/scripts/pdf_tool.py",
-      "sha256": "4aac8648f49313e166f3a5fb2121fffb10ca98da08bda0cffd9677858f5d12d9"
+      "sha256": "0108725a6f517a5dbadf5bcb4c95ed3752284b25c0430083906f39883527bda1"
     },
     {
       "path": "skills/pdf/scripts/smoke_test.py",
-      "sha256": "6e7a1447bec885a9c5be4eac907620197d0931f7ba40e11dbf8c466438a4207d"
+      "sha256": "fa06151c864ff4254a295a4142b6ea1b5e087d88dd7714bff867e05a0ddbf84a"
     },
     {
       "path": "skills/pptx/LICENSE",
@@ -86,19 +98,19 @@
     },
     {
       "path": "skills/pptx/SKILL.md",
-      "sha256": "995d83111847f2b4ebcc57183205ae50b78b072380920aa0b06bf66be20402a8"
+      "sha256": "1e99ec6f4b13edbb3d48876bdec17f37ceda50c6e33e0e3459afd7788cbe3906"
     },
     {
       "path": "skills/pptx/references/examples.md",
-      "sha256": "363faccd4f9a83485ba6df906cf67a9c247e7e89f6df9b2c385dbcc93acddb30"
+      "sha256": "e78c4e23a2b1ad628a3b9b8860fdafc7e5bbcf6645e8a9f812bad77c8b3fa917"
     },
     {
       "path": "skills/pptx/references/limitations.md",
-      "sha256": "8e0cd91f36bed3c771336638678c58f6191b9574a31be85f944e6e661e209b4c"
+      "sha256": "afda2bb5f9483b8e100530e9b5e0680c69e72df2437ba12d4f542e096e40fa0f"
     },
     {
       "path": "skills/pptx/references/operations.md",
-      "sha256": "338f2d72de79bf4eb047fc1be869a5cc485eced4edf5c63ba2f0bac12b8bf66b"
+      "sha256": "4af252aec435ccefeeb74a368bf16206f692915d1a407e862315ec8312dd21ad"
     },
     {
       "path": "skills/pptx/requirements.txt",
@@ -106,11 +118,11 @@
     },
     {
       "path": "skills/pptx/scripts/pptx_tool.py",
-      "sha256": "8b6df02f11d437777c5693e31f38dd79cf49c9016a5e73af3eece35d99900ed5"
+      "sha256": "797010c17f170010d837be9d3541b7bfaa8856a67e34ce41566889b74925cb35"
     },
     {
       "path": "skills/pptx/scripts/smoke_test.py",
-      "sha256": "d9ddeaab515236891a1a7d9215a8502a3ea15226eb6501dab6730cbfdd380164"
+      "sha256": "54ffa99a72c4bdb4effbe6da0ba11920609a28c7d9701fe915e90f6959cc7f2d"
     },
     {
       "path": "skills/review/SKILL.md",
@@ -122,7 +134,7 @@
     },
     {
       "path": "skills/skill-authoring/SKILL.md",
-      "sha256": "a9ace2b51634318cc9125b1aba1e79b5e7f26872eebbcbfe629e5ce8ffcf539b"
+      "sha256": "b98bbeaacb4ec9c11c57644a544e71c27d723eac4d37e0275eae3298f6a627a5"
     },
     {
       "path": "skills/skill-authoring/references/review-checklist.md",
@@ -134,31 +146,35 @@
     },
     {
       "path": "skills/xlsx/SKILL.md",
-      "sha256": "122d8dacb7475ef38cfc3393316d4d47d2f571b464f9fc6fedd0e156374717fb"
+      "sha256": "93e8d26a49261cc2ab6a89dbad9829e3ed5e63340fd1660bdc62f13f2ed57591"
     },
     {
       "path": "skills/xlsx/references/examples.md",
-      "sha256": "44597fd8da012e58a0401acd2a57a82abeed17d4fb40b64e2e701f667afc1d31"
+      "sha256": "e32407221e7c250f85e858cefd64a504c0f15ab04ce2eeb2cc603c8aaf6e6daf"
     },
     {
       "path": "skills/xlsx/references/limitations.md",
-      "sha256": "76e4adbb53981494e95b37c0dfdda684c301cd012bdc91784fa2cd166df6789c"
+      "sha256": "4655f02e823c85235073fc0e5858a25f0343e3a5bc0b03211c087bf5d480c316"
     },
     {
       "path": "skills/xlsx/references/operations.md",
-      "sha256": "8d2c8d849099d4ae07bc0732139119b1e1951f140a05a82090532a9be653080e"
+      "sha256": "fbc270618c8c4f9fb0dc3aca9f84b63f1ba31d2270ddea531f1dc5a55f436f61"
+    },
+    {
+      "path": "skills/xlsx/references/quality.md",
+      "sha256": "3c3d31189a6a1ac256a387e1ba5df1607d763f314e1016d5a37b123774966a2b"
     },
     {
       "path": "skills/xlsx/requirements.txt",
-      "sha256": "1780a489cfe05bf97d33ae71acc612daf5b2ed9fcb0cc22962d2b969315fe7c6"
+      "sha256": "a44a427a5c65fb58bdae6a1c89b320bed1dddf6adacb23d94416ad66b040bb8e"
     },
     {
       "path": "skills/xlsx/scripts/smoke_test.py",
-      "sha256": "da8e3c9a70436eda1c49391b8489dbfc8f7836866588bb220c1aa06bbd757eb0"
+      "sha256": "52c831d46ac9675734396eb2ce2d529ec966bc3a5b2080e0df9d72a14ad36f4d"
     },
     {
       "path": "skills/xlsx/scripts/xlsx_tool.py",
-      "sha256": "85e9de7c83b1db52eccf81624148a4f8fa947aba3cb5673d73e88303dc0b33b1"
+      "sha256": "f883666f17de93163801d4b5fbb4de8a16afd77345be34e165e9ab2ec92593fa"
     }
   ],
   "schema_version": 1,
@@ -171,8 +187,8 @@
     "xlsx"
   ],
   "source": {
-    "commit": "e1ce2110fd7e403dde52920798e71dc6e395bca6",
+    "commit": "fa6aaec9b7fdec1dc10c0a7875ce3981ecd1994e",
     "repository": "https://github.com/kolega-ai/kolega-skills",
-    "tag": "v0.1.0"
+    "tag": "v0.2.0"
   }
 }

--- a/kolega_code/_bundled_skills/skills/docx/SKILL.md
+++ b/kolega_code/_bundled_skills/skills/docx/SKILL.md
@@ -1,80 +1,104 @@
 ---
 name: docx
-description: Create, inspect, edit, extract text from, and convert Microsoft Word DOCX documents while preserving formatting and validating OOXML safely. Use for .docx authoring, reading, structured edits, templates or letterheads, tables, images, headers, footers, fields, DOCX-to-text, and DOCX-to-PDF requests. Do not use for PDF-native, spreadsheet, or presentation work.
+description: Create, inspect, edit, extract text from, convert, and render Microsoft Word DOCX documents while preserving formatting and validating OOXML safely. Use for .docx authoring, reading, structured edits, templates or letterheads, tables, images, headers, footers, fields, DOCX-to-text, DOCX-to-PDF, and page-rendering-for-review requests. Do not use for PDF-native, spreadsheet, or presentation work.
 license: Apache-2.0
-compatibility: Requires Python 3.11+; LibreOffice is optional for DOCX-to-PDF conversion.
+compatibility: Requires Python 3.11+ and the packages declared in requirements.txt. LibreOffice and the optional pypdfium2 package are needed only for PDF conversion and page rendering.
 metadata:
   author: Kolega
-  version: "1.0"
+  version: "1.1"
 ---
 
 # DOCX
 
-Use the bundled deterministic CLI for WordprocessingML work. Treat every source document as
-untrusted and immutable unless the user explicitly authorizes overwrite.
+Use the bundled deterministic CLI. Treat sources as untrusted and immutable unless overwrite
+is explicitly authorized.
+
+## Workspace discipline
+
+Work directly in visible workspace paths. Never create or use `.build` or another hidden
+build/work directory. Write requested deliverables directly to their declared destinations;
+if intermediate files are necessary, keep them in visible, narrowly scoped paths rather than
+staging the task in a hidden subtree.
 
 ## Route the task
 
-- Use this skill for creating, reading, inspecting, editing, or converting `.docx` files.
-- Keep DOCX-to-PDF work here because conversion begins from the DOCX source.
-- Route PDF-native editing or extraction to `pdf`, spreadsheets to `xlsx`, and presentations
-  to `pptx`.
+- Use this skill for DOCX creation, inspection, bounded editing, text extraction,
+  DOCX-to-PDF conversion, and page rendering for visual review. Route PDF-native work to
+  `pdf`, spreadsheets to `xlsx`, and presentations to `pptx`.
+- For creation, read [design intake and templates](references/quality.md#design-intake-and-templates),
+  then the [create contract](references/operations.md#create-schema). Use a supplied or approved
+  template for branded or publication-ready output. Otherwise build a deliberate baseline with
+  `section` and `styles`; do not accept the library defaults as polished design.
+- For existing documents, inspect first using [inspection](references/operations.md#inspect-schema),
+  then use [edit operations](references/operations.md#edit-operations). A placeholder template is content
+  to fill with bounded replacement/insertion, not a blank base to append after.
+- For fields, headers, footers, sections, tables, or images, jump to
+  [content blocks](references/operations.md#content-blocks),
+  [headers and footers](references/operations.md#headers-and-footers), or
+  [edit operations](references/operations.md#edit-operations).
+- For conversion and release, use [conversion](references/operations.md#conversion-contract) and apply the
+  one authoritative [quality contract](references/quality.md#acceptance-criteria) according to the
+  requested [delivery profile](references/quality.md#delivery-profiles).
+- Before advanced or fidelity-sensitive work, read
+  [limitations](references/limitations.md#remaining-limits). Activation preserves formatting
+  best-effort; route signed documents, tracked-change resolution, revision-heavy editing, and
+  fidelity-critical mutation to a native Microsoft Word workflow.
+- Use [examples by task](references/examples.md#example-index) for executable jobs.
 
-## Workflow
+## Core workflow
 
-1. Resolve the skill root and choose any available Python 3.11+ interpreter; do not assume a
-   launcher name. Check the required imports before installing anything. If something is
-   missing, first tell the user what you intend to install, where, and with which installer.
-Use the selected interpreter's `-m pip` for the declared requirements. Use the platform's
-   package manager for Python or optional LibreOffice, preferring Homebrew on macOS when
-   available. A local environment is a fallback, not a prerequisite. See
-   [environment setup](references/operations.md#environment).
-2. Read [the operation contract](references/operations.md) before constructing a job. Read
-   [the examples](references/examples.md) for copy-pasteable invocations.
-3. Inspect an existing document before editing. Review ordered blocks, styles, runs, sections,
-   headers, footers, fields, drawings, comments, revisions, unsupported parts, and warnings.
-4. Prefer named styles and template inheritance over direct formatting. Use the public CLI
-   instead of ad hoc package mutation.
-5. Write to a distinct destination. Use `--overwrite` only after explicit authorization.
-6. Reinspect the output and verify structure, expected text, styles, tables, images, stories,
-   and fields. Optionally render with LibreOffice to review pagination and layout.
-7. Report warnings and preservation uncertainty. Never promise perfect round-trip fidelity.
+1. Resolve the skill root and select Python 3.11+. Follow
+   [environment setup](references/operations.md#environment); never install without first
+   stating what, where, and with which installer.
+2. Capture the design intake and delivery profile. Preflight any template before authoring.
+3. Inspect before editing. Review warnings, ordered blocks, styles, sections, stories, fields,
+   tables, images, fonts, revisions, comments, and unsupported parts.
+4. Prefer template inheritance and named styles over direct formatting. Use only the public
+   CLI schemas in [operations](references/operations.md#invocation-and-envelopes).
+5. Keep edits explicit and bounded. Write to a distinct destination unless overwrite was
+   explicitly authorized.
+6. Reinspect the output and run the profile-dependent checks in
+   [quality](references/quality.md#acceptance-criteria). Resolve every font warning: a
+   `RELEASE BLOCKER` blocks release until the font is replaced, embedded, or the user
+   explicitly accepts the named substitution risk.
+7. **Render and look.** Whenever layout, pagination, print, or PDF matters, run `render`
+   (see [render](references/operations.md#render)), open the produced PNG pages with the
+   Read tool, and examine every changed page plus page 1 for text overflow or truncation,
+   clipped or overlapping content, missing images, broken tables, and header/footer and
+   page-number rendering. Inspect-only PDF metrics are not visual review; never claim visual
+   correctness from JSON output alone. If rendering is unavailable, report "structural
+   checks only; visual QA not performed." Announce before installing the optional
+   `pypdfium2` package.
+8. Report warnings, renderer assumptions, field-refresh status, and preservation uncertainty.
+   Never promise perfect round-trip fidelity.
 
 ## Safety rules
 
-- Do not bypass OOXML preflight, ZIP expansion limits, signature checks, or post-write reopen
-  validation.
-- Never use `sudo pip`, any interpreter under `sudo` to run pip, or pip's
-  `--break-system-packages` option. Do not add these packages to the host project's dependency
-  metadata.
-- Reject macro-enabled, encrypted, malformed, or oversized packages.
-- Reject DOCX external relationships by default. Use the documented explicit opt-in only after
-  review; it permits processing and does not provide network isolation for LibreOffice or
-  another consumer.
-- Keep edits explicit and bounded. Supply expected replacement counts and use the first-run
-  policy only when a cross-run replacement is intentional.
-- Do not flatten text across hyperlinks, fields, drawings, comments, or revisions.
-- Use public `python-docx` APIs for ordinary content. The CLI confines narrow OOXML helpers to
-  field markup, block placement, and image relationship replacement.
-- Remember that page-number and TOC fields are markup only. Pagination and TOC refresh require
-  a layout application.
-- Keep PDF conversion within the generated-PDF byte/page/text-extraction and decompressed-stream
-  bounds. LibreOffice runs with an isolated profile and process group so timeout cleanup
-  reaches ordinary descendants; those lifecycle controls are not a network sandbox.
+- Do not bypass OOXML preflight, ZIP/resource limits, signature checks, external-relationship
+  policy, or post-write reopen validation.
+- Never use `sudo pip`, an interpreter under `sudo` for pip, or `--break-system-packages`;
+  do not add skill dependencies to the host project's dependency metadata.
+- Reject macro-enabled, encrypted, malformed, or oversized packages. Reject external
+  relationships by default; explicit opt-in permits processing but is not a network sandbox.
+- Supply expected replacement counts. Do not flatten text across hyperlinks, fields, drawings,
+  comments, revisions, or unsupported markup.
+- Page, TOC, reference, sequence, and date fields are markup only. A layout application must
+  refresh them; `update_fields_on_open` is a request, not a guarantee.
+- LibreOffice's isolated profile and process-group cleanup are lifecycle controls, not network
+  isolation.
 
 ## Resources
 
-- Read [operations](references/operations.md) for the stable CLI, job schemas, exit statuses,
-  and atomic-write behavior.
-- Read [examples](references/examples.md) when preparing or debugging a job.
-- Read [limitations](references/limitations.md) before promising fidelity or advanced Word
-  features.
-- Run [`scripts/docx_tool.py`](scripts/docx_tool.py) for production operations.
-- Run [`scripts/smoke_test.py`](scripts/smoke_test.py) after installation to verify the active
-  environment. Add `--require-libreoffice` when PDF conversion must be tested.
+- [Operations contract](references/operations.md#operations-contract)
+- [Executable examples](references/examples.md#examples)
+- [Quality contract](references/quality.md#quality-contract)
+- [Remaining limits](references/limitations.md#remaining-limits)
+- Production CLI: [`scripts/docx_tool.py`](scripts/docx_tool.py)
+- Environment smoke test: [`scripts/smoke_test.py`](scripts/smoke_test.py)
 
-## Final verification
-
-Confirm that the source remains unchanged unless overwrite was authorized, the destination
-reopens, requested structures are present, warnings were reviewed, and no temporary files or
-generated fixtures remain in the skill directory.
+Finish by confirming the source was not changed without authorization, the destination
+reopens, requested structures are present, the applicable
+[acceptance criteria](references/quality.md#acceptance-criteria) passed, no unaccepted
+`RELEASE BLOCKER` font warning remains, rendered pages were opened and reviewed (or the
+structural-only disclaimer was reported), and no generated fixtures remain in the skill
+directory.

--- a/kolega_code/_bundled_skills/skills/docx/references/examples.md
+++ b/kolega_code/_bundled_skills/skills/docx/references/examples.md
@@ -1,392 +1,478 @@
 # Examples
 
-## Contents
+All jobs use schema version 1. Paths inside JSON resolve relative to that JSON file.
 
-- [End-to-end create, inspect, edit, and extract](#end-to-end-create-inspect-edit-and-extract)
-- [Representative stdout](#representative-stdout)
+## Example index
+
+- [Setup](#setup)
+- [Polished end-to-end baseline](#polished-end-to-end-baseline)
+- [Approved template creation](#approved-template-creation)
+- [Paragraph pagination and tabs](#paragraph-pagination-and-tabs)
+- [Accessible captioned figure](#accessible-captioned-figure)
+- [Fixed printable table](#fixed-printable-table)
+- [Sections and page numbering](#sections-and-page-numbering)
+- [Update fields on open](#update-fields-on-open)
+- [Edit-time table, image, and style](#edit-time-table-image-and-style)
+- [Inspection and release flow](#inspection-and-release-flow)
+- [Render for visual review](#render-for-visual-review)
 - [Complete job dispatch](#complete-job-dispatch)
-- [Explicit paragraph append](#explicit-paragraph-append)
-- [External-relationship opt-in](#external-relationship-opt-in)
-- [Corrupt input](#corrupt-input)
-- [Optional PDF conversion](#optional-pdf-conversion)
 
-All paths in JSON are relative to the JSON file. Before using these examples, follow
-[environment setup](references/operations.md#environment) to set absolute `SKILL_ROOT` and
-verified `DOCX_PYTHON` values and install any missing requirements. Installation
-guidance is intentionally kept in operations rather than repeated here.
+## Setup
 
-## End-to-end create, inspect, edit, and extract
+```bash
+SKILL_ROOT="/absolute/path/to/skills/docx"
+DOCX_PYTHON="/path/to/python"
+DOCX_TOOL="$SKILL_ROOT/scripts/docx_tool.py"
+WORK="$PWD/docx-work"
+mkdir -p "$WORK"
+```
 
-Create `/tmp/docx-demo/create.json`:
+These examples assume an agreed profile such as: general audience; screen and print brief;
+Letter; target Microsoft Word desktop plus the actual PDF converter; editable-DOCX fidelity
+medium; no brand; accessibility-oriented; TOC omitted because the brief is short; ordinary
+PDF for viewing/print, with no tagged-PDF or PDF/A claim. Font choices below are design
+examples, not portability claims: use a licensed embedded font or ensure every unembedded font
+is installed on every intended renderer.
 
-```json
+## Polished end-to-end baseline
+
+This baseline deliberately defines geometry, styles, metadata, table layout, stories, and
+field-update behavior. It does not rely on default formatting.
+
+```bash
+cat >"$WORK/polished-create.json" <<'JSON'
 {
   "schema_version": 1,
   "content": {
     "metadata": {
-      "title": "Release brief",
-      "author": "Documentation Team"
+      "title": "Service readiness brief",
+      "subject": "Launch readiness",
+      "author": "Operations Team",
+      "language": "en-US",
+      "keywords": "readiness, launch"
     },
-    "blocks": [
+    "section": {
+      "paper_size": "letter",
+      "orientation": "portrait",
+      "top_margin_inches": 0.75,
+      "right_margin_inches": 0.8,
+      "bottom_margin_inches": 0.75,
+      "left_margin_inches": 0.8,
+      "header_distance_inches": 0.3,
+      "footer_distance_inches": 0.3,
+      "different_first_page": true,
+      "page_number_start": 1,
+      "page_number_format": "decimal"
+    },
+    "styles": [
       {
-        "type": "heading",
-        "level": 1,
-        "text": "Release brief"
+        "name": "Normal",
+        "type": "paragraph",
+        "font": "Arial",
+        "size_pt": 10.5,
+        "color": "202124",
+        "paragraph": {
+          "space_after_pt": 6,
+          "line_spacing": 1.15,
+          "widow_control": true
+        }
       },
+      {
+        "name": "Brief Title",
+        "type": "paragraph",
+        "based_on": "Title",
+        "font": "Arial",
+        "size_pt": 24,
+        "bold": true,
+        "color": "17365D",
+        "outline_level": 0,
+        "paragraph": {
+          "space_after_pt": 12,
+          "keep_with_next": true
+        }
+      },
+      {
+        "name": "Brief Heading",
+        "type": "paragraph",
+        "based_on": "Heading 1",
+        "font": "Arial",
+        "size_pt": 15,
+        "bold": true,
+        "color": "17365D",
+        "outline_level": 0,
+        "paragraph": {
+          "space_before_pt": 12,
+          "space_after_pt": 5,
+          "keep_with_next": true,
+          "keep_together": true
+        }
+      }
+    ],
+    "update_fields_on_open": true,
+    "blocks": [
+      {"type": "paragraph", "style": "Brief Title", "text": "Service readiness"},
       {
         "type": "paragraph",
-        "style": "Quote",
-        "runs": [
-          {"text": "Status: ", "bold": true},
-          {"text": "Draft", "italic": true}
-        ]
+        "text": "A concise decision brief for launch owners.",
+        "space_after_pt": 12,
+        "keep_together": true
       },
+      {"type": "paragraph", "style": "Brief Heading", "text": "Decision"},
+      {
+        "type": "paragraph",
+        "text": "Proceed after the two open controls are verified.",
+        "widow_control": true
+      },
+      {"type": "paragraph", "style": "Brief Heading", "text": "Readiness"},
       {
         "type": "table",
         "style": "Table Grid",
         "header_rows": 1,
+        "layout": "fixed",
+        "column_widths_inches": [2.0, 2.2, 2.7],
+        "allow_row_split": false,
+        "row_allow_split": [false, false, false],
         "rows": [
-          ["Owner", "State"],
-          ["Documentation", "Draft"]
+          ["Control", "Owner", "Status"],
+          ["Monitoring", "Platform", "Ready"],
+          ["Rollback", "Release", "Verify"]
         ]
       }
     ],
     "headers": {
+      "first_page": [],
       "default": [
-        {"type": "paragraph", "text": "Internal release brief"}
+        {"type": "paragraph", "text": "Service readiness", "alignment": "right"}
       ]
     },
     "footers": {
       "default": [
-        {"type": "field", "field": "page_number", "prefix": "Page "}
+        {
+          "type": "field",
+          "field": "page_number",
+          "prefix": "Page ",
+          "alignment": "center"
+        }
       ]
     }
   }
 }
+JSON
+
+"$DOCX_PYTHON" "$DOCX_TOOL" create \
+  --spec "$WORK/polished-create.json" --output "$WORK/readiness.docx"
+"$DOCX_PYTHON" "$DOCX_TOOL" inspect \
+  --input "$WORK/readiness.docx" >"$WORK/readiness-inspect.json"
 ```
 
-Create `/tmp/docx-demo/edit.json`:
+For A4, change only the agreed geometry and recheck every table/image against the resulting
+`usable_width_inches`. Add a TOC only if requested or justified by complexity.
 
-```json
-{
-  "schema_version": 1,
-  "operations": [
-    {
-      "type": "replace_text",
-      "find": "Draft",
-      "replace": "Approved",
-      "expected_count": 2,
-      "replace_all": true,
-      "scope": "body"
-    },
-    {
-      "type": "update_table",
-      "table_index": 0,
-      "row": 1,
-      "column": 1,
-      "value": "Approved"
-    },
-    {
-      "type": "set_metadata",
-      "metadata": {
-        "title": "Approved release brief"
-      }
-    }
-  ]
-}
-```
+## Approved template creation
 
-The replacement above intentionally updates both occurrences before the table operation writes
-the same final cell value. This demonstrates count-bounded multi-match replacement. The next
-sequence uses a narrower cross-run match.
-
-A copy-pasteable end-to-end shell sequence with a corrected single text match is:
+Use this only when `approved-template.docx` is a true base document intended to receive
+appended content. Preflight it first:
 
 ```bash
-set -eu
-mkdir -p "/tmp/docx-demo"
-cat >"/tmp/docx-demo/create.json" <<'JSON'
+"$DOCX_PYTHON" "$DOCX_TOOL" inspect \
+  --input "$WORK/approved-template.docx" >"$WORK/template-inspect.json"
+
+cat >"$WORK/template-create.json" <<'JSON'
 {
   "schema_version": 1,
   "content": {
-    "metadata": {"title": "Release brief", "author": "Documentation Team"},
-    "blocks": [
-      {"type": "heading", "level": 1, "text": "Release brief"},
-      {
-        "type": "paragraph",
-        "style": "Quote",
-        "runs": [
-          {"text": "Status: ", "bold": true},
-          {"text": "Draft", "italic": true}
-        ]
-      },
-      {
-        "type": "table",
-        "style": "Table Grid",
-        "header_rows": 1,
-        "rows": [["Owner", "State"], ["Documentation", "Draft"]]
-      }
-    ],
-    "headers": {
-      "default": [{"type": "paragraph", "text": "Internal release brief"}]
+    "template": "approved-template.docx",
+    "metadata": {
+      "title": "Approved-format brief",
+      "author": "Editorial Team",
+      "language": "en-US"
     },
-    "footers": {
-      "default": [{"type": "field", "field": "page_number", "prefix": "Page "}]
-    }
-  }
-}
-JSON
-cat >"/tmp/docx-demo/edit.json" <<'JSON'
-{
-  "schema_version": 1,
-  "operations": [
-    {
-      "type": "replace_text",
-      "find": "Status: Draft",
-      "replace": "Status: Approved",
-      "expected_count": 1,
-      "cross_run_policy": "first_run"
-    },
-    {
-      "type": "update_table",
-      "table_index": 0,
-      "row": 1,
-      "column": 1,
-      "value": "Approved"
-    }
-  ]
-}
-JSON
-"$DOCX_PYTHON" "$SKILL_ROOT/scripts/docx_tool.py" create \
-  --spec "/tmp/docx-demo/create.json" \
-  --output "/tmp/docx-demo/created.docx"
-"$DOCX_PYTHON" "$SKILL_ROOT/scripts/docx_tool.py" inspect \
-  --input "/tmp/docx-demo/created.docx" \
-  >"/tmp/docx-demo/created.inspect.json"
-"$DOCX_PYTHON" "$SKILL_ROOT/scripts/docx_tool.py" edit \
-  --input "/tmp/docx-demo/created.docx" \
-  --spec "/tmp/docx-demo/edit.json" \
-  --output "/tmp/docx-demo/approved.docx"
-"$DOCX_PYTHON" "$SKILL_ROOT/scripts/docx_tool.py" convert \
-  --input "/tmp/docx-demo/approved.docx" \
-  --format text \
-  --output "/tmp/docx-demo/approved.txt"
-"$DOCX_PYTHON" "$SKILL_ROOT/scripts/docx_tool.py" inspect \
-  --input "/tmp/docx-demo/approved.docx" \
-  >"/tmp/docx-demo/approved.inspect.json"
-grep -q '"status": "ok"' "/tmp/docx-demo/approved.inspect.json"
-grep -q 'Status: Approved' "/tmp/docx-demo/approved.txt"
-test -s "/tmp/docx-demo/approved.docx"
-```
-
-Expected artifact assertions:
-
-- `created.docx` and `approved.docx` have ZIP signatures and reopen.
-- `created.docx` remains byte-for-byte unchanged by the edit command.
-- `approved.docx` contains one heading, the `Quote` paragraph, one table, a header, a footer,
-  and a PAGE field.
-- `Status: Approved` uses the first matched run's formatting because the match crossed runs
-  with an explicit `first_run` policy.
-- `approved.txt` contains `Release brief`, `Status: Approved`, and the tab-delimited table.
-- Both inspection summaries report `verification.preflight` and `verification.reopened` as
-  true.
-
-## Representative stdout
-
-Exact counts vary with templates. A successful create emits this shape:
-
-```json
-{
-  "counts": {
-    "footers": 1,
-    "headers": 1,
-    "heading": 1,
-    "metadata": 2,
-    "paragraph": 1,
-    "table": 1
-  },
-  "operation": "create",
-  "paths": {
-    "output": "/tmp/docx-demo/created.docx",
-    "template": null
-  },
-  "preservation": {
-    "perfect_round_trip_guaranteed": false,
-    "uncertainty": [],
-    "unknown_untouched_content": "preserved_best_effort"
-  },
-  "result": {
-    "inline_images": 0,
-    "paragraphs": 2,
-    "sections": 1,
-    "tables": 1
-  },
-  "schema_version": 1,
-  "status": "ok",
-  "verification": {
-    "atomic_publish": true,
-    "preflight": true,
-    "reopened": true
-  },
-  "versions": {
-    "libreoffice": null,
-    "lxml": "6.1.1",
-    "pypdf": "6.14.2",
-    "python": "3.11.x",
-    "python-docx": "1.2.0"
-  },
-  "warnings": [
-    {
-      "code": "fields_present",
-      "count": 1,
-      "message": "Fields require a layout application to update."
-    }
-  ]
-}
-```
-
-The actual envelope also includes package byte/member verification. Warning diagnostics are
-repeated as JSON on stderr.
-
-## Complete job dispatch
-
-Create `/tmp/docx-demo/inspect-job.json`:
-
-```json
-{
-  "schema_version": 1,
-  "operation": "inspect",
-  "input": "approved.docx"
-}
-```
-
-Run:
-
-```bash
-"$DOCX_PYTHON" "$SKILL_ROOT/scripts/docx_tool.py" \
-  --job "/tmp/docx-demo/inspect-job.json"
-```
-
-Create a document with a TOC field:
-
-```json
-{
-  "schema_version": 1,
-  "operation": "create",
-  "output": "toc-document.docx",
-  "content": {
     "blocks": [
-      {"type": "heading", "level": 1, "text": "Contents"},
-      {"type": "field", "field": "toc"},
-      {"type": "heading", "level": 1, "text": "Introduction"},
-      {"type": "paragraph", "text": "Body text."}
+      {"type": "heading", "level": 1, "text": "Summary"},
+      {"type": "paragraph", "text": "Approved content."}
     ]
   }
 }
+JSON
+
+"$DOCX_PYTHON" "$DOCX_TOOL" create \
+  --spec "$WORK/template-create.json" --output "$WORK/approved-output.docx"
 ```
 
-The TOC is field markup with a placeholder. Open the file in a layout application and update
-the field before judging entries or pagination.
+If the template contains `{{TITLE}}`, `{{BODY}}`, or other placeholders, do not use append:
+inspect and run bounded `replace_text` operations with exact `expected_count`, then insert
+larger structures relative to inspected anchors.
 
-## Explicit paragraph append
-
-Paragraph insertion never infers append from a missing index. Use `position: "append"`
-explicitly and omit `paragraph_index`:
+## Paragraph pagination and tabs
 
 ```json
 {
-  "schema_version": 1,
-  "operations": [
-    {
-      "type": "insert_paragraph",
-      "position": "append",
-      "block": {"type": "paragraph", "text": "Appended intentionally."}
-    }
+  "type": "paragraph",
+  "style": "Heading 2",
+  "text": "Operational detail",
+  "space_before_pt": 10,
+  "space_after_pt": 4,
+  "line_spacing": "single",
+  "keep_with_next": true,
+  "keep_together": true,
+  "page_break_before": false,
+  "widow_control": true,
+  "tab_stops": [
+    {"position_inches": 5.5, "alignment": "right", "leader": "dots"}
   ]
 }
 ```
 
-For relative insertion, use `position: "before"` or `"after"` and supply
-`paragraph_index`. The index must exist in the top-level paragraph list before insertion; an
-index equal to the old paragraph count is not an append alias.
+For hanging labels, use `hanging_indent_inches`; do not combine it with
+`first_line_indent_inches`.
 
-## External-relationship opt-in
+## Accessible captioned figure
 
-External relationships are rejected by default. After reviewing and accepting the package,
-an inspect command can opt in explicitly:
-
-```bash
-"$DOCX_PYTHON" "$SKILL_ROOT/scripts/docx_tool.py" inspect \
-  --input "/tmp/docx-demo/reviewed-external.docx" \
-  --allow-external-relationships
-```
-
-The equivalent complete-job property is a JSON Boolean:
+Assuming `trend.png` exists next to the JSON:
 
 ```json
 {
-  "schema_version": 1,
-  "operation": "inspect",
-  "input": "reviewed-external.docx",
-  "allow_external_relationships": true
+  "type": "image",
+  "path": "trend.png",
+  "width_inches": 5.5,
+  "alignment": "center",
+  "alt_text": "Monthly completion rose from 62 percent in January to 91 percent in June.",
+  "title": "Monthly completion trend",
+  "caption": "Figure 1. Monthly completion rate, January–June.",
+  "caption_style": "Caption",
+  "attribution": "Source: Operations dashboard"
 }
 ```
 
-The result includes an `external_relationships_allowed` warning. The opt-in permits
-processing but does not network-isolate LibreOffice or another consumer; those applications
-may access external targets. A string such as `"true"` is rejected as `bad_input`.
+Use `"decorative": true` instead of `alt_text` only when the image conveys no information.
+Inspect effective PPI and displayed width after creation.
 
-## Corrupt input
+## Fixed printable table
 
-```bash
-printf 'not OOXML' >"/tmp/docx-demo/corrupt.docx"
-set +e
-"$DOCX_PYTHON" "$SKILL_ROOT/scripts/docx_tool.py" inspect \
-  --input "/tmp/docx-demo/corrupt.docx"
-status=$?
-set -e
-test "$status" -eq 2
-```
-
-Stderr:
+For a 7.0-inch usable width, these columns sum to exactly 7.0:
 
 ```json
-{"error":{"category":"bad_input","details":{"path":"/tmp/docx-demo/corrupt.docx"},"message":"Input does not have a ZIP/OOXML signature."},"schema_version":1,"status":"error"}
+{
+  "type": "table",
+  "style": "Table Grid",
+  "header_rows": 1,
+  "layout": "fixed",
+  "column_widths_inches": [1.6, 3.5, 1.9],
+  "allow_row_split": true,
+  "row_allow_split": [false, true, true],
+  "rows": [
+    ["ID", "Finding", "Status"],
+    ["A-01", "Long finding that may need to split if it grows beyond one page.", "Open"],
+    ["A-02", "Short finding.", "Closed"]
+  ]
+}
 ```
 
-No result is written to stdout. Encrypted, macro-enabled, malformed, path-unsafe, and
-oversized packages likewise fail before `python-docx` opens them; category/status can differ
-according to [the exit table](references/operations.md#exit-statuses).
+Use fixed widths when predictable print layout matters. Reinspect because renderer layout may
+still differ from preferred-width markup.
 
-## Optional PDF conversion
+## Sections and page numbering
 
-LibreOffice is optional and needed only for DOCX-to-PDF conversion. Check whether `soffice`
-is already available:
+```json
+[
+  {
+    "type": "section_break",
+    "start": "new_page",
+    "paper_size": "letter",
+    "orientation": "landscape",
+    "top_margin_inches": 0.6,
+    "right_margin_inches": 0.6,
+    "bottom_margin_inches": 0.6,
+    "left_margin_inches": 0.6,
+    "page_number_start": 1,
+    "page_number_format": "upperRoman"
+  },
+  {"type": "heading", "level": 1, "text": "Landscape appendix"}
+]
+```
+
+Equivalent edit-time section configuration:
+
+```json
+{
+  "type": "configure_section",
+  "section_index": 1,
+  "orientation": "landscape",
+  "page_number_start": 1,
+  "page_number_format": "decimal",
+  "different_first_page": false
+}
+```
+
+Pair numbering markup with a footer field and inspect/render the intended restart.
+
+## Update fields on open
+
+Create-level:
+
+```json
+{
+  "update_fields_on_open": true,
+  "blocks": [
+    {"type": "field", "field": "toc"},
+    {"type": "field", "field": "num_pages", "prefix": "Total pages: "}
+  ]
+}
+```
+
+Edit-time:
+
+```json
+{"type": "set_update_fields_on_open", "enabled": true}
+```
+
+This setting is not a refresh guarantee. Open in the target layout application, update fields,
+save, then inspect the visible results. Omit the TOC for short/simple documents unless asked.
+
+## Edit-time table, image, and style
+
+Assuming `trend.png` exists and inspection confirms paragraph 2:
 
 ```bash
-command -v soffice
-soffice --version
+cat >"$WORK/edit-structures.json" <<'JSON'
+{
+  "schema_version": 1,
+  "operations": [
+    {
+      "type": "upsert_style",
+      "style": {
+        "name": "Callout",
+        "type": "paragraph",
+        "based_on": "Normal",
+        "font": "Arial",
+        "size_pt": 10,
+        "bold": true,
+        "color": "17365D",
+        "paragraph": {
+          "space_before_pt": 6,
+          "space_after_pt": 6,
+          "keep_together": true
+        }
+      }
+    },
+    {
+      "type": "insert_paragraph",
+      "paragraph_index": 2,
+      "position": "after",
+      "block": {"type": "paragraph", "style": "Callout", "text": "Review required."}
+    },
+    {
+      "type": "insert_table",
+      "paragraph_index": 2,
+      "position": "after",
+      "table": {
+        "type": "table",
+        "style": "Table Grid",
+        "header_rows": 1,
+        "layout": "fixed",
+        "column_widths_inches": [2.0, 4.9],
+        "row_allow_split": [false, false],
+        "rows": [["Owner", "Action"], ["Platform", "Verify monitoring"]]
+      }
+    },
+    {
+      "type": "insert_image",
+      "path": "trend.png",
+      "width_inches": 4.5,
+      "alt_text": "Completion trend rising from January through June.",
+      "title": "Completion trend"
+    },
+    {
+      "type": "update_table",
+      "table_index": 0,
+      "row": 1,
+      "column": 1,
+      "value": {
+        "text": "Verify monitoring and rollback",
+        "keep_together": true
+      },
+      "header_rows": 1,
+      "layout": "fixed",
+      "column_widths_inches": [2.0, 4.9],
+      "row_allow_split": [false, false]
+    }
+  ]
+}
+JSON
+
+"$DOCX_PYTHON" "$DOCX_TOOL" edit \
+  --input "$WORK/readiness.docx" --spec "$WORK/edit-structures.json" \
+  --output "$WORK/readiness-edited.docx"
 ```
 
-If it is absent and PDF conversion is required, follow the consent-first, platform-neutral
-installation guidance in [operations](references/operations.md#environment). After
-`soffice --version` succeeds:
+Operations are sequential: inserting a paragraph changes later paragraph indices, but does not
+change table index 0 in this example. Inspect the source and plan indices before dispatch.
+
+## Inspection and release flow
 
 ```bash
-"$DOCX_PYTHON" "$SKILL_ROOT/scripts/docx_tool.py" convert \
-  --input "/tmp/docx-demo/approved.docx" \
-  --format pdf \
-  --output "/tmp/docx-demo/approved.pdf" \
-  --timeout 90
+"$DOCX_PYTHON" "$DOCX_TOOL" inspect \
+  --input "$WORK/readiness-edited.docx" >"$WORK/final-inspect.json"
+
+"$DOCX_PYTHON" - "$WORK/final-inspect.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1], encoding="utf-8"))
+r = d["result"]
+print("warnings:", [w["code"] for w in d["warnings"]])
+print("sections:", r["sections"])
+print("tables:", [
+    (t["index"], t["section_index"], t["column_widths_inches"],
+     t["row_allows_split"], t["header_rows"]) for t in r["tables"]
+])
+print("images:", r["images"]["inline_occurrences"])
+print("fields:", r["fields"])
+print("fonts:", r["fonts"])
+print("settings:", r["settings"])
+PY
+
+"$DOCX_PYTHON" "$DOCX_TOOL" convert \
+  --input "$WORK/readiness-edited.docx" --format pdf \
+  --output "$WORK/readiness-edited.pdf" --timeout 90
 ```
 
-Assert the signature and reopen through the smoke test:
+Then apply [the requested delivery profile](references/quality.md#delivery-profiles). Review all DOCX
+warnings, refresh fields in the target application, and render and review every page as shown
+in [render for visual review](#render-for-visual-review). The PDF's `content_quality_report`
+can flag structural anomalies; it is not visual QA. If visual review or a target renderer is
+unavailable, disclose that instead of claiming print, accessibility, archive, or
+cross-renderer fidelity.
+
+## Render for visual review
 
 ```bash
-"$DOCX_PYTHON" "$SKILL_ROOT/scripts/smoke_test.py" --require-libreoffice
+"$DOCX_PYTHON" "$DOCX_TOOL" render \
+  --input "$WORK/readiness-edited.docx" \
+  --output "$WORK/readiness-pages" --dpi 150 --timeout 90
+ls "$WORK/readiness-pages"
 ```
 
-PDF conversion is layout-engine dependent. The tool rejects generated PDFs over 64 MiB or
-1,000 pages and limits text validation to the first 50 pages and 1,000,000 characters.
-Validate content anchors within those bounds and visually render the actual document; bounded
-structural validation does not prove layout correctness.
+The destination directory must not already exist; rerunning the command against the same
+path exits 9 (`output_conflict`), so render into a fresh directory per revision. Open each
+published `page-NNN.png` with the Read tool and review it against the
+[Visual QA acceptance row](references/quality.md#acceptance-criteria). Render a subset while
+iterating with `--pages 1,3`; page numbers are 1-based positions in the converted PDF, and a
+number past the last page fails with the real `pdf_pages` count in the error details.
+
+## Complete job dispatch
+
+```bash
+cat >"$WORK/inspect-job.json" <<'JSON'
+{
+  "schema_version": 1,
+  "operation": "inspect",
+  "input": "readiness-edited.docx",
+  "allow_external_relationships": false
+}
+JSON
+
+"$DOCX_PYTHON" "$DOCX_TOOL" --job "$WORK/inspect-job.json"
+```
+
+Complete create/edit/convert jobs add the same fields shown in
+[invocation and envelopes](references/operations.md#invocation-and-envelopes), including `output`,
+`overwrite`, and operation-specific `content`, `operations`, `format`, or `timeout`.

--- a/kolega_code/_bundled_skills/skills/docx/references/limitations.md
+++ b/kolega_code/_bundled_skills/skills/docx/references/limitations.md
@@ -1,106 +1,100 @@
-# Limitations
+# Remaining limits
 
 ## Contents
 
-- [Round-trip fidelity](#round-trip-fidelity)
-- [Revisions and comments](#revisions-and-comments)
-- [Drawings and media](#drawings-and-media)
+- [Fidelity and styles](#fidelity-and-styles)
+- [Stories and replacement](#stories-and-replacement)
+- [Images and drawings](#images-and-drawings)
 - [Fields and layout](#fields-and-layout)
-- [Conversion](#conversion)
-- [Security boundaries](#security-boundaries)
+- [Revisions, signatures, and protected workflows](#revisions-signatures-and-protected-workflows)
+- [PDF and conformance](#pdf-and-conformance)
+- [Security boundary](#security-boundary)
 
-## Round-trip fidelity
+## Fidelity and styles
 
-The tool preserves unknown untouched content best-effort where `python-docx` retains package
-parts and relationships. It does not promise lossless arbitrary OOXML editing or perfect
-round trips. Unsupported parts are inventoried when recognizable, but an empty warning list
-is not proof that every producer-specific extension is understood.
+`python-docx` preserves unknown untouched package content only best-effort. Opening and saving
+can normalize OOXML, relationships, compatibility markup, numbering, drawings, fields, themes,
+or application-specific extensions. Inspect warnings before and after mutation and never
+promise byte-identical or perfect round-trip fidelity.
 
-Direct edits can change serialization, relationship ordering, generated identifiers, or
-application metadata. Reinspect the output and compare rendered pages when fidelity matters.
+Style inspection reports direct paragraph/character style definitions and `based_on`; it does
+not compute the fully inherited/effective property cascade from document defaults, themes,
+linked styles, table styles, or direct formatting. A renderer is required to confirm actual
+typography and pagination. For fidelity-critical edits, use native Microsoft Word automation
+or a reviewed manual Word workflow.
 
-Digital signatures are not preserved. Any package mutation invalidates a signature even if
-signature parts remain. Do not use this tool where signature preservation is required.
+## Stories and replacement
 
-## Revisions and comments
+Body, table-cell, header, and footer paragraphs can be inspected. `replace_text` can search
+body/header/footer scopes, but story-address image replacement is body-only:
+`word/document.xml#inline-N`. Header/footer inline images cannot be replaced by story address.
 
-Tracked changes are detected and reported, not interpreted as accepted/rejected text. The
-tool does not create, accept, reject, or safely edit revisions. Replacement refuses matches
-that occupy or cross revision markup.
+Replacement is paragraph-local and rejects protected boundaries. It does not cross paragraphs
+or safely normalize hyperlinks, fields, drawings, comments, revisions, or unsupported markup.
+Insert/delete paragraph and table indices address top-level body content only.
 
-Comment parts and ranges are detected, but complete comment workflows are unsupported. The
-tool does not create, reply to, resolve, or reliably renumber comments. Replacement refuses
-matches that occupy or cross comment ranges.
+## Images and drawings
 
-## Drawings and media
+The tool creates and replaces inline images only. It does not create, reposition, or replace
+floating/anchored drawings, text boxes, SmartArt, charts, equations, OLE objects, or other
+embedded objects. Existing unsupported drawings are preservation-sensitive.
 
-Creation and insertion support inline raster images. Body inline-image replacement changes
-the selected image relationship and can adjust its extent.
-
-The following are not fully supported:
-
-- Floating-image insertion or replacement.
-- Text wrapping, anchors, positioning, crop, rotation, artistic effects, or grouped shapes.
-- Charts, diagrams, SmartArt, ink, OLE objects, ActiveX, and embedded packages.
-- Image replacement inside headers, footers, text boxes, comments, footnotes, or endnotes.
-- Universal preservation of producer-specific drawing extensions.
-
-Image replacement can leave an unused old media part in the package. This favors preserving
-relationships over package compaction.
+Image alt text, title, decorative state, display dimensions, pixels, and effective PPI are
+reported for supported inline occurrences. This does not prove reading order, crop behavior,
+contrast, semantic quality, or renderer presentation.
 
 ## Fields and layout
 
-The tool inserts PAGE and TOC field markup with placeholder result text. It does not run a
-pagination engine.
+PAGE, NUMPAGES, SECTIONPAGES, TOC, SEQ, REF, and DATE operations write field markup and
+placeholder results. `update_fields_on_open` asks a consumer to update fields, but Word,
+LibreOffice, policy settings, locked fields, protected view, or automation mode may ignore it.
+There is no guaranteed field refresh, pagination engine, TOC generation, or reference
+resolution in the CLI.
 
-- Saving a PAGE field does not prove its page number.
-- Saving a TOC field does not refresh entries, page numbers, links, or formatting.
-- Automatic TOC refresh is unsupported.
-- Update fields in a layout application, then inspect rendered output.
+Inspect field instructions/results after opening, refreshing, and saving in the target layout
+application. Do not derive editable-DOCX pagination claims from a PDF rendered elsewhere.
 
-The inspector reports field markup but does not evaluate arbitrary field instructions.
-Section, header, footer, widow/orphan, keep-with-next, font substitution, line-breaking, and
-printer-metric interactions can only be judged after layout.
+## Revisions, signatures, and protected workflows
 
-## Conversion
+Tracked revisions and comments are detected but not interpreted. The tool does not accept,
+reject, resolve, author, or safely rewrite tracked changes. Route revision-heavy documents and
+tracked-change resolution to native Word.
 
-Plain-text conversion represents main-body paragraphs and tables, then non-empty
-header/footer stories and their tables. Inherited stories are deduplicated by package-part
-identity, not displayed text; distinct same-text stories and header/footer roles remain
-distinct. It does not reproduce page layout, columns, text boxes, floating drawings, footnote
-placement, revision semantics, or every field result.
+Do not mutate digitally signed documents. Any package mutation can invalidate signatures; the
+tool does not preserve, verify, or re-sign them. It also does not provide full workflows for
+content controls, forms, document protection, rights management, mail merge, or macros.
 
-DOCX-to-PDF is best-effort and requires an external LibreOffice `soffice` executable.
-LibreOffice output can differ from Microsoft Word because of fonts, layout algorithms,
-platform metrics, fields, external links, and unsupported features. Validation rejects PDFs
-over 64 MiB or 1,000 pages, checks text on at most the first 50 pages, and rejects more than
-1,000,000 extracted validation characters. Signature, reopen, bounded extraction, and
-nonzero-page checks do not prove visual correctness or inspect pages beyond the extraction
-limit.
+## PDF and conformance
 
-If LibreOffice is unavailable, PDF conversion returns `missing_dependency`. The default smoke
-test still validates all core Python workflows and reports the PDF check as skipped.
+LibreOffice conversion is best-effort and may differ from Microsoft Word in font substitution,
+line/table wrapping, page breaks, fields, drawing placement, and TOC references.
 
-## Security boundaries
+`render` output inherits every conversion caveat: the PNG pages show LibreOffice's
+interpretation of the document with unrefreshed fields, not Microsoft Word's layout. Rendered
+pages are a review aid, never a deliverable, and are bounded by the pixel and page budgets in
+[render](references/operations.md#render). Rendering additionally requires the optional
+`pypdfium2` package; without it, only structural checks are available and that must be
+disclosed.
 
-Preflight rejects macros, encrypted packages, unsafe ZIP paths, malformed XML, DTD/entity
-declarations, configured size/member excesses, and DOCX external relationships by default.
-The explicit `--allow-external-relationships` flag or Boolean job opt-in permits processing
-after review.
+`verification.content_quality_report` uses pypdf extraction, page boxes, and limited XObject
+detection. Its text anchors, low-text/nearly-blank flags, and page dimensions are structural
+metrics—not raster rendering or visual QA. They cannot detect clipping, overlap, hierarchy,
+contrast, bad wrapping, or whether a page is visually correct.
 
-These controls reduce common OOXML parser and archive risks but are not a malware scanner,
-data-loss-prevention system, network sandbox, or content trust decision. Secure direct XML
-parsing does not imply that LibreOffice is network-isolated. When external relationships are
-allowed, LibreOffice or another consuming application may access external targets.
-User-supplied templates and images remain the user's responsibility.
+The CLI neither creates nor validates tagged PDF, PDF/UA, or PDF/A. Accessibility-oriented and
+archive-oriented delivery profiles are honest check sets, not conformance claims. Use separate
+specialist tooling and the relevant standard's validator before making such claims.
 
-The standard `customXml` part set emitted by a fresh bundled `python-docx` template is not
-warned about. Additional or differently shaped `customXml` parts remain fidelity-sensitive
-and are reported as unsupported.
+## Security boundary
 
-The CLI redacts credential-shaped diagnostics but cannot determine whether ordinary document
-text is confidential. Store outputs and temporary environments according to the document's
-data classification.
+Preflight rejects macros, encrypted or malformed packages, unsafe ZIP members, DTD/entities,
+oversized resources, and external relationships by default. Allowing external relationships
+permits processing; it is not a network sandbox. XML parser network settings do not prevent
+LibreOffice or another consumer from following external targets.
 
-Read [the operation contract](references/operations.md) for exact safety bounds and
-[examples](references/examples.md) for validation patterns.
+LibreOffice's temporary profile/home and process group bound configuration and cleanup. They
+do not provide OS-level network, filesystem, or process isolation. Treat all source documents
+as untrusted and use stronger sandboxing when the threat model requires it.
+
+For supported syntax see [operations](references/operations.md#operations-contract); for release
+acceptance use the single [quality contract](references/quality.md#acceptance-criteria).

--- a/kolega_code/_bundled_skills/skills/docx/references/operations.md
+++ b/kolega_code/_bundled_skills/skills/docx/references/operations.md
@@ -3,526 +3,375 @@
 ## Contents
 
 - [Environment](#environment)
-- [Invocation forms](#invocation-forms)
-- [JSON and output envelopes](#json-and-output-envelopes)
-- [Inspect](#inspect)
-- [Create](#create)
-- [Edit](#edit)
-- [Convert](#convert)
+- [Invocation and envelopes](#invocation-and-envelopes)
+- [Inspect schema](#inspect-schema)
+- [Create schema](#create-schema)
+- [Edit operations](#edit-operations)
+- [Conversion contract](#conversion-contract)
+- [Render](#render)
 - [Content blocks](#content-blocks)
+- [Sections and styles](#sections-and-styles)
 - [Headers and footers](#headers-and-footers)
-- [Replacement policy](#replacement-policy)
-- [Safety and atomicity](#safety-and-atomicity)
-- [Exit statuses](#exit-statuses)
+- [Warnings](#warnings)
+- [Safety, atomicity, and exits](#safety-atomicity-and-exits)
 
 ## Environment
 
-Resolve the skill root and select any available Python 3.11+ interpreter. Do not assume a
-launcher name. The examples use `DOCX_PYTHON` for the selected interpreter:
+Resolve the skill root and select any Python 3.11+ interpreter; examples use:
 
 ```bash
 SKILL_ROOT="/absolute/path/to/skills/docx"
-DOCX_PYTHON="/path/to/selected/python"
-test -f "$SKILL_ROOT/requirements.txt"
-"$DOCX_PYTHON" -c 'import sys; print(sys.version); raise SystemExit(0 if sys.version_info >= (3, 11) else "Python 3.11+ is required")'
+DOCX_PYTHON="/path/to/python"
+"$DOCX_PYTHON" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3,11) else "Python 3.11+ required")'
+"$DOCX_PYTHON" -c 'import docx,lxml,pypdf'
 ```
 
-Check the required imports. Before installing anything, tell the user what is missing, what
-will be installed, the target scope, and the installer. Use the selected interpreter's
-`-m pip` with the requirements file:
+Before installing a missing dependency, tell the user what will be installed, where, and by
+which installer. Then use `"$DOCX_PYTHON" -m pip install -r
+"$SKILL_ROOT/requirements.txt"`. Never use privileged pip, `--break-system-packages`, or host
+project dependency metadata. LibreOffice/`soffice` is optional and required only for PDF
+conversion and page rendering; install it through the normal platform package manager only
+after notice. The optional `pypdfium2` package is required only for `render`.
 
-```bash
-"$DOCX_PYTHON" -m pip install -r "$SKILL_ROOT/requirements.txt"
-```
+LibreOffice discovery order: the `DOCX_SOFFICE` environment variable (must point to an
+executable; a bad value fails rather than falling through), then `soffice`/`libreoffice` on
+PATH, then the standard macOS app-bundle locations under `/Applications` and
+`~/Applications`.
 
-Prefer the active or user interpreter. If platform policy blocks those scopes, explain the
-fallback before using a local environment. Use the normal platform package manager for a
-missing interpreter or system application; prefer Homebrew on macOS when available. Never
-use privileged pip or `--break-system-packages`, and do not edit host-project dependency
-metadata.
-
-Run `"$SKILL_ROOT/scripts/docx_tool.py"` with the same verified `DOCX_PYTHON`. LibreOffice is
-optional and needed only for PDF conversion. Install it only when required, after the same
-user notice, using the platform's normal package manager.
-
-## Invocation forms
-
-Use one direct subcommand:
+## Invocation and envelopes
 
 ```text
 docx_tool.py inspect --input SOURCE.docx [--allow-external-relationships]
 docx_tool.py create --spec CREATE.json --output DEST.docx [--template BASE.docx] [--allow-external-relationships] [--overwrite]
 docx_tool.py edit --input SOURCE.docx --spec EDIT.json --output DEST.docx [--allow-external-relationships] [--overwrite]
 docx_tool.py convert --input SOURCE.docx --format text|pdf --output DEST [--timeout 90] [--allow-external-relationships] [--overwrite]
-```
-
-Or dispatch one complete job:
-
-```text
+docx_tool.py render --input SOURCE.docx --output DEST_DIR [--dpi 150] [--pages 1,3] [--timeout 90] [--allow-external-relationships]
 docx_tool.py --job JOB.json
 ```
 
-Do not combine `--job` with a subcommand. Paths inside JSON are resolved relative to the JSON
-file. Flag paths are resolved relative to the current directory.
+Do not combine `--job` with a subcommand. JSON-relative paths resolve from the JSON file;
+flag paths resolve from the current directory. Every input has `"schema_version": 1`.
+Operational schemas are strict: unknown keys, wrong JSON types, and unknown operation/block
+types are `bad_input`. Booleans are JSON Booleans; text is never coerced.
 
-## JSON and output envelopes
+Direct create accepts only `schema_version` and `content`. Direct edit accepts only
+`schema_version` and `operations`. A job adds `operation` plus operation-specific paths and
+options. Common job options are `overwrite` and `allow_external_relationships`, both Boolean.
 
-Every JSON input is an object containing exactly this supported version marker:
+Success emits one JSON object on stdout with `schema_version`, `status`, `operation`, `counts`,
+`warnings`, `versions`, `paths`, `verification`, `preservation`, and `result`. Warnings are
+also emitted as JSON lines on stderr. Failure leaves stdout empty and emits
+`{"schema_version":1,"status":"error","error":{"category":...,"message":...,"details":...}}`.
 
-```json
-{"schema_version": 1}
-```
-
-Every object uses a strict operational schema. Unknown top-level, content, block, run,
-header/footer, metadata, job, and edit-operation properties fail as `bad_input`. Unknown
-operation and block types also fail as `bad_input`; values are not stringified or otherwise
-coerced to make invalid JSON fit.
-
-Boolean properties such as `overwrite`, `replace_all`, `ordered`, and run-format flags must
-be JSON `true` or `false`; strings and numbers are rejected. Text-bearing properties must be
-JSON strings. A paragraph-like object may contain `text` or `runs`, but not both.
-
-Success writes one JSON object to stdout:
-
-```json
-{
-  "schema_version": 1,
-  "status": "ok",
-  "operation": "inspect",
-  "counts": {},
-  "warnings": [],
-  "versions": {},
-  "paths": {},
-  "verification": {},
-  "preservation": {},
-  "result": {}
-}
-```
-
-Warnings are repeated as one-line JSON diagnostics on stderr. Failures write a JSON error to
-stderr and leave stdout empty:
-
-```json
-{
-  "schema_version": 1,
-  "status": "error",
-  "error": {
-    "category": "bad_input",
-    "message": "DOCX input does not exist.",
-    "details": {}
-  }
-}
-```
-
-Do not parse human prose from either channel. Treat the named keys and exit statuses below as
-the stable schema-version 1 contract. Additional result fields may be added compatibly.
-
-## Inspect
-
-Direct form:
+## Inspect schema
 
 ```bash
-"$DOCX_PYTHON" "$SKILL_ROOT/scripts/docx_tool.py" inspect --input "report.docx"
+"$DOCX_PYTHON" "$SKILL_ROOT/scripts/docx_tool.py" inspect --input report.docx
 ```
 
-Job form:
+`result` contains:
 
-```json
-{
-  "schema_version": 1,
-  "operation": "inspect",
-  "input": "report.docx",
-  "allow_external_relationships": false
-}
-```
+- `ordered_blocks`: body paragraphs/tables with `block_index`, `type`, and nested `value`;
+  plus top-level `paragraphs` and `tables`.
+- Paragraph records: `index`, `text`, `style`, `heading_level`, list data, `alignment`, runs,
+  and `layout`. Layout reports spacing, line spacing/rule, left/right/first-line indents,
+  pagination flags, and tab stops. A hanging indent is reported as a negative
+  `first_line_indent_inches`.
+- Table records: `index`, `section_index`, style, effective `layout`,
+  `column_widths_inches`, `row_allows_split`, `header_rows`, dimensions, and nested cell
+  paragraphs.
+- `sections`: start type, orientation, dimensions, detected `paper_size`, usable width,
+  margins/distances, first-page setting, and page-number start/format.
+- `headers`/`footers`: every section and `default`, `first_page`, `even_page` story with part,
+  `linked_to_previous`, paragraphs, and tables.
+- `metadata`: supported core properties; `styles`: paragraph/character style definitions;
+  `settings`: `odd_and_even_pages` and `update_fields_on_open`.
+- `fields`: simple and nested complex fields across body/header/footer XML, each with
+  `story_address`, inferred `type`, full `instruction`, `dirty`, `locked`, and visible
+  `result`. Nested complex-field result text is associated with each active containing field.
+- `images.media_parts` and `images.inline_occurrences`: package identity, story/section,
+  dimensions, pixels, effective X/Y PPI, upscaling, alt text, title, and decorative state.
+- `fonts`: `referenced`, `embedded`, `unembedded`, per-part `references`,
+  `theme_tokens_referenced`, and `dangling_embedding_relationships`.
+- feature counts, unsupported parts, and package member/expanded-byte counts.
 
-Inspection reports:
+Inspection is direct, not computed layout. Style records expose direct definition values,
+`based_on`, font values, outline level, and limited paragraph values; they do not resolve the
+fully inherited/effective cascade. A successful inspect proves preflight and reopen, not
+visual fidelity.
 
-- Main-body paragraphs and tables in order.
-- Named paragraph, run, and table styles.
-- Run text and supported formatting.
-- Heading levels and OOXML list identifiers.
-- Section starts, orientation, dimensions, margins, and header/footer distance.
-- Default, first-page, and even-page header/footer stories.
-- Core metadata.
-- Media hashes and inline-image occurrences.
-- Fields, revisions, comments, floating drawings, unsupported drawings, unsupported parts,
-  and explicitly allowed external-relationship warnings.
-- ZIP member and expanded-byte counts.
+## Create schema
 
-Inspect before editing. A successful inspection proves package preflight and library reopen;
-it does not prove visual fidelity.
+`content` accepts only:
 
-## Create
+| Key | Contract |
+|---|---|
+| `template`, `letterhead` | Optional DOCX base path; mutually exclusive. `--template` overrides both. The base is preflighted and unchanged. |
+| `metadata` | Core properties: `title`, `subject`, `author`, `keywords`, `comments`, `category`, `last_modified_by`, `revision` (integer >= 1), `identifier`, `language`, `version`. Other values are strings. |
+| `section` | Initial-section schema in [Sections](#section-schema). |
+| `styles` | Style-definition array in [Styles](#style-definitions). Applied before blocks. |
+| `update_fields_on_open` | Boolean; writes the Word setting. It does not refresh fields itself. |
+| `blocks` | Ordered content blocks. Default `[]`. |
+| `headers`, `footers` | Compact or section-explicit story configuration. |
 
-A direct create specification contains `schema_version` and a `content` object:
+Without a template, creation starts from `python-docx`'s standard document. For polished
+unbranded work, explicitly define `section` and `styles`. With a placeholder template, inspect
+and use `edit` for bounded placeholder replacement/insertion instead of creating by append.
 
-```json
-{
-  "schema_version": 1,
-  "content": {
-    "template": "letterhead.docx",
-    "metadata": {"title": "Quarterly brief", "author": "Example Team"},
-    "blocks": [],
-    "headers": {},
-    "footers": {}
-  }
-}
-```
+Order of application is initial section, styles, field-update setting, body blocks, metadata,
+headers, and footers. Section-break blocks may configure each added section.
 
-For complete `--job` dispatch, add:
+## Edit operations
 
-```json
-{
-  "schema_version": 1,
-  "operation": "create",
-  "output": "brief.docx",
-  "overwrite": false,
-  "allow_external_relationships": false,
-  "content": {"blocks": []}
-}
-```
+Operations execute sequentially in memory; indices address the current state. Any failure
+discards the mutation.
 
-`content.template` and `content.letterhead` are equivalent DOCX base-document inputs; specify
-at most one. `--template` overrides either JSON property. The template is preflighted and
-never modified. Without a base document, the operation starts from the standard
-`python-docx` document.
+- **`replace_text`** — requires `find` (non-empty), `replace` (string), and
+  `expected_count >= 0`; optional `replace_all`, `scope` (`body`, `headers`, `footers`, `all`),
+  and `cross_run_policy` (only `first_run`). Scope defaults to `body`; `replace_all` defaults
+  to `false`. Matches are paragraph-local. Multiple matches require `replace_all: true`; count
+  mismatch is `ambiguous_edit`. Protected hyperlink, field, drawing, comment, revision, and
+  unsupported boundaries are not flattened.
+- **`insert_paragraph`** — requires paragraph-like `block` and `position`. `append` forbids an
+  index; `before`/`after` require top-level `paragraph_index`. Allowed block types are
+  paragraph, heading, page break, image, and field.
+- **`delete_paragraph`** — requires top-level body `paragraph_index`.
+- **`insert_table`** — requires `table`; without an index it appends. With
+  `paragraph_index`, optional `position` is `before`/`after` and defaults to `after`.
+  Accepts full table parity: style, headers, layout, widths, and split controls.
+- **`update_table`** — requires `table_index`. Optionally update one cell by supplying all of
+  `row`, `column`, `value`; and/or update `style`, `header_rows`, `layout`,
+  `column_widths_inches`, `allow_row_split`, and `row_allow_split`. Width count must equal
+  columns; row-split count must equal rows. Property updates preserve cell content.
+- **`insert_image`** — requires `path`; optional body `paragraph_index`, dimensions,
+  `alt_text`, `decorative`, and `title`. Without an index it appends a paragraph. The strict
+  schema also accepts `story_address`, but the current operation does not use it; omit it.
+  Images are inline.
+- **`replace_image`** — requires `path` and either body `inline_image_index` or an inspected
+  `story_address` of form `word/document.xml#inline-N`; optional dimensions and accessibility
+  metadata. If accessibility keys are omitted, existing values remain. Header/footer
+  story-address replacement is unsupported.
+- **`set_metadata`** — requires `metadata` using the create metadata schema.
+- **`set_header` / `set_footer`** — optional `section_index` default 0; `kind` default
+  `default`; `mode` default `replace`; optional `blocks` and `link_to_previous`. If linking
+  `true`, do not supply blocks. Details are in [Headers and footers](#headers-and-footers).
+- **`configure_section`** — optional `section_index` default 0 plus any section-schema keys.
+- **`upsert_style`** — requires one `style` object from [Styles](#style-definitions). Existing
+  type must match; `based_on` must already exist.
+- **`set_update_fields_on_open`** — requires Boolean `enabled`.
 
-Supported metadata properties are `title`, `subject`, `author`, `keywords`, `comments`,
-`category`, `last_modified_by`, `revision`, `identifier`, `language`, and `version`.
+Top-level paragraph/table indices exclude nested table and story content. Inspect again after
+edits; specifically compare `row_allows_split`, widths, style records, story linkage, field
+settings, and image accessibility/PPI.
 
-## Edit
-
-A direct edit specification is:
-
-```json
-{
-  "schema_version": 1,
-  "operations": [
-    {
-      "type": "replace_text",
-      "find": "draft",
-      "replace": "final",
-      "expected_count": 1,
-      "scope": "body"
-    }
-  ]
-}
-```
-
-For complete `--job` dispatch, add `operation`, `input`, `output`, and optional `overwrite`:
-
-```json
-{
-  "schema_version": 1,
-  "operation": "edit",
-  "input": "source.docx",
-  "output": "edited.docx",
-  "overwrite": false,
-  "allow_external_relationships": false,
-  "operations": [{"type": "delete_paragraph", "paragraph_index": 0}]
-}
-```
-
-Operations execute sequentially against one in-memory document. Indices therefore refer to
-the document state at that point in the array. Any failure discards the whole mutation.
-
-Supported edit operations:
-
-- `insert_paragraph`: `block` and an explicit `position`. Use `"position": "append"` with no
-  `paragraph_index`, or use `"position": "before"`/`"after"` with a required top-level
-  `paragraph_index`. Relative indices are validated against the paragraph count before the
-  new paragraph is created.
-- `delete_paragraph`: top-level `paragraph_index`.
-- `replace_text`: `find`, `replace`, `expected_count`, optional `replace_all`, `scope`, and
-  `cross_run_policy`.
-- `insert_table`: `table`, optional `paragraph_index`, and `position`.
-- `update_table`: `table_index`, `row`, `column`, `value`, and optional `style`.
-- `insert_image`: `path`, optional `paragraph_index`, `width_inches`, and `height_inches`.
-- `replace_image`: body `inline_image_index`, `path`, optional dimensions.
-- `set_metadata`: `metadata`.
-- `set_header` and `set_footer`: `section_index`, `kind`, `mode`, and `blocks`.
-
-Top-level paragraph and table indices exclude nested cell/story content. `replace_text` can
-include nested table cells and stories through its scope.
-
-## Convert
-
-DOCX to UTF-8 plain text:
+## Conversion contract
 
 ```bash
 "$DOCX_PYTHON" "$SKILL_ROOT/scripts/docx_tool.py" convert \
-  --input "source.docx" --format text --output "source.txt"
+  --input source.docx --format text --output source.txt
+"$DOCX_PYTHON" "$SKILL_ROOT/scripts/docx_tool.py" convert \
+  --input source.docx --format pdf --output source.pdf --timeout 90
 ```
 
-The converter uses the inspector's ordered body model. Body and header/footer table cells are
-tab-delimited. Non-empty headers and footers are appended with story labels and deduplicated
-only when the same story part is inherited; distinct stories are never collapsed by equal
-displayed text, and header and footer identities remain separate.
+Text conversion uses ordered body content, tab-delimits table cells, and appends labeled,
+part-aware header/footer stories.
 
-DOCX to PDF:
+PDF conversion preflights, runs headless LibreOffice with an isolated temporary profile/home
+and process group, bounds diagnostics/timeout, requires one PDF signature, and atomically
+publishes only after validation. Validation limits are 64 MiB, 1–1,000 pages, 8 MiB per
+decompressed stream, text extraction from at most 50 pages and 1,000,000 characters.
+
+`verification.content_quality_report` contains `deterministic`, method, pypdf version,
+limitation, per-page dimensions/text count/`low_text`/`has_nontext_content`/`nearly_blank` and
+start/end anchors, `nearly_blank_pages`, and `raster_review_artifacts` (empty for `convert`;
+`render` fills it with the published PNG file names). XObject detection is incomplete. This
+report is structural and does not render pixels or replace the
+[visual quality review](references/quality.md#visual-review-versus-structural-checks).
+
+## Render
 
 ```bash
-"$DOCX_PYTHON" "$SKILL_ROOT/scripts/docx_tool.py" convert \
-  --input "source.docx" --format pdf --output "source.pdf" --timeout 90
+"$DOCX_PYTHON" "$SKILL_ROOT/scripts/docx_tool.py" render \
+  --input source.docx --output pages-dir --dpi 150 --pages 1,2
 ```
 
-PDF conversion:
+Render converts the document to PDF through the same LibreOffice contract and limits as
+`convert`, then rasterizes the selected PDF pages to one PNG each with the optional
+`pypdfium2` package. Output naming is `page-001.png` upward, using 1-based PDF page numbers.
+Because DOCX has no fixed pagination, the page count is known only after conversion; `--pages`
+is validated against the converted PDF and a miss reports the real `pdf_pages`. Pages may
+differ in dimensions when sections mix orientation or paper size.
 
-1. Preflights the DOCX.
-2. Locates `soffice`.
-3. Runs headless LibreOffice with a unique temporary user profile, home, temp directory, and
-   POSIX process group.
-4. Applies the bounded timeout, captures at most 4,000 bytes from each diagnostic stream, and
-   terminates the process group (including ordinary descendants) before removing temporary
-   directories.
-5. Requires exactly one output with a `%PDF-` signature and at most 64 MiB.
-6. Reopens the output with `pypdf`, requires 1–1,000 pages, limits each decompressed stream
-   encountered during validation to 8 MiB, and extracts text from at most the first 50 pages
-   with a 1,000,000-character validation limit.
-7. Atomically publishes the validated PDF.
+The destination is a directory that must not already exist; pages are staged in a sibling
+temporary directory and published atomically only after every PNG passes signature, reopen,
+and pixel-budget verification, and the published files are reopened and hash-checked again.
+There is no `--overwrite` for render.
 
-Conversion is best-effort. LibreOffice layout can differ from Word layout.
-The isolated profile and process group are lifecycle/configuration controls, not a network
-sandbox.
+Limits: `--dpi` 36–300 (default 150), at most 200 pages per invocation, 25,000,000 pixels per
+page, and 250,000,000 pixels per run, pre-charged from page geometry before rasterizing.
+`--timeout` bounds the LibreOffice step (default 90 seconds). LibreOffice or PDFium failures
+exit 10; pixel budgets exit 6; an existing destination exits 9.
 
-A complete conversion job is:
-
-```json
-{
-  "schema_version": 1,
-  "operation": "convert",
-  "input": "source.docx",
-  "output": "source.pdf",
-  "format": "pdf",
-  "timeout": 90,
-  "overwrite": false,
-  "allow_external_relationships": false
-}
-```
+The result carries the source inspection warnings (including the font-portability tiers),
+`layout_engine_variance`, `libreoffice_diagnostics` when LibreOffice wrote to stderr, and
+`render_review_required`. Rendering exists to be looked at: open the published PNG pages and
+review layout before claiming visual correctness. The PNGs show LibreOffice's interpretation
+of the document, not Microsoft Word's, and fields are not refreshed before rendering.
 
 ## Content blocks
 
-Use these objects in `content.blocks`, list items, table cells where noted, and header/footer
-stories.
+### Paragraph-like blocks
 
-### Paragraph
+Paragraph and heading (`level` 0–9; default 1) accept `text` or `runs`, never both; optional
+`style`, `alignment`, and all paragraph-layout keys. A run requires string `text` and may set
+Boolean `bold`/`italic`/`underline`, `font`, `size_pt >= 1`, six-digit RGB `color`, and
+character `style`. Heading default style is `Title` for level 0, otherwise `Heading N`.
 
-```json
-{
-  "type": "paragraph",
-  "style": "Quote",
-  "alignment": "left",
-  "runs": [
-    {
-      "text": "Important",
-      "bold": true,
-      "italic": false,
-      "underline": false,
-      "font": "Aptos",
-      "size_pt": 11,
-      "color": "B42318",
-      "style": "Emphasis"
-    }
-  ]
-}
-```
+Paragraph-layout keys:
 
-Use `text` or `runs`, never both. Text and each run's required `text` property must be JSON
-strings. Supported alignments are `left`, `center`, `right`, and `justify`. Prefer named
-styles; direct formatting is for intentional exceptions.
+- `space_before_pt`, `space_after_pt` >= 0
+- `line_spacing`: number >= 0.1 or `single`, `one_and_half`, `double`
+- `left_indent_inches`, `right_indent_inches`, `hanging_indent_inches` >= 0
+- `first_line_indent_inches` (may be negative); mutually exclusive with hanging indent
+- Boolean `keep_with_next`, `keep_together`, `page_break_before`, `widow_control`
+- `tab_stops`: array of `{position_inches, alignment?, leader?}`; position >= 0;
+  alignment defaults `left` and permits `left`, `center`, `right`, `decimal`, `bar`; leader
+  defaults `spaces` and permits `spaces`, `dots`, `dashes`, `lines`, `heavy`, `middle_dot`.
+  Supplying the array clears existing direct tab stops.
 
-### Heading
+`page_break` accepts only `type`. `list` requires `items` and optional Boolean `ordered`;
+items are strings or objects with `text`/`runs` and alignment. Lists use `List Bullet` or
+`List Number`.
 
-```json
-{"type": "heading", "level": 1, "text": "Summary"}
-```
+### Tables
 
-Levels 1–9 use `Heading N`; level 0 uses `Title`.
+A table requires non-empty rectangular `rows`. Each cell is a string or a paragraph object
+with `text`/`runs`, `style`, `alignment`, and paragraph-layout keys. Optional keys:
 
-### List
+- `style`; `header_rows` from 0 through row count (default 0).
+- `layout`: `autofit` or `fixed`; default is fixed when widths are supplied, autofit otherwise.
+- `column_widths_inches`: one value >= 0.1 per column.
+- `allow_row_split`: Boolean global default, default `true`.
+- `row_allow_split`: one Boolean per row; takes precedence over `allow_row_split`.
 
-```json
-{
-  "type": "list",
-  "ordered": false,
-  "items": ["First", {"runs": [{"text": "Second", "bold": true}]}]
-}
-```
+Inspection reports widths and row behavior. For printable-width arithmetic and release rules,
+use [the quality contract](references/quality.md#acceptance-criteria).
 
-Lists use the template's `List Bullet` or `List Number` named style.
+### Images and figures
 
-### Page break and section break
+Image block requires `path`; optional dimensions >= 0.01 inch, paragraph style/alignment,
+formatted `prefix_runs`/`suffix_runs`, `alt_text`, Boolean `decorative`, `title`, `caption`,
+`caption_style`, and `attribution`. Decorative and non-empty alt text conflict. Default
+caption style is `Caption`; caption/attribution creates a following paragraph and applies
+keep controls. Supported signatures are PNG, JPEG, GIF, TIFF, and BMP; maximum 32 MiB. Omit
+one dimension to preserve aspect ratio. Only inline images are created.
 
-```json
-{"type": "page_break"}
-```
+### Fields
 
-```json
-{
-  "type": "section_break",
-  "start": "new_page",
-  "orientation": "landscape",
-  "top_margin_inches": 0.75,
-  "right_margin_inches": 0.75,
-  "bottom_margin_inches": 0.75,
-  "left_margin_inches": 0.75
-}
-```
+Field block requires `field`: `page_number`, `toc`, `num_pages`, `section_pages`, `seq`,
+`ref`, or `date`. All accept optional `prefix`, `suffix`, `placeholder`, style/alignment, and
+Boolean `locked`. `instruction` is accepted only for `toc`, `seq`, `ref`, and `date`; it must
+start with its matching field token. Every custom instruction rejects newline/NUL and lengths
+above 512 characters.
 
-Section starts are `new_page`, `continuous`, `even_page`, `odd_page`, and `new_column`.
-Section breaks are main-body only.
+Default instructions/placeholders are PAGE/`1`; TOC `TOC \o "1-3" \h \z \u`/update prompt;
+NUMPAGES/`1`; SECTIONPAGES/`1`; `SEQ Figure \* ARABIC`/`1`; `REF Bookmark`/missing-reference
+message; and `DATE \@ "MMMM d, yyyy"`/`Date`. Fields are emitted dirty. They are not refreshed.
 
-### Table
+### Section breaks
 
-```json
-{
-  "type": "table",
-  "style": "Table Grid",
-  "header_rows": 1,
-  "rows": [
-    ["Item", "Status"],
-    [{"runs": [{"text": "A", "bold": true}]}, "Ready"]
-  ]
-}
-```
+Main-body-only `section_break` accepts `start` (`new_page` default, `continuous`,
+`even_page`, `odd_page`, `new_column`) plus the full section schema.
 
-`rows` must be a non-empty rectangular array; every row must contain the same positive number
-of cells. A cell accepts a JSON string or a paragraph-style object with `text`/`runs`, `style`,
-and `alignment`. Empty rows, ragged rows, numbers, Booleans, objects outside that schema, and
-other value types fail as `bad_input`.
+## Sections and styles
 
-### Inline image
+### Section schema
 
-```json
-{
-  "type": "image",
-  "path": "chart.png",
-  "width_inches": 5.5,
-  "prefix_runs": [{"text": "Figure 1: "}],
-  "suffix_runs": [{"text": " Source: internal."}]
-}
-```
+Accepted keys are:
 
-Supported signatures are PNG, JPEG, GIF, TIFF, and BMP. Images are bounded to 32 MiB. Omit
-one dimension to retain aspect ratio. Floating images are not created or replaced.
+- `paper_size`: `letter` (8.5 × 11) or `a4` (approximately 8.2677 × 11.6929);
+  `page_width_inches` and `page_height_inches` allow custom dimensions of at least 0.1 inch.
+- `orientation`: `portrait` or `landscape`. Applying orientation swaps current width/height
+  when needed. Paper size without explicit orientation retains an existing landscape state.
+- Nonnegative `top_margin_inches`, `right_margin_inches`, `bottom_margin_inches`,
+  `left_margin_inches`, `header_distance_inches`, `footer_distance_inches`.
+  Horizontal and vertical margin pairs must each leave positive printable space.
+- Boolean `different_first_page`.
+- `page_number_start`: integer >= 0; `page_number_format`: `decimal`, `upperRoman`,
+  `lowerRoman`, `upperLetter`, or `lowerLetter`.
 
-### Field
+The create-level `section` configures section 0. A section-break configures the new section.
+`configure_section` edits one existing section (default index 0).
 
-```json
-{"type": "field", "field": "page_number", "prefix": "Page "}
-```
+### Style definitions
 
-```json
-{
-  "type": "field",
-  "field": "toc",
-  "instruction": " TOC \\o \"1-3\" \\h \\z \\u "
-}
-```
+Each `styles` entry or `upsert_style.style` requires `name` and `type` (`paragraph` or
+`character`). Optional `based_on` must name an existing style. Font properties are `font`,
+`size_pt >= 1`, Boolean `bold`/`italic`/`underline`, and six-digit RGB `color`.
 
-Fields are OOXML markup with placeholder results. Saving does not paginate the document or
-refresh the TOC. Open and update fields in a layout application.
+Paragraph styles additionally accept `paragraph` containing alignment and any
+paragraph-layout keys, plus `outline_level` 0–9. Character styles reject those paragraph-only
+properties. Upsert changes only supplied direct properties; inspection does not calculate
+fully inherited/effective values.
 
 ## Headers and footers
 
-Compact create form applies stories to section 0:
+Create compact form is an object keyed by `default`, `first_page`, and `even_page`, each a
+block array, and applies to section 0. Explicit form is an array of
+`{section_index, kind, blocks}`. Story blocks allow all blocks except section breaks. Writing
+a create story unlinks it from the previous section; first/even kinds enable their document
+settings.
 
-```json
-{
-  "headers": {
-    "default": [{"type": "paragraph", "text": "Confidential"}],
-    "first_page": [{"type": "paragraph", "text": "Cover"}]
-  },
-  "footers": {
-    "default": [{"type": "field", "field": "page_number", "prefix": "Page "}]
-  }
-}
-```
+Edit defaults are section 0, default story, and replace mode. `mode: "append"` retains story
+content. `link_to_previous: true` links and returns without writing; `false` explicitly
+unlinks and may be combined with blocks. Inspect the resulting `linked_to_previous` values.
 
-Explicit create form accepts an array:
+## Warnings
 
-```json
-{
-  "headers": [
-    {
-      "section_index": 1,
-      "kind": "even_page",
-      "blocks": [{"type": "paragraph", "text": "Even page"}]
-    }
-  ]
-}
-```
+Inspection may emit preflight/external-relationship warnings and these public codes:
 
-Kinds are `default`, `first_page`, and `even_page`. Setting a story unlinks it from its
-previous section. Edit operations default to `mode: "replace"`; use `mode: "append"` to retain
-existing story content.
+- Fidelity/features: `fields_present`, `revisions_present`, `comments_present`,
+  `floating_drawings_present`, `unsupported_drawings_present`, `unsupported_parts`.
+- Fonts: `unembedded_fonts`, `common_unembedded_fonts` (Office-bundled families such as
+  Calibri, Cambria, Aptos, or Segoe UI; substitution possible but usually metric-compatible),
+  `nonportable_unembedded_fonts` (`RELEASE BLOCKER`; fonts outside the portable core and
+  common Office sets), `dangling_font_embedding_relationships`. Treat font-name allowlists in
+  warning wording as a heuristic only: portability still depends on embedding/license or
+  availability on every intended renderer.
+- Accessibility/structure: `missing_document_title`, `missing_document_language`,
+  `heading_level_skip`, `data_table_without_header_row`,
+  `informative_image_missing_alt_text`.
+- Fit/media: `table_exceeds_printable_width`, `low_resolution_image` (below 150 PPI),
+  `image_printable_width_uncertain`, `image_exceeds_printable_width`.
+- Fields: `toc_placeholder_only`.
 
-## Replacement policy
+Warnings are diagnostics, not a complete accessibility, typography, or visual audit. Apply
+the requested profile in [quality](references/quality.md#delivery-profiles).
 
-`replace_text` searches each selected paragraph independently:
+## Safety, atomicity, and exits
 
-- `scope` is `body`, `headers`, `footers`, or `all`.
-- `expected_count` is mandatory and must equal the number of visible, non-overlapping
-  matches. A mismatch is `ambiguous_edit`.
-- More than one match additionally requires `"replace_all": true`.
-- A match wholly within one run keeps that run's formatting.
-- A match spanning plain adjacent runs requires `"cross_run_policy": "first_run"`. Replacement
-  text uses the first run's formatting; unaffected suffix text remains in its original last
-  run.
-- A match crossing or occupying a hyperlink, field, drawing, comment range, revision, or
-  unsupported markup is rejected. The operation never flattens those boundaries.
-- Matches do not cross paragraph boundaries.
+Preflight requires `.docx` ZIP/OOXML signatures and required members; at most 2,048 members,
+128 MiB compressed and 256 MiB expanded; safe unique paths; no encryption, macros/VBA,
+DTD/entities, or malformed XML. External relationships are rejected unless explicitly
+allowed. The opt-in is not network isolation.
 
-Inspect runs first and set a narrow expected count. Do not use broad replacement as a document
-normalizer.
+Mutations require a distinct destination unless `--overwrite`; existing destinations also
+require it. A sibling temporary file is flushed, preflighted, reopened, and atomically
+replaced. Unknown untouched content is preserved best-effort; signatures are not preserved as
+valid and signed document mutation is not supported.
 
-## Safety and atomicity
+| Exit | Category |
+|---:|---|
+| 0 | success |
+| 2 | `bad_input` |
+| 3 | `unsupported_operation` |
+| 4 | `missing_dependency` |
+| 5 | `ambiguous_edit` |
+| 6 | `resource_limit` |
+| 7 | `licensing_precondition` (reserved) |
+| 8 | `validation_failed` |
+| 9 | `output_conflict` |
+| 10 | `external_tool_failed` |
 
-Preflight requires:
-
-- A `.docx` path and ZIP signature.
-- Required OOXML package members.
-- At most 2,048 ZIP members.
-- At most 128 MiB compressed input and 256 MiB expanded content.
-- Safe, unique member paths.
-- No encrypted ZIP members.
-- No macro-enabled content types or VBA project.
-- Well-formed XML without DTD/entity declarations.
-
-Direct XML parsing disables DTD loading, entity resolution, huge-tree mode, recovery, and
-network access for those parser calls. DOCX external relationships are rejected by default.
-Use `--allow-external-relationships` or the strictly Boolean job property
-`"allow_external_relationships": true` only after reviewing the package and accepting the
-risk. The opt-in permits processing; it does not disable, proxy, or sandbox network access by
-LibreOffice or another consuming application, which may access external targets.
-
-Mutations require a distinct source and destination unless `--overwrite` is explicit.
-Existing destinations also require `--overwrite`. The tool writes a sibling temporary file,
-flushes it, preflights/reopens it, and uses an atomic filesystem replacement only after
-validation. A failed mutation does not publish partial output.
-
-Unknown untouched package content is preserved best-effort where `python-docx` retains it.
-The summary always states that perfect round-trip fidelity is not guaranteed.
-
-## Exit statuses
-
-| Status | Category | Meaning |
-|---:|---|---|
-| `0` | success | The summary was written to stdout. |
-| `2` | `bad_input` | Missing, malformed, wrong-type, unsafe, or schema-invalid input. |
-| `3` | `unsupported_operation` | Known format/feature or requested operation is unsupported. |
-| `4` | `missing_dependency` | A required Python package or `soffice` is unavailable. |
-| `5` | `ambiguous_edit` | Match count, run policy, or protected-boundary rules failed. |
-| `6` | `resource_limit` | Package, expansion, member, image, or generated-PDF bound failed. |
-| `7` | `licensing_precondition` | A required redistribution/license condition was unmet. |
-| `8` | `validation_failed` | Save, reopen, signature, or post-write verification failed. |
-| `9` | `output_conflict` | Destination exists or aliases the source without overwrite. |
-| `10` | `external_tool_failed` | LibreOffice timed out or returned invalid conversion output. |
-
-`licensing_precondition` is reserved in schema version 1 for workflows that introduce
-redistributed assets. Current create/edit jobs reference user-supplied files and do not
-redistribute bundled third-party assets.
-
-See [examples](references/examples.md) for complete jobs and
-[limitations](references/limitations.md) before using advanced Word features.
+See [examples](references/examples.md#examples) for executable jobs and
+[remaining limits](references/limitations.md#remaining-limits) before fidelity-sensitive work.

--- a/kolega_code/_bundled_skills/skills/docx/references/quality.md
+++ b/kolega_code/_bundled_skills/skills/docx/references/quality.md
@@ -1,0 +1,95 @@
+# Quality contract
+
+## Contents
+
+- [Design intake and templates](#design-intake-and-templates)
+- [Delivery profiles](#delivery-profiles)
+- [Acceptance criteria](#acceptance-criteria)
+- [Visual review versus structural checks](#visual-review-versus-structural-checks)
+
+## Design intake and templates
+
+Record this profile before polished creation:
+
+| Decision | Required intake |
+|---|---|
+| Audience | Primary readers, reading context, and accessibility needs |
+| Document type | Report, brief, letter, manual, form, publication, or other |
+| Page | Letter or A4; note any landscape sections |
+| Renderer | Microsoft Word version/platform, LibreOffice, Word Online, or other target |
+| Editable fidelity | Low, medium, or high importance for reflow and editability |
+| Brand/template | Supplied template, approved template, brand rules, or explicitly unbranded |
+| Accessibility | Requested standard/accommodations, language, alt-text ownership |
+| Medium | Print, screen, or both; monochrome and duplex requirements |
+| TOC | Requested or complexity-triggered; proposed depth |
+| PDF | None, basic viewing, print, accessibility-oriented, or archive-oriented |
+
+Use a supplied or user-approved template for branded, client-facing publication, regulated
+layout, or publication-ready output. Preflight it before use and preserve its theme, styles,
+sections, and stories unless the brief calls for bounded changes. If a template contains
+placeholder text, inspect and replace/insert at those anchors with expected counts; appending
+new content to the end does not fill a template.
+
+If no approved template is required, create a deliberate baseline through `content.section`
+and `content.styles`: establish page geometry, Normal/body typography, heading hierarchy,
+caption/table treatment, spacing, and pagination behavior. Record the renderer and font
+assumptions. A named font is portable only when licensed and embedded in the DOCX or installed
+on every intended renderer.
+
+## Delivery profiles
+
+Profiles describe checks performed, not certifications:
+
+- **Basic viewing:** editable DOCX opens, intended content and hierarchy are present, and
+  representative rendering is legible on the named renderer. No print, accessibility, or
+  archive claim.
+- **Print:** basic viewing plus correct paper size, margins, printable widths, page breaks,
+  headers/footers, numbering, image resolution, color/monochrome behavior, and page-by-page
+  review of the final print PDF.
+- **Accessibility-oriented:** basic viewing plus metadata language/title, logical heading
+  hierarchy, meaningful link text where applicable, informative-image alt text, decorative
+  marking, captions, table header rows, readable order, contrast, and keyboard/native-reader
+  checks in the target Word application. The CLI does **not** validate tagged PDF.
+- **Archive-oriented:** preserve the editable DOCX and provenance, use stable documented fonts
+  and fields, and produce an ordinary PDF only if requested. The CLI does **not** create or
+  validate PDF/A; call output “PDF/A” only after a separate conforming tool validates the
+  required level.
+
+Combine profiles when requested. State renderer, template, unresolved warnings, and any check
+not performed. Never claim tagged PDF, PDF/UA, PDF/A, WCAG, or identical cross-renderer
+pagination from this CLI alone.
+
+## Acceptance criteria
+
+Apply the rows relevant to the delivery profile. A failed required row blocks release unless
+the user explicitly accepts the named exception.
+
+| Area | Measurable acceptance |
+|---|---|
+| Template preflight | Template passes CLI preflight/reopen; external relationships, signatures, revisions/comments, unsupported parts, fonts, sections, stories, and placeholder anchors are reviewed before mutation. Branded/publication-ready output uses a supplied or approved template. |
+| Style hierarchy and typography | Body, title, headings, captions, lists, and tables use named styles; heading levels do not skip; direct formatting is limited to intentional exceptions. Font inventory has no unexplained references. Unembedded fonts are confirmed installed on every intended renderer or replaced; embedded fonts are license-approved. |
+| Section and page geometry | Every section's inspected paper size/orientation/dimensions/margins/header/footer distances match the intake. Usable width equals page width minus left and right margins. Landscape and numbering changes start in the intended section. |
+| Paragraph pagination | Headings use `keep_with_next`; captions stay with figures; short atomic blocks use `keep_together`; body text has widow control when required; page-break-before and explicit breaks are intentional. Rendered pages have no orphan headings, stranded captions, avoidable widows/orphans, or accidental blank pages. |
+| Paragraph rhythm | Named styles define consistent before/after spacing and line spacing; manual blank paragraphs are not used as layout. Tabs use declared positions/alignment/leaders rather than spaces. |
+| Tables | Data tables have at least one repeated header row. For each table, `sum(column_widths_inches) <= section.page_width_inches - left_margin_inches - right_margin_inches` (allow at most 0.01 inch inspection tolerance). Fixed widths are used when predictable print layout is required. Row splitting is disabled only for rows expected to fit on one page; inspect per-row parity after updates. Render confirms no clipping, overflow, unreadably narrow columns, or detached continuation headers. |
+| Images and figures | Every informative image has non-empty alt text; every purely decorative image is marked decorative and has no alt text. Figures have captions when needed for identification/reference and attribution when required. Display width fits the section usable width. Effective PPI is checked in both axes: below 150 is a release warning; target at least 300 PPI for high-quality print unless source constraints are accepted. No unintended stretching or cropping appears in render. |
+| Accessibility | Metadata includes title and BCP-47-style language appropriate to the document; headings form a logical outline; table headers, reading order, contrast, link meaning, image semantics, and native accessibility checker results meet the requested profile. Automated warnings are triage, not certification. |
+| TOC and fields | Include a TOC only when requested or when navigation complexity warrants it (normally multi-section documents with several heading levels or roughly 10+ pages). Use live fields for editable pagination. Inspect field type/instruction/result/dirty/locked state; refresh in the target layout application and confirm the TOC is populated and references are correct. |
+| Headers, footers, numbering | Story kind, section index, first/even-page settings, and `linked_to_previous` match the design. Page-number fields and `page_number_start`/format render correctly, including intentional restarts; no empty or duplicated inherited stories appear. |
+| Font portability | Do not infer portability from font names or PDF embedding. Licensed DOCX-embedded fonts are allowed. The font inventory carries zero unaccepted `RELEASE BLOCKER` warnings; `common_unembedded_fonts` (Office-bundled families) is acceptable when the audience is Office-equipped or the user accepts the substitution risk. Every other unembedded font must exist on every intended renderer; otherwise replace it or disclose reflow risk. Compare wrapping and pagination on each fidelity-critical renderer. |
+| Visual QA | Run `render` and open every produced page with the Read tool, reviewing each final deliverable at normal view and fit-page/print preview. Confirm correct paper/orientation, margins, hierarchy, line/table wrapping, image placement, captions, headers/footers, numbering, fields/TOC, no clipping/overlap, no accidental blank or nearly blank pages, and no unexplained reflow from the approved reference. |
+
+## Visual review versus structural checks
+
+`inspect` verifies package structure and exposes measurable DOCX properties. PDF
+`verification.content_quality_report` verifies signature/reopen bounds and reports extracted
+text anchors, page dimensions, low-text/nearly-blank heuristics, and limited XObject presence.
+These are **structural content checks**, not pixels: they cannot detect overlap, clipping,
+font substitution, bad wrapping, contrast, visual hierarchy, or whether a page looks correct.
+
+Real visual review means producing pixels and looking at them. The bundled `render` command
+(see [render](references/operations.md#render)) is the built-in path: it publishes one PNG per
+page for review with the Read tool. The PNGs show LibreOffice's interpretation; the target
+application (normally Microsoft Word) remains the final authority for fidelity-critical
+deliverables. If neither is possible, report “structural checks only; visual QA not
+performed” and do not make layout, print, accessibility, or archive-conformance claims.

--- a/kolega_code/_bundled_skills/skills/docx/requirements.txt
+++ b/kolega_code/_bundled_skills/skills/docx/requirements.txt
@@ -1,3 +1,4 @@
-python-docx~=1.2
-lxml~=6.1
-pypdf~=6.14
+python-docx>=1.2
+lxml>=6.1
+pypdf>=6.14
+Pillow>=10.0

--- a/kolega_code/_bundled_skills/skills/docx/scripts/docx_tool.py
+++ b/kolega_code/_bundled_skills/skills/docx/scripts/docx_tool.py
@@ -8,6 +8,7 @@ import argparse
 import hashlib
 import importlib.metadata
 import json
+import math
 import os
 import re
 import shutil
@@ -27,7 +28,15 @@ try:
     from docx import Document
     from docx.document import Document as DocumentObject
     from docx.enum.section import WD_ORIENT, WD_SECTION
-    from docx.enum.text import WD_ALIGN_PARAGRAPH, WD_BREAK
+    from docx.enum.style import WD_STYLE_TYPE
+    from docx.enum.text import (
+        WD_ALIGN_PARAGRAPH,
+        WD_BREAK,
+        WD_LINE_SPACING,
+        WD_TAB_ALIGNMENT,
+        WD_TAB_LEADER,
+    )
+    from docx.image.image import Image
     from docx.oxml import OxmlElement
     from docx.oxml.ns import qn
     from docx.section import _Footer, _Header
@@ -36,6 +45,7 @@ try:
     from docx.text.paragraph import Paragraph
     from docx.text.run import Run
     from lxml import etree
+    from PIL import Image as PILImage
     from pypdf import PdfReader
     from pypdf import filters as pdf_filters
     from pypdf.errors import LimitReachedError
@@ -70,6 +80,51 @@ MAX_PDF_DECOMPRESSED_STREAM_BYTES = 8 * 1024 * 1024
 DEFAULT_CONVERSION_TIMEOUT = 90
 PROCESS_TERMINATION_GRACE_SECONDS = 2.0
 MAX_SUBPROCESS_DIAGNOSTIC_BYTES = 4_000
+MIN_RENDER_DPI = 36
+MAX_RENDER_DPI = 300
+DEFAULT_RENDER_DPI = 150
+MAX_RENDER_PAGES = 200
+MAX_RENDER_PIXELS_PER_PAGE = 25_000_000
+MAX_RENDER_TOTAL_PIXELS = 250_000_000
+
+# Portable: shipped with both Windows and macOS for decades; no substitution warning.
+PORTABLE_FONTS = {
+    "arial",
+    "arial black",
+    "comic sans ms",
+    "courier new",
+    "georgia",
+    "impact",
+    "tahoma",
+    "times new roman",
+    "trebuchet ms",
+    "verdana",
+}
+# Common: bundled with Microsoft Office or one major OS; metric-compatible LibreOffice
+# substitutes exist for the Office defaults (Carlito for Calibri, Caladea for Cambria).
+# Courier, Symbol, and Wingdings appear in default Word/python-docx templates (bullet and
+# mono glyphs) and are substituted essentially everywhere; blocking them would flag every
+# default-created document.
+COMMON_FONTS = {
+    "aptos",
+    "aptos display",
+    "calibri",
+    "calibri light",
+    "cambria",
+    "cambria math",
+    "candara",
+    "consolas",
+    "constantia",
+    "corbel",
+    "courier",
+    "franklin gothic",
+    "helvetica",
+    "segoe ui",
+    "segoe ui light",
+    "segoe ui semibold",
+    "symbol",
+    "wingdings",
+}
 
 EXIT_CODES = {
     "bad_input": 2,
@@ -88,6 +143,49 @@ REL_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
 PKG_REL_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
 WP_NS = "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
 A_NS = "http://schemas.openxmlformats.org/drawingml/2006/main"
+A14_NS = "http://schemas.microsoft.com/office/drawing/2010/main"
+W14_NS = "http://schemas.microsoft.com/office/word/2010/wordml"
+DECORATIVE_EXTENSION_URI = "{C183D7F6-B498-43B3-948B-1728B52AA6E4}"
+
+PARAGRAPH_LAYOUT_KEYS = {
+    "space_before_pt",
+    "space_after_pt",
+    "line_spacing",
+    "left_indent_inches",
+    "right_indent_inches",
+    "first_line_indent_inches",
+    "hanging_indent_inches",
+    "keep_with_next",
+    "keep_together",
+    "page_break_before",
+    "widow_control",
+    "tab_stops",
+}
+TABLE_KEYS = {
+    "type",
+    "rows",
+    "style",
+    "header_rows",
+    "layout",
+    "column_widths_inches",
+    "allow_row_split",
+    "row_allow_split",
+}
+SECTION_KEYS = {
+    "paper_size",
+    "page_width_inches",
+    "page_height_inches",
+    "orientation",
+    "top_margin_inches",
+    "right_margin_inches",
+    "bottom_margin_inches",
+    "left_margin_inches",
+    "header_distance_inches",
+    "footer_distance_inches",
+    "different_first_page",
+    "page_number_start",
+    "page_number_format",
+}
 
 REVISION_TAGS = {
     qn("w:ins"),
@@ -237,6 +335,8 @@ def package_versions(include_libreoffice: str | None = None) -> dict[str, str | 
         "python-docx": distribution_version("python-docx"),
         "lxml": distribution_version("lxml"),
         "pypdf": distribution_version("pypdf"),
+        "pillow": distribution_version("Pillow"),
+        "pypdfium2": optional_distribution_version("pypdfium2"),
         "libreoffice": include_libreoffice,
     }
     return versions
@@ -253,6 +353,15 @@ def distribution_version(name: str) -> str:
             f"Required Python distribution is not installed: {name}",
             details={"distribution": name},
         ) from exc
+
+
+def optional_distribution_version(name: str) -> str | None:
+    """Read an optional distribution version, or None when it is not installed."""
+
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
 
 
 def secure_xml_parser() -> etree.XMLParser:
@@ -538,6 +647,49 @@ def paragraph_record(paragraph: Paragraph, index: int) -> dict[str, Any]:
     match = re.fullmatch(r"Heading\s+([1-9])", style or "", re.I)
     if match:
         heading = int(match.group(1))
+    paragraph_format = paragraph.paragraph_format
+    tabs = []
+    for tab in paragraph_format.tab_stops:
+        tabs.append(
+            {
+                "position_inches": length_inches(tab.position),
+                "alignment": tab.alignment.name.lower() if tab.alignment is not None else None,
+                "leader": tab.leader.name.lower() if tab.leader is not None else None,
+            }
+        )
+    line_spacing = paragraph_format.line_spacing
+    layout = {
+        "space_before_pt": (
+            round(paragraph_format.space_before.pt, 3)
+            if paragraph_format.space_before is not None
+            else None
+        ),
+        "space_after_pt": (
+            round(paragraph_format.space_after.pt, 3)
+            if paragraph_format.space_after is not None
+            else None
+        ),
+        "line_spacing": (
+            round(line_spacing.pt, 3)
+            if hasattr(line_spacing, "pt")
+            else round(float(line_spacing), 3)
+            if line_spacing is not None
+            else None
+        ),
+        "line_spacing_rule": (
+            paragraph_format.line_spacing_rule.name.lower()
+            if paragraph_format.line_spacing_rule is not None
+            else None
+        ),
+        "left_indent_inches": length_inches(paragraph_format.left_indent),
+        "right_indent_inches": length_inches(paragraph_format.right_indent),
+        "first_line_indent_inches": length_inches(paragraph_format.first_line_indent),
+        "keep_with_next": paragraph_format.keep_with_next,
+        "keep_together": paragraph_format.keep_together,
+        "page_break_before": paragraph_format.page_break_before,
+        "widow_control": paragraph_format.widow_control,
+        "tab_stops": tabs,
+    }
     return {
         "index": index,
         "text": paragraph.text,
@@ -545,6 +697,7 @@ def paragraph_record(paragraph: Paragraph, index: int) -> dict[str, Any]:
         "heading_level": heading,
         "list": list_info,
         "alignment": paragraph.alignment.name if paragraph.alignment is not None else None,
+        "layout": layout,
         "runs": [
             {"index": run_index, "text": run.text, "format": run_format(run)}
             for run_index, run in enumerate(paragraph.runs)
@@ -552,10 +705,11 @@ def paragraph_record(paragraph: Paragraph, index: int) -> dict[str, Any]:
     }
 
 
-def table_record(table: Table, index: int) -> dict[str, Any]:
+def table_record(table: Table, index: int, section_index: int | None = None) -> dict[str, Any]:
     """Serialize a table and its cell paragraphs."""
 
     rows: list[list[dict[str, Any]]] = []
+    row_allows_split: list[bool] = []
     for row in table.rows:
         cells: list[dict[str, Any]] = []
         for cell in row.cells:
@@ -569,9 +723,25 @@ def table_record(table: Table, index: int) -> dict[str, Any]:
                 }
             )
         rows.append(cells)
+        tr_pr = row._tr.trPr
+        cant_split = tr_pr.find(qn("w:cantSplit")) if tr_pr is not None else None
+        cant_split_value = cant_split.get(qn("w:val")) if cant_split is not None else None
+        row_allows_split.append(cant_split is None or cant_split_value in {"0", "false", "off"})
+    autofit = table.autofit
+    header_rows = 0
+    for row in table.rows:
+        repeat = row._tr.get_or_add_trPr().find(qn("w:tblHeader"))
+        if repeat is None or repeat.get(qn("w:val")) in {"0", "false", "off"}:
+            break
+        header_rows += 1
     return {
         "index": index,
+        "section_index": section_index,
         "style": table.style.name if table.style is not None else None,
+        "layout": ("autofit" if autofit is True else "fixed" if autofit is False else "default"),
+        "column_widths_inches": [length_inches(column.width) for column in table.columns],
+        "row_allows_split": row_allows_split,
+        "header_rows": header_rows,
         "rows": rows,
         "row_count": len(table.rows),
         "column_count": max((len(row.cells) for row in table.rows), default=0),
@@ -598,12 +768,34 @@ def length_inches(value: Any) -> float | None:
 def section_record(section: Any, index: int) -> dict[str, Any]:
     """Serialize page and margin settings."""
 
+    pg_num = section._sectPr.find(qn("w:pgNumType"))
+    width = length_inches(section.page_width)
+    height = length_inches(section.page_height)
+    usable = (
+        round(
+            section.page_width.inches - section.left_margin.inches - section.right_margin.inches, 4
+        )
+        if section.page_width and section.left_margin and section.right_margin
+        else None
+    )
     return {
         "index": index,
         "start_type": section.start_type.name if section.start_type is not None else None,
         "orientation": section.orientation.name if section.orientation is not None else None,
         "page_width_inches": length_inches(section.page_width),
         "page_height_inches": length_inches(section.page_height),
+        "paper_size": (
+            "letter"
+            if width is not None
+            and height is not None
+            and {round(width, 2), round(height, 2)} == {8.5, 11.0}
+            else "a4"
+            if width is not None
+            and height is not None
+            and {round(width, 2), round(height, 2)} == {8.27, 11.69}
+            else None
+        ),
+        "usable_width_inches": usable,
         "top_margin_inches": length_inches(section.top_margin),
         "right_margin_inches": length_inches(section.right_margin),
         "bottom_margin_inches": length_inches(section.bottom_margin),
@@ -611,6 +803,12 @@ def section_record(section: Any, index: int) -> dict[str, Any]:
         "header_distance_inches": length_inches(section.header_distance),
         "footer_distance_inches": length_inches(section.footer_distance),
         "different_first_page": bool(section.different_first_page_header_footer),
+        "page_number_start": (
+            int(pg_num.get(qn("w:start")))
+            if pg_num is not None and pg_num.get(qn("w:start"))
+            else None
+        ),
+        "page_number_format": pg_num.get(qn("w:fmt")) if pg_num is not None else None,
     }
 
 
@@ -653,6 +851,121 @@ def core_properties_record(document: DocumentObject) -> dict[str, Any]:
     return result
 
 
+def inspect_styles(document: DocumentObject) -> list[dict[str, Any]]:
+    """Serialize paragraph/character style definitions relevant to authored content."""
+
+    records = []
+    for style in document.styles:
+        if style.type not in {WD_STYLE_TYPE.PARAGRAPH, WD_STYLE_TYPE.CHARACTER}:
+            continue
+        font = style.font
+        record = {
+            "name": style.name,
+            "type": "paragraph" if style.type == WD_STYLE_TYPE.PARAGRAPH else "character",
+            "based_on": style.base_style.name if style.base_style is not None else None,
+            "font": {
+                "name": font.name,
+                "size_pt": round(font.size.pt, 3) if font.size is not None else None,
+                "bold": font.bold,
+                "italic": font.italic,
+                "underline": font.underline,
+                "color": str(font.color.rgb) if font.color.rgb is not None else None,
+            },
+        }
+        if style.type == WD_STYLE_TYPE.PARAGRAPH:
+            p_pr = style.element.pPr
+            outline = p_pr.find(qn("w:outlineLvl")) if p_pr is not None else None
+            record["outline_level"] = int(outline.get(qn("w:val"))) if outline is not None else None
+            record["paragraph"] = {
+                "alignment": (
+                    style.paragraph_format.alignment.name.lower()
+                    if style.paragraph_format.alignment is not None
+                    else None
+                ),
+                "space_before_pt": (
+                    round(style.paragraph_format.space_before.pt, 3)
+                    if style.paragraph_format.space_before is not None
+                    else None
+                ),
+                "space_after_pt": (
+                    round(style.paragraph_format.space_after.pt, 3)
+                    if style.paragraph_format.space_after is not None
+                    else None
+                ),
+                "keep_with_next": style.paragraph_format.keep_with_next,
+                "keep_together": style.paragraph_format.keep_together,
+            }
+        records.append(record)
+    return records
+
+
+def inspect_fields(path: Path) -> list[dict[str, Any]]:
+    """Inspect simple and complex fields with instruction, state, and visible result."""
+
+    records: list[dict[str, Any]] = []
+    with zipfile.ZipFile(path) as package:
+        for part in sorted(
+            name
+            for name in package.namelist()
+            if name == "word/document.xml" or re.fullmatch(r"word/(header|footer)\d+\.xml", name)
+        ):
+            root = parse_xml_safely(package.read(part), part)
+            for index, simple in enumerate(root.findall(f".//{{{WORD_NS}}}fldSimple")):
+                instruction = simple.get(qn("w:instr"), "")
+                records.append(
+                    {
+                        "story_address": f"{part}#simple-{index}",
+                        "type": instruction.strip().split(maxsplit=1)[0].upper()
+                        if instruction.strip()
+                        else None,
+                        "instruction": instruction,
+                        "dirty": simple.get(qn("w:dirty")) in {"1", "true", "on"},
+                        "locked": simple.get(qn("w:fldLock")) in {"1", "true", "on"},
+                        "result": "".join(simple.itertext()),
+                    }
+                )
+            stack: list[dict[str, Any]] = []
+            complex_index = 0
+            for element in root.iter():
+                if element.tag == qn("w:fldChar"):
+                    field_type = element.get(qn("w:fldCharType"))
+                    if field_type == "begin":
+                        stack.append(
+                            {
+                                "instruction": [],
+                                "result": [],
+                                "separate": False,
+                                "dirty": element.get(qn("w:dirty")) in {"1", "true", "on"},
+                                "locked": element.get(qn("w:fldLock")) in {"1", "true", "on"},
+                            }
+                        )
+                    elif field_type == "separate" and stack:
+                        stack[-1]["separate"] = True
+                    elif field_type == "end" and stack:
+                        active = stack.pop()
+                        instruction = "".join(active["instruction"])
+                        records.append(
+                            {
+                                "story_address": f"{part}#complex-{complex_index}",
+                                "type": instruction.strip().split(maxsplit=1)[0].upper()
+                                if instruction.strip()
+                                else None,
+                                "instruction": instruction,
+                                "dirty": active["dirty"],
+                                "locked": active["locked"],
+                                "result": "".join(active["result"]),
+                            }
+                        )
+                        complex_index += 1
+                elif stack and element.tag == qn("w:instrText") and element.text:
+                    stack[-1]["instruction"].append(element.text)
+                elif stack and element.tag == qn("w:t") and element.text:
+                    for active in stack:
+                        if active["separate"]:
+                            active["result"].append(element.text)
+    return records
+
+
 def inspect_media(path: Path, document: DocumentObject) -> dict[str, Any]:
     """Inventory media members and inline occurrences across XML parts."""
 
@@ -669,27 +982,217 @@ def inspect_media(path: Path, document: DocumentObject) -> dict[str, Any]:
                     }
                 )
 
+    body_sections: list[int] = []
+    section_index = 0
+    for kind, block in iter_body_blocks(document):
+        body_sections.extend(section_index for _ in block._element.iter(f"{{{WP_NS}}}inline"))
+        if kind == "paragraph":
+            p_pr = block._p.pPr
+            if p_pr is not None and p_pr.sectPr is not None:
+                section_index = min(section_index + 1, len(document.sections) - 1)
+
     occurrences: list[dict[str, Any]] = []
     for part in document.part.package.parts:
         element = getattr(part, "element", None)
         if element is None:
             continue
-        for inline in element.iter(f"{{{WP_NS}}}inline"):
+        for local_index, inline in enumerate(element.iter(f"{{{WP_NS}}}inline")):
             blip = next(inline.iter(f"{{{A_NS}}}blip"), None)
             if blip is None or blip.get(f"{{{REL_NS}}}embed") is None:
                 continue
             extent = next(inline.iter(f"{{{WP_NS}}}extent"), None)
+            relationship_id = blip.get(f"{{{REL_NS}}}embed")
+            image_part = part.related_parts.get(relationship_id)
+            pixel_width = pixel_height = None
+            if image_part is not None:
+                try:
+                    source = Image.from_blob(image_part.blob)
+                    pixel_width, pixel_height = source.px_width, source.px_height
+                except Exception:
+                    pass
+            width_emu = int(extent.get("cx")) if extent is not None else None
+            height_emu = int(extent.get("cy")) if extent is not None else None
+            doc_pr = next(inline.iter(f"{{{WP_NS}}}docPr"), None)
+            display_width = round(width_emu / 914400, 4) if width_emu else None
+            display_height = round(height_emu / 914400, 4) if height_emu else None
             occurrences.append(
                 {
                     "container_part": str(part.partname).lstrip("/"),
-                    "relationship_id": (
-                        blip.get(f"{{{REL_NS}}}embed") if blip is not None else None
+                    "story_address": f"{str(part.partname).lstrip('/')}#inline-{local_index}",
+                    "relationship_id": relationship_id,
+                    "section_index": (
+                        body_sections[local_index]
+                        if str(part.partname).lstrip("/") == "word/document.xml"
+                        and local_index < len(body_sections)
+                        else None
                     ),
-                    "width_emu": int(extent.get("cx")) if extent is not None else None,
-                    "height_emu": int(extent.get("cy")) if extent is not None else None,
+                    "width_emu": width_emu,
+                    "height_emu": height_emu,
+                    "display_width_inches": display_width,
+                    "display_height_inches": display_height,
+                    "pixel_width": pixel_width,
+                    "pixel_height": pixel_height,
+                    "effective_ppi_x": (
+                        round(pixel_width / display_width, 1)
+                        if pixel_width and display_width
+                        else None
+                    ),
+                    "effective_ppi_y": (
+                        round(pixel_height / display_height, 1)
+                        if pixel_height and display_height
+                        else None
+                    ),
+                    "upscaled": bool(
+                        pixel_width
+                        and pixel_height
+                        and display_width
+                        and display_height
+                        and (display_width * 96 > pixel_width or display_height * 96 > pixel_height)
+                    ),
+                    "alt_text": doc_pr.get("descr") if doc_pr is not None else None,
+                    "title": doc_pr.get("title") if doc_pr is not None else None,
+                    "decorative": (
+                        doc_pr.find(
+                            f"{{{A_NS}}}extLst/{{{A_NS}}}ext"
+                            f"[@uri='{DECORATIVE_EXTENSION_URI}']/"
+                            f"{{{A14_NS}}}decorative[@val='1']"
+                        )
+                        is not None
+                        if doc_pr is not None
+                        else False
+                    ),
                 }
             )
     return {"media_parts": media, "inline_occurrences": occurrences}
+
+
+def inspect_fonts(path: Path) -> dict[str, Any]:
+    """Inventory referenced fonts and fonts actually embedded in the DOCX package."""
+
+    referenced_by_casefold: dict[str, str] = {}
+    embedded_by_casefold: dict[str, str] = {}
+    references: list[dict[str, str]] = []
+    dangling_embeddings: list[dict[str, str]] = []
+    run_fonts_tag = f"{{{WORD_NS}}}rFonts"
+    font_attributes = {
+        f"{{{WORD_NS}}}ascii",
+        f"{{{WORD_NS}}}hAnsi",
+        f"{{{WORD_NS}}}eastAsia",
+        f"{{{WORD_NS}}}cs",
+    }
+    theme_attributes = {
+        f"{{{WORD_NS}}}asciiTheme",
+        f"{{{WORD_NS}}}hAnsiTheme",
+        f"{{{WORD_NS}}}eastAsiaTheme",
+        f"{{{WORD_NS}}}csTheme",
+    }
+    embedding_tags = {
+        f"{{{WORD_NS}}}embedRegular",
+        f"{{{WORD_NS}}}embedBold",
+        f"{{{WORD_NS}}}embedItalic",
+        f"{{{WORD_NS}}}embedBoldItalic",
+    }
+
+    with zipfile.ZipFile(path) as package:
+        names = set(package.namelist())
+        theme_tokens: set[str] = set()
+        theme_fonts: dict[str, str] = {}
+        for name in names:
+            if name.startswith("word/theme/") and name.endswith(".xml"):
+                root = parse_xml_safely(package.read(name), name)
+                major = root.find(f".//{{{A_NS}}}majorFont")
+                minor = root.find(f".//{{{A_NS}}}minorFont")
+                for prefix, group in (("major", major), ("minor", minor)):
+                    if group is None:
+                        continue
+                    for suffix, tag in (("Ascii", "latin"), ("EastAsia", "ea"), ("Bidi", "cs")):
+                        element = group.find(f"{{{A_NS}}}{tag}")
+                        value = (
+                            (element.get("typeface") or "").strip() if element is not None else ""
+                        )
+                        if value:
+                            theme_fonts[prefix + suffix] = value
+        for name in names:
+            if not name.startswith("word/") or not name.lower().endswith(".xml"):
+                continue
+            root = parse_xml_safely(package.read(name), name)
+            if name != "word/fontTable.xml":
+                for element in root.iter(run_fonts_tag):
+                    for attribute in font_attributes:
+                        value = (element.get(attribute) or "").strip()
+                        if value and not value.startswith("+"):
+                            referenced_by_casefold.setdefault(value.casefold(), value)
+                            references.append(
+                                {
+                                    "part": name,
+                                    "slot": attribute.rsplit("}", 1)[-1],
+                                    "font": value,
+                                    "source": "explicit",
+                                }
+                            )
+                    for attribute in theme_attributes:
+                        token = (element.get(attribute) or "").strip()
+                        if token:
+                            theme_tokens.add(token)
+                            aliases = {
+                                "majorHAnsi": "majorAscii",
+                                "minorHAnsi": "minorAscii",
+                            }
+                            value = theme_fonts.get(aliases.get(token, token))
+                            if value:
+                                referenced_by_casefold.setdefault(value.casefold(), value)
+                                references.append(
+                                    {
+                                        "part": name,
+                                        "slot": attribute.rsplit("}", 1)[-1],
+                                        "font": value,
+                                        "source": token,
+                                    }
+                                )
+
+        font_table = "word/fontTable.xml"
+        if font_table in names:
+            root = parse_xml_safely(package.read(font_table), font_table)
+            relationships: dict[str, str] = {}
+            rel_name = "word/_rels/fontTable.xml.rels"
+            if rel_name in names:
+                rel_root = parse_xml_safely(package.read(rel_name), rel_name)
+                relationships = {
+                    rel.get("Id", ""): str(PurePosixPath("word") / rel.get("Target", ""))
+                    for rel in rel_root
+                    if rel.get("TargetMode") != "External"
+                }
+            for font in root.findall(f".//{{{WORD_NS}}}font"):
+                font_name = (font.get(f"{{{WORD_NS}}}name") or "").strip()
+                for child in font:
+                    if child.tag not in embedding_tags or not font_name:
+                        continue
+                    rid = child.get(f"{{{REL_NS}}}id", "")
+                    target = relationships.get(rid)
+                    if target in names:
+                        embedded_by_casefold.setdefault(font_name.casefold(), font_name)
+                    else:
+                        dangling_embeddings.append(
+                            {"font": font_name, "relationship_id": rid, "target": target or ""}
+                        )
+
+    referenced = list(referenced_by_casefold.values())
+    embedded = list(embedded_by_casefold.values())
+    return {
+        "referenced": sorted(referenced, key=str.casefold),
+        "embedded": sorted(embedded, key=str.casefold),
+        "unembedded": sorted(
+            (
+                value
+                for key, value in referenced_by_casefold.items()
+                if key not in embedded_by_casefold
+            ),
+            key=str.casefold,
+        ),
+        "references": references,
+        "theme_tokens_referenced": sorted(theme_tokens),
+        "dangling_embedding_relationships": dangling_embeddings,
+    }
 
 
 def scan_features(path: Path) -> tuple[dict[str, int], list[str]]:
@@ -751,13 +1254,17 @@ def inspect_document(
     ordered: list[dict[str, Any]] = []
     paragraphs: list[dict[str, Any]] = []
     tables: list[dict[str, Any]] = []
+    section_index = 0
     for block_index, (kind, block) in enumerate(iter_body_blocks(document)):
         if kind == "paragraph":
             record = paragraph_record(block, len(paragraphs))
             paragraphs.append(record)
             ordered.append({"block_index": block_index, "type": kind, "value": record})
+            p_pr = block._p.pPr
+            if p_pr is not None and p_pr.sectPr is not None:
+                section_index = min(section_index + 1, len(document.sections) - 1)
         else:
-            record = table_record(block, len(tables))
+            record = table_record(block, len(tables), section_index)
             tables.append(record)
             ordered.append({"block_index": block_index, "type": kind, "value": record})
 
@@ -780,6 +1287,9 @@ def inspect_document(
         )
 
     feature_counts, unsupported_parts = scan_features(preflight.path)
+    fonts = inspect_fonts(preflight.path)
+    images = inspect_media(preflight.path, document)
+    fields = inspect_fields(preflight.path)
     warnings = list(preflight.warnings)
     warning_specs = (
         ("fields", "fields_present", "Fields require a layout application to update."),
@@ -815,6 +1325,172 @@ def inspect_document(
                 parts=unsupported_parts,
             )
         )
+    if fonts["unembedded"]:
+        warnings.append(
+            warning(
+                "unembedded_fonts",
+                (
+                    "DOCX references fonts that are not embedded in the package. PDF font "
+                    "embedding does not make the DOCX portable; another Word renderer may "
+                    "substitute fonts and change wrapping, page breaks, object flow, and TOC "
+                    "page references. Use conservative cross-renderer fonts or embed licensed "
+                    "fonts, and do not claim DOCX/PDF pagination fidelity from a PDF-only check."
+                ),
+                fonts=fonts["unembedded"],
+            )
+        )
+        common_fonts = [font for font in fonts["unembedded"] if font.casefold() in COMMON_FONTS]
+        nonportable_fonts = [
+            font
+            for font in fonts["unembedded"]
+            if font.casefold() not in PORTABLE_FONTS and font.casefold() not in COMMON_FONTS
+        ]
+        if common_fonts:
+            warnings.append(
+                warning(
+                    "common_unembedded_fonts",
+                    (
+                        "DOCX references unembedded fonts that ship with Microsoft Office or "
+                        "one major operating system. Systems without them substitute fonts "
+                        "(LibreOffice uses metric-compatible Carlito and Caladea for Calibri "
+                        "and Cambria), so wrapping and pagination may shift slightly. This is "
+                        "acceptable for most business documents; embed the fonts or switch to "
+                        "the portable core set for print-critical deliverables."
+                    ),
+                    fonts=common_fonts,
+                )
+            )
+        if nonportable_fonts:
+            warnings.append(
+                warning(
+                    "nonportable_unembedded_fonts",
+                    (
+                        "RELEASE BLOCKER: DOCX references unembedded fonts outside the "
+                        "portable core set and the common Office-bundled set. Renderer "
+                        "substitution can change wrapping and pagination; replace or embed "
+                        "these fonts before releasing matching DOCX and PDF deliverables."
+                    ),
+                    fonts=nonportable_fonts,
+                )
+            )
+    if fonts["dangling_embedding_relationships"]:
+        warnings.append(
+            warning(
+                "dangling_font_embedding_relationships",
+                "Font embedding markup has missing or invalid relationship targets.",
+                relationships=fonts["dangling_embedding_relationships"],
+            )
+        )
+    metadata = core_properties_record(document)
+    if not metadata.get("title"):
+        warnings.append(warning("missing_document_title", "Document metadata has no title."))
+    if not metadata.get("language"):
+        warnings.append(warning("missing_document_language", "Document metadata has no language."))
+    previous_heading = 0
+    for paragraph in paragraphs:
+        level = paragraph["heading_level"]
+        if level and previous_heading and level > previous_heading + 1:
+            warnings.append(
+                warning(
+                    "heading_level_skip",
+                    "Heading hierarchy skips a level.",
+                    paragraph_index=paragraph["index"],
+                    previous_level=previous_heading,
+                    heading_level=level,
+                )
+            )
+        if level:
+            previous_heading = level
+    for table in tables:
+        if table["row_count"] > 1 and table["header_rows"] == 0:
+            warnings.append(
+                warning(
+                    "data_table_without_header_row",
+                    "Table has no repeated header row.",
+                    table_index=table["index"],
+                )
+            )
+        widths = [value or 0 for value in table["column_widths_inches"]]
+        table_section = table["section_index"] if table["section_index"] is not None else 0
+        usable = section_record(document.sections[table_section], table_section)[
+            "usable_width_inches"
+        ]
+        if usable and sum(widths) > usable + 0.01:
+            warnings.append(
+                warning(
+                    "table_exceeds_printable_width",
+                    "Table width exceeds the section usable width.",
+                    table_index=table["index"],
+                    table_width_inches=round(sum(widths), 4),
+                    usable_width_inches=usable,
+                )
+            )
+    section_usable = [
+        section_record(section, index)["usable_width_inches"]
+        for index, section in enumerate(document.sections)
+    ]
+    for image in images["inline_occurrences"]:
+        if not image["decorative"] and not image["alt_text"]:
+            warnings.append(
+                warning(
+                    "informative_image_missing_alt_text",
+                    "Informative image has no alternative text.",
+                    story_address=image["story_address"],
+                )
+            )
+        ppi_values = [
+            value for value in (image["effective_ppi_x"], image["effective_ppi_y"]) if value
+        ]
+        if ppi_values and min(ppi_values) < 150:
+            warnings.append(
+                warning(
+                    "low_resolution_image",
+                    "Effective image resolution is below 150 PPI.",
+                    story_address=image["story_address"],
+                    effective_ppi=min(ppi_values),
+                )
+            )
+        if image["container_part"] == "word/document.xml" and image["display_width_inches"]:
+            image_section = image["section_index"]
+            if image_section is None or image_section >= len(section_usable):
+                warnings.append(
+                    warning(
+                        "image_printable_width_uncertain",
+                        (
+                            "Image could not be mapped to a body section; "
+                            "printable-width fit is unknown."
+                        ),
+                        story_address=image["story_address"],
+                    )
+                )
+            elif (
+                section_usable[image_section]
+                and image["display_width_inches"] > section_usable[image_section]
+            ):
+                warnings.append(
+                    warning(
+                        "image_exceeds_printable_width",
+                        "Image display width exceeds section usable width.",
+                        story_address=image["story_address"],
+                        section_index=image_section,
+                        usable_width_inches=section_usable[image_section],
+                    )
+                )
+    for field in fields:
+        if field["type"] == "TOC" and (
+            not field["result"].strip() or "right-click and update" in field["result"].casefold()
+        ):
+            warnings.append(
+                warning(
+                    "toc_placeholder_only",
+                    (
+                        "TOC visible result is only a placeholder and needs a "
+                        "layout-application update."
+                    ),
+                    story_address=field["story_address"],
+                )
+            )
+    update_fields = document.settings.element.find(qn("w:updateFields"))
 
     result = {
         "ordered_blocks": ordered,
@@ -825,8 +1501,18 @@ def inspect_document(
         ],
         "headers": headers,
         "footers": footers,
-        "metadata": core_properties_record(document),
-        "images": inspect_media(preflight.path, document),
+        "metadata": metadata,
+        "styles": inspect_styles(document),
+        "images": images,
+        "fonts": fonts,
+        "fields": fields,
+        "settings": {
+            "odd_and_even_pages": bool(document.settings.odd_and_even_pages_header_footer),
+            "update_fields_on_open": (
+                update_fields is not None
+                and update_fields.get(qn("w:val"), "true") not in {"0", "false", "off"}
+            ),
+        },
         "features": feature_counts,
         "unsupported_parts": unsupported_parts,
         "package": {
@@ -1025,6 +1711,68 @@ def apply_paragraph_format(paragraph: Paragraph, block: dict[str, Any]) -> None:
         if alignment not in alignments:
             raise ToolError("bad_input", "Unsupported paragraph alignment.")
         paragraph.alignment = alignments[alignment]
+    paragraph_format = paragraph.paragraph_format
+    for key, attr in (
+        ("space_before_pt", "space_before"),
+        ("space_after_pt", "space_after"),
+    ):
+        if key in block:
+            setattr(paragraph_format, attr, Pt(required_number(block[key], key, minimum=0)))
+    for key, attr in (
+        ("left_indent_inches", "left_indent"),
+        ("right_indent_inches", "right_indent"),
+    ):
+        if key in block:
+            setattr(paragraph_format, attr, Inches(required_number(block[key], key, minimum=0)))
+    if "first_line_indent_inches" in block and "hanging_indent_inches" in block:
+        raise ToolError("bad_input", "first_line_indent_inches and hanging_indent_inches conflict.")
+    if "first_line_indent_inches" in block:
+        paragraph_format.first_line_indent = Inches(
+            required_number(block["first_line_indent_inches"], "first_line_indent_inches")
+        )
+    if "hanging_indent_inches" in block:
+        paragraph_format.first_line_indent = Inches(
+            -required_number(block["hanging_indent_inches"], "hanging_indent_inches", minimum=0)
+        )
+    if "line_spacing" in block:
+        value = block["line_spacing"]
+        if isinstance(value, str):
+            rules = {
+                "single": WD_LINE_SPACING.SINGLE,
+                "one_and_half": WD_LINE_SPACING.ONE_POINT_FIVE,
+                "double": WD_LINE_SPACING.DOUBLE,
+            }
+            if value not in rules:
+                raise ToolError("bad_input", "line_spacing string is unsupported.")
+            paragraph_format.line_spacing_rule = rules[value]
+        else:
+            paragraph_format.line_spacing = required_number(value, "line_spacing", minimum=0.1)
+    for key in ("keep_with_next", "keep_together", "page_break_before", "widow_control"):
+        if key in block:
+            setattr(paragraph_format, key, optional_boolean(block[key], key))
+    if "tab_stops" in block:
+        paragraph_format.tab_stops.clear_all()
+        alignments = {
+            "left": WD_TAB_ALIGNMENT.LEFT,
+            "center": WD_TAB_ALIGNMENT.CENTER,
+            "right": WD_TAB_ALIGNMENT.RIGHT,
+            "decimal": WD_TAB_ALIGNMENT.DECIMAL,
+            "bar": WD_TAB_ALIGNMENT.BAR,
+        }
+        leaders = {
+            "spaces": WD_TAB_LEADER.SPACES,
+            "dots": WD_TAB_LEADER.DOTS,
+            "dashes": WD_TAB_LEADER.DASHES,
+            "lines": WD_TAB_LEADER.LINES,
+            "heavy": WD_TAB_LEADER.HEAVY,
+            "middle_dot": WD_TAB_LEADER.MIDDLE_DOT,
+        }
+        for tab in block["tab_stops"]:
+            paragraph_format.tab_stops.add_tab_stop(
+                Inches(tab["position_inches"]),
+                alignments[tab.get("alignment", "left")],
+                leaders[tab.get("leader", "spaces")],
+            )
 
 
 def required_string(value: Any, field: str) -> str:
@@ -1152,6 +1900,51 @@ def validate_text_and_runs(spec: dict[str, Any], field: str) -> None:
         alignment = string_value(spec["alignment"], f"{field}.alignment")
         if alignment not in {"left", "center", "right", "justify"}:
             raise ToolError("bad_input", f"{field}.alignment is unsupported.")
+    for name in (
+        "space_before_pt",
+        "space_after_pt",
+        "left_indent_inches",
+        "right_indent_inches",
+        "hanging_indent_inches",
+    ):
+        if name in spec:
+            required_number(spec[name], f"{field}.{name}", minimum=0)
+    if "first_line_indent_inches" in spec:
+        required_number(spec["first_line_indent_inches"], f"{field}.first_line_indent_inches")
+    if "first_line_indent_inches" in spec and "hanging_indent_inches" in spec:
+        raise ToolError("bad_input", f"{field} cannot combine first-line and hanging indents.")
+    if "line_spacing" in spec:
+        value = spec["line_spacing"]
+        if isinstance(value, str):
+            if value not in {"single", "one_and_half", "double"}:
+                raise ToolError("bad_input", f"{field}.line_spacing is unsupported.")
+        else:
+            required_number(value, f"{field}.line_spacing", minimum=0.1)
+    for name in ("keep_with_next", "keep_together", "page_break_before", "widow_control"):
+        if name in spec:
+            optional_boolean(spec[name], f"{field}.{name}")
+    if "tab_stops" in spec:
+        tabs = spec["tab_stops"]
+        if not isinstance(tabs, list):
+            raise ToolError("bad_input", f"{field}.tab_stops must be an array.")
+        for index, tab in enumerate(tabs):
+            tab_field = f"{field}.tab_stops[{index}]"
+            if not isinstance(tab, dict):
+                raise ToolError("bad_input", f"{tab_field} must be an object.")
+            allow_keys(tab, {"position_inches", "alignment", "leader"}, tab_field)
+            require_keys(tab, {"position_inches"}, tab_field)
+            required_number(tab["position_inches"], f"{tab_field}.position_inches", minimum=0)
+            if tab.get("alignment", "left") not in {"left", "center", "right", "decimal", "bar"}:
+                raise ToolError("bad_input", f"{tab_field}.alignment is unsupported.")
+            if tab.get("leader", "spaces") not in {
+                "spaces",
+                "dots",
+                "dashes",
+                "lines",
+                "heavy",
+                "middle_dot",
+            }:
+                raise ToolError("bad_input", f"{tab_field}.leader is unsupported.")
 
 
 def validate_cell_value(value: Any, field: str) -> None:
@@ -1164,7 +1957,7 @@ def validate_cell_value(value: Any, field: str) -> None:
             "bad_input",
             f"{field} must be a string or paragraph object.",
         )
-    allow_keys(value, {"text", "runs", "style", "alignment"}, field)
+    allow_keys(value, {"text", "runs", "style", "alignment"} | PARAGRAPH_LAYOUT_KEYS, field)
     validate_text_and_runs(value, field)
 
 
@@ -1203,6 +1996,48 @@ def validate_table_block(block: dict[str, Any], field: str) -> None:
             minimum=0,
             maximum=len(rows),
         )
+    if "layout" in block:
+        layout = string_value(block["layout"], f"{field}.layout")
+        if layout not in {"autofit", "fixed"}:
+            raise ToolError(
+                "bad_input",
+                f"{field}.layout must be 'autofit' or 'fixed'.",
+            )
+    if "column_widths_inches" in block:
+        widths = block["column_widths_inches"]
+        if not isinstance(widths, list):
+            raise ToolError(
+                "bad_input",
+                f"{field}.column_widths_inches must be an array.",
+            )
+        if width is None or len(widths) != width:
+            raise ToolError(
+                "bad_input",
+                f"{field}.column_widths_inches must contain one width per column.",
+                details={
+                    "expected_columns": width,
+                    "actual_widths": len(widths),
+                },
+            )
+        for column_index, value in enumerate(widths):
+            required_number(
+                value,
+                f"{field}.column_widths_inches[{column_index}]",
+                minimum=0.1,
+            )
+    if "allow_row_split" in block:
+        optional_boolean(
+            block["allow_row_split"],
+            f"{field}.allow_row_split",
+        )
+    if "row_allow_split" in block:
+        values = block["row_allow_split"]
+        if not isinstance(values, list) or len(values) != len(rows):
+            raise ToolError(
+                "bad_input", f"{field}.row_allow_split must contain one Boolean per row."
+            )
+        for index, value in enumerate(values):
+            optional_boolean(value, f"{field}.row_allow_split[{index}]")
 
 
 def validate_block(block: Any, field: str, *, allow_sections: bool) -> None:
@@ -1213,7 +2048,7 @@ def validate_block(block: Any, field: str, *, allow_sections: bool) -> None:
     block_type = block.get("type", "paragraph")
     if not isinstance(block_type, str):
         raise ToolError("bad_input", f"{field}.type must be a string.")
-    paragraph_keys = {"type", "text", "runs", "style", "alignment"}
+    paragraph_keys = {"type", "text", "runs", "style", "alignment"} | PARAGRAPH_LAYOUT_KEYS
     if block_type == "paragraph":
         allow_keys(block, paragraph_keys, field)
         validate_text_and_runs(block, field)
@@ -1239,6 +2074,12 @@ def validate_block(block: Any, field: str, *, allow_sections: bool) -> None:
                 "alignment",
                 "prefix_runs",
                 "suffix_runs",
+                "alt_text",
+                "decorative",
+                "title",
+                "caption",
+                "caption_style",
+                "attribution",
             },
             field,
         )
@@ -1254,11 +2095,25 @@ def validate_block(block: Any, field: str, *, allow_sections: bool) -> None:
         for name in ("prefix_runs", "suffix_runs"):
             if name in block:
                 validate_runs(block[name], f"{field}.{name}")
+        for name in ("alt_text", "title", "caption", "caption_style", "attribution"):
+            if name in block:
+                string_value(block[name], f"{field}.{name}")
+        decorative = optional_boolean(block.get("decorative"), f"{field}.decorative")
+        if decorative and block.get("alt_text"):
+            raise ToolError("bad_input", f"{field} cannot combine decorative and alt_text.")
         return
     if block_type == "field":
         require_keys(block, {"field"}, field)
         field_name = required_string(block["field"], f"{field}.field")
-        if field_name not in {"page_number", "toc"}:
+        if field_name not in {
+            "page_number",
+            "toc",
+            "num_pages",
+            "section_pages",
+            "seq",
+            "ref",
+            "date",
+        }:
             raise ToolError("bad_input", f"{field}.field is unsupported.")
         allowed_field_keys = {
             "type",
@@ -1269,8 +2124,9 @@ def validate_block(block: Any, field: str, *, allow_sections: bool) -> None:
             "style",
             "alignment",
         }
-        if field_name == "toc":
+        if field_name in {"toc", "seq", "ref", "date"}:
             allowed_field_keys.add("instruction")
+        allowed_field_keys |= {"locked"}
         allow_keys(
             block,
             allowed_field_keys,
@@ -1279,6 +2135,8 @@ def validate_block(block: Any, field: str, *, allow_sections: bool) -> None:
         for name in ("prefix", "suffix", "placeholder", "instruction"):
             if name in block:
                 string_value(block[name], f"{field}.{name}")
+        if "locked" in block:
+            optional_boolean(block["locked"], f"{field}.locked")
         if "style" in block:
             required_string(block["style"], f"{field}.style")
         if "alignment" in block:
@@ -1305,7 +2163,7 @@ def validate_block(block: Any, field: str, *, allow_sections: bool) -> None:
             validate_text_and_runs(item, item_field)
         return
     if block_type == "table":
-        allow_keys(block, {"type", "rows", "style", "header_rows"}, field)
+        allow_keys(block, TABLE_KEYS, field)
         validate_table_block(block, field)
         return
     if block_type == "section_break":
@@ -1314,17 +2172,7 @@ def validate_block(block: Any, field: str, *, allow_sections: bool) -> None:
                 "bad_input",
                 f"{field} cannot contain a section break.",
             )
-        section_keys = {
-            "type",
-            "start",
-            "orientation",
-            "top_margin_inches",
-            "right_margin_inches",
-            "bottom_margin_inches",
-            "left_margin_inches",
-            "header_distance_inches",
-            "footer_distance_inches",
-        }
+        section_keys = {"type", "start"} | SECTION_KEYS
         allow_keys(block, section_keys, field)
         if "start" in block:
             start = string_value(block["start"], f"{field}.start")
@@ -1340,9 +2188,7 @@ def validate_block(block: Any, field: str, *, allow_sections: bool) -> None:
             orientation = string_value(block["orientation"], f"{field}.orientation")
             if orientation not in {"portrait", "landscape"}:
                 raise ToolError("bad_input", f"{field}.orientation is unsupported.")
-        for name in section_keys.difference({"type", "start", "orientation"}):
-            if name in block:
-                required_number(block[name], f"{field}.{name}", minimum=0)
+        validate_section_spec(block, field, extra_keys={"type", "start"})
         return
     raise ToolError("bad_input", f"{field}.type is unsupported.", details={"type": block_type})
 
@@ -1406,13 +2252,118 @@ def validate_metadata(metadata: Any, field: str) -> None:
             string_value(value, f"{field}.{key}")
 
 
+def validate_section_spec(spec: Any, field: str, *, extra_keys: set[str] | None = None) -> None:
+    """Validate page geometry and numbering controls."""
+
+    if not isinstance(spec, dict):
+        raise ToolError("bad_input", f"{field} must be an object.")
+    allow_keys(spec, SECTION_KEYS | (extra_keys or set()), field)
+    if "paper_size" in spec and spec["paper_size"] not in {"letter", "a4"}:
+        raise ToolError("bad_input", f"{field}.paper_size must be letter or a4.")
+    for name in SECTION_KEYS - {
+        "paper_size",
+        "orientation",
+        "different_first_page",
+        "page_number_start",
+        "page_number_format",
+    }:
+        if name in spec:
+            minimum = 0.1 if name in {"page_width_inches", "page_height_inches"} else 0
+            required_number(spec[name], f"{field}.{name}", minimum=minimum)
+    if spec.get("orientation") not in {None, "portrait", "landscape"}:
+        raise ToolError("bad_input", f"{field}.orientation is unsupported.")
+    if "different_first_page" in spec:
+        optional_boolean(spec["different_first_page"], f"{field}.different_first_page")
+    if "page_number_start" in spec:
+        required_integer(spec["page_number_start"], f"{field}.page_number_start", minimum=0)
+    formats = {
+        "decimal",
+        "upperRoman",
+        "lowerRoman",
+        "upperLetter",
+        "lowerLetter",
+    }
+    if "page_number_format" in spec and spec["page_number_format"] not in formats:
+        raise ToolError("bad_input", f"{field}.page_number_format is unsupported.")
+
+
+def validate_style_definitions(raw: Any, field: str) -> None:
+    """Validate paragraph and character style definitions."""
+
+    if not isinstance(raw, list):
+        raise ToolError("bad_input", f"{field} must be an array.")
+    for index, spec in enumerate(raw):
+        item = f"{field}[{index}]"
+        if not isinstance(spec, dict):
+            raise ToolError("bad_input", f"{item} must be an object.")
+        allow_keys(
+            spec,
+            {
+                "name",
+                "type",
+                "based_on",
+                "font",
+                "size_pt",
+                "bold",
+                "italic",
+                "underline",
+                "color",
+                "paragraph",
+                "outline_level",
+            },
+            item,
+        )
+        require_keys(spec, {"name", "type"}, item)
+        required_string(spec["name"], f"{item}.name")
+        if spec["type"] not in {"paragraph", "character"}:
+            raise ToolError("bad_input", f"{item}.type is unsupported.")
+        if "based_on" in spec:
+            required_string(spec["based_on"], f"{item}.based_on")
+        validate_runs(
+            [
+                {
+                    "text": "",
+                    **{
+                        key: spec[key]
+                        for key in ("font", "size_pt", "bold", "italic", "underline", "color")
+                        if key in spec
+                    },
+                }
+            ],
+            f"{item}.font",
+        )
+        if "paragraph" in spec:
+            if spec["type"] != "paragraph" or not isinstance(spec["paragraph"], dict):
+                raise ToolError("bad_input", f"{item}.paragraph requires a paragraph style.")
+            allow_keys(
+                spec["paragraph"], PARAGRAPH_LAYOUT_KEYS | {"alignment"}, f"{item}.paragraph"
+            )
+            validate_text_and_runs(spec["paragraph"], f"{item}.paragraph")
+        if "outline_level" in spec:
+            if spec["type"] != "paragraph":
+                raise ToolError("bad_input", f"{item}.outline_level requires a paragraph style.")
+            required_integer(spec["outline_level"], f"{item}.outline_level", minimum=0, maximum=9)
+
+
 def validate_create_content(content: Any, field: str = "content") -> None:
     """Validate the complete create-content object."""
 
     if not isinstance(content, dict):
         raise ToolError("bad_input", f"{field} must be an object.")
     allow_keys(
-        content, {"template", "letterhead", "metadata", "blocks", "headers", "footers"}, field
+        content,
+        {
+            "template",
+            "letterhead",
+            "metadata",
+            "section",
+            "styles",
+            "update_fields_on_open",
+            "blocks",
+            "headers",
+            "footers",
+        },
+        field,
     )
     if "template" in content and "letterhead" in content:
         raise ToolError("bad_input", f"{field} must specify only one of template or letterhead.")
@@ -1421,6 +2372,12 @@ def validate_create_content(content: Any, field: str = "content") -> None:
             required_string(content[name], f"{field}.{name}")
     if "metadata" in content:
         validate_metadata(content["metadata"], f"{field}.metadata")
+    if "section" in content:
+        validate_section_spec(content["section"], f"{field}.section")
+    if "styles" in content:
+        validate_style_definitions(content["styles"], f"{field}.styles")
+    if "update_fields_on_open" in content:
+        optional_boolean(content["update_fields_on_open"], f"{field}.update_fields_on_open")
     if "blocks" in content:
         validate_blocks(content["blocks"], f"{field}.blocks", allow_sections=True)
     for name in ("headers", "footers"):
@@ -1500,7 +2457,7 @@ def validate_edit_operation(operation: Any, field: str) -> None:
         table = operation["table"]
         if not isinstance(table, dict):
             raise ToolError("bad_input", f"{field}.table must be an object.")
-        allow_keys(table, {"type", "rows", "style", "header_rows"}, f"{field}.table")
+        allow_keys(table, TABLE_KEYS, f"{field}.table")
         if table.get("type", "table") != "table":
             raise ToolError("bad_input", f"{field}.table.type must be table.")
         validate_table_block(table, f"{field}.table")
@@ -1516,28 +2473,86 @@ def validate_edit_operation(operation: Any, field: str) -> None:
     if operation_type == "update_table":
         allow_keys(
             operation,
-            {"type", "table_index", "row", "column", "value", "style"},
+            {
+                "type",
+                "table_index",
+                "row",
+                "column",
+                "value",
+                "style",
+                "header_rows",
+                "layout",
+                "column_widths_inches",
+                "allow_row_split",
+                "row_allow_split",
+            },
             field,
         )
-        require_keys(operation, {"table_index", "row", "column", "value"}, field)
+        require_keys(operation, {"table_index"}, field)
+        cell_keys = {"row", "column", "value"}
+        if cell_keys.intersection(operation) and not cell_keys.issubset(operation):
+            raise ToolError("bad_input", f"{field} must supply row, column, and value together.")
         for name in ("table_index", "row", "column"):
+            if name not in operation:
+                continue
             required_integer(operation[name], f"{field}.{name}", minimum=0)
-        validate_cell_value(operation["value"], f"{field}.value")
+        if "value" in operation:
+            validate_cell_value(operation["value"], f"{field}.value")
         if "style" in operation:
             required_string(operation["style"], f"{field}.style")
+        if "header_rows" in operation:
+            required_integer(operation["header_rows"], f"{field}.header_rows", minimum=0)
+        if operation.get("layout") not in {None, "autofit", "fixed"}:
+            raise ToolError("bad_input", f"{field}.layout is unsupported.")
+        if "column_widths_inches" in operation:
+            widths = operation["column_widths_inches"]
+            if not isinstance(widths, list) or not widths:
+                raise ToolError("bad_input", f"{field}.column_widths_inches must be an array.")
+            for index, width in enumerate(widths):
+                required_number(width, f"{field}.column_widths_inches[{index}]", minimum=0.1)
+        if "allow_row_split" in operation:
+            optional_boolean(operation["allow_row_split"], f"{field}.allow_row_split")
+        if "row_allow_split" in operation:
+            values = operation["row_allow_split"]
+            if not isinstance(values, list):
+                raise ToolError("bad_input", f"{field}.row_allow_split must be an array.")
+            for index, value in enumerate(values):
+                optional_boolean(value, f"{field}.row_allow_split[{index}]")
         return
     if operation_type in {"insert_image", "replace_image"}:
         index_name = "paragraph_index" if operation_type == "insert_image" else "inline_image_index"
-        allowed = {"type", "path", "width_inches", "height_inches", index_name}
+        allowed = {
+            "type",
+            "path",
+            "width_inches",
+            "height_inches",
+            index_name,
+            "story_address",
+            "alt_text",
+            "decorative",
+            "title",
+        }
         allow_keys(operation, allowed, field)
-        required = {"path", "inline_image_index"} if operation_type == "replace_image" else {"path"}
+        required = {"path"} if operation_type == "replace_image" else {"path"}
         require_keys(operation, required, field)
+        if operation_type == "replace_image" and not {
+            "inline_image_index",
+            "story_address",
+        }.intersection(operation):
+            raise ToolError("bad_input", f"{field} requires inline_image_index or story_address.")
         required_string(operation["path"], f"{field}.path")
         if index_name in operation:
             required_integer(operation[index_name], f"{field}.{index_name}", minimum=0)
         for name in ("width_inches", "height_inches"):
             if name in operation:
                 required_number(operation[name], f"{field}.{name}", minimum=0.01)
+        for name in ("alt_text", "title", "story_address"):
+            if name in operation:
+                string_value(operation[name], f"{field}.{name}")
+        if "decorative" in operation:
+            optional_boolean(operation["decorative"], f"{field}.decorative")
+        if operation.get("decorative") and operation.get("alt_text"):
+            raise ToolError("bad_input", f"{field} cannot combine decorative and alt_text.")
         return
     if operation_type == "set_metadata":
         allow_keys(operation, {"type", "metadata"}, field)
@@ -1545,8 +2560,13 @@ def validate_edit_operation(operation: Any, field: str) -> None:
         validate_metadata(operation["metadata"], f"{field}.metadata")
         return
     if operation_type in {"set_header", "set_footer"}:
-        allow_keys(operation, {"type", "section_index", "kind", "mode", "blocks"}, field)
-        require_keys(operation, {"blocks"}, field)
+        allow_keys(
+            operation,
+            {"type", "section_index", "kind", "mode", "blocks", "link_to_previous"},
+            field,
+        )
+        if "link_to_previous" not in operation:
+            require_keys(operation, {"blocks"}, field)
         if "section_index" in operation:
             required_integer(operation["section_index"], f"{field}.section_index", minimum=0)
         if "kind" in operation:
@@ -1557,7 +2577,31 @@ def validate_edit_operation(operation: Any, field: str) -> None:
             mode = required_string(operation["mode"], f"{field}.mode")
             if mode not in {"replace", "append"}:
                 raise ToolError("bad_input", f"{field}.mode is unsupported.")
-        validate_blocks(operation["blocks"], f"{field}.blocks", allow_sections=False)
+        if "link_to_previous" in operation:
+            optional_boolean(operation["link_to_previous"], f"{field}.link_to_previous")
+            if operation["link_to_previous"] and "blocks" in operation:
+                raise ToolError(
+                    "bad_input",
+                    f"{field} cannot write blocks while link_to_previous is true.",
+                )
+        if "blocks" in operation:
+            validate_blocks(operation["blocks"], f"{field}.blocks", allow_sections=False)
+        return
+    if operation_type == "configure_section":
+        allow_keys(operation, {"type", "section_index"} | SECTION_KEYS, field)
+        if "section_index" in operation:
+            required_integer(operation["section_index"], f"{field}.section_index", minimum=0)
+        validate_section_spec(operation, field, extra_keys={"type", "section_index"})
+        return
+    if operation_type == "upsert_style":
+        allow_keys(operation, {"type", "style"}, field)
+        require_keys(operation, {"style"}, field)
+        validate_style_definitions([operation["style"]], f"{field}.style")
+        return
+    if operation_type == "set_update_fields_on_open":
+        allow_keys(operation, {"type", "enabled"}, field)
+        require_keys(operation, {"enabled"}, field)
+        optional_boolean(operation["enabled"], f"{field}.enabled")
         return
     raise ToolError(
         "bad_input",
@@ -1631,6 +2675,19 @@ def validate_job(job: dict[str, Any]) -> str:
             required_integer(job["timeout"], "timeout", minimum=1, maximum=3_600)
         if "overwrite" in job:
             optional_boolean(job["overwrite"], "overwrite")
+    elif operation == "render":
+        allow_keys(
+            job,
+            common | {"input", "output", "dpi", "pages", "timeout"},
+            "render job",
+        )
+        require_keys(job, {"input", "output"}, "render job")
+        if "dpi" in job:
+            required_integer(job["dpi"], "dpi", minimum=MIN_RENDER_DPI, maximum=MAX_RENDER_DPI)
+        if "pages" in job:
+            required_string(job["pages"], "pages")
+        if "timeout" in job:
+            required_integer(job["timeout"], "timeout", minimum=1, maximum=3_600)
     else:
         raise ToolError(
             "bad_input",
@@ -1688,7 +2745,7 @@ def image_dimensions(spec: dict[str, Any]) -> tuple[Any | None, Any | None]:
 
 
 def append_field(paragraph: Paragraph, field_name: str, spec: dict[str, Any]) -> None:
-    """Append PAGE or TOC complex-field markup."""
+    """Append bounded common complex-field markup."""
 
     if field_name == "page_number":
         instruction = " PAGE "
@@ -1705,12 +2762,39 @@ def append_field(paragraph: Paragraph, field_name: str, spec: dict[str, Any]) ->
             "field.placeholder",
         )
     else:
-        raise ToolError("unsupported_operation", f"Unsupported field type: {field_name}")
+        defaults = {
+            "num_pages": (" NUMPAGES ", "1"),
+            "section_pages": (" SECTIONPAGES ", "1"),
+            "seq": (" SEQ Figure \\* ARABIC ", "1"),
+            "ref": (" REF Bookmark ", "Error! Reference source not found."),
+            "date": (' DATE \\@ "MMMM d, yyyy" ', "Date"),
+        }
+        if field_name not in defaults:
+            raise ToolError("unsupported_operation", f"Unsupported field type: {field_name}")
+        instruction, default_placeholder = defaults[field_name]
+        if "instruction" in spec:
+            instruction = string_value(spec["instruction"], "field.instruction")
+        expected = {
+            "seq": "SEQ",
+            "ref": "REF",
+            "date": "DATE",
+        }.get(field_name)
+        if expected and not instruction.strip().upper().startswith(expected):
+            raise ToolError("bad_input", f"{field_name} instruction must begin with {expected}.")
+        if len(instruction) > 512 or any(character in instruction for character in "\r\n\x00"):
+            raise ToolError("bad_input", "field.instruction is unsafe or too long.")
+        placeholder = string_value(
+            spec.get("placeholder", default_placeholder), "field.placeholder"
+        )
 
+    if len(instruction) > 512 or any(character in instruction for character in "\r\n\x00"):
+        raise ToolError("bad_input", "field.instruction is unsafe or too long.")
     begin_run = OxmlElement("w:r")
     begin = OxmlElement("w:fldChar")
     begin.set(qn("w:fldCharType"), "begin")
     begin.set(qn("w:dirty"), "true")
+    if optional_boolean(spec.get("locked"), "field.locked"):
+        begin.set(qn("w:fldLock"), "true")
     begin_run.append(begin)
 
     instruction_run = OxmlElement("w:r")
@@ -1771,7 +2855,8 @@ def add_paragraph_block(
         image = resolve_path(block.get("path"), base_dir, "image.path")
         validate_image(image)
         width, height = image_dimensions(block)
-        paragraph.add_run().add_picture(str(image), width=width, height=height)
+        shape = paragraph.add_run().add_picture(str(image), width=width, height=height)
+        set_drawing_accessibility(shape._inline, block)
         add_runs(paragraph, {"runs": block.get("suffix_runs", [])})
     elif block_type == "field":
         paragraph = container.add_paragraph()
@@ -1788,7 +2873,61 @@ def add_paragraph_block(
             f"Block type is not paragraph-like: {block_type}",
         )
     apply_paragraph_format(paragraph, block)
+    if block_type == "image" and ("caption" in block or "attribution" in block):
+        caption_text = string_value(block.get("caption", ""), "image.caption")
+        attribution = string_value(block.get("attribution", ""), "image.attribution")
+        text = caption_text + (f" — {attribution}" if attribution else "")
+        caption = container.add_paragraph(text)
+        assign_named_style(caption, block.get("caption_style", "Caption"), "image.caption_style")
+        paragraph.paragraph_format.keep_with_next = True
+        paragraph.paragraph_format.keep_together = True
+        caption.paragraph_format.keep_together = True
     return paragraph
+
+
+def set_drawing_accessibility(inline: Any, spec: dict[str, Any]) -> None:
+    """Write title, description, and decorative drawing metadata."""
+
+    doc_pr = inline.find(qn("wp:docPr"))
+    if doc_pr is None:
+        return
+    for name in ("descr", "title"):
+        doc_pr.attrib.pop(name, None)
+    if spec.get("alt_text"):
+        doc_pr.set("descr", string_value(spec["alt_text"], "image.alt_text"))
+    if spec.get("title"):
+        doc_pr.set("title", string_value(spec["title"], "image.title"))
+    ext_list = doc_pr.find(f"{{{A_NS}}}extLst")
+    if ext_list is not None:
+        for extension in list(ext_list):
+            if extension.get("uri") == DECORATIVE_EXTENSION_URI:
+                ext_list.remove(extension)
+        if not len(ext_list):
+            doc_pr.remove(ext_list)
+    if optional_boolean(spec.get("decorative"), "image.decorative"):
+        ext_list = doc_pr.find(f"{{{A_NS}}}extLst")
+        if ext_list is None:
+            ext_list = etree.Element(f"{{{A_NS}}}extLst")
+            doc_pr.append(ext_list)
+        extension = etree.SubElement(ext_list, f"{{{A_NS}}}ext")
+        extension.set("uri", DECORATIVE_EXTENSION_URI)
+        decorative = etree.Element(f"{{{A14_NS}}}decorative", nsmap={"a14": A14_NS})
+        decorative.set("val", "1")
+        extension.append(decorative)
+
+
+def apply_cell_widths(table: Table, widths: list[Any]) -> None:
+    """Set preferred widths, summing covered grid columns for merged cells."""
+
+    for column, width in zip(table.columns, widths, strict=True):
+        column.width = width
+    for row in table.rows:
+        grid_column = 0
+        for tc in row._tr.tc_lst:
+            grid_span = tc.tcPr.find(qn("w:gridSpan"))
+            span = int(grid_span.get(qn("w:val"), "1")) if grid_span is not None else 1
+            _Cell(tc, table).width = sum(widths[grid_column : grid_column + span])
+            grid_column += span
 
 
 def fill_table(table: Table, block: dict[str, Any]) -> None:
@@ -1809,12 +2948,37 @@ def fill_table(table: Table, block: dict[str, Any]) -> None:
             required_string(block["style"], "table.style"),
             "table.style",
         )
+    layout = block.get(
+        "layout",
+        "fixed" if "column_widths_inches" in block else "autofit",
+    )
+    table.autofit = layout == "autofit"
+    if "column_widths_inches" in block:
+        widths = [
+            Inches(required_number(value, "column_width", minimum=0.1))
+            for value in block["column_widths_inches"]
+        ]
+        apply_cell_widths(table, widths)
     header_rows = required_integer(block.get("header_rows", 0), "header_rows", minimum=0)
-    for row in table.rows[:header_rows]:
+    for row_index, row in enumerate(table.rows):
         tr_pr = row._tr.get_or_add_trPr()
-        repeat = OxmlElement("w:tblHeader")
-        repeat.set(qn("w:val"), "true")
-        tr_pr.append(repeat)
+        for existing in list(tr_pr.findall(qn("w:tblHeader"))):
+            tr_pr.remove(existing)
+        if row_index < header_rows:
+            repeat = OxmlElement("w:tblHeader")
+            repeat.set(qn("w:val"), "true")
+            tr_pr.append(repeat)
+        for existing in list(tr_pr.findall(qn("w:cantSplit"))):
+            tr_pr.remove(existing)
+        row_split = (
+            block["row_allow_split"][row_index]
+            if "row_allow_split" in block
+            else block.get("allow_row_split", True)
+        )
+        if not optional_boolean(row_split, "allow_row_split", default=True):
+            cant_split = OxmlElement("w:cantSplit")
+            cant_split.set(qn("w:val"), "true")
+            tr_pr.append(cant_split)
 
 
 def set_cell_value(cell: _Cell, value: Any) -> None:
@@ -1845,7 +3009,25 @@ def add_table_block(container: Any, block: dict[str, Any]) -> Table:
     if columns < 1:
         raise ToolError("bad_input", "A table must have at least one column.")
     if isinstance(container, (_Header, _Footer)):
-        table = container.add_table(rows=len(rows), cols=columns, width=Inches(6))
+        document = container._document_part.document
+        usable = next(
+            (
+                section.page_width - section.left_margin - section.right_margin
+                for section in document.sections
+                if (
+                    section.header.part is container.part
+                    or section.first_page_header.part is container.part
+                    or section.even_page_header.part is container.part
+                    or section.footer.part is container.part
+                    or section.first_page_footer.part is container.part
+                    or section.even_page_footer.part is container.part
+                )
+            ),
+            document.sections[0].page_width
+            - document.sections[0].left_margin
+            - document.sections[0].right_margin,
+        )
+        table = container.add_table(rows=len(rows), cols=columns, width=usable)
     else:
         table = container.add_table(rows=len(rows), cols=columns)
     fill_table(table, block)
@@ -1855,13 +3037,40 @@ def add_table_block(container: Any, block: dict[str, Any]) -> Table:
 def configure_section(section: Any, spec: dict[str, Any]) -> None:
     """Apply supported section page settings."""
 
-    if "orientation" in spec:
-        orientation = spec["orientation"]
-        if orientation not in {"portrait", "landscape"}:
-            raise ToolError("bad_input", "section.orientation must be portrait or landscape.")
-        desired = WD_ORIENT.LANDSCAPE if orientation == "landscape" else WD_ORIENT.PORTRAIT
-        if section.orientation != desired:
-            section.orientation = desired
+    requested_orientation = spec.get("orientation")
+    if requested_orientation not in {None, "portrait", "landscape"}:
+        raise ToolError("bad_input", "section.orientation must be portrait or landscape.")
+    current_landscape = section.orientation == WD_ORIENT.LANDSCAPE or (
+        section.page_width is not None
+        and section.page_height is not None
+        and section.page_width > section.page_height
+    )
+    final_landscape = (
+        requested_orientation == "landscape"
+        if requested_orientation is not None
+        else current_landscape
+    )
+    if "paper_size" in spec:
+        sizes = {"letter": (8.5, 11.0), "a4": (8.2677, 11.6929)}
+        width, height = sizes[required_string(spec["paper_size"], "section.paper_size")]
+        if final_landscape:
+            width, height = height, width
+        section.page_width, section.page_height = Inches(width), Inches(height)
+    if "page_width_inches" in spec:
+        section.page_width = Inches(required_number(spec["page_width_inches"], "page_width_inches"))
+    if "page_height_inches" in spec:
+        section.page_height = Inches(
+            required_number(spec["page_height_inches"], "page_height_inches")
+        )
+    if requested_orientation is not None:
+        desired = WD_ORIENT.LANDSCAPE if final_landscape else WD_ORIENT.PORTRAIT
+        section.orientation = desired
+        dimensions_are_landscape = (
+            section.page_width is not None
+            and section.page_height is not None
+            and section.page_width > section.page_height
+        )
+        if dimensions_are_landscape != final_landscape:
             section.page_width, section.page_height = section.page_height, section.page_width
     margin_fields = {
         "top_margin_inches": "top_margin",
@@ -1878,6 +3087,63 @@ def configure_section(section: Any, spec: dict[str, Any]) -> None:
                 property_name,
                 Inches(required_number(spec[input_name], input_name, minimum=0)),
             )
+    if (
+        section.page_width is not None
+        and section.left_margin is not None
+        and section.right_margin is not None
+        and section.page_width <= section.left_margin + section.right_margin
+    ):
+        raise ToolError(
+            "bad_input",
+            "Section left and right margins must leave positive printable width.",
+        )
+    if (
+        section.page_height is not None
+        and section.top_margin is not None
+        and section.bottom_margin is not None
+        and section.page_height <= section.top_margin + section.bottom_margin
+    ):
+        raise ToolError(
+            "bad_input",
+            "Section top and bottom margins must leave positive printable height.",
+        )
+    if "different_first_page" in spec:
+        section.different_first_page_header_footer = optional_boolean(
+            spec["different_first_page"], "different_first_page"
+        )
+    if "page_number_start" in spec or "page_number_format" in spec:
+        pg_num = section._sectPr.find(qn("w:pgNumType"))
+        if pg_num is None:
+            pg_num = OxmlElement("w:pgNumType")
+            later_children = {
+                qn(f"w:{name}")
+                for name in (
+                    "cols",
+                    "formProt",
+                    "vAlign",
+                    "noEndnote",
+                    "titlePg",
+                    "textDirection",
+                    "bidi",
+                    "rtlGutter",
+                    "docGrid",
+                    "printerSettings",
+                    "sectPrChange",
+                )
+            }
+            insertion_index = next(
+                (
+                    index
+                    for index, child in enumerate(section._sectPr)
+                    if child.tag in later_children
+                ),
+                len(section._sectPr),
+            )
+            section._sectPr.insert(insertion_index, pg_num)
+        if "page_number_start" in spec:
+            pg_num.set(qn("w:start"), str(spec["page_number_start"]))
+        if "page_number_format" in spec:
+            pg_num.set(qn("w:fmt"), spec["page_number_format"])
 
 
 def apply_blocks(
@@ -2037,6 +3303,65 @@ def set_metadata(document: DocumentObject, metadata: Any) -> int:
     return len(metadata)
 
 
+def set_update_fields_on_open(document: DocumentObject, enabled: bool) -> None:
+    """Set Word's update-fields-on-open document setting without duplicates."""
+
+    settings = document.settings.element
+    for existing in list(settings.findall(qn("w:updateFields"))):
+        settings.remove(existing)
+    element = OxmlElement("w:updateFields")
+    element.set(qn("w:val"), "true" if enabled else "false")
+    settings.append(element)
+
+
+def upsert_style(document: DocumentObject, spec: dict[str, Any]) -> None:
+    """Create or update a paragraph/character named style."""
+
+    name = required_string(spec["name"], "style.name")
+    style_type = WD_STYLE_TYPE.PARAGRAPH if spec["type"] == "paragraph" else WD_STYLE_TYPE.CHARACTER
+    try:
+        style = document.styles[name]
+        if style.type != style_type:
+            raise ToolError(
+                "bad_input", "Existing style has a different type.", details={"style": name}
+            )
+    except KeyError:
+        style = document.styles.add_style(name, style_type)
+    if "based_on" in spec:
+        try:
+            style.base_style = document.styles[spec["based_on"]]
+        except KeyError as exc:
+            raise ToolError("bad_input", "style.based_on does not exist.") from exc
+    font_spec = {
+        key: spec[key]
+        for key in ("font", "size_pt", "bold", "italic", "underline", "color")
+        if key in spec
+    }
+    apply_run_format(type("_StyleRun", (), {"font": style.font, "style": None})(), font_spec)
+    if spec["type"] == "paragraph" and "paragraph" in spec:
+        paragraph_spec = spec["paragraph"]
+        pseudo = type(
+            "_StyleParagraph",
+            (),
+            {"paragraph_format": style.paragraph_format, "alignment": None},
+        )()
+        apply_paragraph_format(pseudo, paragraph_spec)
+        if "alignment" in paragraph_spec:
+            style.paragraph_format.alignment = {
+                "left": WD_ALIGN_PARAGRAPH.LEFT,
+                "center": WD_ALIGN_PARAGRAPH.CENTER,
+                "right": WD_ALIGN_PARAGRAPH.RIGHT,
+                "justify": WD_ALIGN_PARAGRAPH.JUSTIFY,
+            }[paragraph_spec["alignment"]]
+    if "outline_level" in spec:
+        p_pr = style.element.get_or_add_pPr()
+        for existing in list(p_pr.findall(qn("w:outlineLvl"))):
+            p_pr.remove(existing)
+        outline = OxmlElement("w:outlineLvl")
+        outline.set(qn("w:val"), str(spec["outline_level"]))
+        p_pr.append(outline)
+
+
 def create_document(
     spec: dict[str, Any],
     base_dir: Path,
@@ -2073,7 +3398,14 @@ def create_document(
     else:
         document = Document()
 
+    if "section" in content:
+        configure_section(document.sections[0], content["section"])
+    for style in content.get("styles", []):
+        upsert_style(document, style)
+    if "update_fields_on_open" in content:
+        set_update_fields_on_open(document, content["update_fields_on_open"])
     counts = apply_blocks(document, content.get("blocks", []), base_dir, allow_sections=True)
+    counts["styles"] += len(content.get("styles", []))
     counts["metadata"] += set_metadata(document, content.get("metadata"))
     counts["headers"] += apply_story_configuration(
         document, content.get("headers"), base_dir, header=True
@@ -2493,7 +3825,7 @@ def insert_table(document: DocumentObject, operation: dict[str, Any]) -> None:
 
 
 def update_table(document: DocumentObject, operation: dict[str, Any]) -> None:
-    """Update one table cell and optionally its table style."""
+    """Update table properties and optionally one cell."""
 
     table = table_at(document, operation.get("table_index"))
     if "style" in operation:
@@ -2502,11 +3834,66 @@ def update_table(document: DocumentObject, operation: dict[str, Any]) -> None:
             required_string(operation["style"], "update_table.style"),
             "update_table.style",
         )
-    row_index = required_integer(operation.get("row"), "update_table.row", minimum=0)
-    column_index = required_integer(operation.get("column"), "update_table.column", minimum=0)
-    if row_index >= len(table.rows) or column_index >= len(table.rows[row_index].cells):
-        raise ToolError("bad_input", "Table cell index is out of range.")
-    set_cell_value(table.cell(row_index, column_index), operation.get("value", ""))
+    property_spec = {
+        key: operation[key]
+        for key in (
+            "header_rows",
+            "layout",
+            "column_widths_inches",
+            "allow_row_split",
+            "row_allow_split",
+        )
+        if key in operation
+    }
+    if "column_widths_inches" in property_spec and len(
+        property_spec["column_widths_inches"]
+    ) != len(table.columns):
+        raise ToolError("bad_input", "column_widths_inches must contain one width per column.")
+    if "header_rows" in property_spec and property_spec["header_rows"] > len(table.rows):
+        raise ToolError("bad_input", "header_rows exceeds the table row count.")
+    if "row_allow_split" in property_spec and len(property_spec["row_allow_split"]) != len(
+        table.rows
+    ):
+        raise ToolError("bad_input", "row_allow_split must contain one Boolean per row.")
+    if property_spec:
+        fill_table_properties(table, property_spec)
+    if "row" in operation:
+        row_index = required_integer(operation["row"], "update_table.row", minimum=0)
+        column_index = required_integer(operation["column"], "update_table.column", minimum=0)
+        if row_index >= len(table.rows) or column_index >= len(table.rows[row_index].cells):
+            raise ToolError("bad_input", "Table cell index is out of range.")
+        set_cell_value(table.cell(row_index, column_index), operation["value"])
+
+
+def fill_table_properties(table: Table, spec: dict[str, Any]) -> None:
+    """Apply table layout properties without touching cell content."""
+
+    table.autofit = spec.get("layout", "autofit" if table.autofit else "fixed") == "autofit"
+    if "column_widths_inches" in spec:
+        widths = [Inches(value) for value in spec["column_widths_inches"]]
+        apply_cell_widths(table, widths)
+    header_rows = spec.get("header_rows")
+    for row_index, row in enumerate(table.rows):
+        tr_pr = row._tr.get_or_add_trPr()
+        if header_rows is not None:
+            for node in list(tr_pr.findall(qn("w:tblHeader"))):
+                tr_pr.remove(node)
+            if row_index < header_rows:
+                node = OxmlElement("w:tblHeader")
+                node.set(qn("w:val"), "true")
+                tr_pr.append(node)
+        if "allow_row_split" in spec or "row_allow_split" in spec:
+            for node in list(tr_pr.findall(qn("w:cantSplit"))):
+                tr_pr.remove(node)
+            allows = (
+                spec["row_allow_split"][row_index]
+                if "row_allow_split" in spec
+                else spec["allow_row_split"]
+            )
+            if not allows:
+                node = OxmlElement("w:cantSplit")
+                node.set(qn("w:val"), "true")
+                tr_pr.append(node)
 
 
 def insert_image(
@@ -2523,7 +3910,8 @@ def insert_image(
         paragraph = paragraph_at(document, operation["paragraph_index"])
     else:
         paragraph = document.add_paragraph()
-    paragraph.add_run().add_picture(str(image), width=width, height=height)
+    shape = paragraph.add_run().add_picture(str(image), width=width, height=height)
+    set_drawing_accessibility(shape._inline, operation)
 
 
 def replace_image(
@@ -2533,7 +3921,15 @@ def replace_image(
 ) -> None:
     """Replace one body inline image relationship without flattening its drawing."""
 
-    index = required_integer(operation.get("inline_image_index"), "inline_image_index", minimum=0)
+    if "story_address" in operation:
+        match = re.fullmatch(r"([^#]+)#inline-(\d+)", operation["story_address"])
+        if not match or match.group(1) != "word/document.xml":
+            raise ToolError("bad_input", "Only body story_address image replacement is supported.")
+        index = int(match.group(2))
+    else:
+        index = required_integer(
+            operation.get("inline_image_index"), "inline_image_index", minimum=0
+        )
     shapes = document.inline_shapes
     if index >= len(shapes):
         raise ToolError("bad_input", "inline_image_index is out of range.")
@@ -2549,6 +3945,21 @@ def replace_image(
             shapes[index].width = width
         if height is not None:
             shapes[index].height = height
+        if {"alt_text", "decorative", "title"}.intersection(operation):
+            decorative = (
+                inline.docPr.find(
+                    f"{{{A_NS}}}extLst/{{{A_NS}}}ext"
+                    f"[@uri='{DECORATIVE_EXTENSION_URI}']/"
+                    f"{{{A14_NS}}}decorative[@val='1']"
+                )
+                is not None
+            )
+            existing = {
+                "alt_text": inline.docPr.get("descr"),
+                "title": inline.docPr.get("title"),
+                "decorative": decorative,
+            }
+            set_drawing_accessibility(inline, {**existing, **operation})
     except Exception as exc:
         raise ToolError(
             "validation_failed",
@@ -2574,7 +3985,14 @@ def set_story_operation(
         required_string(operation.get("kind", "default"), "story.kind"),
         header,
     )
-    story.is_linked_to_previous = False
+    if operation.get("link_to_previous") and "blocks" in operation:
+        raise ToolError("bad_input", "Cannot write blocks while link_to_previous is true.")
+    if "link_to_previous" in operation:
+        story.is_linked_to_previous = operation["link_to_previous"]
+        if operation["link_to_previous"] and "blocks" not in operation:
+            return
+    else:
+        story.is_linked_to_previous = False
     mode = operation.get("mode", "replace")
     if mode == "replace":
         clear_story(story)
@@ -2619,6 +4037,15 @@ def apply_edit_operations(
             set_story_operation(document, operation, base_dir, header=True)
         elif operation_type == "set_footer":
             set_story_operation(document, operation, base_dir, header=False)
+        elif operation_type == "configure_section":
+            index = required_integer(operation.get("section_index", 0), "section_index", minimum=0)
+            if index >= len(document.sections):
+                raise ToolError("bad_input", "section_index is out of range.")
+            configure_section(document.sections[index], operation)
+        elif operation_type == "upsert_style":
+            upsert_style(document, operation["style"])
+        elif operation_type == "set_update_fields_on_open":
+            set_update_fields_on_open(document, operation["enabled"])
         else:
             raise ToolError(
                 "unsupported_operation",
@@ -2771,6 +4198,7 @@ def validate_pdf(path: Path) -> dict[str, Any]:
                 )
             text_characters = 0
             extraction_failures = 0
+            page_quality: list[dict[str, Any]] = []
             text_pages_checked = min(page_count, MAX_PDF_TEXT_PAGES)
             for index in range(text_pages_checked):
                 try:
@@ -2792,6 +4220,31 @@ def validate_pdf(path: Path) -> dict[str, Any]:
                     extraction_failures += 1
                     continue
                 text_characters += len(extracted)
+                media_box = page.mediabox
+                normalized = " ".join(extracted.split())
+                resources = page.get("/Resources")
+                if resources is not None and hasattr(resources, "get_object"):
+                    resources = resources.get_object()
+                xobjects = resources.get("/XObject") if resources is not None else None
+                if xobjects is not None and hasattr(xobjects, "get_object"):
+                    xobjects = xobjects.get_object()
+                has_nontext_content = bool(xobjects)
+                low_text = len(normalized) < 20
+                page_quality.append(
+                    {
+                        "page_index": index,
+                        "width_points": round(float(media_box.width), 3),
+                        "height_points": round(float(media_box.height), 3),
+                        "text_characters": len(extracted),
+                        "low_text": low_text,
+                        "has_nontext_content": has_nontext_content,
+                        "nearly_blank": low_text and not has_nontext_content,
+                        "content_anchors": {
+                            "start": normalized[:80],
+                            "end": normalized[-80:] if normalized else "",
+                        },
+                    }
+                )
                 if text_characters > MAX_PDF_TEXT_CHARACTERS:
                     raise ToolError(
                         "resource_limit",
@@ -2817,6 +4270,20 @@ def validate_pdf(path: Path) -> dict[str, Any]:
             "text_character_limit": MAX_PDF_TEXT_CHARACTERS,
             "decompressed_stream_byte_limit": MAX_PDF_DECOMPRESSED_STREAM_BYTES,
             "text_extraction_failures": extraction_failures,
+            "content_quality_report": {
+                "deterministic": True,
+                "method": "pypdf text extraction and page-resource XObject detection",
+                "renderer_version": distribution_version("pypdf"),
+                "limitation": (
+                    "This is not visual rendering. Non-text detection is limited to page "
+                    "XObject resources and may not identify all visible vector content."
+                ),
+                "pages": page_quality,
+                "nearly_blank_pages": [
+                    page["page_index"] for page in page_quality if page["nearly_blank"]
+                ],
+                "raster_review_artifacts": [],
+            },
         }
     except ToolError:
         raise
@@ -2906,6 +4373,45 @@ def bounded_process_run(
     return process.returncode, stdout, stderr, timed_out, process_group_cleaned
 
 
+def find_soffice() -> str:
+    """Resolve LibreOffice: explicit override, PATH, then well-known app locations."""
+
+    override = os.environ.get("DOCX_SOFFICE")
+    if override:
+        candidate = Path(override)
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
+        raise ToolError(
+            "missing_dependency",
+            "DOCX_SOFFICE does not point to an executable LibreOffice binary.",
+            details={"path": override},
+        )
+    for name in ("soffice", "libreoffice"):
+        executable = shutil.which(name)
+        if executable is not None:
+            return executable
+    if sys.platform == "darwin":
+        for candidate in (
+            Path("/Applications/LibreOffice.app/Contents/MacOS/soffice"),
+            Path.home() / "Applications/LibreOffice.app/Contents/MacOS/soffice",
+        ):
+            if candidate.is_file() and os.access(candidate, os.X_OK):
+                return str(candidate)
+    raise ToolError(
+        "missing_dependency",
+        "LibreOffice soffice is required for DOCX-to-PDF conversion.",
+        details={
+            "searched": [
+                "DOCX_SOFFICE",
+                "PATH:soffice",
+                "PATH:libreoffice",
+                "darwin:/Applications/LibreOffice.app/Contents/MacOS/soffice",
+                "darwin:~/Applications/LibreOffice.app/Contents/MacOS/soffice",
+            ],
+        },
+    )
+
+
 def libreoffice_version(executable: str) -> str:
     """Read a bounded LibreOffice version string."""
 
@@ -2937,15 +4443,90 @@ def libreoffice_version(executable: str) -> str:
     return text[:300] or "unknown"
 
 
+def require_pypdfium2() -> Any:
+    """Import the optional pypdfium2 rasterizer or fail with an install hint."""
+
+    try:
+        import pypdfium2
+    except ModuleNotFoundError as exc:
+        raise ToolError(
+            "missing_dependency",
+            "Page rendering requires the optional pypdfium2 package.",
+            details={"install": f'"{sys.executable}" -m pip install pypdfium2'},
+        ) from exc
+    return pypdfium2
+
+
+def file_sha256(path: Path) -> str:
+    """Hash a file in bounded chunks."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def parse_render_pages(value: str | None, page_count: int) -> list[int]:
+    """Select 1-based PDF page numbers, validated against the converted page count."""
+
+    if value is None:
+        selected = list(range(1, page_count + 1))
+    else:
+        chosen: set[int] = set()
+        for part in value.split(","):
+            text = part.strip()
+            if not text.isdigit():
+                raise ToolError(
+                    "bad_input",
+                    "pages must be a comma-separated list of 1-based page numbers.",
+                    details={"pages": value},
+                )
+            page = int(text)
+            if not 1 <= page <= page_count:
+                raise ToolError(
+                    "bad_input",
+                    "Requested page does not exist in the converted PDF.",
+                    details={"page": page, "pdf_pages": page_count},
+                )
+            chosen.add(page)
+        if not chosen:
+            raise ToolError("bad_input", "pages must select at least one page.")
+        selected = sorted(chosen)
+    if len(selected) > MAX_RENDER_PAGES:
+        raise ToolError(
+            "resource_limit",
+            "Rendering would produce too many pages; select a subset with pages.",
+            details={"pages": len(selected), "limit": MAX_RENDER_PAGES},
+        )
+    return selected
+
+
+def publish_directory_atomic(staged: Path, output: Path) -> None:
+    """Publish a staged directory to a destination that must not already exist."""
+
+    if output.exists():
+        raise ToolError(
+            "output_conflict",
+            "Atomic render publication requires a destination directory that does not "
+            "already exist.",
+            details={"path": str(output)},
+        )
+    try:
+        os.replace(staged, output)
+    except OSError as exc:
+        shutil.rmtree(staged, ignore_errors=True)
+        raise ToolError(
+            "validation_failed",
+            "Could not atomically publish the output directory.",
+            details={"path": str(output), "reason": str(exc)},
+        ) from exc
+
+
 def convert_pdf_bytes(source: Path, timeout: int) -> tuple[bytes, dict[str, Any], str]:
     """Run headless LibreOffice with an isolated temporary profile."""
 
-    executable = shutil.which("soffice")
-    if executable is None:
-        raise ToolError(
-            "missing_dependency",
-            "LibreOffice soffice is required for DOCX-to-PDF conversion.",
-        )
+    executable = find_soffice()
     version = libreoffice_version(executable)
     with tempfile.TemporaryDirectory(prefix="docx-tool-lo-") as temp_name:
         root = Path(temp_name)
@@ -3130,6 +4711,219 @@ def convert_document(
     )
 
 
+def render_document(
+    source: Path,
+    output: Path,
+    *,
+    dpi: int,
+    pages: str | None,
+    timeout: int,
+    allow_external_relationships: bool,
+) -> dict[str, Any]:
+    """Render document pages to one PNG each through LibreOffice and PDFium."""
+
+    if (
+        isinstance(dpi, bool)
+        or not isinstance(dpi, int)
+        or not MIN_RENDER_DPI <= dpi <= MAX_RENDER_DPI
+    ):
+        raise ToolError(
+            "bad_input",
+            f"dpi must be an integer between {MIN_RENDER_DPI} and {MAX_RENDER_DPI}.",
+            details={"dpi": dpi},
+        )
+    if timeout < 1 or timeout > 3_600:
+        raise ToolError("bad_input", "timeout must be between 1 and 3600 seconds.")
+    if output.suffix:
+        raise ToolError(
+            "bad_input",
+            "Render output must be a directory path without a suffix.",
+            details={"path": str(output)},
+        )
+    if output.exists():
+        raise ToolError(
+            "output_conflict",
+            "Atomic render publication requires a destination directory that does not "
+            "already exist.",
+            details={"path": str(output)},
+        )
+    if not output.parent.is_dir():
+        raise ToolError(
+            "bad_input",
+            "Destination parent directory does not exist.",
+            details={"path": str(output.parent)},
+        )
+    pdfium = require_pypdfium2()
+    preflight_docx(source, allow_external_relationships=allow_external_relationships)
+    source_inspection, source_warnings = inspect_document(
+        source,
+        allow_external_relationships=allow_external_relationships,
+    )
+    source_hash = file_sha256(source)
+    data, conversion_diagnostics, version = convert_pdf_bytes(source, timeout)
+    images: list[dict[str, Any]] = []
+    staged = Path(tempfile.mkdtemp(prefix=f".{output.name}.", dir=output.parent))
+    try:
+        with tempfile.TemporaryDirectory(prefix="docx-tool-render-") as temp_name:
+            temp_pdf = Path(temp_name) / "converted.pdf"
+            temp_pdf.write_bytes(data)
+            pdf_verification = validate_pdf(temp_pdf)
+            page_count = pdf_verification["page_count"]
+            try:
+                document = pdfium.PdfDocument(str(temp_pdf))
+            except Exception as exc:
+                raise ToolError(
+                    "external_tool_failed",
+                    "PDFium could not open the converted PDF.",
+                    details={"reason": str(exc)},
+                ) from exc
+            try:
+                if len(document) != page_count:
+                    raise ToolError(
+                        "validation_failed",
+                        "PDFium and pypdf disagree about the converted page count.",
+                        details={"pypdf_pages": page_count, "pdfium_pages": len(document)},
+                    )
+                selected = parse_render_pages(pages, page_count)
+                total_pixels = 0
+                for page_number in selected:
+                    page = document[page_number - 1]
+                    width_pt, height_pt = page.get_size()
+                    pixels = math.ceil(width_pt / 72 * dpi) * math.ceil(height_pt / 72 * dpi)
+                    if pixels > MAX_RENDER_PIXELS_PER_PAGE:
+                        raise ToolError(
+                            "resource_limit",
+                            "Rendered pixel count for one page exceeds the limit.",
+                            details={
+                                "page": page_number,
+                                "pixels": pixels,
+                                "limit": MAX_RENDER_PIXELS_PER_PAGE,
+                            },
+                        )
+                    total_pixels += pixels
+                    if total_pixels > MAX_RENDER_TOTAL_PIXELS:
+                        raise ToolError(
+                            "resource_limit",
+                            "Total rendered pixel count exceeds the limit.",
+                            details={"pixels": total_pixels, "limit": MAX_RENDER_TOTAL_PIXELS},
+                        )
+                    file_name = f"page-{page_number:03d}.png"
+                    staged_file = staged / file_name
+                    try:
+                        page.render(scale=dpi / 72).to_pil().save(staged_file, format="PNG")
+                    except Exception as exc:
+                        raise ToolError(
+                            "external_tool_failed",
+                            "PDFium could not rasterize a PDF page.",
+                            details={"page": page_number, "reason": str(exc)},
+                        ) from exc
+                    with staged_file.open("rb") as rendered:
+                        if rendered.read(8) != b"\x89PNG\r\n\x1a\n":
+                            raise ToolError(
+                                "validation_failed",
+                                "Rendered file does not have a PNG signature.",
+                                details={"file": file_name},
+                            )
+                    with PILImage.open(staged_file) as verified:
+                        verified.load()
+                        size = verified.size
+                    if size[0] * size[1] > MAX_RENDER_PIXELS_PER_PAGE:
+                        raise ToolError(
+                            "validation_failed",
+                            "Rendered image exceeds the per-page pixel limit.",
+                            details={"file": file_name},
+                        )
+                    png_bytes = staged_file.read_bytes()
+                    images.append(
+                        {
+                            "page": page_number,
+                            "file": file_name,
+                            "width_px": size[0],
+                            "height_px": size[1],
+                            "bytes": len(png_bytes),
+                            "sha256": hashlib.sha256(png_bytes).hexdigest(),
+                        }
+                    )
+            finally:
+                document.close()
+        if file_sha256(source) != source_hash:
+            raise ToolError(
+                "validation_failed",
+                "Source changed before the destination publication gate.",
+                details={"path": str(source)},
+            )
+        publish_directory_atomic(staged, output)
+    except Exception:
+        shutil.rmtree(staged, ignore_errors=True)
+        raise
+    reopened = 0
+    for record in images:
+        published = output / record["file"]
+        png_bytes = published.read_bytes()
+        if hashlib.sha256(png_bytes).hexdigest() != record["sha256"]:
+            raise ToolError(
+                "validation_failed",
+                "Published rendering does not match its staged hash.",
+                details={"file": record["file"]},
+            )
+        with PILImage.open(published) as verified:
+            verified.load()
+        reopened += 1
+    pdf_verification["content_quality_report"]["raster_review_artifacts"] = [
+        record["file"] for record in images
+    ]
+    warnings = [
+        *source_warnings,
+        warning(
+            "layout_engine_variance",
+            "DOCX-to-PDF is best-effort and may differ from Microsoft Word layout.",
+        ),
+        warning(
+            "render_review_required",
+            "Rendering exists to be looked at: open the published PNG pages and review "
+            "layout before claiming visual correctness.",
+        ),
+    ]
+    if conversion_diagnostics.get("stderr"):
+        warnings.append(
+            warning(
+                "libreoffice_diagnostics",
+                "LibreOffice emitted diagnostics; inspect result.conversion.",
+            )
+        )
+    diagnostic(
+        "info",
+        "libreoffice",
+        "LibreOffice conversion completed.",
+        **conversion_diagnostics,
+    )
+    return success_summary(
+        "render",
+        paths={"input": str(source), "output": str(output)},
+        counts={
+            "pdf_pages": page_count,
+            "pages_rendered": len(images),
+            "source_fields": source_inspection["features"]["fields"],
+            "source_revisions": source_inspection["features"]["revisions"],
+            "source_comments": source_inspection["features"]["comments"],
+        },
+        warnings=warnings,
+        verification={
+            "atomic_publish": True,
+            "png_reopened": reopened,
+            "source_unchanged_at_publish_gate": True,
+            **pdf_verification,
+        },
+        result={
+            "format": "png",
+            "dpi": dpi,
+            "images": images,
+            "conversion": conversion_diagnostics,
+        },
+        libreoffice=version,
+    )
+
+
 def preservation_summary(warnings: Sequence[dict[str, Any]]) -> dict[str, Any]:
     """Report preservation uncertainty without claiming universal round trips."""
 
@@ -3262,6 +5056,31 @@ def build_parser() -> argparse.ArgumentParser:
     )
     add_external_relationship_argument(convert_parser)
     add_common_output_arguments(convert_parser)
+
+    render_parser = subparsers.add_parser("render", help="Render DOCX pages to PNG images.")
+    render_parser.add_argument("--input", required=True, help="Source DOCX path.")
+    render_parser.add_argument(
+        "--output",
+        required=True,
+        help="Destination directory; must not already exist.",
+    )
+    render_parser.add_argument(
+        "--dpi",
+        type=int,
+        default=DEFAULT_RENDER_DPI,
+        help=f"Raster resolution between {MIN_RENDER_DPI} and {MAX_RENDER_DPI}.",
+    )
+    render_parser.add_argument(
+        "--pages",
+        help="Comma-separated 1-based PDF page numbers; default renders every page.",
+    )
+    render_parser.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_CONVERSION_TIMEOUT,
+        help="LibreOffice timeout in seconds.",
+    )
+    add_external_relationship_argument(render_parser)
     return parser
 
 
@@ -3303,6 +5122,15 @@ def execute_direct(args: argparse.Namespace) -> dict[str, Any]:
             resolve_path(args.output, cwd, "output"),
             args.format,
             overwrite=args.overwrite,
+            timeout=args.timeout,
+            allow_external_relationships=args.allow_external_relationships,
+        )
+    if args.command == "render":
+        return render_document(
+            resolve_path(args.input, cwd, "input"),
+            resolve_path(args.output, cwd, "output"),
+            dpi=args.dpi,
+            pages=args.pages,
             timeout=args.timeout,
             allow_external_relationships=args.allow_external_relationships,
         )
@@ -3348,6 +5176,25 @@ def execute_job(job_path: str) -> dict[str, Any]:
             resolve_path(job.get("output"), base_dir, "output"),
             required_string(job.get("format"), "format"),
             overwrite=overwrite,
+            timeout=required_integer(
+                job.get("timeout", DEFAULT_CONVERSION_TIMEOUT),
+                "timeout",
+                minimum=1,
+                maximum=3_600,
+            ),
+            allow_external_relationships=allow_external_relationships,
+        )
+    if operation == "render":
+        return render_document(
+            resolve_path(job.get("input"), base_dir, "input"),
+            resolve_path(job.get("output"), base_dir, "output"),
+            dpi=required_integer(
+                job.get("dpi", DEFAULT_RENDER_DPI),
+                "dpi",
+                minimum=MIN_RENDER_DPI,
+                maximum=MAX_RENDER_DPI,
+            ),
+            pages=(required_string(job["pages"], "pages") if "pages" in job else None),
             timeout=required_integer(
                 job.get("timeout", DEFAULT_CONVERSION_TIMEOUT),
                 "timeout",

--- a/kolega_code/_bundled_skills/skills/docx/scripts/smoke_test.py
+++ b/kolega_code/_bundled_skills/skills/docx/scripts/smoke_test.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import importlib.util
 import json
 import os
 import shutil
@@ -22,9 +23,12 @@ from typing import Any
 from xml.etree import ElementTree
 
 from docx import Document
+from docx.enum.section import WD_ORIENT, WD_SECTION
+from docx.oxml import OxmlElement
 from docx.oxml.ns import qn
+from docx.shared import Inches
 from pypdf import PdfReader, PdfWriter
-from pypdf.generic import DecodedStreamObject, NameObject
+from pypdf.generic import DecodedStreamObject, DictionaryObject, NameObject, NumberObject
 
 CLI_TIMEOUT_SECONDS = 30
 MAX_PDF_BYTES = 64 * 1024 * 1024
@@ -150,6 +154,50 @@ def add_custom_xml_part(source: Path, destination: Path) -> None:
         target_zip.writestr("customXml/smoke-extra.xml", b"<smoke>extra</smoke>")
 
 
+def rewrite_font_references(
+    source: Path, destination: Path, font_name: str, *, add_decoys: bool = False
+) -> None:
+    """Rewrite real font references and optionally add misleading non-font attributes."""
+
+    word_namespace = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+    font_attributes = tuple(
+        f"{{{word_namespace}}}{name}" for name in ("ascii", "hAnsi", "eastAsia", "cs")
+    )
+    with (
+        zipfile.ZipFile(source) as source_zip,
+        zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED) as target_zip,
+    ):
+        for info in source_zip.infolist():
+            data = source_zip.read(info)
+            if info.filename.startswith("word/") and info.filename.endswith(".xml"):
+                root = ElementTree.fromstring(data)
+                for element in root.iter(f"{{{word_namespace}}}rFonts"):
+                    for attribute in font_attributes:
+                        if element.get(attribute) is not None:
+                            element.set(attribute, font_name)
+                if info.filename.startswith("word/theme/"):
+                    for element in root.iter():
+                        if element.get("typeface") is not None:
+                            element.set("typeface", font_name)
+                if add_decoys and info.filename == "word/settings.xml":
+                    ElementTree.SubElement(
+                        root,
+                        f"{{{word_namespace}}}lang",
+                        {f"{{{word_namespace}}}eastAsia": "ja-JP"},
+                    )
+                    ElementTree.SubElement(
+                        root,
+                        f"{{{word_namespace}}}decimalSymbol",
+                        {
+                            f"{{{word_namespace}}}val": ".",
+                            f"{{{word_namespace}}}ascii": ".",
+                            f"{{{word_namespace}}}hAnsi": ",",
+                        },
+                    )
+                data = ElementTree.tostring(root, encoding="utf-8", xml_declaration=True)
+            target_zip.writestr(info, data)
+
+
 def write_pdf(path: Path, pages: int) -> None:
     """Write a deterministic blank PDF fixture."""
 
@@ -170,6 +218,62 @@ def write_compressed_stream_pdf(path: Path) -> None:
     page[NameObject("/Contents")] = writer._add_object(stream.flate_encode())
     with path.open("wb") as handle:
         writer.write(handle)
+
+
+def write_image_only_pdf(path: Path) -> None:
+    """Write a one-page PDF whose only visible content is an image XObject."""
+
+    writer = PdfWriter()
+    page = writer.add_blank_page(width=72, height=72)
+    image = DecodedStreamObject()
+    image.set_data(b"\x80")
+    image.update(
+        {
+            NameObject("/Type"): NameObject("/XObject"),
+            NameObject("/Subtype"): NameObject("/Image"),
+            NameObject("/Width"): NumberObject(1),
+            NameObject("/Height"): NumberObject(1),
+            NameObject("/ColorSpace"): NameObject("/DeviceGray"),
+            NameObject("/BitsPerComponent"): NumberObject(8),
+        }
+    )
+    image_reference = writer._add_object(image)
+    page[NameObject("/Resources")] = DictionaryObject(
+        {NameObject("/XObject"): DictionaryObject({NameObject("/ImSmoke"): image_reference})}
+    )
+    contents = DecodedStreamObject()
+    contents.set_data(b"q 36 0 0 36 18 18 cm /ImSmoke Do Q")
+    page[NameObject("/Contents")] = writer._add_object(contents)
+    with path.open("wb") as handle:
+        writer.write(handle)
+
+
+def rewrite_theme_tokens(source: Path, destination: Path) -> None:
+    """Reference HAnsi theme tokens and give major/minor Latin fonts distinct names."""
+
+    word_namespace = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+    drawing_namespace = "http://schemas.openxmlformats.org/drawingml/2006/main"
+    with (
+        zipfile.ZipFile(source) as source_zip,
+        zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED) as target_zip,
+    ):
+        for info in source_zip.infolist():
+            data = source_zip.read(info)
+            if info.filename.startswith("word/") and info.filename.endswith(".xml"):
+                root = ElementTree.fromstring(data)
+                for fonts in root.iter(f"{{{word_namespace}}}rFonts"):
+                    fonts.attrib.clear()
+                    fonts.set(f"{{{word_namespace}}}hAnsiTheme", "majorHAnsi")
+                    fonts.set(f"{{{word_namespace}}}asciiTheme", "minorHAnsi")
+                if info.filename.startswith("word/theme/"):
+                    major = root.find(f".//{{{drawing_namespace}}}majorFont")
+                    minor = root.find(f".//{{{drawing_namespace}}}minorFont")
+                    if major is not None:
+                        major.find(f"{{{drawing_namespace}}}latin").set("typeface", "Major Smoke")
+                    if minor is not None:
+                        minor.find(f"{{{drawing_namespace}}}latin").set("typeface", "Minor Smoke")
+                data = ElementTree.tostring(root, encoding="utf-8", xml_declaration=True)
+            target_zip.writestr(info, data)
 
 
 def make_fake_soffice(path: Path) -> None:
@@ -244,7 +348,11 @@ def assert_docx_structure(path: Path, replacement_image: Path) -> None:
     assert styled.runs[1].text == "ta"
     assert styled.runs[1].italic is True
     assert any(paragraph.text == "Done Done" for paragraph in document.paragraphs)
-    assert document.tables[0].cell(1, 1).text == "Updated"
+    table = document.tables[0]
+    assert table.cell(1, 1).text == "Updated"
+    assert table.autofit is False
+    assert [round(column.width.inches, 2) for column in table.columns] == [1.4, 4.6]
+    assert all(row._tr.get_or_add_trPr().find(qn("w:cantSplit")) is not None for row in table.rows)
     assert len(document.inline_shapes) == 1
     expected_hash = hashlib.sha256(replacement_image.read_bytes()).hexdigest()
     assert inline_image_sha256(document, 0) == expected_hash
@@ -266,12 +374,63 @@ def assert_inspection(payload: dict[str, Any]) -> None:
     assert payload["counts"]["tables"] == 1
     assert payload["counts"]["inline_images"] == 1
     assert payload["counts"]["fields"] >= 1
+    fonts = payload["result"]["fonts"]
+    assert fonts["referenced"]
+    assert set(fonts["unembedded"]) == set(fonts["referenced"])
+    assert fonts["embedded"] == []
+    font_warning = next(item for item in payload["warnings"] if item["code"] == "unembedded_fonts")
+    assert set(font_warning["fonts"]) == set(fonts["unembedded"])
+    assert "PDF font embedding does not make the DOCX portable" in font_warning["message"]
     assert any(item["heading_level"] == 1 for item in payload["result"]["paragraphs"])
+    table = payload["result"]["tables"][0]
+    assert table["layout"] == "fixed"
+    assert table["column_widths_inches"] == [1.4, 4.6]
+    assert table["row_allows_split"] == [False, False]
     assert any(
         story["paragraphs"][0]["text"] == "Smoke header"
         for story in payload["result"]["headers"]
         if story["paragraphs"]
     )
+
+
+def run_font_portability_regressions(tool: Path, root: Path, source: Path) -> None:
+    """Exclude non-font attributes and distinguish allowed from custom fonts."""
+
+    for index, font_name in enumerate(("aRiAl", "Times New Roman", "Courier New")):
+        allowed = root / f"allowed-font-{index}.docx"
+        rewrite_font_references(source, allowed, font_name, add_decoys=index == 0)
+        payload = run_cli(tool, "inspect", "--input", str(allowed))
+        fonts = payload["result"]["fonts"]
+        assert fonts["referenced"] == [font_name]
+        assert "ja-JP" not in fonts["referenced"]
+        assert "." not in fonts["referenced"]
+        assert "," not in fonts["referenced"]
+        assert not any(
+            item["code"] == "nonportable_unembedded_fonts" for item in payload["warnings"]
+        )
+
+    common = root / "common-font.docx"
+    rewrite_font_references(source, common, "Calibri")
+    payload = run_cli(tool, "inspect", "--input", str(common))
+    assert payload["result"]["fonts"]["referenced"] == ["Calibri"]
+    common_warning = next(
+        item for item in payload["warnings"] if item["code"] == "common_unembedded_fonts"
+    )
+    assert common_warning["fonts"] == ["Calibri"]
+    assert "RELEASE BLOCKER" not in common_warning["message"]
+    assert not any(item["code"] == "nonportable_unembedded_fonts" for item in payload["warnings"])
+
+    custom = root / "custom-font.docx"
+    rewrite_font_references(source, custom, "Avenir")
+    payload = run_cli(tool, "inspect", "--input", str(custom))
+    assert payload["result"]["fonts"]["referenced"] == ["Avenir"]
+    blocker = next(
+        item for item in payload["warnings"] if item["code"] == "nonportable_unembedded_fonts"
+    )
+    assert blocker["fonts"] == ["Avenir"]
+    assert blocker["message"].startswith("RELEASE BLOCKER:")
+    assert not any(item["code"] == "common_unembedded_fonts" for item in payload["warnings"])
+    assert any(item["code"] == "unembedded_fonts" for item in payload["warnings"])
 
 
 def run_pdf_check(tool: Path, source: Path, output: Path) -> dict[str, Any]:
@@ -301,6 +460,550 @@ def run_pdf_check(tool: Path, source: Path, output: Path) -> dict[str, Any]:
     }
 
 
+def run_quality_upgrade_regressions(
+    tool: Path, root: Path, image: Path, *, libreoffice: bool
+) -> dict[str, Any]:
+    """Exercise section, layout, style, table, field, and accessibility upgrades."""
+
+    spec = root / "quality-create.json"
+    created = root / "quality-created.docx"
+    write_json(
+        spec,
+        {
+            "schema_version": 1,
+            "content": {
+                "metadata": {"title": "Quality fixture", "language": "en-US"},
+                "section": {
+                    "paper_size": "letter",
+                    "margin_left_inches": 1,
+                    "different_first_page": True,
+                    "page_number_start": 3,
+                    "page_number_format": "lowerRoman",
+                },
+                "styles": [
+                    {
+                        "name": "Smoke Body",
+                        "type": "paragraph",
+                        "based_on": "Normal",
+                        "font": "Arial",
+                        "size_pt": 10,
+                        "paragraph": {
+                            "alignment": "justify",
+                            "space_after_pt": 6,
+                            "widow_control": True,
+                        },
+                        "outline_level": 0,
+                    },
+                    {
+                        "name": "Smoke Emphasis",
+                        "type": "character",
+                        "based_on": "Default Paragraph Font",
+                        "italic": True,
+                    },
+                ],
+                "update_fields_on_open": True,
+                "blocks": [
+                    {"type": "heading", "level": 1, "text": "Quality"},
+                    {
+                        "type": "paragraph",
+                        "style": "Smoke Body",
+                        "text": "Pagination controls",
+                        "space_before_pt": 4,
+                        "space_after_pt": 8,
+                        "line_spacing": "one_and_half",
+                        "left_indent_inches": 0.2,
+                        "first_line_indent_inches": 0.1,
+                        "keep_with_next": True,
+                        "keep_together": True,
+                        "page_break_before": False,
+                        "widow_control": True,
+                        "tab_stops": [
+                            {
+                                "position_inches": 2,
+                                "alignment": "right",
+                                "leader": "dots",
+                            }
+                        ],
+                    },
+                    {
+                        "type": "table",
+                        "style": "Table Grid",
+                        "layout": "fixed",
+                        "column_widths_inches": [2, 3],
+                        "header_rows": 1,
+                        "row_allow_split": [False, True],
+                        "rows": [["Name", "Value"], ["A", "B"]],
+                    },
+                    {
+                        "type": "image",
+                        "path": image.name,
+                        "width_inches": 2,
+                        "alt_text": "A red smoke-test square",
+                        "title": "Smoke image",
+                        "caption": "Figure smoke",
+                        "attribution": "Generated fixture",
+                    },
+                    {
+                        "type": "image",
+                        "path": image.name,
+                        "width_inches": 0.5,
+                        "decorative": True,
+                    },
+                    {"type": "heading", "level": 3, "text": "Skipped heading"},
+                    {
+                        "type": "table",
+                        "rows": [["No", "Header"], ["Data", "Row"]],
+                    },
+                    {"type": "field", "field": "num_pages"},
+                    {"type": "field", "field": "seq", "instruction": " SEQ Figure "},
+                    {"type": "field", "field": "toc"},
+                    {"type": "page_break"},
+                    {"type": "paragraph", "text": "Second-page anchor"},
+                ],
+                "headers": {"first_page": [{"type": "paragraph", "text": "First"}]},
+                "footers": {
+                    "default": [{"type": "field", "field": "page_number", "prefix": "Page "}]
+                },
+            },
+        },
+    )
+    # Catch accidental schema drift in the shared section vocabulary.
+    content = json.loads(spec.read_text(encoding="utf-8"))
+    content["content"]["section"]["left_margin_inches"] = content["content"]["section"].pop(
+        "margin_left_inches"
+    )
+    write_json(spec, content)
+    run_cli(tool, "create", "--spec", str(spec), "--output", str(created))
+    inspected = run_cli(tool, "inspect", "--input", str(created))
+    result = inspected["result"]
+    section = result["sections"][0]
+    assert section["paper_size"] == "letter"
+    assert section["page_number_start"] == 3
+    assert section["page_number_format"] == "lowerRoman"
+    assert result["settings"]["update_fields_on_open"] is True
+    paragraph = next(item for item in result["paragraphs"] if item["text"] == "Pagination controls")
+    assert paragraph["layout"]["keep_with_next"] is True
+    assert paragraph["layout"]["tab_stops"][0]["position_inches"] == 2
+    table = result["tables"][0]
+    assert table["layout"] == "fixed" and table["header_rows"] == 1
+    assert table["row_allows_split"] == [False, True]
+    occurrence = result["images"]["inline_occurrences"][0]
+    assert occurrence["alt_text"] == "A red smoke-test square"
+    assert occurrence["decorative"] is False
+    assert occurrence["effective_ppi_x"] is not None
+    assert result["images"]["inline_occurrences"][1]["decorative"] is True
+    assert {field["type"] for field in result["fields"]} >= {"NUMPAGES", "SEQ", "TOC"}
+    assert any(item["code"] == "toc_placeholder_only" for item in inspected["warnings"])
+    assert not any(
+        item["code"] == "informative_image_missing_alt_text" for item in inspected["warnings"]
+    )
+    assert any(item["code"] == "heading_level_skip" for item in inspected["warnings"])
+    assert any(item["code"] == "data_table_without_header_row" for item in inspected["warnings"])
+    smoke_style = next(style for style in result["styles"] if style["name"] == "Smoke Body")
+    assert smoke_style["paragraph"]["alignment"] == "justify"
+
+    edit_spec = root / "quality-edit.json"
+    edited = root / "quality-edited.docx"
+    write_json(
+        edit_spec,
+        {
+            "schema_version": 1,
+            "operations": [
+                {
+                    "type": "insert_table",
+                    "table": {
+                        "rows": [["H"], ["V"]],
+                        "style": "Table Grid",
+                        "layout": "fixed",
+                        "column_widths_inches": [2],
+                        "header_rows": 1,
+                        "allow_row_split": False,
+                    },
+                },
+                {
+                    "type": "update_table",
+                    "table_index": 0,
+                    "style": "Table Grid",
+                    "layout": "fixed",
+                    "column_widths_inches": [2.5, 2.5],
+                    "header_rows": 1,
+                    "row_allow_split": [True, False],
+                },
+                {
+                    "type": "configure_section",
+                    "section_index": 0,
+                    "paper_size": "a4",
+                    "orientation": "portrait",
+                    "page_number_start": 1,
+                    "page_number_format": "decimal",
+                },
+                {
+                    "type": "upsert_style",
+                    "style": {
+                        "name": "Smoke Body",
+                        "type": "paragraph",
+                        "based_on": "Normal",
+                        "font": "Arial",
+                        "paragraph": {"keep_together": True},
+                    },
+                },
+                {
+                    "type": "set_header",
+                    "section_index": 0,
+                    "kind": "default",
+                    "link_to_previous": False,
+                    "blocks": [{"type": "paragraph", "text": "Default header"}],
+                },
+            ],
+        },
+    )
+    run_cli(
+        tool, "edit", "--input", str(created), "--spec", str(edit_spec), "--output", str(edited)
+    )
+    edited_result = run_cli(tool, "inspect", "--input", str(edited))["result"]
+    assert edited_result["sections"][0]["paper_size"] == "a4"
+    assert edited_result["tables"][0]["row_allows_split"] == [True, False]
+    assert edited_result["tables"][2]["header_rows"] == 1
+    assert edited_result["headers"][0]["linked_to_previous"] is False
+
+    pdf = {"status": "skipped"}
+    if libreoffice:
+        pdf_path = root / "quality.pdf"
+        payload = run_cli(
+            tool,
+            "convert",
+            "--input",
+            str(edited),
+            "--format",
+            "pdf",
+            "--output",
+            str(pdf_path),
+            timeout=120,
+        )
+        report = payload["verification"]["content_quality_report"]
+        assert payload["verification"]["page_count"] >= 2
+        assert len(report["pages"]) >= 2
+        assert all("content_anchors" in page for page in report["pages"])
+        pdf = {"status": "passed", "pages": payload["verification"]["page_count"]}
+    return {"status": "passed", "pdf": pdf}
+
+
+def run_confirmed_defect_regressions(tool: Path, root: Path, image: Path) -> None:
+    """Cover ordering, shared stories, metadata, fields, widths, and section geometry."""
+
+    ordered_spec = root / "ordered-section.json"
+    ordered_docx = root / "ordered-section.docx"
+    write_json(
+        ordered_spec,
+        {
+            "schema_version": 1,
+            "content": {
+                "section": {
+                    "different_first_page": True,
+                    "page_number_start": 2,
+                },
+                "blocks": [],
+            },
+        },
+    )
+    run_cli(tool, "create", "--spec", str(ordered_spec), "--output", str(ordered_docx))
+    with zipfile.ZipFile(ordered_docx) as package:
+        root_xml = ElementTree.fromstring(package.read("word/document.xml"))
+    sect_pr = root_xml.find(
+        ".//{http://schemas.openxmlformats.org/wordprocessingml/2006/main}sectPr"
+    )
+    assert sect_pr is not None
+    child_names = [child.tag.rsplit("}", 1)[-1] for child in sect_pr]
+    assert child_names.index("pgNumType") < child_names.index("titlePg")
+
+    decorative_spec = root / "decorative.json"
+    decorative_docx = root / "decorative.docx"
+    write_json(
+        decorative_spec,
+        {
+            "schema_version": 1,
+            "content": {"blocks": [{"type": "image", "path": image.name, "decorative": True}]},
+        },
+    )
+    run_cli(tool, "create", "--spec", str(decorative_spec), "--output", str(decorative_docx))
+    with zipfile.ZipFile(decorative_docx) as package:
+        drawing_root = ElementTree.fromstring(package.read("word/document.xml"))
+    wp = "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+    a = "http://schemas.openxmlformats.org/drawingml/2006/main"
+    a14 = "http://schemas.microsoft.com/office/drawing/2010/main"
+    doc_pr = drawing_root.find(f".//{{{wp}}}docPr")
+    assert doc_pr is not None
+    ext_list = doc_pr.find(f"{{{a}}}extLst")
+    assert ext_list is not None and len(ext_list) == 1
+    extension = ext_list[0]
+    assert extension.tag == f"{{{a}}}ext"
+    assert extension.get("uri") == "{C183D7F6-B498-43B3-948B-1728B52AA6E4}"
+    assert len(extension) == 1
+    assert extension[0].tag == f"{{{a14}}}decorative"
+    assert extension[0].get("val") == "1"
+    assert (
+        run_cli(tool, "inspect", "--input", str(decorative_docx))["result"]["images"][
+            "inline_occurrences"
+        ][0]["decorative"]
+        is True
+    )
+
+    insert_spec = root / "insert-image-metadata.json"
+    inserted_docx = root / "insert-image-metadata.docx"
+    write_json(
+        insert_spec,
+        {
+            "schema_version": 1,
+            "operations": [
+                {
+                    "type": "insert_image",
+                    "path": image.name,
+                    "alt_text": "Inserted smoke image",
+                    "title": "Inserted title",
+                }
+            ],
+        },
+    )
+    run_cli(
+        tool,
+        "edit",
+        "--input",
+        str(ordered_docx),
+        "--spec",
+        str(insert_spec),
+        "--output",
+        str(inserted_docx),
+    )
+    inserted = run_cli(tool, "inspect", "--input", str(inserted_docx))["result"]["images"][
+        "inline_occurrences"
+    ][0]
+    assert inserted["alt_text"] == "Inserted smoke image"
+    assert inserted["title"] == "Inserted title"
+    assert inserted["decorative"] is False
+
+    landscape_source = root / "landscape-source.docx"
+    landscape = Document()
+    section = landscape.sections[0]
+    section.orientation = WD_ORIENT.LANDSCAPE
+    section.page_width, section.page_height = Inches(11), Inches(8.5)
+    landscape.save(landscape_source)
+    landscape_spec = root / "landscape-paper.json"
+    landscape_output = root / "landscape-paper.docx"
+    write_json(
+        landscape_spec,
+        {
+            "schema_version": 1,
+            "operations": [{"type": "configure_section", "section_index": 0, "paper_size": "a4"}],
+        },
+    )
+    run_cli(
+        tool,
+        "edit",
+        "--input",
+        str(landscape_source),
+        "--spec",
+        str(landscape_spec),
+        "--output",
+        str(landscape_output),
+    )
+    landscape_record = run_cli(tool, "inspect", "--input", str(landscape_output))["result"][
+        "sections"
+    ][0]
+    assert landscape_record["orientation"] == "LANDSCAPE"
+    assert landscape_record["page_width_inches"] > landscape_record["page_height_inches"]
+
+    for orientation, expect_landscape in (("landscape", True), ("portrait", False)):
+        explicit_spec = root / f"landscape-paper-{orientation}.json"
+        explicit_output = root / f"landscape-paper-{orientation}.docx"
+        write_json(
+            explicit_spec,
+            {
+                "schema_version": 1,
+                "operations": [
+                    {
+                        "type": "configure_section",
+                        "section_index": 0,
+                        "paper_size": "letter",
+                        "orientation": orientation,
+                    }
+                ],
+            },
+        )
+        run_cli(
+            tool,
+            "edit",
+            "--input",
+            str(landscape_source),
+            "--spec",
+            str(explicit_spec),
+            "--output",
+            str(explicit_output),
+        )
+        explicit_record = run_cli(tool, "inspect", "--input", str(explicit_output))["result"][
+            "sections"
+        ][0]
+        assert (explicit_record["page_width_inches"] > explicit_record["page_height_inches"]) is (
+            expect_landscape
+        )
+        assert explicit_record["orientation"] == orientation.upper()
+
+    shared_source = root / "shared-header.docx"
+    shared = Document()
+    shared.sections[0].header.is_linked_to_previous = False
+    shared.sections[0].header.paragraphs[0].text = "Prior story survives"
+    shared.add_section(WD_SECTION.NEW_PAGE).header.is_linked_to_previous = True
+    shared.save(shared_source)
+    shared_spec = root / "shared-header-edit.json"
+    shared_output = root / "shared-header-output.docx"
+    write_json(
+        shared_spec,
+        {
+            "schema_version": 1,
+            "operations": [
+                {
+                    "type": "set_header",
+                    "section_index": 1,
+                    "link_to_previous": True,
+                    "blocks": [{"type": "paragraph", "text": "Must not overwrite"}],
+                }
+            ],
+        },
+    )
+    payload = run_cli(
+        tool,
+        "edit",
+        "--input",
+        str(shared_source),
+        "--spec",
+        str(shared_spec),
+        "--output",
+        str(shared_output),
+        expected_status=2,
+    )
+    assert payload["error"]["category"] == "bad_input"
+    assert not shared_output.exists()
+    reopened_shared = Document(str(shared_source))
+    assert reopened_shared.sections[0].header.paragraphs[0].text == "Prior story survives"
+    assert reopened_shared.sections[1].header.is_linked_to_previous is True
+
+    nested_docx = root / "nested-fields.docx"
+    nested = Document()
+    paragraph = nested.add_paragraph()
+
+    def field_char(kind: str) -> Any:
+        run = OxmlElement("w:r")
+        char = OxmlElement("w:fldChar")
+        char.set(qn("w:fldCharType"), kind)
+        run.append(char)
+        return run
+
+    def field_text(tag: str, text: str) -> Any:
+        run = OxmlElement("w:r")
+        node = OxmlElement(tag)
+        node.text = text
+        run.append(node)
+        return run
+
+    for node in (
+        field_char("begin"),
+        field_text("w:instrText", ' TOC \\o "1-3" '),
+        field_char("separate"),
+        field_text("w:t", "Entry "),
+        field_char("begin"),
+        field_text("w:instrText", " PAGEREF _Toc1 "),
+        field_char("separate"),
+        field_text("w:t", "7"),
+        field_char("end"),
+        field_text("w:t", " tail"),
+        field_char("end"),
+    ):
+        paragraph._p.append(node)
+    nested.save(nested_docx)
+    fields = run_cli(tool, "inspect", "--input", str(nested_docx))["result"]["fields"]
+    pageref = next(field for field in fields if field["type"] == "PAGEREF")
+    toc = next(field for field in fields if field["type"] == "TOC")
+    assert pageref["result"] == "7"
+    assert toc["result"] == "Entry 7 tail"
+
+    themed_docx = root / "theme-tokens.docx"
+    rewrite_theme_tokens(ordered_docx, themed_docx)
+    themed_fonts = run_cli(tool, "inspect", "--input", str(themed_docx))["result"]["fonts"]
+    assert {"majorHAnsi", "minorHAnsi"} <= set(themed_fonts["theme_tokens_referenced"])
+    assert {"Major Smoke", "Minor Smoke"} <= set(themed_fonts["referenced"])
+
+    merged_source = root / "merged-source.docx"
+    merged = Document()
+    table = merged.add_table(rows=1, cols=3)
+    table.cell(0, 0).merge(table.cell(0, 1))
+    merged.save(merged_source)
+    merged_spec = root / "merged-widths.json"
+    merged_output = root / "merged-widths.docx"
+    write_json(
+        merged_spec,
+        {
+            "schema_version": 1,
+            "operations": [
+                {
+                    "type": "update_table",
+                    "table_index": 0,
+                    "layout": "fixed",
+                    "column_widths_inches": [1, 2, 3],
+                }
+            ],
+        },
+    )
+    run_cli(
+        tool,
+        "edit",
+        "--input",
+        str(merged_source),
+        "--spec",
+        str(merged_spec),
+        "--output",
+        str(merged_output),
+    )
+    merged_reopened = Document(str(merged_output))
+    physical_cells = merged_reopened.tables[0].rows[0]._tr.tc_lst
+    assert int(physical_cells[0].tcPr.tcW.w) == 4320
+    assert int(physical_cells[1].tcPr.tcW.w) == 4320
+
+    section_image_spec = root / "section-image.json"
+    section_image_docx = root / "section-image.docx"
+    write_json(
+        section_image_spec,
+        {
+            "schema_version": 1,
+            "content": {
+                "blocks": [
+                    {
+                        "type": "image",
+                        "path": image.name,
+                        "width_inches": 7,
+                        "alt_text": "Too wide in first section",
+                    },
+                    {
+                        "type": "section_break",
+                        "orientation": "landscape",
+                        "left_margin_inches": 0.5,
+                        "right_margin_inches": 0.5,
+                    },
+                    {"type": "paragraph", "text": "Wide second section"},
+                ]
+            },
+        },
+    )
+    run_cli(tool, "create", "--spec", str(section_image_spec), "--output", str(section_image_docx))
+    section_image = run_cli(tool, "inspect", "--input", str(section_image_docx))
+    occurrence = section_image["result"]["images"]["inline_occurrences"][0]
+    assert occurrence["section_index"] == 0
+    warning_item = next(
+        item
+        for item in section_image["warnings"]
+        if item["code"] == "image_exceeds_printable_width"
+    )
+    assert warning_item["section_index"] == 0
+
+
 def run_schema_regressions(tool: Path, root: Path, source: Path) -> None:
     """Prove malformed and ambiguous JSON fails closed as bad_input."""
 
@@ -318,6 +1021,33 @@ def run_schema_regressions(tool: Path, root: Path, source: Path) -> None:
         {"blocks": [{"type": "paragraph", "text": 17}]},
         {"blocks": [{"type": "table", "rows": [["A", "B"], ["C"]]}]},
         {"blocks": [{"type": "table", "rows": [["A"], []]}]},
+        {
+            "blocks": [
+                {
+                    "type": "table",
+                    "rows": [["A", "B"]],
+                    "column_widths_inches": [2.0],
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "table",
+                    "rows": [["A"]],
+                    "layout": "fluid",
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "table",
+                    "rows": [["A"]],
+                    "allow_row_split": "false",
+                }
+            ]
+        },
         {"metadata": {"author": False}, "blocks": []},
         {
             "blocks": [
@@ -325,6 +1055,15 @@ def run_schema_regressions(tool: Path, root: Path, source: Path) -> None:
                     "type": "field",
                     "field": "page_number",
                     "instruction": " PAGE ",
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "field",
+                    "field": "toc",
+                    "instruction": "TOC\nINJECTED",
                 }
             ]
         },
@@ -345,6 +1084,23 @@ def run_schema_regressions(tool: Path, root: Path, source: Path) -> None:
                     "style": "Smoke Missing Style",
                 }
             ]
+        },
+        {"section": {"page_width_inches": 0}, "blocks": []},
+        {
+            "section": {
+                "page_width_inches": 1,
+                "left_margin_inches": 0.5,
+                "right_margin_inches": 0.5,
+            },
+            "blocks": [],
+        },
+        {
+            "section": {
+                "page_height_inches": 1,
+                "top_margin_inches": 0.5,
+                "bottom_margin_inches": 0.5,
+            },
+            "blocks": [],
         },
     )
     for index, content in enumerate(invalid_create_contents):
@@ -709,6 +1465,34 @@ def run_fake_pdf_regressions(tool: Path, root: Path, source: Path) -> None:
     assert payload["verification"]["pdf_byte_limit"] == MAX_PDF_BYTES
     assert payload["verification"]["page_limit"] == MAX_PDF_PAGES
     assert payload["verification"]["text_pages_checked"] == 1
+    blank_page = payload["verification"]["content_quality_report"]["pages"][0]
+    assert blank_page["low_text"] is True
+    assert blank_page["has_nontext_content"] is False
+    assert blank_page["nearly_blank"] is True
+    assert payload["verification"]["content_quality_report"]["limitation"]
+
+    image_pdf = root / "image-only-fixture.pdf"
+    write_image_only_pdf(image_pdf)
+    image_output = root / "fake-image-only.pdf"
+    payload = run_cli(
+        tool,
+        "convert",
+        "--input",
+        str(source),
+        "--format",
+        "pdf",
+        "--output",
+        str(image_output),
+        environment={
+            **environment,
+            "DOCX_SMOKE_SOFFICE_MODE": "copy",
+            "DOCX_SMOKE_PDF_FIXTURE": str(image_pdf),
+        },
+    )
+    image_page = payload["verification"]["content_quality_report"]["pages"][0]
+    assert image_page["low_text"] is True
+    assert image_page["has_nontext_content"] is True
+    assert image_page["nearly_blank"] is False
 
     oversized_output = root / "fake-oversized.pdf"
     payload = run_cli(
@@ -821,6 +1605,236 @@ def run_fake_pdf_regressions(tool: Path, root: Path, source: Path) -> None:
     assert_process_gone(int(child_pid_path.read_text(encoding="utf-8")))
 
 
+def run_fake_render_regressions(tool: Path, root: Path, source: Path) -> dict[str, Any]:
+    """Exercise render mechanics and failure paths without real LibreOffice."""
+
+    if importlib.util.find_spec("pypdfium2") is None:
+        result = {
+            "status": "skipped",
+            "reason": "pypdfium2 is not installed; fake render regressions skipped.",
+        }
+        print(json.dumps({"diagnostic": "fake_render", **result}), file=sys.stderr)
+        return result
+
+    fake_bin = root / "fake-render-bin"
+    fake_bin.mkdir()
+    make_fake_soffice(fake_bin / "soffice")
+    fixture = root / "render-fixture.pdf"
+    write_pdf(fixture, 3)
+    environment = {
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}",
+        "DOCX_SMOKE_SOFFICE_MODE": "copy",
+        "DOCX_SMOKE_PDF_FIXTURE": str(fixture),
+    }
+
+    output = root / "rendered-fake"
+    payload = run_cli(
+        tool,
+        "render",
+        "--input",
+        str(source),
+        "--output",
+        str(output),
+        environment=environment,
+    )
+    assert payload["status"] == "ok"
+    assert payload["operation"] == "render"
+    assert payload["counts"]["pdf_pages"] == 3
+    assert payload["counts"]["pages_rendered"] == 3
+    assert payload["verification"]["atomic_publish"] is True
+    assert payload["verification"]["png_reopened"] == 3
+    assert payload["verification"]["source_unchanged_at_publish_gate"] is True
+    artifacts = payload["verification"]["content_quality_report"]["raster_review_artifacts"]
+    assert artifacts == ["page-001.png", "page-002.png", "page-003.png"]
+    assert any(item["code"] == "render_review_required" for item in payload["warnings"])
+    for record in payload["result"]["images"]:
+        data = (output / record["file"]).read_bytes()
+        assert data[:8] == b"\x89PNG\r\n\x1a\n"
+        assert hashlib.sha256(data).hexdigest() == record["sha256"]
+        assert record["width_px"] > 0 and record["height_px"] > 0
+    assert sorted(item.name for item in output.iterdir()) == artifacts
+
+    subset_output = root / "rendered-subset"
+    payload = run_cli(
+        tool,
+        "render",
+        "--input",
+        str(source),
+        "--output",
+        str(subset_output),
+        "--pages",
+        "2",
+        environment=environment,
+    )
+    assert payload["counts"]["pages_rendered"] == 1
+    assert [item.name for item in subset_output.iterdir()] == ["page-002.png"]
+
+    bad_dpi_output = root / "rendered-bad-dpi"
+    payload = run_cli(
+        tool,
+        "render",
+        "--input",
+        str(source),
+        "--output",
+        str(bad_dpi_output),
+        "--dpi",
+        "20",
+        expected_status=2,
+        environment=environment,
+    )
+    assert payload["error"]["category"] == "bad_input"
+    assert not bad_dpi_output.exists()
+
+    payload = run_cli(
+        tool,
+        "render",
+        "--input",
+        str(source),
+        "--output",
+        str(output),
+        expected_status=9,
+        environment=environment,
+    )
+    assert payload["error"]["category"] == "output_conflict"
+
+    missing_page_output = root / "rendered-missing-page"
+    payload = run_cli(
+        tool,
+        "render",
+        "--input",
+        str(source),
+        "--output",
+        str(missing_page_output),
+        "--pages",
+        "9",
+        expected_status=2,
+        environment=environment,
+    )
+    assert payload["error"]["category"] == "bad_input"
+    assert payload["error"]["details"]["pdf_pages"] == 3
+    assert not missing_page_output.exists()
+
+    malformed_output = root / "rendered-malformed"
+    payload = run_cli(
+        tool,
+        "render",
+        "--input",
+        str(source),
+        "--output",
+        str(malformed_output),
+        expected_status=10,
+        environment={**environment, "DOCX_SMOKE_SOFFICE_MODE": "malformed"},
+    )
+    assert payload["error"]["category"] == "external_tool_failed"
+    assert not malformed_output.exists()
+    assert not any(item.name.startswith(".rendered-") for item in root.iterdir())
+
+    return {"status": "passed", "pages": 3}
+
+
+def run_soffice_discovery_regressions(tool: Path, root: Path, source: Path) -> None:
+    """Exercise the DOCX_SOFFICE override, including its no-fallthrough failure."""
+
+    fake_bin = root / "fake-discovery-bin"
+    fake_bin.mkdir()
+    fake_soffice = fake_bin / "soffice"
+    make_fake_soffice(fake_soffice)
+    fixture = root / "discovery-fixture.pdf"
+    write_pdf(fixture, 1)
+
+    override_output = root / "discovery-valid.pdf"
+    payload = run_cli(
+        tool,
+        "convert",
+        "--input",
+        str(source),
+        "--format",
+        "pdf",
+        "--output",
+        str(override_output),
+        environment={
+            "DOCX_SOFFICE": str(fake_soffice),
+            "DOCX_SMOKE_SOFFICE_MODE": "copy",
+            "DOCX_SMOKE_PDF_FIXTURE": str(fixture),
+        },
+    )
+    assert payload["verification"]["page_count"] == 1
+    # The blank fixture proves the override binary ran, not any soffice from PATH.
+    assert payload["verification"]["content_quality_report"]["pages"][0]["nearly_blank"] is True
+    assert override_output.is_file()
+
+    missing_binary = root / "missing-soffice"
+    missing_output = root / "discovery-missing.pdf"
+    payload = run_cli(
+        tool,
+        "convert",
+        "--input",
+        str(source),
+        "--format",
+        "pdf",
+        "--output",
+        str(missing_output),
+        expected_status=4,
+        environment={"DOCX_SOFFICE": str(missing_binary)},
+    )
+    assert payload["error"]["category"] == "missing_dependency"
+    assert payload["error"]["details"]["path"] == str(missing_binary)
+    assert not missing_output.exists()
+
+
+def find_soffice_for_smoke() -> str | None:
+    """Mirror the tool's LibreOffice discovery order for gating optional checks."""
+
+    override = os.environ.get("DOCX_SOFFICE")
+    if override:
+        candidate = Path(override)
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
+        return None
+    for name in ("soffice", "libreoffice"):
+        executable = shutil.which(name)
+        if executable:
+            return executable
+    if sys.platform == "darwin":
+        for candidate in (
+            Path("/Applications/LibreOffice.app/Contents/MacOS/soffice"),
+            Path.home() / "Applications/LibreOffice.app/Contents/MacOS/soffice",
+        ):
+            if candidate.is_file() and os.access(candidate, os.X_OK):
+                return str(candidate)
+    return None
+
+
+def run_render_check(tool: Path, source: Path, output: Path) -> dict[str, Any]:
+    """Render through real LibreOffice and verify the published PNG pages."""
+
+    if importlib.util.find_spec("pypdfium2") is None:
+        result = {
+            "status": "skipped",
+            "reason": "pypdfium2 is not installed; optional render check skipped.",
+        }
+        print(json.dumps({"diagnostic": "render_check", **result}), file=sys.stderr)
+        return result
+    payload = run_cli(
+        tool,
+        "render",
+        "--input",
+        str(source),
+        "--output",
+        str(output),
+        timeout=120,
+    )
+    assert payload["counts"]["pages_rendered"] == payload["counts"]["pdf_pages"]
+    assert payload["counts"]["pages_rendered"] >= 1
+    assert payload["verification"]["png_reopened"] == payload["counts"]["pages_rendered"]
+    for record in payload["result"]["images"]:
+        data = (output / record["file"]).read_bytes()
+        assert data[:8] == b"\x89PNG\r\n\x1a\n"
+        assert hashlib.sha256(data).hexdigest() == record["sha256"]
+        assert record["width_px"] > 0 and record["height_px"] > 0
+    return {"status": "passed", "pages_rendered": payload["counts"]["pages_rendered"]}
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build smoke-test arguments."""
 
@@ -871,6 +1885,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                             "type": "table",
                             "style": "Table Grid",
                             "header_rows": 1,
+                            "layout": "fixed",
+                            "column_widths_inches": [1.4, 4.6],
+                            "allow_row_split": False,
                             "rows": [["Key", "Value"], ["State", "Original"]],
                         },
                         {
@@ -927,6 +1944,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
         inspect_payload = run_cli(tool, "inspect", "--input", str(created))
         assert_inspection(inspect_payload)
+        run_font_portability_regressions(tool, root, created)
+        run_confirmed_defect_regressions(tool, root, original_image)
 
         edit_spec = root / "edit.json"
         edited = root / "edited.docx"
@@ -1004,6 +2023,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         run_external_relationship_regression(tool, root, created)
         run_custom_xml_regression(tool, root, created)
         run_fake_pdf_regressions(tool, root, created)
+        fake_render_result = run_fake_render_regressions(tool, root, created)
+        run_soffice_discovery_regressions(tool, root, created)
 
         corrupt = root / "corrupt.docx"
         corrupt.write_bytes(b"not a zip")
@@ -1016,9 +2037,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         assert failure["error"]["category"] == "bad_input"
 
-        soffice = shutil.which("soffice")
+        soffice = find_soffice_for_smoke()
+        quality_result = run_quality_upgrade_regressions(
+            tool, root, original_image, libreoffice=bool(soffice)
+        )
         if soffice:
             pdf_result = run_pdf_check(tool, edited, root / "edited.pdf")
+            render_result = run_render_check(tool, edited, root / "rendered-pages")
         elif args.require_libreoffice:
             print(
                 json.dumps(
@@ -1041,6 +2066,11 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "reason": "LibreOffice soffice is not installed; optional PDF check skipped.",
             }
             print(json.dumps({"diagnostic": "pdf_check", **pdf_result}), file=sys.stderr)
+            render_result = {
+                "status": "skipped",
+                "reason": "LibreOffice soffice is not installed; optional render check skipped.",
+            }
+            print(json.dumps({"diagnostic": "render_check", **render_result}), file=sys.stderr)
 
         print(
             json.dumps(
@@ -1051,6 +2081,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                     "checks": {
                         "create": "passed",
                         "inspect": "passed",
+                        "font_portability": "passed",
+                        "confirmed_defect_regressions": "passed",
                         "edit": "passed",
                         "reopen": "passed",
                         "formatting_policy": "first_run passed",
@@ -1062,8 +2094,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                         "external_relationships": "passed",
                         "custom_xml": "passed",
                         "bounded_pdf_and_process_cleanup": "passed",
+                        "fake_render": fake_render_result,
+                        "soffice_discovery": "passed",
+                        "quality_upgrade": quality_result,
                         "corrupt_input": "passed",
                         "pdf_conversion": pdf_result,
+                        "render": render_result,
                     },
                     "fixtures": "temporary_directory_removed",
                 },

--- a/kolega_code/_bundled_skills/skills/pdf/SKILL.md
+++ b/kolega_code/_bundled_skills/skills/pdf/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: pdf
-description: Create, inspect, extract, edit, secure, reorganize, and convert PDF-native documents; diagnose scanned or hybrid PDFs and run explicitly selected local OCR. Use for PDF page operations, forms, metadata, encryption, spatial text or table extraction, image/text-to-PDF generation, and scanned-PDF OCR planning. Do not use for authoring DOCX, XLSX, or PPTX source files before PDF export.
+description: Create, inspect, render, extract, edit, secure, redact, reorganize, and convert PDF-native documents; diagnose scanned or hybrid PDFs, run explicitly selected local OCR, and compose searchable PDFs from OCR results. Use for PDF page operations, forms, metadata, encryption, spatial text or table extraction, image/text-to-PDF generation, page rasterization for visual review, true content redaction, scanned-PDF OCR planning, and making scanned PDFs searchable. Do not use for authoring DOCX, XLSX, or PPTX source files before PDF export.
 license: Apache-2.0
 compatibility: Requires Python 3.11+ and the declared core environment. OCR engines, model weights, language data, and compatible acceleration are optional external capabilities installed separately.
 metadata:
   author: Kolega
-  version: "1.0"
+  version: "1.1"
   schema_version: "1"
 ---
 
@@ -14,24 +14,39 @@ metadata:
 Use `scripts/pdf_tool.py` for deterministic PDF-native work. Keep every source immutable,
 write to a distinct destination, and verify the published output.
 
+## Workspace discipline
+
+Work directly in visible workspace paths. Never create or use `.build` or another hidden
+build/work directory. Write requested deliverables directly to their declared destinations;
+if intermediate files are necessary, keep them in visible, narrowly scoped paths rather than
+staging the task in a hidden subtree.
+
 ## Route the task
 
-- Use `inspect` before mutation to inventory pages, encryption, forms, images, text, and
-  likely scanned content.
+- Use `inspect` before mutation to inventory pages, encryption, forms, fonts, images,
+  text, and likely scanned content.
 - Use `extract` for text, coordinates, tables, and embedded images.
+- Use `render` to rasterize pages to PNG files for visual review.
 - Use `create` for a new PDF from a versioned JSON layout or story specification.
 - Use `pages` to merge, split, select, reorder, repeat, delete, or rotate pages.
 - Use `edit` for stamps, form values, metadata, encryption, or decryption.
+- Use `redact` for true content removal with a verification report. Never present `edit`
+  stamps, white rectangles, or crops as redaction.
 - Use `convert` only for the explicit lossy mappings it supports.
+- Use `manifest` to derive or check an OCR model manifest before OCR; it hashes local
+  files and never runs an engine.
 - Use `ocr-plan` before OCR. Use `ocr` only after the user selects an engine and approves
   its separately provisioned models or language data. If Surya and PaddleOCR are unavailable,
   tell the user and offer Tesseract as the explicit fallback.
+- Use `ocr-compose` after `ocr` to turn the sidecar into a searchable PDF with an
+  invisible text layer; it never runs an engine.
 - Keep DOCX/XLSX/PPTX authoring and their PDF export in the source-format workflow.
 
 Read [operations](references/operations.md) for command and job schemas. Read
 [examples](references/examples.md) before the first end-to-end invocation. Read
-[limitations](references/limitations.md) before promising fidelity, redaction, signatures,
-or searchable OCR PDFs.
+[quality](references/quality.md) before promising a polished deliverable, and
+[limitations](references/limitations.md) before promising fidelity or signatures. Read
+[redaction](references/redaction.md) before any redaction request.
 
 ## Core workflow
 
@@ -49,8 +64,16 @@ Use the selected interpreter's `-m pip` for the declared core or explicitly sele
 4. Write to a new path. Use `--overwrite` only when replacing an existing destination is
    intentional; it never permits a source path to be its own destination.
 5. Reopen the output and inspect the JSON verification result. Treat warnings as unresolved
-   preservation or interpretation questions, not as success noise.
-6. Open or render representative pages when layout is important.
+   preservation or interpretation questions, not as success noise. Review the `fonts`
+   inventory and resolve every `RELEASE BLOCKER` font warning before release.
+6. **Render and look.** When layout, formatting, or visual fidelity matters, run `render`
+   to produce one PNG per page, then open the rendered PNG files with the Read tool and
+   examine them — at minimum every page you changed, plus the first page. Check for text
+   overflow or truncation, overlapping or clipped content, missing images, and broken
+   table layout. Do not claim visual correctness from JSON verification alone. The PNG
+   files are PDFium rasters of the delivered PDF itself, so they are authoritative for
+   static page appearance; non-embedded fonts still render with local substitutes, and
+   interactive form or annotation appearance can differ per viewer.
 
 The CLI emits a schema-versioned JSON object on stdout. Errors and diagnostics are JSON on
 stderr with stable categories and nonzero exit statuses. It bounds source size, page count,
@@ -94,9 +117,13 @@ OCR.
 ## Resources
 
 - [Operations](references/operations.md): CLI options, JSON jobs, limits, and exit statuses.
-- [Examples](references/examples.md): copy-pasteable core and OCR workflows.
-- [OCR](references/ocr.md): decision matrix, artifact preflight, adapters, and normalized
-  output.
+- [Examples](references/examples.md): copy-pasteable core, redaction, and OCR workflows.
+- [Quality](references/quality.md): design intake, delivery profiles, acceptance criteria,
+  and the structural-versus-visual review contract.
+- [Redaction](references/redaction.md): leakage policy table, verification contract, and
+  explicit non-guarantees.
+- [OCR](references/ocr.md): decision matrix, artifact preflight, manifest derivation,
+  adapters, and normalized output.
 - [Limitations](references/limitations.md): fidelity and security boundaries.
 - `scripts/smoke_test.py`: generated-fixture core smoke test; add `--ocr-engine` only in a
   separately prepared optional engine environment.
@@ -110,7 +137,10 @@ Run:
 ```
 
 Use the absolute `SKILL_ROOT` and `PDF_PYTHON` selected by the canonical environment
-procedure. For
-a requested artifact, also confirm the expected page count/order, text anchors, form and
-encryption state, metadata, output signature, and representative visual layout. Report
-every optional OCR profile not exercised.
+procedure. For a requested artifact, also confirm against the
+[acceptance criteria](references/quality.md#acceptance-criteria): expected page
+count/order, text anchors, a font inventory with zero `RELEASE BLOCKER` warnings, form and
+encryption state, metadata, output signature — and rendered-page review of every changed
+page plus page 1 via `render` and the Read tool. For a redaction, additionally confirm the
+report's removal evidence, clean residual scan, and the published verification rasters.
+Report every optional OCR profile not exercised.

--- a/kolega_code/_bundled_skills/skills/pdf/references/examples.md
+++ b/kolega_code/_bundled_skills/skills/pdf/references/examples.md
@@ -3,12 +3,15 @@
 ## Contents
 
 - [Create, inspect, edit, and verify](#create-inspect-edit-and-verify)
+- [Render and visual review](#render-and-visual-review)
 - [Page merge and split](#page-merge-and-split)
+- [Redaction](#redaction)
 - [Conversions](#conversions)
 - [OCR plan](#ocr-plan)
 - [Surya preflight and OCR](#surya-preflight-and-ocr)
 - [PaddleOCR preflight and OCR](#paddleocr-preflight-and-ocr)
 - [Tesseract preflight and OCR](#tesseract-preflight-and-ocr)
+- [Searchable OCR composition](#searchable-ocr-composition)
 - [Expected normalized output](#expected-normalized-output)
 - [Failure examples](#failure-examples)
 
@@ -139,6 +142,48 @@ Expected assertions:
 - `APPROVED` is visible and extractable;
 - table cells are checked against a rendered page because extraction is heuristic.
 
+## Render and visual review
+
+Rasterize the published output and look at it:
+
+```bash
+"$PDF_PYTHON" "$SKILL_ROOT/scripts/pdf_tool.py" render \
+  --input invoice.pdf \
+  --output invoice-render \
+  --dpi 150
+```
+
+Expected summary shape:
+
+```json
+{
+  "operation": "render",
+  "dpi": 150,
+  "renders": [
+    {"page": 1, "file": "page-0001.png", "width_px": 1275, "height_px": 1650,
+     "sha256": "…"}
+  ],
+  "counts": {"pages_rendered": 1, "total_pixels": 2103750},
+  "verification": {"valid": true, "atomic_publish": true, "pngs_reopened": 1,
+                   "renderer": "pdfplumber/pypdfium2"}
+}
+```
+
+Then open `invoice-render/page-0001.png` (and every other changed page) with the Read tool
+and examine it. The summary above is structural evidence that PNG files were produced — it
+says nothing about how the pages look.
+
+Review the font inventory from the same `inspect` you already ran:
+
+```bash
+"$PDF_PYTHON" "$SKILL_ROOT/scripts/pdf_tool.py" inspect --input invoice.pdf \
+  --output invoice-inspect.json
+```
+
+In the sidecar, `fonts.unembedded_non_base14` must be empty and no warning may begin with
+`RELEASE BLOCKER:` before release. A base-14-only document instead carries an informational
+substitution warning, which is acceptable when disclosed.
+
 ## Page merge and split
 
 Create `pages.json`:
@@ -174,6 +219,56 @@ Create `pages.json`:
 Assert `packet.pdf` has four pages in the listed order, page two is rotated 90 degrees, and
 `appendix-page-3.pdf` has one page. Each output is atomic, but the two-output publication is
 not a transaction.
+
+## Redaction
+
+Create `redact.json` (full schema and policy in
+[Operations](references/operations.md#redact) and [Redaction](references/redaction.md)):
+
+```json
+{
+  "schema_version": 1,
+  "targets": [
+    {"type": "text", "text": "ACME-SECRET-9931", "pages": "all",
+     "match": "exact", "grow_points": 2.0},
+    {"type": "rect", "page": 2, "rect": [72, 640, 468, 60],
+     "coordinate_origin": "top-left"}
+  ]
+}
+```
+
+```bash
+"$PDF_PYTHON" "$SKILL_ROOT/scripts/pdf_tool.py" redact \
+  --input contract.pdf \
+  --job redact.json \
+  --output contract-redacted.pdf \
+  --report contract-redacted.report.json \
+  --render-check-dir contract-redacted-qa
+```
+
+Expected report excerpt — note the target text appears only as a digest:
+
+```json
+{
+  "targets": [
+    {"index": 0, "type": "text", "text_sha256": "…",
+     "resolved_rects": [{"page": 1, "rect": [175.0, 140.9, 255.3, 158.9]}]}
+  ],
+  "removal_evidence": {
+    "pages": [{"page": 1, "text_operators_removed": 1, "characters_removed": 26,
+               "image_xobjects_removed": 0, "annotations_removed": 0}],
+    "incremental_history_dropped": true
+  },
+  "residual_scan": {"raw_byte_hits": 0, "decompressed_stream_hits": 0},
+  "verification": {"visual_diff": {"checked": true,
+                   "max_fraction_changed_outside_expected": 0.0}}
+}
+```
+
+Open the published `contract-redacted-qa/after-*.png` rasters and confirm the black boxes
+sit exactly where intended. `characters_removed` larger than the term length is the
+documented whole-operator collateral — text sharing a show operator with the target is
+removed with it.
 
 ## Conversions
 
@@ -455,8 +550,31 @@ test -n "$ENGINE_EXECUTABLE"
 "$ENGINE_EXECUTABLE" --version
 ```
 
-Record the exact `.traineddata` path, source/package version, immutable upstream revision
-where applicable, license, byte size, and checksum:
+The fastest correct path is manifest derivation — the tool measures paths, sizes, and
+hashes; you declare the origin and approvals explicitly after reviewing them:
+
+```bash
+"$PDF_PYTHON" "$SKILL_ROOT/scripts/pdf_tool.py" manifest \
+  --mode derive \
+  --engine tesseract \
+  --languages eng \
+  --assume-source tessdata_fast \
+  --accept-license \
+  --confirm-eligibility \
+  --output tesseract-model.json
+
+"$PDF_PYTHON" "$SKILL_ROOT/scripts/pdf_tool.py" manifest \
+  --mode check \
+  --engine tesseract \
+  --languages eng \
+  --model-manifest tesseract-model.json
+```
+
+`--assume-source` records that you assert the local files came from the pinned official
+repository revision in [OCR](references/ocr.md); omit it to get `REVIEW-REQUIRED`
+placeholders that preflight rejects until you fill them. The check mode reports every
+problem at once with expected and actual hashes. The equivalent hand-written manifest —
+still the authoritative schema reference — is:
 
 ```json
 {
@@ -509,10 +627,47 @@ empty.
 ```
 
 Expect line blocks derived from TSV, pixel coordinates, and confidence only where Tesseract
-supplied nonnegative word values. The normalized engine metadata reports `cpu` and
-`tesseract-cpu` even if another device label was requested. The one `--timeout` budget is
-shared by every selected page. Do not expect headings, reading order, table HTML, math, or
-layout semantics.
+supplied nonnegative word values. The Tesseract adapter also records word-level geometry
+under `blocks[].words`, which `ocr-compose` uses for word-accurate placement. The
+normalized engine metadata reports `cpu` and `tesseract-cpu` even if another device label
+was requested. The one `--timeout` budget is shared by every selected page. Do not expect
+headings, reading order, table HTML, math, or layout semantics.
+
+## Searchable OCR composition
+
+After any successful `ocr` run, compose the sidecar into a searchable PDF — no engine, no
+manifest, fully re-runnable:
+
+```bash
+"$PDF_PYTHON" "$SKILL_ROOT/scripts/pdf_tool.py" ocr-compose \
+  --input scanned.pdf \
+  --sidecar scanned.tesseract.json \
+  --output scanned-searchable.pdf
+```
+
+Expected verification shape:
+
+```json
+{
+  "operation": "ocr-compose",
+  "counts": {"pages_composed": 4, "pages_skipped": 0, "words_drawn": 812,
+             "characters_dropped": 0},
+  "font": {"name": "Helvetica", "embedded": false},
+  "verification": {
+    "page_count_unchanged": true,
+    "anchors": {"checked": 20, "found": 20},
+    "geometry_spot_check_max_delta_points": 0.4,
+    "visual_diff": {"checked": true, "max_fraction_changed": 0.0002,
+                    "threshold": 0.002}
+  }
+}
+```
+
+The run fails rather than publishing when composed text does not extract, when its
+geometry deviates, or when the supposedly invisible layer visibly changes a page. The
+sidecar's recorded source hash must match `--input`; re-run OCR if the scan changed.
+Non-Latin sidecars need `--font /path/to/covering.ttf`. Confirm selectability the same way
+a user would: `extract` the output and check the recognized anchors appear.
 
 ## Expected normalized output
 
@@ -567,9 +722,29 @@ The first command is rejected because PDF-producing edits require `.pdf`; the se
 rejected because geometry and margins must be finite. Normalized OCR output similarly
 requires `.json`, and `ocr-plan --languages ' , '` is rejected before planning.
 
+Render refuses unsafe destinations and oversized rasters:
+
+```bash
+"$PDF_PYTHON" "$SKILL_ROOT/scripts/pdf_tool.py" render \
+  --input invoice.pdf --output occupied-directory --overwrite   # bad_input (2)
+"$PDF_PYTHON" "$SKILL_ROOT/scripts/pdf_tool.py" render \
+  --input invoice.pdf --output out --dpi 1200                   # bad_input (2)
+"$PDF_PYTHON" "$SKILL_ROOT/scripts/pdf_tool.py" render \
+  --input poster-5000pt.pdf --output out --dpi 600              # resource_limit (6)
+```
+
+A redaction text target that matches nothing exits `2` (`bad_input`) without writing
+anything — silent no-op redaction does not exist. A redaction target intersecting a Form
+XObject exits `3` (`unsupported_operation`) naming the page and XObject; flatten or
+rasterize first. Redacting an encrypted input exits `3`; decrypt explicitly with `edit`
+first. `ocr-compose` with a sidecar whose recorded source hash mismatches `--input` exits
+`2`. `manifest --mode check` against a tampered artifact exits `7` with every failed check,
+including expected and actual hashes, in `details`.
+
 Encrypted input without an approved password exits `3` with `unsupported_operation`.
 An OCR request without a model manifest is rejected by argument parsing. A manifest without
-operator approval exits `7` with `license_precondition`. An untested engine major exits `3`;
+operator approval — or with `REVIEW-REQUIRED`/`replace-with` placeholder provenance —
+exits `7` with `license_precondition`. An untested engine major exits `3`;
 the tool never downgrades, installs, downloads, or switches engines within an invocation.
 If Surya and PaddleOCR are unavailable, tell the user before starting a separate explicit
 Tesseract fallback invocation.

--- a/kolega_code/_bundled_skills/skills/pdf/references/limitations.md
+++ b/kolega_code/_bundled_skills/skills/pdf/references/limitations.md
@@ -7,6 +7,7 @@
 - [Forms, metadata, and encryption](#forms-metadata-and-encryption)
 - [OCR](#ocr)
 - [Security](#security)
+- [OCR composition](#ocr-composition)
 - [Future work](#future-work)
 
 ## Extraction and rendering
@@ -21,6 +22,17 @@
   Masks, inline images, tiling patterns, and reused XObjects can be represented differently.
 - Page classification is routing evidence, not proof. Sparse digital pages may look scanned;
   scanned pages with an existing text layer may look hybrid.
+- `render` rasterizes the delivered PDF itself with PDFium (via pdfplumber). Unlike office
+  formats reviewed through an intermediate converter, the pixels reflect the actual
+  artifact — a strictly stronger review guarantee. Two bounds on that claim: rasters are
+  fully deterministic only when every font is embedded (non-embedded fonts render with this
+  machine's substitutes, which is exactly what the font `RELEASE BLOCKER` warning guards),
+  and rasters do not prove viewer-interactive behavior — form-field appearance
+  regeneration, annotation states, JavaScript, optional-content layers, overprint, or ICC
+  color handling.
+- The font inventory walks page, form, and annotation resource dictionaries with bounded
+  depth. Fonts referenced only from constructs beyond that walk are reported as
+  `truncated`, never silently ignored.
 - This tool does not render HTML and does not claim browser-equivalent conversion.
 
 ## Creation and page mutation
@@ -71,7 +83,15 @@
 ## Security
 
 - Crop, overlay, white rectangles, stamps, and watermarks are **not secure redaction**.
-  Underlying text, images, revisions, attachments, metadata, or object streams may remain.
+  Underlying text, images, revisions, attachments, metadata, or object streams remain. The
+  only supported removal path is the `redact` command, which deletes intersecting content,
+  rewrites the document as a single revision, and verifies the result — read
+  [Redaction](references/redaction.md) for its policy table, verification contract, and the explicit
+  non-guarantees (prior copies, backups, attachments, and collateral whole-operator
+  removal, among others).
+- Redaction v1 refuses rather than guesses: encrypted inputs, Type3 or width-unmeasurable
+  fonts inside targets, intersecting Form XObjects, text-clipping modes, XFA, and term hits
+  in outlines, named destinations, or form-field values all fail loudly with instructions.
 - Deleting visible pages does not constitute forensic sanitization.
 - Embedded files, JavaScript, launch actions, malicious links, and other active content are
   not comprehensively analyzed or removed.
@@ -82,20 +102,30 @@
 - Atomic replacement protects against partial publication of one output, not disk failure,
   malicious concurrent replacement, or rollback across multiple destinations.
 
+## OCR composition
+
+- `ocr-compose` writes an invisible text layer from a completed sidecar; the layer inherits
+  every OCR recognition error, and its verification proves extractability and geometry, not
+  transcription correctness.
+- The default base-14 layer maps cp1252 text only; other scripts need an operator-supplied
+  font, which is embedded and subset under the operator's license responsibility.
+- Composition preserves the source pixels (verified by a raster diff) but does not create
+  tagged structure, reading-order guarantees, or accessibility conformance.
+
 ## Future work
 
-The initial release intentionally does not implement:
+This release intentionally does not implement:
 
-- searchable OCR replacement PDFs or invisible text-layer reconstruction;
-- robust, validated redaction and forensic sanitization;
+- forensic sanitization beyond the `redact` contract — no partial image masking, no
+  redaction inside Form XObjects, no encrypted-input redaction, and no claims about copies
+  outside the output file (see [Redaction](references/redaction.md) for the refusal list);
 - digital signing, signature validation, or long-term validation;
 - XFA creation or editing;
-- arbitrary word-level PDF editing;
+- arbitrary word-level PDF editing beyond removal — covering and retyping text is still not
+  editing it;
 - complete annotation, attachment, JavaScript, portfolio, 3D, or multimedia workflows;
 - accessibility tree repair, tagged-PDF authoring, or PDF/UA certification;
 - HTML rendering;
-- remote OCR endpoints;
-- guaranteed preservation of vectors, links, forms, annotations, signatures, and
-  accessibility while adding OCR text.
+- remote OCR endpoints.
 
 Use a specialized reviewed workflow for any of these outcomes.

--- a/kolega_code/_bundled_skills/skills/pdf/references/ocr.md
+++ b/kolega_code/_bundled_skills/skills/pdf/references/ocr.md
@@ -7,6 +7,7 @@
 - [Engine boundaries](#engine-boundaries)
 - [Artifact and license preflight](#artifact-and-license-preflight)
 - [Model manifest schema](#model-manifest-schema)
+- [Manifest derivation and checking](#manifest-derivation-and-checking)
 - [Rendering and execution](#rendering-and-execution)
 - [Normalized sidecar](#normalized-sidecar)
 - [Engine normalization](#engine-normalization)
@@ -28,8 +29,11 @@
    unavailable, tell the user and explicitly select Tesseract for a new fallback invocation.
 7. Keep processing local. A hosted endpoint requires a separate privacy and security
    decision.
-8. Produce sidecar JSON only. Do not modify the source or synthesize a searchable PDF.
-   The normalized destination must use a `.json` extension.
+8. The `ocr` command produces sidecar JSON only and never modifies the source. The
+   normalized destination must use a `.json` extension. Producing a searchable PDF is the
+   separate, explicit `ocr-compose` step, which consumes a completed sidecar
+   deterministically and never runs an engine
+   (see [Operations](references/operations.md#searchable-ocr-composition)).
 
 On hybrid pages, the adapter renders detected embedded-image regions when practical. It
 skips digital and blank pages unless `--force` is explicit. `--force` means OCR the selected
@@ -269,6 +273,40 @@ official `source`, `license`, and `license_terms_accepted`. The backend must be 
 executable file with exact `size_bytes` and `sha256`, must pass its bounded `--version`
 probe, and must report a recognized llama.cpp/`llama-server` signature.
 
+Preflight rejects every textual placeholder (`REVIEW-REQUIRED`, `replace-with-…`) in model,
+runtime, or artifact provenance fields, in addition to rejecting absent required fields.
+
+## Manifest derivation and checking
+
+The `manifest` command reduces hand-written-manifest ceremony without weakening any gate.
+It never executes a binary — filesystem stat and hashing only. Full CLI forms are in
+[Operations](references/operations.md#manifest-derive-and-check).
+
+Derivation fills two kinds of fields differently:
+
+- **Measured facts** — paths, byte sizes, SHA-256 values, and canonical Paddle directory
+  inventories — are computed by the tool from the local files.
+- **Provenance facts** — identifier, revision, source, license — are filled only from an
+  explicit operator declaration or an exact SHA-256 match against the reviewed artifacts
+  recorded in this document (the two Surya GGUF files and the two PP-OCRv6 main parameter
+  files). Everything else is emitted as `REVIEW-REQUIRED`, which preflight rejects, and the
+  derive summary lists every reason the manifest is not ready.
+
+For Tesseract, `--assume-source tessdata_fast|tessdata_best` is an operator declaration
+that the local `.traineddata` files came from the pinned official repository revisions
+above; the manifest records which fields were declared versus measured, and the tool warns
+that it verified only path, size, and hash — not origin. Language files are located via
+`--tessdata-dir`, `$TESSDATA_PREFIX`, or well-known directories; ambiguity or a missing
+language fails rather than guessing. The six PP-StructureV3 structure roles are **never**
+auto-filled by any flag. `license_terms_accepted` and `use_case_eligibility_confirmed`
+default to `false` and flip only via the explicit `--accept-license` and
+`--confirm-eligibility` flags.
+
+`manifest --mode check` sweeps an existing manifest without fail-fast and reports every
+problem with expected and actual values — the diagnosis tool when `ocr` preflight fails
+with a single mismatch. It excludes, and names, the engine-execution checks that only `ocr`
+performs.
+
 ## Rendering and execution
 
 The core environment renders only selected pages or hybrid image regions with pdfplumber/
@@ -334,6 +372,11 @@ The output JSON contains:
       "source_page": 2,
       "source_region": null,
       "classification": "likely-scanned",
+      "page_geometry": {
+        "width_points": 612,
+        "height_points": 792,
+        "rotation": 0
+      },
       "coordinate_space": {
         "unit": "rendered_pixel",
         "dpi": 300,
@@ -347,7 +390,11 @@ The output JSON contains:
           "block_type": "line",
           "bbox": [100.0, 80.0, 900.0, 160.0],
           "polygon": [[100.0, 80.0], [900.0, 80.0], [900.0, 160.0], [100.0, 160.0]],
-          "confidence": 0.94
+          "confidence": 0.94,
+          "words": [
+            {"text": "Example", "bbox": [100.0, 80.0, 480.0, 160.0], "confidence": 0.95},
+            {"text": "heading", "bbox": [500.0, 80.0, 900.0, 160.0], "confidence": 0.93}
+          ]
         }
       ],
       "warnings": [],
@@ -366,6 +413,13 @@ The output JSON contains:
 complete the schema. `bbox`, `polygon`, and block type remain `null` or conservative when
 the source engine is flat. Table HTML/Markdown is retained only when supplied. Fields that
 cannot be normalized without loss remain under `engine_specific`.
+
+`page_geometry` records the displayed page size and rotation of the source page so
+consumers can cross-check coordinate mappings. `blocks[].words` carries word-level geometry
+**only when the engine supplied it** (the Tesseract adapter records its TSV word rows);
+words are never synthesized for engines that emit line or block geometry only. Both fields
+are additive within `schema_version` 1, and `ocr-compose` uses them for word-accurate
+invisible text placement.
 
 ## Engine normalization
 

--- a/kolega_code/_bundled_skills/skills/pdf/references/operations.md
+++ b/kolega_code/_bundled_skills/skills/pdf/references/operations.md
@@ -5,11 +5,16 @@
 - [Environment and JSON contract](#environment-and-json-contract)
 - [Input safety and limits](#input-safety-and-limits)
 - [Inspect and extract](#inspect-and-extract)
+- [Font inventory](#font-inventory)
+- [Render](#render)
 - [Create](#create)
 - [Pages](#pages)
 - [Edit](#edit)
+- [Redact](#redact)
 - [Convert](#convert)
 - [OCR planning and execution](#ocr-planning-and-execution)
+- [Manifest derive and check](#manifest-derive-and-check)
+- [Searchable OCR composition](#searchable-ocr-composition)
 - [Exit statuses](#exit-statuses)
 
 ## Environment and JSON contract
@@ -79,10 +84,14 @@ The initial release enforces these hard limits:
 | JSON job | 20 MiB |
 | Story items | 10,000 |
 | Split outputs | 500 |
-| OCR render per page/region | 40,000,000 pixels |
-| OCR renders per invocation | 200,000,000 pixels |
-| OCR DPI | 72–600 |
+| Rasterized render per page/region (`render`, `ocr`, verification rasters) | 40,000,000 pixels |
+| Rasterized pixels per invocation (`render`, `ocr`, verification rasters) | 200,000,000 pixels |
+| Render/OCR DPI (`render` default 150, `ocr` default 300, verification 96) | 72–600 |
 | OCR timeout | 1–86,400 seconds |
+| Font inventory entries | 2,000 |
+| Font resource-walk visits / XObject depth | 10,000 / 8 |
+| Redaction targets per job | 1,000 |
+| Content operations per redacted page | 500,000 |
 
 The parser requires a PDF signature in the first 1,024 bytes and opens PDFs in strict mode.
 It rejects missing passwords and page references outside the document. Page expressions are
@@ -117,6 +126,74 @@ coordinates. `--tables` adds heuristic table arrays. `extract --images-dir` writ
 deterministically named embedded streams and reports per-image failures without discarding
 successful extractions. An `--output` JSON sidecar receives the full result; stdout then
 contains a bounded summary.
+
+## Font inventory
+
+Every `inspect` and `extract` result carries a whole-document `fonts` block regardless of
+`--pages`, built from page, Form-XObject, AcroForm, and annotation appearance resources:
+
+```json
+"fonts": {
+  "scope": "document",
+  "count": 2,
+  "entries": [
+    {
+      "base_font": "ABCDEF+Lato-Regular",
+      "name": "Lato-Regular",
+      "subtype": "TrueType",
+      "descendant_subtype": null,
+      "embedded": true,
+      "subset": true,
+      "encoding": "WinAnsiEncoding",
+      "base14": false,
+      "pages": [1, 2]
+    }
+  ],
+  "unembedded": ["Helvetica"],
+  "unembedded_non_base14": [],
+  "truncated": false
+}
+```
+
+`embedded` reflects a `FontFile`/`FontFile2`/`FontFile3` in the descriptor; Type3 fonts are
+always embedded because their glyph procedures live in the document. `base14` covers the
+standard fourteen Type1 fonts plus the universally substituted Arial, Times New Roman, and
+Courier New alias families. The release gate:
+
+- Unembedded fonts **outside** the base-14 set add a warning that begins
+  `RELEASE BLOCKER: non-embedded fonts outside the standard base-14 set: …`. Resolve it
+  before releasing the document — other viewers substitute different glyphs and metrics,
+  which can change line breaks, spacing, and symbol coverage.
+- Unembedded base-14 fonts add only an informational substitution warning.
+- A `truncated: true` inventory hit the bounded resource walk; treat it as incomplete, not
+  as clean.
+
+## Render
+
+```text
+pdf_tool.py render --input INPUT.pdf --output DIRECTORY
+                   [--pages EXPR] [--dpi 150]
+                   [--password-env NAME] [--overwrite]
+```
+
+Rasterizes each selected page to `page-NNNN.png` (1-based source page numbers) in a new or
+empty directory with the same non-clobbering, staged, atomic semantics as
+`extract --images-dir`. The full pixel budget is charged from page geometry before any
+rasterization, every PNG is signature-checked, reopened, and hashed, and the published
+files are reopened once more after the atomic publish. There is no `--timeout`: rendering is
+in-process PDFium (via pdfplumber), not a subprocess.
+
+Rendering exists to be looked at. Open the produced PNG files and examine them; a
+successful render summary is structural evidence only, never visual proof. The rasters are
+produced from the delivered PDF itself by PDFium, so for static page appearance they are
+authoritative — with two carve-outs: non-embedded fonts render with this machine's
+substitutes (other viewers may differ; see the font inventory gate), and viewer-interactive
+behavior (form appearance regeneration, annotations, JavaScript, overprint) is not proven
+by any raster. Encrypted sources render after authentication with a warning that the PNG
+files themselves are not password protected.
+
+At 150 DPI a letter page is about 2.1 million pixels, so roughly 95 letter pages fit one
+invocation's 200,000,000-pixel budget; select pages or lower `--dpi` for longer documents.
 
 ## Create
 
@@ -314,6 +391,76 @@ Example:
 Encryption passwords in a JSON job are sensitive. Generate that job in a protected temporary
 location and delete it after use. The CLI never reports password values.
 
+## Redact
+
+```text
+pdf_tool.py redact --input INPUT.pdf --job REDACT.json --output OUTPUT.pdf
+                   [--report REPORT.json] [--render-check-dir DIRECTORY]
+                   [--overwrite]
+```
+
+`redact` removes content — text-showing operators, images, vector paints, and annotations
+whose measured extents intersect the target regions — then rewrites the document as a
+single revision and draws an opaque confirmation rectangle over each target. It is the only
+supported redaction path; `edit` stamps and white rectangles are cosmetic overlays, never
+redaction. Read [Redaction](references/redaction.md) for the full leakage-policy table, the
+verification contract, and everything v1 refuses.
+
+Job schema (closed; unknown keys fail):
+
+```json
+{
+  "schema_version": 1,
+  "targets": [
+    {
+      "type": "rect",
+      "page": 3,
+      "rect": [72, 144, 200, 40],
+      "coordinate_origin": "top-left"
+    },
+    {
+      "type": "text",
+      "text": "ACME-SECRET-9931",
+      "pages": "all",
+      "match": "exact",
+      "grow_points": 2.0
+    }
+  ],
+  "image_policy": "remove",
+  "annotation_policy": "remove-intersecting",
+  "fill_color": "#000000",
+  "strip_docinfo_keys": "matched",
+  "strip_xmp": "if-matched",
+  "strip_thumbnails": true,
+  "strip_structure_tree": false,
+  "acknowledge": {
+    "signatures_invalidated": false,
+    "attachments_present": false
+  }
+}
+```
+
+- `rect` targets use `[x, y, width, height]` in displayed-page points; `coordinate_origin`
+  is `top-left` (default, matching inspect/extract word coordinates) or `bottom-left`.
+- `text` targets resolve to rectangles through extracted word geometry on their selected
+  pages, grown by `grow_points` (default 2). A target that matches nothing fails as
+  `bad_input` — nothing is silently skipped. Text targets match only extractable digital
+  text; redact scanned pixels with `rect` targets.
+- Whole intersecting operators are removed and their advance is preserved so retained text
+  does not shift; adjacent text inside the same operator is removed with it, counted, and
+  visible in the verification rasters.
+- `image_policy: remove` (default) drops any intersecting image entirely; `refuse` fails
+  instead. There is no partial image masking in v1.
+- Verification before publication: zero extractable characters inside every target region,
+  target terms unextractable on their selected pages, a byte-level residual scan over the
+  raw file and every decompressed stream, removed image streams unreachable, page geometry
+  unchanged, exactly one `%%EOF`, and a before/after raster diff that must be clean outside
+  the expected change regions. Any failure aborts with `validation_failed` and publishes
+  nothing.
+- `--report` writes the full JSON report; it carries SHA-256 digests of text targets, never
+  the target text. `--render-check-dir` publishes the before/after verification rasters for
+  review.
+
 ## Convert
 
 ```text
@@ -364,8 +511,85 @@ reported as the resolved device. `--paddle-pipeline structure` explicitly select
 classification, wired/wireless table-structure, and wired/wireless cell-detection artifact
 roles listed in [OCR](references/ocr.md).
 `--raw-output-dir` and the normalized JSON are staged before publication and rolled back
-together if publication raises an error. A normal OCR run writes only sidecars; it never
-changes the source or creates a searchable replacement PDF.
+together if publication raises an error. An `ocr` run writes only sidecars and never
+changes the source; producing a searchable PDF is the separate, explicit
+[`ocr-compose`](#searchable-ocr-composition) step.
+
+## Manifest derive and check
+
+```text
+pdf_tool.py manifest --mode derive --engine tesseract --languages eng,deu
+                     [--tessdata-dir DIR] [--assume-source tessdata_fast|tessdata_best]
+                     [--accept-license] [--confirm-eligibility]
+                     --output MANIFEST.json [--overwrite]
+
+pdf_tool.py manifest --mode derive --engine surya
+                     --artifact model=/models/surya/surya-2.gguf
+                     --artifact mmproj=/models/surya/surya-2-mmproj.gguf
+                     --artifact backend=/opt/llama.cpp/llama-server
+                     --output MANIFEST.json
+
+pdf_tool.py manifest --mode derive --engine paddle
+                     --artifact text_detection_model_dir=/models/paddle/det
+                     --artifact text_recognition_model_dir=/models/paddle/rec
+                     --output MANIFEST.json
+
+pdf_tool.py manifest --mode check --engine ENGINE --languages LANGS
+                     --model-manifest MANIFEST.json
+```
+
+`manifest` never executes any binary — it stats and hashes local files only. The derive
+principle: **the tool measures; the operator declares; approval is never inferred.**
+Measured facts (paths, byte sizes, SHA-256, canonical directory inventories) are filled
+automatically. Provenance (identifier, revision, source, license) is filled only from an
+explicit operator declaration (`--assume-source` for the pinned tessdata repositories) or
+an exact SHA-256 match against the artifacts already reviewed in [OCR](references/ocr.md); everything
+else is emitted as `REVIEW-REQUIRED`, which `ocr` preflight rejects. The six PP-StructureV3
+structure roles are never auto-filled by any flag. `--accept-license` and
+`--confirm-eligibility` are explicit operator acts; without them the emitted approvals are
+`false` and the stdout summary lists every reason the manifest is not preflight-ready.
+
+`--mode check` verifies an existing manifest without fail-fast: it reports every problem at
+once with expected and actual sizes/hashes, then exits 0 when preflight would pass or 7
+with the full check array in `details`. It excludes (and names) the checks only `ocr` can
+perform: the engine version probe, the Tesseract language query, and the backend probe.
+
+## Searchable OCR composition
+
+```text
+pdf_tool.py ocr-compose --input SCANNED.pdf --sidecar RESULT.json --output OUT.pdf
+                        [--pages EXPR] [--min-confidence 0.0]
+                        [--font FONT.ttf] [--on-unmappable fail|skip-block]
+                        [--allow-duplicate-text]
+                        [--max-visual-diff 0.002] [--visual-check-dpi 96]
+                        [--skip-visual-check]
+                        [--password-env NAME] [--allow-decrypted-output] [--overwrite]
+```
+
+`ocr-compose` overlays the recognized text from a completed OCR sidecar as an invisible
+text layer (text render mode 3), producing a searchable, selectable PDF. It is
+deterministic: it never runs an engine, needs no model manifest, and can be re-run with
+different options against the same sidecar. The sidecar's recorded `source.sha256` must
+match `--input` exactly; there is no override.
+
+- Word geometry (`blocks[].words`, recorded by the Tesseract adapter) is used when present;
+  otherwise whole blocks are placed. Blocks below `--min-confidence` or without geometry
+  are skipped and counted.
+- The default Helvetica layer maps cp1252 text only. Unmappable characters fail the run
+  (default) listing the affected pages, or are dropped with counts under
+  `--on-unmappable skip-block`; characters are never silently substituted. Pass `--font`
+  with a covering TTF/OTF for other scripts — it is embedded and subset, and the operator
+  owns its embedding license.
+- Pages classified `digital-text` (or `hybrid` composed without a region) are skipped by
+  default because composing them duplicates extractable text; `--allow-duplicate-text`
+  overrides. Hybrid region results overlay only their region. Pages absent from the
+  sidecar pass through unchanged.
+- Encrypted sources require the password and `--allow-decrypted-output`, mirroring `pages`.
+- Verification before publication: page count, dimensions, and rotation unchanged; the
+  highest-confidence composed texts must extract from the output; one anchor per page must
+  extract within 3 points of its composed position; and a before/after raster diff must
+  stay under `--max-visual-diff` — an invisible layer must be invisible. The composed text
+  inherits OCR recognition errors; the output records confidence statistics per page.
 
 ## Exit statuses
 

--- a/kolega_code/_bundled_skills/skills/pdf/references/quality.md
+++ b/kolega_code/_bundled_skills/skills/pdf/references/quality.md
@@ -1,0 +1,81 @@
+# Quality contract
+
+## Contents
+
+- [Design intake](#design-intake)
+- [Delivery profiles](#delivery-profiles)
+- [Acceptance criteria](#acceptance-criteria)
+- [Visual review versus structural checks](#visual-review-versus-structural-checks)
+
+## Design intake
+
+Record this profile before creating or mutating a deliverable:
+
+| Decision | Required intake |
+|---|---|
+| Audience | Primary readers, reading context, and assistive-technology needs |
+| Deliverable type | New PDF, page assembly (merge/split/reorder), stamp/fill/metadata edit, redaction, OCR sidecar, or searchable composition |
+| Source of truth | Digital-native, scanned, or hybrid — this drives the extraction, OCR, and redaction posture |
+| Target viewers | Acrobat, browser built-ins, mobile viewers, print RIP, or unspecified |
+| Medium | Print, screen, or both; monochrome and duplex requirements |
+| Page | Letter, A4, or custom; orientation; mixed sizes |
+| Fonts | Base-14 only, or embedded fonts with license approval for embedding |
+| Forms | Fillable AcroForm preserved, values flattened, or none; XFA disclosed as unsupported |
+| Encryption | None, user password, owner password; algorithm; who holds the passwords |
+| Metadata | Title/author/language to set; removal requests (removal is not sanitization) |
+| PDF profile expectation | None, basic viewing, print, accessibility-oriented, or archive-oriented |
+
+## Delivery profiles
+
+Profiles describe checks performed, not certifications:
+
+- **Basic viewing:** the output reopens in strict mode, has the expected page count and
+  order, named text anchors extract, and representative rendered pages are legible.
+- **Print:** basic viewing plus paper size, orientation, and margins verified from inspected
+  geometry; image effective PPI checked; page-by-page render review at 150 DPI or higher;
+  monochrome legibility when requested.
+- **Accessibility-oriented:** basic viewing plus metadata title and language, logical
+  content order in extraction, and meaningful link/anchor text. The CLI does **not** author
+  or validate tagged PDF; never claim tagged PDF or PDF/UA from this CLI alone.
+- **Archive-oriented:** provenance recorded, every font embedded or base-14, no encryption
+  unless requested. The CLI does **not** create or validate PDF/A; call output "PDF/A" only
+  after a separate conforming validator passes it.
+
+Combine profiles when requested. State unresolved warnings and any check not performed.
+
+## Acceptance criteria
+
+Apply the rows relevant to the delivery profile. A failed required row blocks release unless
+the user explicitly accepts the named exception.
+
+| Area | Measurable acceptance |
+|---|---|
+| Source discipline | Every source was inspected before mutation; sources are byte-identical afterward; the destination is distinct from every source; the JSON `verification` object was reopened and reviewed. |
+| Page inventory | Output page count, order, rotation, and dimensions match the plan exactly, verified from `inspect` geometry — not assumed from the request. |
+| Text anchors | Named anchor strings extract on the expected pages of the published output. |
+| Font portability | The `fonts` inventory was reviewed and carries zero `RELEASE BLOCKER:` warnings. Embedded fonts are license-approved for embedding. Base-14-only output is acceptable when the metric-substitution caveat is disclosed. A `truncated` inventory is incomplete, not clean. |
+| Images | Effective PPI per axis is `source_pixels / (placed_points / 72)` from inspected image records; below 150 is a release warning; target at least 300 PPI for print. No unintended stretching or cropping in render. |
+| Forms | Field inventory, values, and flags match intent after edits (`edit --read-fields`); no unintended flattening; XFA presence is disclosed as unsupported. |
+| Metadata | Title/author/language are as requested; removals are verified by reopening; metadata removal is never described as sanitization or redaction. |
+| Encryption | Output encryption state and algorithm match the request; publishing decrypted content from an encrypted source was explicitly authorized (`allow_decrypted_output` / `--allow-decrypted-output`). |
+| Stamps and watermarks | Position, opacity, and page coverage confirmed visually. Stamps, white rectangles, and crops are never presented as redaction — true removal is the `redact` command with its verification report. |
+| Redaction | The `redact` report shows the expected removal evidence, a clean residual scan, and a clean out-of-region visual diff; the black boxes were confirmed in rendered pages. |
+| Visual QA | `render` every changed page plus page 1 at 150 DPI or higher and open each PNG with the Read tool: no clipping, overlap, truncation, missing images, broken tables, or accidental blank pages. |
+
+## Visual review versus structural checks
+
+The CLI's `verification` JSON (signature, reopen, page count, encryption state) and the
+inspect/extract results — including classifications, warnings, and the font inventory — are
+**structural checks only**. They cannot detect overlap, clipping, glyph substitution or
+tofu, z-order mistakes, or whether a page looks right. Do not cite them as visual proof.
+
+Real visual review is `render` plus opening every relevant PNG with the Read tool. Unlike
+DOCX or PPTX review through an intermediate converter, these rasters are produced from the
+delivered PDF itself by PDFium, so the pixels reflect the actual artifact — a strictly
+stronger guarantee, with two carve-outs: rasters are fully deterministic only when every
+font is embedded (non-embedded fonts show this machine's substitutes), and no raster proves
+viewer-interactive behavior (form appearance regeneration, annotation states, JavaScript,
+layers, overprint, or color management).
+
+If rendering cannot be performed, report "structural checks only; visual QA not performed"
+and make no layout, print, accessibility, or archive-conformance claims.

--- a/kolega_code/_bundled_skills/skills/pdf/references/redaction.md
+++ b/kolega_code/_bundled_skills/skills/pdf/references/redaction.md
@@ -1,0 +1,104 @@
+# Redaction policy and verification contract
+
+## Contents
+
+- [What redact does](#what-redact-does)
+- [Leakage policy table](#leakage-policy-table)
+- [Verification contract](#verification-contract)
+- [Redacting scanned pages](#redacting-scanned-pages)
+- [What redact does not guarantee](#what-redact-does-not-guarantee)
+
+## What redact does
+
+`redact` interprets each targeted page's content stream with a bounded graphics-state
+machine: it tracks the transformation and text matrices, measures every text-showing
+operator's extent from the font's width tables (conservatively over-approximating when a
+width is missing), and removes any operator whose extent intersects a target rectangle.
+Removed text operators are replaced by advance-preserving no-ops so retained text does not
+shift; intersecting images, inline images, vector paints, and annotations are removed
+whole. The document is then rewritten as a single revision (dropping prior incremental
+revisions and orphaned objects) and an opaque rectangle is drawn over each target region as
+visual confirmation — the rectangle is confirmation, not the mechanism.
+
+The whole-operator policy is deliberate: any overlap removes the entire show operator, so
+text adjacent to the target inside the same operator is removed with it. The report counts
+this collateral and the verification rasters make it visible. Prefer tight targets;
+`grow_points` (default 2) trades collateral for margin against sub-glyph leakage.
+
+## Leakage policy table
+
+Every known channel is handled, or detected and refused — never silently ignored.
+
+| Channel | v1 policy |
+| --- | --- |
+| Text operators (`Tj`/`TJ`/`'`/`"`) | **Handled**: whole-operator removal on any overlap, conservative extents from width tables |
+| Unmeasurable glyph widths (broken or exotic font dictionaries) | Extent detection over-approximates via the font bounding box; an intersecting operator whose widths cannot be measured is **refused** rather than guessed |
+| Type3 fonts shown inside a target | **Refused** — glyph procedures are content streams with unmeasurable extents |
+| Text-clipping render modes (Tr 4–7) inside a target | **Refused** — rewriting text clips changes later content |
+| Inline images (`BI`/`ID`/`EI`) | **Handled**: removed whole on any overlap |
+| Image XObjects | **Handled**: removed whole (default) or the run is refused under `image_policy: refuse`; removed streams are verified unreachable in the output |
+| Form XObjects whose transformed `/BBox` intersects | **Refused** — their inner streams can carry text and may be shared across pages; flatten or rasterize first |
+| Vector paths painted inside a target | **Handled**: the painting operator becomes a no-op (`n`) so path data cannot be painted later; clipping paths are preserved |
+| Optional-content (OCG) hidden text | **Handled implicitly**: the interpreter ignores visibility, so hidden operators in the region are removed; `BDC`/`EMC` stay balanced |
+| Annotations intersecting a target | **Handled**: the whole annotation (including appearance streams) is removed |
+| Annotations elsewhere containing a target term | **Handled**: the term sweep removes them and reports it |
+| Document information (DocInfo) | **Handled** per `strip_docinfo_keys` (`matched` default); a term hit under `none` is refused |
+| XMP metadata | **Handled** per `strip_xmp` (`if-matched` default); a term hit under `never` is refused |
+| Page thumbnails (`/Thumb`) | **Handled**: stripped on every page by default |
+| Structure tree (`/ActualText`, `/Alt`) | Term hits are **refused** unless `strip_structure_tree: true`, which removes the whole structure tree (and its accessibility tagging) |
+| Outlines and named destinations containing a term | **Refused** — rewrite them before redacting |
+| Form field values containing a term | **Refused** — clear them with an `edit` `fill_form` operation first |
+| Embedded files / attachments | **Detected**; requires `acknowledge.attachments_present` — attachment contents are not scanned |
+| Digital signatures (`/SigFlags`, signed `/Sig` fields) | **Detected**; requires `acknowledge.signatures_invalidated` because rewriting invalidates signatures |
+| XFA forms | **Refused** — the XFA XML can duplicate page content |
+| Prior incremental revisions, orphan objects, object streams | **Handled** by the single-revision rewrite; verified (exactly one `%%EOF`, stale bytes absent) |
+| Encrypted input | **Refused** in v1 — decrypt explicitly with `edit` first |
+| JavaScript / launch actions | **Detected and warned** elsewhere in the skill; their code is not term-scanned |
+
+## Verification contract
+
+All checks run on the staged output before publication; any failure exits
+`validation_failed` and publishes nothing.
+
+1. **Region extraction:** zero extractable characters inside every target rectangle
+   (0.5-point inset tolerance).
+2. **Term extraction:** every text target is unextractable on its selected pages.
+3. **Residual byte scan:** the raw file and every decompressed stream are scanned for
+   UTF-8, UTF-16BE, and Latin-1 encodings of each term (case variants included). A hit for
+   a term whose scope was every page is a hard failure; hits for page-scoped terms are
+   reported because instances outside the selected pages were intentionally retained. The
+   scan cannot enumerate every conceivable glyph-code encoding of text it never removed —
+   the extraction checks above are the primary gate.
+4. **Image reachability:** the decoded bytes of every removed image are verified absent
+   from all streams in the output.
+5. **Structure:** page count and page dimensions unchanged; exactly one `%%EOF`.
+6. **Visual diff:** before/after rasters of every affected page; pixel changes outside the
+   union of target regions and removed-content extents fail the run. `--render-check-dir`
+   publishes these rasters — open them and confirm the black boxes sit exactly where
+   intended.
+
+The report (`--report`) records resolved rectangles, per-page removal evidence, sweep
+results, and the residual scan. Text targets appear as SHA-256 digests only; the report is
+designed not to become a leak channel itself.
+
+## Redacting scanned pages
+
+Text targets match extractable digital text only — on `likely-scanned` pages the text is
+pixels and cannot be matched. Redact scanned content with `rect` targets. To locate the
+rectangles, run OCR and convert the sidecar's word geometry to displayed points: each
+bbox coordinate times `72 / coordinate_space.dpi`, plus the `source_region` offset when the
+page was region-rendered. The intersecting page image is then removed whole (v1 has no
+partial image masking), so re-add retained imagery separately if needed.
+
+## What redact does not guarantee
+
+- No protection against prior copies, backups, version-control history, filesystem
+  journaling or slack space, swap, or anything outside this one output file.
+- Attachment contents are not scanned; JavaScript is not term-scanned.
+- Whole-operator removal deletes adjacent text inside the same show operator; the report
+  quantifies it, but content integrity immediately around the target is not promised.
+- Removing an intersecting page image removes the whole image, which can blank a full
+  scanned page; the visual check makes this obvious rather than preventing it.
+- Rewriting invalidates digital signatures and drops incremental history by design.
+- `strip_structure_tree` removes accessibility tagging for the whole document, not just the
+  matched entries.

--- a/kolega_code/_bundled_skills/skills/pdf/requirements-ocr-paddle.txt
+++ b/kolega_code/_bundled_skills/skills/pdf/requirements-ocr-paddle.txt
@@ -1,2 +1,2 @@
-paddleocr~=3.7
-paddlepaddle~=3.3
+paddleocr
+paddlepaddle

--- a/kolega_code/_bundled_skills/skills/pdf/requirements-ocr-surya.txt
+++ b/kolega_code/_bundled_skills/skills/pdf/requirements-ocr-surya.txt
@@ -1,1 +1,1 @@
-surya-ocr~=0.21.2
+surya-ocr

--- a/kolega_code/_bundled_skills/skills/pdf/requirements.txt
+++ b/kolega_code/_bundled_skills/skills/pdf/requirements.txt
@@ -1,4 +1,7 @@
-Pillow~=12.3
-pdfplumber~=0.11.10
-pypdf[crypto]~=6.14
-reportlab~=5.0
+Pillow
+pdfplumber
+pypdf[crypto]
+# pdfplumber rasterizes through pypdfium2; render, ocr, and redaction verification
+# depend on that raster path directly, so the dependency is declared explicitly.
+pypdfium2
+reportlab

--- a/kolega_code/_bundled_skills/skills/pdf/scripts/pdf_tool.py
+++ b/kolega_code/_bundled_skills/skills/pdf/scripts/pdf_tool.py
@@ -23,20 +23,32 @@ import time
 from collections import defaultdict
 from collections.abc import Callable, Generator, Iterable, Sequence
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from dataclasses import field as dataclass_field
 from pathlib import Path
 from typing import Any, NoReturn
 
 import pdfplumber
-from PIL import Image
+from PIL import Image, ImageChops, ImageDraw
 from pypdf import PdfReader, PdfWriter, Transformation
 from pypdf.errors import PdfReadError
+from pypdf.generic import (
+    ArrayObject,
+    ByteStringObject,
+    ContentStream,
+    FloatObject,
+    IndirectObject,
+    NameObject,
+    TextStringObject,
+)
 from reportlab.lib import colors
 from reportlab.lib.enums import TA_CENTER, TA_JUSTIFY, TA_LEFT, TA_RIGHT
 from reportlab.lib.pagesizes import A3, A4, A5, LEGAL, LETTER
 from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
 from reportlab.lib.utils import ImageReader
+from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.pdfmetrics import stringWidth
+from reportlab.pdfbase.ttfonts import TTFont
 from reportlab.pdfgen import canvas
 from reportlab.platypus import (
     Image as FlowImage,
@@ -51,7 +63,7 @@ from reportlab.platypus import (
 )
 
 SCHEMA_VERSION = 1
-TOOL_VERSION = "1.0.0"
+TOOL_VERSION = "1.1.0"
 MAX_SOURCE_BYTES = 512 * 1024 * 1024
 MAX_PAGES = 500
 MAX_EXTRACTED_CHARS = 20_000_000
@@ -64,6 +76,104 @@ MAX_IMAGE_BYTES = 100 * 1024 * 1024
 MAX_JSON_BYTES = 20 * 1024 * 1024
 MAX_STORY_ITEMS = 10_000
 MAX_OUTPUTS = 500
+DEFAULT_RENDER_DPI = 150
+DEFAULT_VISUAL_CHECK_DPI = 96
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+MAX_FONT_ENTRIES = 2_000
+MAX_FONT_OBJECT_VISITS = 10_000
+MAX_FONT_XOBJECT_DEPTH = 8
+MAX_CONTENT_OPERATIONS = 500_000
+MAX_REDACTION_TARGETS = 1_000
+BASE14_FONT_NAMES = frozenset(
+    {
+        "Courier",
+        "Courier-Bold",
+        "Courier-Oblique",
+        "Courier-BoldOblique",
+        "Helvetica",
+        "Helvetica-Bold",
+        "Helvetica-Oblique",
+        "Helvetica-BoldOblique",
+        "Times-Roman",
+        "Times-Bold",
+        "Times-Italic",
+        "Times-BoldItalic",
+        "Symbol",
+        "ZapfDingbats",
+    }
+)
+BASE14_ALIAS_FAMILIES = ("arial", "timesnewroman", "couriernew")
+BASE14_ALIAS_SUFFIXES = frozenset(
+    {
+        "",
+        "mt",
+        "ps",
+        "psmt",
+        "bold",
+        "boldmt",
+        "boldps",
+        "boldpsmt",
+        "italic",
+        "italicmt",
+        "oblique",
+        "bolditalic",
+        "bolditalicmt",
+        "bolditalicps",
+        "bolditalicpsmt",
+        "boldoblique",
+    }
+)
+SUBSET_PREFIX_PATTERN = re.compile(r"^[A-Z]{6}\+")
+REVIEW_REQUIRED = "REVIEW-REQUIRED"
+# Provenance below matches reviewed artifacts recorded in references/ocr.md; a manifest
+# derive fills these fields only on an exact SHA-256 match against a local file.
+KNOWN_ARTIFACTS = {
+    "1f18abe17b1ed8b4e47ee9b1ad0e274c93daf5efbb6b29a04ff1712e37051e05": {
+        "identifier": "datalab-to/surya-ocr-2-gguf/surya-2.gguf",
+        "revision": "6a3a4c30e5e74446d4f8b6afd05b2f2da970f470",
+        "source": "https://huggingface.co/datalab-to/surya-ocr-2-gguf",
+        "license": "modified AI Pubs Open Rail-M",
+    },
+    "98c0563673b1657ff6d021d1e5f04af06cbf61bb40c63ac613e8bb71b42fb2c0": {
+        "identifier": "datalab-to/surya-ocr-2-gguf/surya-2-mmproj.gguf",
+        "revision": "6a3a4c30e5e74446d4f8b6afd05b2f2da970f470",
+        "source": "https://huggingface.co/datalab-to/surya-ocr-2-gguf",
+        "license": "modified AI Pubs Open Rail-M",
+    },
+    "85218d2e3d98f5a21c58b4220627be923a97aee5db3cc71f39536ab31ac53960": {
+        "identifier": "PaddlePaddle/PP-OCRv6_medium_det",
+        "revision": "8e0f56fb2ef86b461d99cfc7ac5c137738985f61",
+        "source": "https://huggingface.co/PaddlePaddle/PP-OCRv6_medium_det",
+        "license": "Apache-2.0",
+    },
+    "1b01c79a914587933f615569e75de54f2e638ebb5d3f3b3c1b38c24ede8c7319": {
+        "identifier": "PaddlePaddle/PP-OCRv6_medium_rec",
+        "revision": "e5a92bcbc5cc1b494628e458d267778f0704fd7c",
+        "source": "https://huggingface.co/PaddlePaddle/PP-OCRv6_medium_rec",
+        "license": "Apache-2.0",
+    },
+}
+TESSDATA_SOURCES = {
+    "tessdata_fast": {
+        "identifier_prefix": "tesseract-ocr/tessdata_fast",
+        "revision": "87416418657359cb625c412a48b6e1d6d41c29bd",
+        "source": "https://github.com/tesseract-ocr/tessdata_fast",
+        "license": "Apache-2.0",
+    },
+    "tessdata_best": {
+        "identifier_prefix": "tesseract-ocr/tessdata_best",
+        "revision": "e12c65a915945e4c28e237a9b52bc4a8f39a0cec",
+        "source": "https://github.com/tesseract-ocr/tessdata_best",
+        "license": "Apache-2.0",
+    },
+}
+WELL_KNOWN_TESSDATA_DIRS = (
+    "/opt/homebrew/share/tessdata",
+    "/usr/local/share/tessdata",
+    "/usr/share/tessdata",
+    "/usr/share/tesseract-ocr/5/tessdata",
+    "/usr/share/tesseract-ocr/4.00/tessdata",
+)
 PAGE_SIZES = {
     "a3": A3,
     "a4": A4,
@@ -173,7 +283,7 @@ def success(operation: str, **fields: Any) -> dict[str, Any]:
 
 def library_versions() -> dict[str, str]:
     versions = {}
-    for package in ("pypdf", "pdfplumber", "reportlab", "Pillow"):
+    for package in ("pypdf", "pdfplumber", "pypdfium2", "reportlab", "Pillow"):
         try:
             versions[package] = importlib.metadata.version(package)
         except importlib.metadata.PackageNotFoundError:
@@ -474,6 +584,247 @@ def form_inventory(reader: PdfReader) -> dict[str, Any]:
     return {"count": len(items), "fields": items, "has_xfa": has_xfa}
 
 
+_NORMALIZED_BASE14 = frozenset(
+    re.sub(r"[^a-z0-9]", "", name.casefold()) for name in BASE14_FONT_NAMES
+)
+
+
+def is_base14_font_name(name: str) -> bool:
+    if name in BASE14_FONT_NAMES:
+        return True
+    normalized = re.sub(r"[^a-z0-9]", "", name.casefold())
+    if normalized in _NORMALIZED_BASE14:
+        return True
+    for family in BASE14_ALIAS_FAMILIES:
+        if normalized.startswith(family) and normalized[len(family) :] in BASE14_ALIAS_SUFFIXES:
+            return True
+    return False
+
+
+def font_record(font_object: Any) -> dict[str, Any]:
+    font = font_object.get_object()
+    subtype = str(font.get("/Subtype", "")).lstrip("/") or None
+    base_font = font.get("/BaseFont")
+    descendant_subtype = None
+    descriptor = font.get("/FontDescriptor")
+    if subtype == "Type0":
+        descendants = font.get("/DescendantFonts")
+        if descendants is not None:
+            descendant_array = descendants.get_object()
+            if descendant_array:
+                descendant = descendant_array[0].get_object()
+                descendant_value = descendant.get("/Subtype")
+                if descendant_value is not None:
+                    descendant_subtype = str(descendant_value).lstrip("/") or None
+                descriptor = descendant.get("/FontDescriptor")
+                if base_font is None:
+                    base_font = descendant.get("/BaseFont")
+    raw_name = str(base_font).lstrip("/") if base_font is not None else "(unnamed)"
+    name = SUBSET_PREFIX_PATTERN.sub("", raw_name)
+    subset = bool(SUBSET_PREFIX_PATTERN.match(raw_name))
+    if subtype == "Type3":
+        embedded = True
+    else:
+        descriptor_object = descriptor.get_object() if descriptor is not None else {}
+        embedded = any(
+            key in descriptor_object for key in ("/FontFile", "/FontFile2", "/FontFile3")
+        )
+    encoding = font.get("/Encoding")
+    if encoding is None:
+        encoding_name = None
+    else:
+        encoding_object = encoding.get_object() if hasattr(encoding, "get_object") else encoding
+        if isinstance(encoding_object, dict):
+            base_encoding = encoding_object.get("/BaseEncoding")
+            encoding_name = str(base_encoding).lstrip("/") if base_encoding else "Custom"
+        else:
+            encoding_name = str(encoding_object).lstrip("/")
+    return {
+        "base_font": raw_name,
+        "name": name,
+        "subtype": subtype,
+        "descendant_subtype": descendant_subtype,
+        "embedded": embedded,
+        "subset": subset,
+        "encoding": encoding_name,
+        "base14": is_base14_font_name(name),
+    }
+
+
+def collect_fonts(reader: PdfReader) -> tuple[dict[str, Any], list[str]]:
+    """Inventory every font reachable from page, form, and annotation resources."""
+    entries: dict[tuple[Any, ...], dict[str, Any]] = {}
+    warnings: list[str] = []
+    truncated = False
+    visits = 0
+    visited_references: set[tuple[int, int]] = set()
+
+    def record(font_object: Any, page_number: int | None) -> None:
+        nonlocal truncated
+        try:
+            item = font_record(font_object)
+        except Exception as exc:
+            warnings.append(f"Font inventory entry failed: {clean_text(exc)}")
+            return
+        key = (item["base_font"], item["subtype"], item["embedded"], item["encoding"])
+        existing = entries.get(key)
+        if existing is None:
+            if len(entries) >= MAX_FONT_ENTRIES:
+                truncated = True
+                return
+            item["pages"] = set()
+            entries[key] = item
+            existing = item
+        if page_number is not None:
+            existing["pages"].add(page_number)
+
+    def charge_visit() -> bool:
+        nonlocal visits, truncated
+        visits += 1
+        if visits > MAX_FONT_OBJECT_VISITS:
+            truncated = True
+            return False
+        return True
+
+    def walk_resources(resources: Any, page_number: int | None, depth: int) -> None:
+        nonlocal truncated
+        if resources is None:
+            return
+        if depth > MAX_FONT_XOBJECT_DEPTH:
+            truncated = True
+            return
+        try:
+            resources = resources.get_object()
+        except Exception as exc:
+            warnings.append(f"Font inventory resource lookup failed: {clean_text(exc)}")
+            return
+        if not isinstance(resources, dict):
+            return
+        fonts = resources.get("/Font")
+        if fonts is not None:
+            try:
+                font_map = fonts.get_object()
+                for font_reference in font_map.values():
+                    if not charge_visit():
+                        return
+                    record(font_reference, page_number)
+            except Exception as exc:
+                warnings.append(f"Font inventory font map failed: {clean_text(exc)}")
+        xobjects = resources.get("/XObject")
+        if xobjects is None:
+            return
+        try:
+            xobject_map = xobjects.get_object()
+        except Exception as exc:
+            warnings.append(f"Font inventory XObject lookup failed: {clean_text(exc)}")
+            return
+        if not isinstance(xobject_map, dict):
+            return
+        for xobject_reference in xobject_map.values():
+            if not charge_visit():
+                return
+            if isinstance(xobject_reference, IndirectObject):
+                reference_key = (xobject_reference.idnum, xobject_reference.generation)
+                if reference_key in visited_references:
+                    continue
+                visited_references.add(reference_key)
+            try:
+                xobject = xobject_reference.get_object()
+                if str(xobject.get("/Subtype", "")) == "/Form":
+                    walk_resources(xobject.get("/Resources"), page_number, depth + 1)
+            except Exception as exc:
+                warnings.append(f"Font inventory XObject walk failed: {clean_text(exc)}")
+
+    def walk_annotations(page: Any, page_number: int) -> None:
+        annotations = page.get("/Annots")
+        if annotations is None:
+            return
+        try:
+            annotation_array = annotations.get_object()
+        except Exception:
+            return
+        for annotation_reference in annotation_array:
+            if not charge_visit():
+                return
+            try:
+                annotation = annotation_reference.get_object()
+                appearances = annotation.get("/AP")
+                if appearances is None:
+                    continue
+                appearance_map = appearances.get_object()
+                if not isinstance(appearance_map, dict):
+                    continue
+                for state in appearance_map.values():
+                    state_object = state.get_object()
+                    if isinstance(state_object, dict) and "/Resources" not in state_object:
+                        for nested in state_object.values():
+                            nested_object = nested.get_object()
+                            if isinstance(nested_object, dict):
+                                walk_resources(nested_object.get("/Resources"), page_number, 1)
+                    elif isinstance(state_object, dict):
+                        walk_resources(state_object.get("/Resources"), page_number, 1)
+            except Exception as exc:
+                warnings.append(f"Font inventory annotation walk failed: {clean_text(exc)}")
+
+    try:
+        for page_index, page in enumerate(reader.pages):
+            walk_resources(page.get("/Resources"), page_index + 1, 0)
+            walk_annotations(page, page_index + 1)
+        root = reader.trailer.get("/Root", {})
+        acroform = root.get("/AcroForm") if hasattr(root, "get") else None
+        if acroform is not None:
+            acroform_object = acroform.get_object()
+            walk_resources(acroform_object.get("/DR"), None, 0)
+    except Exception as exc:
+        warnings.append(f"Font inventory walk failed: {clean_text(exc)}")
+        truncated = True
+
+    normalized_entries = []
+    for item in sorted(entries.values(), key=lambda entry: (entry["name"], entry["base_font"])):
+        pages = sorted(item.pop("pages"))
+        item["pages"] = pages[:200]
+        normalized_entries.append(item)
+    unembedded = sorted({item["name"] for item in normalized_entries if not item["embedded"]})
+    unembedded_non_base14 = sorted(
+        {item["name"] for item in normalized_entries if not item["embedded"] and not item["base14"]}
+    )
+    inventory = {
+        "scope": "document",
+        "count": len(normalized_entries),
+        "entries": normalized_entries,
+        "unembedded": unembedded,
+        "unembedded_non_base14": unembedded_non_base14,
+        "truncated": truncated,
+    }
+    return inventory, warnings
+
+
+def font_release_warnings(fonts: dict[str, Any]) -> list[str]:
+    warnings: list[str] = []
+    if fonts["unembedded_non_base14"]:
+        names = ", ".join(fonts["unembedded_non_base14"])
+        warnings.append(
+            "RELEASE BLOCKER: non-embedded fonts outside the standard base-14 set: "
+            f"{names}. Other viewers will substitute different glyphs and metrics, which "
+            "can change line breaks, spacing, and symbol coverage. Re-export with these "
+            "fonts embedded or replace them before release."
+        )
+    unembedded_base14 = [
+        name for name in fonts["unembedded"] if name not in fonts["unembedded_non_base14"]
+    ]
+    if unembedded_base14:
+        warnings.append(
+            f"Non-embedded standard fonts are in use ({', '.join(unembedded_base14)}); "
+            "conforming viewers substitute metrics-compatible fonts, but appearance can "
+            "vary slightly."
+        )
+    if fonts["truncated"]:
+        warnings.append(
+            "Font inventory truncated at resource-walk limits; the inventory may be incomplete."
+        )
+    return warnings
+
+
 def plumber_page_data(
     page: Any,
     *,
@@ -583,11 +934,14 @@ def inspect_document(
             result["geometry"] = page_geometry(source.reader.pages[page_index])
             page_results.append(result)
     forms = form_inventory(source.reader)
+    fonts, font_walk_warnings = collect_fonts(source.reader)
     warnings = []
     if forms["has_xfa"]:
         warnings.append("XFA is present and is not supported for editing.")
     if source.reader.is_encrypted:
         warnings.append("Encrypted source was opened; output encryption depends on the operation.")
+    warnings.extend(font_walk_warnings)
+    warnings.extend(font_release_warnings(fonts))
     return {
         "source": str(path.resolve()),
         "encrypted": bool(source.reader.is_encrypted),
@@ -596,6 +950,7 @@ def inspect_document(
         "selected_pages": [page + 1 for page in selected],
         "metadata": normalize_metadata(source.reader),
         "forms": forms,
+        "fonts": fonts,
         "pages": page_results,
         "warnings": warnings,
     }
@@ -680,6 +1035,38 @@ def atomic_publish(temp_path: Path, destination: Path) -> None:
         os.replace(temp_path, destination.resolve())
     except OSError as exc:
         raise ToolError("validation_failed", f"Atomic publish failed: {clean_text(exc)}") from exc
+
+
+def check_directory_destination(
+    output_dir: Path,
+    *,
+    overwrite: bool,
+    exists_message: str,
+    not_directory_message: str,
+    nonempty_message: str,
+) -> None:
+    if output_dir.exists():
+        if not overwrite:
+            raise ToolError("bad_input", exists_message)
+        if output_dir.is_symlink() or not output_dir.is_dir():
+            raise ToolError("bad_input", not_directory_message)
+        if any(output_dir.iterdir()):
+            raise ToolError("bad_input", nonempty_message)
+
+
+def stage_directory(output_dir: Path) -> Path:
+    output_dir.parent.mkdir(parents=True, exist_ok=True)
+    return Path(tempfile.mkdtemp(prefix=f".{output_dir.name}.", dir=output_dir.parent.resolve()))
+
+
+def atomic_publish_directory(staged_dir: Path, output_dir: Path, *, label: str) -> None:
+    try:
+        os.replace(staged_dir, output_dir.resolve())
+    except OSError as exc:
+        raise ToolError(
+            "validation_failed",
+            f"Atomic {label} publish failed: {clean_text(exc)}",
+        ) from exc
 
 
 def write_json_atomic(
@@ -1468,21 +1855,14 @@ def extract_embedded_images(
     *,
     overwrite: bool,
 ) -> tuple[list[dict[str, Any]], list[str]]:
-    output_existed = output_dir.exists()
-    if output_existed:
-        if not overwrite:
-            raise ToolError("bad_input", f"Image output directory exists: {output_dir}")
-        if output_dir.is_symlink() or not output_dir.is_dir():
-            raise ToolError("bad_input", f"Image output must be a directory: {output_dir}")
-        if any(output_dir.iterdir()):
-            raise ToolError(
-                "bad_input",
-                "Refusing to overwrite a nonempty image output directory",
-            )
-    output_dir.parent.mkdir(parents=True, exist_ok=True)
-    staged_dir = Path(
-        tempfile.mkdtemp(prefix=f".{output_dir.name}.", dir=output_dir.parent.resolve())
+    check_directory_destination(
+        output_dir,
+        overwrite=overwrite,
+        exists_message=f"Image output directory exists: {output_dir}",
+        not_directory_message=f"Image output must be a directory: {output_dir}",
+        nonempty_message="Refusing to overwrite a nonempty image output directory",
     )
+    staged_dir = stage_directory(output_dir)
     extracted = []
     warnings = []
     count = 0
@@ -1516,13 +1896,7 @@ def extract_embedded_images(
                         f"Page {page_index + 1} image {image_index} extraction failed: "
                         f"{clean_text(exc)}"
                     )
-        try:
-            os.replace(staged_dir, output_dir.resolve())
-        except OSError as exc:
-            raise ToolError(
-                "validation_failed",
-                f"Atomic image-directory publish failed: {clean_text(exc)}",
-            ) from exc
+        atomic_publish_directory(staged_dir, output_dir, label="image-directory")
     finally:
         shutil.rmtree(staged_dir, ignore_errors=True)
     return extracted, warnings
@@ -1556,6 +1930,141 @@ def handle_inspect_or_extract(args: argparse.Namespace) -> dict[str, Any]:
         Path(args.output) if args.output else None,
         overwrite=args.overwrite,
         protected_sources=[path],
+    )
+
+
+def handle_render(args: argparse.Namespace) -> dict[str, Any]:
+    password = resolve_password(args.password, args.password_env)
+    source_path = Path(args.input)
+    source = open_pdf(source_path, password)
+    selected = parse_page_selection(args.pages, len(source.reader.pages))
+    if not selected:
+        raise ToolError("bad_input", "Source PDF has no pages to render")
+    output_dir = Path(args.output)
+    if paths_alias(output_dir, source_path):
+        raise ToolError("bad_input", "Render output directory must differ from the source")
+    check_directory_destination(
+        output_dir,
+        overwrite=args.overwrite,
+        exists_message=f"Render output directory exists: {output_dir}",
+        not_directory_message=f"Render output must be a directory: {output_dir}",
+        nonempty_message="Refusing to overwrite a nonempty render output directory",
+    )
+    dpi = args.dpi
+    warnings: list[str] = []
+    fonts, font_walk_warnings = collect_fonts(source.reader)
+    warnings.extend(font_walk_warnings)
+    if fonts["unembedded_non_base14"]:
+        warnings.append(
+            "Rendered rasters substitute this machine's local fonts for non-embedded "
+            "fonts; other viewers may substitute differently."
+        )
+    if source.reader.is_encrypted:
+        warnings.append(
+            "Encrypted source was rendered; the published PNG files are not password protected."
+        )
+    budget = RenderBudget(
+        total_message=(
+            f"Render total exceeds {MAX_TOTAL_RENDER_PIXELS} pixels; "
+            "select fewer pages or lower --dpi"
+        )
+    )
+    renders: list[dict[str, Any]] = []
+    with pdfplumber.open(str(source_path), password=password) as plumber_pdf:
+        for page_index in selected:
+            page = plumber_pdf.pages[page_index]
+            budget.charge(
+                float(page.width),
+                float(page.height),
+                dpi,
+                page_label=f"Page {page_index + 1}",
+            )
+        staged_dir = stage_directory(output_dir)
+        try:
+            for page_index in selected:
+                page = plumber_pdf.pages[page_index]
+                name = f"page-{page_index + 1:04d}.png"
+                staged_path = staged_dir / name
+                rasterize_region(
+                    page,
+                    None,
+                    dpi,
+                    staged_path,
+                    page_label=f"page {page_index + 1}",
+                )
+                with staged_path.open("rb") as handle:
+                    if handle.read(8) != PNG_SIGNATURE:
+                        raise ToolError(
+                            "validation_failed",
+                            f"Rendered file is not a PNG: {name}",
+                        )
+                try:
+                    with Image.open(staged_path) as image:
+                        image.load()
+                        actual_width, actual_height = image.size
+                except Exception as exc:
+                    raise ToolError(
+                        "validation_failed",
+                        f"Cannot reopen rendered PNG {name}: {clean_text(exc)}",
+                    ) from exc
+                if actual_width * actual_height > MAX_PIXELS_PER_RENDER:
+                    raise ToolError(
+                        "resource_limit",
+                        f"Page {page_index + 1} render exceeds {MAX_PIXELS_PER_RENDER} pixels",
+                    )
+                renders.append(
+                    {
+                        "page": page_index + 1,
+                        "file": name,
+                        "output_path": str((output_dir / name).resolve()),
+                        "width_px": actual_width,
+                        "height_px": actual_height,
+                        "bytes": staged_path.stat().st_size,
+                        "sha256": sha256_file(staged_path),
+                    }
+                )
+            atomic_publish_directory(staged_dir, output_dir, label="render-directory")
+        finally:
+            shutil.rmtree(staged_dir, ignore_errors=True)
+    reopened = 0
+    for item in renders:
+        published = Path(item["output_path"])
+        try:
+            published_hash = sha256_file(published)
+        except OSError as exc:
+            raise ToolError(
+                "validation_failed",
+                f"Cannot reopen published PNG {item['file']}",
+            ) from exc
+        if published_hash != item["sha256"]:
+            raise ToolError(
+                "validation_failed",
+                f"Published PNG hash changed: {item['file']}",
+            )
+        reopened += 1
+    if len({(item["width_px"], item["height_px"]) for item in renders}) > 1:
+        warnings.append(
+            "Rendered pages have differing pixel dimensions because source page sizes differ."
+        )
+    return success(
+        "render",
+        source=str(source_path.resolve()),
+        output_dir=str(output_dir.resolve()),
+        encrypted=bool(source.reader.is_encrypted),
+        password_used=source.password_used,
+        page_count=len(source.reader.pages),
+        selected_pages=[index + 1 for index in selected],
+        dpi=dpi,
+        renders=renders,
+        counts={"pages_rendered": len(renders), "total_pixels": budget.total_pixels},
+        fonts=fonts,
+        warnings=warnings + font_release_warnings(fonts),
+        verification={
+            "valid": True,
+            "atomic_publish": True,
+            "pngs_reopened": reopened,
+            "renderer": "pdfplumber/pypdfium2",
+        },
     )
 
 
@@ -2002,6 +2511,1888 @@ def handle_edit(args: argparse.Namespace) -> dict[str, Any]:
         warnings=warnings,
         verification=verification,
     )
+
+
+# ---------------------------------------------------------------------------
+# Secure redaction: true content removal with layered verification.
+# ---------------------------------------------------------------------------
+
+REDACT_JOB_KEYS = {
+    "schema_version",
+    "targets",
+    "image_policy",
+    "annotation_policy",
+    "fill_color",
+    "strip_docinfo_keys",
+    "strip_xmp",
+    "strip_thumbnails",
+    "strip_structure_tree",
+    "acknowledge",
+}
+REDACT_TARGET_KEYS = {
+    "type",
+    "page",
+    "rect",
+    "coordinate_origin",
+    "text",
+    "pages",
+    "match",
+    "grow_points",
+}
+REDACT_ACKNOWLEDGE_KEYS = {"signatures_invalidated", "attachments_present"}
+REDACT_VISUAL_DIFF_LIMIT = 0.0005
+REDACT_MASK_DILATION_PIXELS = 3
+REDACT_CHECK_DPI = 96
+PATH_PAINT_OPERATORS = {b"S", b"s", b"f", b"F", b"f*", b"B", b"B*", b"b", b"b*"}
+
+
+def identity_matrix() -> tuple[float, float, float, float, float, float]:
+    return (1.0, 0.0, 0.0, 1.0, 0.0, 0.0)
+
+
+def mat_mult(
+    a: Sequence[float], b: Sequence[float]
+) -> tuple[float, float, float, float, float, float]:
+    return (
+        a[0] * b[0] + a[1] * b[2],
+        a[0] * b[1] + a[1] * b[3],
+        a[2] * b[0] + a[3] * b[2],
+        a[2] * b[1] + a[3] * b[3],
+        a[4] * b[0] + a[5] * b[2] + b[4],
+        a[4] * b[1] + a[5] * b[3] + b[5],
+    )
+
+
+def apply_matrix(m: Sequence[float], x: float, y: float) -> tuple[float, float]:
+    return (m[0] * x + m[2] * y + m[4], m[1] * x + m[3] * y + m[5])
+
+
+def transform_rect(m: Sequence[float], rect: Sequence[float]) -> tuple[float, float, float, float]:
+    corners = [
+        apply_matrix(m, rect[0], rect[1]),
+        apply_matrix(m, rect[2], rect[1]),
+        apply_matrix(m, rect[0], rect[3]),
+        apply_matrix(m, rect[2], rect[3]),
+    ]
+    xs = [corner[0] for corner in corners]
+    ys = [corner[1] for corner in corners]
+    return (min(xs), min(ys), max(xs), max(ys))
+
+
+def rects_overlap(a: Sequence[float], b: Sequence[float]) -> bool:
+    return a[0] < b[2] and b[0] < a[2] and a[1] < b[3] and b[1] < a[3]
+
+
+def quad_corners(m: Sequence[float], rect: Sequence[float]) -> list[tuple[float, float]]:
+    return [
+        apply_matrix(m, rect[0], rect[1]),
+        apply_matrix(m, rect[2], rect[1]),
+        apply_matrix(m, rect[2], rect[3]),
+        apply_matrix(m, rect[0], rect[3]),
+    ]
+
+
+def convex_polygons_overlap(
+    poly_a: Sequence[tuple[float, float]], poly_b: Sequence[tuple[float, float]]
+) -> bool:
+    """Separating-axis test for two convex polygons (touching edges do not count)."""
+    for polygon in (poly_a, poly_b):
+        count = len(polygon)
+        for index in range(count):
+            x1, y1 = polygon[index]
+            x2, y2 = polygon[(index + 1) % count]
+            axis_x, axis_y = -(y2 - y1), x2 - x1
+            if axis_x == 0 and axis_y == 0:
+                continue
+            a_min = min(axis_x * px + axis_y * py for px, py in poly_a)
+            a_max = max(axis_x * px + axis_y * py for px, py in poly_a)
+            b_min = min(axis_x * px + axis_y * py for px, py in poly_b)
+            b_max = max(axis_x * px + axis_y * py for px, py in poly_b)
+            if a_max <= b_min or b_max <= a_min:
+                return False
+    return True
+
+
+def quad_intersects_rect(corners: Sequence[tuple[float, float]], rect: Sequence[float]) -> bool:
+    rect_polygon = [
+        (rect[0], rect[1]),
+        (rect[2], rect[1]),
+        (rect[2], rect[3]),
+        (rect[0], rect[3]),
+    ]
+    return convex_polygons_overlap(corners, rect_polygon)
+
+
+def displayed_rect_to_user(
+    rect: Sequence[float], reader_page: Any
+) -> tuple[float, float, float, float]:
+    _, displayed_height = displayed_page_size(reader_page)
+    rotation = int(reader_page.rotation or 0) % 360
+    box = reader_page.mediabox
+    origin_x = float(box.left)
+    origin_y = float(box.bottom)
+    width = float(box.width)
+    height = float(box.height)
+    corners = []
+    for x, y_top in (
+        (rect[0], rect[1]),
+        (rect[2], rect[1]),
+        (rect[0], rect[3]),
+        (rect[2], rect[3]),
+    ):
+        y_up = displayed_height - y_top
+        if rotation == 90:
+            a, b = width - y_up, x
+        elif rotation == 180:
+            a, b = width - x, height - y_up
+        elif rotation == 270:
+            a, b = y_up, height - x
+        else:
+            a, b = x, y_up
+        corners.append((origin_x + a, origin_y + b))
+    xs = [corner[0] for corner in corners]
+    ys = [corner[1] for corner in corners]
+    return (min(xs), min(ys), max(xs), max(ys))
+
+
+def user_rect_to_displayed(
+    rect: Sequence[float], reader_page: Any
+) -> tuple[float, float, float, float]:
+    rotation = int(reader_page.rotation or 0) % 360
+    box = reader_page.mediabox
+    origin_x = float(box.left)
+    origin_y = float(box.bottom)
+    width = float(box.width)
+    height = float(box.height)
+    corners = []
+    for u, v in (
+        (rect[0], rect[1]),
+        (rect[2], rect[1]),
+        (rect[0], rect[3]),
+        (rect[2], rect[3]),
+    ):
+        a, b = u - origin_x, v - origin_y
+        if rotation == 90:
+            x, y_top = b, a
+        elif rotation == 180:
+            x, y_top = width - a, b
+        elif rotation == 270:
+            x, y_top = height - b, width - a
+        else:
+            x, y_top = a, height - b
+        corners.append((x, y_top))
+    xs = [corner[0] for corner in corners]
+    ys = [corner[1] for corner in corners]
+    return (min(xs), min(ys), max(xs), max(ys))
+
+
+BASE14_STYLE_MAP = {
+    ("helvetica", ""): "Helvetica",
+    ("helvetica", "bold"): "Helvetica-Bold",
+    ("helvetica", "italic"): "Helvetica-Oblique",
+    ("helvetica", "bolditalic"): "Helvetica-BoldOblique",
+    ("times", ""): "Times-Roman",
+    ("times", "bold"): "Times-Bold",
+    ("times", "italic"): "Times-Italic",
+    ("times", "bolditalic"): "Times-BoldItalic",
+    ("courier", ""): "Courier",
+    ("courier", "bold"): "Courier-Bold",
+    ("courier", "italic"): "Courier-Oblique",
+    ("courier", "bolditalic"): "Courier-BoldOblique",
+    ("symbol", ""): "Symbol",
+    ("zapfdingbats", ""): "ZapfDingbats",
+}
+
+
+def canonical_base14_name(name: str) -> str | None:
+    normalized = re.sub(r"[^a-z0-9]", "", name.casefold())
+    family = None
+    remainder = ""
+    for prefix, canonical in (
+        ("helvetica", "helvetica"),
+        ("arial", "helvetica"),
+        ("timesnewroman", "times"),
+        ("timesroman", "times"),
+        ("times", "times"),
+        ("couriernew", "courier"),
+        ("courier", "courier"),
+        ("zapfdingbats", "zapfdingbats"),
+        ("symbol", "symbol"),
+    ):
+        if normalized.startswith(prefix):
+            family = canonical
+            remainder = normalized[len(prefix) :]
+            break
+    if family is None:
+        return None
+    if "bold" in remainder and ("italic" in remainder or "oblique" in remainder):
+        style = "bolditalic"
+    elif "bold" in remainder:
+        style = "bold"
+    elif "italic" in remainder or "oblique" in remainder:
+        style = "italic"
+    else:
+        style = ""
+    return BASE14_STYLE_MAP.get((family, style))
+
+
+@dataclass
+class InterpreterFont:
+    resource_name: str
+    subtype: str
+    bytes_per_code: int
+    widths: dict[int, float]
+    default_width: float | None
+    bbox_width: float
+    ascent: float
+    descent: float
+    reliable: bool
+    type3: bool
+
+
+FALLBACK_INTERPRETER_FONT = InterpreterFont(
+    resource_name="",
+    subtype="",
+    bytes_per_code=1,
+    widths={},
+    default_width=None,
+    bbox_width=1000.0,
+    ascent=900.0,
+    descent=-300.0,
+    reliable=False,
+    type3=False,
+)
+
+
+def parse_cid_widths(w_array: Any) -> dict[int, float]:
+    widths: dict[int, float] = {}
+    items = [item.get_object() if hasattr(item, "get_object") else item for item in w_array]
+    index = 0
+    while index < len(items):
+        try:
+            first = int(items[index])
+        except (TypeError, ValueError):
+            break
+        if index + 1 < len(items) and isinstance(items[index + 1], (list, ArrayObject)):
+            for offset, value in enumerate(items[index + 1]):
+                try:
+                    widths[first + offset] = float(value)
+                except (TypeError, ValueError):
+                    continue
+            index += 2
+        elif index + 2 < len(items):
+            try:
+                last = int(items[index + 1])
+                value = float(items[index + 2])
+            except (TypeError, ValueError):
+                break
+            for code in range(first, min(last, first + 65_535) + 1):
+                widths[code] = value
+            index += 3
+        else:
+            break
+    return widths
+
+
+def build_interpreter_font(resource_name: str, font_reference: Any) -> InterpreterFont:
+    try:
+        font = font_reference.get_object()
+    except Exception:
+        return replace(FALLBACK_INTERPRETER_FONT, resource_name=resource_name)
+    subtype = str(font.get("/Subtype", "")).lstrip("/")
+    if subtype == "Type3":
+        return replace(
+            FALLBACK_INTERPRETER_FONT,
+            resource_name=resource_name,
+            subtype=subtype,
+            type3=True,
+        )
+    widths: dict[int, float] = {}
+    default_width: float | None = None
+    bytes_per_code = 1
+    reliable = True
+    descriptor = None
+    try:
+        if subtype == "Type0":
+            bytes_per_code = 2
+            encoding = font.get("/Encoding")
+            encoding_name = ""
+            if encoding is not None:
+                encoding_object = (
+                    encoding.get_object() if hasattr(encoding, "get_object") else encoding
+                )
+                if not isinstance(encoding_object, dict):
+                    encoding_name = str(encoding_object)
+            if "Identity" not in encoding_name:
+                reliable = False
+            descendants = font.get("/DescendantFonts")
+            if descendants is not None:
+                descendant = descendants.get_object()[0].get_object()
+                w_array = descendant.get("/W")
+                if w_array is not None:
+                    widths = parse_cid_widths(w_array.get_object())
+                default_value = descendant.get("/DW")
+                default_width = float(default_value) if default_value is not None else 1000.0
+                descriptor = descendant.get("/FontDescriptor")
+        else:
+            first_char = font.get("/FirstChar")
+            widths_array = font.get("/Widths")
+            if widths_array is not None and first_char is not None:
+                for offset, value in enumerate(widths_array.get_object()):
+                    try:
+                        widths[int(first_char) + offset] = float(
+                            value.get_object() if hasattr(value, "get_object") else value
+                        )
+                    except (TypeError, ValueError):
+                        continue
+            else:
+                base_name = SUBSET_PREFIX_PATTERN.sub(
+                    "", str(font.get("/BaseFont", "")).lstrip("/")
+                )
+                canonical = canonical_base14_name(base_name)
+                if canonical is not None:
+                    try:
+                        standard_font = pdfmetrics.getFont(canonical)
+                        widths = {
+                            code: float(width) for code, width in enumerate(standard_font.widths)
+                        }
+                    except Exception:
+                        reliable = False
+                else:
+                    reliable = False
+                encoding = font.get("/Encoding")
+                if encoding is not None:
+                    encoding_object = (
+                        encoding.get_object() if hasattr(encoding, "get_object") else encoding
+                    )
+                    if isinstance(encoding_object, dict) and ("/Differences" in encoding_object):
+                        reliable = False
+            descriptor = font.get("/FontDescriptor")
+            if descriptor is not None:
+                missing = descriptor.get_object().get("/MissingWidth")
+                if missing is not None:
+                    default_width = float(missing)
+    except Exception:
+        reliable = False
+    ascent, descent, bbox_width = 900.0, -300.0, 1000.0
+    try:
+        if descriptor is not None:
+            descriptor_object = descriptor.get_object()
+            ascent_value = descriptor_object.get("/Ascent")
+            if ascent_value is not None and float(ascent_value):
+                ascent = float(ascent_value)
+            descent_value = descriptor_object.get("/Descent")
+            if descent_value is not None and float(descent_value):
+                descent = min(float(descent_value), 0.0)
+            bbox = descriptor_object.get("/FontBBox")
+            if bbox is not None:
+                values = [float(item) for item in bbox.get_object()]
+                bbox_width = max(abs(values[2] - values[0]), 1.0)
+                ascent = max(ascent, values[3])
+                descent = min(descent, values[1])
+    except Exception:
+        pass
+    if not reliable:
+        widths = {}
+        default_width = None
+    return InterpreterFont(
+        resource_name=resource_name,
+        subtype=subtype,
+        bytes_per_code=bytes_per_code,
+        widths=widths,
+        default_width=default_width,
+        bbox_width=bbox_width,
+        ascent=ascent,
+        descent=descent,
+        reliable=reliable,
+        type3=False,
+    )
+
+
+@dataclass
+class InterpreterTextState:
+    font: InterpreterFont | None = None
+    font_size: float = 0.0
+    char_spacing: float = 0.0
+    word_spacing: float = 0.0
+    horizontal_scale: float = 100.0
+    leading: float = 0.0
+    rise: float = 0.0
+    render_mode: int = 0
+
+
+@dataclass
+class PageRedactionResult:
+    text_operators_removed: int = 0
+    characters_removed: int = 0
+    inline_images_removed: int = 0
+    image_xobjects_removed: int = 0
+    vector_paints_removed: int = 0
+    annotations_removed: int = 0
+    removed_extents_user: list[tuple[float, float, float, float]] = dataclass_field(
+        default_factory=list
+    )
+    removed_operand_bytes: list[bytes] = dataclass_field(default_factory=list)
+    removed_decoded_text: list[str] = dataclass_field(default_factory=list)
+    removed_image_hashes: list[str] = dataclass_field(default_factory=list)
+
+
+def string_segment_bytes(value: Any) -> bytes:
+    resolved = value.get_object() if hasattr(value, "get_object") else value
+    if isinstance(resolved, ByteStringObject):
+        return bytes(resolved)
+    if isinstance(resolved, TextStringObject):
+        original = getattr(resolved, "original_bytes", None)
+        if original is not None:
+            return bytes(original)
+        return str(resolved).encode("latin-1", "ignore")
+    if isinstance(resolved, bytes):
+        return resolved
+    return str(resolved).encode("latin-1", "ignore")
+
+
+def iterate_codes(data: bytes, bytes_per_code: int) -> Iterable[int]:
+    if bytes_per_code == 1:
+        yield from data
+        return
+    for index in range(0, len(data) - 1, 2):
+        yield (data[index] << 8) | data[index + 1]
+    if len(data) % 2:
+        yield data[-1] << 8
+
+
+def show_operation_metrics(
+    font: InterpreterFont,
+    state: InterpreterTextState,
+    segments: Sequence[Any],
+) -> tuple[float, float, float, list[bytes], str, int]:
+    horizontal = state.horizontal_scale / 100.0
+    x = 0.0
+    min_x = 0.0
+    max_x = 0.0
+    raw_segments: list[bytes] = []
+    decoded_parts: list[str] = []
+    glyphs = 0
+    for segment in segments:
+        resolved = segment.get_object() if hasattr(segment, "get_object") else segment
+        if isinstance(resolved, (int, float)) and not isinstance(resolved, bool):
+            x -= float(resolved) / 1000.0 * state.font_size * horizontal
+            min_x = min(min_x, x)
+            max_x = max(max_x, x)
+            continue
+        raw = string_segment_bytes(resolved)
+        raw_segments.append(raw)
+        if font.bytes_per_code == 1:
+            decoded_parts.append(raw.decode("cp1252", "ignore"))
+        for code in iterate_codes(raw, font.bytes_per_code):
+            glyphs += 1
+            width_units = font.widths.get(code)
+            if width_units is None:
+                width_units = (
+                    font.default_width if font.default_width is not None else font.bbox_width
+                )
+            advance = (
+                width_units / 1000.0 * state.font_size
+                + state.char_spacing
+                + (state.word_spacing if code == 32 and font.bytes_per_code == 1 else 0.0)
+            ) * horizontal
+            x += advance
+            min_x = min(min_x, x)
+            max_x = max(max_x, x)
+    return min_x, max_x, x, raw_segments, "".join(decoded_parts), glyphs
+
+
+def page_font_map(writer_page: Any) -> dict[str, InterpreterFont]:
+    fonts: dict[str, InterpreterFont] = {}
+    try:
+        resources = writer_page.get("/Resources")
+        if resources is None:
+            return fonts
+        font_dict = resources.get_object().get("/Font")
+        if font_dict is None:
+            return fonts
+        for name, reference in font_dict.get_object().items():
+            fonts[str(name)] = build_interpreter_font(str(name), reference)
+    except Exception:
+        pass
+    return fonts
+
+
+def page_xobject_map(writer_page: Any) -> dict[str, dict[str, Any]]:
+    xobjects: dict[str, dict[str, Any]] = {}
+    try:
+        resources = writer_page.get("/Resources")
+        if resources is None:
+            return xobjects
+        xobject_dict = resources.get_object().get("/XObject")
+        if xobject_dict is None:
+            return xobjects
+        for name, reference in xobject_dict.get_object().items():
+            try:
+                xobject = reference.get_object()
+                subtype = str(xobject.get("/Subtype", ""))
+                info: dict[str, Any] = {"subtype": subtype, "object": xobject}
+                if subtype == "/Form":
+                    bbox = xobject.get("/BBox")
+                    matrix = xobject.get("/Matrix")
+                    info["bbox"] = (
+                        [float(item) for item in bbox.get_object()]
+                        if bbox is not None
+                        else [0.0, 0.0, 1.0, 1.0]
+                    )
+                    info["matrix"] = (
+                        tuple(float(item) for item in matrix.get_object())
+                        if matrix is not None
+                        else identity_matrix()
+                    )
+                xobjects[str(name)] = info
+            except Exception:
+                continue
+    except Exception:
+        pass
+    return xobjects
+
+
+def redact_page_content(
+    writer_page: Any,
+    writer: PdfWriter,
+    user_rects: list[tuple[float, float, float, float]],
+    *,
+    image_policy: str,
+    page_number: int,
+    fill_rects_user: list[tuple[float, float, float, float]],
+    fill_rgb: tuple[float, float, float],
+) -> PageRedactionResult:
+    result = PageRedactionResult()
+    contents = writer_page.get_contents()
+    if contents is None:
+        raise ToolError(
+            "unsupported_operation",
+            f"Page {page_number} has no content stream to redact",
+        )
+    fonts = page_font_map(writer_page)
+    xobjects = page_xobject_map(writer_page)
+    stream = ContentStream(contents, writer)
+    operations = stream.operations
+    if len(operations) > MAX_CONTENT_OPERATIONS:
+        raise ToolError(
+            "resource_limit",
+            f"Page {page_number} content exceeds {MAX_CONTENT_OPERATIONS} operations",
+        )
+    new_operations: list[tuple[Any, bytes]] = []
+    ctm = identity_matrix()
+    stack: list[tuple[tuple[float, ...], InterpreterTextState]] = []
+    text = InterpreterTextState()
+    tm = identity_matrix()
+    tlm = identity_matrix()
+    clip_pending = False
+    path_points: list[tuple[float, float]] = []
+    removed_image_names: set[str] = set()
+
+    def record_removed_text(
+        extent: tuple[float, float, float, float],
+        raw_segments: list[bytes],
+        decoded: str,
+        glyphs: int,
+    ) -> None:
+        result.text_operators_removed += 1
+        result.characters_removed += glyphs
+        result.removed_extents_user.append(extent)
+        result.removed_operand_bytes.extend(
+            segment for segment in raw_segments if len(segment) >= 3
+        )
+        cleaned = decoded.strip()
+        if len(cleaned) >= 4:
+            result.removed_decoded_text.append(cleaned)
+
+    for operands, operator in operations:
+        if operator == b"q":
+            stack.append((ctm, replace(text)))
+            new_operations.append((operands, operator))
+            continue
+        if operator == b"Q":
+            if stack:
+                ctm, text = stack.pop()
+            new_operations.append((operands, operator))
+            continue
+        if operator == b"cm":
+            try:
+                matrix = tuple(float(value) for value in operands)
+                ctm = mat_mult(matrix, ctm)
+            except (TypeError, ValueError):
+                pass
+            new_operations.append((operands, operator))
+            continue
+        if operator == b"BT":
+            tm = identity_matrix()
+            tlm = identity_matrix()
+            new_operations.append((operands, operator))
+            continue
+        if operator == b"ET":
+            new_operations.append((operands, operator))
+            continue
+        if operator == b"Tf":
+            text.font = fonts.get(str(operands[0]), FALLBACK_INTERPRETER_FONT)
+            try:
+                text.font_size = float(operands[1])
+            except (TypeError, ValueError):
+                text.font_size = 0.0
+            new_operations.append((operands, operator))
+            continue
+        if operator == b"Tc":
+            text.char_spacing = float(operands[0])
+            new_operations.append((operands, operator))
+            continue
+        if operator == b"Tw":
+            text.word_spacing = float(operands[0])
+            new_operations.append((operands, operator))
+            continue
+        if operator == b"Tz":
+            text.horizontal_scale = float(operands[0])
+            new_operations.append((operands, operator))
+            continue
+        if operator == b"TL":
+            text.leading = float(operands[0])
+            new_operations.append((operands, operator))
+            continue
+        if operator == b"Ts":
+            text.rise = float(operands[0])
+            new_operations.append((operands, operator))
+            continue
+        if operator == b"Tr":
+            try:
+                text.render_mode = int(operands[0])
+            except (TypeError, ValueError):
+                text.render_mode = 0
+            new_operations.append((operands, operator))
+            continue
+        if operator == b"Td":
+            tlm = mat_mult((1, 0, 0, 1, float(operands[0]), float(operands[1])), tlm)
+            tm = tlm
+            new_operations.append((operands, operator))
+            continue
+        if operator == b"TD":
+            text.leading = -float(operands[1])
+            tlm = mat_mult((1, 0, 0, 1, float(operands[0]), float(operands[1])), tlm)
+            tm = tlm
+            new_operations.append((operands, operator))
+            continue
+        if operator == b"Tm":
+            tlm = tuple(float(value) for value in operands)
+            tm = tlm
+            new_operations.append((operands, operator))
+            continue
+        if operator == b"T*":
+            tlm = mat_mult((1, 0, 0, 1, 0, -text.leading), tlm)
+            tm = tlm
+            new_operations.append((operands, operator))
+            continue
+        if operator in (b"Tj", b"'", b'"', b"TJ"):
+            if operator == b'"':
+                text.word_spacing = float(operands[0])
+                text.char_spacing = float(operands[1])
+                string_operand = operands[2]
+            elif operator == b"TJ":
+                string_operand = None
+            else:
+                string_operand = operands[0]
+            if operator in (b"'", b'"'):
+                tlm = mat_mult((1, 0, 0, 1, 0, -text.leading), tlm)
+                tm = tlm
+            if operator == b"TJ":
+                array = operands[0]
+                segments = list(array.get_object() if hasattr(array, "get_object") else array)
+            else:
+                segments = [string_operand]
+            font = text.font or FALLBACK_INTERPRETER_FONT
+            min_x, max_x, net_advance, raw_segments, decoded, glyphs = show_operation_metrics(
+                font, text, segments
+            )
+            y_low = font.descent / 1000.0 * text.font_size + text.rise
+            y_high = font.ascent / 1000.0 * text.font_size + text.rise
+            text_matrix = mat_mult(tm, ctm)
+            text_box = (min_x, min(y_low, y_high), max_x, max(y_low, y_high))
+            # Test the true oriented text quad, not its axis-aligned bounding box: a
+            # rotated stamp's AABB is far larger than the glyphs and would trigger
+            # spurious removal of unrelated content it merely spans. The quad is still the
+            # conservative whole-operator bound, just not inflated by rotation.
+            corners = quad_corners(text_matrix, text_box)
+            extent = transform_rect(text_matrix, text_box)
+            intersects = any(quad_intersects_rect(corners, rect) for rect in user_rects)
+            if intersects:
+                if font.type3:
+                    raise ToolError(
+                        "unsupported_operation",
+                        f"Page {page_number} shows Type3 font text inside a redaction "
+                        "target; Type3 glyph extents cannot be measured safely",
+                    )
+                if text.render_mode >= 4:
+                    raise ToolError(
+                        "unsupported_operation",
+                        f"Page {page_number} uses text-clipping render mode inside a "
+                        "redaction target; redact cannot rewrite text clips safely",
+                    )
+                if not font.reliable:
+                    raise ToolError(
+                        "unsupported_operation",
+                        f"Page {page_number} text inside a redaction target uses a font "
+                        "without measurable glyph widths; redact refuses rather than "
+                        "guess extents",
+                    )
+                record_removed_text(extent, raw_segments, decoded, glyphs)
+                if operator == b'"':
+                    new_operations.append(([FloatObject(text.word_spacing)], b"Tw"))
+                    new_operations.append(([FloatObject(text.char_spacing)], b"Tc"))
+                if operator in (b"'", b'"'):
+                    new_operations.append(([], b"T*"))
+                horizontal = text.horizontal_scale / 100.0
+                if abs(net_advance) > 1e-9 and text.font_size > 0 and horizontal > 0:
+                    offset = -net_advance / horizontal / text.font_size * 1000.0
+                    new_operations.append(([ArrayObject([FloatObject(offset)])], b"TJ"))
+            else:
+                new_operations.append((operands, operator))
+            tm = mat_mult((1, 0, 0, 1, net_advance, 0), tm)
+            continue
+        if operator == b"INLINE IMAGE":
+            extent = transform_rect(ctm, (0.0, 0.0, 1.0, 1.0))
+            if any(rects_overlap(extent, rect) for rect in user_rects):
+                if image_policy == "refuse":
+                    raise ToolError(
+                        "unsupported_operation",
+                        f"Page {page_number} inline image intersects a redaction "
+                        "target and image_policy is refuse",
+                    )
+                result.inline_images_removed += 1
+                result.removed_extents_user.append(extent)
+                continue
+            new_operations.append((operands, operator))
+            continue
+        if operator == b"Do":
+            name = str(operands[0])
+            info = xobjects.get(name)
+            if info is None:
+                new_operations.append((operands, operator))
+                continue
+            if info["subtype"] == "/Image":
+                extent = transform_rect(ctm, (0.0, 0.0, 1.0, 1.0))
+                if any(rects_overlap(extent, rect) for rect in user_rects):
+                    if image_policy == "refuse":
+                        raise ToolError(
+                            "unsupported_operation",
+                            f"Page {page_number} image XObject {name} intersects a "
+                            "redaction target and image_policy is refuse",
+                        )
+                    result.image_xobjects_removed += 1
+                    result.removed_extents_user.append(extent)
+                    removed_image_names.add(name)
+                    try:
+                        digest = hashlib.sha256(info["object"].get_data()).hexdigest()
+                        result.removed_image_hashes.append(digest)
+                    except Exception:
+                        pass
+                    continue
+                new_operations.append((operands, operator))
+                continue
+            if info["subtype"] == "/Form":
+                extent = transform_rect(mat_mult(info["matrix"], ctm), info["bbox"])
+                if any(rects_overlap(extent, rect) for rect in user_rects):
+                    raise ToolError(
+                        "unsupported_operation",
+                        f"Page {page_number} Form XObject {name} intersects a "
+                        "redaction target; redaction inside Form XObjects is not "
+                        "supported — flatten or rasterize the page first",
+                    )
+                new_operations.append((operands, operator))
+                continue
+            new_operations.append((operands, operator))
+            continue
+        if operator in (b"m", b"l"):
+            try:
+                path_points.append(apply_matrix(ctm, float(operands[0]), float(operands[1])))
+            except (TypeError, ValueError, IndexError):
+                pass
+            new_operations.append((operands, operator))
+            continue
+        if operator == b"c":
+            try:
+                for index in range(0, 6, 2):
+                    path_points.append(
+                        apply_matrix(ctm, float(operands[index]), float(operands[index + 1]))
+                    )
+            except (TypeError, ValueError, IndexError):
+                pass
+            new_operations.append((operands, operator))
+            continue
+        if operator in (b"v", b"y"):
+            try:
+                for index in range(0, 4, 2):
+                    path_points.append(
+                        apply_matrix(ctm, float(operands[index]), float(operands[index + 1]))
+                    )
+            except (TypeError, ValueError, IndexError):
+                pass
+            new_operations.append((operands, operator))
+            continue
+        if operator == b"re":
+            try:
+                x0 = float(operands[0])
+                y0 = float(operands[1])
+                w = float(operands[2])
+                h = float(operands[3])
+                for corner_x, corner_y in (
+                    (x0, y0),
+                    (x0 + w, y0),
+                    (x0, y0 + h),
+                    (x0 + w, y0 + h),
+                ):
+                    path_points.append(apply_matrix(ctm, corner_x, corner_y))
+            except (TypeError, ValueError, IndexError):
+                pass
+            new_operations.append((operands, operator))
+            continue
+        if operator in (b"W", b"W*"):
+            clip_pending = True
+            new_operations.append((operands, operator))
+            continue
+        if operator in PATH_PAINT_OPERATORS:
+            if path_points and not clip_pending:
+                xs = [point[0] for point in path_points]
+                ys = [point[1] for point in path_points]
+                extent = (min(xs), min(ys), max(xs), max(ys))
+                if any(rects_overlap(extent, rect) for rect in user_rects):
+                    result.vector_paints_removed += 1
+                    result.removed_extents_user.append(extent)
+                    path_points = []
+                    new_operations.append(([], b"n"))
+                    continue
+            path_points = []
+            clip_pending = False
+            new_operations.append((operands, operator))
+            continue
+        if operator == b"n":
+            path_points = []
+            clip_pending = False
+            new_operations.append((operands, operator))
+            continue
+        new_operations.append((operands, operator))
+
+    for name in sorted(removed_image_names):
+        still_used = any(
+            operator == b"Do" and str(operands[0]) == name for operands, operator in new_operations
+        )
+        if not still_used:
+            try:
+                xobject_dict = writer_page["/Resources"].get_object()["/XObject"].get_object()
+                if name in xobject_dict:
+                    del xobject_dict[name]
+            except Exception:
+                pass
+    for rect in fill_rects_user:
+        new_operations.append(([], b"q"))
+        new_operations.append(
+            (
+                [
+                    FloatObject(fill_rgb[0]),
+                    FloatObject(fill_rgb[1]),
+                    FloatObject(fill_rgb[2]),
+                ],
+                b"rg",
+            )
+        )
+        new_operations.append(
+            (
+                [
+                    FloatObject(rect[0]),
+                    FloatObject(rect[1]),
+                    FloatObject(rect[2] - rect[0]),
+                    FloatObject(rect[3] - rect[1]),
+                ],
+                b"re",
+            )
+        )
+        new_operations.append(([], b"f"))
+        new_operations.append(([], b"Q"))
+    stream.operations = new_operations
+    writer_page.replace_contents(stream)
+    return result
+
+
+def normalize_redaction_term(text: str) -> str:
+    return re.sub(r"\s+", " ", text.strip())
+
+
+def parse_redact_job(job: dict[str, Any]) -> dict[str, Any]:
+    unknown = sorted(set(job) - REDACT_JOB_KEYS)
+    if unknown:
+        raise ToolError("bad_input", f"Unknown redact job keys: {', '.join(unknown)}")
+    targets = job.get("targets")
+    if not isinstance(targets, list) or not targets:
+        raise ToolError("bad_input", "Redact job requires a nonempty targets array")
+    if len(targets) > MAX_REDACTION_TARGETS:
+        raise ToolError("resource_limit", f"Redact job exceeds {MAX_REDACTION_TARGETS} targets")
+    image_policy = job.get("image_policy", "remove")
+    if image_policy not in {"remove", "refuse"}:
+        raise ToolError("bad_input", "image_policy must be remove or refuse")
+    annotation_policy = job.get("annotation_policy", "remove-intersecting")
+    if annotation_policy != "remove-intersecting":
+        raise ToolError("bad_input", "annotation_policy must be remove-intersecting")
+    strip_docinfo = job.get("strip_docinfo_keys", "matched")
+    if strip_docinfo not in {"matched", "all", "none"}:
+        raise ToolError("bad_input", "strip_docinfo_keys must be matched, all, or none")
+    strip_xmp = job.get("strip_xmp", "if-matched")
+    if strip_xmp not in {"if-matched", "always", "never"}:
+        raise ToolError("bad_input", "strip_xmp must be if-matched, always, or never")
+    for flag_name in ("strip_thumbnails", "strip_structure_tree"):
+        if flag_name in job and not isinstance(job[flag_name], bool):
+            raise ToolError("bad_input", f"{flag_name} must be a boolean")
+    acknowledge = job.get("acknowledge", {})
+    if not isinstance(acknowledge, dict):
+        raise ToolError("bad_input", "acknowledge must be an object")
+    unknown_acknowledge = sorted(set(acknowledge) - REDACT_ACKNOWLEDGE_KEYS)
+    if unknown_acknowledge:
+        raise ToolError(
+            "bad_input",
+            f"Unknown acknowledge keys: {', '.join(unknown_acknowledge)}",
+        )
+    for key, value in acknowledge.items():
+        if not isinstance(value, bool):
+            raise ToolError("bad_input", f"acknowledge.{key} must be a boolean")
+    fill = color_value(job.get("fill_color", "#000000"))
+    return {
+        "targets": targets,
+        "image_policy": image_policy,
+        "strip_docinfo_keys": strip_docinfo,
+        "strip_xmp": strip_xmp,
+        "strip_thumbnails": bool(job.get("strip_thumbnails", True)),
+        "strip_structure_tree": bool(job.get("strip_structure_tree", False)),
+        "acknowledge": {
+            "signatures_invalidated": bool(acknowledge.get("signatures_invalidated")),
+            "attachments_present": bool(acknowledge.get("attachments_present")),
+        },
+        "fill_rgb": (float(fill.red), float(fill.green), float(fill.blue)),
+    }
+
+
+def validate_redact_targets(targets: list[Any], page_count: int) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    for index, target in enumerate(targets):
+        if not isinstance(target, dict):
+            raise ToolError("bad_input", "Every redact target must be an object")
+        unknown = sorted(set(target) - REDACT_TARGET_KEYS)
+        if unknown:
+            raise ToolError("bad_input", f"Unknown redact target keys: {', '.join(unknown)}")
+        kind = target.get("type")
+        if kind == "rect":
+            page = finite_integer(
+                target.get("page"),
+                f"targets[{index}].page",
+                minimum=1,
+                maximum=page_count,
+            )
+            rect = target.get("rect")
+            if not isinstance(rect, (list, tuple)) or len(rect) != 4:
+                raise ToolError(
+                    "bad_input",
+                    f"targets[{index}].rect must be [x, y, width, height]",
+                )
+            values = [
+                finite_number(item, f"targets[{index}].rect[{position}]", minimum=0)
+                for position, item in enumerate(rect)
+            ]
+            if values[2] <= 0 or values[3] <= 0:
+                raise ToolError(
+                    "bad_input", f"targets[{index}].rect requires positive width/height"
+                )
+            origin = target.get("coordinate_origin", "top-left")
+            if origin not in {"top-left", "bottom-left"}:
+                raise ToolError(
+                    "bad_input",
+                    f"targets[{index}].coordinate_origin must be top-left or bottom-left",
+                )
+            normalized.append(
+                {
+                    "kind": "rect",
+                    "index": index,
+                    "page": page,
+                    "rect": tuple(values),
+                    "origin": origin,
+                }
+            )
+        elif kind == "text":
+            text = target.get("text")
+            if not isinstance(text, str) or not text.strip():
+                raise ToolError("bad_input", f"targets[{index}].text must be a nonempty string")
+            match = target.get("match", "exact")
+            if match not in {"exact", "case-insensitive"}:
+                raise ToolError(
+                    "bad_input",
+                    f"targets[{index}].match must be exact or case-insensitive",
+                )
+            grow = finite_number(
+                target.get("grow_points", 2.0),
+                f"targets[{index}].grow_points",
+                minimum=0,
+                maximum=72,
+            )
+            pages_expression = target.get("pages", "all")
+            if pages_expression is not None and not isinstance(pages_expression, str):
+                raise ToolError("bad_input", f"targets[{index}].pages must be a string expression")
+            normalized.append(
+                {
+                    "kind": "text",
+                    "index": index,
+                    "text": text,
+                    "pages": pages_expression,
+                    "match": match,
+                    "grow": grow,
+                }
+            )
+        else:
+            raise ToolError("unsupported_operation", f"Unsupported redact target type: {kind}")
+    return normalized
+
+
+def resolve_redaction_rects(
+    source: SourceInfo,
+    plumber_pdf: Any,
+    targets: list[dict[str, Any]],
+    page_count: int,
+) -> dict[int, list[dict[str, Any]]]:
+    rects_by_page: dict[int, list[dict[str, Any]]] = {}
+
+    def add_rect(page_number: int, rect: tuple[float, float, float, float], index: int) -> None:
+        if rect[2] <= rect[0] or rect[3] <= rect[1]:
+            raise ToolError(
+                "bad_input",
+                f"targets[{index}] resolves to an empty rectangle on page {page_number}",
+            )
+        rects_by_page.setdefault(page_number, []).append({"rect": rect, "target_index": index})
+
+    for target in targets:
+        if target["kind"] == "rect":
+            page_number = target["page"]
+            reader_page = source.reader.pages[page_number - 1]
+            displayed_width, displayed_height = displayed_page_size(reader_page)
+            x, y, width, height = target["rect"]
+            top = displayed_height - y - height if target["origin"] == "bottom-left" else y
+            rect = (
+                min(max(x, 0.0), displayed_width),
+                min(max(top, 0.0), displayed_height),
+                min(max(x + width, 0.0), displayed_width),
+                min(max(top + height, 0.0), displayed_height),
+            )
+            add_rect(page_number, rect, target["index"])
+            continue
+        term = normalize_redaction_term(target["text"])
+        tokens = term.split(" ")
+        case_insensitive = target["match"] == "case-insensitive"
+        page_indexes = parse_page_selection(target["pages"], page_count)
+        matches = 0
+        for page_index in page_indexes:
+            page = plumber_pdf.pages[page_index]
+            displayed_width = float(page.width)
+            displayed_height = float(page.height)
+            try:
+                words = page.extract_words()
+            except Exception as exc:
+                raise ToolError(
+                    "unsupported_operation",
+                    f"Cannot resolve text targets on page {page_index + 1}: {clean_text(exc)}",
+                ) from exc
+            for start in range(len(words)):
+                window = words[start : start + len(tokens)]
+                if len(window) < len(tokens):
+                    continue
+                joined = " ".join(str(word["text"]) for word in window)
+                if case_insensitive:
+                    matched = joined.casefold() == term.casefold()
+                else:
+                    matched = joined == term
+                if not matched and len(tokens) == 1:
+                    haystack = str(words[start]["text"])
+                    if case_insensitive:
+                        matched = term.casefold() in haystack.casefold()
+                    else:
+                        matched = term in haystack
+                if not matched:
+                    continue
+                grow = target["grow"]
+                rect = (
+                    max(0.0, min(float(word["x0"]) for word in window) - grow),
+                    max(0.0, min(float(word["top"]) for word in window) - grow),
+                    min(
+                        displayed_width,
+                        max(float(word["x1"]) for word in window) + grow,
+                    ),
+                    min(
+                        displayed_height,
+                        max(float(word["bottom"]) for word in window) + grow,
+                    ),
+                )
+                add_rect(page_index + 1, rect, target["index"])
+                matches += 1
+        if not matches:
+            raise ToolError(
+                "bad_input",
+                f"Redaction text target {target['index']} matched nothing on its "
+                "selected pages; nothing was redacted",
+            )
+    return rects_by_page
+
+
+def collect_object_strings(value: Any, depth: int = 0, budget: int = 500) -> list[str]:
+    if depth > 4 or budget <= 0:
+        return []
+    strings: list[str] = []
+    try:
+        resolved = value.get_object() if hasattr(value, "get_object") else value
+    except Exception:
+        return []
+    if isinstance(resolved, str):
+        return [str(resolved)]
+    if isinstance(resolved, dict):
+        for item in resolved.values():
+            found = collect_object_strings(item, depth + 1, budget - len(strings))
+            strings.extend(found)
+            if len(strings) >= budget:
+                break
+    elif isinstance(resolved, (list, tuple)):
+        for item in resolved:
+            found = collect_object_strings(item, depth + 1, budget - len(strings))
+            strings.extend(found)
+            if len(strings) >= budget:
+                break
+    return strings
+
+
+def term_in_text(term: str, text: str) -> bool:
+    normalized_term = re.sub(r"\s+", "", term).casefold()
+    normalized_text = re.sub(r"\s+", "", text).casefold()
+    return bool(normalized_term) and normalized_term in normalized_text
+
+
+def prune_acroform_fields(writer: PdfWriter, removed_references: list[Any]) -> None:
+    """Detach removed widget annotations from the AcroForm field tree.
+
+    Deleting a widget from a page's /Annots without pruning the AcroForm /Fields entry
+    leaves an orphaned field that some viewers still render and whose value stays
+    extractable. Remove the top-level field entries that point at removed widgets and
+    clear their value.
+    """
+    removed_ids = {
+        (reference.idnum, reference.generation)
+        for reference in removed_references
+        if isinstance(reference, IndirectObject)
+    }
+    if not removed_ids:
+        return
+    try:
+        acroform = writer._root_object.get("/AcroForm")
+        if acroform is None:
+            return
+        fields = acroform.get_object().get("/Fields")
+        if fields is None:
+            return
+        field_array = fields.get_object()
+    except Exception:
+        return
+    retained_fields = ArrayObject()
+    for field_reference in field_array:
+        drop = (
+            isinstance(field_reference, IndirectObject)
+            and (field_reference.idnum, field_reference.generation) in removed_ids
+        )
+        if not drop:
+            try:
+                field = field_reference.get_object()
+                kids = field.get("/Kids")
+                if kids is not None:
+                    kid_ids = {
+                        (kid.idnum, kid.generation)
+                        for kid in kids.get_object()
+                        if isinstance(kid, IndirectObject)
+                    }
+                    if kid_ids and kid_ids <= removed_ids:
+                        drop = True
+            except Exception:
+                drop = False
+        if drop:
+            try:
+                field_reference.get_object()[NameObject("/V")] = TextStringObject("")
+            except Exception:
+                pass
+        else:
+            retained_fields.append(field_reference)
+    acroform.get_object()[NameObject("/Fields")] = retained_fields
+
+
+def sweep_annotations(
+    writer: PdfWriter,
+    user_rects_by_page: dict[int, list[tuple[float, float, float, float]]],
+    terms: list[str],
+) -> dict[int, int]:
+    removed_by_page: dict[int, int] = {}
+    removed_references: list[Any] = []
+    for page_index, page in enumerate(writer.pages):
+        annotations = page.get("/Annots")
+        if annotations is None:
+            continue
+        try:
+            annotation_array = annotations.get_object()
+        except Exception:
+            continue
+        retained = ArrayObject()
+        removed = 0
+        for annotation_reference in annotation_array:
+            remove = False
+            try:
+                annotation = annotation_reference.get_object()
+                rect_value = annotation.get("/Rect")
+                if rect_value is not None:
+                    raw = [float(item) for item in rect_value.get_object()]
+                    annotation_rect = (
+                        min(raw[0], raw[2]),
+                        min(raw[1], raw[3]),
+                        max(raw[0], raw[2]),
+                        max(raw[1], raw[3]),
+                    )
+                    for user_rect in user_rects_by_page.get(page_index + 1, []):
+                        if rects_overlap(annotation_rect, user_rect):
+                            remove = True
+                            break
+                if not remove and terms:
+                    for value in collect_object_strings(annotation):
+                        if any(term_in_text(term, value) for term in terms):
+                            remove = True
+                            break
+            except Exception:
+                remove = False
+            if remove:
+                removed += 1
+                removed_references.append(annotation_reference)
+            else:
+                retained.append(annotation_reference)
+        if removed:
+            removed_by_page[page_index + 1] = removed
+            if retained:
+                page[NameObject("/Annots")] = retained
+            elif "/Annots" in page:
+                del page[NameObject("/Annots")]
+    prune_acroform_fields(writer, removed_references)
+    return removed_by_page
+
+
+def redact_document_level(
+    writer: PdfWriter,
+    config: dict[str, Any],
+    terms: list[str],
+) -> dict[str, Any]:
+    evidence: dict[str, Any] = {
+        "docinfo_keys_stripped": [],
+        "xmp_stripped": False,
+        "structure_tree": "absent",
+        "thumbnails_stripped": 0,
+    }
+    metadata = dict(writer.metadata or {})
+    if config["strip_docinfo_keys"] == "all":
+        if metadata:
+            evidence["docinfo_keys_stripped"] = sorted(str(key) for key in metadata)
+            writer.metadata = None
+    elif metadata:
+        matched_keys = [
+            key
+            for key, value in metadata.items()
+            if any(term_in_text(term, str(value)) for term in terms)
+        ]
+        if matched_keys:
+            if config["strip_docinfo_keys"] == "none":
+                raise ToolError(
+                    "unsupported_operation",
+                    "Document information values contain redaction terms and "
+                    "strip_docinfo_keys is none",
+                )
+            for key in matched_keys:
+                metadata.pop(key, None)
+            evidence["docinfo_keys_stripped"] = sorted(str(key) for key in matched_keys)
+            writer.metadata = metadata
+    root = writer._root_object
+    metadata_stream = root.get("/Metadata")
+    if metadata_stream is not None:
+        xmp_text = ""
+        try:
+            xmp_text = metadata_stream.get_object().get_data().decode("utf-8", "ignore")
+        except Exception:
+            xmp_text = ""
+        xmp_matched = any(term_in_text(term, xmp_text) for term in terms)
+        if config["strip_xmp"] == "always" or (config["strip_xmp"] == "if-matched" and xmp_matched):
+            del root[NameObject("/Metadata")]
+            evidence["xmp_stripped"] = True
+        elif xmp_matched:
+            raise ToolError(
+                "unsupported_operation",
+                "XMP metadata contains redaction terms and strip_xmp is never",
+            )
+    if config["strip_thumbnails"]:
+        for page in writer.pages:
+            if "/Thumb" in page:
+                del page[NameObject("/Thumb")]
+                evidence["thumbnails_stripped"] += 1
+    structure_root = root.get("/StructTreeRoot")
+    if structure_root is not None:
+        evidence["structure_tree"] = "present"
+        structure_matched = False
+        if terms:
+            for value in collect_object_strings(structure_root, budget=2000):
+                if any(term_in_text(term, value) for term in terms):
+                    structure_matched = True
+                    break
+        if structure_matched:
+            if not config["strip_structure_tree"]:
+                raise ToolError(
+                    "unsupported_operation",
+                    "The structure tree contains redaction terms; set "
+                    "strip_structure_tree true to remove the whole structure tree",
+                )
+            del root[NameObject("/StructTreeRoot")]
+            if "/MarkInfo" in root:
+                del root[NameObject("/MarkInfo")]
+            evidence["structure_tree"] = "stripped"
+    outlines = root.get("/Outlines")
+    if outlines is not None and terms:
+        for value in collect_object_strings(outlines, budget=2000):
+            if any(term_in_text(term, value) for term in terms):
+                raise ToolError(
+                    "unsupported_operation",
+                    "Document outlines contain redaction terms; remove or rewrite "
+                    "the outlines before redacting",
+                )
+    names = root.get("/Names")
+    if names is not None and terms:
+        names_object = names.get_object()
+        destinations = names_object.get("/Dests")
+        if destinations is not None:
+            for value in collect_object_strings(destinations, budget=2000):
+                if any(term_in_text(term, value) for term in terms):
+                    raise ToolError(
+                        "unsupported_operation",
+                        "Named destinations contain redaction terms; remove them before redacting",
+                    )
+    return evidence
+
+
+def redact_preconditions(
+    source: SourceInfo,
+    config: dict[str, Any],
+    terms: list[str],
+) -> dict[str, Any]:
+    forms = form_inventory(source.reader)
+    if forms["has_xfa"]:
+        raise ToolError(
+            "unsupported_operation",
+            "XFA forms can duplicate page content in XML; redaction of XFA "
+            "documents is not supported",
+        )
+    root = source.reader.trailer.get("/Root", {})
+    acroform = root.get("/AcroForm") if hasattr(root, "get") else None
+    signatures_present = False
+    if acroform is not None:
+        acroform_object = acroform.get_object()
+        sig_flags = acroform_object.get("/SigFlags")
+        if sig_flags:
+            signatures_present = True
+    fields = source.reader.get_fields() or {}
+    for name, field_value in fields.items():
+        if str(field_value.get("/FT")) == "/Sig" and field_value.get("/V") is not None:
+            signatures_present = True
+        value = field_value.get("/V")
+        if value is not None and terms:
+            if any(term_in_text(term, str(value)) for term in terms):
+                raise ToolError(
+                    "unsupported_operation",
+                    f"Form field {name} contains a redaction term; clear it with an "
+                    "edit fill_form operation before redacting",
+                )
+    if signatures_present and not config["acknowledge"]["signatures_invalidated"]:
+        raise ToolError(
+            "unsupported_operation",
+            "The document carries digital signatures that redaction invalidates; "
+            "set acknowledge.signatures_invalidated true to proceed",
+        )
+    attachments_present = False
+    names = root.get("/Names") if hasattr(root, "get") else None
+    if names is not None:
+        try:
+            if names.get_object().get("/EmbeddedFiles") is not None:
+                attachments_present = True
+        except Exception:
+            attachments_present = False
+    if attachments_present and not config["acknowledge"]["attachments_present"]:
+        raise ToolError(
+            "unsupported_operation",
+            "The document carries embedded files that redaction does not scan; "
+            "set acknowledge.attachments_present true to proceed",
+        )
+    return {
+        "signatures_present": signatures_present,
+        "attachments_present": attachments_present,
+    }
+
+
+def redact_residual_scan(
+    output_bytes: bytes,
+    output_reader: PdfReader,
+    full_scope_terms: list[str],
+    partial_scope_terms: list[str],
+    removed_operand_bytes: list[bytes],
+) -> dict[str, Any]:
+    def term_encodings(term: str) -> list[bytes]:
+        compact = re.sub(r"\s+", " ", term.strip())
+        variants = {compact, compact.lower(), compact.upper()}
+        encoded: list[bytes] = []
+        for variant in variants:
+            encoded.append(variant.encode("utf-8"))
+            encoded.append(variant.encode("utf-16-be"))
+            encoded.append(variant.encode("latin-1", "ignore"))
+        return [item for item in encoded if len(item) >= 3]
+
+    stream_datas: list[bytes] = []
+    size = int(output_reader.trailer.get("/Size", 0))
+    for object_number in range(1, min(size, 50_000)):
+        try:
+            candidate = IndirectObject(object_number, 0, output_reader).get_object()
+        except Exception:
+            continue
+        if hasattr(candidate, "get_data"):
+            try:
+                stream_datas.append(candidate.get_data())
+            except Exception:
+                continue
+    raw_hits = 0
+    stream_hits = 0
+    hard_failures: list[str] = []
+    for term in full_scope_terms + partial_scope_terms:
+        is_full_scope = term in full_scope_terms
+        for encoded in term_encodings(term):
+            in_raw = encoded in output_bytes
+            in_stream = any(encoded in data for data in stream_datas)
+            if in_raw:
+                raw_hits += 1
+            if in_stream:
+                stream_hits += 1
+            if is_full_scope and (in_raw or in_stream):
+                hard_failures.append(term)
+                break
+    operand_hits = 0
+    for operand in removed_operand_bytes:
+        if len(operand) < 4:
+            continue
+        if operand in output_bytes or any(operand in data for data in stream_datas):
+            operand_hits += 1
+    if hard_failures:
+        raise ToolError(
+            "validation_failed",
+            "Redaction residual scan found target terms in the output",
+            details={
+                "terms_sha256": [
+                    hashlib.sha256(term.encode("utf-8")).hexdigest() for term in hard_failures
+                ]
+            },
+        )
+    return {
+        "streams_scanned": len(stream_datas),
+        "raw_byte_hits": raw_hits,
+        "decompressed_stream_hits": stream_hits,
+        "operand_byte_matches_elsewhere": operand_hits,
+    }
+
+
+def handle_redact(args: argparse.Namespace) -> dict[str, Any]:
+    source_path = Path(args.input)
+    require_extension(source_path, ".pdf", "Redact input")
+    job_path = Path(args.job)
+    job = read_json(job_path)
+    output = Path(args.output)
+    require_extension(output, ".pdf", "Redact output")
+    report_path = Path(args.report) if args.report else None
+    if report_path is not None:
+        require_extension(report_path, ".json", "Redact report")
+    render_check_dir = Path(args.render_check_dir) if args.render_check_dir else None
+    try:
+        source = open_pdf(source_path, None)
+    except ToolError as exc:
+        if "encrypted" in exc.message.lower():
+            raise ToolError(
+                "unsupported_operation",
+                "Redaction of encrypted PDFs is not supported; decrypt explicitly "
+                "with an edit decrypt operation first",
+            ) from exc
+        raise
+    config = parse_redact_job(job)
+    page_count = len(source.reader.pages)
+    targets = validate_redact_targets(config["targets"], page_count)
+    text_targets = [target for target in targets if target["kind"] == "text"]
+    terms = [normalize_redaction_term(target["text"]) for target in text_targets]
+    full_scope_terms = [
+        normalize_redaction_term(target["text"])
+        for target in text_targets
+        if target["pages"] in (None, "", "all")
+    ]
+    partial_scope_terms = [term for term in terms if term not in full_scope_terms]
+    precondition_evidence = redact_preconditions(source, config, terms)
+    with pdfplumber.open(str(source_path)) as plumber_pdf:
+        rects_by_page = resolve_redaction_rects(source, plumber_pdf, targets, page_count)
+    writer = PdfWriter()
+    writer.clone_document_from_reader(source.reader)
+    warnings: list[str] = [
+        "Redaction is not forensic file sanitization; prior copies, backups, "
+        "version control history, and filesystem artifacts are outside this tool.",
+    ]
+    page_evidence: dict[int, PageRedactionResult] = {}
+    user_rects_by_page: dict[int, list[tuple[float, float, float, float]]] = {}
+    displayed_rects_by_page: dict[int, list[tuple[float, float, float, float]]] = {}
+    classifications: dict[int, str] = {}
+    for page_number, page_rects in sorted(rects_by_page.items()):
+        reader_page = source.reader.pages[page_number - 1]
+        writer_page = writer.pages[page_number - 1]
+        displayed_rects = [item["rect"] for item in page_rects]
+        user_rects = [displayed_rect_to_user(rect, reader_page) for rect in displayed_rects]
+        user_rects_by_page[page_number] = user_rects
+        displayed_rects_by_page[page_number] = displayed_rects
+        result = redact_page_content(
+            writer_page,
+            writer,
+            user_rects,
+            image_policy=config["image_policy"],
+            page_number=page_number,
+            fill_rects_user=user_rects,
+            fill_rgb=config["fill_rgb"],
+        )
+        page_evidence[page_number] = result
+    with pdfplumber.open(str(source_path)) as plumber_pdf:
+        for page_number in rects_by_page:
+            page = plumber_pdf.pages[page_number - 1]
+            try:
+                page_data = plumber_page_data(
+                    page, mode="plain", include_words=False, include_tables=False
+                )
+                classifications[page_number] = page_data["classification"]
+            except Exception:
+                classifications[page_number] = "unknown"
+    for page_number, classification in classifications.items():
+        if classification in {"likely-scanned", "hybrid"} and terms:
+            warnings.append(
+                f"Page {page_number} is {classification}: text targets match only "
+                "extractable digital text, not pixels. Redact scanned content with "
+                "rect targets (build them from OCR sidecar geometry if needed)."
+            )
+    # Sweep annotations for the operator's actual targets only, mirroring the
+    # document-level sweep. Collateral text removed by the whole-operator policy is not a
+    # redaction target and must not drive further removal (a stamp reading "APPROVED"
+    # collaterally removed near a target must never delete a field named "approved_by").
+    annotations_removed = sweep_annotations(writer, user_rects_by_page, terms)
+    for page_number, count in annotations_removed.items():
+        if page_number in page_evidence:
+            page_evidence[page_number].annotations_removed = count
+    document_evidence = redact_document_level(writer, config, terms)
+    check_destination(output, sources=[source_path, job_path], overwrite=args.overwrite)
+    removed_operand_bytes = [
+        operand for result in page_evidence.values() for operand in result.removed_operand_bytes
+    ]
+    removed_image_hashes = {
+        digest for result in page_evidence.values() for digest in result.removed_image_hashes
+    }
+    residual_scan: dict[str, Any] = {}
+    visual_check: dict[str, Any] = {"checked": False}
+    render_outputs: list[str] = []
+    with temporary_sibling(output, ".pdf") as temp_path:
+        intermediate = io.BytesIO()
+        writer.write(intermediate)
+        intermediate.seek(0)
+        try:
+            intermediate_reader = PdfReader(intermediate, strict=True)
+        except Exception as exc:
+            raise ToolError(
+                "validation_failed",
+                f"Redacted document failed to reopen: {clean_text(exc)}",
+            ) from exc
+        final_writer = PdfWriter()
+        final_writer.clone_document_from_reader(intermediate_reader)
+        with temp_path.open("wb") as handle:
+            final_writer.write(handle)
+        verification = validate_pdf_output(temp_path, expected_pages=page_count)
+        output_bytes = temp_path.read_bytes()
+        if output_bytes.count(b"%%EOF") != 1:
+            raise ToolError(
+                "validation_failed",
+                "Redacted output does not contain exactly one revision",
+            )
+        output_reader = PdfReader(str(temp_path), strict=True)
+        for index in range(page_count):
+            source_box = source.reader.pages[index].mediabox
+            output_box = output_reader.pages[index].mediabox
+            if (
+                abs(float(output_box.width) - float(source_box.width)) > 0.01
+                or abs(float(output_box.height) - float(source_box.height)) > 0.01
+            ):
+                raise ToolError(
+                    "validation_failed",
+                    f"Page {index + 1} geometry changed during redaction",
+                )
+        for digest in removed_image_hashes:
+            size = int(output_reader.trailer.get("/Size", 0))
+            for object_number in range(1, min(size, 50_000)):
+                try:
+                    candidate = IndirectObject(object_number, 0, output_reader).get_object()
+                except Exception:
+                    continue
+                if hasattr(candidate, "get_data"):
+                    try:
+                        if hashlib.sha256(candidate.get_data()).hexdigest() == digest:
+                            raise ToolError(
+                                "validation_failed",
+                                "A removed image stream is still reachable in the redacted output",
+                            )
+                    except ToolError:
+                        raise
+                    except Exception:
+                        continue
+        with pdfplumber.open(str(temp_path)) as plumber_output:
+            for page_number, displayed_rects in displayed_rects_by_page.items():
+                page = plumber_output.pages[page_number - 1]
+                try:
+                    characters = page.chars
+                except Exception:
+                    characters = []
+                for rect in displayed_rects:
+                    inset = 0.5
+                    x0, top, x1, bottom = (
+                        rect[0] + inset,
+                        rect[1] + inset,
+                        rect[2] - inset,
+                        rect[3] - inset,
+                    )
+                    residual_characters = [
+                        character
+                        for character in characters
+                        if x0 < (float(character["x0"]) + float(character["x1"])) / 2 < x1
+                        and top
+                        < (float(character["top"]) + float(character["bottom"])) / 2
+                        < bottom
+                    ]
+                    if residual_characters:
+                        raise ToolError(
+                            "validation_failed",
+                            f"Page {page_number} still extracts "
+                            f"{len(residual_characters)} characters inside a "
+                            "redaction target",
+                        )
+            for target in text_targets:
+                term = normalize_redaction_term(target["text"])
+                page_indexes = parse_page_selection(target["pages"], page_count)
+                for page_index in page_indexes:
+                    page = plumber_output.pages[page_index]
+                    try:
+                        page_text = page.extract_text() or ""
+                    except Exception:
+                        page_text = ""
+                    if term_in_text(term, page_text):
+                        raise ToolError(
+                            "validation_failed",
+                            f"Redaction term for target {target['index']} is still "
+                            f"extractable on page {page_index + 1}",
+                        )
+        residual_scan = redact_residual_scan(
+            output_bytes,
+            output_reader,
+            full_scope_terms,
+            partial_scope_terms,
+            removed_operand_bytes,
+        )
+        if partial_scope_terms and (
+            residual_scan["raw_byte_hits"] or residual_scan["decompressed_stream_hits"]
+        ):
+            warnings.append(
+                "Byte-level scan found matches for page-scoped terms; instances "
+                "outside the selected pages were intentionally retained."
+            )
+        visual_budget = RenderBudget(
+            total_message=(
+                "Redaction visual check exceeds the render pixel budget; redact "
+                "fewer pages per invocation"
+            )
+        )
+        max_outside_fraction = 0.0
+        with tempfile.TemporaryDirectory(prefix="pdf-redact-check-") as check_name:
+            check_dir = Path(check_name)
+            with (
+                pdfplumber.open(str(source_path)) as before_pdf,
+                pdfplumber.open(str(temp_path)) as after_pdf,
+            ):
+                for page_number in sorted(displayed_rects_by_page):
+                    reader_page = source.reader.pages[page_number - 1]
+                    before_page = before_pdf.pages[page_number - 1]
+                    after_page = after_pdf.pages[page_number - 1]
+                    for _ in range(2):
+                        visual_budget.charge(
+                            float(before_page.width),
+                            float(before_page.height),
+                            REDACT_CHECK_DPI,
+                            page_label=f"Page {page_number}",
+                        )
+                    before_png = check_dir / f"before-{page_number:04d}.png"
+                    after_png = check_dir / f"after-{page_number:04d}.png"
+                    rasterize_region(
+                        before_page,
+                        None,
+                        REDACT_CHECK_DPI,
+                        before_png,
+                        page_label=f"page {page_number}",
+                    )
+                    rasterize_region(
+                        after_page,
+                        None,
+                        REDACT_CHECK_DPI,
+                        after_png,
+                        page_label=f"page {page_number}",
+                    )
+                    scale = REDACT_CHECK_DPI / 72.0
+                    with (
+                        Image.open(before_png) as before_image,
+                        Image.open(after_png) as after_image,
+                    ):
+                        before_rgb = before_image.convert("RGB")
+                        after_rgb = after_image.convert("RGB")
+                        if before_rgb.size != after_rgb.size:
+                            raise ToolError(
+                                "validation_failed",
+                                f"Page {page_number} raster size changed during redaction",
+                            )
+                        mask = Image.new("1", before_rgb.size, 0)
+                        mask_draw = ImageDraw.Draw(mask)
+                        expected_rects = list(displayed_rects_by_page[page_number])
+                        evidence = page_evidence.get(page_number)
+                        if evidence is not None:
+                            expected_rects.extend(
+                                user_rect_to_displayed(extent, reader_page)
+                                for extent in evidence.removed_extents_user
+                            )
+                        for rect in expected_rects:
+                            mask_draw.rectangle(
+                                (
+                                    int(rect[0] * scale) - REDACT_MASK_DILATION_PIXELS,
+                                    int(rect[1] * scale) - REDACT_MASK_DILATION_PIXELS,
+                                    int(rect[2] * scale) + REDACT_MASK_DILATION_PIXELS,
+                                    int(rect[3] * scale) + REDACT_MASK_DILATION_PIXELS,
+                                ),
+                                fill=1,
+                            )
+                        difference = ImageChops.difference(before_rgb, after_rgb).convert("L")
+                        threshold = difference.point(lambda v: 255 if v > 8 else 0)
+                        outside = ImageChops.subtract(
+                            threshold.convert("L"),
+                            mask.convert("L").point(lambda v: 255 if v else 0),
+                        )
+                        outside_pixels = sum(outside.histogram()[1:])
+                        total_pixels = before_rgb.size[0] * before_rgb.size[1]
+                        fraction = outside_pixels / total_pixels if total_pixels else 0.0
+                        max_outside_fraction = max(max_outside_fraction, fraction)
+                        if fraction > REDACT_VISUAL_DIFF_LIMIT:
+                            raise ToolError(
+                                "validation_failed",
+                                f"Page {page_number} changed visually outside the "
+                                f"expected redaction regions (fraction {fraction:.6f})",
+                            )
+                if render_check_dir is not None:
+                    check_directory_destination(
+                        render_check_dir,
+                        overwrite=args.overwrite,
+                        exists_message=(f"Render check directory exists: {render_check_dir}"),
+                        not_directory_message=(
+                            f"Render check output must be a directory: {render_check_dir}"
+                        ),
+                        nonempty_message=(
+                            "Refusing to overwrite a nonempty render check directory"
+                        ),
+                    )
+                    staged_dir = stage_directory(render_check_dir)
+                    try:
+                        for item in sorted(check_dir.iterdir()):
+                            shutil.copy2(item, staged_dir / item.name)
+                            render_outputs.append(str((render_check_dir / item.name).resolve()))
+                        atomic_publish_directory(staged_dir, render_check_dir, label="render-check")
+                    finally:
+                        shutil.rmtree(staged_dir, ignore_errors=True)
+        visual_check = {
+            "checked": True,
+            "dpi": REDACT_CHECK_DPI,
+            "max_fraction_changed_outside_expected": round(max_outside_fraction, 6),
+            "threshold": REDACT_VISUAL_DIFF_LIMIT,
+        }
+        atomic_publish(temp_path, output)
+    target_reports = []
+    for target in targets:
+        resolved = [
+            {"page": page_number, "rect": [round(value, 3) for value in item["rect"]]}
+            for page_number, items in sorted(rects_by_page.items())
+            for item in items
+            if item["target_index"] == target["index"]
+        ]
+        entry: dict[str, Any] = {
+            "index": target["index"],
+            "type": target["kind"],
+            "resolved_rects": resolved,
+        }
+        if target["kind"] == "text":
+            entry["text_sha256"] = hashlib.sha256(
+                normalize_redaction_term(target["text"]).encode("utf-8")
+            ).hexdigest()
+            entry["match"] = target["match"]
+        target_reports.append(entry)
+    removal_evidence = {
+        "pages": [
+            {
+                "page": page_number,
+                "classification": classifications.get(page_number),
+                "text_operators_removed": evidence.text_operators_removed,
+                "characters_removed": evidence.characters_removed,
+                "inline_images_removed": evidence.inline_images_removed,
+                "image_xobjects_removed": evidence.image_xobjects_removed,
+                "vector_paints_removed": evidence.vector_paints_removed,
+                "annotations_removed": evidence.annotations_removed,
+            }
+            for page_number, evidence in sorted(page_evidence.items())
+        ],
+        **document_evidence,
+        "signatures_present": precondition_evidence["signatures_present"],
+        "attachments_present": precondition_evidence["attachments_present"],
+        "incremental_history_dropped": True,
+    }
+    payload = success(
+        "redact",
+        output_path=str(output.resolve()),
+        source=str(source_path.resolve()),
+        targets=target_reports,
+        removal_evidence=removal_evidence,
+        residual_scan=residual_scan,
+        render_check_outputs=render_outputs,
+        warnings=warnings,
+        verification={
+            **verification,
+            "page_count_unchanged": True,
+            "dimensions_unchanged": True,
+            "single_revision": True,
+            "visual_diff": visual_check,
+        },
+    )
+    if report_path is not None:
+        write_json_atomic(
+            report_path,
+            payload,
+            overwrite=args.overwrite,
+            protected_sources=[source_path, job_path],
+        )
+        payload["report_path"] = str(report_path.resolve())
+    return payload
 
 
 def pdf_to_text_or_json(args: argparse.Namespace, to_format: str) -> dict[str, Any]:
@@ -2597,6 +4988,13 @@ def directory_inventory(path: Path) -> tuple[int, str, int]:
     return total_size, digest.hexdigest(), file_count
 
 
+def placeholder_value(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    lowered = value.strip().lower()
+    return lowered == REVIEW_REQUIRED.lower() or lowered.startswith("replace-with")
+
+
 def preflight_manifest(
     manifest_path: Path,
     engine: str,
@@ -2617,6 +5015,15 @@ def preflight_manifest(
         raise ToolError(
             "license_precondition",
             f"Manifest model is missing: {', '.join(missing)}",
+        )
+    placeholder_fields = [
+        field for field in required_model_fields if placeholder_value(model.get(field))
+    ]
+    if placeholder_fields:
+        raise ToolError(
+            "license_precondition",
+            "Manifest model contains unreviewed placeholder values: "
+            + ", ".join(placeholder_fields),
         )
     if not model.get("license_terms_accepted"):
         raise ToolError("license_precondition", "Model/license-data terms are not accepted")
@@ -2645,6 +5052,15 @@ def preflight_manifest(
             raise ToolError(
                 "license_precondition",
                 f"Surya runtime is missing: {', '.join(missing_runtime)}",
+            )
+        runtime_placeholders = [
+            field for field in required_runtime_fields if placeholder_value(runtime.get(field))
+        ]
+        if runtime_placeholders:
+            raise ToolError(
+                "license_precondition",
+                "Surya runtime contains unreviewed placeholder values: "
+                + ", ".join(runtime_placeholders),
             )
         if not runtime.get("license_terms_accepted"):
             raise ToolError(
@@ -2686,6 +5102,18 @@ def preflight_manifest(
         expected_hash = artifact.get("sha256")
         if role in roles:
             raise ToolError("license_precondition", f"Duplicate artifact role: {role}")
+        provenance_placeholders = [
+            field
+            for field in ("identifier", "revision", "source", "license")
+            if placeholder_value(artifact.get(field))
+        ]
+        if provenance_placeholders:
+            raise ToolError(
+                "license_precondition",
+                f"Artifact {role} contains unreviewed placeholder values "
+                f"({', '.join(provenance_placeholders)}); explicit artifact-level "
+                "preflight is required",
+            )
         if engine == "paddle" and role in PADDLE_BASE_ROLES | PADDLE_STRUCTURE_ROLES:
             required_artifact_fields = ("identifier", "revision", "source", "license")
             missing_provenance = [
@@ -2728,9 +5156,27 @@ def preflight_manifest(
             actual_size = path.stat().st_size
             actual_hash = sha256_file(path) if normalized_hash else None
             if normalized_size is not None and actual_size != normalized_size:
-                raise ToolError("license_precondition", f"Artifact size mismatch: {path}")
+                raise ToolError(
+                    "license_precondition",
+                    f"Artifact size mismatch: {path}",
+                    details={
+                        "role": role,
+                        "path": str(path),
+                        "expected_size_bytes": normalized_size,
+                        "actual_size_bytes": actual_size,
+                    },
+                )
             if normalized_hash and actual_hash != normalized_hash:
-                raise ToolError("license_precondition", f"Artifact checksum mismatch: {path}")
+                raise ToolError(
+                    "license_precondition",
+                    f"Artifact checksum mismatch: {path}",
+                    details={
+                        "role": role,
+                        "path": str(path),
+                        "expected_sha256": normalized_hash,
+                        "actual_sha256": actual_hash,
+                    },
+                )
         elif path.is_dir():
             actual_size = None
             actual_hash = None
@@ -2742,11 +5188,23 @@ def preflight_manifest(
                 raise ToolError(
                     "license_precondition",
                     f"Artifact directory inventory size mismatch: {path}",
+                    details={
+                        "role": role,
+                        "path": str(path),
+                        "expected_size_bytes": normalized_size,
+                        "actual_size_bytes": actual_size,
+                    },
                 )
             if normalized_hash and actual_hash != normalized_hash:
                 raise ToolError(
                     "license_precondition",
                     f"Artifact directory inventory checksum mismatch: {path}",
+                    details={
+                        "role": role,
+                        "path": str(path),
+                        "expected_sha256": normalized_hash,
+                        "actual_sha256": actual_hash,
+                    },
                 )
         else:
             raise ToolError("license_precondition", f"Artifact must be a file or directory: {path}")
@@ -2827,6 +5285,571 @@ def tesseract_languages(executable: Path, tessdata_dir: Path) -> list[str]:
         for line in completed.stdout.splitlines()
         if line.strip() and not line.lower().startswith("list of available")
     ]
+
+
+MANIFEST_EXCLUDED_CHECKS = ("engine_version", "tesseract_language_query", "backend_probe")
+
+
+def parse_artifact_arguments(values: Sequence[str]) -> dict[str, Path]:
+    artifacts: dict[str, Path] = {}
+    for item in values:
+        role, separator, path_value = item.partition("=")
+        if not separator or not role or not path_value:
+            raise ToolError("bad_input", f"--artifact requires ROLE=PATH: {item}")
+        if role in artifacts:
+            raise ToolError("bad_input", f"Duplicate --artifact role: {role}")
+        artifacts[role] = Path(path_value).expanduser()
+    return artifacts
+
+
+def measure_artifact(role: str, path: Path) -> dict[str, Any]:
+    if path.is_symlink() or not path.exists():
+        raise ToolError("bad_input", f"Artifact is not provisioned: {path}")
+    if path.is_file():
+        return {
+            "role": role,
+            "path": str(path.resolve()),
+            "size_bytes": path.stat().st_size,
+            "sha256": sha256_file(path),
+        }
+    if path.is_dir():
+        size, digest, file_count = directory_inventory(path)
+        return {
+            "role": role,
+            "path": str(path.resolve()),
+            "size_bytes": size,
+            "sha256": digest,
+            "inventory_file_count": file_count,
+        }
+    raise ToolError("bad_input", f"Artifact must be a file or directory: {path}")
+
+
+def manifest_placeholder_provenance() -> dict[str, str]:
+    return {
+        "identifier": REVIEW_REQUIRED,
+        "revision": REVIEW_REQUIRED,
+        "source": REVIEW_REQUIRED,
+        "license": REVIEW_REQUIRED,
+    }
+
+
+def locate_tessdata_directory(languages: list[str], explicit: str | None) -> Path:
+    searched: list[str] = []
+    candidates: list[Path] = []
+    if explicit:
+        candidates.append(Path(explicit).expanduser())
+    else:
+        env_value = os.environ.get("TESSDATA_PREFIX")
+        if env_value:
+            candidates.append(Path(env_value).expanduser())
+            candidates.append(Path(env_value).expanduser() / "tessdata")
+        candidates.extend(Path(item) for item in WELL_KNOWN_TESSDATA_DIRS)
+    qualifying: list[Path] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        key = str(candidate)
+        if key in seen:
+            continue
+        seen.add(key)
+        searched.append(key)
+        # A symlinked directory is normal here (Homebrew symlinks its share tree); is_dir
+        # follows the link. The no-symlink rule applies to the traineddata files, which the
+        # manifest preflight enforces on the resolved artifact paths.
+        if not candidate.is_dir():
+            continue
+        if all(
+            (candidate / f"{language}.traineddata").is_file()
+            and not (candidate / f"{language}.traineddata").is_symlink()
+            for language in languages
+        ):
+            qualifying.append(candidate)
+    if not qualifying:
+        raise ToolError(
+            "bad_input",
+            "No tessdata directory contains every requested language "
+            f"({', '.join(languages)}); searched: {', '.join(searched)}. "
+            "Pass --tessdata-dir explicitly.",
+        )
+    if len(qualifying) > 1:
+        raise ToolError(
+            "bad_input",
+            "Multiple tessdata directories contain the requested languages: "
+            + ", ".join(str(path) for path in qualifying)
+            + ". Pass --tessdata-dir explicitly.",
+        )
+    return qualifying[0]
+
+
+def derive_manifest(
+    engine: str,
+    languages: list[str] | None,
+    artifacts_by_role: dict[str, Path],
+    *,
+    tessdata_dir: str | None,
+    assume_source: str | None,
+    accept_license: bool,
+    confirm_eligibility: bool,
+) -> tuple[dict[str, Any], list[str], list[str]]:
+    warnings: list[str] = []
+    reasons: list[str] = []
+    declared_fields: list[str] = []
+    approvals = {
+        "license_terms_accepted": accept_license,
+        "use_case_eligibility_confirmed": confirm_eligibility,
+    }
+    runtime: dict[str, Any] | None = None
+    if engine == "tesseract":
+        if not languages:
+            raise ToolError("bad_input", "Tesseract manifest derivation requires --languages")
+        if artifacts_by_role:
+            raise ToolError(
+                "bad_input",
+                "Tesseract derivation locates language data itself; use --tessdata-dir, "
+                "not --artifact",
+            )
+        directory = locate_tessdata_directory(languages, tessdata_dir)
+        declared = TESSDATA_SOURCES[assume_source] if assume_source else None
+        artifact_entries = []
+        for language in languages:
+            entry = measure_artifact(
+                f"language_data:{language}", directory / f"{language}.traineddata"
+            )
+            if declared:
+                entry.update(
+                    {
+                        "identifier": (f"{declared['identifier_prefix']}/{language}.traineddata"),
+                        "revision": declared["revision"],
+                        "source": declared["source"],
+                        "license": declared["license"],
+                        "provenance": "declared-by-operator",
+                    }
+                )
+            else:
+                entry.update(manifest_placeholder_provenance())
+                entry["provenance"] = REVIEW_REQUIRED
+            artifact_entries.append(entry)
+        if declared:
+            model_provenance = {
+                "identifier": f"{declared['identifier_prefix']}:{'+'.join(languages)}",
+                "revision": declared["revision"],
+                "source": declared["source"],
+                "license": declared["license"],
+            }
+            declared_fields.extend(["identifier", "revision", "source", "license"])
+            warnings.append(
+                "Operator declared artifact provenance via --assume-source; the tool "
+                "verified only local paths, sizes, and SHA-256 values, not the files' "
+                "origin."
+            )
+        else:
+            model_provenance = manifest_placeholder_provenance()
+            reasons.append(
+                "Model provenance is REVIEW-REQUIRED; pass --assume-source after "
+                "confirming the files' origin, or record reviewed facts in the manifest."
+            )
+        model: dict[str, Any] = {**model_provenance, "languages": languages, **approvals}
+    elif engine == "surya":
+        required_roles = {"model", "mmproj", "backend"}
+        missing = sorted(required_roles - set(artifacts_by_role))
+        if missing:
+            raise ToolError(
+                "bad_input",
+                f"Surya derivation requires --artifact roles: {', '.join(missing)}",
+            )
+        unknown = sorted(set(artifacts_by_role) - required_roles)
+        if unknown:
+            raise ToolError("bad_input", f"Unknown Surya artifact roles: {', '.join(unknown)}")
+        artifact_entries = []
+        model_match: dict[str, str] | None = None
+        for role in ("model", "mmproj", "backend"):
+            entry = measure_artifact(role, artifacts_by_role[role])
+            if role in {"model", "mmproj"}:
+                known = KNOWN_ARTIFACTS.get(entry["sha256"])
+                if known:
+                    entry.update(
+                        {
+                            field: known[field]
+                            for field in ("identifier", "revision", "source", "license")
+                        }
+                    )
+                    entry["provenance"] = "matched-reviewed-artifact"
+                    if role == "model":
+                        model_match = known
+                else:
+                    entry.update(manifest_placeholder_provenance())
+                    entry["provenance"] = REVIEW_REQUIRED
+                    reasons.append(
+                        f"Surya {role} artifact SHA-256 does not match a reviewed "
+                        "artifact; review and record its provenance."
+                    )
+            else:
+                entry["provenance"] = "measured-local-binary"
+            artifact_entries.append(entry)
+        if model_match:
+            model_provenance = {
+                "identifier": model_match["identifier"].rsplit("/", 1)[0],
+                "revision": model_match["revision"],
+                "source": model_match["source"],
+                "license": model_match["license"],
+            }
+        else:
+            model_provenance = manifest_placeholder_provenance()
+        model = {**model_provenance, **approvals}
+        if languages:
+            model["languages"] = languages
+        runtime = {
+            "identifier": "ggerganov/llama.cpp",
+            "revision": REVIEW_REQUIRED,
+            "source": "https://github.com/ggml-org/llama.cpp",
+            "license": "MIT",
+            "license_terms_accepted": False,
+        }
+        reasons.append(
+            "Surya runtime revision is REVIEW-REQUIRED; record the reviewed llama.cpp "
+            "build revision and accept its terms in the manifest."
+        )
+        warnings.append(
+            "Review the Surya model license before running OCR: "
+            + surya_license_summary()["current_weight_terms_summary"]
+        )
+    else:
+        valid_roles = PADDLE_BASE_ROLES | PADDLE_STRUCTURE_ROLES
+        unknown = sorted(set(artifacts_by_role) - valid_roles)
+        if unknown:
+            raise ToolError("bad_input", f"Unknown Paddle artifact roles: {', '.join(unknown)}")
+        missing_base = sorted(PADDLE_BASE_ROLES - set(artifacts_by_role))
+        if missing_base:
+            raise ToolError(
+                "bad_input",
+                f"Paddle derivation requires --artifact roles: {', '.join(missing_base)}",
+            )
+        artifact_entries = []
+        for role in sorted(artifacts_by_role):
+            path = artifacts_by_role[role]
+            if path.is_symlink() or not path.is_dir():
+                raise ToolError(
+                    "bad_input", f"Paddle artifact {role} must be a model directory: {path}"
+                )
+            entry = measure_artifact(role, path)
+            known = None
+            if role in PADDLE_BASE_ROLES:
+                main_parameters = path / "inference.pdiparams"
+                if main_parameters.is_file():
+                    known = KNOWN_ARTIFACTS.get(sha256_file(main_parameters))
+            if known:
+                entry.update(
+                    {
+                        field: known[field]
+                        for field in ("identifier", "revision", "source", "license")
+                    }
+                )
+                entry["provenance"] = "matched-reviewed-main-parameter-file"
+                warnings.append(
+                    f"Paddle role {role} matched the reviewed main parameter file for "
+                    f"{known['identifier']}; the recorded size/sha256 cover the complete "
+                    "directory inventory, while the review match covers only the main "
+                    "parameter file."
+                )
+            else:
+                entry.update(manifest_placeholder_provenance())
+                entry["provenance"] = REVIEW_REQUIRED
+                if role in PADDLE_STRUCTURE_ROLES:
+                    reasons.append(
+                        f"Structure role {role} is never auto-filled; review and record "
+                        "its provenance explicitly."
+                    )
+                else:
+                    reasons.append(
+                        f"Paddle role {role} did not match a reviewed main parameter "
+                        "file; review and record its provenance."
+                    )
+            artifact_entries.append(entry)
+        model = {**manifest_placeholder_provenance(), **approvals}
+        if languages:
+            model["languages"] = languages
+        reasons.append(
+            "Paddle model provenance is REVIEW-REQUIRED; record the reviewed model "
+            "identifier and revision in the manifest."
+        )
+    if accept_license:
+        declared_fields.append("license_terms_accepted")
+    else:
+        reasons.append(
+            "license_terms_accepted is false; pass --accept-license after reviewing "
+            "the artifact license terms."
+        )
+    if confirm_eligibility:
+        declared_fields.append("use_case_eligibility_confirmed")
+    else:
+        reasons.append(
+            "use_case_eligibility_confirmed is false; pass --confirm-eligibility after "
+            "confirming this use case is eligible."
+        )
+    manifest: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "engine": engine,
+        "model": model,
+        "artifacts": artifact_entries,
+        "derivation": {
+            "mode": "derive",
+            "tool_version": TOOL_VERSION,
+            "measured": ["path", "size_bytes", "sha256"],
+            "declared_by_operator": declared_fields,
+        },
+    }
+    if runtime is not None:
+        manifest["runtime"] = runtime
+    return manifest, warnings, reasons
+
+
+def manifest_check(
+    manifest_path: Path,
+    engine: str,
+    languages: list[str] | None,
+) -> dict[str, Any]:
+    manifest = read_json(manifest_path)
+    checks: list[dict[str, Any]] = []
+
+    def add(name: str, ok: Any, **details: Any) -> None:
+        checks.append({"check": name, "ok": bool(ok), **details})
+
+    add(
+        "engine_matches",
+        manifest.get("engine") == engine,
+        expected=engine,
+        actual=manifest.get("engine"),
+    )
+    model = manifest.get("model")
+    model_ok = isinstance(model, dict)
+    add("model_object", model_ok)
+    if model_ok:
+        for field in ("identifier", "revision", "source", "license"):
+            value = model.get(field)
+            add(
+                f"model_{field}",
+                bool(value) and not placeholder_value(value),
+                actual=value if isinstance(value, str) else None,
+            )
+        add("model_license_terms_accepted", bool(model.get("license_terms_accepted")))
+        add(
+            "model_use_case_eligibility_confirmed",
+            bool(model.get("use_case_eligibility_confirmed")),
+        )
+        declared_languages = model.get("languages")
+        if languages and isinstance(declared_languages, list):
+            add(
+                "languages_covered",
+                set(languages) <= {str(item) for item in declared_languages},
+                requested=languages,
+                declared=declared_languages,
+            )
+    if engine == "surya":
+        if model_ok:
+            stated = str(model.get("license", "")).lower()
+            add(
+                "surya_model_license_records_open_rail",
+                "open rail" in stated or "openrail" in stated,
+            )
+        runtime = manifest.get("runtime")
+        runtime_ok = isinstance(runtime, dict)
+        add("runtime_object", runtime_ok)
+        if runtime_ok:
+            for field in ("identifier", "revision", "source", "license"):
+                value = runtime.get(field)
+                add(
+                    f"runtime_{field}",
+                    bool(value) and not placeholder_value(value),
+                    actual=value if isinstance(value, str) else None,
+                )
+            add("runtime_license_terms_accepted", bool(runtime.get("license_terms_accepted")))
+    artifacts = manifest.get("artifacts")
+    artifacts_ok = isinstance(artifacts, list) and bool(artifacts)
+    add("artifacts_array", artifacts_ok)
+    roles: set[str] = set()
+    if artifacts_ok:
+        for index, artifact in enumerate(artifacts):
+            if not isinstance(artifact, dict):
+                add(f"artifact_{index}_object", False)
+                continue
+            role_value = artifact.get("role")
+            role = role_value if isinstance(role_value, str) and role_value else f"#{index}"
+            path_value = artifact.get("path")
+            record = {"role": role, "path": path_value}
+            if role in roles:
+                add("artifact_role_unique", False, **record)
+            roles.add(role)
+            if not isinstance(path_value, str) or not path_value:
+                add("artifact_path", False, **record)
+                continue
+            path = Path(path_value).expanduser()
+            provisioned = path.exists() and not path.is_symlink()
+            add("artifact_provisioned", provisioned, **record)
+            if not provisioned:
+                continue
+            expected_size = artifact.get("size_bytes")
+            expected_hash_value = artifact.get("sha256")
+            expected_hash = str(expected_hash_value).lower() if expected_hash_value else None
+            if expected_hash and not re.fullmatch(r"[0-9a-f]{64}", expected_hash):
+                add("artifact_sha256_format", False, **record, expected_sha256=expected_hash)
+                expected_hash = None
+            try:
+                if path.is_file():
+                    actual_size = path.stat().st_size
+                    actual_hash = sha256_file(path)
+                else:
+                    actual_size, actual_hash, _ = directory_inventory(path)
+            except ToolError as exc:
+                add("artifact_inventory", False, **record, error=exc.message)
+                continue
+            size_hash_required = (
+                engine == "paddle" and role in PADDLE_BASE_ROLES | PADDLE_STRUCTURE_ROLES
+            ) or (engine == "surya" and role == "backend")
+            if expected_size is not None:
+                try:
+                    normalized_size = finite_integer(expected_size, "size_bytes", minimum=0)
+                except ToolError:
+                    add(
+                        "artifact_size_format",
+                        False,
+                        **record,
+                        expected_size_bytes=expected_size,
+                    )
+                else:
+                    add(
+                        "artifact_size",
+                        normalized_size == actual_size,
+                        **record,
+                        expected_size_bytes=normalized_size,
+                        actual_size_bytes=actual_size,
+                    )
+            else:
+                add(
+                    "artifact_size_recorded",
+                    not size_hash_required,
+                    **record,
+                    actual_size_bytes=actual_size,
+                    note="size_bytes is not recorded in the manifest",
+                )
+            if expected_hash:
+                add(
+                    "artifact_sha256",
+                    expected_hash == actual_hash,
+                    **record,
+                    expected_sha256=expected_hash,
+                    actual_sha256=actual_hash,
+                )
+            else:
+                add(
+                    "artifact_sha256_recorded",
+                    not size_hash_required,
+                    **record,
+                    actual_sha256=actual_hash,
+                    note="sha256 is not recorded in the manifest",
+                )
+            placeholders = [
+                field
+                for field in ("identifier", "revision", "source", "license")
+                if placeholder_value(artifact.get(field))
+            ]
+            add(
+                "artifact_provenance_reviewed",
+                not placeholders,
+                **record,
+                placeholder_fields=placeholders,
+            )
+            if engine == "paddle" and role in PADDLE_BASE_ROLES | PADDLE_STRUCTURE_ROLES:
+                missing_fields = [
+                    field
+                    for field in ("identifier", "revision", "source", "license")
+                    if not artifact.get(field)
+                ]
+                add(
+                    "paddle_artifact_provenance_complete",
+                    not missing_fields,
+                    **record,
+                    missing_fields=missing_fields,
+                )
+    required_roles = {
+        "surya": {"backend", "model", "mmproj"},
+        "paddle": set(PADDLE_BASE_ROLES),
+        "tesseract": set(),
+    }[engine]
+    add(
+        "required_roles_present",
+        required_roles <= roles,
+        required=sorted(required_roles),
+        present=sorted(roles),
+    )
+    failures = [item for item in checks if not item["ok"]]
+    summary = {"checks": len(checks), "failed": len(failures)}
+    if failures:
+        raise ToolError(
+            "license_precondition",
+            f"Manifest check found {len(failures)} problem(s)",
+            details={
+                "summary": summary,
+                "checks": checks,
+                "excluded_checks": list(MANIFEST_EXCLUDED_CHECKS),
+            },
+        )
+    return success(
+        "manifest",
+        mode="check",
+        engine=engine,
+        manifest_path=str(manifest_path.resolve()),
+        summary=summary,
+        checks=checks,
+        preflight_would_pass=True,
+        excluded_checks=list(MANIFEST_EXCLUDED_CHECKS),
+        warnings=[],
+        verification={"engine_executed": False},
+    )
+
+
+def handle_manifest(args: argparse.Namespace) -> dict[str, Any]:
+    languages = (
+        parse_languages(args.languages, field="manifest languages") if args.languages else None
+    )
+    if args.mode == "check":
+        if not args.model_manifest:
+            raise ToolError("bad_input", "manifest --mode check requires --model-manifest")
+        return manifest_check(Path(args.model_manifest), args.engine, languages)
+    if not args.output:
+        raise ToolError("bad_input", "manifest --mode derive requires --output")
+    output = Path(args.output)
+    require_extension(output, ".json", "Derived manifest output")
+    artifacts_by_role = parse_artifact_arguments(args.artifact)
+    manifest, warnings, reasons = derive_manifest(
+        args.engine,
+        languages,
+        artifacts_by_role,
+        tessdata_dir=args.tessdata_dir,
+        assume_source=args.assume_source,
+        accept_license=args.accept_license,
+        confirm_eligibility=args.confirm_eligibility,
+    )
+    write_json_atomic(output, manifest, overwrite=args.overwrite)
+    return success(
+        "manifest",
+        mode="derive",
+        engine=args.engine,
+        output_path=str(output.resolve()),
+        artifacts=[
+            {
+                "role": entry["role"],
+                "path": entry["path"],
+                "size_bytes": entry["size_bytes"],
+                "sha256": entry["sha256"],
+                "provenance": entry.get("provenance"),
+            }
+            for entry in manifest["artifacts"]
+        ],
+        ready_for_preflight=not reasons,
+        reasons_not_ready=reasons,
+        license_summary=surya_license_summary() if args.engine == "surya" else None,
+        warnings=warnings,
+        verification={"engine_executed": False, "manifest_reopened": True},
+    )
 
 
 def check_engine_preflight(
@@ -2931,6 +5954,54 @@ def check_engine_preflight(
     return manifest, roles, executable
 
 
+@dataclass
+class RenderBudget:
+    """Shared pixel accounting for every rasterization path."""
+
+    total_message: str = f"Render total exceeds {MAX_TOTAL_RENDER_PIXELS} pixels"
+    total_pixels: int = 0
+
+    def charge(
+        self,
+        width_points: float,
+        height_points: float,
+        dpi: int,
+        *,
+        page_label: str,
+    ) -> tuple[int, int]:
+        pixel_width = math.ceil(width_points * dpi / 72)
+        pixel_height = math.ceil(height_points * dpi / 72)
+        pixels = pixel_width * pixel_height
+        if pixels > MAX_PIXELS_PER_RENDER:
+            raise ToolError(
+                "resource_limit",
+                f"{page_label} render exceeds {MAX_PIXELS_PER_RENDER} pixels",
+            )
+        self.total_pixels += pixels
+        if self.total_pixels > MAX_TOTAL_RENDER_PIXELS:
+            raise ToolError("resource_limit", self.total_message)
+        return pixel_width, pixel_height
+
+
+def rasterize_region(
+    plumber_page: Any,
+    bbox: tuple[float, float, float, float] | None,
+    dpi: int,
+    destination: Path,
+    *,
+    page_label: str,
+) -> None:
+    crop = plumber_page.crop(bbox) if bbox else plumber_page
+    try:
+        rendered = crop.to_image(resolution=dpi, antialias=True)
+        rendered.save(str(destination), format="PNG")
+    except Exception as exc:
+        raise ToolError(
+            "validation_failed",
+            f"Cannot render {page_label}: {clean_text(exc)}",
+        ) from exc
+
+
 def render_regions_for_ocr(
     source_path: Path,
     password: str | None,
@@ -2950,7 +6021,9 @@ def render_regions_for_ocr(
     )
     render_jobs = []
     warnings = list(data["warnings"])
-    total_pixels = 0
+    budget = RenderBudget(
+        total_message=f"OCR render total exceeds {MAX_TOTAL_RENDER_PIXELS} pixels"
+    )
     with pdfplumber.open(str(source_path), password=password) as plumber_pdf:
         for page_data in data["pages"]:
             page_number = page_data["page"]
@@ -2985,41 +6058,44 @@ def render_regions_for_ocr(
                 crop = page.crop(bbox) if bbox else page
                 width_points = float(crop.width)
                 height_points = float(crop.height)
-                pixels = math.ceil(width_points * dpi / 72) * math.ceil(height_points * dpi / 72)
-                total_pixels += pixels
-                if pixels > MAX_PIXELS_PER_RENDER:
-                    raise ToolError(
-                        "resource_limit",
-                        f"Page {page_number} render exceeds {MAX_PIXELS_PER_RENDER} pixels",
-                    )
-                if total_pixels > MAX_TOTAL_RENDER_PIXELS:
-                    raise ToolError(
-                        "resource_limit",
-                        f"OCR render total exceeds {MAX_TOTAL_RENDER_PIXELS} pixels",
-                    )
+                pixel_width, pixel_height = budget.charge(
+                    width_points,
+                    height_points,
+                    dpi,
+                    page_label=f"Page {page_number}",
+                )
                 image_path = work_dir / f"page-{page_number:04d}-region-{region_index:04d}.png"
-                try:
-                    rendered = crop.to_image(resolution=dpi, antialias=True)
-                    rendered.save(str(image_path), format="PNG")
-                except Exception as exc:
-                    raise ToolError(
-                        "validation_failed",
-                        f"Cannot render page {page_number}: {clean_text(exc)}",
-                    ) from exc
+                rasterize_region(
+                    page,
+                    bbox,
+                    dpi,
+                    image_path,
+                    page_label=f"page {page_number}",
+                )
                 render_jobs.append(
                     {
                         "source_page": page_number,
                         "region": list(bbox) if bbox else None,
                         "image_path": image_path,
                         "dpi": dpi,
-                        "pixel_width": math.ceil(width_points * dpi / 72),
-                        "pixel_height": math.ceil(height_points * dpi / 72),
+                        "pixel_width": pixel_width,
+                        "pixel_height": pixel_height,
                         "classification": classification,
+                        "page_geometry": page_data["geometry"],
                     }
                 )
     if not render_jobs:
         raise ToolError("unsupported_operation", "No selected page or image region needs OCR")
     return render_jobs, warnings
+
+
+def sidecar_page_geometry(job: dict[str, Any]) -> dict[str, Any]:
+    geometry = job["page_geometry"]
+    return {
+        "width_points": geometry["width"],
+        "height_points": geometry["height"],
+        "rotation": geometry["rotation"],
+    }
 
 
 def run_process(
@@ -3160,6 +6236,23 @@ def bbox_to_polygon(box: list[float] | None) -> list[list[float]] | None:
     return [[x0, y0], [x1, y0], [x1, y1], [x0, y1]]
 
 
+def coerce_engine_error(value: Any) -> str | None:
+    """Normalize an engine-supplied block/page error flag.
+
+    Surya reports a healthy block as ``"error": false`` and an error as a message string;
+    older schema versions used null. Coerce the boolean form (false -> no error, true ->
+    an unlabeled error marker) and stringify any other unexpected type rather than failing
+    a whole run over a benign flag type.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return "error" if value else None
+    if isinstance(value, str):
+        return value or None
+    return clean_text(value)
+
+
 def tesseract_blocks(tsv_path: Path) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     required_fields = {
         "page_num",
@@ -3270,6 +6363,21 @@ def tesseract_blocks(tsv_path: Path) -> tuple[list[dict[str, Any]], dict[str, An
         confidences = [row["confidence"] for row in line_rows if row["confidence"] >= 0]
         confidence = sum(confidences) / len(confidences) / 100 if confidences else None
         box = [float(x0), float(y0), float(x1), float(y1)]
+        words = [
+            {
+                "text": row["text"],
+                "bbox": [
+                    float(row["left"]),
+                    float(row["top"]),
+                    float(row["left"] + row["width"]),
+                    float(row["top"] + row["height"]),
+                ],
+                "confidence": (
+                    round(row["confidence"] / 100, 6) if row["confidence"] >= 0 else None
+                ),
+            }
+            for row in line_rows
+        ]
         blocks.append(
             {
                 "order": order,
@@ -3278,6 +6386,7 @@ def tesseract_blocks(tsv_path: Path) -> tuple[list[dict[str, Any]], dict[str, An
                 "bbox": box,
                 "polygon": bbox_to_polygon(box),
                 "confidence": round(confidence, 6) if confidence is not None else None,
+                "words": words,
             }
         )
     return blocks, {"tsv_rows": len(parsed_rows)}
@@ -3337,6 +6446,7 @@ def run_tesseract(
                 "source_page": job["source_page"],
                 "source_region": job["region"],
                 "classification": job["classification"],
+                "page_geometry": sidecar_page_geometry(job),
                 "coordinate_space": {
                     "unit": "rendered_pixel",
                     "dpi": job["dpi"],
@@ -3452,16 +6562,8 @@ def run_surya(
                     )
                 skipped = block.get("skipped")
                 if skipped is not None and not isinstance(skipped, bool):
-                    raise ToolError(
-                        "engine_failed",
-                        f"Surya block {order} skipped for {stem} must be boolean or null",
-                    )
-                block_error = block.get("error")
-                if block_error is not None and not isinstance(block_error, str):
-                    raise ToolError(
-                        "engine_failed",
-                        f"Surya block {order} error for {stem} must be a string or null",
-                    )
+                    skipped = bool(skipped)
+                block_error = coerce_engine_error(block.get("error"))
                 blocks.append(
                     {
                         "order": reading_order,
@@ -3497,17 +6599,13 @@ def run_surya(
                 height=job["pixel_height"],
                 engine="Surya",
             )
-            page_error = raw_page.get("error")
-            if page_error is not None and not isinstance(page_error, str):
-                raise ToolError(
-                    "engine_failed",
-                    f"Surya page error for {stem} must be a string or null",
-                )
+            page_error = coerce_engine_error(raw_page.get("error"))
             pages.append(
                 {
                     "source_page": job["source_page"],
                     "source_region": job["region"],
                     "classification": job["classification"],
+                    "page_geometry": sidecar_page_geometry(job),
                     "coordinate_space": {
                         "unit": "rendered_pixel",
                         "dpi": job["dpi"],
@@ -3789,6 +6887,7 @@ def run_paddle(
                 "source_page": job["source_page"],
                 "source_region": job["region"],
                 "classification": job["classification"],
+                "page_geometry": sidecar_page_geometry(job),
                 "coordinate_space": {
                     "unit": "rendered_pixel",
                     "dpi": job["dpi"],
@@ -4074,6 +7173,670 @@ def handle_ocr(args: argparse.Namespace) -> dict[str, Any]:
     )
 
 
+def displayed_page_size(reader_page: Any) -> tuple[float, float]:
+    box = reader_page.mediabox
+    width = float(box.width)
+    height = float(box.height)
+    rotation = int(reader_page.rotation or 0) % 360
+    if rotation in {90, 270}:
+        return height, width
+    return width, height
+
+
+def displayed_to_user_transformation(rotation: int, mediabox: Any) -> Transformation:
+    """Map displayed-orientation coordinates back into raw page user space."""
+    origin_x = float(mediabox.left)
+    origin_y = float(mediabox.bottom)
+    width = float(mediabox.width)
+    height = float(mediabox.height)
+    if rotation == 90:
+        return Transformation().rotate(90).translate(tx=origin_x + width, ty=origin_y)
+    if rotation == 180:
+        return Transformation().rotate(180).translate(tx=origin_x + width, ty=origin_y + height)
+    if rotation == 270:
+        return Transformation().rotate(270).translate(tx=origin_x, ty=origin_y + height)
+    return Transformation().translate(tx=origin_x, ty=origin_y)
+
+
+def pixel_bbox_to_displayed(
+    bbox: Sequence[float],
+    dpi: float,
+    region: Sequence[float] | None,
+) -> tuple[float, float, float, float]:
+    scale = 72.0 / dpi
+    offset_x = float(region[0]) if region else 0.0
+    offset_top = float(region[1]) if region else 0.0
+    return (
+        float(bbox[0]) * scale + offset_x,
+        float(bbox[1]) * scale + offset_top,
+        float(bbox[2]) * scale + offset_x,
+        float(bbox[3]) * scale + offset_top,
+    )
+
+
+def image_diff_fraction(first: Path, second: Path, *, channel_tolerance: int = 8) -> float:
+    with Image.open(first) as image_a, Image.open(second) as image_b:
+        composite_a = image_a.convert("RGB")
+        composite_b = image_b.convert("RGB")
+        if composite_a.size != composite_b.size:
+            return 1.0
+        difference = ImageChops.difference(composite_a, composite_b).convert("L")
+        histogram = difference.histogram()
+        total = composite_a.size[0] * composite_a.size[1]
+        if not total:
+            return 0.0
+        return sum(histogram[channel_tolerance + 1 :]) / total
+
+
+def load_compose_sidecar(sidecar_path: Path, source_path: Path) -> dict[str, Any]:
+    sidecar = read_json(sidecar_path)
+    if sidecar.get("operation") != "ocr":
+        raise ToolError("bad_input", "Compose sidecar operation must be 'ocr'")
+    source_info = sidecar.get("source")
+    if not isinstance(source_info, dict):
+        raise ToolError("bad_input", "Compose sidecar requires a source object")
+    recorded_hash = str(source_info.get("sha256", "")).lower()
+    if not re.fullmatch(r"[0-9a-f]{64}", recorded_hash):
+        raise ToolError("bad_input", "Compose sidecar source sha256 is malformed")
+    actual_hash = sha256_file(source_path)
+    if actual_hash != recorded_hash:
+        raise ToolError(
+            "bad_input",
+            "Compose sidecar was produced from a different PDF (source sha256 mismatch)",
+            details={"expected_sha256": recorded_hash, "actual_sha256": actual_hash},
+        )
+    pages = sidecar.get("pages")
+    if not isinstance(pages, list) or not pages:
+        raise ToolError("bad_input", "Compose sidecar requires a nonempty pages array")
+    return sidecar
+
+
+def validate_sidecar_page(entry: Any, page_count: int) -> tuple[int, float, list[float] | None]:
+    if not isinstance(entry, dict):
+        raise ToolError("bad_input", "Every compose sidecar page must be an object")
+    source_page = finite_integer(
+        entry.get("source_page"), "Sidecar source_page", minimum=1, maximum=page_count
+    )
+    coordinate_space = entry.get("coordinate_space")
+    if not isinstance(coordinate_space, dict) or coordinate_space.get("unit") != "rendered_pixel":
+        raise ToolError(
+            "bad_input",
+            f"Sidecar page {source_page} requires a rendered_pixel coordinate space",
+        )
+    dpi = finite_number(
+        coordinate_space.get("dpi"),
+        f"Sidecar page {source_page} dpi",
+        minimum=72,
+        maximum=600,
+    )
+    region_value = entry.get("source_region")
+    region: list[float] | None = None
+    if region_value is not None:
+        if not isinstance(region_value, (list, tuple)) or len(region_value) != 4:
+            raise ToolError(
+                "bad_input",
+                f"Sidecar page {source_page} source_region must have four coordinates",
+            )
+        region = [
+            finite_number(
+                value,
+                f"Sidecar page {source_page} source_region[{index}]",
+                minimum=0,
+            )
+            for index, value in enumerate(region_value)
+        ]
+        if region[2] <= region[0] or region[3] <= region[1]:
+            raise ToolError(
+                "bad_input",
+                f"Sidecar page {source_page} source_region has impossible ordering",
+            )
+    return source_page, dpi, region
+
+
+def prepare_compose_font(font_path_value: str | None) -> dict[str, Any]:
+    if not font_path_value:
+        return {
+            "name": "Helvetica",
+            "embedded": False,
+            "path": None,
+            "sha256": None,
+            "coverage": None,
+        }
+    path = Path(font_path_value).expanduser()
+    require_regular_file(path)
+    if path.suffix.lower() not in {".ttf", ".otf"}:
+        raise ToolError("bad_input", "Compose font must be a .ttf or .otf file")
+    font_name = f"ComposeFont-{path.stem}"
+    try:
+        font = TTFont(font_name, str(path))
+        pdfmetrics.registerFont(font)
+    except Exception as exc:
+        raise ToolError("bad_input", f"Cannot register compose font: {clean_text(exc)}") from exc
+    coverage = None
+    char_map = getattr(getattr(font, "face", None), "charToGlyph", None)
+    if isinstance(char_map, dict) and char_map:
+        coverage = set(char_map)
+    return {
+        "name": font_name,
+        "embedded": True,
+        "path": str(path.resolve()),
+        "sha256": sha256_file(path),
+        "coverage": coverage,
+    }
+
+
+def unmappable_compose_characters(text: str, font: dict[str, Any]) -> list[str]:
+    unmappable: set[str] = set()
+    if font["coverage"] is not None:
+        for character in text:
+            if not character.isspace() and ord(character) not in font["coverage"]:
+                unmappable.add(character)
+    elif not font["embedded"]:
+        for character in text:
+            try:
+                character.encode("cp1252")
+            except UnicodeEncodeError:
+                unmappable.add(character)
+    return sorted(unmappable)
+
+
+def handle_ocr_compose(args: argparse.Namespace) -> dict[str, Any]:
+    password = resolve_password(args.password, args.password_env)
+    source_path = Path(args.input)
+    require_extension(source_path, ".pdf", "Compose input")
+    output = Path(args.output)
+    require_extension(output, ".pdf", "Compose output")
+    sidecar_path = Path(args.sidecar)
+    sidecar = load_compose_sidecar(sidecar_path, source_path)
+    source = open_pdf(source_path, password)
+    if source.reader.is_encrypted and not args.allow_decrypted_output:
+        raise ToolError(
+            "unsupported_operation",
+            "Composing an encrypted source produces a decrypted output; pass "
+            "--allow-decrypted-output to authorize it",
+        )
+    page_count = len(source.reader.pages)
+    selected = set(parse_page_selection(args.pages, page_count))
+    font = prepare_compose_font(args.font)
+    warnings: list[str] = []
+    if font["embedded"]:
+        warnings.append(
+            "The declared compose font is embedded and subset into the output; the "
+            "operator is responsible for its embedding license."
+        )
+    if source.reader.is_encrypted:
+        warnings.append(
+            "Encrypted source was composed into an explicitly authorized decrypted "
+            "output; re-encrypt with edit if needed."
+        )
+    warnings.append(
+        "OCR text is probabilistic; the invisible text layer inherits recognition errors."
+    )
+    counts = {
+        "pages_total": page_count,
+        "pages_composed": 0,
+        "pages_skipped": 0,
+        "blocks_drawn": 0,
+        "words_drawn": 0,
+        "characters_dropped": 0,
+        "blocks_without_geometry": 0,
+    }
+    clamp_counts = {"font_size": 0, "horizontal_scale": 0, "page_bounds": 0}
+    page_reports: list[dict[str, Any]] = []
+    composed_records: dict[int, dict[str, Any]] = {}
+    unmappable_report: list[dict[str, Any]] = []
+    writer = PdfWriter()
+    writer.clone_document_from_reader(source.reader)
+    seen_entries: set[tuple[int, tuple[float, ...] | None]] = set()
+    for entry in sidecar["pages"]:
+        source_page, sidecar_dpi, region = validate_sidecar_page(entry, page_count)
+        page_index = source_page - 1
+        if page_index not in selected:
+            continue
+        entry_key = (source_page, tuple(region) if region else None)
+        if entry_key in seen_entries:
+            warnings.append(f"Duplicate sidecar entry for page {source_page} was skipped.")
+            continue
+        seen_entries.add(entry_key)
+        classification = entry.get("classification")
+        if classification == "digital-text" or (classification == "hybrid" and region is None):
+            if not args.allow_duplicate_text:
+                warnings.append(
+                    f"Page {source_page} skipped: composing {classification} content "
+                    "would duplicate extractable text; pass --allow-duplicate-text to "
+                    "include it."
+                )
+                counts["pages_skipped"] += 1
+                page_reports.append(
+                    {
+                        "page": source_page,
+                        "blocks_drawn": 0,
+                        "mean_confidence": None,
+                        "skipped_reason": "duplicate-digital-text",
+                    }
+                )
+                continue
+        blocks = entry.get("blocks")
+        if not isinstance(blocks, list):
+            raise ToolError("bad_input", f"Sidecar page {source_page} blocks must be an array")
+        reader_page = source.reader.pages[page_index]
+        displayed_width, displayed_height = displayed_page_size(reader_page)
+        rotation = int(reader_page.rotation or 0) % 360
+        drawable_units: list[dict[str, Any]] = []
+        confidences: list[float] = []
+        for block in blocks:
+            if not isinstance(block, dict):
+                raise ToolError("bad_input", f"Sidecar page {source_page} blocks must be objects")
+            confidence = block.get("confidence")
+            if confidence is not None:
+                confidence = finite_number(
+                    confidence,
+                    f"Sidecar page {source_page} block confidence",
+                    minimum=0,
+                    maximum=1,
+                )
+                confidences.append(confidence)
+                if confidence < args.min_confidence:
+                    continue
+            block_text = block.get("text")
+            if not isinstance(block_text, str) or not block_text.strip():
+                continue
+            words = block.get("words")
+            units: list[dict[str, Any]]
+            if isinstance(words, list) and words:
+                units = []
+                for word in words:
+                    if not isinstance(word, dict):
+                        raise ToolError(
+                            "bad_input",
+                            f"Sidecar page {source_page} words must be objects",
+                        )
+                    units.append(
+                        {
+                            "text": word.get("text"),
+                            "bbox": word.get("bbox"),
+                            "kind": "word",
+                        }
+                    )
+            else:
+                units = [{"text": block_text, "bbox": block.get("bbox"), "kind": "block"}]
+            block_units = []
+            for unit in units:
+                unit_text = unit["text"]
+                bbox = unit["bbox"]
+                if not isinstance(unit_text, str) or not unit_text.strip():
+                    continue
+                if bbox is None:
+                    counts["blocks_without_geometry"] += 1
+                    continue
+                if not isinstance(bbox, (list, tuple)) or len(bbox) != 4:
+                    raise ToolError(
+                        "bad_input",
+                        f"Sidecar page {source_page} unit bbox must have four coordinates",
+                    )
+                normalized_bbox = [
+                    finite_number(
+                        value,
+                        f"Sidecar page {source_page} unit bbox[{index}]",
+                        minimum=0,
+                    )
+                    for index, value in enumerate(bbox)
+                ]
+                if normalized_bbox[2] <= normalized_bbox[0]:
+                    continue
+                if normalized_bbox[3] <= normalized_bbox[1]:
+                    continue
+                unmappable = unmappable_compose_characters(unit_text, font)
+                if unmappable:
+                    if args.on_unmappable == "fail":
+                        unmappable_report.append(
+                            {
+                                "page": source_page,
+                                "sample_characters": unmappable[:8],
+                            }
+                        )
+                        continue
+                    counts["characters_dropped"] += len(unit_text)
+                    continue
+                block_units.append(
+                    {
+                        "text": unit_text.strip(),
+                        "bbox": normalized_bbox,
+                        "kind": unit["kind"],
+                        "confidence": confidence,
+                    }
+                )
+            if block_units:
+                counts["blocks_drawn"] += 1
+                drawable_units.extend(
+                    {**unit, "dpi": sidecar_dpi, "region": region} for unit in block_units
+                )
+        if args.on_unmappable == "fail" and unmappable_report:
+            continue
+        if not drawable_units:
+            warnings.append(f"Page {source_page} skipped: no OCR blocks to compose.")
+            counts["pages_skipped"] += 1
+            page_reports.append(
+                {
+                    "page": source_page,
+                    "blocks_drawn": 0,
+                    "mean_confidence": (
+                        round(sum(confidences) / len(confidences), 6) if confidences else None
+                    ),
+                    "skipped_reason": "no-blocks",
+                }
+            )
+            continue
+        buffer = io.BytesIO()
+        overlay = canvas.Canvas(
+            buffer, pagesize=(displayed_width, displayed_height), pageCompression=1
+        )
+        record = composed_records.setdefault(
+            source_page,
+            {
+                "page": source_page,
+                "anchors": [],
+                "drawn_units": [],
+                "spot_anchor": None,
+                "units_drawn": 0,
+                "blocks_drawn": 0,
+            },
+        )
+        for unit in drawable_units:
+            x0, top, x1, bottom = pixel_bbox_to_displayed(unit["bbox"], unit["dpi"], unit["region"])
+            clamped_x0 = min(max(x0, 0.0), displayed_width)
+            clamped_x1 = min(max(x1, 0.0), displayed_width)
+            clamped_top = min(max(top, 0.0), displayed_height)
+            clamped_bottom = min(max(bottom, 0.0), displayed_height)
+            if (
+                clamped_x0 != x0
+                or clamped_x1 != x1
+                or clamped_top != top
+                or clamped_bottom != bottom
+            ):
+                clamp_counts["page_bounds"] += 1
+            if clamped_x1 <= clamped_x0 or clamped_bottom <= clamped_top:
+                continue
+            box_height = clamped_bottom - clamped_top
+            box_width = clamped_x1 - clamped_x0
+            font_size = min(max(box_height, 1.0), 144.0)
+            if font_size != box_height:
+                clamp_counts["font_size"] += 1
+            descent = pdfmetrics.getDescent(font["name"]) / 1000.0 * font_size
+            baseline = displayed_height - clamped_bottom - descent
+            try:
+                natural_width = stringWidth(unit["text"], font["name"], font_size)
+            except Exception as exc:
+                raise ToolError(
+                    "bad_input",
+                    f"Cannot measure compose text width: {clean_text(exc)}",
+                ) from exc
+            horizontal_scale = 100.0
+            if natural_width > 0 and box_width > 0:
+                horizontal_scale = 100.0 * box_width / natural_width
+                clamped_scale = min(max(horizontal_scale, 10.0), 1000.0)
+                if clamped_scale != horizontal_scale:
+                    clamp_counts["horizontal_scale"] += 1
+                horizontal_scale = clamped_scale
+            text_object = overlay.beginText()
+            text_object.setTextRenderMode(3)
+            text_object.setFont(font["name"], font_size)
+            text_object.setTextOrigin(clamped_x0, baseline)
+            text_object.setHorizScale(horizontal_scale)
+            text_object.textOut(unit["text"])
+            overlay.drawText(text_object)
+            record["units_drawn"] += 1
+            record["drawn_units"].append(unit)
+            if unit["kind"] == "word":
+                counts["words_drawn"] += 1
+            alphanumeric = re.sub(r"[^0-9A-Za-z]", "", unit["text"])
+            if (
+                record["spot_anchor"] is None
+                and unit["kind"] == "word"
+                and " " not in unit["text"]
+                and len(alphanumeric) >= 4
+            ):
+                record["spot_anchor"] = {
+                    "text": unit["text"],
+                    "x0": clamped_x0,
+                    "top": clamped_top,
+                }
+        overlay.showPage()
+        overlay.save()
+        buffer.seek(0)
+        overlay_reader = PdfReader(buffer)
+        transformation = displayed_to_user_transformation(rotation, reader_page.mediabox)
+        writer.pages[page_index].merge_transformed_page(
+            overlay_reader.pages[0], transformation, over=True
+        )
+        drawn_candidates = sorted(
+            (
+                unit
+                for unit in record["drawn_units"]
+                if len(re.sub(r"[^0-9A-Za-z]", "", unit["text"])) >= 4
+            ),
+            key=lambda unit: -(unit["confidence"] or 0.0),
+        )
+        record["anchors"] = [{"text": unit["text"]} for unit in drawn_candidates[:5]]
+        record["mean_confidence"] = (
+            round(sum(confidences) / len(confidences), 6) if confidences else None
+        )
+    if unmappable_report:
+        raise ToolError(
+            "unsupported_operation",
+            "Sidecar text contains characters the compose font cannot map; supply "
+            "--font with coverage or use --on-unmappable skip-block",
+            details={"unmappable": unmappable_report[:20]},
+        )
+    if not composed_records:
+        raise ToolError(
+            "unsupported_operation",
+            "No sidecar page produced drawable OCR text for composition",
+        )
+    for record in composed_records.values():
+        counts["pages_composed"] += 1
+        page_reports.append(
+            {
+                "page": record["page"],
+                "blocks_drawn": record["units_drawn"],
+                "mean_confidence": record.get("mean_confidence"),
+                "skipped_reason": None,
+            }
+        )
+    page_reports.sort(key=lambda item: item["page"])
+    if clamp_counts["font_size"]:
+        warnings.append(
+            f"{clamp_counts['font_size']} composed units clamped font size into 1-144 pt."
+        )
+    if clamp_counts["horizontal_scale"]:
+        warnings.append(
+            f"{clamp_counts['horizontal_scale']} composed units clamped horizontal "
+            "scale into 10-1000%."
+        )
+    if clamp_counts["page_bounds"]:
+        warnings.append(
+            f"{clamp_counts['page_bounds']} composed units were clamped to the page bounds."
+        )
+    if counts["blocks_without_geometry"]:
+        warnings.append(
+            f"{counts['blocks_without_geometry']} OCR units had no geometry and were not composed."
+        )
+    check_destination(output, sources=[source_path, sidecar_path], overwrite=args.overwrite)
+    anchors_checked = 0
+    anchors_found = 0
+    max_spot_delta = 0.0
+    visual_diff_summary: dict[str, Any] = {"checked": False}
+    with temporary_sibling(output, ".pdf") as temp_path:
+        with temp_path.open("wb") as handle:
+            writer.write(handle)
+        verification = validate_pdf_output(temp_path, expected_pages=page_count)
+        output_reader = PdfReader(str(temp_path), strict=True)
+        for index in range(page_count):
+            source_box = source.reader.pages[index].mediabox
+            output_box = output_reader.pages[index].mediabox
+            if (
+                abs(float(output_box.width) - float(source_box.width)) > 0.01
+                or abs(float(output_box.height) - float(source_box.height)) > 0.01
+                or (int(output_reader.pages[index].rotation or 0) % 360)
+                != (int(source.reader.pages[index].rotation or 0) % 360)
+            ):
+                raise ToolError(
+                    "validation_failed",
+                    f"Page {index + 1} geometry changed during composition",
+                )
+        missing_anchors: list[dict[str, Any]] = []
+        with pdfplumber.open(str(temp_path)) as plumber_output:
+            for record in composed_records.values():
+                page = plumber_output.pages[record["page"] - 1]
+                try:
+                    page_text = page.extract_text() or ""
+                except Exception:
+                    page_text = ""
+                normalized_page = re.sub(r"\s+", "", page_text).casefold()
+                for anchor in record["anchors"]:
+                    anchors_checked += 1
+                    normalized_anchor = re.sub(r"\s+", "", anchor["text"]).casefold()
+                    if normalized_anchor and normalized_anchor in normalized_page:
+                        anchors_found += 1
+                    else:
+                        missing_anchors.append(
+                            {"page": record["page"], "anchor": anchor["text"][:80]}
+                        )
+                spot = record.get("spot_anchor")
+                if spot:
+                    try:
+                        words = page.extract_words()
+                    except Exception:
+                        words = []
+                    matches = [
+                        word
+                        for word in words
+                        if str(word.get("text", "")).strip().casefold()
+                        == spot["text"].strip().casefold()
+                    ]
+                    if matches:
+                        best = min(
+                            matches,
+                            key=lambda word: (
+                                abs(float(word["x0"]) - spot["x0"])
+                                + abs(float(word["top"]) - spot["top"])
+                            ),
+                        )
+                        delta = max(
+                            abs(float(best["x0"]) - spot["x0"]),
+                            abs(float(best["top"]) - spot["top"]),
+                        )
+                        max_spot_delta = max(max_spot_delta, delta)
+                        if delta > 3.0:
+                            raise ToolError(
+                                "validation_failed",
+                                f"Composed text geometry deviates by {delta:.2f} points "
+                                f"on page {record['page']}",
+                            )
+                    else:
+                        warnings.append(
+                            f"Page {record['page']} geometry spot-check anchor was not "
+                            "extractable as a standalone word; the containment check "
+                            "still applies."
+                        )
+        if missing_anchors:
+            raise ToolError(
+                "validation_failed",
+                "Composed OCR text is not extractable from the output",
+                details={"missing_anchors": missing_anchors[:10]},
+            )
+        if not args.skip_visual_check:
+            max_fraction = 0.0
+            visual_budget = RenderBudget(
+                total_message=(
+                    "Compose visual check exceeds the render pixel budget; lower "
+                    "--visual-check-dpi, select fewer pages, or pass --skip-visual-check"
+                )
+            )
+            with tempfile.TemporaryDirectory(prefix="pdf-compose-check-") as check_name:
+                check_dir = Path(check_name)
+                with (
+                    pdfplumber.open(str(source_path), password=password) as before_pdf,
+                    pdfplumber.open(str(temp_path)) as after_pdf,
+                ):
+                    for record in sorted(composed_records):
+                        page_number = record
+                        before_page = before_pdf.pages[page_number - 1]
+                        after_page = after_pdf.pages[page_number - 1]
+                        for _ in range(2):
+                            visual_budget.charge(
+                                float(before_page.width),
+                                float(before_page.height),
+                                args.visual_check_dpi,
+                                page_label=f"Page {page_number}",
+                            )
+                        before_png = check_dir / f"before-{page_number:04d}.png"
+                        after_png = check_dir / f"after-{page_number:04d}.png"
+                        rasterize_region(
+                            before_page,
+                            None,
+                            args.visual_check_dpi,
+                            before_png,
+                            page_label=f"page {page_number}",
+                        )
+                        rasterize_region(
+                            after_page,
+                            None,
+                            args.visual_check_dpi,
+                            after_png,
+                            page_label=f"page {page_number}",
+                        )
+                        fraction = image_diff_fraction(before_png, after_png)
+                        max_fraction = max(max_fraction, fraction)
+                        if fraction > args.max_visual_diff:
+                            raise ToolError(
+                                "validation_failed",
+                                f"Invisible text layer visibly changed page "
+                                f"{page_number} (diff fraction {fraction:.6f} exceeds "
+                                f"{args.max_visual_diff})",
+                            )
+            visual_diff_summary = {
+                "checked": True,
+                "dpi": args.visual_check_dpi,
+                "max_fraction_changed": round(max_fraction, 6),
+                "threshold": args.max_visual_diff,
+            }
+        atomic_publish(temp_path, output)
+    low_confidence_pages = [
+        report["page"]
+        for report in page_reports
+        if report["skipped_reason"] is None
+        and report["mean_confidence"] is not None
+        and report["mean_confidence"] < 0.5
+    ]
+    if low_confidence_pages:
+        warnings.append(f"Low engine-supplied confidence on composed pages: {low_confidence_pages}")
+    return success(
+        "ocr-compose",
+        output_path=str(output.resolve()),
+        source=str(source_path.resolve()),
+        sidecar_path=str(sidecar_path.resolve()),
+        sidecar_source_sha256_matched=True,
+        font={
+            "name": font["name"],
+            "embedded": font["embedded"],
+            "path": font["path"],
+            "sha256": font["sha256"],
+        },
+        counts=counts,
+        pages=page_reports,
+        warnings=warnings,
+        verification={
+            **verification,
+            "page_count_unchanged": True,
+            "dimensions_unchanged": True,
+            "anchors": {"checked": anchors_checked, "found": anchors_found},
+            "geometry_spot_check_max_delta_points": round(max_spot_delta, 3),
+            "visual_diff": visual_diff_summary,
+        },
+    )
+
+
 def add_password_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--password", help="PDF password; never emitted")
     parser.add_argument(
@@ -4114,6 +7877,19 @@ def build_parser() -> argparse.ArgumentParser:
     add_extract_options(extract_parser)
     extract_parser.add_argument("--images-dir", help="Extract embedded images")
     extract_parser.set_defaults(handler=handle_inspect_or_extract)
+
+    render_parser = subparsers.add_parser(
+        "render", help="Rasterize pages to PNG files for visual review"
+    )
+    render_parser.add_argument("--input", required=True)
+    render_parser.add_argument(
+        "--output", required=True, help="New or empty directory for one PNG per page"
+    )
+    render_parser.add_argument("--pages", default="all", help="1-based list/ranges or all")
+    render_parser.add_argument("--dpi", type=int, default=DEFAULT_RENDER_DPI)
+    add_password_options(render_parser)
+    add_overwrite_option(render_parser)
+    render_parser.set_defaults(handler=handle_render)
 
     create_parser = subparsers.add_parser("create", help="Create a PDF from JSON")
     create_parser.add_argument("--job", required=True)
@@ -4187,12 +7963,78 @@ def build_parser() -> argparse.ArgumentParser:
     add_overwrite_option(ocr_parser)
     ocr_parser.set_defaults(handler=handle_ocr)
 
+    compose_parser = subparsers.add_parser(
+        "ocr-compose",
+        help="Compose a searchable PDF from a completed OCR sidecar without running an engine",
+    )
+    compose_parser.add_argument("--input", required=True)
+    compose_parser.add_argument("--sidecar", required=True, help="Completed OCR sidecar JSON")
+    compose_parser.add_argument("--output", required=True)
+    compose_parser.add_argument("--pages", default="all")
+    compose_parser.add_argument("--min-confidence", type=float, default=0.0)
+    compose_parser.add_argument(
+        "--font", help="TTF/OTF font for text the base-14 default cannot map"
+    )
+    compose_parser.add_argument("--on-unmappable", choices=("fail", "skip-block"), default="fail")
+    compose_parser.add_argument("--allow-duplicate-text", action="store_true")
+    compose_parser.add_argument("--max-visual-diff", type=float, default=0.002)
+    compose_parser.add_argument("--visual-check-dpi", type=int, default=DEFAULT_VISUAL_CHECK_DPI)
+    compose_parser.add_argument("--skip-visual-check", action="store_true")
+    compose_parser.add_argument("--allow-decrypted-output", action="store_true")
+    add_password_options(compose_parser)
+    add_overwrite_option(compose_parser)
+    compose_parser.set_defaults(handler=handle_ocr_compose)
+
+    manifest_parser = subparsers.add_parser(
+        "manifest", help="Derive or check an OCR model manifest without running any engine"
+    )
+    manifest_parser.add_argument("--mode", required=True, choices=("derive", "check"))
+    manifest_parser.add_argument(
+        "--engine", required=True, choices=("surya", "paddle", "tesseract")
+    )
+    manifest_parser.add_argument("--languages")
+    manifest_parser.add_argument("--tessdata-dir")
+    manifest_parser.add_argument("--assume-source", choices=("tessdata_fast", "tessdata_best"))
+    manifest_parser.add_argument(
+        "--artifact",
+        action="append",
+        default=[],
+        metavar="ROLE=PATH",
+        help="Provisioned local artifact for derive",
+    )
+    manifest_parser.add_argument("--accept-license", action="store_true")
+    manifest_parser.add_argument("--confirm-eligibility", action="store_true")
+    manifest_parser.add_argument("--model-manifest", help="Existing manifest for --mode check")
+    manifest_parser.add_argument("--output", help="Derived manifest destination (.json)")
+    add_overwrite_option(manifest_parser)
+    manifest_parser.set_defaults(handler=handle_manifest)
+
+    redact_parser = subparsers.add_parser(
+        "redact", help="Remove content under target regions; not a cosmetic overlay"
+    )
+    redact_parser.add_argument("--input", required=True)
+    redact_parser.add_argument("--job", required=True, help="Redaction job JSON")
+    redact_parser.add_argument("--output", required=True)
+    redact_parser.add_argument("--report", help="Optional full report destination (.json)")
+    redact_parser.add_argument(
+        "--render-check-dir",
+        help="Publish before/after verification rasters to this new directory",
+    )
+    add_overwrite_option(redact_parser)
+    redact_parser.set_defaults(handler=handle_redact)
+
     return parser
 
 
 def validate_cli_limits(args: argparse.Namespace) -> None:
     if hasattr(args, "dpi") and not 72 <= args.dpi <= 600:
         raise ToolError("bad_input", "DPI must be between 72 and 600")
+    if hasattr(args, "visual_check_dpi") and not 72 <= args.visual_check_dpi <= 600:
+        raise ToolError("bad_input", "Visual-check DPI must be between 72 and 600")
+    if hasattr(args, "min_confidence"):
+        finite_number(args.min_confidence, "Minimum confidence", minimum=0, maximum=1)
+    if hasattr(args, "max_visual_diff"):
+        finite_number(args.max_visual_diff, "Maximum visual diff", minimum=0, maximum=1)
     if hasattr(args, "timeout") and not 1 <= args.timeout <= 86_400:
         raise ToolError("bad_input", "Timeout must be between 1 and 86400 seconds")
     if hasattr(args, "low_confidence_threshold"):

--- a/kolega_code/_bundled_skills/skills/pdf/scripts/smoke_test.py
+++ b/kolega_code/_bundled_skills/skills/pdf/scripts/smoke_test.py
@@ -16,10 +16,19 @@ from pathlib import Path
 from typing import Any
 
 from PIL import Image, ImageDraw
-from pypdf import PdfReader
+from pypdf import PdfReader, PdfWriter
+from pypdf.generic import (
+    ArrayObject,
+    ContentStream,
+    DictionaryObject,
+    NameObject,
+    NumberObject,
+    StreamObject,
+)
 
 SCHEMA_VERSION = 1
 TOOL = Path(__file__).with_name("pdf_tool.py")
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
 
 class SmokeFailure(Exception):
@@ -786,6 +795,871 @@ def run_core(root: Path) -> dict[str, Any]:
     }
 
 
+def write_font_fixture(source_pdf: Path, out_pdf: Path, *, embedded: bool) -> None:
+    """Inject a synthetic /Font entry so the inventory has a deterministic subject."""
+    reader = PdfReader(str(source_pdf))
+    writer = PdfWriter()
+    writer.clone_document_from_reader(reader)
+    page = writer.pages[0]
+    base_name = "/ABCDEF+FakeSans" if embedded else "/FakeSans"
+    descriptor = DictionaryObject(
+        {
+            NameObject("/Type"): NameObject("/FontDescriptor"),
+            NameObject("/FontName"): NameObject(base_name),
+            NameObject("/Flags"): NumberObject(32),
+            NameObject("/ItalicAngle"): NumberObject(0),
+            NameObject("/Ascent"): NumberObject(800),
+            NameObject("/Descent"): NumberObject(-200),
+            NameObject("/CapHeight"): NumberObject(700),
+            NameObject("/StemV"): NumberObject(80),
+            NameObject("/FontBBox"): ArrayObject(
+                [NumberObject(0), NumberObject(-200), NumberObject(1000), NumberObject(800)]
+            ),
+        }
+    )
+    if embedded:
+        font_file = StreamObject()
+        font_file.set_data(b"\x00\x01\x00\x00fake-truetype-data")
+        descriptor[NameObject("/FontFile2")] = writer._add_object(font_file)
+    font = DictionaryObject(
+        {
+            NameObject("/Type"): NameObject("/Font"),
+            NameObject("/Subtype"): NameObject("/TrueType"),
+            NameObject("/BaseFont"): NameObject(base_name),
+            NameObject("/FirstChar"): NumberObject(32),
+            NameObject("/LastChar"): NumberObject(32),
+            NameObject("/Widths"): ArrayObject([NumberObject(500)]),
+            NameObject("/FontDescriptor"): writer._add_object(descriptor),
+            NameObject("/Encoding"): NameObject("/WinAnsiEncoding"),
+        }
+    )
+    resources = page["/Resources"].get_object()
+    fonts = resources.get("/Font")
+    if fonts is None:
+        fonts = DictionaryObject()
+        resources[NameObject("/Font")] = fonts
+    else:
+        fonts = fonts.get_object()
+    fonts[NameObject("/FZZ1")] = writer._add_object(font)
+    with out_pdf.open("wb") as handle:
+        writer.write(handle)
+
+
+def run_render_and_fonts(root: Path) -> dict[str, Any]:
+    base = root / "render-fonts"
+    base.mkdir()
+    fixture = base / "fixture.pdf"
+    job = base / "job.json"
+    write_json(
+        job,
+        {
+            "schema_version": 1,
+            "page_size": "letter",
+            "pages": [
+                {
+                    "elements": [
+                        {
+                            "type": "text",
+                            "text": "RENDER FIXTURE PAGE ONE",
+                            "x": 72,
+                            "y": 90,
+                            "font_size": 16,
+                        }
+                    ]
+                },
+                {
+                    "elements": [
+                        {
+                            "type": "text",
+                            "text": "RENDER FIXTURE PAGE TWO",
+                            "x": 72,
+                            "y": 90,
+                            "font_size": 16,
+                        }
+                    ]
+                },
+            ],
+        },
+    )
+    run_tool(["create", "--job", str(job), "--output", str(fixture)])
+
+    inspect_result = run_tool(["inspect", "--input", str(fixture)])
+    document = inspect_result["result"]
+    fonts = document.get("fonts")
+    if not fonts or fonts.get("scope") != "document":
+        raise SmokeFailure(f"Inspect omitted the document font inventory: {fonts}")
+    helvetica = [entry for entry in fonts["entries"] if entry["name"] == "Helvetica"]
+    if not helvetica or helvetica[0]["embedded"] or not helvetica[0]["base14"]:
+        raise SmokeFailure(f"Helvetica inventory entry is wrong: {fonts['entries']}")
+    if helvetica[0]["subtype"] != "Type1":
+        raise SmokeFailure(f"Helvetica subtype changed: {helvetica}")
+    if any(w.startswith("RELEASE BLOCKER") for w in document["warnings"]):
+        raise SmokeFailure("Base-14-only fixture raised a release blocker")
+    if not any(w.startswith("Non-embedded standard fonts") for w in document["warnings"]):
+        raise SmokeFailure("Base-14 informational font warning is missing")
+    extract_result = run_tool(["extract", "--input", str(fixture), "--pages", "1"])
+    if "fonts" not in extract_result["result"]:
+        raise SmokeFailure("Extract result omitted the font inventory")
+
+    unembedded_pdf = base / "unembedded.pdf"
+    write_font_fixture(fixture, unembedded_pdf, embedded=False)
+    unembedded = run_tool(["inspect", "--input", str(unembedded_pdf)])["result"]
+    if unembedded["fonts"]["unembedded_non_base14"] != ["FakeSans"]:
+        raise SmokeFailure(f"FakeSans was not flagged: {unembedded['fonts']}")
+    blockers = [
+        w
+        for w in unembedded["warnings"]
+        if w.startswith("RELEASE BLOCKER: non-embedded fonts outside the standard base-14 set")
+    ]
+    if len(blockers) != 1 or "FakeSans" not in blockers[0]:
+        raise SmokeFailure(f"Release blocker warning is wrong: {unembedded['warnings']}")
+
+    embedded_pdf = base / "embedded.pdf"
+    write_font_fixture(fixture, embedded_pdf, embedded=True)
+    embedded = run_tool(["inspect", "--input", str(embedded_pdf)])["result"]
+    fake_entries = [entry for entry in embedded["fonts"]["entries"] if entry["name"] == "FakeSans"]
+    if not fake_entries or not fake_entries[0]["embedded"] or not fake_entries[0]["subset"]:
+        raise SmokeFailure(f"Embedded subset fixture inventory is wrong: {fake_entries}")
+    if any(w.startswith("RELEASE BLOCKER") for w in embedded["warnings"]):
+        raise SmokeFailure("Embedded fixture raised a release blocker")
+
+    render_dir = base / "pngs"
+    render_result = run_tool(
+        ["render", "--input", str(fixture), "--output", str(render_dir), "--dpi", "96"]
+    )
+    if render_result["counts"]["pages_rendered"] != 2:
+        raise SmokeFailure(f"Render page count wrong: {render_result['counts']}")
+    if render_result["verification"]["pngs_reopened"] != 2:
+        raise SmokeFailure("Render did not reopen every published PNG")
+    for item in render_result["renders"]:
+        png = Path(item["output_path"])
+        if not png.is_file():
+            raise SmokeFailure(f"Rendered PNG missing: {png}")
+        with png.open("rb") as handle:
+            if handle.read(8) != PNG_SIGNATURE:
+                raise SmokeFailure(f"Rendered file is not a PNG: {png}")
+        with Image.open(png) as image:
+            width, height = image.size
+        expected_width = math.ceil(612 * 96 / 72)
+        expected_height = math.ceil(792 * 96 / 72)
+        if (width, height) != (expected_width, expected_height):
+            raise SmokeFailure(f"Rendered dimensions wrong: {(width, height)}")
+        if (item["width_px"], item["height_px"]) != (width, height):
+            raise SmokeFailure("Render summary dimensions disagree with the PNG")
+        if sha256(png) != item["sha256"]:
+            raise SmokeFailure(f"Rendered PNG hash mismatch: {png}")
+
+    selection_dir = base / "pngs-page2"
+    selection = run_tool(
+        [
+            "render",
+            "--input",
+            str(fixture),
+            "--output",
+            str(selection_dir),
+            "--pages",
+            "2",
+            "--dpi",
+            "96",
+        ]
+    )
+    files = sorted(path.name for path in selection_dir.iterdir())
+    if files != ["page-0002.png"] or selection["counts"]["pages_rendered"] != 1:
+        raise SmokeFailure(f"Render page selection wrong: {files}")
+
+    rotated_pdf = base / "rotated.pdf"
+    rotate_job = base / "rotate.json"
+    write_json(
+        rotate_job,
+        {
+            "schema_version": 1,
+            "inputs": [{"id": "fixture", "path": str(fixture)}],
+            "outputs": [
+                {
+                    "path": str(rotated_pdf),
+                    "pages": [{"input": "fixture", "page": 1, "rotate": 90}],
+                }
+            ],
+        },
+    )
+    run_tool(["pages", "--job", str(rotate_job)])
+    rotated_dir = base / "pngs-rotated"
+    rotated = run_tool(
+        ["render", "--input", str(rotated_pdf), "--output", str(rotated_dir), "--dpi", "96"]
+    )
+    rotated_render = rotated["renders"][0]
+    if (rotated_render["width_px"], rotated_render["height_px"]) != (
+        math.ceil(792 * 96 / 72),
+        math.ceil(612 * 96 / 72),
+    ):
+        raise SmokeFailure(f"Rotated render did not swap dimensions: {rotated_render}")
+
+    nonempty_dir = base / "nonempty"
+    nonempty_dir.mkdir()
+    (nonempty_dir / "existing.txt").write_text("occupied", encoding="utf-8")
+    assert_bad_input(
+        [
+            "render",
+            "--input",
+            str(fixture),
+            "--output",
+            str(nonempty_dir),
+            "--overwrite",
+        ],
+        "Nonempty render directory",
+    )
+    assert_bad_input(
+        [
+            "render",
+            "--input",
+            str(fixture),
+            "--output",
+            str(base / "too-high-dpi"),
+            "--dpi",
+            "1200",
+        ],
+        "Render DPI ceiling",
+    )
+    big_job = base / "big.json"
+    big_pdf = base / "big.pdf"
+    write_json(
+        big_job,
+        {
+            "schema_version": 1,
+            "page_size": [5000, 5000],
+            "pages": [{"elements": []}],
+        },
+    )
+    run_tool(["create", "--job", str(big_job), "--output", str(big_pdf)])
+    over_limit = run_tool(
+        [
+            "render",
+            "--input",
+            str(big_pdf),
+            "--output",
+            str(base / "over-limit"),
+            "--dpi",
+            "600",
+        ],
+        expected_status=6,
+    )
+    if over_limit["category"] != "resource_limit":
+        raise SmokeFailure(f"Oversized render failure category changed: {over_limit}")
+    return {
+        "render": True,
+        "render_rotation": True,
+        "render_failure_paths": True,
+        "font_inventory": True,
+        "font_release_blocker": True,
+    }
+
+
+def run_manifest_compose_redact(root: Path) -> dict[str, Any]:
+    base = root / "advanced"
+    base.mkdir()
+
+    # Manifest derive and check.
+    tessdata = base / "tessdata"
+    tessdata.mkdir()
+    (tessdata / "eng.traineddata").write_bytes(os.urandom(2_048))
+    manifest_path = base / "manifest.json"
+    derive = run_tool(
+        [
+            "manifest",
+            "--mode",
+            "derive",
+            "--engine",
+            "tesseract",
+            "--languages",
+            "eng",
+            "--tessdata-dir",
+            str(tessdata),
+            "--assume-source",
+            "tessdata_fast",
+            "--output",
+            str(manifest_path),
+        ]
+    )
+    if derive["ready_for_preflight"]:
+        raise SmokeFailure("Derive without approvals claimed preflight readiness")
+    derive = run_tool(
+        [
+            "manifest",
+            "--mode",
+            "derive",
+            "--engine",
+            "tesseract",
+            "--languages",
+            "eng",
+            "--tessdata-dir",
+            str(tessdata),
+            "--assume-source",
+            "tessdata_fast",
+            "--accept-license",
+            "--confirm-eligibility",
+            "--output",
+            str(manifest_path),
+            "--overwrite",
+        ]
+    )
+    if not derive["ready_for_preflight"]:
+        raise SmokeFailure(f"Approved derive is not preflight-ready: {derive}")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not manifest["model"]["license_terms_accepted"]:
+        raise SmokeFailure("Derived manifest lost the license approval flag")
+    if manifest["artifacts"][0]["provenance"] != "declared-by-operator":
+        raise SmokeFailure(f"Derived provenance wrong: {manifest['artifacts']}")
+    check = run_tool(
+        [
+            "manifest",
+            "--mode",
+            "check",
+            "--engine",
+            "tesseract",
+            "--languages",
+            "eng",
+            "--model-manifest",
+            str(manifest_path),
+        ]
+    )
+    if not check["preflight_would_pass"] or check["summary"]["failed"]:
+        raise SmokeFailure(f"Clean manifest check failed: {check['summary']}")
+    with (tessdata / "eng.traineddata").open("ab") as handle:
+        handle.write(b"tampered")
+    tampered = run_tool(
+        [
+            "manifest",
+            "--mode",
+            "check",
+            "--engine",
+            "tesseract",
+            "--languages",
+            "eng",
+            "--model-manifest",
+            str(manifest_path),
+        ],
+        expected_status=7,
+    )
+    failed_checks = [item for item in tampered["details"]["checks"] if not item["ok"]]
+    if not any(
+        item["check"] == "artifact_sha256"
+        and item.get("expected_sha256")
+        and item.get("actual_sha256")
+        for item in failed_checks
+    ):
+        raise SmokeFailure(f"Tampered check lacks expected/actual hashes: {failed_checks}")
+    missing_language = run_tool(
+        [
+            "manifest",
+            "--mode",
+            "derive",
+            "--engine",
+            "tesseract",
+            "--languages",
+            "deu",
+            "--tessdata-dir",
+            str(tessdata),
+            "--output",
+            str(base / "missing.json"),
+        ],
+        expected_status=2,
+    )
+    if missing_language["category"] != "bad_input":
+        raise SmokeFailure(f"Missing language derive category changed: {missing_language}")
+    paddle_root = base / "paddle"
+    for role_dir in ("det", "rec", "layout"):
+        (paddle_root / role_dir).mkdir(parents=True)
+        (paddle_root / role_dir / "inference.pdiparams").write_bytes(os.urandom(1_024))
+    paddle_manifest = base / "paddle-manifest.json"
+    paddle_derive = run_tool(
+        [
+            "manifest",
+            "--mode",
+            "derive",
+            "--engine",
+            "paddle",
+            "--languages",
+            "en",
+            "--artifact",
+            f"text_detection_model_dir={paddle_root / 'det'}",
+            "--artifact",
+            f"text_recognition_model_dir={paddle_root / 'rec'}",
+            "--artifact",
+            f"layout_detection_model_dir={paddle_root / 'layout'}",
+            "--output",
+            str(paddle_manifest),
+        ]
+    )
+    if paddle_derive["ready_for_preflight"]:
+        raise SmokeFailure("Unreviewed Paddle derive claimed readiness")
+    paddle_data = json.loads(paddle_manifest.read_text(encoding="utf-8"))
+    structure_entries = [
+        entry for entry in paddle_data["artifacts"] if entry["role"] == "layout_detection_model_dir"
+    ]
+    if structure_entries[0]["identifier"] != "REVIEW-REQUIRED":
+        raise SmokeFailure("Paddle structure role provenance was auto-filled")
+
+    # Searchable OCR composition from a fabricated sidecar.
+    scan_image = base / "scan.png"
+    image = Image.new("RGB", (1_275, 1_650), "white")
+    draw = ImageDraw.Draw(image)
+    draw.text((240, 240), "COMPOSE FIXTURE WORDS", fill="black")
+    image.save(scan_image)
+    scan_pdf = base / "scan.pdf"
+    run_tool(
+        [
+            "convert",
+            "--images",
+            str(scan_image),
+            "--to",
+            "pdf",
+            "--output",
+            str(scan_pdf),
+            "--page-size",
+            "letter",
+            "--margin",
+            "0",
+        ]
+    )
+    sidecar_path = base / "sidecar.json"
+    sidecar = {
+        "schema_version": 1,
+        "operation": "ocr",
+        "source": {
+            "path": str(scan_pdf.resolve()),
+            "sha256": sha256(scan_pdf),
+            "selected_pages": [1],
+            "immutable": True,
+        },
+        "pages": [
+            {
+                "source_page": 1,
+                "source_region": None,
+                "classification": "likely-scanned",
+                "page_geometry": {
+                    "width_points": 612,
+                    "height_points": 792,
+                    "rotation": 0,
+                },
+                "coordinate_space": {
+                    "unit": "rendered_pixel",
+                    "dpi": 150,
+                    "width": 1275,
+                    "height": 1650,
+                },
+                "blocks": [
+                    {
+                        "order": 0,
+                        "text": "COMPOSE FIXTURE WORDS",
+                        "block_type": "line",
+                        "bbox": [240, 240, 760, 280],
+                        "confidence": 0.9,
+                        "words": [
+                            {
+                                "text": "COMPOSE",
+                                "bbox": [240, 240, 420, 280],
+                                "confidence": 0.9,
+                            },
+                            {
+                                "text": "FIXTURE",
+                                "bbox": [435, 240, 600, 280],
+                                "confidence": 0.9,
+                            },
+                            {
+                                "text": "WORDS",
+                                "bbox": [615, 240, 760, 280],
+                                "confidence": 0.9,
+                            },
+                        ],
+                    }
+                ],
+                "warnings": [],
+                "engine_specific": {},
+            }
+        ],
+    }
+    write_json(sidecar_path, sidecar)
+    searchable_pdf = base / "searchable.pdf"
+    compose = run_tool(
+        [
+            "ocr-compose",
+            "--input",
+            str(scan_pdf),
+            "--sidecar",
+            str(sidecar_path),
+            "--output",
+            str(searchable_pdf),
+        ]
+    )
+    anchors = compose["verification"]["anchors"]
+    if anchors["checked"] == 0 or anchors["checked"] != anchors["found"]:
+        raise SmokeFailure(f"Compose anchors failed: {anchors}")
+    if compose["verification"]["geometry_spot_check_max_delta_points"] > 3:
+        raise SmokeFailure("Compose geometry spot check deviated")
+    if not compose["verification"]["visual_diff"]["checked"]:
+        raise SmokeFailure("Compose skipped its visual check")
+    composed_text = run_tool(["extract", "--input", str(searchable_pdf)])["result"]["pages"][0][
+        "text"
+    ]
+    if "COMPOSE" not in composed_text or "WORDS" not in composed_text:
+        raise SmokeFailure(f"Composed text not extractable: {composed_text!r}")
+    mismatched = dict(sidecar)
+    mismatched["source"] = dict(sidecar["source"], sha256="0" * 64)
+    mismatch_path = base / "sidecar-mismatch.json"
+    write_json(mismatch_path, mismatched)
+    assert_bad_input(
+        [
+            "ocr-compose",
+            "--input",
+            str(scan_pdf),
+            "--sidecar",
+            str(mismatch_path),
+            "--output",
+            str(base / "never.pdf"),
+        ],
+        "Compose sidecar hash mismatch",
+    )
+    digital = dict(sidecar)
+    digital_pages = [dict(sidecar["pages"][0], classification="digital-text")]
+    digital["pages"] = digital_pages
+    digital_path = base / "sidecar-digital.json"
+    write_json(digital_path, digital)
+    skipped = run_tool(
+        [
+            "ocr-compose",
+            "--input",
+            str(scan_pdf),
+            "--sidecar",
+            str(digital_path),
+            "--output",
+            str(base / "never2.pdf"),
+        ],
+        expected_status=3,
+    )
+    if skipped["category"] != "unsupported_operation":
+        raise SmokeFailure(f"Digital-text compose skip category changed: {skipped}")
+
+    # Redaction.
+    doc_job = base / "redact-doc.json"
+    doc_pdf = base / "redact-doc.pdf"
+    write_json(
+        doc_job,
+        {
+            "schema_version": 1,
+            "page_size": "letter",
+            "pages": [
+                {
+                    "elements": [
+                        {
+                            "type": "text",
+                            "text": "PUBLIC HEADER LINE",
+                            "x": 72,
+                            "y": 90,
+                            "font_size": 14,
+                        },
+                        {
+                            "type": "text",
+                            "text": "CODEWORD REDACT-ME-42 END",
+                            "x": 72,
+                            "y": 140,
+                            "font_size": 14,
+                        },
+                        {
+                            "type": "text",
+                            "text": "PUBLIC FOOTER LINE",
+                            "x": 72,
+                            "y": 190,
+                            "font_size": 14,
+                        },
+                    ]
+                }
+            ],
+        },
+    )
+    run_tool(["create", "--job", str(doc_job), "--output", str(doc_pdf)])
+    # Simulate an incremental-update tail (stale bytes plus a second trailer block
+    # that re-points at the original xref) so the rewrite must drop it.
+    original_bytes = doc_pdf.read_bytes()
+    startxref_offset = original_bytes.rfind(b"startxref")
+    if startxref_offset < 0:
+        raise SmokeFailure("Fixture PDF has no startxref to duplicate")
+    xref_pointer = original_bytes[startxref_offset:].split()[1]
+    doc_pdf.write_bytes(
+        original_bytes + b"\n% JUNK-REVISION-MARKER-99\nstartxref\n" + xref_pointer + b"\n%%EOF\n"
+    )
+    redact_job = base / "redact-job.json"
+    write_json(
+        redact_job,
+        {
+            "schema_version": 1,
+            "targets": [
+                {
+                    "type": "text",
+                    "text": "REDACT-ME-42",
+                    "pages": "all",
+                    "match": "exact",
+                    "grow_points": 2.0,
+                }
+            ],
+        },
+    )
+    redacted_pdf = base / "redacted.pdf"
+    report_path = base / "redact-report.json"
+    redact = run_tool(
+        [
+            "redact",
+            "--input",
+            str(doc_pdf),
+            "--job",
+            str(redact_job),
+            "--output",
+            str(redacted_pdf),
+            "--report",
+            str(report_path),
+        ]
+    )
+    evidence = redact["removal_evidence"]["pages"][0]
+    if evidence["text_operators_removed"] < 1:
+        raise SmokeFailure(f"Redaction removed no text operators: {evidence}")
+    if evidence["characters_removed"] <= len("REDACT-ME-42"):
+        raise SmokeFailure(f"Whole-operator collateral removal was not measured: {evidence}")
+    if redact["residual_scan"]["raw_byte_hits"]:
+        raise SmokeFailure(f"Residual scan found raw hits: {redact['residual_scan']}")
+    if not redact["verification"]["visual_diff"]["checked"]:
+        raise SmokeFailure("Redaction skipped its visual diff check")
+    redacted_bytes = redacted_pdf.read_bytes()
+    if b"REDACT-ME-42" in redacted_bytes:
+        raise SmokeFailure("Redacted output still contains the term bytes")
+    if b"JUNK-REVISION-MARKER-99" in redacted_bytes:
+        raise SmokeFailure("Redacted output retained stale revision bytes")
+    if redacted_bytes.count(b"%%EOF") != 1:
+        raise SmokeFailure("Redacted output is not a single revision")
+    redacted_text = run_tool(["extract", "--input", str(redacted_pdf)])["result"]["pages"][0][
+        "text"
+    ]
+    if "REDACT-ME-42" in redacted_text:
+        raise SmokeFailure("Redacted term is still extractable")
+    if "PUBLIC HEADER LINE" not in redacted_text or "PUBLIC FOOTER LINE" not in redacted_text:
+        raise SmokeFailure(f"Redaction damaged retained text: {redacted_text!r}")
+    if not report_path.is_file():
+        raise SmokeFailure("Redaction report file was not published")
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    if any("REDACT-ME-42" in json.dumps(target) for target in report["targets"]):
+        raise SmokeFailure("Redaction report leaked the target text")
+    no_match_job = base / "redact-nomatch.json"
+    write_json(
+        no_match_job,
+        {
+            "schema_version": 1,
+            "targets": [{"type": "text", "text": "NO-SUCH-TERM-EXISTS", "pages": "all"}],
+        },
+    )
+    assert_bad_input(
+        [
+            "redact",
+            "--input",
+            str(doc_pdf),
+            "--job",
+            str(no_match_job),
+            "--output",
+            str(base / "never3.pdf"),
+        ],
+        "Redaction no-match",
+    )
+    encrypt_job = base / "redact-encrypt.json"
+    encrypted_pdf = base / "redact-encrypted.pdf"
+    write_json(
+        encrypt_job,
+        {
+            "schema_version": 1,
+            "operations": [
+                {
+                    "op": "encrypt",
+                    "algorithm": "AES-256",
+                    "user_password": "redact-smoke-password",
+                }
+            ],
+        },
+    )
+    run_tool(
+        [
+            "edit",
+            "--input",
+            str(doc_pdf),
+            "--job",
+            str(encrypt_job),
+            "--output",
+            str(encrypted_pdf),
+        ]
+    )
+    refused = run_tool(
+        [
+            "redact",
+            "--input",
+            str(encrypted_pdf),
+            "--job",
+            str(redact_job),
+            "--output",
+            str(base / "never4.pdf"),
+        ],
+        expected_status=3,
+    )
+    if refused["category"] != "unsupported_operation":
+        raise SmokeFailure(f"Encrypted redaction category changed: {refused}")
+    form_pdf = base / "form-xobject.pdf"
+    reader = PdfReader(str(doc_pdf))
+    writer = PdfWriter()
+    writer.clone_document_from_reader(reader)
+    page = writer.pages[0]
+    form = StreamObject()
+    form[NameObject("/Type")] = NameObject("/XObject")
+    form[NameObject("/Subtype")] = NameObject("/Form")
+    form[NameObject("/BBox")] = ArrayObject(
+        [NumberObject(0), NumberObject(0), NumberObject(612), NumberObject(792)]
+    )
+    form.set_data(b"q Q")
+    form_reference = writer._add_object(form)
+    resources = page["/Resources"].get_object()
+    xobjects = resources.get("/XObject")
+    if xobjects is None:
+        xobjects = DictionaryObject()
+        resources[NameObject("/XObject")] = xobjects
+    else:
+        xobjects = xobjects.get_object()
+    xobjects[NameObject("/FXZ1")] = form_reference
+    content = ContentStream(page.get_contents(), writer)
+    content.operations.append(([NameObject("/FXZ1")], b"Do"))
+    page.replace_contents(content)
+    with form_pdf.open("wb") as handle:
+        writer.write(handle)
+    form_refused = run_tool(
+        [
+            "redact",
+            "--input",
+            str(form_pdf),
+            "--job",
+            str(redact_job),
+            "--output",
+            str(base / "never5.pdf"),
+        ],
+        expected_status=3,
+    )
+    if form_refused["category"] != "unsupported_operation" or "FXZ1" not in form_refused["message"]:
+        raise SmokeFailure(f"Form XObject refusal changed: {form_refused}")
+
+    # A large rotated stamp near a target must not be removed: its axis-aligned bounding
+    # box overlaps the target rect, but its true oriented glyph quad does not. Redaction
+    # tests the oriented quad, so the stamp survives while the target is removed.
+    stamp_doc_job = base / "redact-stamp.json"
+    stamp_pdf = base / "redact-stamp.pdf"
+    write_json(
+        stamp_doc_job,
+        {
+            "schema_version": 1,
+            "page_size": "letter",
+            "pages": [
+                {
+                    "elements": [
+                        {
+                            "type": "text",
+                            "text": "SECRET GAMMA-88 CODE",
+                            "x": 72,
+                            "y": 700,
+                            "width": 300,
+                            "font_size": 12,
+                        }
+                    ]
+                }
+            ],
+        },
+    )
+    run_tool(["create", "--job", str(stamp_doc_job), "--output", str(stamp_pdf)])
+    stamp_edit_job = base / "redact-stamp-edit.json"
+    stamped_pdf = base / "redact-stamped.pdf"
+    write_json(
+        stamp_edit_job,
+        {
+            "schema_version": 1,
+            "operations": [
+                {
+                    "op": "stamp_text",
+                    "pages": "1",
+                    "text": "CONFIDENTIAL",
+                    "x": 306,
+                    "y": 300,
+                    "angle": 45,
+                    "font_size": 72,
+                    "opacity": 0.3,
+                }
+            ],
+        },
+    )
+    run_tool(
+        [
+            "edit",
+            "--input",
+            str(stamp_pdf),
+            "--job",
+            str(stamp_edit_job),
+            "--output",
+            str(stamped_pdf),
+        ]
+    )
+    stamp_redact_job = base / "redact-stamp-target.json"
+    write_json(
+        stamp_redact_job,
+        {
+            "schema_version": 1,
+            "targets": [{"type": "text", "text": "GAMMA-88", "pages": "all", "match": "exact"}],
+        },
+    )
+    stamp_redacted = base / "redact-stamp-out.pdf"
+    stamp_redaction = run_tool(
+        [
+            "redact",
+            "--input",
+            str(stamped_pdf),
+            "--job",
+            str(stamp_redact_job),
+            "--output",
+            str(stamp_redacted),
+        ]
+    )
+    # Assert on removal evidence, not extracted text: pdfplumber renders the 45-degree
+    # stamp as one letter per line, so the contiguous word never appears in extraction
+    # even when every stamp glyph survives. Exactly one operator (the target line, 20
+    # chars) must be removed; a regression to axis-aligned extents would also remove the
+    # stamp operator, doubling both counts.
+    stamp_evidence = stamp_redaction["removal_evidence"]["pages"][0]
+    if stamp_evidence["text_operators_removed"] != 1:
+        raise SmokeFailure(
+            "Rotated stamp removed by a distant target — oriented-quad extent regressed "
+            f"to an axis-aligned bounding box: {stamp_evidence}"
+        )
+    if stamp_evidence["characters_removed"] != len("SECRET GAMMA-88 CODE"):
+        raise SmokeFailure(f"Unexpected redaction collateral near stamp: {stamp_evidence}")
+    stamp_text = run_tool(["extract", "--input", str(stamp_redacted)])["result"]["pages"][0]["text"]
+    if "GAMMA-88" in stamp_text:
+        raise SmokeFailure("Redaction target survived near a rotated stamp")
+    # The stamp glyphs (CONFIDENTIAL, rendered reversed one-per-line) must still be present.
+    if "".join(stamp_text.split()).count("C") < 1 or "AITNEDIFNOC" not in "".join(
+        stamp_text.split()
+    ):
+        raise SmokeFailure(f"Rotated stamp glyphs did not survive redaction: {stamp_text!r}")
+
+    return {
+        "manifest_derive_and_check": True,
+        "manifest_structure_roles_never_autofilled": True,
+        "ocr_compose": True,
+        "ocr_compose_failure_paths": True,
+        "redact_text_target": True,
+        "redact_single_revision": True,
+        "redact_failure_paths": True,
+        "redact_form_xobject_refused": True,
+        "redact_oriented_quad_spares_rotated_stamp": True,
+    }
+
+
 def run_optional_ocr(
     root: Path,
     *,
@@ -1031,6 +1905,8 @@ def main() -> int:
         with tempfile.TemporaryDirectory(prefix="pdf-skill-smoke-") as temp_name:
             root = Path(temp_name)
             core = run_core(root)
+            core.update(run_render_and_fonts(root))
+            core.update(run_manifest_compose_redact(root))
             optional = None
             if args.ocr_engine:
                 optional = run_optional_ocr(

--- a/kolega_code/_bundled_skills/skills/pptx/SKILL.md
+++ b/kolega_code/_bundled_skills/skills/pptx/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: pptx
-description: Create, inspect, edit, and convert PowerPoint presentations (`.pptx`) with template-first layouts, structured text, images, editable tables and charts, speaker notes, and guarded slide operations. Use for presentation-native work such as building a deck from an outline or template, inventorying slide content, replacing text or media, updating tables/charts/notes, adding/removing/reordering slides, or converting PPTX to PDF. Do not use for PDF-native editing or for spreadsheets and word-processing documents.
+description: Create, inspect, edit, and convert PowerPoint presentations (`.pptx`) with template-first layouts, structured text, images, image extraction, editable tables and charts, speaker notes, hyperlinks, and guarded slide operations. Use for presentation-native work such as building a deck from an outline or template, inventorying slide content, replacing text or media, updating tables/charts/notes, adding or removing table rows and columns, setting or removing hyperlinks, adding/removing/reordering slides, or converting PPTX to PDF. Do not use for PDF-native editing or for spreadsheets and word-processing documents.
 license: Apache-2.0
-compatibility: Requires Python 3.11+ and dependencies from requirements.txt. LibreOffice is optional for PPTX-to-PDF conversion.
+compatibility: Requires Python 3.11+ and dependencies from requirements.txt. LibreOffice and the pypdfium2 Python package are optional, needed only for PPTX-to-PDF conversion and slide rendering respectively.
 metadata:
   author: Kolega
   version: "1.0"
@@ -12,6 +12,13 @@ metadata:
 
 Use `scripts/pptx_tool.py` for deterministic presentation work. Keep source files unchanged,
 write to a distinct destination, and use `--overwrite` only when replacement is intentional.
+
+## Workspace discipline
+
+Work directly in visible workspace paths. Never create or use `.build` or another hidden
+build/work directory. Write requested deliverables directly to their declared destinations;
+if intermediate files are necessary, keep them in visible, narrowly scoped paths rather than
+staging the task in a hidden subtree.
 
 ## Workflow
 
@@ -24,7 +31,9 @@ and with which installer. Use the selected interpreter's `-m pip` for the declar
    prerequisite. See
    [runtime installation](references/operations.md#runtime-prerequisite-and-installation).
 2. **Inspect first.** Run `inspect` before editing. Review slide IDs and order, layout names,
-   placeholders, geometry, runs, images, tables, charts, notes, and preservation warnings.
+   placeholders, geometry, runs, images, tables, charts, notes, and preservation warnings. Use
+   `extract` when the actual image bytes are needed outside the deck; it writes picture-shape
+   images to a new directory and refuses to overwrite non-empty destinations.
 3. **Choose a template.** For branded decks, start `create` from a supplied `.pptx` and select
    its layouts by exact name or index. Prefer existing masters, layouts, and placeholders over
    direct formatting. If `layout` is omitted, index 1 is used. Do not attempt arbitrary theme or
@@ -38,9 +47,27 @@ and with which installer. Use the selected interpreter's `-m pip` for the declar
    the affected text frame is acceptable.
 6. **Verify the result.** Require the successful JSON summary, package preflight, reopen check,
    expected slide IDs/order/count, existing internal relationship targets, and resolved owner
-   relationship references. Inspect the output again and render it in the target presentation
-   application when visual fidelity matters.
-7. **Convert optionally.** PPTX-to-PDF remains owned by this skill. When conversion is requested,
+   relationship references. Inspect the output again; when visual fidelity matters, continue
+   with step 7 and treat the target presentation application as the final authority. Review the
+   font inventory (`fonts.referenced`,
+   `fonts.embedded`, `fonts.unembedded`). For PPTX+PDF deliverables apply this release gate: use
+   only Arial for headings and sans body, Times New Roman for serif body, and Courier New for
+   code or logs, including table and chart text. Do not use Avenir, Calibri, Calibri Light,
+   Cambria, Georgia, Trebuchet, Palatino, or any other unembedded custom/system font; replace
+   every `RELEASE BLOCKER` font warning before release. Decks built on the default Office theme
+   report Calibri through `+mj-lt`/`+mn-lt` until the template's theme fonts are changed or
+   genuinely embedded. PDF font embedding is not PPTX font embedding. A clean LibreOffice PDF
+   alone does not prove that PowerPoint will preserve wrapping, autofit, or slide layout.
+7. **Render and look.** When layout or visual fidelity matters and LibreOffice plus the optional
+   `pypdfium2` package are available, run `render` to produce one PNG per slide, then open the
+   rendered PNGs with the Read tool and examine them — at minimum every slide you changed, plus
+   the first slide. Check for text overflow or truncation, overlapping or clipped shapes,
+   missing images, and table or chart layout problems. Do not claim visual correctness from
+   JSON verification alone. Rendering shows LibreOffice's interpretation, not
+   renderer-identical PowerPoint output; the target presentation application remains the final
+   authority. If `pypdfium2` is missing, tell the user before installing it with the selected
+   interpreter's `-m pip`.
+8. **Convert optionally.** PPTX-to-PDF remains owned by this skill. When conversion is requested,
    verify `soffice` or `libreoffice` on `PATH`. If it is missing, first tell the user the intended
    optional system install and mechanism, then use the platform's normal package manager,
    preferring Homebrew on macOS when available. Use `convert` only when LibreOffice is available
@@ -71,3 +98,13 @@ and with which installer. Use the selected interpreter's `-m pip` for the declar
   presentation features.
 - Run `"$PPTX_PYTHON" "$SKILL_ROOT/scripts/smoke_test.py"` after installation. Add
   `--require-libreoffice` only when PDF conversion must also be exercised.
+
+## Final verification
+
+Confirm that the source remains unchanged unless overwrite was authorized, the destination
+reopens, requested structures are present, every unembedded-font warning was resolved or
+explicitly reviewed, and no temporary files or generated fixtures remain in the skill directory.
+For matching PPTX/PDF deliverables, treat the `RELEASE BLOCKER` font warning as a release
+blocker; confirm typography, table and chart text, and slide layout in both files before
+trusting the export. `pdffonts` can inspect only the PDF and must never be cited as evidence
+that the PPTX embeds or preserves those fonts.

--- a/kolega_code/_bundled_skills/skills/pptx/references/examples.md
+++ b/kolega_code/_bundled_skills/skills/pptx/references/examples.md
@@ -4,7 +4,8 @@
 
 - [Create and inspect](#create-and-inspect)
 - [Edit safely](#edit-safely)
-- [Convert to PDF](#convert-to-pdf)
+- [Convert and render](#convert-and-render)
+- [Font portability check](#font-portability-check)
 - [Failure examples](#failure-examples)
 - [Expected assertions](#expected-assertions)
 
@@ -86,6 +87,15 @@ Representative stdout fields:
 Absolute paths and version fields are omitted above; callers must not assume this abbreviated
 object is the complete output.
 
+To export the deck's images (picture shapes only, written verbatim to a new directory):
+
+```bash
+"$PPTX_PYTHON" "$PPTX_TOOL" extract "/tmp/field-report.pptx" --output "/tmp/field-report-images"
+```
+
+Each summary record pairs a `slide-<id>-shape-<id>-<hash>.<ext>` file with its slide/shape
+identity and SHA-256; verify the hash against the matching `inspect` image record.
+
 ## Edit safely
 
 Use slide IDs from `inspect`, not guessed indexes. Save this as `edit.json`:
@@ -114,6 +124,43 @@ Use slide IDs from `inspect`, not guessed indexes. Save this as `edit.json`:
       "action": "set_notes",
       "slide": {"slide_id": 257},
       "text": "The final week includes the recovered shift."
+    },
+    {
+      "action": "set_hyperlink",
+      "slide": {"slide_id": 257},
+      "find": "recovered shift",
+      "url": "https://wiki.example.com/recovered-shift"
+    },
+    {
+      "action": "remove_hyperlink",
+      "slide": {"slide_id": 256},
+      "find": "Field report"
+    }
+  ]
+}
+```
+
+`set_hyperlink`/`remove_hyperlink` require the matched text to align with whole runs and accept
+only `http`, `https`, or `mailto` URLs. Use `scope: "shape"` with a shape selector (and no
+`find`) to set or remove a shape's click action instead.
+
+To restructure a table, provide ordered changes; each is validated against the table as already
+changed by the preceding entries:
+
+```json
+{
+  "schema_version": 1,
+  "operation": "edit",
+  "operations": [
+    {
+      "action": "update_table_structure",
+      "slide": {"slide_id": 257},
+      "shape": {"shape_name": "Metrics Table"},
+      "changes": [
+        {"op": "insert_row", "index": 2, "cells": ["Refunds", "3"]},
+        {"op": "insert_column", "index": 0, "cells": ["Kind", "A", "B"]},
+        {"op": "remove_row", "index": 1}
+      ]
     }
   ]
 }
@@ -140,7 +187,7 @@ For reordering, provide every current ID once:
 }
 ```
 
-## Convert to PDF
+## Convert and render
 
 PPTX-to-PDF remains owned by this skill. Verify LibreOffice is on `PATH`:
 
@@ -160,6 +207,33 @@ Convert only after the check succeeds:
 
 Require `verification.pdf_openable: true` and equal `source_slide_count`/`pdf_page_count`.
 Conversion success does not replace visual review.
+
+To review slides visually, render one PNG per slide (requires LibreOffice plus the optional
+`pypdfium2` package, installed only with user approval):
+
+```bash
+"$PPTX_PYTHON" "$PPTX_TOOL" render \
+  "/tmp/field-report-v2.pptx" --output "/tmp/field-report-v2-slides" --dpi 96
+```
+
+Then open each produced `slide-<ordinal>-id-<slide_id>.png` and look at it — check text
+overflow, truncation, overlapping or clipped shapes, missing images, and table/chart layout.
+The render summary alone proves file integrity, not visual correctness.
+
+## Font portability check
+
+Before releasing matching PPTX and PDF deliverables, inspect the final deck and review its font
+inventory:
+
+```bash
+"$PPTX_PYTHON" "$PPTX_TOOL" inspect "/tmp/field-report-v2.pptx"
+```
+
+Review `fonts.referenced`, `fonts.embedded`, and `fonts.unembedded`, and resolve every
+unembedded-font warning. Do not leave a `RELEASE BLOCKER:` font warning unreviewed for a
+PPTX+PDF fidelity task. A correct PDF rendering and clean `pdffonts` output do not prove PPTX
+font portability: they describe the generated PDF, not what another PowerPoint renderer will
+substitute when opening the deck.
 
 ## Failure examples
 
@@ -196,4 +270,5 @@ After create/edit:
 - all internal relationship targets exist, and relationship-namespace references in owner XML
   resolve through that owner's relationship part;
 - table/chart/image/note inspection reflects the requested values;
+- for PPTX+PDF deliverables, no `RELEASE BLOCKER:` font warning remains in the final inspection;
 - no sibling temporary output remains after success or failure.

--- a/kolega_code/_bundled_skills/skills/pptx/references/limitations.md
+++ b/kolega_code/_bundled_skills/skills/pptx/references/limitations.md
@@ -32,10 +32,15 @@ or execute them.
 - Layout names must match exactly and uniquely. Indexes are stable only for the specific template.
 - Text replacement does not infer intent. Cross-run formatting needs an explicit policy. Destructive
   reconstruction flattens formatting, fields, and hyperlinks in the affected text frame.
+- Hyperlink editing sets or removes one external `http`, `https`, or `mailto` address on whole
+  runs or on a shape click action. It never splits runs, and internal slide jumps, hover
+  actions, tooltips, and `ppaction` behaviors are not authored.
 - Image replacement requires the same media content type. It does not change crop, geometry, or
   aspect settings.
-- Table updates do not add/delete rows or columns. Merged-cell semantics and advanced table styles
-  are not authored.
+- Structural table edits insert or remove whole rows and columns only. Tables containing merged
+  cells are rejected for structural edits, and merged-cell authoring and advanced table styles
+  remain unsupported. New rows and columns clone neighbor formatting with cleared text, and the
+  table's overall width or height grows or shrinks rather than redistributing existing sizes.
 - Chart updates replace the complete cached/native data payload supported by `python-pptx`. Complex
   combination charts, secondary axes, trendlines, error bars, data labels, external workbook links,
   and chart extensions are not preserved by a data replacement guarantee.
@@ -43,10 +48,14 @@ or execute them.
   layout already present in the destination.
 - Shape z-order editing, grouping/ungrouping, connector repair, and arbitrary relationship editing
   are outside the interface.
+- Extraction exports picture shapes only. Shape-fill images, slide backgrounds, and audio/video
+  media are not exported, and extracted bytes are copied verbatim without decode validation.
 
-Slide removal/reordering uses a small adapter constrained to the supported `python-pptx` range because
-the library has no public mutation API for those operations. Every slide-graph mutation is
-checkpointed and reopened, but structural verification cannot prove rendering equivalence.
+Slide removal/reordering and table row/column mutation use a small adapter constrained to the
+supported `python-pptx` range because the library has no public mutation API for those
+operations. Every slide-graph mutation is checkpointed and reopened, and every table structure
+change is verified against an expected text matrix, but structural verification cannot prove
+rendering equivalence.
 
 ## Conversion boundaries
 
@@ -62,6 +71,20 @@ rejected rather than passed to LibreOffice. Results otherwise vary with:
 The tool proves PDF signature, openability, and page count only. Text extraction anchors used by the
 opt-in smoke test are not a general visual-fidelity test. Keep the source presentation and visually
 review important exports.
+
+`render` shares every LibreOffice variance above because its PNGs are rasterized from the same
+LibreOffice PDF. PNG verification proves signature, openability, page count, and dimensions —
+not renderer-identical pixels. Rendered slides support layout review, not a PowerPoint-fidelity
+claim.
+
+The font inventory over-approximates: fonts referenced only by unused layouts, masters, notes or
+handout masters, or table styles still count as referenced because they ship with the deck and
+re-engage as soon as a layout is used. Script-specific theme fonts (`a:font script="..."`), VML
+text, chart-style (`cs:`) parts, embedded chart workbooks, and renderer fallback chains are not
+scanned. Symbol and bullet fonts (`a:sym`, `a:buFont`) are inventoried under
+`fonts.symbol_and_bullet` but excluded from the release blocker because substitution changes a
+glyph, not text layout. Embedding detection proves a resolvable in-package font part exists, not
+that its payload is a valid, complete, or licensed font; obfuscated embedded fonts are not parsed.
 
 ## Future work
 

--- a/kolega_code/_bundled_skills/skills/pptx/references/operations.md
+++ b/kolega_code/_bundled_skills/skills/pptx/references/operations.md
@@ -6,12 +6,16 @@
 - [Invocation and result contract](#invocation-and-result-contract)
 - [Safe package handling](#safe-package-handling)
 - [Inspect](#inspect)
+- [Extract](#extract)
 - [Create jobs](#create-jobs)
 - [Edit jobs](#edit-jobs)
 - [Selectors and replacement rules](#selectors-and-replacement-rules)
 - [Content specifications](#content-specifications)
 - [LibreOffice prerequisite](#libreoffice-prerequisite)
 - [Convert](#convert)
+- [Render](#render)
+- [Font portability](#font-portability)
+- [PPTX and PDF release gate](#pptx-and-pdf-release-gate)
 - [Exit statuses](#exit-statuses)
 
 ## Runtime prerequisite and installation
@@ -48,9 +52,11 @@ path so skill locations and documents containing spaces remain safe:
 
 ```bash
 "$PPTX_PYTHON" "$PPTX_TOOL" inspect "/path/to/input deck.pptx"
+"$PPTX_PYTHON" "$PPTX_TOOL" extract "/path/to/input deck.pptx" --output "/path/to/image dir"
 "$PPTX_PYTHON" "$PPTX_TOOL" create --job "/path/to/create job.json" --output "/path/to/output deck.pptx"
 "$PPTX_PYTHON" "$PPTX_TOOL" edit "/path/to/input deck.pptx" --job "/path/to/edit job.json" --output "/path/to/output deck.pptx"
 "$PPTX_PYTHON" "$PPTX_TOOL" convert "/path/to/input deck.pptx" --output "/path/to/output deck.pdf"
+"$PPTX_PYTHON" "$PPTX_TOOL" render "/path/to/input deck.pptx" --output "/path/to/slide images"
 "$PPTX_PYTHON" "$PPTX_SMOKE_TEST"
 ```
 
@@ -103,10 +109,30 @@ representations rather than byte-identical source values.
 - image filename/type/byte count/dimensions/SHA-256;
 - table cell text and chart type/title/categories/series values available through public APIs;
 - plain speaker-note text read from package XML without creating a notes part;
+- a package font inventory under `fonts`: `referenced`, `embedded`, `unembedded`, per-part
+  `references`, `theme_tokens_referenced`, `symbol_and_bullet`, and
+  `dangling_embedding_relationships`, with an informational warning for unembedded fonts and a
+  `RELEASE BLOCKER:` warning for unembedded fonts outside Arial, Times New Roman, and Courier
+  New;
 - package feature warnings for signatures, comments, SmartArt, embedded objects, media,
   transitions, animations, and other uncertain content.
 
 Inspection is read-only. Unsupported chart metadata is reported as a warning rather than invented.
+
+## Extract
+
+`extract INPUT.pptx --output DIR [--overwrite]` exports every picture shape's image bytes to a
+new directory, verbatim and without re-encoding. File names follow
+`slide-<slide_id>-shape-<shape_id>-<sha256 prefix>.<ext>`, so the same image placed on two
+shapes produces two files whose shared hash makes the duplication visible. The summary lists
+each image's slide/shape identity, content type, byte count, SHA-256, and file name.
+
+Scope is picture shapes only: shape-fill images, slide backgrounds, audio, video, and embedded
+objects are not exported; unexported `ppt/media/` members are counted and named in a warning.
+An image above the per-image byte limit is skipped with a warning rather than failing the whole
+extraction. The destination must not already exist; with `--overwrite` it must be an empty
+directory — the tool never deletes existing files. Output is staged and atomically published,
+then every published file is re-read and its hash verified.
 
 ## Create jobs
 
@@ -153,8 +179,21 @@ Supported actions:
   insertion `index`.
 - `replace_text`: provide `find`, `replace`, optional slide/shape selectors, and exactly one of
   `replace_all: true` or `occurrence` when the selection is not unique.
+- `set_hyperlink`: with the default `scope: "text"`, provide `find` (plus `occurrence` when not
+  unique) and a validated `url`; every covered run receives the address. With `scope: "shape"`,
+  select exactly one shape and set its click action instead; `find`/`occurrence` are rejected.
+- `remove_hyperlink`: same selection rules without `url`. Every covered run (or the shape click
+  action) must currently carry an address; partial or absent coverage is rejected.
 - `update_table`: select one table and provide an exact-size `data` matrix or `cells` entries
   such as `{"row": 1, "column": 2, "text": "42"}`.
+- `update_table_structure`: select one table and provide ordered `changes`, each
+  `{"op": "insert_row"|"remove_row"|"insert_column"|"remove_column", "index": N}` with optional
+  scalar `cells` content for insertions (sized to the current cross-dimension). Each change is
+  validated against the table as already changed. Insert indexes run `0..n` (`n` appends);
+  removal indexes run `0..n-1`, and the final row or column cannot be removed. Tables containing
+  merged cells are rejected. New rows and columns clone neighbor formatting with cleared text; an
+  inserted column widens the table rather than redistributing widths. A before/after text-matrix
+  verification guards every structural edit.
 - `update_chart`: select one chart and provide a complete category or XY chart data specification.
 - `replace_image`: select one picture and provide `path`. The replacement must use the same media
   content type. Geometry/crop and unselected picture relationships remain unchanged; the selected
@@ -186,6 +225,13 @@ runs. Matches crossing paragraphs, fields, or incompatible hyperlink boundaries 
 Set `destructive_reconstruction: true` only to replace within a flattened text frame and accept
 loss of run/paragraph formatting, fields, and hyperlink structure. Empty search strings are
 invalid.
+
+Hyperlink actions never split runs: the matched text must align exactly with whole-run
+boundaries, or the action fails as ambiguous with guidance to isolate the target text with
+`replace_text` first. URLs must be `http`, `https`, or `mailto`, at most 2048 characters, and
+free of whitespace and control characters; other schemes (`file:`, `javascript:`, `data:`,
+`ppaction:`) are rejected as unsupported. Inspection continues to report sanitized URL
+representations regardless of how a hyperlink was authored.
 
 ## Content specifications
 
@@ -256,6 +302,58 @@ proves the decisive pre-commit check, not indefinite immutability of the path af
 
 Conversion is best effort. Always visually review typography, line wrapping, charts, and media in
 the target environment.
+
+## Render
+
+`render INPUT.pptx --output DIR [--overwrite] [--dpi 96] [--slides ID,ID] [--timeout 120]`
+produces one PNG per slide so the result can be reviewed visually. Rendering exists to be
+looked at: open the produced PNGs and examine them; do not treat a successful render summary as
+visual proof by itself.
+
+Prerequisites are LibreOffice (as for `convert`) plus the optional `pypdfium2` Python package.
+Neither is installed automatically: if `pypdfium2` is missing, the command fails with
+`missing_dependency` and an install hint; tell the user what will be installed and where before
+running `"$PPTX_PYTHON" -m pip install pypdfium2`. Users who decline the package can instead
+convert to PDF and rasterize with an external tool such as poppler's `pdftoppm`.
+
+Behavior:
+
+1. The source is preflighted and any external relationship is rejected, exactly as `convert`.
+2. LibreOffice converts the whole deck to a PDF in an isolated workspace; the PDF must contain
+   one page per slide, which also proves the page-to-slide mapping.
+3. Requested pages (all slides, or the `--slides` comma-separated slide-ID subset) are
+   rasterized with PDFium at `--dpi` (36-300). Predicted pixel sizes are bounded per slide and
+   in total before LibreOffice launches.
+4. Files are named `slide-<ordinal>-id-<slide_id>.png`, verified (PNG signature, Pillow reopen,
+   identical dimensions, pixel caps), staged, and atomically published to a new directory with
+   the same empty-destination rules as `extract`.
+
+The PNGs show LibreOffice's interpretation of the deck, not renderer-identical PowerPoint
+output; treat them as a layout review aid, with the target presentation application as the
+final authority.
+
+## Font portability
+
+A font counts as embedded only when `ppt/presentation.xml` declares it in `p:embeddedFontLst`
+and the embedding relationship resolves to a font part inside the package. Theme tokens such as
+`+mj-lt` and `+mn-lt` are resolved through the theme font scheme; slide masters always reference
+them, so the theme's major and minor fonts always count as referenced even before any slide sets
+an explicit font. Fonts embedded in a generated PDF are not thereby embedded in the source PPTX,
+and `pdffonts` describes only the PDF. Renderer substitution changes wrapping, autofit
+shrink-to-fit, overflow, and slide layout even when the LibreOffice PDF looks correct.
+
+## PPTX and PDF release gate
+
+For matching PPTX and PDF deliverables:
+
+1. Use only Arial for headings and sans body, Times New Roman for serif body, and Courier New
+   for code or logs, including table and chart text.
+2. Do not release while an unembedded font outside that set remains; replace every
+   `RELEASE BLOCKER:` font warning or genuinely embed the licensed font in the PPTX.
+3. Inspect the final PPTX and review its `fonts` inventory; render the final PDF and review it
+   slide by slide.
+4. PDF font embedding does not satisfy PPTX portability, and a clean LibreOffice PDF alone does
+   not prove that PowerPoint preserves wrapping, autofit, or slide layout.
 
 ## Exit statuses
 

--- a/kolega_code/_bundled_skills/skills/pptx/scripts/pptx_tool.py
+++ b/kolega_code/_bundled_skills/skills/pptx/scripts/pptx_tool.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import hashlib
 import io
 import json
@@ -48,7 +49,10 @@ except ModuleNotFoundError as exc:
                     "category": "missing_dependency",
                     "message": f"missing Python dependency: {exc.name}",
                     "details": {
-                        "install": "python -m pip install -r requirements.txt",
+                        "install": (
+                            f'"{sys.executable}" -m pip install -r '
+                            f'"{Path(__file__).resolve().parent.parent / "requirements.txt"}"'
+                        ),
                     },
                 },
             },
@@ -77,6 +81,10 @@ MAX_TABLE_ROWS = 200
 MAX_TABLE_COLUMNS = 200
 MAX_CHART_POINTS = 10_000
 MAX_GEOMETRY_INCHES = 100.0
+MIN_RENDER_DPI = 36
+MAX_RENDER_DPI = 300
+MAX_RENDER_PIXELS_PER_SLIDE = 25_000_000
+MAX_RENDER_TOTAL_PIXELS = 250_000_000
 
 CONTENT_TYPES = "[Content_Types].xml"
 PRESENTATION_PART = "ppt/presentation.xml"
@@ -128,6 +136,8 @@ SENSITIVE_QUERY_KEYS = {
 }
 RELATIONSHIP_ID_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9._-]*$")
 SENSITIVE_QUERY_KEYS_COMPACT = {key.replace("_", "") for key in SENSITIVE_QUERY_KEYS}
+ALLOWED_HYPERLINK_SCHEMES = {"http", "https", "mailto"}
+MAX_HYPERLINK_URL_CHARS = 2048
 CHART_TYPES = {
     "column": XL_CHART_TYPE.COLUMN_CLUSTERED,
     "bar": XL_CHART_TYPE.BAR_CLUSTERED,
@@ -258,6 +268,7 @@ def _versions() -> dict[str, str]:
         ("Pillow", "Pillow"),
         ("XlsxWriter", "XlsxWriter"),
         ("typing_extensions", "typing-extensions"),
+        ("pypdfium2", "pypdfium2"),
     ):
         try:
             versions[key] = metadata.version(distribution)
@@ -808,6 +819,71 @@ class OoxmlAdapter:
         cls.require_supported_version()
         return bool(paragraph._p.xpath("./a:fld"))
 
+    @staticmethod
+    def _strip_extension_lists(element: Any) -> None:
+        for ext_list in element.findall(f".//{{{A_NS}}}extLst"):
+            ext_list.getparent().remove(ext_list)
+
+    @staticmethod
+    def _clear_cell_text(cell_element: Any) -> None:
+        text_body = cell_element.find(f"{{{A_NS}}}txBody")
+        if text_body is None:
+            return
+        for paragraph in text_body.findall(f"{{{A_NS}}}p"):
+            text_body.remove(paragraph)
+        etree.SubElement(text_body, f"{{{A_NS}}}p")
+
+    @classmethod
+    def insert_table_row(cls, table: Any, index: int) -> None:
+        cls.require_supported_version()
+        rows = table._tbl.findall(f"{{{A_NS}}}tr")
+        new_row = copy.deepcopy(rows[min(index, len(rows) - 1)])
+        cls._strip_extension_lists(new_row)
+        for cell_element in new_row.findall(f"{{{A_NS}}}tc"):
+            cls._clear_cell_text(cell_element)
+        if index >= len(rows):
+            rows[-1].addnext(new_row)
+        else:
+            rows[index].addprevious(new_row)
+
+    @classmethod
+    def remove_table_row(cls, table: Any, index: int) -> None:
+        cls.require_supported_version()
+        row = table._tbl.findall(f"{{{A_NS}}}tr")[index]
+        row.getparent().remove(row)
+
+    @classmethod
+    def insert_table_column(cls, table: Any, index: int) -> None:
+        cls.require_supported_version()
+        tbl = table._tbl
+        grid = tbl.find(f"{{{A_NS}}}tblGrid")
+        grid_columns = grid.findall(f"{{{A_NS}}}gridCol")
+        new_column = copy.deepcopy(grid_columns[min(index, len(grid_columns) - 1)])
+        cls._strip_extension_lists(new_column)
+        if index >= len(grid_columns):
+            grid_columns[-1].addnext(new_column)
+        else:
+            grid_columns[index].addprevious(new_column)
+        for row in tbl.findall(f"{{{A_NS}}}tr"):
+            cells = row.findall(f"{{{A_NS}}}tc")
+            new_cell = copy.deepcopy(cells[min(index, len(cells) - 1)])
+            cls._strip_extension_lists(new_cell)
+            cls._clear_cell_text(new_cell)
+            if index >= len(cells):
+                cells[-1].addnext(new_cell)
+            else:
+                cells[index].addprevious(new_cell)
+
+    @classmethod
+    def remove_table_column(cls, table: Any, index: int) -> None:
+        cls.require_supported_version()
+        tbl = table._tbl
+        grid_column = tbl.find(f"{{{A_NS}}}tblGrid").findall(f"{{{A_NS}}}gridCol")[index]
+        grid_column.getparent().remove(grid_column)
+        for row in tbl.findall(f"{{{A_NS}}}tr"):
+            cell_element = row.findall(f"{{{A_NS}}}tc")[index]
+            cell_element.getparent().remove(cell_element)
+
     @classmethod
     def replace_picture_relationship(cls, picture: Any, blob: bytes) -> None:
         cls.require_supported_version()
@@ -1017,6 +1093,33 @@ def _sanitize_url(value: str) -> str:
     )
 
 
+def _validate_hyperlink_url(value: Any, label: str) -> str:
+    url = _require_string(value, label)
+    if len(url) > MAX_HYPERLINK_URL_CHARS:
+        raise ToolError(
+            "bad_input",
+            f"{label} exceeds {MAX_HYPERLINK_URL_CHARS} characters",
+        )
+    if any(ord(char) < 33 or ord(char) == 127 or char.isspace() for char in url):
+        raise ToolError("bad_input", f"{label} contains whitespace or control characters")
+    try:
+        parts = urlsplit(url)
+    except ValueError as exc:
+        raise ToolError("bad_input", f"{label} is malformed", {"reason": str(exc)}) from exc
+    scheme = parts.scheme.lower()
+    if scheme not in ALLOWED_HYPERLINK_SCHEMES:
+        raise ToolError(
+            "unsupported_operation",
+            f"{label} scheme must be one of: http, https, mailto",
+            {"scheme": scheme or "<missing>"},
+        )
+    if scheme != "mailto" and not parts.netloc:
+        raise ToolError("bad_input", f"{label} must include a host")
+    if scheme == "mailto" and not parts.path:
+        raise ToolError("bad_input", f"{label} must include a recipient address")
+    return url
+
+
 def _text_frame_info(text_frame: Any) -> dict[str, Any]:
     paragraphs: list[dict[str, Any]] = []
     for paragraph_index, paragraph in enumerate(text_frame.paragraphs):
@@ -1135,6 +1238,133 @@ def _notes_by_slide_part(path: Path, report: PackageReport) -> dict[str, str]:
     return notes
 
 
+def inspect_fonts(path: Path) -> dict[str, Any]:
+    """Inventory referenced fonts and fonts actually embedded in the PPTX package."""
+
+    referenced_by_casefold: dict[str, str] = {}
+    embedded_by_casefold: dict[str, str] = {}
+    symbol_and_bullet_by_casefold: dict[str, str] = {}
+    references: list[dict[str, str]] = []
+    dangling_embeddings: list[dict[str, str]] = []
+    font_tags = (f"{{{A_NS}}}latin", f"{{{A_NS}}}ea", f"{{{A_NS}}}cs")
+    symbol_tags = (f"{{{A_NS}}}sym", f"{{{A_NS}}}buFont")
+    theme_token_groups = {"mj": "major", "mn": "minor"}
+    theme_token_scripts = {"lt": "Latin", "ea": "EastAsia", "cs": "ComplexScript"}
+    embedding_tags = {
+        f"{{{P_NS}}}regular",
+        f"{{{P_NS}}}bold",
+        f"{{{P_NS}}}italic",
+        f"{{{P_NS}}}boldItalic",
+    }
+
+    with zipfile.ZipFile(path) as package:
+        names = set(package.namelist())
+        theme_tokens: set[str] = set()
+        theme_fonts: dict[str, str] = {}
+        for name in names:
+            if name.startswith("ppt/theme/") and name.endswith(".xml"):
+                scheme = _safe_xml(package.read(name), name).find(f".//{{{A_NS}}}fontScheme")
+                if scheme is None:
+                    continue
+                for group_key, group_tag in (("major", "majorFont"), ("minor", "minorFont")):
+                    group = scheme.find(f"{{{A_NS}}}{group_tag}")
+                    if group is None:
+                        continue
+                    for script_key, tag in (
+                        ("Latin", "latin"),
+                        ("EastAsia", "ea"),
+                        ("ComplexScript", "cs"),
+                    ):
+                        element = group.find(f"{{{A_NS}}}{tag}")
+                        value = (
+                            (element.get("typeface") or "").strip() if element is not None else ""
+                        )
+                        if value:
+                            theme_fonts[group_key + script_key] = value
+        for name in names:
+            if not name.startswith("ppt/") or not name.lower().endswith(".xml"):
+                continue
+            if name.startswith("ppt/theme/"):
+                continue
+            root = _safe_xml(package.read(name), name)
+            for element in root.iter(*font_tags):
+                slot = etree.QName(element).localname
+                value = (element.get("typeface") or "").strip()
+                if not value:
+                    continue
+                if not value.startswith("+"):
+                    referenced_by_casefold.setdefault(value.casefold(), value)
+                    references.append(
+                        {"part": name, "slot": slot, "font": value, "source": "explicit"}
+                    )
+                    continue
+                theme_tokens.add(value)
+                token_parts = value.removeprefix("+").split("-", 1)
+                if len(token_parts) != 2:
+                    continue
+                group_key = theme_token_groups.get(token_parts[0])
+                script_key = theme_token_scripts.get(token_parts[1])
+                if not group_key or not script_key:
+                    continue
+                resolved = theme_fonts.get(group_key + script_key)
+                if resolved:
+                    referenced_by_casefold.setdefault(resolved.casefold(), resolved)
+                    references.append(
+                        {"part": name, "slot": slot, "font": resolved, "source": value}
+                    )
+            for element in root.iter(*symbol_tags):
+                value = (element.get("typeface") or "").strip()
+                if value and not value.startswith("+"):
+                    symbol_and_bullet_by_casefold.setdefault(value.casefold(), value)
+        relationships: dict[str, str] = {}
+        if PRESENTATION_RELS in names:
+            rel_root = _safe_xml(package.read(PRESENTATION_RELS), PRESENTATION_RELS)
+            for rel in rel_root.findall(f"{{{REL_NS}}}Relationship"):
+                if (rel.get("TargetMode") or "").lower() == "external":
+                    continue
+                relationships[rel.get("Id", "")] = _resolve_target(
+                    PRESENTATION_PART, rel.get("Target") or ""
+                )
+        if PRESENTATION_PART in names:
+            root = _safe_xml(package.read(PRESENTATION_PART), PRESENTATION_PART)
+            embedded_list = f".//{{{P_NS}}}embeddedFontLst/{{{P_NS}}}embeddedFont"
+            for embedded_font in root.findall(embedded_list):
+                font_element = embedded_font.find(f"{{{P_NS}}}font")
+                font_name = (
+                    (font_element.get("typeface") or "").strip() if font_element is not None else ""
+                )
+                if not font_name:
+                    continue
+                for child in embedded_font:
+                    if child.tag not in embedding_tags:
+                        continue
+                    rid = child.get(f"{{{R_NS}}}id", "")
+                    target = relationships.get(rid)
+                    if target in names:
+                        embedded_by_casefold.setdefault(font_name.casefold(), font_name)
+                    else:
+                        dangling_embeddings.append(
+                            {"font": font_name, "relationship_id": rid, "target": target or ""}
+                        )
+
+    return {
+        "referenced": sorted(referenced_by_casefold.values(), key=str.casefold),
+        "embedded": sorted(embedded_by_casefold.values(), key=str.casefold),
+        "unembedded": sorted(
+            (
+                value
+                for key, value in referenced_by_casefold.items()
+                if key not in embedded_by_casefold
+            ),
+            key=str.casefold,
+        ),
+        "references": references,
+        "theme_tokens_referenced": sorted(theme_tokens),
+        "symbol_and_bullet": sorted(symbol_and_bullet_by_casefold.values(), key=str.casefold),
+        "dangling_embedding_relationships": dangling_embeddings,
+    }
+
+
 def _inspect_pptx_snapshot(
     path: Path,
     source: Path,
@@ -1142,6 +1372,7 @@ def _inspect_pptx_snapshot(
 ) -> dict[str, Any]:
     presentation = _open_presentation(path)
     notes = _notes_by_slide_part(path, report)
+    fonts = inspect_fonts(path)
     warnings = list(report.warnings)
     slides: list[dict[str, Any]] = []
     image_count = table_count = chart_count = shape_count = text_chars = 0
@@ -1234,6 +1465,35 @@ def _inspect_pptx_snapshot(
             "version",
         )
     }
+    if fonts["unembedded"]:
+        warnings.append(
+            "PPTX references fonts that are not embedded in the package ("
+            + ", ".join(fonts["unembedded"])
+            + "). PDF font embedding does not make the PPTX portable; another renderer may "
+            "substitute fonts and change wrapping, autofit, overflow, and slide layout. Use "
+            "conservative cross-renderer fonts or embed licensed fonts, and do not claim "
+            "PPTX/PDF fidelity from a PDF-only check."
+        )
+        portable_fonts = {"arial", "times new roman", "courier new"}
+        nonportable_fonts = [
+            font for font in fonts["unembedded"] if font.casefold() not in portable_fonts
+        ]
+        if nonportable_fonts:
+            warnings.append(
+                "RELEASE BLOCKER: PPTX references unembedded fonts outside the conservative "
+                "cross-renderer set (Arial, Times New Roman, Courier New): "
+                + ", ".join(nonportable_fonts)
+                + ". Replace these fonts before releasing matching PPTX and PDF deliverables; "
+                "renderer substitution can change wrapping and slide layout."
+            )
+    if fonts["dangling_embedding_relationships"]:
+        warnings.append(
+            "Font embedding markup has missing or invalid relationship targets: "
+            + ", ".join(
+                f"{item['font']} ({item['relationship_id']})"
+                for item in fonts["dangling_embedding_relationships"]
+            )
+        )
     return {
         "schema_version": SCHEMA_VERSION,
         "success": True,
@@ -1259,6 +1519,7 @@ def _inspect_pptx_snapshot(
             ],
             "slides": slides,
         },
+        "fonts": fonts,
         "counts": {
             "slides": len(slides),
             "shapes": shape_count,
@@ -1299,6 +1560,166 @@ def inspect_pptx(path: Path) -> dict[str, Any]:
         )
         result["warnings"] = sorted(set(result["warnings"]))
     return result
+
+
+def _prepare_directory_destination(destination: Path, overwrite: bool) -> Path:
+    destination = destination.expanduser()
+    if destination.is_symlink():
+        raise ToolError("bad_input", "destination must not be a symbolic link")
+    destination = destination.resolve()
+    if destination.exists():
+        if not destination.is_dir():
+            raise ToolError("bad_input", "destination exists and is not a directory")
+        if not overwrite:
+            raise ToolError(
+                "bad_input",
+                "destination directory already exists; pass --overwrite to replace it",
+                {"path": str(destination)},
+            )
+        if any(destination.iterdir()):
+            raise ToolError(
+                "bad_input",
+                "destination directory is not empty; this tool never deletes existing files",
+                {"path": str(destination)},
+            )
+    try:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise ToolError("bad_input", "could not create destination parent directory") from exc
+    return destination
+
+
+def _atomic_publish_directory(staged: Path, destination: Path) -> None:
+    try:
+        for staged_file in sorted(staged.rglob("*")):
+            if staged_file.is_file():
+                _fsync(staged_file)
+        if destination.exists():
+            destination.rmdir()
+        os.replace(staged, destination)
+        directory_fd = os.open(destination.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    except OSError as exc:
+        raise ToolError(
+            "post_write_validation",
+            "could not atomically publish the output directory",
+            {"path": str(destination)},
+        ) from exc
+
+
+def extract_pptx(source: Path, output_dir: Path, overwrite: bool) -> dict[str, Any]:
+    with _pptx_source_snapshot(source) as snapshot:
+        destination = _prepare_directory_destination(output_dir, overwrite)
+        presentation = _open_presentation(snapshot.snapshot_path)
+        warnings = list(snapshot.report.warnings)
+        images: list[dict[str, Any]] = []
+        blobs: dict[str, bytes] = {}
+        picture_count = 0
+        pictures_skipped = 0
+        for slide_index, slide in enumerate(presentation.slides):
+            for shape in slide.shapes:
+                if shape.shape_type != MSO_SHAPE_TYPE.PICTURE:
+                    continue
+                picture_count += 1
+                image = shape.image
+                blob = image.blob
+                if len(blob) > MAX_IMAGE_BYTES:
+                    pictures_skipped += 1
+                    warnings.append(
+                        f"slide {int(slide.slide_id)} shape {int(shape.shape_id)}: image "
+                        "exceeds the byte limit and was not extracted"
+                    )
+                    continue
+                sha256 = hashlib.sha256(blob).hexdigest()
+                file_name = (
+                    f"slide-{int(slide.slide_id):04d}-shape-{int(shape.shape_id):04d}-"
+                    f"{sha256[:12]}.{image.ext}"
+                )
+                blobs[file_name] = blob
+                images.append(
+                    {
+                        "slide_id": int(slide.slide_id),
+                        "slide_index": slide_index,
+                        "shape_id": int(shape.shape_id),
+                        "shape_name": shape.name,
+                        "content_type": image.content_type,
+                        "bytes": len(blob),
+                        "sha256": sha256,
+                        "file": file_name,
+                    }
+                )
+        if picture_count == 0:
+            warnings.append("presentation contains no picture shapes to extract")
+        exported_hashes = {record["sha256"] for record in images}
+        skipped_media: list[str] = []
+        with zipfile.ZipFile(snapshot.snapshot_path) as package:
+            for name in sorted(package.namelist()):
+                if not name.startswith("ppt/media/"):
+                    continue
+                digest = hashlib.sha256(package.read(name)).hexdigest()
+                if digest not in exported_hashes:
+                    skipped_media.append(name)
+        if skipped_media:
+            warnings.append(
+                "media members were not extracted (picture shapes only): "
+                + ", ".join(skipped_media)
+            )
+        staged = destination.parent / f".{destination.name}.{uuid.uuid4().hex}.tmp"
+        try:
+            staged.mkdir()
+            for file_name, blob in blobs.items():
+                (staged / file_name).write_bytes(blob)
+            _atomic_publish_directory(staged, destination)
+        finally:
+            if staged.exists():
+                shutil.rmtree(staged, ignore_errors=True)
+        reopened = 0
+        for record in images:
+            published = destination / record["file"]
+            if hashlib.sha256(published.read_bytes()).hexdigest() != record["sha256"]:
+                raise ToolError(
+                    "post_write_validation",
+                    "published image does not match its source hash",
+                    {"file": record["file"]},
+                )
+            reopened += 1
+        path_matches_snapshot = _source_hash_matches(
+            snapshot.original_path,
+            snapshot.sha256,
+        )
+    if not path_matches_snapshot:
+        warnings.append(
+            "source path changed during extraction; results describe the validated immutable "
+            "snapshot"
+        )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "success": True,
+        "operation": "extract",
+        "source": str(snapshot.original_path.resolve()),
+        "output": str(destination),
+        "versions": _versions(),
+        "counts": {
+            "slides": len(snapshot.report.slide_ids),
+            "pictures": picture_count,
+            "files_written": len(images),
+            "pictures_skipped": pictures_skipped,
+            "skipped_media_members": len(skipped_media),
+        },
+        "images": images,
+        "warnings": sorted(set(warnings)),
+        "verification": {
+            "immutable_source_snapshot": True,
+            "package_preflight": True,
+            "atomic_publish": True,
+            "files_reopened": reopened,
+            "hashes_verified": True,
+            "source_path_matched_snapshot_at_completion": path_matches_snapshot,
+        },
+    }
 
 
 def _load_job(path_value: str, expected_operation: str) -> tuple[dict[str, Any], Path]:
@@ -2416,6 +2837,100 @@ def _replace_text(presentation: Any, operation: dict[str, Any]) -> tuple[int, li
     return len(selected), warnings
 
 
+def _hyperlink_scope(operation: dict[str, Any], action: str) -> str:
+    scope = operation.get("scope", "text")
+    if scope not in {"text", "shape"}:
+        raise ToolError("bad_input", f"{action}.scope must be text or shape")
+    if scope == "shape" and (
+        operation.get("find") is not None or operation.get("occurrence") is not None
+    ):
+        raise ToolError(
+            "bad_input",
+            f"{action} with shape scope does not accept find or occurrence",
+        )
+    return scope
+
+
+def _aligned_hyperlink_matches(
+    presentation: Any,
+    operation: dict[str, Any],
+    action: str,
+) -> list[RunMatch]:
+    needle = _require_string(operation.get("find"), f"{action}.find")
+    matches, unsafe = _collect_run_matches(presentation, operation, needle)
+    if unsafe:
+        raise ToolError(
+            "ambiguous_edit",
+            "hyperlink text selection crosses a paragraph or field boundary",
+            {"matches": unsafe},
+        )
+    selected = _choose_matches(matches, operation)
+    for match in selected:
+        runs = list(match.paragraph.runs)
+        if match.first_offset != 0 or match.last_offset != len(runs[match.last_run].text):
+            raise ToolError(
+                "ambiguous_edit",
+                "hyperlink text must cover whole runs; use replace_text to isolate the "
+                "target text first",
+                {
+                    "first_offset": match.first_offset,
+                    "last_offset": match.last_offset,
+                },
+            )
+    return selected
+
+
+def _set_hyperlink(presentation: Any, operation: dict[str, Any]) -> int:
+    _reject_unknown(
+        operation,
+        {"action", "slide", "shape", "scope", "find", "occurrence", "url"},
+        "set_hyperlink operation",
+    )
+    url = _validate_hyperlink_url(operation.get("url"), "set_hyperlink.url")
+    if _hyperlink_scope(operation, "set_hyperlink") == "shape":
+        _, shape = _select_one_shape_across_scope(presentation, operation)
+        shape.click_action.hyperlink.address = url
+        return 1
+    selected = _aligned_hyperlink_matches(presentation, operation, "set_hyperlink")
+    for match in selected:
+        runs = list(match.paragraph.runs)
+        for index in range(match.first_run, match.last_run + 1):
+            runs[index].hyperlink.address = url
+    return len(selected)
+
+
+def _remove_hyperlink(presentation: Any, operation: dict[str, Any]) -> int:
+    _reject_unknown(
+        operation,
+        {"action", "slide", "shape", "scope", "find", "occurrence"},
+        "remove_hyperlink operation",
+    )
+    if _hyperlink_scope(operation, "remove_hyperlink") == "shape":
+        _, shape = _select_one_shape_across_scope(presentation, operation)
+        hyperlink = shape.click_action.hyperlink
+        if hyperlink.address is None:
+            raise ToolError(
+                "ambiguous_edit",
+                "selected shape has no click hyperlink to remove",
+            )
+        hyperlink.address = None
+        return 1
+    selected = _aligned_hyperlink_matches(presentation, operation, "remove_hyperlink")
+    for match in selected:
+        runs = list(match.paragraph.runs)
+        covered = runs[match.first_run : match.last_run + 1]
+        if any(run.hyperlink.address is None for run in covered):
+            raise ToolError(
+                "ambiguous_edit",
+                "selected text is not fully covered by a hyperlink to remove",
+            )
+    for match in selected:
+        runs = list(match.paragraph.runs)
+        for index in range(match.first_run, match.last_run + 1):
+            runs[index].hyperlink.address = None
+    return len(selected)
+
+
 def _update_table(presentation: Any, operation: dict[str, Any]) -> int:
     _reject_unknown(
         operation,
@@ -2478,6 +2993,130 @@ def _update_table(presentation: Any, operation: dict[str, Any]) -> int:
             )
             updates += 1
     return updates
+
+
+def _table_cell_text(value: Any, label: str) -> str:
+    if not isinstance(value, (str, int, float, bool)) and value is not None:
+        raise ToolError("bad_input", f"{label} must contain JSON scalar values")
+    return "" if value is None else str(value)
+
+
+def _read_table_matrix(table: Any) -> list[list[str]]:
+    return [
+        [table.cell(row, column).text for column in range(len(table.columns))]
+        for row in range(len(table.rows))
+    ]
+
+
+def _update_table_structure(presentation: Any, operation: dict[str, Any]) -> int:
+    _reject_unknown(
+        operation,
+        {"action", "slide", "shape", "changes"},
+        "update_table_structure operation",
+    )
+    _, shape = _select_one_shape_across_scope(presentation, operation)
+    if not shape.has_table:
+        raise ToolError("ambiguous_edit", "selected shape is not a table")
+    table = shape.table
+    if any(cell.is_merge_origin or cell.is_spanned for cell in table.iter_cells()):
+        raise ToolError(
+            "unsupported_operation",
+            "structural table edits are unsupported on tables containing merged cells",
+        )
+    changes = _require_list(operation.get("changes"), "update_table_structure.changes")
+    if not changes:
+        raise ToolError("bad_input", "update_table_structure.changes must not be empty")
+    expected_matrix = _read_table_matrix(table)
+    applied = 0
+    for change_index, value in enumerate(changes):
+        label = f"update_table_structure.changes[{change_index}]"
+        change = _require_mapping(value, label)
+        _reject_unknown(change, {"op", "index", "cells"}, label)
+        change_op = _require_string(change.get("op"), f"{label}.op")
+        index = change.get("index")
+        if not isinstance(index, int) or isinstance(index, bool) or index < 0:
+            raise ToolError("bad_input", f"{label}.index must be a non-negative integer")
+        rows = len(expected_matrix)
+        columns = len(expected_matrix[0]) if expected_matrix else 0
+        if change_op in {"insert_row", "insert_column"}:
+            limit = rows if change_op == "insert_row" else columns
+            if index > limit:
+                raise ToolError(
+                    "bad_input",
+                    f"{label}.index is out of range for insertion",
+                    {"index": index, "rows": rows, "columns": columns},
+                )
+            cells = change.get("cells")
+            expected_length = columns if change_op == "insert_row" else rows
+            if cells is not None:
+                cells = _require_list(cells, f"{label}.cells")
+                if len(cells) != expected_length:
+                    raise ToolError(
+                        "bad_input",
+                        f"{label}.cells must contain exactly {expected_length} entries",
+                        {"expected": expected_length, "actual": len(cells)},
+                    )
+            texts = [
+                _table_cell_text(cell, f"{label}.cells")
+                for cell in (cells if cells is not None else [None] * expected_length)
+            ]
+            if change_op == "insert_row":
+                if rows + 1 > MAX_TABLE_ROWS:
+                    raise ToolError("resource_limit", "table row limit exceeded")
+                OoxmlAdapter.insert_table_row(table, index)
+                for column, text in enumerate(texts):
+                    table.cell(index, column).text = text
+                expected_matrix.insert(index, texts)
+            else:
+                if columns + 1 > MAX_TABLE_COLUMNS:
+                    raise ToolError("resource_limit", "table column limit exceeded")
+                OoxmlAdapter.insert_table_column(table, index)
+                for row, text in enumerate(texts):
+                    table.cell(row, index).text = text
+                for row, text in enumerate(texts):
+                    expected_matrix[row].insert(index, text)
+        elif change_op in {"remove_row", "remove_column"}:
+            if change.get("cells") is not None:
+                raise ToolError("bad_input", f"{label}.cells is not accepted for removal")
+            limit = rows if change_op == "remove_row" else columns
+            if index >= limit:
+                raise ToolError(
+                    "bad_input",
+                    f"{label}.index is out of range for removal",
+                    {"index": index, "rows": rows, "columns": columns},
+                )
+            if limit <= 1:
+                raise ToolError(
+                    "unsupported_operation",
+                    f"removing the final table {change_op.removeprefix('remove_')} is unsupported",
+                )
+            if change_op == "remove_row":
+                OoxmlAdapter.remove_table_row(table, index)
+                expected_matrix.pop(index)
+            else:
+                OoxmlAdapter.remove_table_column(table, index)
+                for row_values in expected_matrix:
+                    row_values.pop(index)
+        else:
+            raise ToolError(
+                "unsupported_operation",
+                "unsupported table structure change",
+                {"op": change_op},
+            )
+        applied += 1
+    actual_matrix = _read_table_matrix(table)
+    if actual_matrix != expected_matrix:
+        raise ToolError(
+            "post_write_validation",
+            "table structure verification failed",
+            {
+                "expected_rows": len(expected_matrix),
+                "expected_columns": len(expected_matrix[0]) if expected_matrix else 0,
+                "actual_rows": len(actual_matrix),
+                "actual_columns": len(actual_matrix[0]) if actual_matrix else 0,
+            },
+        )
+    return applied
 
 
 def _chart_type_name(value: Any) -> str | None:
@@ -2604,7 +3243,10 @@ def edit_pptx(
         "slides_removed": 0,
         "slides_reordered": 0,
         "text_replacements": 0,
+        "hyperlinks_set": 0,
+        "hyperlinks_removed": 0,
         "table_cells_updated": 0,
+        "table_structure_changes": 0,
         "chart_points_updated": 0,
         "images_replaced": 0,
         "notes_updated": 0,
@@ -2655,8 +3297,16 @@ def edit_pptx(
                 replacements, replacement_warnings = _replace_text(presentation, operation)
                 counts["text_replacements"] += replacements
                 warnings.extend(replacement_warnings)
+            elif action == "set_hyperlink":
+                counts["hyperlinks_set"] += _set_hyperlink(presentation, operation)
+            elif action == "remove_hyperlink":
+                counts["hyperlinks_removed"] += _remove_hyperlink(presentation, operation)
             elif action == "update_table":
                 counts["table_cells_updated"] += _update_table(presentation, operation)
+            elif action == "update_table_structure":
+                counts["table_structure_changes"] += _update_table_structure(
+                    presentation, operation
+                )
             elif action == "update_chart":
                 counts["chart_points_updated"] += _update_chart(presentation, operation)
             elif action == "replace_image":
@@ -2776,7 +3426,7 @@ def _find_libreoffice() -> str:
     return executable
 
 
-def _validate_pdf(path: Path, expected_pages: int) -> tuple[int, list[str]]:
+def _validate_pdf(path: Path, expected_pages: int) -> int:
     try:
         with path.open("rb") as source:
             if source.read(5) != b"%PDF-":
@@ -2786,7 +3436,6 @@ def _validate_pdf(path: Path, expected_pages: int) -> tuple[int, list[str]]:
                 )
         reader = pypdf.PdfReader(str(path), strict=True)
         pages = len(reader.pages)
-        warnings = list(reader.metadata.keys()) if reader.metadata else []
     except ToolError:
         raise
     except Exception as exc:
@@ -2800,7 +3449,7 @@ def _validate_pdf(path: Path, expected_pages: int) -> tuple[int, list[str]]:
             "converted PDF page count does not equal the PPTX slide count",
             {"slides": expected_pages, "pages": pages},
         )
-    return pages, warnings
+    return pages
 
 
 def _libreoffice_environment(work: Path) -> dict[str, str]:
@@ -2860,6 +3509,115 @@ def _redact_diagnostic(text: str, paths: list[Path]) -> str:
     return redacted
 
 
+@dataclass
+class LibreOfficePdf:
+    generated: Path
+    stdout: str
+    stderr: str
+    office_version: str
+    engine: str
+
+
+def _run_libreoffice_pdf(
+    snapshot: PptxSourceSnapshot,
+    work: Path,
+    timeout: float,
+    redact_paths: list[Path],
+) -> LibreOfficePdf:
+    executable = _find_libreoffice()
+    output_dir = work / "output"
+    profile = work / "profile"
+    output_dir.mkdir()
+    profile.mkdir()
+    environment = _libreoffice_environment(work)
+    command = [
+        executable,
+        "--headless",
+        "--nologo",
+        "--nodefault",
+        "--nolockcheck",
+        "--nofirststartwizard",
+        f"-env:UserInstallation={profile.resolve().as_uri()}",
+        "--convert-to",
+        "pdf",
+        "--outdir",
+        str(output_dir),
+        str(snapshot.snapshot_path),
+    ]
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=environment,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ToolError(
+            "external_tool_failure",
+            "LibreOffice conversion timed out",
+            {"timeout_seconds": timeout},
+        ) from exc
+    except OSError as exc:
+        raise ToolError(
+            "external_tool_failure",
+            "LibreOffice could not be launched",
+        ) from exc
+    diagnostic_paths = [
+        snapshot.original_path,
+        snapshot.snapshot_path,
+        work,
+        output_dir,
+        profile,
+        *redact_paths,
+    ]
+    stdout = _redact_diagnostic(completed.stdout, diagnostic_paths)
+    stderr = _redact_diagnostic(completed.stderr, diagnostic_paths)
+    if completed.returncode != 0:
+        raise ToolError(
+            "external_tool_failure",
+            "LibreOffice conversion failed",
+            {
+                "returncode": completed.returncode,
+                "stdout": stdout,
+                "stderr": stderr,
+            },
+        )
+    generated = output_dir / f"{snapshot.original_path.stem}.pdf"
+    if not generated.is_file():
+        candidates = sorted(output_dir.glob("*.pdf"))
+        if len(candidates) != 1:
+            raise ToolError(
+                "external_tool_failure",
+                "LibreOffice did not produce exactly one PDF",
+                {"outputs": [path.name for path in candidates]},
+            )
+        generated = candidates[0]
+    try:
+        version_result = subprocess.run(
+            [executable, "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=environment,
+        )
+        office_version = _redact_diagnostic(
+            version_result.stdout.strip(),
+            diagnostic_paths,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        office_version = "unknown"
+    return LibreOfficePdf(
+        generated=generated,
+        stdout=stdout,
+        stderr=stderr,
+        office_version=office_version or "unknown",
+        engine=Path(executable).name,
+    )
+
+
 def _convert_pptx_snapshot(
     snapshot: PptxSourceSnapshot,
     destination: Path,
@@ -2878,101 +3636,22 @@ def _convert_pptx_snapshot(
         )
     source_hash = snapshot.sha256
     destination = _prepare_destination(destination, ".pdf", overwrite, source)
-    executable = _find_libreoffice()
     temporary = _temporary_sibling(destination, ".pdf")
-    stdout = ""
-    stderr = ""
-    office_version = "unknown"
     try:
         with tempfile.TemporaryDirectory(prefix="pptx-libreoffice-") as temp_dir:
             work = Path(temp_dir)
-            output_dir = work / "output"
-            profile = work / "profile"
-            output_dir.mkdir()
-            profile.mkdir()
-            environment = _libreoffice_environment(work)
-            command = [
-                executable,
-                "--headless",
-                "--nologo",
-                "--nodefault",
-                "--nolockcheck",
-                "--nofirststartwizard",
-                f"-env:UserInstallation={profile.resolve().as_uri()}",
-                "--convert-to",
-                "pdf",
-                "--outdir",
-                str(output_dir),
-                str(snapshot.snapshot_path),
-            ]
-            try:
-                completed = subprocess.run(
-                    command,
-                    check=False,
-                    capture_output=True,
-                    text=True,
-                    timeout=timeout,
-                    env=environment,
-                )
-            except subprocess.TimeoutExpired as exc:
-                raise ToolError(
-                    "external_tool_failure",
-                    "LibreOffice conversion timed out",
-                    {"timeout_seconds": timeout},
-                ) from exc
-            except OSError as exc:
-                raise ToolError(
-                    "external_tool_failure",
-                    "LibreOffice could not be launched",
-                ) from exc
-            diagnostic_paths = [
-                source,
-                snapshot.snapshot_path,
-                destination,
-                temporary,
+            office = _run_libreoffice_pdf(
+                snapshot,
                 work,
-                output_dir,
-                profile,
-            ]
-            stdout = _redact_diagnostic(completed.stdout, diagnostic_paths)
-            stderr = _redact_diagnostic(completed.stderr, diagnostic_paths)
-            if completed.returncode != 0:
-                raise ToolError(
-                    "external_tool_failure",
-                    "LibreOffice conversion failed",
-                    {
-                        "returncode": completed.returncode,
-                        "stdout": stdout,
-                        "stderr": stderr,
-                    },
-                )
-            generated = output_dir / f"{source.stem}.pdf"
-            if not generated.is_file():
-                candidates = sorted(output_dir.glob("*.pdf"))
-                if len(candidates) != 1:
-                    raise ToolError(
-                        "external_tool_failure",
-                        "LibreOffice did not produce exactly one PDF",
-                        {"outputs": [path.name for path in candidates]},
-                    )
-                generated = candidates[0]
-            shutil.copyfile(generated, temporary)
-            try:
-                version_result = subprocess.run(
-                    [executable, "--version"],
-                    check=False,
-                    capture_output=True,
-                    text=True,
-                    timeout=10,
-                    env=environment,
-                )
-                office_version = _redact_diagnostic(
-                    version_result.stdout.strip(),
-                    diagnostic_paths,
-                )
-            except (OSError, subprocess.TimeoutExpired):
-                office_version = "unknown"
-        pages, _ = _validate_pdf(temporary, len(source_report.slide_ids))
+                timeout,
+                [destination, temporary],
+            )
+            stdout = office.stdout
+            stderr = office.stderr
+            office_version = office.office_version
+            engine = office.engine
+            shutil.copyfile(office.generated, temporary)
+        pages = _validate_pdf(temporary, len(source_report.slide_ids))
         if not _source_hash_matches(source, source_hash):
             raise ToolError(
                 "post_write_validation",
@@ -3003,7 +3682,7 @@ def _convert_pptx_snapshot(
         },
         "warnings": sorted(set(warnings)),
         "conversion": {
-            "engine": Path(executable).name,
+            "engine": engine,
             "timeout_seconds": timeout,
             "diagnostics": {"stdout": stdout, "stderr": stderr},
         },
@@ -3033,12 +3712,241 @@ def convert_pptx(
         return _convert_pptx_snapshot(snapshot, destination, overwrite, timeout)
 
 
+def _require_pypdfium2() -> Any:
+    try:
+        import pypdfium2
+    except ModuleNotFoundError as exc:
+        raise ToolError(
+            "missing_dependency",
+            "slide rendering requires the optional pypdfium2 package",
+            {"install": f'"{sys.executable}" -m pip install pypdfium2'},
+        ) from exc
+    return pypdfium2
+
+
+def _parse_render_slides(value: str | None, slide_ids: list[int]) -> set[int]:
+    if value is None:
+        return set(slide_ids)
+    selected: set[int] = set()
+    for part in value.split(","):
+        text = part.strip()
+        if not text.isdigit():
+            raise ToolError(
+                "bad_input",
+                "slides must be a comma-separated list of slide IDs",
+                {"slides": value},
+            )
+        slide_id = int(text)
+        if slide_id not in slide_ids:
+            raise ToolError(
+                "bad_input",
+                "requested slide ID does not exist",
+                {"slide_id": slide_id, "current": slide_ids},
+            )
+        selected.add(slide_id)
+    if not selected:
+        raise ToolError("bad_input", "slides must select at least one slide ID")
+    return selected
+
+
+def render_pptx(
+    source: Path,
+    output_dir: Path,
+    overwrite: bool,
+    dpi: int,
+    slides_argument: str | None,
+    timeout: float,
+) -> dict[str, Any]:
+    if (
+        not isinstance(dpi, int)
+        or isinstance(dpi, bool)
+        or not MIN_RENDER_DPI <= dpi <= MAX_RENDER_DPI
+    ):
+        raise ToolError(
+            "bad_input",
+            f"dpi must be an integer between {MIN_RENDER_DPI} and {MAX_RENDER_DPI}",
+            {"dpi": dpi},
+        )
+    if not math.isfinite(timeout) or not 1 <= timeout <= 1800:
+        raise ToolError("bad_input", "timeout must be between 1 and 1800 seconds")
+    with _pptx_source_snapshot(source) as snapshot:
+        report = snapshot.report
+        if report.external_relationships:
+            raise ToolError(
+                "unsupported_operation",
+                "rendering rejects presentations containing external relationships",
+                {"count": report.external_relationships},
+            )
+        slide_ids = list(report.slide_ids)
+        selected_ids = _parse_render_slides(slides_argument, slide_ids)
+        pdfium = _require_pypdfium2()
+        destination = _prepare_directory_destination(output_dir, overwrite)
+        presentation = _open_presentation(snapshot.snapshot_path)
+        pixels_per_slide = math.ceil(presentation.slide_width / 914400 * dpi) * math.ceil(
+            presentation.slide_height / 914400 * dpi
+        )
+        if pixels_per_slide > MAX_RENDER_PIXELS_PER_SLIDE:
+            raise ToolError(
+                "resource_limit",
+                "rendered pixel count per slide exceeds the limit",
+                {"pixels": pixels_per_slide, "limit": MAX_RENDER_PIXELS_PER_SLIDE},
+            )
+        if pixels_per_slide * len(selected_ids) > MAX_RENDER_TOTAL_PIXELS:
+            raise ToolError(
+                "resource_limit",
+                "total rendered pixel count exceeds the limit",
+                {
+                    "pixels": pixels_per_slide * len(selected_ids),
+                    "limit": MAX_RENDER_TOTAL_PIXELS,
+                },
+            )
+        images: list[dict[str, Any]] = []
+        staged = destination.parent / f".{destination.name}.{uuid.uuid4().hex}.tmp"
+        try:
+            with tempfile.TemporaryDirectory(prefix="pptx-libreoffice-") as temp_dir:
+                work = Path(temp_dir)
+                office = _run_libreoffice_pdf(snapshot, work, timeout, [destination])
+                _validate_pdf(office.generated, len(slide_ids))
+                staged.mkdir()
+                dimensions: tuple[int, int] | None = None
+                try:
+                    document = pdfium.PdfDocument(str(office.generated))
+                except Exception as exc:
+                    raise ToolError(
+                        "external_tool_failure",
+                        "PDFium could not open the converted PDF",
+                    ) from exc
+                try:
+                    for ordinal, slide_id in enumerate(slide_ids):
+                        if slide_id not in selected_ids:
+                            continue
+                        file_name = f"slide-{ordinal:02d}-id-{slide_id:04d}.png"
+                        staged_file = staged / file_name
+                        try:
+                            page = document[ordinal]
+                            page.render(scale=dpi / 72).to_pil().save(staged_file, format="PNG")
+                        except Exception as exc:
+                            raise ToolError(
+                                "external_tool_failure",
+                                "PDFium could not rasterize a slide page",
+                                {"slide_id": slide_id},
+                            ) from exc
+                        with staged_file.open("rb") as rendered:
+                            if rendered.read(8) != b"\x89PNG\r\n\x1a\n":
+                                raise ToolError(
+                                    "post_write_validation",
+                                    "rendered file does not have a PNG signature",
+                                    {"file": file_name},
+                                )
+                        with Image.open(staged_file) as verified:
+                            verified.load()
+                            size = verified.size
+                        if size[0] * size[1] > MAX_RENDER_PIXELS_PER_SLIDE:
+                            raise ToolError(
+                                "post_write_validation",
+                                "rendered image exceeds the per-slide pixel limit",
+                                {"file": file_name},
+                            )
+                        if dimensions is None:
+                            dimensions = size
+                        elif size != dimensions:
+                            raise ToolError(
+                                "post_write_validation",
+                                "rendered slides do not share identical dimensions",
+                                {"file": file_name},
+                            )
+                        data = staged_file.read_bytes()
+                        images.append(
+                            {
+                                "slide_id": slide_id,
+                                "index": ordinal,
+                                "file": file_name,
+                                "width_px": size[0],
+                                "height_px": size[1],
+                                "bytes": len(data),
+                                "sha256": hashlib.sha256(data).hexdigest(),
+                            }
+                        )
+                finally:
+                    document.close()
+            if not _source_hash_matches(snapshot.original_path, snapshot.sha256):
+                raise ToolError(
+                    "post_write_validation",
+                    "source changed before the destination publication gate",
+                )
+            _atomic_publish_directory(staged, destination)
+            post_publish_source_changed = not _source_hash_matches(
+                snapshot.original_path, snapshot.sha256
+            )
+        finally:
+            if staged.exists():
+                shutil.rmtree(staged, ignore_errors=True)
+        reopened = 0
+        for record in images:
+            published = destination / record["file"]
+            data = published.read_bytes()
+            if hashlib.sha256(data).hexdigest() != record["sha256"]:
+                raise ToolError(
+                    "post_write_validation",
+                    "published rendering does not match its staged hash",
+                    {"file": record["file"]},
+                )
+            with Image.open(published) as verified:
+                verified.load()
+            reopened += 1
+    warnings = list(report.warnings)
+    if office.stderr.strip():
+        warnings.append("LibreOffice emitted diagnostics; inspect conversion.diagnostics")
+    if post_publish_source_changed:
+        warnings.append(
+            "source path changed after destination publication; the published renderings "
+            "were built from the validated immutable snapshot"
+        )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "success": True,
+        "operation": "render",
+        "source": str(snapshot.original_path.resolve()),
+        "output": str(destination),
+        "versions": {**_versions(), "libreoffice": office.office_version},
+        "counts": {
+            "source_slides": len(slide_ids),
+            "pages_rendered": len(images),
+        },
+        "images": images,
+        "warnings": sorted(set(warnings)),
+        "conversion": {
+            "engine": office.engine,
+            "timeout_seconds": timeout,
+            "dpi": dpi,
+            "diagnostics": {"stdout": office.stdout, "stderr": office.stderr},
+        },
+        "verification": {
+            "atomic_publish": True,
+            "source_unchanged_at_publish_gate": True,
+            "post_publish_source_changed": post_publish_source_changed,
+            "package_preflight": True,
+            "immutable_source_snapshot": True,
+            "pdf_page_count": len(slide_ids),
+            "source_slide_count": len(slide_ids),
+            "png_reopened": reopened,
+        },
+    }
+
+
 def _build_parser() -> JsonArgumentParser:
     parser = JsonArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     inspect_parser = subparsers.add_parser("inspect", help="inspect a PPTX")
     inspect_parser.add_argument("source", type=Path)
+
+    extract_parser = subparsers.add_parser(
+        "extract", help="export embedded picture-shape images to a directory"
+    )
+    extract_parser.add_argument("source", type=Path)
+    extract_parser.add_argument("--output", required=True, type=Path)
+    extract_parser.add_argument("--overwrite", action="store_true")
 
     create_parser = subparsers.add_parser("create", help="create a PPTX from a JSON job")
     create_parser.add_argument("--job", required=True, help="schema-version-1 JSON file or -")
@@ -3056,6 +3964,16 @@ def _build_parser() -> JsonArgumentParser:
     convert_parser.add_argument("--output", required=True, type=Path)
     convert_parser.add_argument("--overwrite", action="store_true")
     convert_parser.add_argument("--timeout", type=float, default=120.0)
+
+    render_parser = subparsers.add_parser(
+        "render", help="render slides to one PNG each via LibreOffice and PDFium"
+    )
+    render_parser.add_argument("source", type=Path)
+    render_parser.add_argument("--output", required=True, type=Path)
+    render_parser.add_argument("--overwrite", action="store_true")
+    render_parser.add_argument("--dpi", type=int, default=96)
+    render_parser.add_argument("--slides", help="comma-separated slide IDs to rasterize")
+    render_parser.add_argument("--timeout", type=float, default=120.0)
     return parser
 
 
@@ -3064,6 +3982,8 @@ def main(argv: list[str] | None = None) -> int:
         args = _build_parser().parse_args(argv)
         if args.command == "inspect":
             result = inspect_pptx(args.source)
+        elif args.command == "extract":
+            result = extract_pptx(args.source, args.output, args.overwrite)
         elif args.command == "create":
             job, base_dir = _load_job(args.job, "create")
             result = create_pptx(job, base_dir, args.output, args.overwrite)
@@ -3081,6 +4001,15 @@ def main(argv: list[str] | None = None) -> int:
                 args.source,
                 args.output,
                 args.overwrite,
+                args.timeout,
+            )
+        elif args.command == "render":
+            result = render_pptx(
+                args.source,
+                args.output,
+                args.overwrite,
+                args.dpi,
+                args.slides,
                 args.timeout,
             )
         else:

--- a/kolega_code/_bundled_skills/skills/pptx/scripts/smoke_test.py
+++ b/kolega_code/_bundled_skills/skills/pptx/scripts/smoke_test.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import importlib.util
 import io
 import json
 import shutil
@@ -17,6 +18,7 @@ import zipfile
 import zlib
 from pathlib import Path
 from typing import Any
+from xml.etree import ElementTree
 
 DEPENDENCY_ERROR: ModuleNotFoundError | None = None
 Image: Any = None
@@ -133,6 +135,107 @@ def _rewrite_zip(
     with zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED) as output:
         for name, data in members.items():
             output.writestr(name, data)
+
+
+def _rewrite_font_typefaces(
+    source: Path,
+    destination: Path,
+    font_name: str,
+    *,
+    add_decoys: bool = False,
+) -> None:
+    """Rewrite every DrawingML latin/ea/cs typeface to one font, keeping theme tokens."""
+
+    font_tags = {
+        f"{{{PptxTool.A_NS}}}latin",
+        f"{{{PptxTool.A_NS}}}ea",
+        f"{{{PptxTool.A_NS}}}cs",
+    }
+    replacements: dict[str, bytes] = {}
+    with zipfile.ZipFile(source) as archive:
+        for name in archive.namelist():
+            if not name.startswith("ppt/") or not name.lower().endswith(".xml"):
+                continue
+            root = ElementTree.fromstring(archive.read(name))
+            in_theme = name.startswith("ppt/theme/")
+            changed = False
+            for element in root.iter():
+                if element.tag not in font_tags:
+                    continue
+                value = (element.get("typeface") or "").strip()
+                if not in_theme and value.startswith("+"):
+                    continue
+                element.set("typeface", font_name)
+                changed = True
+            if add_decoys and name.startswith("ppt/slides/"):
+                fill = root.find(f".//{{{PptxTool.A_NS}}}solidFill")
+                if fill is not None:
+                    fill.set("typeface", "ja-JP")
+                decoy = ElementTree.SubElement(root, "{urn:smoke-decoy}latin")
+                decoy.set("typeface", ".")
+                changed = True
+            if changed:
+                replacements[name] = ElementTree.tostring(
+                    root, encoding="UTF-8", xml_declaration=True
+                )
+    _rewrite_zip(source, destination, replacements=replacements)
+
+
+def _embed_font_fixture(
+    source: Path,
+    destination: Path,
+    font_name: str,
+    *,
+    dangling: bool,
+) -> None:
+    """Synthesize a p:embeddedFontLst entry, either resolvable in-package or dangling."""
+
+    p_ns = PptxTool.P_NS
+    with zipfile.ZipFile(source) as archive:
+        presentation_xml = archive.read("ppt/presentation.xml")
+        rels_xml = archive.read("ppt/_rels/presentation.xml.rels")
+        content_types_xml = archive.read("[Content_Types].xml")
+
+    root = ElementTree.fromstring(presentation_xml)
+    font_list = ElementTree.Element(f"{{{p_ns}}}embeddedFontLst")
+    embedded_font = ElementTree.SubElement(font_list, f"{{{p_ns}}}embeddedFont")
+    ElementTree.SubElement(embedded_font, f"{{{p_ns}}}font").set("typeface", font_name)
+    ElementTree.SubElement(embedded_font, f"{{{p_ns}}}regular").set(
+        f"{{{PptxTool.R_NS}}}id", "rIdSmokeFont"
+    )
+    notes_size_index = next(
+        index for index, child in enumerate(list(root)) if child.tag == f"{{{p_ns}}}notesSz"
+    )
+    root.insert(notes_size_index + 1, font_list)
+
+    rel_root = ElementTree.fromstring(rels_xml)
+    relationship = ElementTree.SubElement(rel_root, f"{{{PptxTool.REL_NS}}}Relationship")
+    relationship.set("Id", "rIdSmokeFont")
+    relationship.set("Type", f"{PptxTool.R_NS}/font")
+    if dangling:
+        relationship.set("Target", "https://fonts.example/font1.fntdata")
+        relationship.set("TargetMode", "External")
+    else:
+        relationship.set("Target", "fonts/font1.fntdata")
+
+    types_root = ElementTree.fromstring(content_types_xml)
+    default = ElementTree.SubElement(types_root, f"{{{PptxTool.CONTENT_TYPE_NS}}}Default")
+    default.set("Extension", "fntdata")
+    default.set("ContentType", "application/x-fontdata")
+
+    replacements = {
+        "ppt/presentation.xml": ElementTree.tostring(root, encoding="UTF-8", xml_declaration=True),
+        "ppt/_rels/presentation.xml.rels": ElementTree.tostring(
+            rel_root, encoding="UTF-8", xml_declaration=True
+        ),
+        "[Content_Types].xml": ElementTree.tostring(
+            types_root, encoding="UTF-8", xml_declaration=True
+        ),
+    }
+    additions: dict[str, bytes] = {}
+    if not dangling:
+        additions["ppt/fonts/font1.fntdata"] = b"\x00\x01smoke-fntdata"
+    _rewrite_zip(source, destination, replacements=replacements, additions=additions)
 
 
 def _shape_with_name(slide: dict[str, Any], name: str) -> dict[str, Any]:
@@ -380,6 +483,284 @@ def _run_smoke(require_libreoffice: bool) -> dict[str, Any]:
         body_name = body_shape["name"]
         checks.append("inspect/content-inventory")
 
+        fonts_report = first_inspection["fonts"]
+        _assert(
+            {"+mj-lt", "+mn-lt"} <= set(fonts_report["theme_tokens_referenced"]),
+            "theme font tokens were not inventoried",
+        )
+        _assert(bool(fonts_report["referenced"]), "font inventory found no referenced fonts")
+        _assert(fonts_report["embedded"] == [], "fixture unexpectedly reports embedded fonts")
+        _assert(
+            fonts_report["unembedded"] == fonts_report["referenced"],
+            "unembedded fonts should equal referenced fonts in the fixture",
+        )
+        _assert(
+            any(warning.startswith("RELEASE BLOCKER:") for warning in first_inspection["warnings"]),
+            "default-theme fonts did not raise the portability blocker",
+        )
+        _assert(
+            any(
+                "PDF font embedding does not make the PPTX portable" in warning
+                for warning in first_inspection["warnings"]
+            ),
+            "informational unembedded-font warning missing",
+        )
+        checks.append("inspect/font-inventory")
+
+        for font_index, allowed_font in enumerate(("aRiAl", "Times New Roman", "Courier New")):
+            allowed_deck = work / f"allowed-font-{font_index}.pptx"
+            _rewrite_font_typefaces(created, allowed_deck, allowed_font, add_decoys=font_index == 0)
+            allowed_inspection = _run(["inspect", str(allowed_deck)])
+            _assert(
+                allowed_inspection["fonts"]["referenced"] == [allowed_font],
+                f"allowed font inventory mismatch for {allowed_font!r}: "
+                f"{allowed_inspection['fonts']['referenced']}",
+            )
+            _assert(
+                not any(
+                    warning.startswith("RELEASE BLOCKER:")
+                    for warning in allowed_inspection["warnings"]
+                ),
+                f"allowed font {allowed_font!r} raised the portability blocker",
+            )
+        checks.append("inspect/font-portability-allowed")
+
+        avenir_deck = work / "avenir-font.pptx"
+        _rewrite_font_typefaces(created, avenir_deck, "Avenir")
+        avenir_inspection = _run(["inspect", str(avenir_deck)])
+        _assert(
+            avenir_inspection["fonts"]["referenced"] == ["Avenir"],
+            "nonportable font inventory mismatch",
+        )
+        blockers = [
+            warning
+            for warning in avenir_inspection["warnings"]
+            if warning.startswith("RELEASE BLOCKER:")
+        ]
+        _assert(
+            len(blockers) == 1 and "Avenir" in blockers[0],
+            "nonportable font did not raise exactly one release blocker",
+        )
+        _assert(
+            any(
+                "PDF font embedding does not make the PPTX portable" in warning
+                for warning in avenir_inspection["warnings"]
+            ),
+            "nonportable deck lacks the informational unembedded-font warning",
+        )
+        checks.append("inspect/font-portability-blocker")
+
+        embedded_deck = work / "embedded-font.pptx"
+        _embed_font_fixture(avenir_deck, embedded_deck, "Avenir", dangling=False)
+        embedded_inspection = _run(["inspect", str(embedded_deck)])
+        _assert(
+            embedded_inspection["fonts"]["embedded"] == ["Avenir"],
+            "embedded font was not detected",
+        )
+        _assert(
+            embedded_inspection["fonts"]["unembedded"] == [],
+            "embedded font still reported as unembedded",
+        )
+        _assert(
+            not any(
+                warning.startswith("RELEASE BLOCKER:")
+                for warning in embedded_inspection["warnings"]
+            ),
+            "embedded font raised the portability blocker",
+        )
+        checks.append("inspect/font-embedding")
+
+        dangling_deck = work / "dangling-font.pptx"
+        _embed_font_fixture(avenir_deck, dangling_deck, "Avenir", dangling=True)
+        dangling_inspection = _run(["inspect", str(dangling_deck)])
+        _assert(
+            dangling_inspection["fonts"]["dangling_embedding_relationships"]
+            == [{"font": "Avenir", "relationship_id": "rIdSmokeFont", "target": ""}],
+            "dangling font embedding relationship record mismatch",
+        )
+        _assert(
+            any(
+                "Font embedding markup has missing or invalid relationship targets" in warning
+                for warning in dangling_inspection["warnings"]
+            ),
+            "dangling font embedding warning missing",
+        )
+        _assert(
+            any(
+                warning.startswith("RELEASE BLOCKER:")
+                for warning in dangling_inspection["warnings"]
+            ),
+            "dangling embedding suppressed the portability blocker",
+        )
+        checks.append("inspect/font-embedding-dangling")
+
+        table_structure_job = work / "table-structure.json"
+        table_structure_deck = work / "table-structure.pptx"
+        _write_json(
+            table_structure_job,
+            {
+                "schema_version": 1,
+                "operation": "edit",
+                "operations": [
+                    {
+                        "action": "update_table_structure",
+                        "slide": {"slide_id": original_ids[1]},
+                        "shape": {"shape_name": "Metrics Table"},
+                        "changes": [
+                            {"op": "insert_row", "index": 2, "cells": ["Refunds", "3"]},
+                            {"op": "insert_column", "index": 0, "cells": ["Kind", "A", "B"]},
+                            {"op": "remove_row", "index": 1},
+                        ],
+                    }
+                ],
+            },
+        )
+        table_structure_result = _run(
+            [
+                "edit",
+                str(created),
+                "--job",
+                str(table_structure_job),
+                "--output",
+                str(table_structure_deck),
+            ]
+        )
+        _assert(
+            table_structure_result["counts"]["table_structure_changes"] == 3,
+            "table structure change count mismatch",
+        )
+        structure_inspection = _run(["inspect", str(table_structure_deck)])
+        structure_slide = structure_inspection["presentation"]["slides"][1]
+        structure_table = _shape_with_name(structure_slide, "Metrics Table")["table"]
+        _assert(
+            structure_table["rows"] == 2 and structure_table["columns"] == 3,
+            "table structure dimensions mismatch",
+        )
+        _assert(
+            structure_table["data"] == [["Kind", "Metric", "Value"], ["B", "Refunds", "3"]],
+            f"table structure data mismatch: {structure_table['data']}",
+        )
+        checks.append("edit/table-structure-rows-columns")
+
+        structure_fixture = work / "structure-fixture.pptx"
+        fixture_presentation = Presentation()
+        fixture_slide = fixture_presentation.slides.add_slide(fixture_presentation.slide_layouts[5])
+        merged_shape = fixture_slide.shapes.add_table(
+            2,
+            2,
+            PptxTool.Inches(0.5),
+            PptxTool.Inches(1.5),
+            PptxTool.Inches(4.0),
+            PptxTool.Inches(1.5),
+        )
+        merged_shape.name = "Merged Table"
+        merged_table = merged_shape.table
+        merged_table.cell(0, 0).merge(merged_table.cell(0, 1))
+        narrow_shape = fixture_slide.shapes.add_table(
+            2,
+            1,
+            PptxTool.Inches(5.0),
+            PptxTool.Inches(1.5),
+            PptxTool.Inches(2.0),
+            PptxTool.Inches(1.5),
+        )
+        narrow_shape.name = "Narrow Table"
+        fixture_presentation.save(str(structure_fixture))
+
+        merged_job = work / "table-structure-merged.json"
+        _write_json(
+            merged_job,
+            {
+                "schema_version": 1,
+                "operation": "edit",
+                "operations": [
+                    {
+                        "action": "update_table_structure",
+                        "shape": {"shape_name": "Merged Table"},
+                        "changes": [{"op": "insert_row", "index": 0}],
+                    }
+                ],
+            },
+        )
+        merged_failure = _run(
+            [
+                "edit",
+                str(structure_fixture),
+                "--job",
+                str(merged_job),
+                "--output",
+                str(work / "table-structure-merged.pptx"),
+            ],
+            expected_status=3,
+        )
+        _assert(
+            merged_failure["error"]["category"] == "unsupported_operation",
+            "merged table structural edit failure category mismatch",
+        )
+        checks.append("failure/table-structure-merged")
+
+        out_of_range_job = work / "table-structure-range.json"
+        _write_json(
+            out_of_range_job,
+            {
+                "schema_version": 1,
+                "operation": "edit",
+                "operations": [
+                    {
+                        "action": "update_table_structure",
+                        "shape": {"shape_name": "Narrow Table"},
+                        "changes": [{"op": "remove_row", "index": 99}],
+                    }
+                ],
+            },
+        )
+        out_of_range_failure = _run(
+            [
+                "edit",
+                str(structure_fixture),
+                "--job",
+                str(out_of_range_job),
+                "--output",
+                str(work / "table-structure-range.pptx"),
+            ],
+            expected_status=2,
+        )
+        _assert(
+            out_of_range_failure["error"]["category"] == "bad_input",
+            "table structure range failure category mismatch",
+        )
+        last_column_job = work / "table-structure-last-column.json"
+        _write_json(
+            last_column_job,
+            {
+                "schema_version": 1,
+                "operation": "edit",
+                "operations": [
+                    {
+                        "action": "update_table_structure",
+                        "shape": {"shape_name": "Narrow Table"},
+                        "changes": [{"op": "remove_column", "index": 0}],
+                    }
+                ],
+            },
+        )
+        last_column_failure = _run(
+            [
+                "edit",
+                str(structure_fixture),
+                "--job",
+                str(last_column_job),
+                "--output",
+                str(work / "table-structure-last-column.pptx"),
+            ],
+            expected_status=3,
+        )
+        _assert(
+            last_column_failure["error"]["category"] == "unsupported_operation",
+            "final-column removal failure category mismatch",
+        )
+        checks.append("failure/table-structure-bounds")
+
         first_edit_job = work / "edit-content.json"
         first_edit = work / "edited-content.pptx"
         _write_json(
@@ -495,6 +876,62 @@ def _run_smoke(require_libreoffice: bool) -> dict[str, Any]:
             "replacement changed a picture that shared the original image part",
         )
         checks.append("edit/text-global-table-chart-image-notes-add")
+
+        extract_source_hash = _sha256(first_edit)
+        extract_dir = work / "extracted-images"
+        extract_result = _run(["extract", str(first_edit), "--output", str(extract_dir)])
+        expected_picture_count = second_inspection["counts"]["images"]
+        _assert(
+            extract_result["counts"]["pictures"] == expected_picture_count
+            and extract_result["counts"]["files_written"] == expected_picture_count
+            and extract_result["counts"]["pictures_skipped"] == 0,
+            "extract counts mismatch",
+        )
+        inspected_image_hashes = {
+            shape["image"]["sha256"]
+            for slide in second_slides
+            for shape in slide["shapes"]
+            if "image" in shape
+        }
+        for record in extract_result["images"]:
+            published = extract_dir / record["file"]
+            _assert(published.is_file(), f"extracted file missing: {record['file']}")
+            _assert(
+                hashlib.sha256(published.read_bytes()).hexdigest() == record["sha256"],
+                "extracted file hash mismatch",
+            )
+            _assert(
+                record["sha256"] in inspected_image_hashes,
+                "extracted image does not match the inspected image inventory",
+            )
+        _assert(_sha256(first_edit) == extract_source_hash, "extract modified its source")
+        checks.append("extract/images-directory")
+
+        occupied_dir = work / "occupied-extract"
+        occupied_dir.mkdir()
+        sentinel = occupied_dir / "keep.txt"
+        sentinel.write_text("do not delete", encoding="utf-8")
+        occupied_failure = _run(
+            ["extract", str(first_edit), "--output", str(occupied_dir)],
+            expected_status=2,
+        )
+        _assert(
+            occupied_failure["error"]["category"] == "bad_input",
+            "occupied extract directory failure category mismatch",
+        )
+        occupied_overwrite_failure = _run(
+            ["extract", str(first_edit), "--output", str(occupied_dir), "--overwrite"],
+            expected_status=2,
+        )
+        _assert(
+            occupied_overwrite_failure["error"]["category"] == "bad_input",
+            "non-empty overwrite extract failure category mismatch",
+        )
+        _assert(
+            sentinel.read_text(encoding="utf-8") == "do not delete",
+            "extract deleted files from an existing directory",
+        )
+        checks.append("failure/extract-occupied-directory")
 
         graph_job = work / "edit-graph.json"
         final_deck = work / "final.pptx"
@@ -912,6 +1349,139 @@ def _run_smoke(require_libreoffice: bool) -> dict[str, Any]:
             "hyperlink sanitization did not preserve useful URL structure",
         )
         checks.append("inspect/hyperlink-redaction")
+
+        hyperlink_job = work / "hyperlink-edit.json"
+        hyperlink_deck = work / "hyperlink-edited.pptx"
+        _write_json(
+            hyperlink_job,
+            {
+                "schema_version": 1,
+                "operation": "edit",
+                "operations": [
+                    {
+                        "action": "set_hyperlink",
+                        "find": "Password link",
+                        "url": "https://docs.example.invalid/portal",
+                    },
+                    {
+                        "action": "remove_hyperlink",
+                        "find": " Username link",
+                    },
+                    {
+                        "action": "set_hyperlink",
+                        "scope": "shape",
+                        "shape": {"shape_name": external_title.name},
+                        "url": "mailto:team@example.invalid",
+                    },
+                ],
+            },
+        )
+        hyperlink_result = _run(
+            [
+                "edit",
+                str(external_deck),
+                "--job",
+                str(hyperlink_job),
+                "--output",
+                str(hyperlink_deck),
+            ]
+        )
+        _assert(
+            hyperlink_result["counts"]["hyperlinks_set"] == 2
+            and hyperlink_result["counts"]["hyperlinks_removed"] == 1,
+            "hyperlink edit counts mismatch",
+        )
+        hyperlink_edit_inspection = _run(["inspect", str(hyperlink_deck)])
+        edited_runs = {
+            run["text"]: run["hyperlink"]
+            for slide in hyperlink_edit_inspection["presentation"]["slides"]
+            for shape in slide["shapes"]
+            for paragraph in shape.get("text", {}).get("paragraphs", [])
+            for run in paragraph["runs"]
+        }
+        _assert(
+            edited_runs.get("Password link") == "https://docs.example.invalid/portal",
+            "set_hyperlink did not update the run hyperlink",
+        )
+        _assert(
+            edited_runs.get(" Username link") is None,
+            "remove_hyperlink did not clear the run hyperlink",
+        )
+        reopened_hyperlink_deck = Presentation(str(hyperlink_deck))
+        reopened_title = reopened_hyperlink_deck.slides[0].shapes.title
+        _assert(
+            reopened_title is not None
+            and reopened_title.click_action.hyperlink.address == "mailto:team@example.invalid",
+            "shape-scope hyperlink was not set",
+        )
+        checks.append("edit/hyperlink-set-remove")
+
+        scheme_job = work / "hyperlink-scheme.json"
+        _write_json(
+            scheme_job,
+            {
+                "schema_version": 1,
+                "operation": "edit",
+                "operations": [
+                    {
+                        "action": "set_hyperlink",
+                        "find": "Password link",
+                        "url": "file:///etc/passwd",
+                    }
+                ],
+            },
+        )
+        scheme_failure = _run(
+            [
+                "edit",
+                str(external_deck),
+                "--job",
+                str(scheme_job),
+                "--output",
+                str(work / "hyperlink-scheme.pptx"),
+            ],
+            expected_status=3,
+        )
+        _assert(
+            scheme_failure["error"]["category"] == "unsupported_operation",
+            "hyperlink scheme failure category mismatch",
+        )
+        checks.append("failure/hyperlink-scheme")
+
+        boundary_job = work / "hyperlink-boundary.json"
+        _write_json(
+            boundary_job,
+            {
+                "schema_version": 1,
+                "operation": "edit",
+                "operations": [
+                    {
+                        "action": "set_hyperlink",
+                        "find": "link",
+                        "occurrence": 1,
+                        "url": "https://docs.example.invalid/partial",
+                    }
+                ],
+            },
+        )
+        boundary_failure = _run(
+            [
+                "edit",
+                str(external_deck),
+                "--job",
+                str(boundary_job),
+                "--output",
+                str(work / "hyperlink-boundary.pptx"),
+            ],
+            expected_status=5,
+        )
+        _assert(
+            boundary_failure["error"]["category"] == "ambiguous_edit"
+            and "cover whole runs" in boundary_failure["error"]["message"],
+            "hyperlink run-boundary failure mismatch",
+        )
+        checks.append("failure/hyperlink-run-boundary")
+
         external_failure = _run(
             ["convert", str(external_deck), "--output", str(work / "external.pdf")],
             expected_status=3,
@@ -921,6 +1491,23 @@ def _run_smoke(require_libreoffice: bool) -> dict[str, Any]:
             "external-relationship conversion failure category mismatch",
         )
         checks.append("failure/convert-external-relationship")
+
+        bad_dpi_failure = _run(
+            [
+                "render",
+                str(final_deck),
+                "--output",
+                str(work / "render-bad-dpi"),
+                "--dpi",
+                "9999",
+            ],
+            expected_status=2,
+        )
+        _assert(
+            bad_dpi_failure["error"]["category"] == "bad_input",
+            "render dpi failure category mismatch",
+        )
+        checks.append("failure/render-bad-dpi")
 
         libreoffice = shutil.which("soffice") or shutil.which("libreoffice")
         if libreoffice is None:
@@ -958,6 +1545,51 @@ def _run_smoke(require_libreoffice: bool) -> dict[str, Any]:
                 "pages": len(reader.pages),
                 "text_anchor": "Inserted decision",
             }
+            if importlib.util.find_spec("pypdfium2") is None:
+                conversion["render"] = {
+                    "status": "skipped",
+                    "reason": "optional pypdfium2 package is not installed",
+                }
+            else:
+                render_dir = work / "rendered-slides"
+                render_result = _run(
+                    [
+                        "render",
+                        str(final_deck),
+                        "--output",
+                        str(render_dir),
+                        "--timeout",
+                        "120",
+                    ],
+                    timeout_seconds=150,
+                )
+                _assert(
+                    render_result["counts"]["pages_rendered"] == 3
+                    and render_result["counts"]["source_slides"] == 3,
+                    "render counts mismatch",
+                )
+                rendered_files = sorted(render_dir.glob("*.png"))
+                _assert(len(rendered_files) == 3, "rendered PNG count mismatch")
+                rendered_sizes = set()
+                rendered_hashes = set()
+                for rendered_file in rendered_files:
+                    with Image.open(rendered_file) as rendered_image:
+                        rendered_image.load()
+                        rendered_sizes.add(rendered_image.size)
+                    rendered_hashes.add(_sha256(rendered_file))
+                _assert(
+                    len(rendered_sizes) == 1,
+                    "rendered slides do not share identical dimensions",
+                )
+                _assert(
+                    len(rendered_hashes) >= 2,
+                    "rendered slides are suspiciously identical",
+                )
+                checks.append("render/libreoffice-png")
+                conversion["render"] = {
+                    "status": "passed",
+                    "pages": len(rendered_files),
+                }
 
     return {
         "schema_version": 1,
@@ -981,7 +1613,10 @@ def main(argv: list[str] | None = None) -> int:
                         "category": "missing_dependency",
                         "message": f"missing Python dependency: {DEPENDENCY_ERROR.name}",
                         "details": {
-                            "install": "python -m pip install -r requirements.txt",
+                            "install": (
+                                f'"{sys.executable}" -m pip install -r '
+                                f'"{Path(__file__).resolve().parent.parent / "requirements.txt"}"'
+                            ),
                         },
                     },
                 },

--- a/kolega_code/_bundled_skills/skills/skill-authoring/SKILL.md
+++ b/kolega_code/_bundled_skills/skills/skill-authoring/SKILL.md
@@ -13,6 +13,13 @@ metadata:
 Create focused skills that add procedural knowledge rather than restating general model
 capabilities.
 
+## Workspace discipline
+
+Work directly in visible workspace paths. Never create or use `.build` or another hidden
+build/work directory. Write requested deliverables directly to their declared destinations;
+if intermediate files are necessary, keep them in visible, narrowly scoped paths rather than
+staging the task in a hidden subtree.
+
 ## Workflow
 
 1. **Clarify activation.** Collect at least three realistic requests that should trigger the

--- a/kolega_code/_bundled_skills/skills/xlsx/SKILL.md
+++ b/kolega_code/_bundled_skills/skills/xlsx/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: xlsx
-description: Create, inspect, extract, edit, clean, summarize, and convert Microsoft Excel .xlsx workbooks, including formulas, styles, tables, conditional formatting, validation, native charts, and CSV/TSV interchange. Use for spreadsheet artifact work where workbook semantics or safe tabular conversion matter; do not use for legacy .xls, macro-enabled .xlsm, PDF-native work, or general analysis that does not require a spreadsheet artifact.
+description: Create, inspect, extract, edit, clean, summarize, convert, and render Microsoft Excel .xlsx workbooks, including formulas, styles, tables, conditional formatting, validation, native charts, CSV/TSV interchange, PDF export, and PNG page rendering for visual review. Use for spreadsheet artifact work where workbook semantics, safe tabular conversion, or reviewable spreadsheet output matter; do not use for legacy .xls, macro-enabled .xlsm, PDF-native editing, or general analysis that does not require a spreadsheet artifact.
 license: Apache-2.0
-compatibility: Requires Python 3.11+ and the packages declared in requirements.txt.
+compatibility: Requires Python 3.11+ and the packages declared in requirements.txt. LibreOffice and the optional pypdfium2 package are needed only for PDF export and page rendering.
 metadata:
   author: Kolega
   version: "1.0"
@@ -14,6 +14,13 @@ metadata:
 Operate on `.xlsx` files with a deterministic CLI. Keep source workbooks immutable, refuse
 macro-enabled content, and verify every workbook after saving.
 
+## Workspace discipline
+
+Work directly in visible workspace paths. Never create or use `.build` or another hidden
+build/work directory. Write requested deliverables directly to their declared destinations;
+if intermediate files are necessary, keep them in visible, narrowly scoped paths rather than
+staging the task in a hidden subtree.
+
 ## Workflow
 
 1. **Prepare the runtime proactively.** Resolve the skill root and choose any available Python
@@ -24,8 +31,9 @@ declared requirements. Use the platform's package manager for Python itself, pre
    Homebrew on macOS when available. A local environment is a fallback, not a prerequisite.
    Read the runtime section in [operations](references/operations.md).
 2. **Inventory before mutation.** Run `inspect` and review sheet order and visibility, used
-   ranges, merges, formulas and cached values, names, external links, tables, styles,
-   validations, conditional formatting, charts, pivots, and warnings.
+   ranges, merges, formulas and cached values, stored error values, fonts, names, external
+   links, tables, styles, validations, conditional formatting, charts, pivots, page setup,
+   and warnings.
 3. **Choose the semantic path.**
    - Use `openpyxl`-backed `create` and `edit` for rich workbook semantics.
    - Use `clean` or `summarize` only for explicit rectangular pandas transformations. These
@@ -44,6 +52,18 @@ sheet order/counts, warnings, output paths, and library versions.
 7. **Inspect the output again.** Confirm workbook structure and content. If formulas exist,
    open in a calculation application when fresh results are required; calculation flags
    request recalculation but do not prove it happened.
+8. **Render and look when appearance matters.** Pick the delivery profile in
+   [quality](references/quality.md). For visual and print/PDF deliverables, run `render`,
+   open the produced PNG pages with the Read tool, and examine every changed sheet's pages
+   for column overflow (`#####`), clipped text, merge layout, chart appearance, and
+   conditional formatting. Never claim visual correctness from JSON output alone; if
+   rendering is unavailable, report "structural checks only; visual QA not performed."
+   Unstyled cells use the default font (Calibri), which fails the conservative font gate —
+   style cells with portable fonts when the deliverable is print/PDF.
+9. **Export PDF through `convert` when requested.** Review the release gate: the PDF reopens
+   with at least one page, no `RELEASE BLOCKER` font warning remains unaccepted, and the
+   LibreOffice calculation and pagination caveats fit the deliverable. Review the final PDF
+   page by page.
 
 ## Safety rules
 
@@ -75,16 +95,20 @@ flags.
 
 - Read [operations](references/operations.md) for CLI behavior, job schemas, exit statuses,
   safety limits, and operation details.
+- Read [quality](references/quality.md) for design intake, delivery profiles, and the
+  acceptance criteria that bind visual and print/PDF deliverables.
 - Read [examples](references/examples.md) for copy-pasteable workflows, representative JSON,
   assertions, and failure paths.
 - Read [limitations](references/limitations.md) before working with formulas, pivots,
   external links, unsupported OOXML, or renderer-specific output.
 - Run `"$XLSX_PYTHON" "$SKILL_ROOT/scripts/smoke_test.py"` after installation. It creates every
   fixture in a temporary directory and exercises create, inspect, extract, edit, clean,
-  summarize,
-  raw all-sheet/static-summary export, JSON formula preservation, case-insensitive
-  dependencies, cumulative budgets, CSV/TSV policies, XML security, timeout handling, and
-  categorized failure paths.
+  summarize, raw all-sheet/static-summary export, JSON formula preservation,
+  case-insensitive dependencies, cumulative budgets, CSV/TSV policies, XML security, timeout
+  handling, merge/unmerge and sheet settings, auto width, the formula-error scan, the font
+  inventory, categorized failure paths, and — when LibreOffice (plus optionally pypdfium2)
+  is installed — PDF export and page rendering. Pass `--require-libreoffice` to fail rather
+  than skip the conversion checks.
 
 ## Completion checks
 
@@ -96,5 +120,12 @@ flags.
 - Raw all-sheet exports include blank and static-summary sheets under deterministic numbered
   names; delimited outputs preserve the declared encoding/header/NA/schema behavior and apply
   the expected formula-injection policy.
-- Warnings about stale formula caches, external links, pivots, or accepted dependency
-  uncertainty are reported to the caller.
+- The error scan is clean (`counts.error_cells` is 0) or every stored error value is
+  explained; zero stored errors is not proof of successful recalculation.
+- The font inventory was reviewed; for print/PDF deliverables no `RELEASE BLOCKER` font
+  warning remains unaccepted.
+- When appearance matters, rendered pages were opened and reviewed per the delivery profile
+  in [quality](references/quality.md); PDF deliverables passed the release gate
+  (signature, reopen, page count, reviewed diagnostics).
+- Warnings about stale formula caches, external links, pivots, destructive merges, or
+  accepted dependency uncertainty are reported to the caller.

--- a/kolega_code/_bundled_skills/skills/xlsx/references/examples.md
+++ b/kolega_code/_bundled_skills/skills/xlsx/references/examples.md
@@ -4,8 +4,11 @@
 
 - [Install and smoke test](#install-and-smoke-test)
 - [End-to-end create, inspect, edit, and extract](#end-to-end-create-inspect-edit-and-extract)
+- [Merge, unmerge, and sheet settings](#merge-unmerge-and-sheet-settings)
+- [Formula-error scan](#formula-error-scan)
 - [Static summary](#static-summary)
 - [UTF-8 CSV/TSV interchange](#utf-8-csvtsv-interchange)
+- [PDF export and render-and-look](#pdf-export-and-render-and-look)
 - [Expected artifact assertions](#expected-artifact-assertions)
 - [Failure examples](#failure-examples)
 
@@ -20,10 +23,12 @@ SKILL_ROOT="/absolute/path/to/skills/xlsx"
 "$XLSX_PYTHON" "$SKILL_ROOT/scripts/smoke_test.py"
 ```
 
-Expected final stdout:
+Expected final stdout (the `libreoffice` object varies by machine: `"status": "passed"` with
+an executable path and page counts where LibreOffice/pypdfium2 are installed, otherwise
+`"status": "skipped"` with a reason; pass `--require-libreoffice` to fail instead of skip):
 
 ```json
-{"fixtures":"temporary","ok":true,"operations":["create","inspect","extract","edit","clean","summarize","convert_csv_xlsx_tsv_xlsx","raw_all_sheet_static_summary_export","header_aware_export","conversion_option_direction_validation","json_formula_preservation","case_insensitive_formula_dependencies","bad_input_categories","xml_encoding_security","subprocess_timeout","cumulative_json_cell_budget","external_link_preservation_warning","macro_refusal"],"schema_version":1,"test":"xlsx_smoke"}
+{"fixtures":"temporary","libreoffice":{"...":"machine-dependent"},"ok":true,"operations":["create","inspect","extract","edit","clean","summarize","convert_csv_xlsx_tsv_xlsx","raw_all_sheet_static_summary_export","header_aware_export","conversion_option_direction_validation","json_formula_preservation","case_insensitive_formula_dependencies","bad_input_categories","xml_encoding_security","subprocess_timeout","cumulative_json_cell_budget","external_link_preservation_warning","macro_refusal","set_sheet_visual_settings_merge_unmerge","auto_width","formula_error_scan","font_portability_inventory","pdf_and_render_option_validation","xlsx_to_pdf_and_page_render"],"schema_version":1,"test":"xlsx_smoke"}
 ```
 
 The test uses `TemporaryDirectory`; no workbook or delimited fixture is left in the skill.
@@ -164,6 +169,76 @@ JSON extraction is data-preserving rather than spreadsheet-executable: formula e
 and text such as `=2+2` remain exactly `=2+2` in the JSON row matrix. Apostrophe formula
 injection guarding applies only to CSV/TSV output.
 
+## Merge, unmerge, and sheet settings
+
+`set_sheet` refuses a merge that would discard values unless the loss is acknowledged:
+
+```bash
+cat >"$work/merge.json" <<'JSON'
+{
+  "schema_version": 1,
+  "operations": [
+    {"op": "set_sheet", "sheet": "Sales", "merges": ["A1:B1"]}
+  ]
+}
+JSON
+"$XLSX_PYTHON" "$SKILL_ROOT/scripts/xlsx_tool.py" edit \
+  "$work/report.xlsx" "$work/merge.json" "$work/merged.xlsx"
+echo "$?"
+```
+
+Status 5 with the occupied coordinates:
+
+```json
+{"error":{"category":"ambiguous_edit","details":{"occupied_cells":["B1"],"occupied_count":1,"range":"A1:B1","resolution":"Set allow_merge_data_loss to true to accept the loss.","sheet":"Sales"},"message":"Merging this range would discard non-top-left cell values."},"ok":false,"schema_version":1}
+```
+
+Acknowledge the loss and adjust the sheet's presentation in the same operation:
+
+```bash
+cat >"$work/merge-ok.json" <<'JSON'
+{
+  "schema_version": 1,
+  "operations": [
+    {
+      "op": "set_sheet",
+      "sheet": "Sales",
+      "merges": ["A1:B1"],
+      "allow_merge_data_loss": true,
+      "unmerge": [],
+      "tab_color": "FF1F4E78",
+      "show_gridlines": false,
+      "zoom_scale": 120,
+      "auto_width": {"columns": ["B", "C"], "max_width": 40}
+    }
+  ]
+}
+JSON
+"$XLSX_PYTHON" "$SKILL_ROOT/scripts/xlsx_tool.py" edit \
+  "$work/report.xlsx" "$work/merge-ok.json" "$work/merged.xlsx"
+```
+
+The result counts `ranges_merged` and `columns_auto_sized`, warns about the discarded
+value, and a follow-up `inspect` reports the merge, tab color, gridline setting, and zoom.
+To undo a merge later, pass `"unmerge": ["A1:B1"]`; each entry must exactly match a currently
+merged range, and the discarded values do not come back.
+
+## Formula-error scan
+
+`inspect` counts stored error values per sheet and in `counts.error_cells`:
+
+```bash
+"$XLSX_PYTHON" "$SKILL_ROOT/scripts/xlsx_tool.py" inspect "$work/edited.xlsx" --no-cells \
+  | "$XLSX_PYTHON" -c 'import json,sys; r=json.load(sys.stdin)["result"]; \
+print(r["counts"]["error_cells"], [s["errors"]["by_error"] for s in r["sheets"]])'
+```
+
+A sheet with a cached `#DIV/0!` reports
+`"errors": {"count": 1, "by_error": {"#DIV/0!": 1}, "samples": [{"coordinate": "D4", "error": "#DIV/0!", "kind": "cached_formula"}]}`
+and a warning. Zero means no *stored* errors: a workbook that was never calculated has no
+cached error values to find, so pair the scan with the recalculation caveats in
+[limitations](references/limitations.md#formula-calculation).
+
 ## Static summary
 
 ```bash
@@ -277,6 +352,51 @@ for example `001-Sales.csv` and `004-Static_Summary.csv`; the JSON result retain
 sheet-to-file mapping. Add `--sheet-policy header` only for conventional unique, non-empty
 headers when `--schema`, `--header-row`, or `--index` is needed. The directory is published
 after all numbered sheet files are written and reopened.
+
+## PDF export and render-and-look
+
+Export the workbook to PDF and render its pages for visual review:
+
+```bash
+"$XLSX_PYTHON" "$SKILL_ROOT/scripts/xlsx_tool.py" convert \
+  "$work/summarized.xlsx" "$work/report.pdf" --timeout 120
+
+"$XLSX_PYTHON" "$SKILL_ROOT/scripts/xlsx_tool.py" render \
+  "$work/summarized.xlsx" "$work/review-pages" --dpi 96 --timeout 120
+```
+
+Representative PDF-convert result fields:
+
+```json
+{
+  "ok": true,
+  "operation": "convert",
+  "result": {
+    "output_format": "pdf",
+    "counts": {"sheets": 4, "hidden_sheets": 0, "pdf_pages": 4},
+    "conversion": {"engine": "soffice", "timeout_seconds": 120.0},
+    "verification": {
+      "atomic_publish": true,
+      "pdf_signature": true,
+      "pdf_openable": true,
+      "source_unchanged_at_publish_gate": true
+    }
+  }
+}
+```
+
+Assert the release gate before delivering a PDF:
+
+- `verification.pdf_openable` is true and `counts.pdf_pages` is at least 1;
+- no warning starts with `RELEASE BLOCKER` — otherwise replace the offending fonts and
+  re-export (see [quality](references/quality.md) for the profile that requires this);
+- the formula-calculation and print-semantics warnings are acceptable for the deliverable.
+
+Then **look at the rendered pages**. `render` writes `page-001.png`, `page-002.png`, … —
+open each changed page with the Read tool and check column overflow (`#####`), clipped or
+wrapped text, merge layout, chart appearance, and conditional formatting. A successful JSON
+result proves publication, not appearance. Select pages with `--pages 1,3` when the workbook
+paginates widely, and control content with print areas or hidden sheets.
 
 ## Expected artifact assertions
 

--- a/kolega_code/_bundled_skills/skills/xlsx/references/limitations.md
+++ b/kolega_code/_bundled_skills/skills/xlsx/references/limitations.md
@@ -24,6 +24,11 @@ Loading cached values for `clean`, `summarize`, or cached extraction can therefo
 missing or outdated input. Recalculate the source in a trusted calculation application first
 when current values are required.
 
+The `inspect` error scan detects literal error cells and cached formula error results. It
+cannot detect an error a formula *would* produce: a workbook that was never calculated
+reports `counts.error_cells: 0` alongside its formula warnings. A zero therefore means "no
+stored errors", not "no errors after recalculation".
+
 ## Macros, encryption, and signatures
 
 The tool refuses `.xlsm`, `.xltm`, `.xla`, `.xlam`, macro-bearing OOXML packages, and encrypted
@@ -48,6 +53,11 @@ reference embedded in unsupported parts.
 
 Formula text is not rewritten when ranges, table boundaries, or sheet names change. Guaranteed
 structural-reference updates and external-link repair are not supported.
+
+Merging cells discards every covered value except the top-left one. Edits refuse a
+destructive merge unless `allow_merge_data_loss` is explicitly true; create-time merges warn
+instead because the job just wrote those cells. Unmerging restores nothing — the discarded
+values are gone.
 
 ## Pivot tables and advanced workbook content
 
@@ -108,10 +118,27 @@ to avoid partially replacing a set of files.
 
 ## Rendering and conversion
 
-The skill does not render workbooks, compare visual layout, export PDF, or guarantee
-renderer-identical output. Native charts and dimensions are structurally verified, not
-pixel-rendered. PDF-native work belongs to a PDF workflow; renderer-identical XLSX-to-PDF
-export remains unsupported.
+PDF export and PNG page rendering are LibreOffice-backed. They show one renderer's honest
+interpretation, not Excel's: pagination, calculation results, chart drawing, and font
+substitution can differ, and hidden sheets are excluded. Values in the PDF come from
+LibreOffice's load-time calculation of stored formulas. Renderer-identical output is not
+guaranteed and is never claimed; the render exists so pages can be visually reviewed.
+
+XLSX cannot embed fonts. Every referenced font must be installed on each intended renderer,
+or substitution changes column fit, wrapping, and pagination. The font inventory covers
+fonts effectively used by non-empty cells and chart text; fonts referenced only by
+unsupported parts (for example rich-text runs inside shared strings) are not detected.
+Result sheets written by `clean` and `summarize` use the workbook default font (normally
+Calibri), so they re-trigger the conservative font gate — restyle them with `format_range`
+before a print/PDF release that requires the portable set.
+
+`auto_width` is a character-count heuristic over stored cell text — formula text, not
+calculated results, and no renderer text metrics. Verify visually with `render` when column
+fit matters. PDF-native editing still belongs to a PDF workflow.
+
+Page-setup (orientation, paper size, fit, print areas, print titles) is read-only in
+`inspect`; writing it requires a spreadsheet application. Use print areas, hidden sheets, or
+`--pages` to control what PDF export and rendering produce.
 
 ## Resource limits
 
@@ -134,5 +161,5 @@ complete sandbox. Use an isolated environment for untrusted documents.
 - Native pivot creation/editing and refresh validation.
 - Macro, ActiveX, encryption, and digital-signature workflows.
 - External-link and guaranteed structured-reference repair.
-- Renderer-backed visual review and validated PDF export.
+- Page-setup and print-area write support.
 - Broader chart, validation, conditional-format, comment, and drawing semantics.

--- a/kolega_code/_bundled_skills/skills/xlsx/references/operations.md
+++ b/kolega_code/_bundled_skills/skills/xlsx/references/operations.md
@@ -12,6 +12,8 @@
 - [Clean job](#clean-job)
 - [Summarize job](#summarize-job)
 - [Convert](#convert)
+- [PDF export](#pdf-export)
+- [Render](#render)
 - [Styles, tables, validation, and charts](#styles-tables-validation-and-charts)
 - [Formula policy](#formula-policy)
 - [Exit statuses](#exit-statuses)
@@ -55,10 +57,15 @@ Every successful command prints one JSON object to stdout and exits 0:
     "python": "3.11.4",
     "openpyxl": "3.1.5",
     "pandas": "3.0.3",
-    "numpy": "2.4.6"
+    "numpy": "2.4.6",
+    "pypdf": "6.1.3"
   }
 }
 ```
+
+PDF export and page rendering additionally use LibreOffice (`soffice` on PATH) and, for
+rendering only, the optional `pypdfium2` package. Both are reported as `missing_dependency`
+with an install hint when absent; no other operation needs them.
 
 Expected failures print one JSON object to stderr, leave stdout empty, and use a stable nonzero
 status:
@@ -100,7 +107,8 @@ Rectangular operations are limited to 2,000,000 cells. Create/edit JSON row matr
 maps, and range operations share one cumulative per-job budget, including ragged rows.
 `create` and `edit` accept `--cell-limit N` to lower (never raise) that cumulative limit for
 more restrictive callers and controlled validation.
-`inspect --max-cells` is capped at 100,000 emitted cell records per selected sheet.
+`inspect --max-cells` defaults to 10,000 and is capped at 100,000 emitted cell records per
+selected sheet; a truncated inventory is flagged by `cell_inventory_truncated` and a warning.
 
 Mutation writes a temporary sibling, saves, applies the same package preflight, reopens the
 workbook, confirms sheet order, fsyncs, and atomically replaces the destination. The source is
@@ -124,6 +132,8 @@ xlsx_tool.py edit SOURCE JOB OUTPUT [--overwrite]
 xlsx_tool.py clean SOURCE JOB OUTPUT [--overwrite]
 xlsx_tool.py summarize SOURCE JOB OUTPUT [--overwrite]
 xlsx_tool.py convert SOURCE OUTPUT [conversion options] [--overwrite]
+xlsx_tool.py convert SOURCE OUTPUT.pdf [--timeout SECONDS] [--overwrite]
+xlsx_tool.py render SOURCE OUTPUT_DIR [--dpi N] [--pages 1,3] [--timeout SECONDS]
 ```
 
 `--debug` is a global option placed before the subcommand. It adds a traceback only to
@@ -135,15 +145,28 @@ unexpected internal-error JSON.
 
 - compressed/expanded byte counts and ZIP member count;
 - sheet order, active sheet, visibility, selected/used ranges, merges, dimensions, freeze
-  panes, filters, and grid settings where exposed;
+  panes, filters, tab color, gridline visibility, zoom, and read-only page setup
+  (orientation, paper size, scale, fit-to settings, print area, print titles);
 - non-empty, styled, and formula cell counts;
 - cell coordinates, values/formulas, cached values, data types, style IDs, and number formats;
+- a per-sheet `errors` block counting formula error values (`#REF!`, `#DIV/0!`, `#VALUE!`,
+  `#NAME?`, `#N/A`, `#NULL!`, `#NUM!`, `#SPILL!`, `#CALC!`) as literal error cells or cached
+  formula results, with capped coordinate samples, plus a workbook `counts.error_cells`
+  total for the selected sheets/range;
+- a workbook `fonts` inventory (`referenced`, `by_source` for cells/named styles/charts,
+  `theme`, always-empty `embedded`, and `unembedded`) built from fonts effectively used by
+  non-empty cells and chart text — see [PDF export](#pdf-export) for the portability gate;
 - named ranges, workbook properties, calculation settings, and external-link inventory;
 - tables, chart type/title/anchor/series count, pivots, conditional formats, and validations;
-- warnings for formulas, external links, pivots, and truncated cell inventories.
+- warnings for formulas, error values, font portability, external links, pivots, and
+  truncated cell inventories.
 
 Without `--sheet`, all sheets are inventoried. `--range` applies to each selected sheet.
-`--no-cells` omits cell records while retaining structural counts.
+`--no-cells` omits cell records while retaining structural counts; the error scan and font
+inventory still run. `--max-cells` defaults to 10,000 records per sheet (cap 100,000), so
+large sheets truncate the `cells` array — raise it explicitly when full cell inventories
+matter. A cached formula error can only be detected when a cached value exists; a workbook
+that was never calculated reports formulas, not errors.
 
 ## Extract
 
@@ -194,9 +217,14 @@ A sheet object requires `name` and accepts:
 - `state`: `visible`, `hidden`, or `veryHidden`;
 - `merges`, `freeze_panes`, `dimensions`, `auto_filter`, `tab_color`, `show_gridlines`, and
   `zoom_scale`;
+- `auto_width`: `true` for every used column, or an object with `columns` (letters),
+  `min_width`, `max_width`, and `sample_rows`; widths use a character-count heuristic over
+  stored cell text (formula text, not results), run before `dimensions` so explicit widths
+  win, and default to bounds 8/60 over 200 sampled rows;
 - `tables`, `conditional_formats`, `data_validations`, and `charts`.
 
-At least one sheet must remain visible.
+At least one sheet must remain visible. Merging a range that covers non-top-left values
+keeps only the top-left value; during create this is reported as a warning.
 
 A delimited `source` object accepts:
 
@@ -272,7 +300,7 @@ Supported operations:
 | `add_sheet` | `name`, optional `index`, and create-sheet fields. |
 | `remove_sheet` | `sheet`; optional `allow_unupdated_dependencies`. |
 | `rename_sheet` | `sheet`, `new_name`; optional `allow_unupdated_dependencies`. |
-| `set_sheet` | `sheet`; optional state, freeze panes, filter, dimensions. |
+| `set_sheet` | `sheet`; optional state, freeze panes, filter, dimensions, `auto_width`, `merges` (with `allow_merge_data_loss`), `unmerge`, `tab_color`, `show_gridlines`, `zoom_scale`. |
 | `add_table` | `sheet`, `table`. |
 | `update_table` | `table` containing current `name` and optional new range/name/style. |
 | `add_chart` | `sheet`, `chart`. |
@@ -286,6 +314,12 @@ Insert/delete/move row, column, and range operation names are explicitly refused
 rename/removal inspects formula, defined-name, and chart dependencies and rejects uncertainty
 unless `allow_unupdated_dependencies` accepts unchanged/dangling references. Sheet-reference
 matching is case-insensitive, like Excel sheet names.
+
+`set_sheet` merges are guarded: merging a range whose non-top-left cells hold values is
+`ambiguous_edit` unless the operation sets `"allow_merge_data_loss": true`, because the merge
+discards those values. Each `unmerge` entry must exactly match one currently merged range
+(the failure lists the current merges). Merge data-loss scanning is bounded at 100,000 cells
+per range.
 
 Every edit warns that rewriting through `openpyxl` can alter or drop unsupported OOXML
 extension content. If external-link parts are present, edit also warns that targets, cached
@@ -368,7 +402,8 @@ An optional native chart references the static result.
 
 ## Convert
 
-Supported directions are CSV/TSV to XLSX and XLSX to CSV/TSV:
+Supported directions are CSV/TSV to XLSX, XLSX to CSV/TSV, and XLSX to PDF (see
+[PDF export](#pdf-export)):
 
 ```bash
 # Preserve account codes as strings and coerce declared amounts.
@@ -431,6 +466,56 @@ including raw rows and header-aware column labels. It is never applied to JSON e
 Leading spaces, tabs, CR/LF, BOM, and non-breaking spaces are considered before `=`, `+`, `-`,
 or `@`; leading tab/CR/LF/BOM is itself guarded.
 
+## PDF export
+
+`convert SOURCE OUTPUT.pdf` exports the whole workbook to PDF through headless LibreOffice
+with an isolated profile, converting an immutable snapshot copy of the preflighted source:
+
+```bash
+"$XLSX_PYTHON" "$SKILL_ROOT/scripts/xlsx_tool.py" convert report.xlsx report.pdf --timeout 120
+```
+
+- Only `--timeout` (seconds, 1–1800, default 120) and `--overwrite` apply; every delimited or
+  sheet-selection option is rejected as `bad_input`. Sheet-level control uses the workbook
+  itself: hidden sheets are excluded from the PDF, and print areas/page setup bound what each
+  sheet prints.
+- Workbooks with external links are refused (`unsupported_operation`) because LibreOffice may
+  try to resolve them.
+- The output is verified (`%PDF-` signature, pypdf reopen, at least one page) and atomically
+  published behind a source-hash gate. The spreadsheet page count is not predictable from the
+  sheet count; the result reports `counts.pdf_pages`.
+- The result embeds the `fonts` inventory and its portability warnings. Fonts outside the
+  conservative cross-renderer set (Arial, Times New Roman, Courier New) raise a
+  `RELEASE BLOCKER` warning: XLSX cannot embed fonts, so any renderer without them
+  substitutes metrics and can change column fit, wrapping, and pagination.
+- Values in the PDF come from LibreOffice's load-time calculation; pagination follows
+  LibreOffice print semantics (print areas, fit settings, printed gridlines are off by
+  default) and is not proven identical to Excel's. These caveats are emitted as warnings.
+
+## Render
+
+`render SOURCE OUTPUT_DIR` converts the workbook to PDF the same way, then rasterizes pages
+to PNG with PDFium (`pypdfium2`):
+
+```bash
+"$XLSX_PYTHON" "$SKILL_ROOT/scripts/xlsx_tool.py" render report.xlsx review-pages --dpi 96
+```
+
+- `--dpi` accepts 36–300 (default 96). `--pages` selects 1-based PDF page numbers
+  (`--pages 1,3`); page numbers are validated against the actual converted page count.
+  `--timeout` bounds the LibreOffice step.
+- The destination directory must not exist; pages are staged and published atomically as
+  `page-001.png`, `page-002.png`, … with an `images` array reporting per-page dimensions,
+  byte counts, and SHA-256 hashes. Pages may legitimately differ in size when sheets mix
+  orientation or paper settings.
+- Limits: at most 200 pages per invocation (select `--pages`, set print areas, or hide
+  sheets), 25,000,000 pixels per page, and 250,000,000 pixels per run.
+- Rendering exists to be looked at. Open the published PNG files and review layout — column
+  overflow (`#####`), clipped or wrapped text, merge layout, chart appearance, conditional
+  formatting — before claiming visual correctness; structural JSON cannot show any of that.
+- The same external-link refusal, snapshot, hash-gate, formula-calculation, and
+  print-semantics behavior as PDF export applies.
+
 ## Styles, tables, validation, and charts
 
 Style objects support:
@@ -449,7 +534,9 @@ Colors are six- or eight-digit hexadecimal RGB/ARGB strings.
 Tables require a workbook-unique valid `name`, bounded rectangular `range`, non-empty unique
 headers, and at least one data row. Add and update use the same name, range, header, and style
 validation before mutating a table. Table style fields are `name`, `show_first_column`,
-`show_last_column`, `show_row_stripes`, and `show_column_stripes`.
+`show_last_column`, `show_row_stripes`, and `show_column_stripes`. Adding a table clears a
+sheet-level auto filter whose range overlaps the table: Excel treats that combination as
+invalid content, and the table provides its own filter.
 
 Conditional-format types:
 
@@ -476,7 +563,8 @@ is forced to XLSX string type.
 Formula caches reported by `inspect`, cached `extract`, `clean`, `summarize`, and cached
 `convert` may be stale or absent. Warnings are part of the successful JSON result.
 
-The production CLI does not impose a wall-clock timeout. Callers should enforce a subprocess
+The production CLI does not impose an overall wall-clock timeout; only the LibreOffice step
+of PDF export and rendering honors `--timeout`. Callers should still enforce a subprocess
 deadline appropriate to their workload and treat a timeout as an aborted operation. Graceful
 Python failures clean temporary outputs; an operating-system hard kill cannot guarantee
 cleanup.
@@ -488,9 +576,10 @@ cleanup.
 | 0 | success | Verified operation completed. |
 | 2 | `bad_input` | Missing, malformed, invalid encoding/name/style/value, unknown schema key, wrong extension/range, or conflicting flags. |
 | 3 | `unsupported_operation` | Macro/encryption, unsupported format/operation, or atomic-directory constraint. |
-| 4 | `missing_dependency` | Required Python packages are not installed. |
-| 5 | `ambiguous_edit` | Unsafe dependency, duplicate name, or unresolved replacement choice. |
-| 6 | `resource_limit` | Package/member/cell/inspection bound exceeded. |
+| 4 | `missing_dependency` | Required Python packages, LibreOffice (PDF/render), or pypdfium2 (render) are not installed. |
+| 5 | `ambiguous_edit` | Unsafe dependency, duplicate name, destructive merge, or unresolved replacement choice. |
+| 6 | `resource_limit` | Package/member/cell/inspection/merge-scan/render bound exceeded. |
 | 7 | `licensing_precondition` | Reserved common-contract status; no XLSX core operation currently uses it. |
 | 8 | `post_write_validation` | Save, reopen, verification, fsync, or atomic publication failed. |
 | 9 | `internal_error` | Unexpected implementation/runtime failure or interruption. |
+| 10 | `external_tool_failure` | LibreOffice or PDFium launch, conversion, timeout, or output validation failed. |

--- a/kolega_code/_bundled_skills/skills/xlsx/references/quality.md
+++ b/kolega_code/_bundled_skills/skills/xlsx/references/quality.md
@@ -1,0 +1,80 @@
+# Quality contract
+
+## Contents
+
+- [Design intake](#design-intake)
+- [Delivery profiles](#delivery-profiles)
+- [Acceptance criteria](#acceptance-criteria)
+- [Visual review versus structural checks](#visual-review-versus-structural-checks)
+
+## Design intake
+
+Record this profile before polished workbook creation or release:
+
+| Decision | Required intake |
+|---|---|
+| Consumer | People reading the workbook, downstream tools ingesting it, or both |
+| Deliverable type | Data handoff, working model, formatted report, print/PDF, or interchange files |
+| Target renderer | Excel version/platform, LibreOffice, Google Sheets, or other |
+| Recalculation | Who recalculates and where; whether cached values are acceptable |
+| Fonts | Approved fonts; whether the conservative set (Arial, Times New Roman, Courier New) is required |
+| Print geometry | Paper size, orientation, print areas, title rows/columns, fit settings |
+| Interchange | Encoding, header, NA, date, quoting, schema, and formula-injection policies |
+| Protection | Sheet/workbook protection expectations (styling only — never security) |
+
+XLSX cannot embed fonts, so a named font is portable only when installed on every intended
+renderer. Page setup is read-only in this tool: when print geometry must change, set it in a
+spreadsheet application before conversion, or bound the output with print areas, hidden
+sheets, and `--pages`.
+
+## Delivery profiles
+
+Profiles describe checks performed, not certifications:
+
+- **Data fidelity:** structure and content verified through `inspect`/`extract` — sheet
+  order, values, formulas, types, tables, names, validations match the job;
+  `counts.error_cells` is zero or every error is explained; recalculation status is stated.
+  No visual claim. Font warnings are informational.
+- **Visual review:** data fidelity plus `render`, then page-by-page examination of the PNG
+  output for column overflow (`#####`), clipped or wrapped text, merge layout, chart
+  appearance, and conditional-format rendering, remembering the renderer is LibreOffice.
+- **Print/PDF:** visual review plus print geometry matching the intake, intended hidden-sheet
+  exclusion, the font `RELEASE BLOCKER` resolved, and page-by-page review of the final PDF.
+  State that values reflect LibreOffice's calculation and that pagination is not proven
+  identical to Excel's.
+- **Interchange:** declared encoding/header/NA/date/schema policies asserted on the delimited
+  or JSON output, leading zeros preserved where declared, and the formula-injection policy
+  confirmed for the trust level of the data.
+
+Combine profiles when requested. State the renderer, unresolved warnings, and any check not
+performed.
+
+## Acceptance criteria
+
+Apply the rows relevant to the delivery profile. A failed required row blocks release unless
+the user explicitly accepts the named exception.
+
+| Area | Measurable acceptance |
+|---|---|
+| Package integrity | Source preflight passes; result reports atomic publication and reopen verification; source hash unchanged unless same-path `--overwrite` was requested. |
+| Structure | Sheet names/order, tables, named ranges, validations, conditional formats, and chart counts match the job; merges are intentional and destructive merges were explicitly acknowledged. |
+| Formula integrity | `counts.error_cells` is zero or each stored error is explained; recalculation ownership is stated and cached-value caveats are surfaced, never silently dropped. |
+| Column fit | No truncated numbers (`#####`) or clipped text on rendered pages; `auto_width` or explicit dimensions cover columns whose content matters. |
+| Print geometry | Inspected `page_setup` (orientation, paper, fit, print areas, titles) matches the intake for print/PDF deliverables; hidden sheets excluded from output are intended. |
+| Font portability | `fonts.referenced` reviewed; for print/PDF deliverables no `RELEASE BLOCKER` warning remains, or the user accepts the named substitution risk. Never infer portability from a clean local PDF. |
+| PDF gate | `verification.pdf_signature`/`pdf_openable` true, `counts.pdf_pages` at least 1, LibreOffice diagnostics reviewed when warned. |
+| Visual QA | Every changed page of the rendered output examined with the Read tool; layout, merges, charts, and conditional formats look correct on the rendering renderer. |
+| Interchange | Encoding, header policy, NA policy, schema typing, leading zeros, and injection guarding asserted on the produced files. |
+
+## Visual review versus structural checks
+
+`inspect` verifies package structure and exposes measurable workbook properties. The PDF
+gate verifies signature, reopenability, and page count. These are **structural checks**, not
+pixels: they cannot detect `#####` overflow, clipped text, font substitution, chart
+appearance, or whether a page looks correct.
+
+Real visual review means rendering and looking: run `render`, open the PNG pages with the
+Read tool, and examine every changed sheet's pages. The renderer is LibreOffice — an honest
+renderer, but not proof of Excel-identical appearance. If rendering cannot be performed
+(LibreOffice or pypdfium2 unavailable), report "structural checks only; visual QA not
+performed" and make no layout or print claim.

--- a/kolega_code/_bundled_skills/skills/xlsx/requirements.txt
+++ b/kolega_code/_bundled_skills/skills/xlsx/requirements.txt
@@ -1,2 +1,4 @@
-openpyxl~=3.1
-pandas~=3.0
+openpyxl>=3.1
+pandas>=2.2
+pypdf>=4.0
+Pillow>=10.0

--- a/kolega_code/_bundled_skills/skills/xlsx/scripts/smoke_test.py
+++ b/kolega_code/_bundled_skills/skills/xlsx/scripts/smoke_test.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import importlib.util
 import json
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -148,7 +150,15 @@ def create_fixture(temp: Path) -> Path:
                         "data": "C1:C5",
                         "categories": "B2:B5",
                         "anchor": "J2",
-                    }
+                    },
+                    {
+                        "type": "scatter",
+                        "title": "Revenue vs units",
+                        "x_values": "D2:D5",
+                        "y_values": ["C2:C5"],
+                        "series_titles": ["Revenue"],
+                        "anchor": "J20",
+                    },
                 ],
             },
             {
@@ -179,7 +189,11 @@ def create_fixture(temp: Path) -> Path:
     assert workbook["Sales"]["F2"].data_type == "s"
     assert len(workbook["Sales"].tables) == 1
     assert len(workbook["Sales"].conditional_formatting) == 1
-    assert len(workbook["Sales"]._charts) == 1
+    assert len(workbook["Sales"]._charts) == 2
+    scatter = workbook["Sales"]._charts[1]
+    assert type(scatter).__name__ == "ScatterChart"
+    assert len(scatter.series) == 1
+    assert scatter.scatterStyle is not None
     workbook.close()
     return output
 
@@ -188,7 +202,7 @@ def inspect_extract_edit(temp: Path, source: Path) -> Path:
     before = sha256(source)
     inspection = run_tool("inspect", source, "--max-cells", "100")
     assert inspection["result"]["counts"]["sheets"] == 4
-    assert inspection["result"]["counts"]["charts"] == 1
+    assert inspection["result"]["counts"]["charts"] == 2
     assert inspection["result"]["counts"]["formulas"] == 2
 
     extracted = temp / "sales.json"
@@ -262,7 +276,7 @@ def inspect_extract_edit(temp: Path, source: Path) -> Path:
     assert workbook["Sales"]["B2"].value == "Café au lait"
     assert workbook["Sales"]["C2"].number_format == "$#,##0.00"
     assert workbook["Sales"].tables["SalesTable"].totalsRowShown is True
-    assert len(workbook["Sales"]._charts) == 1
+    assert len(workbook["Sales"]._charts) == 2
     workbook.close()
     return output
 
@@ -291,6 +305,8 @@ def clean_and_summarize(temp: Path, source: Path) -> Path:
     workbook = load_workbook(cleaned)
     assert "Sales" in workbook.sheetnames and "Cleaned" in workbook.sheetnames
     assert workbook["Cleaned"]["C2"].value == 150
+    assert workbook["Cleaned"].auto_filter.ref is None
+    assert "CleanedSales" in workbook["Cleaned"].tables
     workbook.close()
 
     summary_job = {
@@ -713,6 +729,270 @@ def external_link_warning(temp: Path) -> None:
     payload = run_tool("edit", source, job_path, temp / "external-link-edited.xlsx")
     assert any("external link(s)" in warning for warning in payload["warnings"])
 
+    failure = run_tool("convert", source, temp / "external-link.pdf", expect_status=3)
+    assert failure["error"]["category"] == "unsupported_operation"
+
+
+def merge_and_sheet_settings(temp: Path, source: Path) -> None:
+    refused_job = temp / "merge-refused.json"
+    write_json(
+        refused_job,
+        {
+            "schema_version": 1,
+            "operations": [{"op": "set_sheet", "sheet": "Raw Headers", "merges": ["A2:B2"]}],
+        },
+    )
+    failure = run_tool("edit", source, refused_job, temp / "merge-refused.xlsx", expect_status=5)
+    assert failure["error"]["category"] == "ambiguous_edit"
+    assert failure["error"]["details"]["occupied_cells"] == ["B2"]
+
+    merged_job = temp / "merge-acknowledged.json"
+    write_json(
+        merged_job,
+        {
+            "schema_version": 1,
+            "operations": [
+                {
+                    "op": "set_sheet",
+                    "sheet": "Raw Headers",
+                    "merges": ["A2:B2"],
+                    "allow_merge_data_loss": True,
+                    "tab_color": "FF3366CC",
+                    "show_gridlines": False,
+                    "zoom_scale": 150,
+                    "auto_width": {"columns": ["C"], "max_width": 24},
+                }
+            ],
+        },
+    )
+    merged_path = temp / "merge-acknowledged.xlsx"
+    payload = run_tool("edit", source, merged_job, merged_path)
+    assert payload["result"]["counts"]["ranges_merged"] == 1
+    assert payload["result"]["counts"]["columns_auto_sized"] == 1
+    assert any("discarded 1 non-top-left cell value(s)" in w for w in payload["warnings"])
+    inspection = run_tool("inspect", merged_path, "--sheet", "Raw Headers", "--no-cells")
+    sheet = inspection["result"]["sheets"][0]
+    assert sheet["merged_cells"] == ["A2:B2"]
+    assert sheet["tab_color"]["rgb"] == "FF3366CC"
+    assert sheet["show_gridlines"] is False
+    assert sheet["zoom_scale"] == 150
+    assert 8 <= sheet["dimensions"]["columns"]["C"]["width"] <= 24
+
+    unmerged_job = temp / "unmerge.json"
+    write_json(
+        unmerged_job,
+        {
+            "schema_version": 1,
+            "operations": [{"op": "set_sheet", "sheet": "Raw Headers", "unmerge": ["A2:B2"]}],
+        },
+    )
+    unmerged_path = temp / "unmerged.xlsx"
+    payload = run_tool("edit", merged_path, unmerged_job, unmerged_path)
+    assert payload["result"]["counts"]["ranges_unmerged"] == 1
+    inspection = run_tool("inspect", unmerged_path, "--sheet", "Raw Headers", "--no-cells")
+    assert inspection["result"]["sheets"][0]["merged_cells"] == []
+
+    bad_unmerge_job = temp / "bad-unmerge.json"
+    write_json(
+        bad_unmerge_job,
+        {
+            "schema_version": 1,
+            "operations": [{"op": "set_sheet", "sheet": "Raw Headers", "unmerge": ["A9:B9"]}],
+        },
+    )
+    failure = run_tool("edit", source, bad_unmerge_job, temp / "bad-unmerge.xlsx", expect_status=2)
+    assert failure["error"]["category"] == "bad_input"
+    assert failure["error"]["details"]["range"] == "A9:B9"
+
+
+def auto_width_create(temp: Path) -> None:
+    job_path = temp / "auto-width.json"
+    write_json(
+        job_path,
+        {
+            "schema_version": 1,
+            "sheets": [
+                {
+                    "name": "Wide",
+                    "rows": [
+                        ["Header long enough", "x"],
+                        ["Value that is much longer than the header", "y"],
+                    ],
+                    "auto_width": True,
+                }
+            ],
+        },
+    )
+    output = temp / "auto-width.xlsx"
+    payload = run_tool("create", job_path, output)
+    assert payload["result"]["counts"]["columns_auto_sized"] == 2
+    inspection = run_tool("inspect", output, "--no-cells")
+    columns = inspection["result"]["sheets"][0]["dimensions"]["columns"]
+    assert 40 <= columns["A"]["width"] <= 60
+    assert columns["B"]["width"] == 10
+
+
+def formula_error_scan(temp: Path) -> None:
+    plain = temp / "plain-errors.xlsx"
+    workbook = Workbook()
+    workbook.active["A1"] = "ok"
+    workbook.save(plain)
+    workbook.close()
+    crafted = temp / "crafted-errors.xlsx"
+    with zipfile.ZipFile(plain) as bundle, zipfile.ZipFile(crafted, "w") as target:
+        for item in bundle.infolist():
+            data = bundle.read(item.filename)
+            if item.filename == "xl/worksheets/sheet1.xml":
+                text = data.decode("utf-8")
+                assert "</sheetData>" in text
+                injected = (
+                    '<row r="2">'
+                    '<c r="A2" t="e"><v>#REF!</v></c>'
+                    '<c r="B2" t="e"><f>1/0</f><v>#DIV/0!</v></c>'
+                    "</row></sheetData>"
+                )
+                data = text.replace("</sheetData>", injected).encode("utf-8")
+            target.writestr(item, data)
+    inspection = run_tool("inspect", crafted)
+    assert inspection["result"]["counts"]["error_cells"] == 2
+    sheet = inspection["result"]["sheets"][0]
+    assert sheet["errors"]["count"] == 2
+    assert sheet["errors"]["by_error"] == {"#DIV/0!": 1, "#REF!": 1}
+    kinds = {sample["error"]: sample["kind"] for sample in sheet["errors"]["samples"]}
+    assert kinds == {"#REF!": "literal", "#DIV/0!": "cached_formula"}
+    assert any("error value(s)" in warning for warning in inspection["warnings"])
+
+
+def font_inventory(temp: Path, source: Path) -> None:
+    inspection = run_tool("inspect", source, "--no-cells")
+    fonts = inspection["result"]["workbook"]["fonts"]
+    referenced = [name.casefold() for name in fonts["referenced"]]
+    assert "calibri" in referenced
+    assert fonts["embedded"] == []
+    assert fonts["unembedded"] == fonts["referenced"]
+    assert any(warning.startswith("RELEASE BLOCKER") for warning in inspection["warnings"])
+
+    arial_job = temp / "arial.json"
+    write_json(
+        arial_job,
+        {
+            "schema_version": 1,
+            "sheets": [
+                {
+                    "name": "Portable",
+                    "rows": [[{"value": "Arial only", "font": {"name": "Arial"}}]],
+                }
+            ],
+        },
+    )
+    arial_path = temp / "arial.xlsx"
+    run_tool("create", arial_job, arial_path)
+    inspection = run_tool("inspect", arial_path, "--no-cells")
+    fonts = inspection["result"]["workbook"]["fonts"]
+    assert fonts["referenced"] == ["Arial"]
+    assert not any(warning.startswith("RELEASE BLOCKER") for warning in inspection["warnings"])
+
+
+def pdf_render_option_validation(temp: Path, source: Path) -> None:
+    failure = run_tool(
+        "convert",
+        source,
+        temp / "option-check.pdf",
+        "--sheet",
+        "Sales",
+        expect_status=2,
+    )
+    assert failure["error"]["category"] == "bad_input"
+    failure = run_tool(
+        "convert",
+        source,
+        temp / "option-check.csv",
+        "--timeout",
+        "30",
+        expect_status=2,
+    )
+    assert failure["error"]["category"] == "bad_input"
+    failure = run_tool(
+        "render",
+        source,
+        temp / "render-bad-dpi",
+        "--dpi",
+        "9999",
+        expect_status=2,
+    )
+    assert failure["error"]["category"] == "bad_input"
+
+
+def pdf_and_render(temp: Path, source: Path, require_libreoffice: bool) -> dict[str, Any]:
+    libreoffice = shutil.which("soffice") or shutil.which("libreoffice")
+    if libreoffice is None:
+        if require_libreoffice:
+            raise AssertionError("LibreOffice was required but is not available on PATH.")
+        return {"status": "skipped", "reason": "LibreOffice is not available on PATH"}
+    before = sha256(source)
+    pdf = temp / "converted.pdf"
+    conversion = run_tool(
+        "convert",
+        source,
+        pdf,
+        "--timeout",
+        "300",
+        timeout_seconds=360,
+    )
+    pages = conversion["result"]["counts"]["pdf_pages"]
+    assert pages >= 1
+    assert conversion["result"]["verification"]["pdf_openable"]
+    assert conversion["result"]["verification"]["source_unchanged_at_publish_gate"]
+    with pdf.open("rb") as handle:
+        assert handle.read(5) == b"%PDF-"
+    assert sha256(source) == before
+    status: dict[str, Any] = {"status": "passed", "executable": libreoffice, "pdf_pages": pages}
+    if importlib.util.find_spec("pypdfium2") is None:
+        status["render"] = {
+            "status": "skipped",
+            "reason": "optional pypdfium2 package is not installed",
+        }
+        return status
+    render_dir = temp / "rendered-pages"
+    rendered = run_tool(
+        "render",
+        source,
+        render_dir,
+        "--timeout",
+        "300",
+        timeout_seconds=360,
+    )
+    assert rendered["result"]["counts"]["pages_rendered"] == pages
+    files = sorted(render_dir.glob("page-*.png"))
+    assert len(files) == pages
+    hashes = set()
+    for file, record in zip(files, rendered["result"]["images"], strict=True):
+        with file.open("rb") as handle:
+            assert handle.read(8) == b"\x89PNG\r\n\x1a\n"
+        assert record["file"] == file.name
+        assert record["width_px"] > 0 and record["height_px"] > 0
+        hashes.add(sha256(file))
+    if pages > 1:
+        assert len(hashes) >= 2
+    selected_dir = temp / "rendered-first-page"
+    selected = run_tool(
+        "render",
+        source,
+        selected_dir,
+        "--pages",
+        "1",
+        "--timeout",
+        "300",
+        timeout_seconds=360,
+    )
+    assert selected["result"]["counts"]["pages_rendered"] == 1
+    assert (selected_dir / "page-001.png").is_file()
+    failure = run_tool("render", source, render_dir, expect_status=3)
+    assert failure["error"]["category"] == "unsupported_operation"
+    assert sha256(source) == before
+    status["render"] = {"status": "passed", "pages": pages}
+    return status
+
 
 def subprocess_timeout_regression(source: Path) -> None:
     started = time.monotonic()
@@ -752,7 +1032,12 @@ def cumulative_json_budget_regression(temp: Path) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.parse_args()
+    parser.add_argument(
+        "--require-libreoffice",
+        action="store_true",
+        help="fail unless LibreOffice PDF conversion can be exercised",
+    )
+    args = parser.parse_args()
     with tempfile.TemporaryDirectory(prefix="xlsx-skill-smoke-") as raw_temp:
         temp = Path(raw_temp)
         created = create_fixture(temp)
@@ -763,6 +1048,12 @@ def main() -> int:
         case_insensitive_dependency(temp, created)
         failure_path(temp, created)
         external_link_warning(temp)
+        merge_and_sheet_settings(temp, created)
+        auto_width_create(temp)
+        formula_error_scan(temp)
+        font_inventory(temp, created)
+        pdf_render_option_validation(temp, created)
+        libreoffice_status = pdf_and_render(temp, created, args.require_libreoffice)
         subprocess_timeout_regression(created)
         cumulative_json_budget_regression(temp)
     print(
@@ -791,7 +1082,14 @@ def main() -> int:
                     "cumulative_json_cell_budget",
                     "external_link_preservation_warning",
                     "macro_refusal",
+                    "set_sheet_visual_settings_merge_unmerge",
+                    "auto_width",
+                    "formula_error_scan",
+                    "font_portability_inventory",
+                    "pdf_and_render_option_validation",
+                    "xlsx_to_pdf_and_page_render",
                 ],
+                "libreoffice": libreoffice_status,
             },
             sort_keys=True,
         )

--- a/kolega_code/_bundled_skills/skills/xlsx/scripts/xlsx_tool.py
+++ b/kolega_code/_bundled_skills/skills/xlsx/scripts/xlsx_tool.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-"""Safely inspect, extract, create, edit, clean, summarize, and convert XLSX files."""
+"""Safely inspect, extract, create, edit, clean, summarize, convert, and render XLSX files."""
 
 from __future__ import annotations
 
@@ -8,11 +8,13 @@ import argparse
 import codecs
 import csv
 import datetime as dt
+import hashlib
 import json
 import math
 import os
 import re
 import shutil
+import subprocess
 import sys
 import tempfile
 import traceback
@@ -30,9 +32,17 @@ try:
     import numpy as np
     import openpyxl
     import pandas as pd
+    import pypdf
     from openpyxl import Workbook, load_workbook
-    from openpyxl.chart import AreaChart, BarChart, LineChart, PieChart, Reference, ScatterChart
-    from openpyxl.chart.series import Series
+    from openpyxl.chart import (
+        AreaChart,
+        BarChart,
+        LineChart,
+        PieChart,
+        Reference,
+        ScatterChart,
+        Series,
+    )
     from openpyxl.formatting.rule import (
         CellIsRule,
         ColorScaleRule,
@@ -49,11 +59,12 @@ try:
         Protection,
         Side,
     )
-    from openpyxl.utils import get_column_letter, range_boundaries
+    from openpyxl.utils import column_index_from_string, get_column_letter, range_boundaries
     from openpyxl.utils.cell import quote_sheetname
     from openpyxl.workbook.defined_name import DefinedName
     from openpyxl.worksheet.datavalidation import DataValidation
     from openpyxl.worksheet.table import Table, TableStyleInfo
+    from PIL import Image
 except ImportError as exc:  # pragma: no cover - exercised only without required dependencies
     IMPORT_ERROR = exc
 
@@ -83,6 +94,26 @@ DANGEROUS_FORMULA_PREFIXES = ("=", "+", "-", "@")
 FORMULA_LEADING_WHITESPACE = " \t\r\n\ufeff\u00a0"
 SUPPORTED_WORKBOOK_SUFFIX = ".xlsx"
 UNSUPPORTED_WORKBOOK_SUFFIXES = {".xls", ".xlsb", ".xlsm", ".xltm", ".xla", ".xlam"}
+FORMULA_ERROR_LITERALS = {
+    "#REF!",
+    "#DIV/0!",
+    "#VALUE!",
+    "#NAME?",
+    "#N/A",
+    "#NULL!",
+    "#NUM!",
+    "#SPILL!",
+    "#CALC!",
+}
+MAX_FORMULA_ERROR_SAMPLES = 20
+PORTABLE_RELEASE_FONTS = {"arial", "times new roman", "courier new"}
+MIN_RENDER_DPI = 36
+MAX_RENDER_DPI = 300
+MAX_RENDER_PIXELS_PER_PAGE = 25_000_000
+MAX_RENDER_TOTAL_PIXELS = 250_000_000
+MAX_RENDER_PAGES = 200
+DEFAULT_EXTERNAL_TOOL_TIMEOUT = 120.0
+AUTO_WIDTH_DEFAULTS = {"min_width": 8, "max_width": 60, "sample_rows": 200}
 FAILURE_STATUS = {
     "bad_input": 2,
     "unsupported_operation": 3,
@@ -92,6 +123,7 @@ FAILURE_STATUS = {
     "licensing_precondition": 7,
     "post_write_validation": 8,
     "internal_error": 9,
+    "external_tool_failure": 10,
 }
 
 
@@ -172,7 +204,16 @@ def versions() -> dict[str, str]:
         "openpyxl": openpyxl.__version__,
         "pandas": pd.__version__,
         "numpy": np.__version__,
+        "pypdf": pypdf.__version__,
     }
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def success(operation: str, result: Mapping[str, Any], warnings: Sequence[str]) -> dict[str, Any]:
@@ -794,7 +835,11 @@ def color_value(value: Any, label: str) -> str | None:
     text = require_string(value, label)
     if not re.fullmatch(r"(?:[0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})", text):
         fail("bad_input", f"{label} must be a 6- or 8-digit hexadecimal color.")
-    return text.upper()
+    text = text.upper()
+    # openpyxl pads 6-digit values with a fully transparent 00 alpha; make them opaque.
+    if len(text) == 6:
+        text = "FF" + text
+    return text
 
 
 def build_font(spec: Mapping[str, Any] | None) -> Any:
@@ -1161,6 +1206,136 @@ def inventory_pivots(worksheet: Any) -> list[dict[str, Any]]:
     return pivots
 
 
+def inspect_page_setup(worksheet: Any) -> dict[str, Any]:
+    setup = worksheet.page_setup
+    properties = getattr(worksheet.sheet_properties, "pageSetUpPr", None)
+    try:
+        print_area = worksheet.print_area
+    except (TypeError, ValueError):
+        print_area = None
+    return {
+        "orientation": getattr(setup, "orientation", None),
+        "paper_size": getattr(setup, "paperSize", None),
+        "scale": getattr(setup, "scale", None),
+        "fit_to_width": getattr(setup, "fitToWidth", None),
+        "fit_to_height": getattr(setup, "fitToHeight", None),
+        "fit_to_page": getattr(properties, "fitToPage", None) if properties else None,
+        "print_area": print_area or None,
+        "print_title_rows": getattr(worksheet, "print_title_rows", None),
+        "print_title_cols": getattr(worksheet, "print_title_cols", None),
+    }
+
+
+def _package_font_scan(path: Path) -> tuple[set[str], dict[str, str | None]]:
+    """Collect chart and theme typefaces from already-preflighted package XML."""
+
+    chart_fonts: set[str] = set()
+    theme: dict[str, str | None] = {"major": None, "minor": None}
+    try:
+        with zipfile.ZipFile(path) as package:
+            for info in package.infolist():
+                lowered = info.filename.lower()
+                if not lowered.endswith(".xml"):
+                    continue
+                is_chart = lowered.startswith("xl/charts/")
+                is_theme = lowered.startswith("xl/theme/")
+                if not (is_chart or is_theme):
+                    continue
+                text = decode_package_xml(package.read(info), info.filename)
+                root = ElementTree.fromstring(text)
+                if is_chart:
+                    for element in root.iter():
+                        if element.tag.rsplit("}", 1)[-1] in {"latin", "ea", "cs"}:
+                            typeface = element.get("typeface")
+                            if typeface and not typeface.startswith("+"):
+                                chart_fonts.add(typeface)
+                    continue
+                for scheme_key, tag in (("major", "majorFont"), ("minor", "minorFont")):
+                    for element in root.iter():
+                        if element.tag.rsplit("}", 1)[-1] != tag:
+                            continue
+                        for child in element:
+                            if child.tag.rsplit("}", 1)[-1] == "latin":
+                                typeface = child.get("typeface")
+                                if typeface:
+                                    theme[scheme_key] = typeface
+                        break
+    except (OSError, zipfile.BadZipFile, ElementTree.ParseError) as exc:
+        fail("bad_input", "Could not scan package fonts.", path=path, reason=str(exc))
+    return chart_fonts, theme
+
+
+def workbook_font_inventory(workbook: Any, path: Path) -> dict[str, Any]:
+    """Fonts effectively referenced by non-empty cells and chart text.
+
+    XLSX packages cannot embed fonts, so every referenced font is also unembedded and
+    must be installed on each intended renderer. Named-style and theme fonts are
+    reported as separate sources only: a named style applied to any cell already shows
+    up through that cell's resolved font, and an unapplied one renders nothing. Fonts
+    referenced only by unsupported parts (for example rich-text runs in shared strings)
+    are not detected.
+    """
+
+    cell_fonts: dict[str, str] = {}
+    for worksheet in workbook.worksheets:
+        for row in worksheet.iter_rows():
+            for cell in row:
+                if cell.value is None:
+                    continue
+                name = getattr(cell.font, "name", None)
+                if name:
+                    cell_fonts.setdefault(name.casefold(), name)
+    named_style_fonts: dict[str, str] = {}
+    for style in getattr(workbook, "_named_styles", []):
+        name = getattr(getattr(style, "font", None), "name", None)
+        if name:
+            named_style_fonts.setdefault(name.casefold(), name)
+    scanned_chart_fonts, theme = _package_font_scan(path)
+    chart_fonts: dict[str, str] = {}
+    for name in scanned_chart_fonts:
+        chart_fonts.setdefault(name.casefold(), name)
+    referenced: dict[str, str] = {}
+    for source in (cell_fonts, chart_fonts):
+        for key, value in source.items():
+            referenced.setdefault(key, value)
+    ordered = sorted(referenced.values(), key=str.casefold)
+    return {
+        "referenced": ordered,
+        "by_source": {
+            "cells": sorted(cell_fonts.values(), key=str.casefold),
+            "named_styles": sorted(named_style_fonts.values(), key=str.casefold),
+            "charts": sorted(chart_fonts.values(), key=str.casefold),
+        },
+        "theme": theme,
+        "embedded": [],
+        "unembedded": ordered,
+    }
+
+
+def font_portability_warnings(fonts: Mapping[str, Any]) -> list[str]:
+    warnings: list[str] = []
+    referenced = list(fonts.get("referenced", []))
+    if not referenced:
+        return warnings
+    warnings.append(
+        "Workbook references fonts that renderers must supply ("
+        + ", ".join(referenced)
+        + "). XLSX cannot embed fonts; a renderer without them substitutes metrics and can "
+        "change column fit, wrapping, and print pagination. Do not claim visual fidelity "
+        "from structural checks alone."
+    )
+    nonportable = [name for name in referenced if name.casefold() not in PORTABLE_RELEASE_FONTS]
+    if nonportable:
+        warnings.append(
+            "RELEASE BLOCKER: workbook references fonts outside the conservative "
+            "cross-renderer set (Arial, Times New Roman, Courier New): "
+            + ", ".join(nonportable)
+            + ". Replace these fonts before releasing matching XLSX and PDF deliverables; "
+            "renderer substitution can change layout and pagination."
+        )
+    return warnings
+
+
 def inspect_sheet(
     worksheet: Any,
     cached_worksheet: Any,
@@ -1179,6 +1354,8 @@ def inspect_sheet(
     nonempty_count = 0
     style_counts: Counter[tuple[int, str]] = Counter()
     style_samples: dict[tuple[int, str], dict[str, Any]] = {}
+    error_counts: Counter[str] = Counter()
+    error_samples: list[dict[str, Any]] = []
     truncated = False
     for row in worksheet.iter_rows(
         min_row=min_row,
@@ -1230,6 +1407,29 @@ def inspect_sheet(
                 )
             is_formula = cell.data_type == "f"
             formula_count += is_formula
+            cached_value: Any = None
+            if is_formula:
+                cached_value = cached_worksheet[cell.coordinate].value
+            error_text: str | None = None
+            error_kind: str | None = None
+            if cell.data_type == "e" and cell.value is not None:
+                error_text, error_kind = str(cell.value), "literal"
+            elif (
+                is_formula
+                and isinstance(cached_value, str)
+                and cached_value in FORMULA_ERROR_LITERALS
+            ):
+                error_text, error_kind = cached_value, "cached_formula"
+            if error_text is not None:
+                error_counts[error_text] += 1
+                if len(error_samples) < MAX_FORMULA_ERROR_SAMPLES:
+                    error_samples.append(
+                        {
+                            "coordinate": cell.coordinate,
+                            "error": error_text,
+                            "kind": error_kind,
+                        }
+                    )
             if include_cells and len(cells) < max_cells:
                 record = {
                     "coordinate": cell.coordinate,
@@ -1240,8 +1440,7 @@ def inspect_sheet(
                 }
                 if is_formula:
                     record["formula"] = cell.value
-                    cached = cached_worksheet[cell.coordinate].value
-                    record["cached_value"] = serialize_cell_value(cached)
+                    record["cached_value"] = serialize_cell_value(cached_value)
                 cells.append(record)
             elif include_cells:
                 truncated = True
@@ -1252,6 +1451,12 @@ def inspect_sheet(
     if formula_count:
         warnings.append(
             f"Sheet {worksheet.title!r} contains formulas; cached results may be stale or absent."
+        )
+    error_count = sum(error_counts.values())
+    if error_count:
+        breakdown = ", ".join(f"{name} x{count}" for name, count in sorted(error_counts.items()))
+        warnings.append(
+            f"Sheet {worksheet.title!r} contains {error_count} error value(s): {breakdown}."
         )
     dimensions = {
         "columns": {
@@ -1290,6 +1495,15 @@ def inspect_sheet(
             ),
             "merged_cells": [str(item) for item in worksheet.merged_cells.ranges],
             "auto_filter": worksheet.auto_filter.ref,
+            "tab_color": serialize_color(worksheet.sheet_properties.tabColor),
+            "show_gridlines": worksheet.sheet_view.showGridLines,
+            "zoom_scale": worksheet.sheet_view.zoomScale,
+            "page_setup": inspect_page_setup(worksheet),
+            "errors": {
+                "count": error_count,
+                "by_error": dict(sorted(error_counts.items())),
+                "samples": error_samples,
+            },
             "tables": inventory_tables(worksheet),
             "charts": inventory_charts(worksheet),
             "pivots": inventory_pivots(worksheet),
@@ -1343,6 +1557,8 @@ def handle_inspect(args: argparse.Namespace) -> dict[str, Any]:
         warnings.append(
             "External links are inventoried but not repaired or proven to remain resolvable."
         )
+    fonts = workbook_font_inventory(workbook, args.source)
+    warnings.extend(font_portability_warnings(fonts))
     pivot_count = sum(len(sheet["pivots"]) for sheet in sheets)
     if pivot_count:
         warnings.append(
@@ -1356,6 +1572,7 @@ def handle_inspect(args: argparse.Namespace) -> dict[str, Any]:
             "active_sheet": workbook.active.title,
             "defined_names": inventory_defined_names(workbook),
             "external_links": external_links,
+            "fonts": fonts,
             "macros": False,
             "calculation": {
                 "mode": workbook.calculation.calcMode,
@@ -1380,6 +1597,7 @@ def handle_inspect(args: argparse.Namespace) -> dict[str, Any]:
             "charts": sum(len(sheet["charts"]) for sheet in sheets),
             "pivots": pivot_count,
             "formulas": sum(sheet["formula_cells"] for sheet in sheets),
+            "error_cells": sum(sheet["errors"]["count"] for sheet in sheets),
         },
     }
     workbook.close()
@@ -1637,6 +1855,17 @@ def build_table_style(spec: Mapping[str, Any]) -> Any:
     )
 
 
+def ranges_overlap(first: str, second: str) -> bool:
+    a_min_col, a_min_row, a_max_col, a_max_row = range_boundaries(first)
+    b_min_col, b_min_row, b_max_col, b_max_row = range_boundaries(second)
+    return not (
+        a_max_col < b_min_col
+        or b_max_col < a_min_col
+        or a_max_row < b_min_row
+        or b_max_row < a_min_row
+    )
+
+
 def add_table(worksheet: Any, spec: Mapping[str, Any], workbook: Any) -> Any:
     reject_unknown_keys(
         spec,
@@ -1651,6 +1880,11 @@ def add_table(worksheet: Any, spec: Mapping[str, Any], workbook: Any) -> Any:
     table = Table(displayName=name, ref=reference)
     table.tableStyleInfo = style
     table.totalsRowShown = bool(spec.get("totals_row_shown", False))
+    # Excel treats a sheet-level auto filter overlapping a table as invalid content
+    # and offers document recovery; the table supplies its own filter.
+    existing_filter = worksheet.auto_filter.ref
+    if existing_filter and ranges_overlap(existing_filter, reference):
+        worksheet.auto_filter.ref = None
     worksheet.add_table(table)
     return table
 
@@ -1865,6 +2099,10 @@ def add_chart(worksheet: Any, spec: Mapping[str, Any], workbook: Any) -> Any:
     if chart_type not in chart_classes:
         fail("unsupported_operation", "Unsupported native chart type.", type=chart_type)
     chart = chart_classes[chart_type]()
+    if chart_type == "scatter":
+        # ECMA-376 requires CT_ScatterChart/scatterStyle; openpyxl omits it when unset
+        # and Excel then offers document recovery.
+        chart.scatterStyle = "lineMarker"
     chart.title = spec.get("title")
     chart.style = spec.get("style", 10)
     chart.height = spec.get("height", 7.5)
@@ -2166,6 +2404,176 @@ def populate_rows(
     return written
 
 
+MERGE_SCAN_CELL_LIMIT = 100_000
+
+
+def merge_covered_values(worksheet: Any, range_text: str) -> list[str]:
+    """Coordinates of value-bearing cells a merge would discard (all but top-left)."""
+
+    try:
+        min_col, min_row, max_col, max_row = range_boundaries(range_text)
+    except ValueError as exc:
+        fail("bad_input", "Invalid merge range.", range=range_text, reason=str(exc))
+    if None in (min_col, min_row, max_col, max_row):
+        fail("bad_input", "Merge ranges must be bounded A1 rectangles.", range=range_text)
+    span = (max_row - min_row + 1) * (max_col - min_col + 1)
+    if span > MERGE_SCAN_CELL_LIMIT:
+        fail(
+            "resource_limit",
+            "Merge range exceeds the data-loss scan limit.",
+            range=range_text,
+            cells=span,
+            limit=MERGE_SCAN_CELL_LIMIT,
+        )
+    occupied: list[str] = []
+    for row in worksheet.iter_rows(
+        min_row=min_row,
+        min_col=min_col,
+        max_row=max_row,
+        max_col=max_col,
+    ):
+        for cell in row:
+            if cell.row == min_row and cell.column == min_col:
+                continue
+            if cell.value is not None:
+                occupied.append(cell.coordinate)
+    return occupied
+
+
+def parse_auto_width_spec(value: Any, label: str) -> dict[str, Any] | None:
+    if value is None or value is False:
+        return None
+    if value is True:
+        return dict(AUTO_WIDTH_DEFAULTS)
+    spec = require_mapping(value, label)
+    reject_unknown_keys(spec, {"columns", "min_width", "max_width", "sample_rows"}, label)
+    parsed: dict[str, Any] = dict(AUTO_WIDTH_DEFAULTS)
+    if "columns" in spec:
+        columns = require_list(spec["columns"], f"{label}.columns")
+        if not columns:
+            fail("bad_input", f"{label}.columns must not be empty.")
+        parsed["columns"] = [
+            require_string(column, f"{label} column").upper() for column in columns
+        ]
+    for key in ("min_width", "max_width", "sample_rows"):
+        if key in spec:
+            bound = spec[key]
+            if isinstance(bound, bool) or not isinstance(bound, int) or bound < 1:
+                fail("bad_input", f"{label}.{key} must be a positive integer.")
+            parsed[key] = bound
+    if parsed["min_width"] > parsed["max_width"]:
+        fail("bad_input", f"{label}.min_width cannot exceed max_width.")
+    return parsed
+
+
+def auto_width_value(sample_lengths: Sequence[int], *, min_width: int, max_width: int) -> float:
+    widest = max(sample_lengths, default=0)
+    return float(min(max(widest, min_width) + 2, max_width))
+
+
+def apply_auto_width(worksheet: Any, spec: Mapping[str, Any]) -> int:
+    """Set character-count-heuristic column widths from stored cell text."""
+
+    if "columns" in spec:
+        try:
+            targets = [column_index_from_string(letter) for letter in spec["columns"]]
+        except ValueError as exc:
+            fail(
+                "bad_input",
+                "auto_width.columns must contain column letters.",
+                reason=str(exc),
+            )
+    else:
+        targets = list(range(1, (worksheet.max_column or 1) + 1))
+    sample_rows = min(int(spec["sample_rows"]), worksheet.max_row or 1)
+    for column in targets:
+        lengths = [
+            len(str(cell.value))
+            for row in worksheet.iter_rows(
+                min_row=1,
+                max_row=sample_rows,
+                min_col=column,
+                max_col=column,
+            )
+            for cell in row
+            if cell.value is not None
+        ]
+        worksheet.column_dimensions[get_column_letter(column)].width = auto_width_value(
+            lengths,
+            min_width=spec["min_width"],
+            max_width=spec["max_width"],
+        )
+    return len(targets)
+
+
+def apply_sheet_settings(
+    worksheet: Any,
+    spec: Mapping[str, Any],
+    *,
+    context: str,
+    warnings: list[str],
+) -> Counter[str]:
+    """Apply the worksheet settings shared by create sheets, add_sheet, and set_sheet."""
+
+    counts: Counter[str] = Counter()
+    allow_merge_data_loss = bool(spec.get("allow_merge_data_loss", False))
+    for reference in require_list(spec.get("merges", []), "sheet.merges"):
+        range_text = require_string(reference, "merge range").upper()
+        occupied = merge_covered_values(worksheet, range_text)
+        if occupied:
+            if context == "edit" and not allow_merge_data_loss:
+                fail(
+                    "ambiguous_edit",
+                    "Merging this range would discard non-top-left cell values.",
+                    range=range_text,
+                    sheet=worksheet.title,
+                    occupied_cells=occupied[:10],
+                    occupied_count=len(occupied),
+                    resolution="Set allow_merge_data_loss to true to accept the loss.",
+                )
+            warnings.append(
+                f"Merging {range_text} on sheet {worksheet.title!r} discarded "
+                f"{len(occupied)} non-top-left cell value(s); only the top-left value is kept."
+            )
+        worksheet.merge_cells(range_text)
+        counts["ranges_merged"] += 1
+    for reference in require_list(spec.get("unmerge", []), "sheet.unmerge"):
+        range_text = require_string(reference, "unmerge range").upper()
+        existing = sorted(str(item) for item in worksheet.merged_cells.ranges)
+        if range_text not in existing:
+            fail(
+                "bad_input",
+                "unmerge must exactly match an existing merged range.",
+                range=range_text,
+                sheet=worksheet.title,
+                merged=existing,
+            )
+        worksheet.unmerge_cells(range_text)
+        counts["ranges_unmerged"] += 1
+    if "freeze_panes" in spec:
+        worksheet.freeze_panes = spec["freeze_panes"]
+    if "auto_filter" in spec:
+        worksheet.auto_filter.ref = require_string(spec["auto_filter"], "auto_filter")
+    if "tab_color" in spec:
+        worksheet.sheet_properties.tabColor = color_value(spec["tab_color"], "tab_color")
+    if "show_gridlines" in spec:
+        worksheet.sheet_view.showGridLines = bool(spec["show_gridlines"])
+    if "zoom_scale" in spec:
+        zoom = int(spec["zoom_scale"])
+        if not 10 <= zoom <= 400:
+            fail("bad_input", "zoom_scale must be between 10 and 400.")
+        worksheet.sheet_view.zoomScale = zoom
+    auto_width = parse_auto_width_spec(spec.get("auto_width"), "auto_width")
+    if auto_width is not None:
+        counts["columns_auto_sized"] += apply_auto_width(worksheet, auto_width)
+    if "dimensions" in spec:
+        set_sheet_dimensions(
+            worksheet,
+            require_mapping(spec["dimensions"], "sheet.dimensions"),
+        )
+    return counts
+
+
 def configure_worksheet(
     workbook: Any,
     worksheet: Any,
@@ -2173,7 +2581,7 @@ def configure_worksheet(
     *,
     base_directory: Path,
     budget: CellBudget,
-) -> dict[str, int]:
+) -> tuple[dict[str, int], list[str]]:
     reject_unknown_keys(
         spec,
         {
@@ -2188,6 +2596,7 @@ def configure_worksheet(
             "freeze_panes",
             "dimensions",
             "auto_filter",
+            "auto_width",
             "tab_color",
             "show_gridlines",
             "zoom_scale",
@@ -2198,13 +2607,16 @@ def configure_worksheet(
         },
         "sheet",
     )
-    counts = {
-        "cells": 0,
-        "tables": 0,
-        "charts": 0,
-        "conditional_formats": 0,
-        "data_validations": 0,
-    }
+    counts: Counter[str] = Counter(
+        {
+            "cells": 0,
+            "tables": 0,
+            "charts": 0,
+            "conditional_formats": 0,
+            "data_validations": 0,
+        }
+    )
+    warnings: list[str] = []
     if "source" in spec and "rows" in spec:
         fail("bad_input", "A sheet cannot contain both source and rows.")
     if "source" in spec:
@@ -2237,26 +2649,14 @@ def configure_worksheet(
             fail("bad_input", "Cell mapping keys must identify one cell.", coordinate=coordinate)
         set_cell_from_spec(cell, cell_spec)
         counts["cells"] += 1
-    for reference in require_list(spec.get("merges", []), "sheet.merges"):
-        worksheet.merge_cells(require_string(reference, "merge range"))
-    if "freeze_panes" in spec:
-        worksheet.freeze_panes = spec["freeze_panes"]
-    if "dimensions" in spec:
-        set_sheet_dimensions(
+    counts.update(
+        apply_sheet_settings(
             worksheet,
-            require_mapping(spec["dimensions"], "sheet.dimensions"),
+            spec,
+            context="create",
+            warnings=warnings,
         )
-    if "auto_filter" in spec:
-        worksheet.auto_filter.ref = require_string(spec["auto_filter"], "auto_filter")
-    if "tab_color" in spec:
-        worksheet.sheet_properties.tabColor = color_value(spec["tab_color"], "tab_color")
-    if "show_gridlines" in spec:
-        worksheet.sheet_view.showGridLines = bool(spec["show_gridlines"])
-    if "zoom_scale" in spec:
-        zoom = int(spec["zoom_scale"])
-        if not 10 <= zoom <= 400:
-            fail("bad_input", "zoom_scale must be between 10 and 400.")
-        worksheet.sheet_view.zoomScale = zoom
+    )
     for raw_table in require_list(spec.get("tables", []), "sheet.tables"):
         add_table(worksheet, require_mapping(raw_table, "table"), workbook)
         counts["tables"] += 1
@@ -2279,7 +2679,7 @@ def configure_worksheet(
     if state not in {"visible", "hidden", "veryHidden"}:
         fail("bad_input", "Invalid worksheet state.", state=state)
     worksheet.sheet_state = state
-    return counts
+    return dict(counts), warnings
 
 
 def set_workbook_properties(workbook: Any, properties: Mapping[str, Any]) -> None:
@@ -2364,6 +2764,7 @@ def handle_create(args: argparse.Namespace) -> dict[str, Any]:
         fail("bad_input", "Create job must contain at least one sheet.")
     total_counts: Counter[str] = Counter()
     budget = cell_budget_from_args(args)
+    sheet_warnings: list[str] = []
     for index, raw_spec in enumerate(sheets):
         spec = require_mapping(raw_spec, f"sheets[{index}]")
         name = unique_sheet_title(
@@ -2371,15 +2772,15 @@ def handle_create(args: argparse.Namespace) -> dict[str, Any]:
             require_string(spec.get("name"), f"sheets[{index}].name"),
         )
         worksheet = workbook.create_sheet(name)
-        total_counts.update(
-            configure_worksheet(
-                workbook,
-                worksheet,
-                spec,
-                base_directory=args.job.resolve().parent,
-                budget=budget,
-            )
+        sheet_counts, configure_warnings = configure_worksheet(
+            workbook,
+            worksheet,
+            spec,
+            base_directory=args.job.resolve().parent,
+            budget=budget,
         )
+        total_counts.update(sheet_counts)
+        sheet_warnings.extend(configure_warnings)
     if not any(sheet.sheet_state == "visible" for sheet in workbook.worksheets):
         fail("bad_input", "At least one worksheet must remain visible.")
     properties = require_mapping(job.get("properties", {}), "properties")
@@ -2414,11 +2815,12 @@ def handle_create(args: argparse.Namespace) -> dict[str, Any]:
         for cell in row
     )
     workbook.close()
-    warnings = (
-        ["Formulas were written but not calculated; calculation flags request, not prove, refresh."]
-        if formula_count
-        else []
-    )
+    warnings = list(sheet_warnings)
+    if formula_count:
+        warnings.append(
+            "Formulas were written but not calculated; calculation flags request, "
+            "not prove, refresh."
+        )
     return success(
         "create",
         {
@@ -2632,6 +3034,7 @@ def edit_operation(
             "freeze_panes",
             "dimensions",
             "auto_filter",
+            "auto_width",
             "tab_color",
             "show_gridlines",
             "zoom_scale",
@@ -2642,7 +3045,21 @@ def edit_operation(
         },
         "remove_sheet": {"op", "sheet", "allow_unupdated_dependencies"},
         "rename_sheet": {"op", "sheet", "new_name", "allow_unupdated_dependencies"},
-        "set_sheet": {"op", "sheet", "state", "freeze_panes", "auto_filter", "dimensions"},
+        "set_sheet": {
+            "op",
+            "sheet",
+            "state",
+            "freeze_panes",
+            "auto_filter",
+            "auto_width",
+            "dimensions",
+            "merges",
+            "unmerge",
+            "allow_merge_data_loss",
+            "tab_color",
+            "show_gridlines",
+            "zoom_scale",
+        },
         "add_table": {"op", "sheet", "table"},
         "update_table": {"op", "table"},
         "add_chart": {"op", "sheet", "chart"},
@@ -2730,15 +3147,15 @@ def edit_operation(
             require_string(operation.get("name"), "add_sheet.name"),
         )
         worksheet = workbook.create_sheet(name, operation.get("index"))
-        counts.update(
-            configure_worksheet(
-                workbook,
-                worksheet,
-                operation,
-                base_directory=base_directory,
-                budget=budget,
-            )
+        sheet_counts, configure_warnings = configure_worksheet(
+            workbook,
+            worksheet,
+            operation,
+            base_directory=base_directory,
+            budget=budget,
         )
+        counts.update(sheet_counts)
+        warnings.extend(configure_warnings)
         counts["sheets_added"] += 1
     elif op == "remove_sheet":
         name = require_string(operation.get("sheet"), "remove_sheet.sheet")
@@ -2791,15 +3208,14 @@ def edit_operation(
                 if not visible:
                     fail("bad_input", "At least one worksheet must remain visible.")
             worksheet.sheet_state = state
-        if "freeze_panes" in operation:
-            worksheet.freeze_panes = operation["freeze_panes"]
-        if "auto_filter" in operation:
-            worksheet.auto_filter.ref = operation["auto_filter"]
-        if "dimensions" in operation:
-            set_sheet_dimensions(
+        counts.update(
+            apply_sheet_settings(
                 worksheet,
-                require_mapping(operation["dimensions"], "set_sheet.dimensions"),
+                operation,
+                context="edit",
+                warnings=warnings,
             )
+        )
         counts["sheets_updated"] += 1
     elif op == "add_table":
         worksheet = worksheet_by_name(
@@ -3226,11 +3642,15 @@ def write_dataframe_sheet(
         for index, column in enumerate(frame.columns, start=1):
             sample_lengths = [len(str(column))]
             sample_lengths.extend(
-                len(str(value)) for value in frame[column].head(200) if not pd.isna(value)
+                len(str(value))
+                for value in frame[column].head(AUTO_WIDTH_DEFAULTS["sample_rows"])
+                if not pd.isna(value)
             )
-            worksheet.column_dimensions[get_column_letter(index)].width = min(
-                max(sample_lengths, default=8) + 2,
-                60,
+            # min_width 1 keeps the historical header-length-driven widths of result sheets.
+            worksheet.column_dimensions[get_column_letter(index)].width = auto_width_value(
+                sample_lengths,
+                min_width=1,
+                max_width=AUTO_WIDTH_DEFAULTS["max_width"],
             )
         end_row = start_row + len(frame)
         end_col = get_column_letter(frame.shape[1])
@@ -3698,6 +4118,321 @@ def publish_directory_atomic(temp: Path, output: Path) -> None:
         )
 
 
+def require_external_timeout(value: Any) -> float:
+    timeout = float(value)
+    if not math.isfinite(timeout) or not 1 <= timeout <= 1800:
+        fail("bad_input", "--timeout must be between 1 and 1800 seconds.", timeout=value)
+    return timeout
+
+
+def require_pypdfium2() -> Any:
+    try:
+        import pypdfium2
+    except ModuleNotFoundError as exc:
+        raise ToolError(
+            "missing_dependency",
+            "Page rendering requires the optional pypdfium2 package.",
+            details={"install": f'"{sys.executable}" -m pip install pypdfium2'},
+        ) from exc
+    return pypdfium2
+
+
+def _find_libreoffice() -> str:
+    executable = shutil.which("soffice") or shutil.which("libreoffice")
+    if executable is None:
+        fail(
+            "missing_dependency",
+            "LibreOffice is required for PDF conversion and rendering but was not found on PATH.",
+            executables=["soffice", "libreoffice"],
+        )
+    return executable
+
+
+def _libreoffice_environment(work: Path) -> dict[str, str]:
+    environment = {
+        key: value
+        for key, value in os.environ.items()
+        if key in {"PATH", "LANG", "LC_ALL", "LC_CTYPE", "TZ", "SYSTEMROOT", "WINDIR"}
+    }
+    environment.update(
+        {
+            "HOME": str(work),
+            "TMPDIR": str(work),
+            "TMP": str(work),
+            "TEMP": str(work),
+            "XDG_CACHE_HOME": str(work / "cache"),
+            "XDG_CONFIG_HOME": str(work / "config"),
+        }
+    )
+    return environment
+
+
+def _redact_diagnostic(text: str, paths: Sequence[Path]) -> str:
+    redacted = text[-4000:]
+    replacements: set[str] = set()
+    for path in paths:
+        try:
+            resolved = path.resolve()
+            replacements.update({str(path), str(resolved), resolved.as_uri(), path.name})
+        except (OSError, ValueError):
+            replacements.add(str(path))
+    for value in sorted(replacements, key=len, reverse=True):
+        if value:
+            redacted = redacted.replace(value, "<redacted-path>")
+    redacted = re.sub(
+        r"(?i)\b[a-z][a-z0-9+.-]*://[^\s<>'\"]+",
+        "<redacted-url>",
+        redacted,
+    )
+    redacted = re.sub(
+        r"(?i)\b(api[_-]?key|token|password|passwd|secret|authorization|session[_-]?id)"
+        r"\s*[:=]\s*[^\s&;,]+",
+        r"\1=<redacted>",
+        redacted,
+    )
+    return redacted
+
+
+@dataclass
+class LibreOfficePdf:
+    generated: Path
+    stdout: str
+    stderr: str
+    office_version: str
+    engine: str
+
+
+def _run_libreoffice_pdf(
+    source: Path,
+    work: Path,
+    timeout: float,
+    redact_paths: Sequence[Path],
+) -> LibreOfficePdf:
+    """Convert one snapshot copy inside the work directory to PDF via LibreOffice."""
+
+    executable = _find_libreoffice()
+    output_dir = work / "output"
+    profile = work / "profile"
+    output_dir.mkdir()
+    profile.mkdir()
+    environment = _libreoffice_environment(work)
+    command = [
+        executable,
+        "--headless",
+        "--nologo",
+        "--nodefault",
+        "--nolockcheck",
+        "--nofirststartwizard",
+        f"-env:UserInstallation={profile.resolve().as_uri()}",
+        "--convert-to",
+        "pdf",
+        "--outdir",
+        str(output_dir),
+        str(source),
+    ]
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=environment,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ToolError(
+            "external_tool_failure",
+            "LibreOffice conversion timed out.",
+            details={"timeout_seconds": timeout},
+        ) from exc
+    except OSError as exc:
+        raise ToolError(
+            "external_tool_failure",
+            "LibreOffice could not be launched.",
+            details={"reason": str(exc)},
+        ) from exc
+    diagnostic_paths = [source, work, output_dir, profile, *redact_paths]
+    stdout = _redact_diagnostic(completed.stdout, diagnostic_paths)
+    stderr = _redact_diagnostic(completed.stderr, diagnostic_paths)
+    if completed.returncode != 0:
+        raise ToolError(
+            "external_tool_failure",
+            "LibreOffice conversion failed.",
+            details={"returncode": completed.returncode, "stdout": stdout, "stderr": stderr},
+        )
+    generated = output_dir / f"{source.stem}.pdf"
+    if not generated.is_file():
+        candidates = sorted(output_dir.glob("*.pdf"))
+        if len(candidates) != 1:
+            raise ToolError(
+                "external_tool_failure",
+                "LibreOffice did not produce exactly one PDF.",
+                details={"outputs": [path.name for path in candidates]},
+            )
+        generated = candidates[0]
+    try:
+        version_result = subprocess.run(
+            [executable, "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=environment,
+        )
+        office_version = _redact_diagnostic(version_result.stdout.strip(), diagnostic_paths)
+    except (OSError, subprocess.TimeoutExpired):
+        office_version = "unknown"
+    return LibreOfficePdf(
+        generated=generated,
+        stdout=stdout,
+        stderr=stderr,
+        office_version=office_version or "unknown",
+        engine=Path(executable).name,
+    )
+
+
+def _validate_pdf_output(path: Path) -> int:
+    try:
+        with path.open("rb") as handle:
+            if handle.read(5) != b"%PDF-":
+                raise ToolError(
+                    "external_tool_failure",
+                    "LibreOffice output does not have a PDF signature.",
+                )
+        reader = pypdf.PdfReader(str(path), strict=True)
+        pages = len(reader.pages)
+    except ToolError:
+        raise
+    except Exception as exc:
+        raise ToolError(
+            "external_tool_failure",
+            "LibreOffice PDF output could not be opened.",
+            details={"reason": str(exc)},
+        ) from exc
+    if pages < 1:
+        raise ToolError("post_write_validation", "Converted PDF contains no pages.")
+    return pages
+
+
+def workbook_pdf_context(source: Path) -> dict[str, Any]:
+    """Inventory the workbook facts PDF conversion and rendering must report."""
+
+    workbook = open_workbook(source, data_only=False)
+    external_links = inventory_external_links(workbook)
+    if external_links:
+        fail(
+            "unsupported_operation",
+            "PDF conversion and rendering refuse workbooks with external links because "
+            "LibreOffice may attempt to resolve them.",
+            external_links=len(external_links),
+        )
+    context = {
+        "sheet_names": list(workbook.sheetnames),
+        "hidden_sheets": [
+            worksheet.title
+            for worksheet in workbook.worksheets
+            if worksheet.sheet_state != "visible"
+        ],
+        "formula_cells": sum(
+            cell.data_type == "f"
+            for worksheet in workbook.worksheets
+            for row in worksheet.iter_rows()
+            for cell in row
+        ),
+        "fonts": workbook_font_inventory(workbook, source),
+    }
+    workbook.close()
+    return context
+
+
+def print_semantics_warnings(context: Mapping[str, Any], artifact: str) -> list[str]:
+    warnings = font_portability_warnings(context["fonts"])
+    if context["formula_cells"]:
+        warnings.append(
+            f"{artifact} values come from LibreOffice's load-time calculation of stored "
+            "formulas; they are not proven to match another application's results."
+        )
+    if context["hidden_sheets"]:
+        warnings.append(
+            f"{len(context['hidden_sheets'])} hidden sheet(s) were excluded from the "
+            f"{artifact}: " + ", ".join(context["hidden_sheets"]) + "."
+        )
+    warnings.append(
+        f"{artifact} pagination follows LibreOffice print semantics (print areas, page "
+        "setup, printed gridlines, fit settings); it is not proven identical to Excel's."
+    )
+    return warnings
+
+
+def convert_xlsx_to_pdf(args: argparse.Namespace) -> dict[str, Any]:
+    timeout = require_external_timeout(args.timeout)
+    package = preflight_xlsx(args.source)
+    source_hash = sha256_file(args.source)
+    context = workbook_pdf_context(args.source)
+    require_output_path(
+        args.output,
+        source=args.source,
+        overwrite=args.overwrite,
+        suffix=".pdf",
+    )
+    temporary = temporary_sibling(args.output, ".pdf")
+    try:
+        with tempfile.TemporaryDirectory(prefix="xlsx-libreoffice-") as temp_dir:
+            work = Path(temp_dir)
+            snapshot = work / args.source.name
+            shutil.copyfile(args.source, snapshot)
+            office = _run_libreoffice_pdf(
+                snapshot,
+                work,
+                timeout,
+                [args.source, args.output, temporary],
+            )
+            shutil.copyfile(office.generated, temporary)
+        pages = _validate_pdf_output(temporary)
+        if sha256_file(args.source) != source_hash:
+            fail(
+                "post_write_validation",
+                "Source changed before the destination publication gate.",
+                path=args.source,
+            )
+        atomic_publish_file(temporary, args.output)
+    finally:
+        temporary.unlink(missing_ok=True)
+    warnings = print_semantics_warnings(context, "PDF")
+    if office.stderr.strip():
+        warnings.append("LibreOffice emitted diagnostics; inspect conversion.diagnostics.")
+    return success(
+        "convert",
+        {
+            "source": str(args.source.resolve()),
+            "output": str(args.output.resolve()),
+            "input_format": "xlsx",
+            "output_format": "pdf",
+            "counts": {
+                "sheets": len(context["sheet_names"]),
+                "hidden_sheets": len(context["hidden_sheets"]),
+                "pdf_pages": pages,
+            },
+            "fonts": context["fonts"],
+            "conversion": {
+                "engine": office.engine,
+                "libreoffice": office.office_version,
+                "timeout_seconds": timeout,
+                "diagnostics": {"stdout": office.stdout, "stderr": office.stderr},
+            },
+            "source_package": package,
+            "verification": {
+                "atomic_publish": True,
+                "pdf_signature": True,
+                "pdf_openable": True,
+                "pdf_pages": pages,
+                "source_unchanged_at_publish_gate": True,
+            },
+        },
+        warnings,
+    )
+
+
 def convert_xlsx_to_delimited(
     args: argparse.Namespace,
     output_format: str,
@@ -3930,7 +4665,7 @@ def handle_convert(args: argparse.Namespace) -> dict[str, Any]:
         args.input_format,
         allowed={"xlsx", "csv", "tsv"},
     )
-    output_allowed = {"xlsx"} if input_format in {"csv", "tsv"} else {"csv", "tsv"}
+    output_allowed = {"xlsx"} if input_format in {"csv", "tsv"} else {"csv", "tsv", "pdf"}
     output_format = (
         infer_format(
             args.output,
@@ -3940,6 +4675,36 @@ def handle_convert(args: argparse.Namespace) -> dict[str, Any]:
         if not args.all_sheets
         else (args.output_format if args.output_format != "auto" else "csv")
     )
+    if output_format != "pdf" and args.timeout != DEFAULT_EXTERNAL_TOOL_TIMEOUT:
+        fail("bad_input", "--timeout applies only to PDF output.")
+    if input_format == "xlsx" and output_format == "pdf":
+        if (
+            args.sheet is not None
+            or args.range is not None
+            or args.header_row is not None
+            or args.sheet_policy is not None
+            or args.all_sheets
+            or args.values != "cached"
+            or args.schema is not None
+            or args.leading_zeros is not None
+            or args.index
+            or args.no_header
+            or args.input_na_policy != "literal"
+            or args.input_na_value
+            or args.malformed_rows != "error"
+            or args.encoding != "utf-8"
+            or args.delimiter is not None
+            or args.quoting != "minimal"
+            or args.na_value != ""
+            or args.date_format is not None
+            or args.allow_formulas
+        ):
+            fail(
+                "bad_input",
+                "PDF conversion accepts only --timeout and --overwrite; delimited and "
+                "sheet-selection options do not apply.",
+            )
+        return convert_xlsx_to_pdf(args)
     if input_format == "xlsx" and output_format in {"csv", "tsv"}:
         if (
             args.no_header
@@ -3984,6 +4749,222 @@ def handle_convert(args: argparse.Namespace) -> dict[str, Any]:
         "Unsupported conversion direction.",
         input_format=input_format,
         output_format=output_format,
+    )
+
+
+def parse_render_pages(value: str | None, page_count: int) -> list[int]:
+    if value is None:
+        selected = list(range(1, page_count + 1))
+    else:
+        chosen: set[int] = set()
+        for part in value.split(","):
+            text = part.strip()
+            if not text.isdigit():
+                fail(
+                    "bad_input",
+                    "--pages must be a comma-separated list of 1-based page numbers.",
+                    pages=value,
+                )
+            page = int(text)
+            if not 1 <= page <= page_count:
+                fail(
+                    "bad_input",
+                    "Requested page does not exist in the converted PDF.",
+                    page=page,
+                    pdf_pages=page_count,
+                )
+            chosen.add(page)
+        if not chosen:
+            fail("bad_input", "--pages must select at least one page.")
+        selected = sorted(chosen)
+    if len(selected) > MAX_RENDER_PAGES:
+        fail(
+            "resource_limit",
+            "Rendering would produce too many pages; select --pages, set print areas, or "
+            "hide sheets.",
+            pages=len(selected),
+            limit=MAX_RENDER_PAGES,
+        )
+    return selected
+
+
+def handle_render(args: argparse.Namespace) -> dict[str, Any]:
+    dpi = args.dpi
+    if (
+        isinstance(dpi, bool)
+        or not isinstance(dpi, int)
+        or not MIN_RENDER_DPI <= dpi <= MAX_RENDER_DPI
+    ):
+        fail(
+            "bad_input",
+            f"--dpi must be an integer between {MIN_RENDER_DPI} and {MAX_RENDER_DPI}.",
+            dpi=dpi,
+        )
+    timeout = require_external_timeout(args.timeout)
+    pdfium = require_pypdfium2()
+    package = preflight_xlsx(args.source)
+    source_hash = sha256_file(args.source)
+    context = workbook_pdf_context(args.source)
+    output = args.output
+    if output.suffix:
+        fail(
+            "bad_input",
+            "Render output must be a directory path without a suffix.",
+            path=output,
+        )
+    if output.exists():
+        fail(
+            "unsupported_operation",
+            "Atomic render publication requires a destination directory that does not "
+            "already exist.",
+            path=output,
+        )
+    if not output.parent.exists() or not output.parent.is_dir():
+        fail("bad_input", "Destination parent directory does not exist.", path=output.parent)
+    images: list[dict[str, Any]] = []
+    staged = Path(tempfile.mkdtemp(prefix=f".{output.name}.", dir=output.parent))
+    try:
+        with tempfile.TemporaryDirectory(prefix="xlsx-libreoffice-") as temp_dir:
+            work = Path(temp_dir)
+            snapshot = work / args.source.name
+            shutil.copyfile(args.source, snapshot)
+            office = _run_libreoffice_pdf(
+                snapshot,
+                work,
+                timeout,
+                [args.source, output],
+            )
+            page_count = _validate_pdf_output(office.generated)
+            selected = parse_render_pages(args.pages, page_count)
+            try:
+                document = pdfium.PdfDocument(str(office.generated))
+            except Exception as exc:
+                raise ToolError(
+                    "external_tool_failure",
+                    "PDFium could not open the converted PDF.",
+                    details={"reason": str(exc)},
+                ) from exc
+            total_pixels = 0
+            try:
+                for page_number in selected:
+                    page = document[page_number - 1]
+                    width_pt, height_pt = page.get_size()
+                    pixels = math.ceil(width_pt / 72 * dpi) * math.ceil(height_pt / 72 * dpi)
+                    if pixels > MAX_RENDER_PIXELS_PER_PAGE:
+                        raise ToolError(
+                            "resource_limit",
+                            "Rendered pixel count for one page exceeds the limit.",
+                            details={
+                                "page": page_number,
+                                "pixels": pixels,
+                                "limit": MAX_RENDER_PIXELS_PER_PAGE,
+                            },
+                        )
+                    total_pixels += pixels
+                    if total_pixels > MAX_RENDER_TOTAL_PIXELS:
+                        raise ToolError(
+                            "resource_limit",
+                            "Total rendered pixel count exceeds the limit.",
+                            details={"pixels": total_pixels, "limit": MAX_RENDER_TOTAL_PIXELS},
+                        )
+                    file_name = f"page-{page_number:03d}.png"
+                    staged_file = staged / file_name
+                    try:
+                        page.render(scale=dpi / 72).to_pil().save(staged_file, format="PNG")
+                    except Exception as exc:
+                        raise ToolError(
+                            "external_tool_failure",
+                            "PDFium could not rasterize a PDF page.",
+                            details={"page": page_number},
+                        ) from exc
+                    with staged_file.open("rb") as rendered:
+                        if rendered.read(8) != b"\x89PNG\r\n\x1a\n":
+                            raise ToolError(
+                                "post_write_validation",
+                                "Rendered file does not have a PNG signature.",
+                                details={"file": file_name},
+                            )
+                    with Image.open(staged_file) as verified:
+                        verified.load()
+                        size = verified.size
+                    if size[0] * size[1] > MAX_RENDER_PIXELS_PER_PAGE:
+                        raise ToolError(
+                            "post_write_validation",
+                            "Rendered image exceeds the per-page pixel limit.",
+                            details={"file": file_name},
+                        )
+                    data = staged_file.read_bytes()
+                    images.append(
+                        {
+                            "page": page_number,
+                            "file": file_name,
+                            "width_px": size[0],
+                            "height_px": size[1],
+                            "bytes": len(data),
+                            "sha256": hashlib.sha256(data).hexdigest(),
+                        }
+                    )
+            finally:
+                document.close()
+        if sha256_file(args.source) != source_hash:
+            fail(
+                "post_write_validation",
+                "Source changed before the destination publication gate.",
+                path=args.source,
+            )
+        publish_directory_atomic(staged, output)
+    except Exception:
+        shutil.rmtree(staged, ignore_errors=True)
+        raise
+    reopened = 0
+    for record in images:
+        published = output / record["file"]
+        data = published.read_bytes()
+        if hashlib.sha256(data).hexdigest() != record["sha256"]:
+            fail(
+                "post_write_validation",
+                "Published rendering does not match its staged hash.",
+                file=record["file"],
+            )
+        with Image.open(published) as verified:
+            verified.load()
+        reopened += 1
+    warnings = print_semantics_warnings(context, "Rendered page")
+    if office.stderr.strip():
+        warnings.append("LibreOffice emitted diagnostics; inspect conversion.diagnostics.")
+    warnings.append(
+        "Rendering exists to be looked at: open the published PNG pages and review layout "
+        "before claiming visual correctness."
+    )
+    return success(
+        "render",
+        {
+            "source": str(args.source.resolve()),
+            "output": str(output.resolve()),
+            "counts": {
+                "sheets": len(context["sheet_names"]),
+                "hidden_sheets": len(context["hidden_sheets"]),
+                "pdf_pages": page_count,
+                "pages_rendered": len(images),
+            },
+            "images": images,
+            "fonts": context["fonts"],
+            "conversion": {
+                "engine": office.engine,
+                "libreoffice": office.office_version,
+                "timeout_seconds": timeout,
+                "dpi": dpi,
+                "diagnostics": {"stdout": office.stdout, "stderr": office.stderr},
+            },
+            "source_package": package,
+            "verification": {
+                "atomic_publish": True,
+                "pdf_page_count": page_count,
+                "png_reopened": reopened,
+                "source_unchanged_at_publish_gate": True,
+            },
+        },
+        warnings,
     )
 
 
@@ -4090,7 +5071,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     convert_parser = subparsers.add_parser(
         "convert",
-        help="convert XLSX to/from CSV or TSV",
+        help="convert XLSX to/from CSV or TSV, or export XLSX to PDF",
     )
     convert_parser.add_argument("source", type=Path)
     convert_parser.add_argument("output", type=Path)
@@ -4101,8 +5082,14 @@ def build_parser() -> argparse.ArgumentParser:
     )
     convert_parser.add_argument(
         "--output-format",
-        choices=["auto", "xlsx", "csv", "tsv"],
+        choices=["auto", "xlsx", "csv", "tsv", "pdf"],
         default="auto",
+    )
+    convert_parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_EXTERNAL_TOOL_TIMEOUT,
+        help="LibreOffice conversion deadline in seconds; PDF output only",
     )
     convert_parser.add_argument("--sheet")
     convert_parser.add_argument("--range")
@@ -4143,6 +5130,30 @@ def build_parser() -> argparse.ArgumentParser:
     add_delimited_options(convert_parser)
     add_overwrite_argument(convert_parser)
     convert_parser.set_defaults(handler=handle_convert)
+
+    render_parser = subparsers.add_parser(
+        "render",
+        help="render workbook pages to PNG images via LibreOffice and PDFium",
+    )
+    render_parser.add_argument("source", type=Path)
+    render_parser.add_argument("output", type=Path)
+    render_parser.add_argument(
+        "--dpi",
+        type=int,
+        default=96,
+        help=f"raster resolution between {MIN_RENDER_DPI} and {MAX_RENDER_DPI}",
+    )
+    render_parser.add_argument(
+        "--pages",
+        help="comma-separated 1-based PDF page numbers; default renders every page",
+    )
+    render_parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_EXTERNAL_TOOL_TIMEOUT,
+        help="LibreOffice conversion deadline in seconds",
+    )
+    render_parser.set_defaults(handler=handle_render)
     return parser
 
 


### PR DESCRIPTION
## Summary

- update the vendored `kolega-ai/kolega-skills` snapshot from `v0.1.0` to `v0.2.0`
- record upstream commit `fa6aaec9b7fdec1dc10c0a7875ce3981ecd1994e` and regenerated SHA-256 hashes in the bundle manifest
- include the upstream DOCX, PDF, PPTX, XLSX, and skill-authoring quality improvements from the tagged snapshot

## Verification

- `PYTHONDONTWRITEBYTECODE=1 ./run_tests.sh tests/cli/test_bundled_skills.py -ra` (3 passed)
- `uv build`
- `uv run python scripts/verify_bundled_skill_artifacts.py dist/kolega_code-0.21.1-py3-none-any.whl dist/kolega_code-0.21.1.tar.gz`
- commit-time Ruff, formatting, Pyright, and safety hooks
