### PR TITLE
test(cli): wait for onboarding mount initialization

### DIFF
--- a/tests/cli/_app_test_utils.py
+++ b/tests/cli/_app_test_utils.py
@@ -152,14 +152,19 @@ async def wait_for_onboarding_screen(app, pilot):
     The app pushes OnboardingScreen via call_after_refresh and the screen's
     children mount a further message-pump cycle later, so a single
     pilot.pause() can lose the race on slow CI runners (NoMatches on
-    #onboarding_next). Pause until the screen and its widgets both exist.
+    #onboarding_next). Pause until the widgets exist and the screen's mount
+    hook has initialized the owner's screen reference and startup status.
     """
     from kolega_code.cli.tui.onboarding_screen import OnboardingScreen
 
     for _ in range(20):
         await pilot.pause()
         screen = app.screen
-        if isinstance(screen, OnboardingScreen) and screen.query("#onboarding_next"):
+        if (
+            isinstance(screen, OnboardingScreen)
+            and app._onboarding_screen is screen
+            and screen.query("#onboarding_next")
+        ):
             return screen
     raise AssertionError("onboarding screen did not finish mounting")
 


### PR DESCRIPTION
## Summary

- wait for `OnboardingScreen.on_mount()` to finish before the shared TUI test helper returns
- prevent startup-status assertions from racing the screen mount lifecycle on slower CI runners
- follow up on the intermittent Python 3.11 failure observed in #292

## Verification

- `PYTHONDONTWRITEBYTECODE=1 ./run_tests.sh tests/cli/test_tui_settings_screens.py -q` (`6 passed`)
- `PYTHONDONTWRITEBYTECODE=1 ./run_tests.sh` (`2601 passed, 103 deselected`)
- `PYTHONDONTWRITEBYTECODE=1 uv run pre-commit run --files tests/cli/_app_test_utils.py --show-diff-on-failure`