### PR TITLE
fix(terminal): resolve command workdirs from project root

### DIFF
--- a/kolega_code/agent/context.py
+++ b/kolega_code/agent/context.py
@@ -59,7 +59,9 @@ class AgentServices:
         """Default local-machine services rooted at the workspace project path."""
         return cls(
             filesystem=LocalFileSystem(root_path=workspace.project_path),
-            terminal_manager=LocalTerminalManager(workspace.workspace_id, workspace.thread_id, connection_manager),
+            terminal_manager=LocalTerminalManager(
+                workspace.workspace_id, workspace.thread_id, connection_manager, default_workdir=workspace.project_path
+            ),
             browser_manager=PlaywrightBrowserManager(),
         )
 

--- a/kolega_code/agent/tool_backend/terminal_tool.py
+++ b/kolega_code/agent/tool_backend/terminal_tool.py
@@ -47,7 +47,10 @@ class TerminalTool(BaseTool):
         # Use injected terminal_manager if provided, otherwise create local one
         if self.terminal_manager is None:
             self.terminal_manager = LocalTerminalManager(
-                workspace_id=workspace_id, thread_id=thread_id, connection_manager=connection_manager
+                workspace_id=workspace_id,
+                thread_id=thread_id,
+                connection_manager=connection_manager,
+                default_workdir=self.project_path,
             )
 
     async def _run_command_security_check(self, command: str) -> Tuple[bool, str]:
@@ -135,7 +138,8 @@ class TerminalTool(BaseTool):
 
         Args:
             command: Shell command line, executed via `bash -c`.
-            workdir: Working directory for the command. Defaults to project root.
+            workdir: Working directory for the command. Relative paths resolve
+                     against the project root. Defaults to project root.
             yield_time_ms: How long to wait for output/exit before returning,
                            in milliseconds (clamped to 250–30000).
             max_output_tokens: Maximum tokens of output to return in this call.
@@ -151,7 +155,9 @@ class TerminalTool(BaseTool):
             if not allowed:
                 return denied_reason
 
-        wd = workdir or str(self.project_path)
+        # Resolve relative workdirs against the project root (same contract as
+        # the file tools), never against this process's cwd.
+        wd = os.path.normpath(str(self.project_path / workdir)) if workdir else str(self.project_path)
         try:
             result = await self.terminal_manager.exec_command(
                 command,

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -606,7 +606,9 @@ class ToolCollection(LogMixin):
 
         # Create terminal manager instance if not provided
         if terminal_manager is None:
-            self.terminal_manager = LocalTerminalManager(workspace_id, thread_id, connection_manager)
+            self.terminal_manager = LocalTerminalManager(
+                workspace_id, thread_id, connection_manager, default_workdir=self.project_path
+            )
         else:
             self.terminal_manager = terminal_manager
 

--- a/kolega_code/sandbox/local.py
+++ b/kolega_code/sandbox/local.py
@@ -38,7 +38,12 @@ class LocalSandboxManager(SandboxManager):
             self.filesystem = LocalFileSystem(root_path=workspace.directory_path)
         if self.terminal_manager is None:
             assert self.connection_manager is not None, "connection_manager is required for LocalTerminalManager"
-            self.terminal_manager = LocalTerminalManager(workspace_id, thread_id, self.connection_manager)
+            self.terminal_manager = LocalTerminalManager(
+                workspace_id,
+                thread_id,
+                self.connection_manager,
+                default_workdir=workspace.directory_path if workspace else None,
+            )
         if self.browser_manager is None:
             self.browser_manager = PlaywrightBrowserManager()
 

--- a/kolega_code/services/terminal.py
+++ b/kolega_code/services/terminal.py
@@ -19,7 +19,7 @@ import signal
 import struct
 import termios
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 from ..events import AgentConnectionManager
 from ..events import AgentEvent
@@ -333,15 +333,23 @@ class PtySession:
 class LocalTerminalManager(TerminalManager):
     """Registry of local PTY sessions implementing the unified-exec interface."""
 
-    def __init__(self, workspace_id: str, thread_id: str, connection_manager: AgentConnectionManager):
+    def __init__(
+        self,
+        workspace_id: str,
+        thread_id: str,
+        connection_manager: AgentConnectionManager,
+        default_workdir: Optional[Union[str, os.PathLike]] = None,
+    ):
         self.workspace_id = workspace_id
         self.thread_id = thread_id
         self.connection_manager = connection_manager
         self.sessions: Dict[str, PtySession] = {}
         self._counter = 0
         self.auto_activate_venv = True
-        # Default working directory for commands that don't pass one.
-        self.default_workdir = os.getcwd()
+        # Default working directory for commands that don't pass one. Callers
+        # that serve a project should pass its root; the process cwd is only a
+        # fallback for standalone use.
+        self.default_workdir = str(default_workdir) if default_workdir else os.getcwd()
 
     def _next_session_id(self) -> str:
         self._counter += 1
@@ -422,7 +430,9 @@ class LocalTerminalManager(TerminalManager):
         env: Optional[Dict[str, str]] = None,
     ) -> ExecResult:
         yield_ms = clamp_yield(yield_time_ms, poll=False)
-        wd = workdir or self.default_workdir or os.getcwd()
+        # workdir should be absolute; a relative path would chdir relative to
+        # this process's cwd, not default_workdir.
+        wd = workdir or self.default_workdir
         session_id = self._next_session_id()
 
         await self._emit_command(session_id, command)

--- a/tests/agent/services/test_terminal.py
+++ b/tests/agent/services/test_terminal.py
@@ -135,6 +135,15 @@ async def test_workdir_is_respected(manager, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_constructed_default_workdir_is_used_when_workdir_omitted(tmp_path):
+    manager = LocalTerminalManager("workspace", "thread", _RecordingConnectionManager(), default_workdir=tmp_path)
+    result = await manager.exec_command("pwd", yield_time_ms=3000)
+    assert result.status == "exited"
+    # Commands must run in the configured project root, not the process cwd.
+    assert result.output.strip().endswith(tmp_path.name)
+
+
+@pytest.mark.asyncio
 async def test_no_cwd_persistence_between_calls(manager, tmp_path):
     sub = tmp_path / "sub"
     sub.mkdir()

--- a/tests/agent/tool_backend/test_terminal_tool.py
+++ b/tests/agent/tool_backend/test_terminal_tool.py
@@ -175,6 +175,42 @@ class TestUnifiedExecTools:
         assert kwargs["workdir"] == str(terminal_tool.project_path)
 
     @pytest.mark.asyncio
+    async def test_exec_command_resolves_relative_workdir_against_project_root(self, terminal_tool):
+        terminal_tool.terminal_manager = Mock()
+        terminal_tool.terminal_manager.exec_command = AsyncMock(
+            return_value=ExecResult(status="exited", exit_code=0, output="", duration_ms=1)
+        )
+
+        # "." must mean the project root, not the process cwd the CLI was
+        # launched from (regression: commands ran in the launch directory).
+        await terminal_tool.exec_command("pwd", workdir=".")
+        kwargs = terminal_tool.terminal_manager.exec_command.call_args.kwargs
+        assert kwargs["workdir"] == str(terminal_tool.project_path)
+
+        await terminal_tool.exec_command("pwd", workdir="sub/dir")
+        kwargs = terminal_tool.terminal_manager.exec_command.call_args.kwargs
+        assert kwargs["workdir"] == str(terminal_tool.project_path / "sub" / "dir")
+
+    @pytest.mark.asyncio
+    async def test_exec_command_end_to_end_runs_in_project_root(self, terminal_tool):
+        # Real PTY through the default manager: even when the CLI process runs
+        # elsewhere, workdir="." must land in the project root.
+        data = json.loads(await terminal_tool.exec_command("pwd", workdir=".", yield_time_ms=5000))
+        assert data["status"] == "exited"
+        assert data["output"].strip().endswith(terminal_tool.project_path.name)
+
+    @pytest.mark.asyncio
+    async def test_exec_command_passes_absolute_workdir_through(self, terminal_tool):
+        terminal_tool.terminal_manager = Mock()
+        terminal_tool.terminal_manager.exec_command = AsyncMock(
+            return_value=ExecResult(status="exited", exit_code=0, output="", duration_ms=1)
+        )
+
+        await terminal_tool.exec_command("pwd", workdir="/somewhere/else")
+        kwargs = terminal_tool.terminal_manager.exec_command.call_args.kwargs
+        assert kwargs["workdir"] == "/somewhere/else"
+
+    @pytest.mark.asyncio
     async def test_exec_command_running_returns_session_id(self, terminal_tool):
         terminal_tool.terminal_manager = Mock()
         terminal_tool.terminal_manager.exec_command = AsyncMock(


### PR DESCRIPTION
## Summary

- resolve model-provided relative terminal workdirs against the session project root
- inject project-root defaults into every local terminal manager construction path
- preserve the current-directory fallback for external callers that do not provide a default
- add unit and real-PTY regressions for relative, absolute, and omitted workdirs

## Bug

Launching Kolega Code for a project outside the shell's current directory could run shell commands in the launch directory when the model supplied `workdir: "."`. File tools already treated relative paths as project-relative, but the terminal tool passed `.` through to the PTY process unchanged.

## Fix

`TerminalTool.exec_command` now normalizes relative workdirs against `project_path` before dispatch. `LocalTerminalManager` also accepts an optional `default_workdir`, and all internal local construction paths provide their project directory.

## Tests

- `./run_tests.sh tests/agent/services/test_terminal.py tests/agent/tool_backend/test_terminal_tool.py -ra` (35 passed)
- `uv run ruff format --check` on changed files
- `uv run ruff check` on changed files
- `uv run pyright` on changed files
- full `tests/agent` suite previously run: 1502 passed
