### PR TITLE
chore(skills): bundle kolega-skills v0.2.1

### DIFF
--- a/docs/src/content/docs/skills.mdx
+++ b/docs/src/content/docs/skills.mdx
@@ -26,7 +26,7 @@ Skills come from three scopes:
 | **Project** | `<project>/.agents/skills/` |
 
 The bundled catalog is pinned to
-[`kolega-skills` v0.1.0](https://github.com/kolega-ai/kolega-skills/tree/v0.1.0)
+[`kolega-skills` v0.2.1](https://github.com/kolega-ai/kolega-skills/tree/v0.2.1)
 and includes `docx`, `pdf`, `pptx`, `review`, `skill-authoring`, and `xlsx`.
 It is part of the installed package, so listing and activating these skills does not
 download anything or follow the upstream repository's latest branch.

--- a/kolega_code/_bundled_skills/manifest.json
+++ b/kolega_code/_bundled_skills/manifest.json
@@ -98,19 +98,19 @@
     },
     {
       "path": "skills/pptx/SKILL.md",
-      "sha256": "1e99ec6f4b13edbb3d48876bdec17f37ceda50c6e33e0e3459afd7788cbe3906"
+      "sha256": "f4c2ff4db2681de521e16480d34192eeff6c6d8883f196266c2cafa784dd0678"
     },
     {
       "path": "skills/pptx/references/examples.md",
-      "sha256": "e78c4e23a2b1ad628a3b9b8860fdafc7e5bbcf6645e8a9f812bad77c8b3fa917"
+      "sha256": "020ed4fef07d14632fa07cc7fadd106e40877392439422ab4a43acd4fcc47edf"
     },
     {
       "path": "skills/pptx/references/limitations.md",
-      "sha256": "afda2bb5f9483b8e100530e9b5e0680c69e72df2437ba12d4f542e096e40fa0f"
+      "sha256": "dced96e324e70c8c1221481d990c443a23e91d1a2fab7e69cc6a26cfbc815cb4"
     },
     {
       "path": "skills/pptx/references/operations.md",
-      "sha256": "4af252aec435ccefeeb74a368bf16206f692915d1a407e862315ec8312dd21ad"
+      "sha256": "ef0a0f508b562d65d16624cf126075c33924a156b71efbe4cc0ff995a1be87d1"
     },
     {
       "path": "skills/pptx/requirements.txt",
@@ -118,11 +118,11 @@
     },
     {
       "path": "skills/pptx/scripts/pptx_tool.py",
-      "sha256": "797010c17f170010d837be9d3541b7bfaa8856a67e34ce41566889b74925cb35"
+      "sha256": "b67bf31e00ea81904b89b2dc3a48dc346e0a940f99cd86c9c042a81d8b331465"
     },
     {
       "path": "skills/pptx/scripts/smoke_test.py",
-      "sha256": "54ffa99a72c4bdb4effbe6da0ba11920609a28c7d9701fe915e90f6959cc7f2d"
+      "sha256": "200d9d5f1ffdaa8497c589877f0941d8cf79a94743ddb737952e0aeab5179ba0"
     },
     {
       "path": "skills/review/SKILL.md",
@@ -187,8 +187,8 @@
     "xlsx"
   ],
   "source": {
-    "commit": "fa6aaec9b7fdec1dc10c0a7875ce3981ecd1994e",
+    "commit": "22eeee98363a92c199d234a10a798cbdaf3998e2",
     "repository": "https://github.com/kolega-ai/kolega-skills",
-    "tag": "v0.2.0"
+    "tag": "v0.2.1"
   }
 }

--- a/kolega_code/_bundled_skills/skills/pptx/SKILL.md
+++ b/kolega_code/_bundled_skills/skills/pptx/SKILL.md
@@ -49,6 +49,9 @@ and with which installer. Use the selected interpreter's `-m pip` for the declar
    expected slide IDs/order/count, existing internal relationship targets, and resolved owner
    relationship references. Inspect the output again; when visual fidelity matters, continue
    with step 7 and treat the target presentation application as the final authority. Review the
+   `text.word_wrap` value for generated titles, bodies, and text elements and require it to be
+   `true`; LibreOffice can visually wrap a non-wrapping frame that PowerPoint lets overflow.
+   Review the
    font inventory (`fonts.referenced`,
    `fonts.embedded`, `fonts.unembedded`). For PPTX+PDF deliverables apply this release gate: use
    only Arial for headings and sans body, Times New Roman for serif body, and Courier New for

--- a/kolega_code/_bundled_skills/skills/pptx/references/examples.md
+++ b/kolega_code/_bundled_skills/skills/pptx/references/examples.md
@@ -269,6 +269,8 @@ After create/edit:
 - retained slide IDs are unchanged and reported order equals the requested order;
 - all internal relationship targets exist, and relationship-namespace references in owner XML
   resolve through that owner's relationship part;
+- generated title, body, and text-element frames report `text.word_wrap: true`; narrow edits to
+  imported frames preserve their existing wrapping setting;
 - table/chart/image/note inspection reflects the requested values;
 - for PPTX+PDF deliverables, no `RELEASE BLOCKER:` font warning remains in the final inspection;
 - no sibling temporary output remains after success or failure.

--- a/kolega_code/_bundled_skills/skills/pptx/references/limitations.md
+++ b/kolega_code/_bundled_skills/skills/pptx/references/limitations.md
@@ -77,6 +77,13 @@ LibreOffice PDF. PNG verification proves signature, openability, page count, and
 not renderer-identical pixels. Rendered slides support layout review, not a PowerPoint-fidelity
 claim.
 
+LibreOffice can visually wrap text even when the frame's serialized wrapping setting is false,
+while PowerPoint may honor that setting and let the line overflow horizontally. The tool
+explicitly enables wrapping for text frames it authors, but imported frames can retain either
+setting. Use `inspect` and check `text.word_wrap` rather than treating a LibreOffice render as
+proof of PowerPoint wrapping. Wrapping can increase vertical text usage, so box height and
+vertical overflow still require visual review.
+
 The font inventory over-approximates: fonts referenced only by unused layouts, masters, notes or
 handout masters, or table styles still count as referenced because they ship with the deck and
 re-engage as soon as a layout is used. Script-specific theme fonts (`a:font script="..."`), VML

--- a/kolega_code/_bundled_skills/skills/pptx/references/operations.md
+++ b/kolega_code/_bundled_skills/skills/pptx/references/operations.md
@@ -244,6 +244,11 @@ All geometry uses inches:
 `title` may be a string or a paragraph object. `body` is a string or paragraph list. A paragraph
 supports `text` or `runs`, `level` (0-8), and `alignment` (`left`, `center`, `right`, `justify`).
 A run supports `text`, `bold`, `italic`, `font_name`, `font_size`, and six-digit `color`.
+The tool explicitly enables word wrapping for authored title, body, and text-element frames,
+including frames created by `edit`'s `add_slide` action. Narrow edits to existing frames, such as
+`replace_text` or hyperlink changes, preserve the source frame's wrapping setting. `inspect`
+reports the serialized setting as `text.word_wrap`; require `true` for generated prose frames
+instead of inferring PowerPoint behavior from a LibreOffice render.
 
 Elements:
 

--- a/kolega_code/_bundled_skills/skills/pptx/scripts/pptx_tool.py
+++ b/kolega_code/_bundled_skills/skills/pptx/scripts/pptx_tool.py
@@ -1973,6 +1973,7 @@ def _normalize_paragraphs(value: Any, label: str) -> list[dict[str, Any]]:
 def _set_text_frame(text_frame: Any, value: Any, label: str) -> None:
     paragraphs = _normalize_paragraphs(value, label)
     text_frame.clear()
+    text_frame.word_wrap = True
     for index, spec in enumerate(paragraphs):
         _reject_unknown(spec, {"text", "runs", "level", "alignment"}, f"{label}[{index}]")
         if ("text" in spec) == ("runs" in spec):

--- a/kolega_code/_bundled_skills/skills/pptx/scripts/smoke_test.py
+++ b/kolega_code/_bundled_skills/skills/pptx/scripts/smoke_test.py
@@ -483,6 +483,77 @@ def _run_smoke(require_libreoffice: bool) -> dict[str, Any]:
         body_name = body_shape["name"]
         checks.append("inspect/content-inventory")
 
+        authored_text_shapes = [
+            _shape_containing(slides[0], "Operations brief"),
+            _shape_containing(slides[0], "Generated fixture"),
+            _shape_with_name(slides[2], "Appendix Text"),
+        ]
+        _assert(
+            all(shape["text"]["word_wrap"] is True for shape in authored_text_shapes),
+            "created title, body, and text element must explicitly enable word wrapping",
+        )
+        reopened_created = Presentation(str(created))
+        reopened_wrapping = {
+            shape.text_frame.text: shape.text_frame.word_wrap
+            for slide in reopened_created.slides
+            for shape in slide.shapes
+            if shape.has_text_frame
+            and shape.text_frame.text
+            in {"Operations brief", "Generated fixture", "Retained slide identity"}
+        }
+        _assert(
+            reopened_wrapping
+            == {
+                "Operations brief": True,
+                "Generated fixture": True,
+                "Retained slide identity": True,
+            },
+            "word wrapping was not serialized for authored text frames",
+        )
+        checks.append("create/text-wrapping")
+
+        nowrap_source = work / "nowrap-source.pptx"
+        nowrap_presentation = Presentation()
+        nowrap_slide = nowrap_presentation.slides.add_slide(nowrap_presentation.slide_layouts[6])
+        nowrap_shape = nowrap_slide.shapes.add_textbox(
+            PptxTool.Inches(1.0),
+            PptxTool.Inches(1.0),
+            PptxTool.Inches(2.0),
+            PptxTool.Inches(1.0),
+        )
+        nowrap_shape.name = "No-Wrap Text"
+        nowrap_shape.text_frame.word_wrap = False
+        nowrap_shape.text_frame.text = "Original no-wrap content"
+        nowrap_presentation.save(str(nowrap_source))
+        nowrap_job = work / "nowrap-edit.json"
+        nowrap_output = work / "nowrap-edited.pptx"
+        _write_json(
+            nowrap_job,
+            {
+                "schema_version": 1,
+                "operation": "edit",
+                "operations": [
+                    {
+                        "action": "replace_text",
+                        "shape": {"shape_name": "No-Wrap Text"},
+                        "find": "Original",
+                        "replace": "Updated",
+                    }
+                ],
+            },
+        )
+        _run(["edit", str(nowrap_source), "--job", str(nowrap_job), "--output", str(nowrap_output)])
+        nowrap_inspection = _run(["inspect", str(nowrap_output)])
+        edited_nowrap_shape = _shape_with_name(
+            nowrap_inspection["presentation"]["slides"][0], "No-Wrap Text"
+        )
+        _assert(
+            edited_nowrap_shape["text"]["text"] == "Updated no-wrap content"
+            and edited_nowrap_shape["text"]["word_wrap"] is False,
+            "narrow text replacement changed an existing frame's wrapping setting",
+        )
+        checks.append("edit/preserve-existing-text-wrapping")
+
         fonts_report = first_inspection["fonts"]
         _assert(
             {"+mj-lt", "+mn-lt"} <= set(fonts_report["theme_tokens_referenced"]),
@@ -851,6 +922,12 @@ def _run_smoke(require_libreoffice: bool) -> dict[str, Any]:
         _assert(all(slide_id in second_ids for slide_id in original_ids), "retained ID changed")
         new_ids = [slide_id for slide_id in second_ids if slide_id not in original_ids]
         _assert(len(new_ids) == 1 and second_ids[1] == new_ids[0], "inserted slide order mismatch")
+        inserted = next(slide for slide in second_slides if slide["slide_id"] == new_ids[0])
+        _assert(
+            _shape_containing(inserted, "Inserted decision")["text"]["word_wrap"] is True
+            and _shape_with_name(inserted, "Inserted Text")["text"]["word_wrap"] is True,
+            "edit add_slide did not explicitly enable wrapping for authored text frames",
+        )
         evidence = next(slide for slide in second_slides if slide["slide_id"] == original_ids[1])
         _assert(
             "Style-safe replacement" in _shape_containing(evidence, "Style-safe")["text"]["text"],


### PR DESCRIPTION
## Summary
- vendor the immutable `kolega-skills` `v0.2.1` snapshot at commit `22eeee98363a92c199d234a10a798cbdaf3998e2`
- include the PPTX authored-text wrapping fix, regression coverage, and renderer guidance
- regenerate bundled skill hashes and provenance metadata
- update the bundled catalog documentation link to `v0.2.1`

## Verification
- `PYTHONDONTWRITEBYTECODE=1 ./run_tests.sh tests/cli/test_bundled_skills.py -ra`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv build`
- `uv run python scripts/verify_bundled_skill_artifacts.py dist/kolega_code-0.21.1.tar.gz dist/kolega_code-0.21.1-py3-none-any.whl`
- `cd docs && npm run build`
- commit hooks, including Pyright