### PR TITLE
feat(agent): add atomic sub-agent model overrides

### DIFF
--- a/docs/src/content/docs/concepts/agents.md
+++ b/docs/src/content/docs/concepts/agents.md
@@ -40,8 +40,9 @@ their normal General-role inheritance. Omit `model_override` to keep this behavi
 When a particular task needs another model, the agent can call the read-only
 `list_subagent_models` tool. It reports configured providers, provider-qualified
 model IDs, exact effort options, vision support, and current role defaults without
-exposing credentials. The agent should use it before choosing a non-default route
-rather than guessing model or effort names.
+exposing credentials. Its model-facing result is a compact Markdown catalog
+rather than a repetitive JSON payload. The agent should use it before choosing a
+non-default route rather than guessing model or effort names.
 
 An ordinary dispatch accepts one complete object under `model_override`:
 

--- a/docs/src/content/docs/concepts/agents.md
+++ b/docs/src/content/docs/concepts/agents.md
@@ -31,6 +31,50 @@ When [gigacode](../../gigacode/) is enabled, the main agent can also orchestrate
 **many** of these sub-agents at once through a workflow — running them in parallel
 or in pipelines and collecting the results.
 
+### Per-dispatch model routing
+
+Sub-agent dispatches normally inherit the CLI/host model configuration for the
+target role. Custom agents continue to use their Markdown model settings and then
+their normal General-role inheritance. Omit `model_override` to keep this behavior.
+
+When a particular task needs another model, the agent can call the read-only
+`list_subagent_models` tool. It reports configured providers, provider-qualified
+model IDs, exact effort options, vision support, and current role defaults without
+exposing credentials. The agent should use it before choosing a non-default route
+rather than guessing model or effort names.
+
+An ordinary dispatch accepts one complete object under `model_override`:
+
+```json
+{
+  "task": "Review the authentication design for subtle security flaws.",
+  "model_override": {
+    "provider": "anthropic",
+    "model": "claude-opus-4-8",
+    "thinking_effort": "high"
+  }
+}
+```
+
+All three fields are mandatory when the object is present; Kolega Code never
+inherits only the missing provider, model, or effort. A model with effort controls
+requires one of the exact `thinking_effort` strings returned by
+`list_subagent_models`. A model without effort controls requires an explicit
+`"thinking_effort": null`—`null` is valid only in that case.
+
+Selections are revalidated at dispatch time. Unsupported provider/model pairs,
+unconfigured providers, incompatible Browser models, invalid efforts, and
+incomplete objects fail the dispatch instead of falling back to another model.
+A Browser dispatch must select a catalog entry with `supports_vision: true`.
+A complete dispatch override replaces a custom agent's Markdown model and effort
+as a unit.
+
+[Gigacode](../../gigacode/#per-worker-model-overrides) uses the same atomic rule,
+but names the third field `effort` inside `model_override`. Its override applies
+only to the direct workflow worker; descendants keep their role defaults unless
+their own dispatch provides a complete override. In Plan mode, model routing never
+changes the forced read-only Investigation agent or its permissions.
+
 Sub-agent activity is reported live. In the TUI each sub-agent gets a live card in
 the conversation, and pressing `Ctrl+G` opens the
 [sub-agent inspector](../../tui/interface/#sub-agent-inspector) — a full-screen view

--- a/docs/src/content/docs/gigacode.mdx
+++ b/docs/src/content/docs/gigacode.mdx
@@ -109,6 +109,67 @@ unknowns through research and option comparison; a debugging task might cluster
 failures, investigate root causes, test targeted fixes, and run a regression
 review. All of those shapes are built from the same primitives above.
 
+### Per-worker model overrides
+
+Normally, each workflow worker inherits the model configured for its agent role
+through your CLI or host settings. Omitting `model_override` preserves those
+defaults and is the recommended behavior.
+
+For a worker that needs a specific model, the main agent first calls the read-only
+`list_subagent_models` tool. The tool lists only providers configured for this
+session, their exact model IDs and effort options, vision support, and the effective
+defaults for each agent role. It can optionally filter by provider. Discovery is
+informational: the selection is validated again when the worker starts, and the
+tool never returns credentials, tokens, or private endpoint details.
+
+The agent can then put one complete, atomic override on a workflow `agent()` call:
+
+```python
+review = await agent(
+    "Review the authentication design for subtle security flaws.",
+    agent_type="investigation",
+    model_override={
+        "provider": "anthropic",
+        "model": "claude-opus-4-8",
+        "effort": "high",
+    },
+)
+```
+
+The contract is all-or-nothing:
+
+- When `model_override` is present, `provider`, `model`, and `effort` are all
+  mandatory. Fields are not inherited individually.
+- For a model with effort controls, `effort` must be one of the exact strings
+  reported by `list_subagent_models`.
+- Use `"effort": None` only for a model that has no effort control. `None` does
+  not ask Kolega Code to choose that model's default effort.
+- An unknown model, unsupported provider/model pair, unconfigured provider, or
+  model-specific effort violation produces a failed worker result. A malformed
+  `model_override` shape (including missing or extra fields) is a workflow script
+  error; when it escapes the workflow's own `pipeline()`/`parallel()` error
+  handling, it fails the workflow. Neither case silently falls back to the
+  inherited model or a provider default.
+- A Browser worker's selected catalog entry must report
+  `supports_vision: true`.
+
+An override applies only to the direct worker launched by that `agent()` call. It
+does not reroute helper models or descendants. If delegation depth `2` is enabled,
+a child uses its own role default unless its own dispatch supplies a separate,
+complete override.
+
+In Plan mode, Kolega Code first forces the requested workflow worker to the
+read-only Investigation agent, then validates and applies the override to that
+actual worker. Selecting another model never grants editing tools or bypasses
+Plan-mode safety.
+
+<Aside type="caution" title="Migrating saved workflows">
+The old partial `agent(..., model=..., effort=...)` arguments are no longer
+accepted. Replace them with the complete `model_override` object shown above.
+Legacy calls fail with a targeted migration error instead of inheriting missing
+routing fields or falling back.
+</Aside>
+
 ### Delegation depth
 
 Workflow metadata has an optional `max_agent_depth` setting. It defaults to `1`,
@@ -145,9 +206,11 @@ artifact paths when you only need to inspect output.
 
 How workflow sub-agents behave depends on the mode you're in.
 
-**Plan mode** — every workflow sub-agent is **read-only** (an investigation agent),
-no matter what the workflow asks for. Use it to fan out parallel research and
-synthesis while planning; it never edits your code.
+**Plan mode** — every workflow sub-agent is **read-only** (an Investigation agent),
+no matter what the workflow asks for. A `model_override`, when present, is
+validated for and applied to that forced Investigation worker; it changes routing,
+not permissions. Use Plan mode to fan out parallel research and synthesis while
+planning; it never edits your code.
 
 **Build mode** — sub-agents have the full toolset and can edit files and run
 commands.

--- a/docs/src/content/docs/gigacode.mdx
+++ b/docs/src/content/docs/gigacode.mdx
@@ -120,7 +120,9 @@ For a worker that needs a specific model, the main agent first calls the read-on
 session, their exact model IDs and effort options, vision support, and the effective
 defaults for each agent role. It can optionally filter by provider. Discovery is
 informational: the selection is validated again when the worker starts, and the
-tool never returns credentials, tokens, or private endpoint details.
+tool never returns credentials, tokens, or private endpoint details. The result
+uses a compact Markdown table so exact routing values remain readable without
+the repeated keys of a large JSON payload.
 
 The agent can then put one complete, atomic override on a workflow `agent()` call:
 

--- a/kolega_code/agent/custom_agents.py
+++ b/kolega_code/agent/custom_agents.py
@@ -389,11 +389,12 @@ class CustomAgent(BaseAgent):
         hook_dispatcher: Optional[Any] = None,
         max_iterations: Optional[int] = None,
         memory_manager: Optional[Any] = None,
+        resolved_model: Optional[ModelConfig] = None,
     ) -> None:
         self.definition = definition
         self.agent_name = definition.name
-        resolved_model = definition.resolve_model_config(config)
-        custom_config = config.model_copy(update={"long_context_config": resolved_model})
+        effective_model = resolved_model or definition.resolve_model_config(config)
+        custom_config = config.model_copy(update={"long_context_config": effective_model})
 
         super().__init__(
             project_path,

--- a/kolega_code/agent/model_routing.py
+++ b/kolega_code/agent/model_routing.py
@@ -1,0 +1,256 @@
+"""Model discovery and atomic per-dispatch routing for sub-agents."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+from kolega_code.config import AGENT_ROLE_BY_NAME, AgentConfig, AgentRole, ModelConfig, ModelProvider
+from kolega_code.llm.specs import (
+    MODEL_SPECS,
+    default_thinking_effort,
+    get_model_specs,
+    supports_vision,
+    thinking_effort_options,
+    validate_thinking_effort,
+)
+
+
+@dataclass(frozen=True)
+class AtomicModelOverride:
+    """A complete provider/model/effort selection for one dispatched worker."""
+
+    provider: str
+    model: str
+    effort: Optional[str]
+
+    def as_dict(self, *, effort_key: str = "effort") -> dict[str, Any]:
+        return {"provider": self.provider, "model": self.model, effort_key: self.effort}
+
+
+@dataclass(frozen=True)
+class ModelRoutingResolution:
+    """Resolved child config and sanitized identity for one dispatch."""
+
+    config: AgentConfig
+    model_config: ModelConfig
+    requested: Optional[AtomicModelOverride]
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        return {
+            "provider": self.model_config.provider.value,
+            "model": self.model_config.model,
+            "thinking_effort": self.model_config.thinking_effort,
+        }
+
+
+def provider_is_configured(config: AgentConfig, provider: ModelProvider) -> bool:
+    """Whether this config has the credential mechanism needed by ``provider``."""
+
+    if provider == ModelProvider.LLAMA:
+        return True
+    if provider == ModelProvider.OPENAI_CHATGPT:
+        return config.openai_chatgpt_tokens is not None
+    return bool(config.get_api_key(provider))
+
+
+def parse_atomic_model_override(
+    value: Any,
+    *,
+    effort_key: str,
+) -> Optional[AtomicModelOverride]:
+    """Validate the shape of an optional all-or-nothing model override."""
+
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise ValueError("model_override must be an object or null.")
+
+    expected = {"provider", "model", effort_key}
+    actual = set(value)
+    missing = sorted(expected - actual)
+    extra = sorted(actual - expected)
+    if missing:
+        raise ValueError(f"model_override is missing required field(s): {', '.join(missing)}.")
+    if extra:
+        raise ValueError(f"model_override contains unsupported field(s): {', '.join(extra)}.")
+
+    provider_value = value["provider"]
+    model = value["model"]
+    if not isinstance(provider_value, str) or not provider_value.strip():
+        raise ValueError("model_override.provider must be a non-empty string.")
+    if not isinstance(model, str) or not model.strip():
+        raise ValueError("model_override.model must be a non-empty string.")
+
+    effort = value[effort_key]
+    if effort is not None and (not isinstance(effort, str) or not effort.strip()):
+        raise ValueError(f"model_override.{effort_key} must be a non-empty string or null.")
+
+    return AtomicModelOverride(
+        provider=provider_value.strip().lower(),
+        model=model.strip(),
+        effort=effort.strip().lower() if isinstance(effort, str) else None,
+    )
+
+
+def _validated_override_model(
+    config: AgentConfig, override: AtomicModelOverride, inherited: ModelConfig
+) -> ModelConfig:
+    try:
+        provider = ModelProvider(override.provider)
+    except ValueError as exc:
+        valid = ", ".join(item.value for item in ModelProvider)
+        raise ValueError(
+            f"Unsupported model_override provider '{override.provider}'. Valid providers: {valid}."
+        ) from exc
+
+    try:
+        get_model_specs(provider, override.model)
+    except ValueError as exc:
+        raise ValueError(str(exc)) from exc
+
+    if not provider_is_configured(config, provider):
+        raise ValueError(f"Provider '{provider.value}' is not configured for sub-agent model overrides.")
+
+    efforts = thinking_effort_options(provider, override.model)
+    if efforts:
+        if override.effort is None:
+            raise ValueError(
+                f"model_override effort must be a string for {provider.value}/{override.model}. "
+                f"Valid values: {', '.join(efforts)}."
+            )
+        effort = validate_thinking_effort(provider, override.model, override.effort)
+    else:
+        if override.effort is not None:
+            raise ValueError(
+                f"Model {override.model} from provider {provider.value} does not support thinking effort; "
+                "set the override effort to null."
+            )
+        effort = None
+
+    return ModelConfig(
+        provider=provider,
+        model=override.model,
+        rate_limits=inherited.rate_limits.model_copy(deep=True),
+        thinking_effort=effort,
+    )
+
+
+def _config_for_agent_model(config: AgentConfig, agent_name: str, model_config: ModelConfig) -> AgentConfig:
+    role = AGENT_ROLE_BY_NAME.get(agent_name)
+    if role is None:
+        return config
+    agent_models = dict(config.agent_models)
+    agent_models[role.value] = model_config
+    return config.model_copy(update={"agent_models": agent_models})
+
+
+def resolve_subagent_model(
+    config: AgentConfig,
+    agent_name: str,
+    model_override: Any,
+    *,
+    effort_key: str,
+    inherited_model: Optional[ModelConfig] = None,
+) -> ModelRoutingResolution:
+    """Resolve an optional atomic override against one worker's inherited route."""
+
+    inherited = inherited_model or config.model_config_for_agent(agent_name)
+    parsed = parse_atomic_model_override(model_override, effort_key=effort_key)
+    if parsed is None:
+        return ModelRoutingResolution(config=config, model_config=inherited, requested=None)
+
+    selected = _validated_override_model(config, parsed, inherited)
+    return ModelRoutingResolution(
+        config=_config_for_agent_model(config, agent_name, selected),
+        model_config=selected,
+        requested=parsed,
+    )
+
+
+def model_routing_fingerprint(config: AgentConfig) -> str:
+    """Return a secret-free fingerprint of inherited workflow agent routes."""
+
+    routes: dict[str, dict[str, Any]] = {}
+    for role in AgentRole:
+        agent_name = next(
+            (name for name, candidate in AGENT_ROLE_BY_NAME.items() if candidate == role),
+            role.value,
+        )
+        model = config.model_config_for_agent(agent_name)
+        routes[role.value] = {
+            "provider": model.provider.value,
+            "model": model.model,
+            "effort": model.thinking_effort,
+        }
+    encoded = json.dumps(routes, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def subagent_model_catalog(config: AgentConfig, provider: Optional[str] = None) -> dict[str, Any]:
+    """Build a bounded, credential-free model discovery snapshot."""
+
+    provider_filter: Optional[ModelProvider] = None
+    if provider is not None:
+        if not isinstance(provider, str) or not provider.strip():
+            raise ValueError("provider must be a non-empty string when supplied.")
+        try:
+            provider_filter = ModelProvider(provider.strip().lower())
+        except ValueError as exc:
+            raise ValueError(f"Unsupported provider '{provider}'.") from exc
+        if not provider_is_configured(config, provider_filter):
+            raise ValueError(f"Provider '{provider_filter.value}' is not configured.")
+
+    defaults: dict[str, dict[str, Any]] = {}
+    for agent_name, role in AGENT_ROLE_BY_NAME.items():
+        model = config.model_config_for_agent(agent_name)
+        defaults[role.value] = {
+            "provider": model.provider.value,
+            "model": model.model,
+            "thinking_effort": model.thinking_effort,
+        }
+
+    models_by_provider: dict[str, list[dict[str, Any]]] = {}
+    for provider_value, model_name in MODEL_SPECS:
+        try:
+            model_provider = ModelProvider(provider_value)
+        except ValueError:
+            continue
+        if provider_filter is not None and model_provider != provider_filter:
+            continue
+        if not provider_is_configured(config, model_provider):
+            continue
+        efforts = thinking_effort_options(model_provider, model_name)
+        models_by_provider.setdefault(provider_value, []).append(
+            {
+                "model": model_name,
+                "thinking_efforts": list(efforts),
+                "default_thinking_effort": default_thinking_effort(model_provider, model_name),
+                "override_effort": "string" if efforts else "null",
+                "supports_vision": supports_vision(model_provider, model_name),
+            }
+        )
+
+    if provider_filter is not None and not models_by_provider:
+        raise ValueError(f"Provider '{provider_filter.value}' has no supported sub-agent models.")
+
+    return {
+        "override_contract": {
+            "ordinary_dispatch": {
+                "required": ["provider", "model", "thinking_effort"],
+                "effort_field": "thinking_effort",
+            },
+            "gigacode": {
+                "required": ["provider", "model", "effort"],
+                "effort_field": "effort",
+            },
+            "nullable_effort": "Use null only when thinking_efforts is empty.",
+        },
+        "agent_defaults": defaults,
+        "providers": [
+            {"provider": provider_value, "models": models} for provider_value, models in models_by_provider.items()
+        ],
+    }

--- a/kolega_code/agent/model_routing.py
+++ b/kolega_code/agent/model_routing.py
@@ -195,8 +195,14 @@ def subagent_model_catalog(config: AgentConfig, provider: Optional[str] = None) 
 
     provider_filter: Optional[ModelProvider] = None
     if provider is not None:
-        if not isinstance(provider, str) or not provider.strip():
-            raise ValueError("provider must be a non-empty string when supplied.")
+        if not isinstance(provider, str):
+            raise ValueError("provider must be a string when supplied.")
+        # Some model providers serialize an omitted optional string as ``""``.
+        # Treat blank input exactly like omission so an unfiltered discovery
+        # call remains portable across tool-calling APIs.
+        if not provider.strip():
+            provider = None
+    if provider is not None:
         try:
             provider_filter = ModelProvider(provider.strip().lower())
         except ValueError as exc:
@@ -254,3 +260,43 @@ def subagent_model_catalog(config: AgentConfig, provider: Optional[str] = None) 
             {"provider": provider_value, "models": models} for provider_value, models in models_by_provider.items()
         ],
     }
+
+
+def render_subagent_model_catalog(catalog: dict[str, Any]) -> str:
+    """Render discovery data compactly for an LLM and the visible transcript."""
+
+    lines = [
+        "# Available sub-agent models",
+        "",
+        "Use a complete atomic override:",
+        "- Ordinary dispatch: `provider`, `model`, `thinking_effort`",
+        "- Gigacode: `provider`, `model`, `effort`",
+        "- Effort must be an exact listed value; use `null` only where efforts are `null`.",
+        "",
+        "## Effective role defaults",
+        "",
+        "| Role | Provider/model | Effort |",
+        "| --- | --- | --- |",
+    ]
+    for role, route in catalog["agent_defaults"].items():
+        effort = route["thinking_effort"] if route["thinking_effort"] is not None else "null"
+        lines.append(f"| {role} | `{route['provider']}/{route['model']}` | `{effort}` |")
+
+    lines.extend(
+        [
+            "",
+            "## Configured models",
+            "",
+            "| Provider/model | Efforts | Default | Vision |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
+    for provider_entry in catalog["providers"]:
+        provider = provider_entry["provider"]
+        for model in provider_entry["models"]:
+            efforts = ", ".join(model["thinking_efforts"]) or "null"
+            default = model["default_thinking_effort"] or "null"
+            vision = "yes" if model["supports_vision"] else "no"
+            lines.append(f"| `{provider}/{model['model']}` | `{efforts}` | `{default}` | {vision} |")
+
+    return "\n".join(lines)

--- a/kolega_code/agent/orchestration/guide.py
+++ b/kolega_code/agent/orchestration/guide.py
@@ -67,16 +67,61 @@ Opaque host-provided `ToolExtension` dispatch callbacks are unavailable in
 workflows until there is a workflow-aware accounting and depth protocol. Ordinary
 non-workflow extension and agent-delegation behavior is unchanged.
 
+### Choosing a sub-agent model
+
+Omit `model_override` to inherit the normal model settings for the requested agent
+type from the session's CLI/host configuration. This is the default and is almost
+always correct.
+
+When a task genuinely needs a different model, call the read-only
+`list_subagent_models` tool before authoring the workflow. It reports the configured
+providers, exact model IDs, supported effort values, and effective agent defaults
+without exposing credentials. You may filter it by provider. Do not guess model IDs
+or effort values.
+
+A Gigacode override is atomic and applies to one direct workflow worker:
+
+```python
+result = await agent(
+    "Review the authentication design for subtle security flaws.",
+    agent_type="investigation",
+    model_override={
+        "provider": "anthropic",
+        "model": "claude-opus-4-8",
+        "effort": "high",
+    },
+)
+```
+
+If `model_override` is present, it must be a complete object with exactly
+`provider`, `model`, and `effort`. For a model with effort controls, `effort` must
+be one of the strings returned by `list_subagent_models`. Use `effort: None` only
+when that model has no effort control; `None` does not mean "use the default".
+Unsupported models, unconfigured providers, malformed objects, and invalid effort
+values fail that `agent()` call and return `None` through normal workflow failure
+handling. They never fall back to an inherited or provider-default model.
+
+The override affects only the worker launched by that `agent()` call, not its
+helper models or descendants. At depth `2`, a child dispatched by that worker uses
+its own role default unless the child dispatch supplies its own complete ordinary
+dispatch override. In Plan mode, the direct worker is always forced to the
+read-only Investigation agent first, and the override is validated and applied to
+that actual worker.
+
+The legacy partial arguments `model=` and `effort=` are no longer accepted.
+Migrate saved workflows to the complete `model_override={...}` object; legacy calls
+fail with a migration error rather than running with partially inherited routing.
+
 ### Primitives (all available as globals in the script)
 
-- `await agent(prompt, *, label=None, phase=None, schema=None, model=None, effort=None, agent_type=None)`
+- `await agent(prompt, *, label=None, phase=None, schema=None, model_override=None, agent_type=None)`
   Dispatch one sub-agent. Returns its report text, or a validated dict when `schema`
   (a JSON Schema) is given, or `None` if the agent failed/was skipped (so you can
   filter it out). `agent_type` is one of "general" (default, full toolset), "investigation"
-  (read-only), "browser", or "coder". `model`/`effort` override the model and thinking
-  effort for that one call — omit them to inherit the session's settings (almost always correct).
-  In plan mode every sub-agent is forced read-only regardless of `agent_type`, so use
-  workflows there for parallel research and synthesis, not edits.
+  (read-only), "browser", or "coder". Omit `model_override` to inherit the requested
+  role's configured defaults; otherwise supply the complete atomic object documented
+  above. In plan mode every sub-agent is forced read-only regardless of `agent_type`,
+  so use workflows there for parallel research and synthesis, not edits.
 - `await parallel(thunks)` — run zero-arg thunks concurrently and wait for ALL (a barrier).
   A thunk that raises resolves to `None`; the call never rejects. Filter `None` before use.
 - `await pipeline(items, *stages)` — run each item through all stages independently, with

--- a/kolega_code/agent/orchestration/journal.py
+++ b/kolega_code/agent/orchestration/journal.py
@@ -141,6 +141,10 @@ class RunJournal:
         self.ensure_dirs()
         payload = {"index": call_index, "key": key, "label": label, "status": status, "value": value}
         payload.update({k: v for k, v in metadata.items() if v is not None})
+        # ``null`` means this call explicitly inherited routing. Its presence
+        # distinguishes new rows from legacy rows without routing metadata.
+        if "requested_routing" in metadata:
+            payload["requested_routing"] = metadata["requested_routing"]
         line = json.dumps(payload, default=str)
         with self._journal_path.open("a", encoding="utf-8") as handle:
             handle.write(line + "\n")
@@ -183,9 +187,18 @@ class RunJournal:
                 entry = json.loads(raw)
             except json.JSONDecodeError:
                 continue
+            if not isinstance(entry, dict):
+                continue
             if entry.get("status", "completed") != "completed":
                 continue
-            cache[int(entry["index"])] = (entry["key"], entry.get("value"))
+            try:
+                index = int(entry["index"])
+                key = entry["key"]
+            except (KeyError, TypeError, ValueError):
+                continue
+            if not isinstance(key, str):
+                continue
+            cache[index] = (key, entry.get("value"))
         return cache
 
     def agent_transcript_path(self, agent_id: str) -> Path:

--- a/kolega_code/agent/orchestration/runtime.py
+++ b/kolega_code/agent/orchestration/runtime.py
@@ -17,6 +17,7 @@ import os
 import random
 from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional
 
+from ..model_routing import AtomicModelOverride, parse_atomic_model_override
 from .accounting import (
     WorkflowRunAccounting,
     reset_current_agent_reservation,
@@ -81,6 +82,9 @@ class WorkflowRuntime:
         max_agent_depth: int = DEFAULT_MAX_AGENT_DEPTH,
         resume_cache: Optional[Dict[int, Any]] = None,
         workflow_resolver: Optional[WorkflowResolver] = None,
+        routing_fingerprint: Optional[str] = None,
+        actual_agent_type_resolver: Optional[Callable[[Optional[str]], str]] = None,
+        read_only_mode: bool = False,
     ) -> None:
         self._dispatch = dispatch
         self._emit = emit
@@ -92,6 +96,9 @@ class WorkflowRuntime:
         self._sem = asyncio.Semaphore(concurrency or default_concurrency())
         self._max_agent_depth = max_agent_depth
         self._resolver = workflow_resolver
+        self._routing_fingerprint = routing_fingerprint
+        self._actual_agent_type_resolver = actual_agent_type_resolver
+        self._read_only_mode = read_only_mode
 
         self._call_index = 0
         self._current_phase: Optional[str] = None
@@ -131,15 +138,32 @@ class WorkflowRuntime:
         label: Optional[str] = None,
         phase: Optional[str] = None,
         schema: Optional[dict] = None,
-        model: Optional[str] = None,
-        effort: Optional[str] = None,
+        model_override: Any = None,
         agent_type: Optional[str] = None,
+        **legacy_kwargs: Any,
     ) -> Any:
         """Dispatch one sub-agent. Returns its recap text, or the validated dict
         when ``schema`` is given, or ``None`` if the agent failed/was skipped.
         """
+        legacy_routing = sorted({"model", "effort"} & set(legacy_kwargs))
+        if legacy_routing:
+            names = ", ".join(f"{name}=" for name in legacy_routing)
+            raise WorkflowScriptError(
+                f"agent() no longer accepts top-level {names}. Migrate to the complete "
+                "model_override={'provider': ..., 'model': ..., 'effort': ...} object."
+            )
+        if legacy_kwargs:
+            names = ", ".join(sorted(legacy_kwargs))
+            raise WorkflowScriptError(f"agent() got unexpected keyword argument(s): {names}")
         if not isinstance(prompt, str) or not prompt.strip():
             raise WorkflowScriptError("agent() requires a non-empty prompt string")
+        try:
+            parsed_override: Optional[AtomicModelOverride] = parse_atomic_model_override(
+                model_override,
+                effort_key="effort",
+            )
+        except (TypeError, ValueError) as exc:
+            raise WorkflowScriptError(str(exc)) from exc
 
         # Index is assigned synchronously (no await before this point), so it is
         # deterministic across runs for a given script — the basis for resume.
@@ -150,9 +174,13 @@ class WorkflowRuntime:
             label=label,
             phase=phase or self._current_phase,
             schema=schema,
-            model=model,
-            effort=effort,
+            model_override=parsed_override,
             agent_type=agent_type,
+            routing_fingerprint=self._routing_fingerprint,
+            actual_agent_type=(
+                self._actual_agent_type_resolver(agent_type) if self._actual_agent_type_resolver is not None else None
+            ),
+            read_only_mode=self._read_only_mode,
             max_agent_depth=self._max_agent_depth,
             call_index=index,
         )
@@ -202,6 +230,9 @@ class WorkflowRuntime:
             error=result.error,
             transcript_path=result.transcript_path,
             transcript_markdown_path=result.transcript_markdown_path,
+            requested_routing=result.requested_routing,
+            effective_routing=result.effective_routing,
+            actual_agent_type=result.actual_agent_type,
         )
         self._journal.append_transcript_event(
             {
@@ -210,6 +241,9 @@ class WorkflowRuntime:
                 "label": spec.label,
                 "phase": spec.phase,
                 "agent_type": spec.agent_type,
+                "actual_agent_type": result.actual_agent_type,
+                "requested_routing": result.requested_routing,
+                "effective_routing": result.effective_routing,
                 "max_agent_depth": spec.max_agent_depth,
                 "status": result.status,
                 "tokens": result.tokens,

--- a/kolega_code/agent/orchestration/types.py
+++ b/kolega_code/agent/orchestration/types.py
@@ -13,6 +13,8 @@ import json
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Optional
 
+from ..model_routing import AtomicModelOverride
+
 
 @dataclass
 class AgentRunSpec:
@@ -22,9 +24,15 @@ class AgentRunSpec:
     label: Optional[str] = None
     phase: Optional[str] = None
     schema: Optional[dict] = None
-    model: Optional[str] = None
-    effort: Optional[str] = None
+    model_override: Optional[AtomicModelOverride] = None
     agent_type: Optional[str] = None
+    # Secret-free identity of inherited role routing. It participates in cache
+    # identity only when model_override is absent.
+    routing_fingerprint: Optional[str] = None
+    # Resolve execution identity before cache lookup so Plan mode cannot replay
+    # a writable worker result for its forced read-only InvestigationAgent.
+    actual_agent_type: Optional[str] = None
+    read_only_mode: bool = False
     # Workflow-wide delegation ceiling. Direct workflow workers are depth 1.
     max_agent_depth: int = 1
     # Position of this call in the run, assigned by the runtime in invocation
@@ -40,9 +48,11 @@ class AgentRunSpec:
         payload = {
             "prompt": self.prompt,
             "schema": self.schema,
-            "model": self.model,
-            "effort": self.effort,
+            "model_override": (self.model_override.as_dict() if self.model_override is not None else None),
+            "routing_fingerprint": (self.routing_fingerprint if self.model_override is None else None),
             "agent_type": self.agent_type,
+            "actual_agent_type": self.actual_agent_type,
+            "read_only_mode": self.read_only_mode,
             "max_agent_depth": self.max_agent_depth,
         }
         encoded = json.dumps(payload, sort_keys=True, default=str)
@@ -61,6 +71,9 @@ class AgentRunResult:
     error: Optional[str] = None
     transcript_path: Optional[str] = None
     transcript_markdown_path: Optional[str] = None
+    requested_routing: Optional[dict[str, Any]] = None
+    effective_routing: Optional[dict[str, Any]] = None
+    actual_agent_type: Optional[str] = None
 
     @property
     def value(self) -> Any:

--- a/kolega_code/agent/tool_backend/agent_tool.py
+++ b/kolega_code/agent/tool_backend/agent_tool.py
@@ -6,10 +6,12 @@ from typing import Any, Awaitable, Callable, Union, Optional, cast
 from datetime import datetime, timezone
 import time
 
-from kolega_code.config import AgentConfig
+from kolega_code.config import AgentConfig, ModelConfig
 from kolega_code.events import AgentEvent
 from kolega_code.hooks import HookDispatcher, HookEvent
+from kolega_code.llm.specs import supports_vision
 from kolega_code.permissions import PermissionMode, auto_allow_permission_callback
+from ..model_routing import resolve_subagent_model, subagent_model_catalog
 from ..orchestration.accounting import AgentReservation, WorkflowRunAccounting
 from ..orchestration.context import has_workflow_context_marker, validated_workflow_depth
 from .base_tool import BaseTool
@@ -55,6 +57,17 @@ class AgentTool(BaseTool):
         # No need to store these separately since they're already in the parent class
         # self.terminal_manager = terminal_manager
         # self.browser_manager = browser_manager
+
+    def _subagent_dispatch_config(self) -> AgentConfig:
+        """Return the unmodified config descendants should route against.
+
+        A caller launched with a per-dispatch override keeps that override for
+        its own primary loop, but publishes its parent's routing config through
+        ``_subagent_dispatch_config``. This prevents a same-role depth-2 child
+        from accidentally inheriting the direct worker's override.
+        """
+        inherited = getattr(self.caller, "_subagent_dispatch_config", None)
+        return inherited if isinstance(inherited, AgentConfig) else self.config
 
     async def _maybe_await(self, value):
         if inspect.isawaitable(value):
@@ -163,6 +176,9 @@ class AgentTool(BaseTool):
         agent_name_override: Optional[str] = None,
         agent_kwargs: Optional[dict[str, Any]] = None,
         sub_agent_info_extra: Optional[dict[str, Any]] = None,
+        model_override: Any = None,
+        routing_agent_name: Optional[str] = None,
+        inherited_model: Optional[ModelConfig] = None,
     ) -> str:
         """
         Generic method to dispatch any agent type.
@@ -189,9 +205,6 @@ class AgentTool(BaseTool):
             workflow_accounting = getattr(self.caller, "_workflow_accounting", None)
             if not isinstance(workflow_accounting, WorkflowRunAccounting):
                 raise RuntimeError("workflow delegation accounting is unavailable")
-            # Event-loop-confined admission happens before imports, conversation
-            # creation, events, or child construction.
-            reservation = workflow_accounting.reserve_agent()
 
         # Extract the agent name from the class
         module_path, class_name = agent_class_import.rsplit(".", 1)
@@ -200,6 +213,35 @@ class AgentTool(BaseTool):
         module = __import__(module_path, fromlist=[class_name])
         agent_class = getattr(module, class_name)
         agent_name = agent_name_override or agent_class.agent_name
+
+        # Resolve the complete route before any conversation, event, reservation,
+        # or child-construction side effect. Custom agents route their primary loop
+        # through the General role while retaining their model frontmatter as the
+        # inherited value when no runtime override is supplied.
+        dispatch_config = self._subagent_dispatch_config()
+        routing = resolve_subagent_model(
+            dispatch_config,
+            routing_agent_name or agent_name,
+            model_override,
+            effort_key="thinking_effort",
+            inherited_model=inherited_model,
+        )
+        if agent_name == "browser-agent" and not supports_vision(
+            routing.model_config.provider, routing.model_config.model
+        ):
+            raise ValueError(
+                "BrowserAgent requires a vision-capable model; "
+                f"{routing.model_config.provider.value}/{routing.model_config.model} does not support image input."
+            )
+
+        if workflow_accounting is not None:
+            # Event-loop-confined admission remains ahead of conversations, events,
+            # and child construction, but follows atomic route validation.
+            reservation = workflow_accounting.reserve_agent()
+
+        effective_agent_kwargs = dict(agent_kwargs or {})
+        if class_name == "CustomAgent" and routing.requested is not None:
+            effective_agent_kwargs["resolved_model"] = routing.model_config
 
         # Create a unique agent ID
         agent_id = str(uuid.uuid4())
@@ -244,6 +286,10 @@ class AgentTool(BaseTool):
             "conversation_id": conversation_id,
             "parent_tool_call_id": tool_call_id,
             "depth": parent_depth + 1,
+            "requested_routing": (
+                routing.requested.as_dict(effort_key="thinking_effort") if routing.requested is not None else None
+            ),
+            "effective_routing": routing.metadata,
         }
         # A nested dispatch from a workflow worker inherits the workflow's
         # delegation policy and grouping metadata. Cosmetic call labels/indexes
@@ -270,7 +316,7 @@ class AgentTool(BaseTool):
                 workspace_id=self.workspace_id,
                 thread_id=self.thread_id,
                 connection_manager=self.connection_manager,
-                config=self.config,
+                config=routing.config,
                 sub_agent=True,
                 filesystem=self.filesystem,
                 terminal_manager=self.terminal_manager,
@@ -299,7 +345,7 @@ class AgentTool(BaseTool):
                 hook_dispatcher=getattr(self.caller, "hook_dispatcher", None) if self.caller else None,
                 max_iterations=getattr(self.caller, "max_iterations", None),
                 memory_manager=self.memory_manager,
-                **(agent_kwargs or {}),
+                **effective_agent_kwargs,
             )
 
             # Store agent reference
@@ -309,6 +355,10 @@ class AgentTool(BaseTool):
             agent.parent_tool_call_id = tool_call_id
             agent.conversation_id = conversation_id
             agent.sub_agent_context = sub_agent_info
+            # The resolved config is private to this worker's primary loop.
+            # Nested dispatch starts again from the inherited parent config
+            # unless the child call supplies its own complete override.
+            agent._subagent_dispatch_config = dispatch_config
             if workflow_accounting is not None:
                 agent._workflow_accounting = workflow_accounting
                 agent._accounting_reservation = reservation
@@ -473,12 +523,16 @@ class AgentTool(BaseTool):
             if agent_id in self.agents:
                 del self.agents[agent_id]
 
-    async def dispatch_investigation_agent(self, task: str) -> str:
+    async def dispatch_investigation_agent(self, task: str, model_override: Any = None) -> str:
         """
         Dispatch an investigation agent to perform a specific task with read-only access to the codebase.
 
         Args:
             task: A detailed description of the investigation task to perform
+            model_override: Optional complete provider/model/thinking_effort
+                route. Call list_subagent_models before selecting one. All
+                fields are required when present; use null only for a model
+                without effort controls. Invalid routes fail without fallback.
 
         Returns:
             A comprehensive report of the investigation findings
@@ -486,14 +540,19 @@ class AgentTool(BaseTool):
         return await self._dispatch_agent(
             agent_class_import="kolega_code.agent.investigationagent.InvestigationAgent",
             task=task,
+            model_override=model_override,
         )
 
-    async def dispatch_browser_agent(self, task: str) -> str:
+    async def dispatch_browser_agent(self, task: str, model_override: Any = None) -> str:
         """
         Dispatch a browser agent to perform web-based tasks and interactions.
 
         Args:
             task: A detailed description of the browser task to perform
+            model_override: Optional complete provider/model/thinking_effort
+                route from list_subagent_models. The selected catalog entry
+                must have supports_vision=true. All fields are required when
+                present, and invalid routes fail without fallback.
 
         Returns:
             A comprehensive report of the browser agent's findings and actions
@@ -501,14 +560,19 @@ class AgentTool(BaseTool):
         return await self._dispatch_agent(
             agent_class_import="kolega_code.agent.browseragent.BrowserAgent",
             task=task,
+            model_override=model_override,
         )
 
-    async def dispatch_coding_agent(self, task: str) -> str:
+    async def dispatch_coding_agent(self, task: str, model_override: Any = None) -> str:
         """
         Dispatch a coding agent for processing coding-related tasks with streaming output.
 
         Args:
             task: A detailed description of the coding task to perform
+            model_override: Optional complete provider/model/thinking_effort
+                route. Call list_subagent_models before selecting one. All
+                fields are required when present; use null only for a model
+                without effort controls. Invalid routes fail without fallback.
 
         Returns:
             A summary of the coding process outcome
@@ -516,14 +580,19 @@ class AgentTool(BaseTool):
         return await self._dispatch_agent(
             agent_class_import="kolega_code.agent.coder.CoderAgent",
             task=task,
+            model_override=model_override,
         )
 
-    async def dispatch_general_agent(self, task: str) -> str:
+    async def dispatch_general_agent(self, task: str, model_override: Any = None) -> str:
         """
         Dispatch a general-purpose agent to autonomously complete a self-contained task.
 
         Args:
             task: A detailed, self-contained description of the task to perform
+            model_override: Optional complete provider/model/thinking_effort
+                route. Call list_subagent_models before selecting one. All
+                fields are required when present; use null only for a model
+                without effort controls. Invalid routes fail without fallback.
 
         Returns:
             The agent's final report on the completed task
@@ -531,7 +600,12 @@ class AgentTool(BaseTool):
         return await self._dispatch_agent(
             agent_class_import="kolega_code.agent.generalagent.GeneralAgent",
             task=task,
+            model_override=model_override,
         )
+
+    async def list_subagent_models(self, provider: Optional[str] = None) -> dict[str, Any]:
+        """Return configured, credential-free sub-agent model routing choices."""
+        return subagent_model_catalog(self._subagent_dispatch_config(), provider)
 
     def _eligible_custom_agent_tools(self) -> set[str]:
         """Return the caller's propagatable, non-recursive tool surface."""
@@ -542,14 +616,22 @@ class AgentTool(BaseTool):
         eligible = set(collection.registry().names())
         eligible.difference_update(getattr(collection, "agent_dispatch_tools", ()))
         eligible.difference_update(getattr(collection, "orchestration_tools", ()))
+        eligible.difference_update(getattr(collection, "delegation_tools", ()))
 
         for extension in getattr(self.caller, "tool_extensions", None) or []:
             if not getattr(extension, "propagate_to_sub_agents", True):
                 eligible.difference_update(getattr(extension, "tools", {}).keys())
         return eligible
 
-    async def dispatch_custom_agent(self, agent: str, task: str) -> str:
-        """Dispatch a discovered custom agent within the caller's capability ceiling."""
+    async def dispatch_custom_agent(self, agent: str, task: str, model_override: Any = None) -> str:
+        """Dispatch a discovered custom agent within the caller's capability ceiling.
+
+        ``model_override`` is an optional complete provider/model/thinking_effort
+        route from ``list_subagent_models``. It atomically replaces the custom
+        definition's route. All fields are required when present; null is valid
+        only for models without effort controls, and invalid routes never fall
+        back.
+        """
         if getattr(self.caller, "sub_agent", False):
             raise ValueError("Custom agents cannot be dispatched from another sub-agent.")
 
@@ -586,6 +668,9 @@ class AgentTool(BaseTool):
                 "agent_scope": definition.scope,
                 "agent_definition_path": str(definition.source_path),
             },
+            model_override=model_override,
+            routing_agent_name="general-agent",
+            inherited_model=definition.resolve_model_config(self.config),
         )
 
     # ------------------------------------------------------------------
@@ -767,6 +852,16 @@ class AgentTool(BaseTool):
             f"- Status: {status}",
             f"- Tokens: {tokens}",
         ]
+        if "actual_agent_type" in metadata:
+            lines.append(f"- Actual agent type: {metadata.get('actual_agent_type') or ''}")
+        if "requested_routing" in metadata:
+            lines.append(
+                f"- Requested routing: {json.dumps(metadata.get('requested_routing'), sort_keys=True, default=str)}"
+            )
+        if "effective_routing" in metadata:
+            lines.append(
+                f"- Effective routing: {json.dumps(metadata.get('effective_routing'), sort_keys=True, default=str)}"
+            )
         if error:
             lines.append(f"- Error: {error}")
         jsonl_path = artifact_paths.get("jsonl")
@@ -834,6 +929,8 @@ class AgentTool(BaseTool):
         }
         if sub_agent_info_extra:
             sub_agent_info.update({k: v for k, v in sub_agent_info_extra.items() if v is not None})
+            if "requested_routing" in sub_agent_info_extra:
+                sub_agent_info["requested_routing"] = sub_agent_info_extra["requested_routing"]
 
         artifact_metadata = dict(artifact_metadata or {})
         artifact_metadata.setdefault("agent_name", agent_name)
@@ -862,6 +959,9 @@ class AgentTool(BaseTool):
             agent.parent_tool_call_id = tool_call_id
             agent.conversation_id = conversation_id
             agent.sub_agent_context = sub_agent_info
+            # ``config`` may contain a route installed only for this direct
+            # workflow worker. Descendants must route from the inherited config.
+            agent._subagent_dispatch_config = self._subagent_dispatch_config()
             agent._workflow_accounting = workflow_accounting
             agent._accounting_reservation = reservation
 

--- a/kolega_code/agent/tool_backend/agent_tool.py
+++ b/kolega_code/agent/tool_backend/agent_tool.py
@@ -11,7 +11,7 @@ from kolega_code.events import AgentEvent
 from kolega_code.hooks import HookDispatcher, HookEvent
 from kolega_code.llm.specs import supports_vision
 from kolega_code.permissions import PermissionMode, auto_allow_permission_callback
-from ..model_routing import resolve_subagent_model, subagent_model_catalog
+from ..model_routing import render_subagent_model_catalog, resolve_subagent_model, subagent_model_catalog
 from ..orchestration.accounting import AgentReservation, WorkflowRunAccounting
 from ..orchestration.context import has_workflow_context_marker, validated_workflow_depth
 from .base_tool import BaseTool
@@ -603,9 +603,10 @@ class AgentTool(BaseTool):
             model_override=model_override,
         )
 
-    async def list_subagent_models(self, provider: Optional[str] = None) -> dict[str, Any]:
-        """Return configured, credential-free sub-agent model routing choices."""
-        return subagent_model_catalog(self._subagent_dispatch_config(), provider)
+    async def list_subagent_models(self, provider: Optional[str] = None) -> str:
+        """Return configured, credential-free routing choices as compact Markdown."""
+        catalog = subagent_model_catalog(self._subagent_dispatch_config(), provider)
+        return render_subagent_model_catalog(catalog)
 
     def _eligible_custom_agent_tools(self) -> set[str]:
         """Return the caller's propagatable, non-recursive tool surface."""

--- a/kolega_code/agent/tool_backend/workflow_tool.py
+++ b/kolega_code/agent/tool_backend/workflow_tool.py
@@ -16,7 +16,9 @@ from pathlib import Path
 from typing import Any, Optional
 
 from kolega_code.events import AgentEvent
+from kolega_code.llm.specs import supports_vision
 
+from ..model_routing import model_routing_fingerprint, resolve_subagent_model
 from ..orchestration import (
     AgentRunResult,
     AgentRunSpec,
@@ -104,6 +106,16 @@ class WorkflowTool(BaseTool):
             memory_manager=getattr(self.caller, "memory_manager", None),
         )
 
+    def _workflow_is_read_only(self) -> bool:
+        """Whether every direct workflow worker must use read-only tooling."""
+        return bool(getattr(getattr(self.caller, "tool_collection", None), "read_only", False))
+
+    @staticmethod
+    def _agent_import_path(agent_type: Optional[str], *, read_only: bool) -> str:
+        if read_only:
+            return _AGENT_TYPE_IMPORTS["investigation"]
+        return _AGENT_TYPE_IMPORTS.get((agent_type or "").lower(), _DEFAULT_AGENT_IMPORT)
+
     # ------------------------------------------------------------------ tool
     async def run_workflow(
         self,
@@ -175,6 +187,7 @@ class WorkflowTool(BaseTool):
             },
         )
 
+        read_only = self._workflow_is_read_only()
         runtime = WorkflowRuntime(
             dispatch=self._make_dispatch(run_id, journal, accounting),
             emit=emit,
@@ -184,6 +197,11 @@ class WorkflowTool(BaseTool):
             max_agent_depth=meta["max_agent_depth"],
             resume_cache=resume_cache,
             workflow_resolver=self._make_resolver(state_dir),
+            routing_fingerprint=model_routing_fingerprint(self.config),
+            actual_agent_type_resolver=lambda agent_type: self._agent_import_path(
+                agent_type, read_only=read_only
+            ).rsplit(".", 1)[1],
+            read_only_mode=read_only,
         )
 
         status = "completed"
@@ -252,18 +270,49 @@ class WorkflowTool(BaseTool):
         # workflow can research in parallel (including running investigative
         # commands) but cannot edit files, since read_only agents have no
         # file-edit tools.
-        read_only = bool(getattr(getattr(self.caller, "tool_collection", None), "read_only", False))
+        read_only = self._workflow_is_read_only()
 
         async def dispatch(spec: AgentRunSpec) -> AgentRunResult:
             reservation = get_current_agent_reservation()
             if reservation is None:
                 raise RuntimeError("workflow dispatch requires an agent reservation")
-            if read_only:
-                import_path = _AGENT_TYPE_IMPORTS["investigation"]
-            else:
-                import_path = _AGENT_TYPE_IMPORTS.get((spec.agent_type or "").lower(), _DEFAULT_AGENT_IMPORT)
+            import_path = self._agent_import_path(spec.agent_type, read_only=read_only)
             agent_class = _import_agent_class(import_path)
-            config = self._config_override(spec.model, spec.effort)
+            actual_agent_type = agent_class.__name__
+            agent_name = getattr(agent_class, "agent_name", actual_agent_type)
+            requested_routing = spec.model_override.as_dict() if spec.model_override is not None else None
+
+            try:
+                routing = resolve_subagent_model(
+                    self.config,
+                    agent_name,
+                    spec.model_override.as_dict() if spec.model_override is not None else None,
+                    effort_key="effort",
+                )
+                if (
+                    spec.model_override is not None
+                    and agent_name == "browser-agent"
+                    and not supports_vision(routing.model_config.provider, routing.model_config.model)
+                ):
+                    raise ValueError(
+                        "BrowserAgent model_override requires a vision-capable model; "
+                        f"{routing.model_config.provider.value}/{routing.model_config.model} "
+                        "does not support image input."
+                    )
+            except (TypeError, ValueError) as exc:
+                return AgentRunResult(
+                    status="failed",
+                    error=f"invalid model_override: {exc}",
+                    requested_routing=requested_routing,
+                    actual_agent_type=actual_agent_type,
+                )
+
+            effective_routing = {
+                "provider": routing.model_config.provider.value,
+                "model": routing.model_config.model,
+                "effort": routing.model_config.thinking_effort,
+            }
+            config = routing.config if spec.model_override is not None else None
             sub_info_extra = {
                 "workflow_run_id": run_id,
                 "phase": spec.phase,
@@ -271,6 +320,9 @@ class WorkflowTool(BaseTool):
                 "call_index": spec.call_index,
                 "depth": 1,
                 "max_agent_depth": spec.max_agent_depth,
+                "requested_routing": requested_routing,
+                "effective_routing": effective_routing,
+                "actual_agent_type": actual_agent_type,
             }
             label_for_path = spec.label or spec.agent_type or agent_class.__name__
             artifact_paths = journal.agent_artifact_paths(spec.call_index, label_for_path)
@@ -278,9 +330,13 @@ class WorkflowTool(BaseTool):
                 "call_index": spec.call_index,
                 "label": spec.label,
                 "phase": spec.phase,
-                "agent_type": spec.agent_type or agent_class.__name__,
-                "agent_name": getattr(agent_class, "agent_name", agent_class.__name__),
+                "agent_type": actual_agent_type,
+                "requested_agent_type": spec.agent_type,
+                "actual_agent_type": actual_agent_type,
+                "agent_name": agent_name,
                 "max_agent_depth": spec.max_agent_depth,
+                "requested_routing": requested_routing,
+                "effective_routing": effective_routing,
             }
             try:
                 recap, tokens, structured = await self._agent_tool.dispatch_workflow_agent(
@@ -301,6 +357,9 @@ class WorkflowTool(BaseTool):
                     error=str(exc),
                     transcript_path=str(artifact_paths["jsonl"]),
                     transcript_markdown_path=str(artifact_paths["markdown"]),
+                    requested_routing=requested_routing,
+                    effective_routing=effective_routing,
+                    actual_agent_type=actual_agent_type,
                 )
             return AgentRunResult(
                 text=recap,
@@ -309,6 +368,9 @@ class WorkflowTool(BaseTool):
                 status="completed",
                 transcript_path=str(artifact_paths["jsonl"]),
                 transcript_markdown_path=str(artifact_paths["markdown"]),
+                requested_routing=requested_routing,
+                effective_routing=effective_routing,
+                actual_agent_type=actual_agent_type,
             )
 
         return dispatch
@@ -364,26 +426,6 @@ class WorkflowTool(BaseTool):
                 raise WorkflowScriptError(f"could not resolve nested workflow {name_or_ref!r}: {exc}") from exc
 
         return resolve
-
-    def _config_override(self, model: Optional[str], effort: Optional[str]):
-        """Clone the agent config with per-call model/effort overrides, or None."""
-        if not model and not effort:
-            return None
-        lc_update: dict = {}
-        th_update: dict = {}
-        if model:
-            lc_update["model"] = model
-            th_update["model"] = model
-        if effort:
-            lc_update["thinking_effort"] = effort
-            th_update["thinking_effort"] = effort
-        new_long = self.config.long_context_config.model_copy(update=lc_update)
-        new_thinking = self.config.thinking_config.model_copy(update=th_update)
-        # An explicit per-call model/effort is the workflow author's choice and must
-        # win over any per-agent-role override, so drop agent_models on the clone.
-        return self.config.model_copy(
-            update={"long_context_config": new_long, "thinking_config": new_thinking, "agent_models": {}}
-        )
 
     def _result_json_text(self, result: Any) -> str:
         try:
@@ -457,13 +499,13 @@ class WorkflowTool(BaseTool):
 
         lines.extend(["", "## Agent call index", ""])
         if journal_entries:
-            lines.append("| # | Label | Phase | Agent type | Status | Tokens |")
+            lines.append("| # | Label | Phase | Actual agent type | Status | Tokens |")
             lines.append("| --- | --- | --- | --- | --- | ---: |")
             for entry in journal_entries:
                 index = entry.get("index", "")
                 label = str(entry.get("label") or "")
                 phase = str(entry.get("phase") or "")
-                agent_type = str(entry.get("agent_type") or "")
+                agent_type = str(entry.get("actual_agent_type") or entry.get("agent_type") or "")
                 status_text = str(entry.get("status") or "")
                 tokens = entry.get("tokens", "")
                 lines.append(f"| {index} | {label} | {phase} | {agent_type} | {status_text} | {tokens} |")
@@ -478,12 +520,20 @@ class WorkflowTool(BaseTool):
                 lines.extend([f"### Call {index}: {label}", ""])
                 for key in (
                     "phase",
+                    "requested_agent_type",
                     "agent_type",
+                    "actual_agent_type",
+                    "requested_routing",
+                    "effective_routing",
                     "status",
                     "tokens",
                     "error",
                 ):
-                    if entry.get(key) is not None:
+                    if key == "requested_routing" and key in entry:
+                        requested = entry[key]
+                        rendered = "inherited (null)" if requested is None else requested
+                        lines.append(f"- {key}: `{rendered}`")
+                    elif entry.get(key) is not None:
                         lines.append(f"- {key}: `{entry.get(key)}`")
                 value_text = self._render_value_markdown(entry.get("value"))
                 if len(value_text) <= 2000:

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -39,6 +39,68 @@ from .tool_backend.lsp_tool import LspEditTool, LspTool
 from kolega_code.services.lsp import LspManager
 from kolega_code.services.snapshots import SnapshotService
 
+# Atomic ordinary-dispatch routing cannot be represented by signature
+# introspection: all nested fields are required together and effort is nullable.
+_ORDINARY_MODEL_OVERRIDE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "provider": {
+            "type": "string",
+            "description": "Configured provider name returned by list_subagent_models.",
+        },
+        "model": {
+            "type": "string",
+            "description": "Exact model ID returned for that provider by list_subagent_models.",
+        },
+        "thinking_effort": {
+            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "description": (
+                "Exact supported effort string, or null only when the selected model has no effort control."
+            ),
+        },
+    },
+    "required": ["provider", "model", "thinking_effort"],
+}
+
+
+def _dispatch_input_schema(*, custom: bool = False) -> dict[str, Any]:
+    properties: dict[str, Any] = {
+        "task": {
+            "type": "string",
+            "description": "Detailed, self-contained task for the sub-agent.",
+        },
+        "model_override": {
+            **_ORDINARY_MODEL_OVERRIDE_SCHEMA,
+            "description": (
+                "Optional atomic route. Omit it to inherit normal role/custom-agent settings; "
+                "when present all three nested fields are required."
+            ),
+        },
+    }
+    required = ["task"]
+    if custom:
+        properties = {
+            "agent": {"type": "string", "description": "Name of the custom agent to run."},
+            **properties,
+        }
+        required = ["agent", "task"]
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": properties,
+        "required": required,
+    }
+
+
+_AGENT_DISPATCH_INPUT_SCHEMAS: dict[str, dict[str, Any]] = {
+    "dispatch_investigation_agent": _dispatch_input_schema(),
+    "dispatch_browser_agent": _dispatch_input_schema(),
+    "dispatch_coding_agent": _dispatch_input_schema(),
+    "dispatch_general_agent": _dispatch_input_schema(),
+    "dispatch_custom_agent": _dispatch_input_schema(custom=True),
+}
+
 # Explicit input schema for the generic ``lsp`` tool.  The ``operation`` parameter
 # is an enum that signature introspection cannot express.
 _LSP_INPUT_SCHEMA: dict[str, Any] = {
@@ -406,6 +468,7 @@ class ToolCollection(LogMixin):
         "sleep",
         "read_image",
         "lsp",
+        "list_subagent_models",
     ]
 
     browser_tools = [
@@ -457,6 +520,11 @@ class ToolCollection(LogMixin):
     custom_agent_tools = [
         "dispatch_custom_agent",
     ]
+
+    # Informational support for callers that can dispatch a child or author a
+    # workflow. Inclusion is capability-gated separately so leaf agents never
+    # receive the provider/model catalog tool.
+    delegation_tools = ["list_subagent_models"]
 
     # Memory tools group
     memory_tools = [
@@ -822,6 +890,7 @@ class ToolCollection(LogMixin):
         self.extension_schemas["snapshot"] = _SNAPSHOT_INPUT_SCHEMA
         self.extension_schemas["resolve"] = _RESOLVE_INPUT_SCHEMA
         self.extension_schemas.update(BROWSER_TOOL_SCHEMAS)
+        self.extension_schemas.update(_AGENT_DISPATCH_INPUT_SCHEMAS)
         self.browser_tool = BrowserTool(
             self.project_path,
             self.workspace_id,
@@ -1140,7 +1209,7 @@ class ToolCollection(LogMixin):
         return await self.build_tool.build_frontend()
 
     # Agent Dispatch Tools (available when include_agent_dispatch_tools is True)
-    async def dispatch_investigation_agent(self, task: str) -> str:
+    async def dispatch_investigation_agent(self, task: str, model_override: Any = None) -> str:
         """
         Dispatch an investigation agent to perform a specific task with read-only access to the codebase.
 
@@ -1173,13 +1242,15 @@ class ToolCollection(LogMixin):
 
         Args:
             task: A detailed description of the investigation task to perform
+            model_override: Optional complete provider/model/thinking_effort route. Call
+                list_subagent_models before selecting one; omit it to inherit defaults.
 
         Returns:
             A comprehensive report of the investigation findings
         """
-        return await self.agent_tool.dispatch_investigation_agent(task)
+        return await self.agent_tool.dispatch_investigation_agent(task, model_override)
 
-    async def dispatch_browser_agent(self, task: str) -> str:
+    async def dispatch_browser_agent(self, task: str, model_override: Any = None) -> str:
         """
         Dispatch a browser agent to perform web-based tasks and interactions.
 
@@ -1214,25 +1285,29 @@ class ToolCollection(LogMixin):
 
         Args:
             task: A detailed description of the browser task to perform
+            model_override: Optional complete provider/model/thinking_effort route. Call
+                list_subagent_models before selecting one; the model must support vision.
 
         Returns:
             A comprehensive report of the browser agent's findings and actions
         """
-        return await self.agent_tool.dispatch_browser_agent(task)
+        return await self.agent_tool.dispatch_browser_agent(task, model_override)
 
-    async def dispatch_coding_agent(self, task: str) -> str:
+    async def dispatch_coding_agent(self, task: str, model_override: Any = None) -> str:
         """
         Dispatch a coding agent for processing coding-related tasks with streaming output.
 
         Args:
             task: A detailed description of the coding task to perform
+            model_override: Optional complete provider/model/thinking_effort route. Call
+                list_subagent_models before selecting one; omit it to inherit defaults.
 
         Returns:
             A summary of the coding process outcome
         """
-        return await self.agent_tool.dispatch_coding_agent(task)
+        return await self.agent_tool.dispatch_coding_agent(task, model_override)
 
-    async def dispatch_general_agent(self, task: str) -> str:
+    async def dispatch_general_agent(self, task: str, model_override: Any = None) -> str:
         """
         Dispatch an autonomous general-purpose agent to complete a self-contained task.
 
@@ -1267,13 +1342,15 @@ class ToolCollection(LogMixin):
 
         Args:
             task: A detailed, self-contained description of the task to perform
+            model_override: Optional complete provider/model/thinking_effort route. Call
+                list_subagent_models before selecting one; omit it to inherit defaults.
 
         Returns:
             The agent's final report on the completed task
         """
-        return await self.agent_tool.dispatch_general_agent(task)
+        return await self.agent_tool.dispatch_general_agent(task, model_override)
 
-    async def dispatch_custom_agent(self, agent: str, task: str) -> str:
+    async def dispatch_custom_agent(self, agent: str, task: str, model_override: Any = None) -> str:
         """Dispatch a named custom agent defined in project or user Markdown.
 
         Select an agent whose description matches a self-contained task. The agent
@@ -1284,11 +1361,28 @@ class ToolCollection(LogMixin):
         Args:
             agent: Name of the custom agent to run.
             task: Detailed, self-contained task including relevant context and expected output.
+            model_override: Optional complete provider/model/thinking_effort route. A runtime
+                override replaces the custom definition route as one atomic selection.
 
         Returns:
             The custom agent's final report.
         """
-        return await self.agent_tool.dispatch_custom_agent(agent, task)
+        return await self.agent_tool.dispatch_custom_agent(agent, task, model_override)
+
+    async def list_subagent_models(self, provider: Optional[str] = None) -> dict[str, Any]:
+        """List configured models available for ordinary and Gigacode sub-agents.
+
+        Use this before choosing a non-default route. The result contains no
+        credentials and dispatches revalidate every selection at execution time.
+
+        Args:
+            provider: Optional provider name to filter the catalog.
+
+        Returns:
+            Configured agent defaults, supported provider/model pairs, exact effort
+            options, nullable-effort rules, and vision support.
+        """
+        return await self.agent_tool.list_subagent_models(provider)
 
     async def run_workflow(
         self,
@@ -2150,6 +2244,9 @@ class ToolCollection(LogMixin):
                                 "Detailed, self-contained task including relevant context and expected output."
                             ),
                         },
+                        "model_override": _AGENT_DISPATCH_INPUT_SCHEMAS["dispatch_custom_agent"]["properties"][
+                            "model_override"
+                        ],
                     },
                     "required": ["agent", "task"],
                 }
@@ -2174,6 +2271,7 @@ class ToolCollection(LogMixin):
             "custom_agent_tools",
             "memory_tools",
             "orchestration_tools",
+            "delegation_tools",
             *self._extension_group_names,
         }
         return frozenset(
@@ -2258,6 +2356,21 @@ class ToolCollection(LogMixin):
         explicit_schema = self.extension_schemas.get(method_name)
         if explicit_schema is not None:
             definition.input_schema = explicit_schema
+        if method_name == "dispatch_custom_agent":
+            catalog = getattr(self.caller, "custom_agent_catalog", None)
+            if catalog is not None and catalog.has_agents():
+                custom_schema = definition.input_schema or {"type": "object", "properties": {}}
+                definition.input_schema = {
+                    **custom_schema,
+                    "properties": {
+                        **custom_schema.get("properties", {}),
+                        "agent": {
+                            "type": "string",
+                            "enum": catalog.names(),
+                            "description": "Name of the custom agent to run.",
+                        },
+                    },
+                }
         context = getattr(self.caller, "sub_agent_context", None)
         workflow_dispatch = method_name in self.agent_dispatch_tools and (
             validated_workflow_depth(context) is not None or has_workflow_context_marker(context)
@@ -2316,6 +2429,9 @@ class ToolCollection(LogMixin):
                 if method_name in self._extension_dispatch_tools or depth >= maximum:
                     return False
 
+        if method_name in self.delegation_tools and not self._caller_can_delegate_or_author_workflow():
+            return False
+
         if method_name == "dispatch_custom_agent":
             catalog = getattr(self.caller, "custom_agent_catalog", None)
             if getattr(self.caller, "sub_agent", False) or catalog is None or not catalog.has_agents():
@@ -2323,6 +2439,9 @@ class ToolCollection(LogMixin):
 
         if self.tool_config.allowed_tools is not None and method_name not in self.tool_config.allowed_tools:
             return False
+
+        if method_name in self.delegation_tools:
+            return True
 
         # gigacode orchestration: only the top-level (non-sub) agent may run
         # workflows, and only when gigacode has been enabled for the session.
@@ -2393,6 +2512,33 @@ class ToolCollection(LogMixin):
 
         # Include all other core tools by default
         return True
+
+    def _caller_can_delegate_or_author_workflow(self) -> bool:
+        """Whether this collection belongs to a non-leaf routing-capable caller."""
+        if not getattr(self.caller, "sub_agent", False) and bool(getattr(self.caller, "gigacode_enabled", False)):
+            return True
+
+        context = getattr(self.caller, "sub_agent_context", None)
+        if has_workflow_context_marker(context):
+            depth = validated_workflow_depth(context)
+            if depth is None or depth[0] >= depth[1]:
+                return False
+
+        enabled_groups = set(self.tool_config.custom_tool_groups or [])
+        dispatch_candidates = set()
+        if self.tool_config.include_agent_dispatch_tools:
+            dispatch_candidates.update(self.agent_dispatch_tools)
+        for group_name in enabled_groups:
+            dispatch_candidates.update(set(getattr(self, group_name, []) or []) & set(self.agent_dispatch_tools))
+
+        dispatch_candidates.difference_update(self.tool_exclusions)
+        if self.tool_config.allowed_tools is not None:
+            dispatch_candidates.intersection_update(self.tool_config.allowed_tools)
+        if "dispatch_custom_agent" in dispatch_candidates:
+            catalog = getattr(self.caller, "custom_agent_catalog", None)
+            if getattr(self.caller, "sub_agent", False) or catalog is None or not catalog.has_agents():
+                dispatch_candidates.discard("dispatch_custom_agent")
+        return bool(dispatch_candidates)
 
     async def initialize(self) -> list[str]:
         """Perform async one-time initialization (LSP auto-detection, etc.).

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -1369,18 +1369,21 @@ class ToolCollection(LogMixin):
         """
         return await self.agent_tool.dispatch_custom_agent(agent, task, model_override)
 
-    async def list_subagent_models(self, provider: Optional[str] = None) -> dict[str, Any]:
+    async def list_subagent_models(self, provider: Optional[str] = None) -> str:
         """List configured models available for ordinary and Gigacode sub-agents.
 
         Use this before choosing a non-default route. The result contains no
         credentials and dispatches revalidate every selection at execution time.
 
         Args:
-            provider: Optional provider name to filter the catalog.
+            provider: Optional provider name to filter the catalog. Omit it to
+                list every configured provider; a blank value is also treated
+                as an unfiltered request.
 
         Returns:
-            Configured agent defaults, supported provider/model pairs, exact effort
-            options, nullable-effort rules, and vision support.
+            A compact Markdown catalog of agent defaults, supported
+            provider/model pairs, exact effort options, nullable-effort rules,
+            and vision support.
         """
         return await self.agent_tool.list_subagent_models(provider)
 

--- a/tests/agent/orchestration/test_orchestration.py
+++ b/tests/agent/orchestration/test_orchestration.py
@@ -5,6 +5,7 @@ so they need none of the agent/LLM stack.
 """
 
 import asyncio
+import json
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Optional
@@ -24,6 +25,7 @@ from kolega_code.agent.orchestration import (
     extract_meta,
 )
 from kolega_code.agent.orchestration.accounting import WorkflowRunAccounting
+from kolega_code.agent.model_routing import AtomicModelOverride
 
 META = 'meta = {"name": "t", "description": "d"}\n'
 
@@ -137,6 +139,58 @@ async def test_agent_spec_carries_explicit_max_agent_depth(tmp_path: Path) -> No
     runtime, calls, _, _ = make_runtime(tmp_path, max_agent_depth=2)
     await runtime.execute(META + "return await agent('hello')", args=None)
     assert calls[0].max_agent_depth == 2
+
+
+@pytest.mark.asyncio
+async def test_agent_normalizes_atomic_model_override(tmp_path: Path) -> None:
+    runtime, calls, _, _ = make_runtime(tmp_path)
+    script = (
+        META
+        + "return await agent('hello', model_override={"
+        + "'provider': 'DEEPSEEK', 'model': 'deepseek-v4-flash', 'effort': 'HIGH'})"
+    )
+
+    assert await runtime.execute(script, args=None) == "recap:hello"
+    assert calls[0].model_override == AtomicModelOverride(
+        provider="deepseek",
+        model="deepseek-v4-flash",
+        effort="high",
+    )
+    with pytest.raises(Exception):
+        calls[0].model_override.effort = "low"  # type: ignore[misc]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "override",
+    [
+        "{'provider': 'anthropic', 'model': 'claude-opus-4-8'}",
+        "{'provider': 'anthropic', 'model': 'claude-opus-4-8', 'effort': 'high', 'extra': 1}",
+        "['anthropic', 'claude-opus-4-8', 'high']",
+    ],
+)
+async def test_agent_rejects_non_atomic_model_override_before_dispatch(
+    tmp_path: Path,
+    override: str,
+) -> None:
+    runtime, calls, _, _ = make_runtime(tmp_path)
+
+    with pytest.raises(WorkflowScriptError, match="model_override"):
+        await runtime.execute(META + f"return await agent('hello', model_override={override})", args=None)
+    assert calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("legacy", ["model='claude-opus-4-8'", "effort='high'", "model='x', effort='high'"])
+async def test_agent_legacy_routing_kwargs_have_targeted_migration_error(
+    tmp_path: Path,
+    legacy: str,
+) -> None:
+    runtime, calls, _, _ = make_runtime(tmp_path)
+
+    with pytest.raises(WorkflowScriptError, match="Migrate.*model_override"):
+        await runtime.execute(META + f"return await agent('hello', {legacy})", args=None)
+    assert calls == []
 
 
 @pytest.mark.asyncio
@@ -364,3 +418,103 @@ async def test_resume_reruns_when_max_agent_depth_changes(tmp_path: Path) -> Non
 
     assert [call.prompt for call in calls2] == ["one"]
     assert calls2[0].max_agent_depth == 2
+
+
+def test_cache_key_uses_atomic_override_or_inherited_routing_fingerprint() -> None:
+    no_override_a = AgentRunSpec(prompt="same", routing_fingerprint="routing-a")
+    no_override_b = AgentRunSpec(prompt="same", routing_fingerprint="routing-b")
+    with_override_a = AgentRunSpec(
+        prompt="same",
+        model_override=AtomicModelOverride("anthropic", "claude-sonnet-4-5-20250929", None),
+        routing_fingerprint="routing-a",
+    )
+    with_override_b = AgentRunSpec(
+        prompt="same",
+        model_override=AtomicModelOverride("anthropic", "claude-sonnet-4-5-20250929", None),
+        routing_fingerprint="routing-b",
+    )
+
+    assert no_override_a.cache_key() != no_override_b.cache_key()
+    assert with_override_a.cache_key() == with_override_b.cache_key()
+    assert no_override_a.cache_key() != with_override_a.cache_key()
+
+
+def test_cache_key_includes_actual_execution_class_and_read_only_mode() -> None:
+    writable = AgentRunSpec(
+        prompt="same",
+        agent_type="coder",
+        actual_agent_type="CoderAgent",
+        read_only_mode=False,
+    )
+    forced_plan = AgentRunSpec(
+        prompt="same",
+        agent_type="coder",
+        actual_agent_type="InvestigationAgent",
+        read_only_mode=True,
+    )
+
+    assert writable.cache_key() != forced_plan.cache_key()
+
+
+@pytest.mark.asyncio
+async def test_runtime_records_dispatch_routing_metadata(tmp_path: Path) -> None:
+    async def dispatch(_spec: AgentRunSpec) -> AgentRunResult:
+        return AgentRunResult(
+            text="ok",
+            requested_routing={"provider": "deepseek", "model": "deepseek-v4-flash", "effort": "high"},
+            effective_routing={"provider": "deepseek", "model": "deepseek-v4-flash", "effort": "high"},
+            actual_agent_type="InvestigationAgent",
+        )
+
+    runtime, _, _, journal = make_runtime(tmp_path, dispatch=dispatch)
+    await runtime.agent(
+        "hello",
+        model_override={"provider": "deepseek", "model": "deepseek-v4-flash", "effort": "high"},
+    )
+
+    journal_entry = json.loads(journal.journal_path.read_text().splitlines()[0])
+    transcript_entry = json.loads(journal.transcript_jsonl_path.read_text().splitlines()[0])
+    assert journal_entry["requested_routing"]["provider"] == "deepseek"
+    assert journal_entry["effective_routing"]["model"] == "deepseek-v4-flash"
+    assert journal_entry["actual_agent_type"] == "InvestigationAgent"
+    assert transcript_entry["requested_routing"] == journal_entry["requested_routing"]
+    assert transcript_entry["actual_agent_type"] == "InvestigationAgent"
+
+
+@pytest.mark.asyncio
+async def test_runtime_preserves_null_requested_routing_metadata(tmp_path: Path) -> None:
+    async def dispatch(_spec: AgentRunSpec) -> AgentRunResult:
+        return AgentRunResult(
+            text="ok",
+            requested_routing=None,
+            effective_routing={"provider": "anthropic", "model": "inherited", "effort": None},
+            actual_agent_type="GeneralAgent",
+        )
+
+    runtime, _, _, journal = make_runtime(tmp_path, dispatch=dispatch)
+    await runtime.agent("hello")
+
+    journal_entry = json.loads(journal.journal_path.read_text().splitlines()[0])
+    transcript_entry = json.loads(journal.transcript_jsonl_path.read_text().splitlines()[0])
+    assert "requested_routing" in journal_entry
+    assert journal_entry["requested_routing"] is None
+    assert "requested_routing" in transcript_entry
+    assert transcript_entry["requested_routing"] is None
+
+
+def test_old_and_malformed_journal_rows_remain_readable(tmp_path: Path) -> None:
+    journal = RunJournal.for_run(tmp_path, "legacy")
+    journal.ensure_dirs()
+    journal.journal_path.write_text(
+        "\n".join(
+            [
+                '{"index": 0, "key": "legacy-key", "value": "legacy-value"}',
+                "[]",
+                '{"not": "a resume row"}',
+                "{malformed",
+            ]
+        )
+        + "\n"
+    )
+
+    assert journal.load_cache() == {0: ("legacy-key", "legacy-value")}

--- a/tests/agent/test_agent_tools_inventory.py
+++ b/tests/agent/test_agent_tools_inventory.py
@@ -255,6 +255,7 @@ def test_coder_agent_exposes_dispatch_general_agent(project_path, mock_connectio
     assert "dispatch_general_agent" in tool_names
     assert "dispatch_investigation_agent" in tool_names
     assert "dispatch_coding_agent" not in tool_names
+    assert "list_subagent_models" in tool_names
     assert not tool_names.intersection(ToolCollection.browser_tools)
 
 
@@ -300,6 +301,7 @@ def test_general_agent_tool_inventory(project_path, mock_connection_manager, age
     assert not tool_names.intersection(ToolCollection.browser_tools)
     # Recursion guard: no dispatch tools at all
     assert not any(name.startswith("dispatch_") for name in tool_names)
+    assert "list_subagent_models" not in tool_names
 
 
 def test_cli_general_agent_excludes_manifest_build_tools(project_path, mock_connection_manager, agent_config):

--- a/tests/agent/test_custom_agents.py
+++ b/tests/agent/test_custom_agents.py
@@ -222,6 +222,42 @@ def test_custom_agent_applies_prompt_model_tools_permissions_and_dynamic_context
     assert not tool_names.intersection(agent.tool_collection.agent_dispatch_tools)
 
 
+def test_custom_agent_runtime_resolved_model_wins_definition(
+    tmp_path: Path,
+    mock_connection_manager,
+    agent_config,
+) -> None:
+    definition = CustomAgentDefinition(
+        name="reviewer",
+        description="Reviews code",
+        prompt="Review.",
+        source_path=tmp_path / "reviewer.md",
+        scope="project",
+        model="anthropic/claude-opus-4-8",
+        thinking_effort="high",
+    )
+    runtime_model = ModelConfig(
+        provider=ModelProvider.ANTHROPIC,
+        model="claude-sonnet-4-5-20250929",
+        thinking_effort=None,
+    )
+
+    agent = CustomAgent(
+        project_path=tmp_path,
+        workspace_id="workspace",
+        thread_id=str(uuid.uuid4()),
+        connection_manager=mock_connection_manager,
+        config=agent_config,
+        definition=definition,
+        allowed_tools=[],
+        resolved_model=runtime_model,
+    )
+
+    assert agent.primary_model_config.provider == ModelProvider.ANTHROPIC
+    assert agent.primary_model_config.model == "claude-sonnet-4-5-20250929"
+    assert agent.primary_model_config.thinking_effort is None
+
+
 def test_custom_agent_catalog_filters_build_plan_and_all_modes(
     tmp_path: Path,
     mock_connection_manager,
@@ -269,6 +305,10 @@ def test_custom_agent_catalog_filters_build_plan_and_all_modes(
     )
     assert coder_tool.input_schema["properties"]["agent"]["enum"] == ["reviewer", "shared"]
     assert planning_tool.input_schema["properties"]["agent"]["enum"] == ["planner", "shared"]
+    assert planning_tool.input_schema["required"] == ["agent", "task"]
+    override_schema = planning_tool.input_schema["properties"]["model_override"]
+    assert override_schema["required"] == ["provider", "model", "thinking_effort"]
+    assert {"type": "null"} in override_schema["properties"]["thinking_effort"]["anyOf"]
     assert "Reviews code for correctness" in coder_tool.description
     assert "Produces focused plans" in planning_tool.description
 
@@ -377,6 +417,68 @@ async def test_dispatch_passes_resolved_definition_and_narrowed_tools_to_fresh_a
     assert captured["allowed_tools"] == ["read_entire_file"]
     assert captured["permission_mode"] == coder.permission_mode
     assert captured["permission_callback"] is coder.permission_callback
+    assert "resolved_model" not in captured
+
+
+@pytest.mark.asyncio
+async def test_dispatch_runtime_override_replaces_custom_frontmatter_route(
+    tmp_path: Path,
+    mock_connection_manager,
+    agent_config,
+) -> None:
+    _write_agent(
+        tmp_path,
+        ".kolega/agents/reviewer.md",
+        ("name: reviewer\ndescription: Reviews code\nmodel: anthropic/claude-opus-4-8\nthinking_effort: high"),
+    )
+    catalog = discover_custom_agents(tmp_path, tmp_path / "state")
+    coder = CoderAgent(
+        project_path=tmp_path,
+        workspace_id="workspace",
+        thread_id=str(uuid.uuid4()),
+        connection_manager=mock_connection_manager,
+        config=agent_config,
+        agent_mode=AgentMode.CLI,
+        custom_agent_catalog=catalog,
+    )
+
+    class StubCustomAgent:
+        last_kwargs: dict[str, object] | None = None
+
+        def __init__(self, *args, **kwargs):
+            StubCustomAgent.last_kwargs = kwargs
+            self.total_tokens_used = 0
+            self.parent_tool_call_id = None
+            self.conversation_id = None
+            self.sub_agent_context = None
+
+        async def process_message_stream(self, task):
+            if False:
+                yield task
+
+        def dump_message_history(self):
+            return []
+
+        async def recap_agent_outcome(self):
+            return "Review complete"
+
+    with patch("kolega_code.agent.custom_agents.CustomAgent", StubCustomAgent):
+        await coder.tool_collection.agent_tool.dispatch_custom_agent(
+            "reviewer",
+            "Review",
+            {
+                "provider": "anthropic",
+                "model": "claude-sonnet-4-5-20250929",
+                "thinking_effort": None,
+            },
+        )
+
+    captured = StubCustomAgent.last_kwargs
+    assert captured is not None
+    resolved_model = captured["resolved_model"]
+    assert isinstance(resolved_model, ModelConfig)
+    assert resolved_model.model == "claude-sonnet-4-5-20250929"
+    assert resolved_model.thinking_effort is None
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_model_routing.py
+++ b/tests/agent/test_model_routing.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kolega_code.agent.model_routing import (
+    model_routing_fingerprint,
+    resolve_subagent_model,
+    subagent_model_catalog,
+)
+from kolega_code.auth.tokens import OAuthTokens
+from kolega_code.config import AgentConfig, ModelConfig, ModelProvider
+
+
+def _config() -> AgentConfig:
+    return AgentConfig(
+        anthropic_api_key="secret-anthropic-key",
+        deepseek_api_key="secret-deepseek-key",
+        openai_chatgpt_tokens=OAuthTokens(
+            access_token="secret-access-token",
+            refresh_token="secret-refresh-token",
+            email="private@example.com",
+            account_id="acct-private",
+        ),
+    )
+
+
+def test_complete_override_replaces_only_target_role() -> None:
+    config = _config()
+    original_thinking = config.thinking_config
+
+    resolved = resolve_subagent_model(
+        config,
+        "investigation-agent",
+        {"provider": "deepseek", "model": "deepseek-v4-flash", "thinking_effort": "HIGH"},
+        effort_key="thinking_effort",
+    )
+
+    selected = resolved.config.model_config_for_agent("investigation-agent")
+    assert selected.provider == ModelProvider.DEEPSEEK
+    assert selected.model == "deepseek-v4-flash"
+    assert selected.thinking_effort == "high"
+    assert resolved.config.model_config_for_agent("general-agent") == config.long_context_config
+    assert resolved.config.thinking_config == original_thinking
+    assert config.agent_models == {}
+
+
+@pytest.mark.parametrize(
+    ("override", "message"),
+    [
+        ({"provider": "anthropic", "model": "claude-opus-4-8"}, "missing required"),
+        (
+            {
+                "provider": "anthropic",
+                "model": "claude-opus-4-8",
+                "thinking_effort": "high",
+                "extra": True,
+            },
+            "unsupported field",
+        ),
+        ({"provider": "", "model": "claude-opus-4-8", "thinking_effort": "high"}, "non-empty"),
+        (["anthropic", "claude-opus-4-8", "high"], "must be an object"),
+    ],
+)
+def test_override_shape_is_atomic(override: object, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        resolve_subagent_model(
+            _config(),
+            "general-agent",
+            override,
+            effort_key="thinking_effort",
+        )
+
+
+def test_no_effort_model_requires_explicit_null() -> None:
+    config = _config()
+    resolved = resolve_subagent_model(
+        config,
+        "general-agent",
+        {
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-5-20250929",
+            "thinking_effort": None,
+        },
+        effort_key="thinking_effort",
+    )
+    assert resolved.model_config.thinking_effort is None
+
+    with pytest.raises(ValueError, match="does not support thinking effort"):
+        resolve_subagent_model(
+            config,
+            "general-agent",
+            {
+                "provider": "anthropic",
+                "model": "claude-sonnet-4-5-20250929",
+                "thinking_effort": "none",
+            },
+            effort_key="thinking_effort",
+        )
+
+
+def test_effort_model_rejects_null() -> None:
+    with pytest.raises(ValueError, match="effort must be a string"):
+        resolve_subagent_model(
+            _config(),
+            "general-agent",
+            {"provider": "anthropic", "model": "claude-opus-4-8", "thinking_effort": None},
+            effort_key="thinking_effort",
+        )
+
+
+def test_unconfigured_provider_is_rejected() -> None:
+    with pytest.raises(ValueError, match="not configured"):
+        resolve_subagent_model(
+            _config(),
+            "general-agent",
+            {"provider": "google", "model": "gemini-3.1-pro-preview", "thinking_effort": "high"},
+            effort_key="thinking_effort",
+        )
+
+
+def test_catalog_is_filtered_and_contains_no_credentials() -> None:
+    catalog = subagent_model_catalog(_config())
+    providers = {entry["provider"] for entry in catalog["providers"]}
+    assert {"anthropic", "deepseek", "openai_chatgpt"} <= providers
+    assert "google" not in providers
+
+    rendered = json.dumps(catalog)
+    for secret in (
+        "secret-anthropic-key",
+        "secret-deepseek-key",
+        "secret-access-token",
+        "secret-refresh-token",
+        "private@example.com",
+        "acct-private",
+    ):
+        assert secret not in rendered
+
+
+def test_catalog_provider_filter_and_nullable_effort_marker() -> None:
+    catalog = subagent_model_catalog(_config(), "anthropic")
+    assert [entry["provider"] for entry in catalog["providers"]] == ["anthropic"]
+    no_effort = next(
+        model for model in catalog["providers"][0]["models"] if model["model"] == "claude-sonnet-4-5-20250929"
+    )
+    assert no_effort["thinking_efforts"] == []
+    assert no_effort["override_effort"] == "null"
+
+
+def test_routing_fingerprint_changes_without_including_secrets() -> None:
+    first = _config()
+    second = first.model_copy(
+        update={
+            "agent_models": {
+                "general": ModelConfig(
+                    provider=ModelProvider.DEEPSEEK,
+                    model="deepseek-v4-flash",
+                    thinking_effort="high",
+                )
+            }
+        }
+    )
+    assert model_routing_fingerprint(first) != model_routing_fingerprint(second)
+    assert "secret" not in model_routing_fingerprint(first)

--- a/tests/agent/test_model_routing.py
+++ b/tests/agent/test_model_routing.py
@@ -6,6 +6,7 @@ import pytest
 
 from kolega_code.agent.model_routing import (
     model_routing_fingerprint,
+    render_subagent_model_catalog,
     resolve_subagent_model,
     subagent_model_catalog,
 )
@@ -146,6 +147,29 @@ def test_catalog_provider_filter_and_nullable_effort_marker() -> None:
     )
     assert no_effort["thinking_efforts"] == []
     assert no_effort["override_effort"] == "null"
+
+
+@pytest.mark.parametrize("provider", [None, "", "   "])
+def test_catalog_omitted_or_blank_provider_lists_all_configured_models(provider: str | None) -> None:
+    catalog = subagent_model_catalog(_config(), provider)
+    providers = {entry["provider"] for entry in catalog["providers"]}
+    assert {"anthropic", "deepseek", "openai_chatgpt"} <= providers
+
+
+def test_catalog_markdown_is_compact_readable_and_credential_free() -> None:
+    catalog = subagent_model_catalog(_config())
+    rendered = render_subagent_model_catalog(catalog)
+    compact_json = json.dumps(catalog, separators=(",", ":"))
+
+    assert rendered.startswith("# Available sub-agent models")
+    assert "| Role | Provider/model | Effort |" in rendered
+    assert "`anthropic/claude-opus-4-8`" in rendered
+    assert "`null`" in rendered
+    assert "Vision" in rendered
+    assert not rendered.lstrip().startswith("{")
+    assert len(rendered) < len(compact_json) * 0.7
+    assert "secret-" not in rendered
+    assert "private@example.com" not in rendered
 
 
 def test_routing_fingerprint_changes_without_including_secrets() -> None:

--- a/tests/agent/test_prompts.py
+++ b/tests/agent/test_prompts.py
@@ -94,6 +94,18 @@ def test_gigacode_guide_recommends_leaf_workers_by_default() -> None:
     assert "pipeline()" in GIGACODE_AUTHORING_GUIDE
 
 
+def test_gigacode_guide_documents_atomic_model_overrides() -> None:
+    assert "list_subagent_models" in GIGACODE_AUTHORING_GUIDE
+    assert "model_override=None" in GIGACODE_AUTHORING_GUIDE
+    assert "complete object with exactly" in GIGACODE_AUTHORING_GUIDE
+    assert "`provider`, `model`, and `effort`" in GIGACODE_AUTHORING_GUIDE
+    assert "Use `effort: None` only" in GIGACODE_AUTHORING_GUIDE
+    assert "They never fall back" in GIGACODE_AUTHORING_GUIDE
+    assert "only the worker launched by that `agent()` call" in GIGACODE_AUTHORING_GUIDE
+    assert "forced to the" in GIGACODE_AUTHORING_GUIDE
+    assert "`model=` and `effort=` are no longer accepted" in GIGACODE_AUTHORING_GUIDE
+
+
 def test_init_agents_prompt_renders_arguments() -> None:
     rendered = prompts.build_init_agents_prompt("focus on Python packaging")
 

--- a/tests/agent/test_tool_collection_config.py
+++ b/tests/agent/test_tool_collection_config.py
@@ -214,6 +214,26 @@ class TestToolCollection:
         # Should include investigation tools
         assert "dispatch_investigation_agent" in tool_names
         assert "dispatch_browser_agent" in tool_names
+        assert "list_subagent_models" in tool_names
+
+        dispatch_names = [
+            "dispatch_investigation_agent",
+            "dispatch_browser_agent",
+            "dispatch_coding_agent",
+            "dispatch_general_agent",
+        ]
+        definitions = {tool.name: tool for tool in tool_list}
+        for name in dispatch_names:
+            schema = definitions[name].input_schema
+            assert schema is not None
+            assert schema["required"] == ["task"]
+            override = schema["properties"]["model_override"]
+            assert override["required"] == ["provider", "model", "thinking_effort"]
+            assert override["additionalProperties"] is False
+            assert {"type": "null"} in override["properties"]["thinking_effort"]["anyOf"]
+
+        discovery = tool_collection.registry().get("list_subagent_models")
+        assert discovery.parallel_safe is True
 
     async def test_workflow_depth_gate_cannot_be_bypassed_by_dispatch_extension_group(
         self,
@@ -251,6 +271,49 @@ class TestToolCollection:
         )
         names_at_limit = set(tool_collection.registry().names())
         assert not names_at_limit.intersection(ToolCollection.agent_dispatch_tools)
+
+    async def test_model_discovery_is_exposed_to_workflow_authors_but_hidden_from_leaves(
+        self,
+        project_path: Path,
+        mock_connection_manager: AgentConnectionManager,
+        agent_config: AgentConfig,
+        mock_base_agent: BaseAgent,
+    ) -> None:
+        mock_base_agent.sub_agent = False
+        mock_base_agent.gigacode_enabled = False
+        leaf_collection = ToolCollection(
+            project_path,
+            "test_workspace",
+            str(uuid.uuid4()),
+            mock_connection_manager,
+            agent_config,
+            mock_base_agent,
+        )
+        assert "list_subagent_models" not in leaf_collection.registry()
+
+        mock_base_agent.gigacode_enabled = True
+        workflow_collection = ToolCollection(
+            project_path,
+            "test_workspace",
+            str(uuid.uuid4()),
+            mock_connection_manager,
+            agent_config,
+            mock_base_agent,
+        )
+        discovery = workflow_collection.registry().get("list_subagent_models")
+        assert discovery.parallel_safe is True
+
+        mock_base_agent.sub_agent = True
+        setattr(
+            mock_base_agent,
+            "sub_agent_context",
+            {
+                "workflow_run_id": "run-1",
+                "depth": 1,
+                "max_agent_depth": 1,
+            },
+        )
+        assert "list_subagent_models" not in workflow_collection.registry()
 
     async def test_backward_compatibility_legacy_parameters(
         self,

--- a/tests/agent/tool_backend/test_agent_tool.py
+++ b/tests/agent/tool_backend/test_agent_tool.py
@@ -298,7 +298,7 @@ class TestAgentTool:
         assert start_event.sub_agent_info["workflow_run_id"] == "workflow-run"
         MockAgent.configure_streaming([])
 
-    async def test_nested_dispatch_rejects_cap_before_import_or_events(
+    async def test_nested_dispatch_rejects_cap_after_routing_but_before_conversation_or_events(
         self,
         agent_tool: AgentTool,
         mock_connection_manager: AsyncMock,
@@ -318,8 +318,10 @@ class TestAgentTool:
             with pytest.raises(Exception, match="lifetime agent cap"):
                 await agent_tool._dispatch_agent(agent_class_import="test.module.MockAgent", task="Nested task")
 
-        mock_import.assert_not_called()
+        # The class/role must be known to validate routing before the reservation.
+        mock_import.assert_called_once_with("test.module", fromlist=["MockAgent"])
         assert accounting.agent_count == 1
+        assert mock_caller.sub_agent_recorder.start_conversation.await_count == 0
         assert not any(
             call.args[0].content.get("status") == "GENERATING"
             for call in mock_connection_manager.broadcast_event.call_args_list
@@ -427,6 +429,7 @@ class TestAgentTool:
             mock_dispatch.assert_called_once_with(
                 agent_class_import="kolega_code.agent.investigationagent.InvestigationAgent",
                 task="Investigate this code",
+                model_override=None,
             )
             assert result == "Investigation completed"
 
@@ -440,6 +443,7 @@ class TestAgentTool:
             mock_dispatch.assert_called_once_with(
                 agent_class_import="kolega_code.agent.browseragent.BrowserAgent",
                 task="Browse the web",
+                model_override=None,
             )
             assert result == "Browser task completed"
 
@@ -453,8 +457,183 @@ class TestAgentTool:
             mock_dispatch.assert_called_once_with(
                 agent_class_import="kolega_code.agent.coder.CoderAgent",
                 task="Write some code",
+                model_override=None,
             )
             assert result == "Coding completed"
+
+    async def test_atomic_override_is_applied_and_reported_without_mutating_parent(
+        self,
+        agent_tool: AgentTool,
+        mock_connection_manager: AsyncMock,
+    ) -> None:
+        original_import = builtins.__import__
+        parent_general = agent_tool.config.model_config_for_agent("investigation-agent")
+
+        with patch.object(builtins, "__import__") as mock_import:
+            mock_module = MagicMock()
+            mock_module.InvestigationAgent = MockInvestigationAgent
+
+            def mock_import_func(name: str, *args: Any, **kwargs: Any) -> Any:
+                if name == "kolega_code.agent.investigationagent":
+                    return mock_module
+                return original_import(name, *args, **kwargs)
+
+            mock_import.side_effect = mock_import_func
+            MockInvestigationAgent.configure_streaming([])
+            MockAgent.last_instance = None
+
+            await agent_tool.dispatch_investigation_agent(
+                "Investigate",
+                {
+                    "provider": "openai",
+                    "model": "gpt-5.4",
+                    "thinking_effort": "high",
+                },
+            )
+
+        assert MockAgent.last_instance is not None
+        child_config = MockAgent.last_instance.init_kwargs["config"]
+        selected = child_config.model_config_for_agent("investigation-agent")
+        assert selected.provider == ModelProvider.OPENAI
+        assert selected.model == "gpt-5.4"
+        assert selected.thinking_effort == "high"
+        assert agent_tool.config.model_config_for_agent("investigation-agent") is parent_general
+
+        start_event = next(
+            call.args[0]
+            for call in mock_connection_manager.broadcast_event.call_args_list
+            if call.args[0].content.get("status") == "GENERATING"
+        )
+        assert start_event.sub_agent_info["requested_routing"] == {
+            "provider": "openai",
+            "model": "gpt-5.4",
+            "thinking_effort": "high",
+        }
+        assert start_event.sub_agent_info["effective_routing"] == {
+            "provider": "openai",
+            "model": "gpt-5.4",
+            "thinking_effort": "high",
+        }
+        MockInvestigationAgent.configure_streaming([])
+
+    async def test_override_is_scoped_to_direct_worker_for_same_role_child(
+        self,
+        agent_tool: AgentTool,
+        mock_connection_manager: AsyncMock,
+    ) -> None:
+        """A depth-2 same-role child starts from the inherited role default."""
+        original_import = builtins.__import__
+        mock_module = MagicMock()
+        mock_module.InvestigationAgent = MockInvestigationAgent
+
+        def mock_import_func(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name == "kolega_code.agent.investigationagent":
+                return mock_module
+            return original_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", side_effect=mock_import_func):
+            MockInvestigationAgent.configure_streaming([])
+            await agent_tool.dispatch_investigation_agent(
+                "Direct worker",
+                {"provider": "openai", "model": "gpt-5.4", "thinking_effort": "high"},
+            )
+            direct_worker = MockAgent.last_instance
+            assert direct_worker is not None
+            assert getattr(direct_worker, "_subagent_dispatch_config") is agent_tool.config
+
+            direct_config = direct_worker.init_kwargs["config"]
+            assert direct_config.model_config_for_agent("investigation-agent").model == "gpt-5.4"
+
+            nested_tool = AgentTool(
+                project_path=agent_tool.project_path,
+                workspace_id=agent_tool.workspace_id,
+                thread_id=agent_tool.thread_id,
+                connection_manager=mock_connection_manager,
+                config=direct_config,
+                caller=direct_worker,
+            )
+            await nested_tool.dispatch_investigation_agent("Same-role child")
+
+        nested_worker = MockAgent.last_instance
+        assert nested_worker is not None
+        nested_route = nested_worker.init_kwargs["config"].model_config_for_agent("investigation-agent")
+        assert nested_route.provider == ModelProvider.ANTHROPIC
+        assert nested_route.model == "test-model"
+
+    async def test_invalid_override_precedes_conversation_events_and_workflow_reservation(
+        self,
+        agent_tool: AgentTool,
+        mock_connection_manager: AsyncMock,
+        mock_caller: Mock,
+    ) -> None:
+        original_import = builtins.__import__
+        accounting = WorkflowRunAccounting(Budget(), agent_cap=2)
+        mock_caller.sub_agent = True
+        mock_caller.sub_agent_context = {
+            "workflow_run_id": "workflow-run",
+            "depth": 1,
+            "max_agent_depth": 2,
+        }
+        mock_caller._workflow_accounting = accounting
+
+        with patch.object(builtins, "__import__") as mock_import:
+            mock_module = MagicMock()
+            mock_module.InvestigationAgent = MockInvestigationAgent
+
+            def mock_import_func(name: str, *args: Any, **kwargs: Any) -> Any:
+                if name == "kolega_code.agent.investigationagent":
+                    return mock_module
+                return original_import(name, *args, **kwargs)
+
+            mock_import.side_effect = mock_import_func
+            with pytest.raises(ValueError, match="missing required field.*thinking_effort"):
+                await agent_tool.dispatch_investigation_agent(
+                    "Investigate",
+                    {"provider": "openai", "model": "gpt-5.4"},
+                )
+
+        assert accounting.agent_count == 0
+        assert mock_caller.sub_agent_recorder.start_conversation.await_count == 0
+        assert mock_connection_manager.broadcast_event.await_count == 0
+
+    async def test_browser_override_rejects_nonvision_route_before_lifecycle(
+        self,
+        agent_tool: AgentTool,
+        mock_connection_manager: AsyncMock,
+        mock_caller: Mock,
+    ) -> None:
+        agent_tool.config = agent_tool.config.model_copy(update={"deepseek_api_key": "test-key"})
+
+        with pytest.raises(ValueError, match="vision-capable"):
+            await agent_tool.dispatch_browser_agent(
+                "Browse",
+                {
+                    "provider": "deepseek",
+                    "model": "deepseek-v4-pro",
+                    "thinking_effort": "high",
+                },
+            )
+
+        assert mock_caller.sub_agent_recorder.start_conversation.await_count == 0
+        assert mock_connection_manager.broadcast_event.await_count == 0
+
+    async def test_workflow_markdown_renders_supplied_routing_metadata(self, agent_tool: AgentTool, tmp_path) -> None:
+        markdown = tmp_path / "agent.md"
+        agent_tool._write_workflow_agent_markdown(
+            {"markdown": markdown},
+            metadata={
+                "actual_agent_type": "InvestigationAgent",
+                "requested_routing": {"provider": "openai", "model": "gpt-5.4", "effort": "high"},
+                "effective_routing": {"provider": "openai", "model": "gpt-5.4", "effort": "high"},
+            },
+            prompt="Investigate",
+            status="completed",
+        )
+
+        rendered = markdown.read_text(encoding="utf-8")
+        assert "- Actual agent type: InvestigationAgent" in rendered
+        assert '- Requested routing: {"effort": "high", "model": "gpt-5.4", "provider": "openai"}' in rendered
+        assert '- Effective routing: {"effort": "high", "model": "gpt-5.4", "provider": "openai"}' in rendered
 
     async def test_agent_name_consistency(self, agent_tool):
         """Test that all agent names follow kebab-case convention."""

--- a/tests/agent/tool_backend/test_agent_tool.py
+++ b/tests/agent/tool_backend/test_agent_tool.py
@@ -461,6 +461,14 @@ class TestAgentTool:
             )
             assert result == "Coding completed"
 
+    async def test_list_subagent_models_accepts_blank_optional_provider(self, agent_tool: AgentTool) -> None:
+        catalog = await agent_tool.list_subagent_models("")
+
+        assert catalog.startswith("# Available sub-agent models")
+        assert "`anthropic/" in catalog
+        assert "`openai/" in catalog
+        assert not catalog.lstrip().startswith("{")
+
     async def test_atomic_override_is_applied_and_reported_without_mutating_parent(
         self,
         agent_tool: AgentTool,

--- a/tests/agent/tool_backend/test_workflow_tool.py
+++ b/tests/agent/tool_backend/test_workflow_tool.py
@@ -41,7 +41,10 @@ def caller():
 @pytest.fixture
 def workflow_tool(tmp_path, connection_manager, caller, monkeypatch):
     monkeypatch.setenv("KOLEGA_CODE_STATE_DIR", str(tmp_path))
-    config = Mock(spec=AgentConfig)
+    config = AgentConfig(
+        anthropic_api_key="anthropic-key",
+        deepseek_api_key="deepseek-key",
+    )
     tool = WorkflowTool(
         str(tmp_path / "project"),
         "ws",
@@ -240,18 +243,47 @@ async def test_failed_agent_call_is_recorded_in_transcript(
 
 @pytest.mark.asyncio
 async def test_run_workflow_carries_phase_and_label_to_dispatch(workflow_tool):
-    tool, _ = workflow_tool
+    tool, state_dir = workflow_tool
     stub, calls = _stub_dispatch()
     tool._agent_tool.dispatch_workflow_agent = stub
 
     script = 'meta = {"name": "p", "description": "d"}\nphase("Build")\nawait agent("go", label="my-label")\nreturn 1\n'
-    await tool.run_workflow(script=script)
+    summary = await tool.run_workflow(script=script)
     _task, _schema, extra, _artifact_paths, _artifact_metadata = calls[0]
     assert extra["phase"] == "Build"
     assert extra["label"] == "my-label"
     assert "workflow_run_id" in extra
     assert extra["depth"] == 1
     assert extra["max_agent_depth"] == 1
+    assert extra["effective_routing"]["provider"] == "anthropic"
+    assert extra["requested_routing"] is None
+    assert extra["actual_agent_type"] == "GeneralAgent"
+    run_id = next(line.split("runId:")[1].strip() for line in summary.splitlines() if "runId:" in line)
+    journal_entry = json.loads((state_dir / "workflows" / run_id / "journal.jsonl").read_text().splitlines()[0])
+    transcript = (state_dir / "workflows" / run_id / "transcript.md").read_text()
+    assert "requested_routing" in journal_entry
+    assert journal_entry["requested_routing"] is None
+    assert "requested_routing: `inherited (null)`" in transcript
+
+
+@pytest.mark.asyncio
+async def test_resume_cache_distinguishes_plan_mode_forced_worker(workflow_tool) -> None:
+    tool, _ = workflow_tool
+    stub, calls = _stub_dispatch()
+    tool._agent_tool.dispatch_workflow_agent = stub
+    script = 'meta = {"name": "cache-mode", "description": "d"}\nreturn await agent("same task", agent_type="coder")\n'
+
+    first_summary = await tool.run_workflow(script=script)
+    first_run_id = next(line.split("runId:")[1].strip() for line in first_summary.splitlines() if "runId:" in line)
+    assert len(calls) == 1
+    assert calls[0][2]["actual_agent_type"] == "CoderAgent"
+
+    calls.clear()
+    tool.caller.tool_collection.read_only = True
+    await tool.run_workflow(resume_from_run_id=first_run_id)
+
+    assert len(calls) == 1
+    assert calls[0][2]["actual_agent_type"] == "InvestigationAgent"
 
 
 @pytest.mark.asyncio
@@ -312,7 +344,11 @@ async def test_per_agent_markdown_and_jsonl_are_written(workflow_tool):
     markdown_text = markdown.read_text()
     assert "artifact task" in markdown_text
     assert "final artifact recap" in markdown_text
+    assert "- Requested routing: null" in markdown_text
     assert "Tokens: 11" in markdown_text
+    assert "Actual agent type: ArtifactAgent" in markdown_text
+    assert "Requested routing: null" in markdown_text
+    assert '"provider": "anthropic"' in markdown_text
     assert "artifact answer" in raw.read_text()
     assert json.loads((Path(state_dir) / "workflows" / run_id / "run.json").read_text())["total_tokens"] == 11
 
@@ -347,7 +383,7 @@ async def test_read_only_caller_forces_investigation_agents(workflow_tool, calle
     seen = []
 
     async def stub(agent_class, task, *, config=None, schema=None, sub_agent_info_extra=None, **kwargs):
-        seen.append(agent_class.__name__)
+        seen.append((agent_class.__name__, config, sub_agent_info_extra))
         return (f"recap:{task}", 1, None)
 
     tool._agent_tool.dispatch_workflow_agent = stub
@@ -358,7 +394,8 @@ async def test_read_only_caller_forces_investigation_agents(workflow_tool, calle
         "return 1\n"
     )
     await tool.run_workflow(script=script)
-    assert seen == ["InvestigationAgent", "InvestigationAgent"]
+    assert [entry[0] for entry in seen] == ["InvestigationAgent", "InvestigationAgent"]
+    assert all(entry[2]["actual_agent_type"] == "InvestigationAgent" for entry in seen)
 
 
 @pytest.mark.asyncio
@@ -383,24 +420,219 @@ def _config_with_investigation_override() -> AgentConfig:
     )
 
 
-def test_config_override_clears_agent_models_for_explicit_model(tmp_path, connection_manager, caller):
+@pytest.mark.asyncio
+async def test_atomic_override_replaces_only_actual_worker_role(tmp_path, connection_manager, caller):
     config = _config_with_investigation_override()
     tool = WorkflowTool(str(tmp_path / "project"), "ws", "thread", connection_manager, config, caller, None)
+    original_fast = config.fast_config
+    original_thinking = config.thinking_config
+    original_agent_models = dict(config.agent_models)
+    captured: list[AgentConfig] = []
 
-    overridden = tool._config_override("claude-opus-4-7", "high")
-    assert overridden is not None
+    async def stub(
+        agent_class: type[Any],
+        task: str,
+        *,
+        config: AgentConfig | None = None,
+        **kwargs: Any,
+    ):
+        assert agent_class.__name__ == "InvestigationAgent"
+        assert config is not None
+        captured.append(config)
+        return ("ok", 1, None)
 
-    assert overridden.long_context_config.model == "claude-opus-4-7"
-    assert overridden.long_context_config.thinking_effort == "high"
-    # The workflow author's explicit model wins over the role override.
-    assert overridden.agent_models == {}
-    assert overridden.model_config_for_agent("investigation-agent").model == "claude-opus-4-7"
+    tool._agent_tool.dispatch_workflow_agent = stub
+    script = (
+        'meta = {"name": "override", "description": "d"}\n'
+        'return await agent("route", agent_type="investigation", '
+        'model_override={"provider": "anthropic", "model": "claude-opus-4-7", "effort": "high"})\n'
+    )
+    await tool.run_workflow(script=script)
+
+    overridden = captured[0]
+    selected = overridden.model_config_for_agent("investigation-agent")
+    assert selected.provider == ModelProvider.ANTHROPIC
+    assert selected.model == "claude-opus-4-7"
+    assert selected.thinking_effort == "high"
+    assert overridden.fast_config == original_fast
+    assert overridden.thinking_config == original_thinking
+    assert config.agent_models == original_agent_models
 
 
-def test_config_override_none_preserves_role_overrides(tmp_path, connection_manager, caller):
+@pytest.mark.asyncio
+async def test_atomic_override_accepts_explicit_null_for_no_effort_model(workflow_tool):
+    tool, _ = workflow_tool
+    captured: list[AgentConfig] = []
+
+    async def stub(
+        agent_class: type[Any],
+        task: str,
+        *,
+        config: AgentConfig | None = None,
+        **kwargs: Any,
+    ):
+        assert config is not None
+        captured.append(config)
+        return ("ok", 1, None)
+
+    tool._agent_tool.dispatch_workflow_agent = stub
+    script = (
+        'meta = {"name": "no-effort", "description": "d"}\n'
+        'return await agent("route", model_override={"provider": "anthropic", '
+        '"model": "claude-sonnet-4-5-20250929", "effort": None})\n'
+    )
+    await tool.run_workflow(script=script)
+
+    selected = captured[0].model_config_for_agent("general-agent")
+    assert selected.model == "claude-sonnet-4-5-20250929"
+    assert selected.thinking_effort is None
+
+
+@pytest.mark.asyncio
+async def test_no_override_passes_through_role_configuration(tmp_path, connection_manager, caller):
     config = _config_with_investigation_override()
     tool = WorkflowTool(str(tmp_path / "project"), "ws", "thread", connection_manager, config, caller, None)
+    captured: list[Any] = []
 
-    # No explicit model/effort -> no clone, role overrides still flow to sub-agents.
-    assert tool._config_override(None, None) is None
+    async def stub(agent_class, task, *, config=None, sub_agent_info_extra=None, **kwargs):
+        captured.append((config, sub_agent_info_extra))
+        return ("ok", 1, None)
+
+    tool._agent_tool.dispatch_workflow_agent = stub
+    script = 'meta = {"name": "inherit", "description": "d"}\nreturn await agent("route", agent_type="investigation")\n'
+    await tool.run_workflow(script=script)
+
+    assert captured[0][0] is None
+    assert captured[0][1]["effective_routing"] == {
+        "provider": "deepseek",
+        "model": "deepseek-v4-flash",
+        "effort": None,
+    }
     assert config.model_config_for_agent("investigation-agent").model == "deepseek-v4-flash"
+
+
+@pytest.mark.asyncio
+async def test_invalid_override_is_a_failed_agent_result_without_dispatch(workflow_tool):
+    tool, state_dir = workflow_tool
+    stub = AsyncMock()
+    tool._agent_tool.dispatch_workflow_agent = stub
+    script = (
+        'meta = {"name": "invalid-route", "description": "d"}\n'
+        'return await agent("route", model_override={'
+        '"provider": "anthropic", "model": "claude-opus-4-8", "effort": None})\n'
+    )
+
+    summary = await tool.run_workflow(script=script)
+
+    stub.assert_not_awaited()
+    run_id = next(line.split("runId:")[1].strip() for line in summary.splitlines() if "runId:" in line)
+    run_dir = Path(state_dir) / "workflows" / run_id
+    journal_entry = json.loads((run_dir / "journal.jsonl").read_text().splitlines()[0])
+    assert journal_entry["status"] == "failed"
+    assert "effort must be a string" in journal_entry["error"]
+    assert journal_entry["actual_agent_type"] == "GeneralAgent"
+
+
+@pytest.mark.asyncio
+async def test_browser_override_requires_vision_after_actual_class_selection(workflow_tool):
+    tool, state_dir = workflow_tool
+    stub = AsyncMock()
+    tool._agent_tool.dispatch_workflow_agent = stub
+    script = (
+        'meta = {"name": "browser-route", "description": "d"}\n'
+        'return await agent("browse", agent_type="browser", model_override={'
+        '"provider": "deepseek", "model": "deepseek-v4-flash", "effort": "high"})\n'
+    )
+
+    summary = await tool.run_workflow(script=script)
+
+    stub.assert_not_awaited()
+    run_id = next(line.split("runId:")[1].strip() for line in summary.splitlines() if "runId:" in line)
+    entry = json.loads((Path(state_dir) / "workflows" / run_id / "journal.jsonl").read_text().splitlines()[0])
+    assert entry["status"] == "failed"
+    assert "vision-capable" in entry["error"]
+    assert entry["actual_agent_type"] == "BrowserAgent"
+
+
+@pytest.mark.asyncio
+async def test_plan_mode_resolves_override_for_forced_investigation_agent(workflow_tool, caller):
+    tool, state_dir = workflow_tool
+    caller.tool_collection.read_only = True
+    captured: list[tuple[type[Any], AgentConfig, dict[str, Any], dict[str, Any]]] = []
+
+    async def stub(
+        agent_class: type[Any],
+        task: str,
+        *,
+        config: AgentConfig | None = None,
+        sub_agent_info_extra: dict[str, Any] | None = None,
+        artifact_metadata: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ):
+        assert config is not None
+        assert sub_agent_info_extra is not None
+        assert artifact_metadata is not None
+        captured.append((agent_class, config, sub_agent_info_extra, artifact_metadata))
+        return ("ok", 1, None)
+
+    tool._agent_tool.dispatch_workflow_agent = stub
+    script = (
+        'meta = {"name": "plan-route", "description": "d"}\n'
+        'return await agent("route", agent_type="browser", model_override={'
+        '"provider": "deepseek", "model": "deepseek-v4-flash", "effort": "high"})\n'
+    )
+    summary = await tool.run_workflow(script=script)
+
+    agent_class, config, sub_info, artifact_metadata = captured[0]
+    assert agent_class.__name__ == "InvestigationAgent"
+    assert config.model_config_for_agent("investigation-agent").provider == ModelProvider.DEEPSEEK
+    assert sub_info["actual_agent_type"] == "InvestigationAgent"
+    assert sub_info["requested_routing"]["provider"] == "deepseek"
+    assert artifact_metadata["actual_agent_type"] == "InvestigationAgent"
+
+    run_id = next(line.split("runId:")[1].strip() for line in summary.splitlines() if "runId:" in line)
+    run_dir = Path(state_dir) / "workflows" / run_id
+    journal_entry = json.loads((run_dir / "journal.jsonl").read_text().splitlines()[0])
+    assert journal_entry["actual_agent_type"] == "InvestigationAgent"
+    assert journal_entry["effective_routing"]["provider"] == "deepseek"
+    transcript = (run_dir / "transcript.md").read_text()
+    assert "InvestigationAgent" in transcript
+    assert "deepseek-v4-flash" in transcript
+
+
+@pytest.mark.asyncio
+async def test_changed_inherited_routing_invalidates_resume(
+    tmp_path: Path,
+    connection_manager,
+    caller,
+    monkeypatch,
+):
+    monkeypatch.setenv("KOLEGA_CODE_STATE_DIR", str(tmp_path))
+    first_config = _config_with_investigation_override()
+    first = WorkflowTool(str(tmp_path / "project"), "ws", "thread", connection_manager, first_config, caller, None)
+    first_stub, first_calls = _stub_dispatch()
+    first._agent_tool.dispatch_workflow_agent = first_stub
+    script = (
+        'meta = {"name": "fingerprint", "description": "d"}\nreturn await agent("route", agent_type="investigation")\n'
+    )
+    first_summary = await first.run_workflow(script=script)
+    first_run_id = next(line.split("runId:")[1].strip() for line in first_summary.splitlines() if "runId:" in line)
+    assert len(first_calls) == 1
+
+    second_config = first_config.model_copy(
+        update={
+            "agent_models": {
+                "investigation": ModelConfig(
+                    provider=ModelProvider.ANTHROPIC,
+                    model="claude-opus-4-8",
+                    thinking_effort="high",
+                )
+            }
+        }
+    )
+    second = WorkflowTool(str(tmp_path / "project"), "ws", "thread", connection_manager, second_config, caller, None)
+    second_stub, second_calls = _stub_dispatch()
+    second._agent_tool.dispatch_workflow_agent = second_stub
+
+    await second.run_workflow(script=script, resume_from_run_id=first_run_id)
+    assert len(second_calls) == 1

--- a/tests/cli/test_app_goal_command.py
+++ b/tests/cli/test_app_goal_command.py
@@ -165,9 +165,10 @@ async def _wait_goal_terminal(app, pilot, *, timeout: float = 8.0) -> None:
         return goal is None or goal.met or goal.paused
 
     await _wait_for(app, pilot, _terminal, timeout=timeout)
-    # Let the worker finish any post-terminal bookkeeping / notify calls.
-    for _ in range(5):
-        await pilot.pause(0.02)
+    # Goal state becomes terminal before persistence and transcript notifications
+    # finish. The turn worker owns ``agent_worker`` for the complete goal loop, so
+    # its release is the deterministic post-terminal completion boundary.
+    await _wait_for(app, pilot, lambda: app.agent_worker is None, timeout=timeout)
 
 
 async def _wait_turn_idle(app, pilot, *, timeout: float = 6.0) -> None:


### PR DESCRIPTION
## Summary

- add sanitized, credential-free sub-agent model discovery through `list_subagent_models`
- treat omitted, `null`, empty, and whitespace-only provider filters as unfiltered discovery for tool-calling API portability
- render model-facing discovery as compact Markdown while retaining structured internal catalog data
- support complete atomic `model_override` objects across built-in/custom dispatch and Gigacode workers
- validate provider/model/effort combinations without fallback, including nullable effort and Browser vision requirements
- scope overrides to direct workers, preserve role/helper routing, and make resume identity sensitive to actual worker class, Plan mode, and inherited routing
- persist requested/effective routing and actual worker metadata in workflow journals, events, transcripts, and per-agent artifacts
- document the API, migration from Gigacode `model=`/`effort=`, failure semantics, and direct-worker scope
- stabilize goal-loop CI tests by waiting for the owning turn worker instead of a fixed post-terminal sleep

## Testing

- `PYTHONDONTWRITEBYTECODE=1 ./run_tests.sh` — 2,644 passed, 103 deselected (Python 3.11)
- focused routing/tool/goal suite — 95 passed
- Python 3.11 CI regression cases repeated 10 times — 20 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `npm run build --prefix docs`
- commit hooks passed

The docs dependency install reports the repository's existing npm audit findings (3 moderate and 4 high), but the Astro build succeeds.

## Prompt for exercising this in Kolega Code

Paste the following into a configured Kolega Code session. Enable Gigacode first if it is not already enabled. The prompt intentionally adapts to whichever providers/models are configured rather than assuming credentials:

```text
Exercise the atomic per-dispatch sub-agent model routing feature end to end without modifying project files.

1. Call list_subagent_models without a provider filter and summarize the effective role defaults and configured provider-qualified models from its compact Markdown result. Do not expose credentials.
2. Choose a configured model that differs from the Investigation role default, if one exists. Dispatch an Investigation agent with one complete model_override using provider, model, and thinking_effort exactly as the catalog requires. If the model has no effort control, use explicit null. Report the requested and effective route from the emitted metadata.
3. If a configured model reports vision support, dispatch a Browser agent with a complete override and ask it to open https://example.com and report the page title. Do not route Browser to a model without vision support.
4. Run a Gigacode workflow with max_agent_depth=2. Give its direct Coder worker a complete model_override (Gigacode uses the field name effort), and have that worker dispatch an Investigation child without an override; Coder supports this delegation, while General workers intentionally do not gain new dispatch tools from max_agent_depth. Also run one direct General worker with no override. Read the workflow transcript, emitted sub-agent metadata, and per-agent artifacts, then verify that:
   - the direct Coder override records requested/effective routing and actual worker class CoderAgent;
   - the no-override direct General call records requested_routing as null plus its effective inherited route;
   - the depth-2 Investigation child uses its Investigation role default rather than inheriting the direct Coder override;
   - the depth-2 child is a leaf and cannot dispatch another agent.
5. Run a tiny saved-style workflow that calls agent(..., model=..., effort=...) and confirm it fails with the targeted migration guidance to use a complete model_override object.
6. Summarize each successful and expected-failure case, including artifact paths. If the catalog has no suitable non-default or vision-capable route, clearly mark that case skipped rather than guessing or falling back.
```
