### PR TITLE
fix(terminal): scrub runtime venv from child shells

### DIFF
--- a/kolega_code/agent/tool_backend/terminal_tool.py
+++ b/kolega_code/agent/tool_backend/terminal_tool.py
@@ -12,7 +12,7 @@ from kolega_code.llm.models import Message, MessageHistory, TextBlock
 from kolega_code.llm.specs import get_model_specs
 from kolega_code.events import AgentEvent
 from kolega_code.services.base import ExecResult
-from kolega_code.services.terminal import LocalTerminalManager
+from kolega_code.services.terminal import LocalTerminalManager, build_child_env
 from .base_tool import BaseTool
 
 
@@ -277,6 +277,7 @@ class TerminalTool(BaseTool):
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=str(self.project_path),
+                env=build_child_env(),
                 shell=True,
             )
 

--- a/kolega_code/services/terminal.py
+++ b/kolega_code/services/terminal.py
@@ -17,6 +17,7 @@ import pty
 import shlex
 import signal
 import struct
+import sys
 import termios
 import time
 from typing import Any, Dict, Optional, Union
@@ -49,6 +50,45 @@ CLEAN_ENV = {
 }
 
 _VENV_ACTIVATE_REL = os.path.join(".venv", "bin", "activate")
+
+# Env vars `uv run` injects when launching this app from a source checkout.
+_RUNTIME_VENV_VARS = ("VIRTUAL_ENV", "VIRTUAL_ENV_PROMPT", "UV", "UV_RUN_RECURSION_DEPTH")
+
+
+def _strip_runtime_venv(env: Dict[str, str], runtime_prefix: Optional[str] = None) -> Dict[str, str]:
+    """Remove this process's own venv from ``env`` (mutating and returning it).
+
+    Launching from a source checkout via ``uv run`` exports the app's dev venv
+    (VIRTUAL_ENV + a PATH prepend), which child shells would otherwise inherit —
+    making ``python``/``pip`` resolve into the app's venv instead of behaving
+    like a fresh user terminal. Only the app's own venv is stripped: a venv the
+    user activated deliberately is a different prefix and passes through.
+    """
+    venv = env.get("VIRTUAL_ENV")
+    prefix = runtime_prefix or sys.prefix
+    if not venv or os.path.realpath(venv) != os.path.realpath(prefix):
+        return env
+    for var in _RUNTIME_VENV_VARS:
+        env.pop(var, None)
+    venv_bin = os.path.realpath(os.path.join(venv, "bin"))
+    path = env.get("PATH")
+    if path:
+        env["PATH"] = os.pathsep.join(entry for entry in path.split(os.pathsep) if os.path.realpath(entry) != venv_bin)
+    return env
+
+
+def build_child_env(extra: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+    """Assemble the environment for a model-facing child shell.
+
+    The user's own environment minus the app's runtime venv, plus per-session
+    overrides, plus the CLEAN_ENV overlay. Overrides are applied after the
+    scrub so a caller can still set VIRTUAL_ENV deliberately.
+    """
+    env = _strip_runtime_venv(os.environ.copy())
+    if extra:
+        env.update(extra)
+    env.update(CLEAN_ENV)
+    return env
 
 
 def _pick_shell() -> str:
@@ -113,10 +153,7 @@ class PtySession:
     # -- lifecycle ---------------------------------------------------------
 
     async def start(self) -> None:
-        env = os.environ.copy()
-        if self.env:
-            env.update(self.env)
-        env.update(CLEAN_ENV)
+        env = build_child_env(self.env)
 
         command = self.command
         if self.auto_activate_venv:

--- a/tests/agent/services/test_terminal.py
+++ b/tests/agent/services/test_terminal.py
@@ -1,9 +1,12 @@
 import asyncio
+import os
+import sys
+from unittest.mock import patch
 
 import pytest
 
 from kolega_code.events import AgentConnectionManager
-from kolega_code.services.terminal import LocalTerminalManager, PtySession
+from kolega_code.services.terminal import LocalTerminalManager, PtySession, _strip_runtime_venv
 
 
 class _RecordingConnectionManager(AgentConnectionManager):
@@ -151,6 +154,53 @@ async def test_no_cwd_persistence_between_calls(manager, tmp_path):
     await manager.exec_command(f"cd {sub}", workdir=str(tmp_path), yield_time_ms=3000)
     result = await manager.exec_command("pwd", workdir=str(tmp_path), yield_time_ms=3000)
     assert result.output.strip().endswith(tmp_path.name)
+
+
+def test_strip_runtime_venv_removes_own_venv():
+    env = {
+        "VIRTUAL_ENV": "/opt/app/.venv",
+        "VIRTUAL_ENV_PROMPT": "app",
+        "UV": "/usr/local/bin/uv",
+        "UV_RUN_RECURSION_DEPTH": "1",
+        "PATH": "/opt/app/.venv/bin:/usr/local/bin:/usr/bin",
+        "HOME": "/Users/u",
+    }
+    out = _strip_runtime_venv(env, runtime_prefix="/opt/app/.venv")
+    for var in ("VIRTUAL_ENV", "VIRTUAL_ENV_PROMPT", "UV", "UV_RUN_RECURSION_DEPTH"):
+        assert var not in out
+    assert out["PATH"] == "/usr/local/bin:/usr/bin"
+    assert out["HOME"] == "/Users/u"
+
+
+def test_strip_runtime_venv_keeps_user_activated_venv():
+    env = {
+        "VIRTUAL_ENV": "/Users/u/venvs/proj",
+        "PATH": "/Users/u/venvs/proj/bin:/usr/bin",
+        "UV": "/usr/local/bin/uv",
+    }
+    out = _strip_runtime_venv(dict(env), runtime_prefix="/opt/app/.venv")
+    assert out == env
+
+
+def test_strip_runtime_venv_without_active_venv_is_untouched():
+    env = {"PATH": "/usr/local/bin:/usr/bin", "HOME": "/Users/u"}
+    assert _strip_runtime_venv(dict(env), runtime_prefix="/opt/app/.venv") == env
+
+
+@pytest.mark.asyncio
+async def test_child_shell_does_not_inherit_runtime_venv(manager, tmp_path):
+    # Simulate launching from the checkout via `uv run`: the app's own venv is
+    # exported and prepended to PATH. The child shell must see neither.
+    polluted = {"VIRTUAL_ENV": sys.prefix, "PATH": f"{sys.prefix}/bin{os.pathsep}" + os.environ.get("PATH", "")}
+    with patch.dict(os.environ, polluted):
+        # workdir without a .venv so auto-activation doesn't re-set VIRTUAL_ENV
+        result = await manager.exec_command(
+            'echo "V=${VIRTUAL_ENV:-unset}"; echo "P=$PATH"', workdir=str(tmp_path), yield_time_ms=5000
+        )
+    assert result.status == "exited"
+    assert "V=unset" in result.output
+    path_line = next(line for line in result.output.splitlines() if line.startswith("P="))
+    assert f"{sys.prefix}/bin" not in path_line
 
 
 @pytest.mark.asyncio

--- a/tests/agent/tool_backend/test_terminal_tool.py
+++ b/tests/agent/tool_backend/test_terminal_tool.py
@@ -1,6 +1,7 @@
 import os
 import asyncio
 import json
+import sys
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -140,6 +141,24 @@ class TestTerminalTool:
             result = await terminal_tool.execute_terminal_command("empty command")
 
             assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_execute_terminal_command_env_scrubbed_and_clean(self, terminal_tool, mock_connection_manager):
+        mock_process = AsyncMock()
+        mock_process.communicate = AsyncMock(return_value=(b"", b""))
+
+        # Simulate `uv run` from the checkout: the app's own venv leaks into the env.
+        polluted = {"VIRTUAL_ENV": sys.prefix, "PATH": f"{sys.prefix}/bin{os.pathsep}" + os.environ.get("PATH", "")}
+        with patch.dict(os.environ, polluted):
+            with patch("asyncio.create_subprocess_shell", return_value=mock_process) as mock_create:
+                await terminal_tool.execute_terminal_command("pwd")
+
+        env = mock_create.call_args.kwargs["env"]
+        assert "VIRTUAL_ENV" not in env
+        assert f"{sys.prefix}/bin" not in env["PATH"].split(os.pathsep)
+        # CLEAN_ENV overlay now applies to this path too
+        assert env["TERM"] == "dumb"
+        assert env["NO_COLOR"] == "1"
 
     @pytest.mark.asyncio
     async def test_execute_terminal_command_working_directory(self, terminal_tool, mock_connection_manager):


### PR DESCRIPTION
## Summary

- strip Kolega Code's own runtime virtualenv from model-facing child-shell environments
- preserve unrelated user-activated virtualenvs and explicit per-session overrides
- share the sanitized environment assembly across PTY and legacy terminal execution paths
- retain project `.venv` auto-activation after the inherited runtime environment is scrubbed

## Bug

When Kolega Code is launched from its source checkout with `uv run`, `uv` exports the checkout's `.venv` through `VIRTUAL_ENV` and prepends its `bin` directory to `PATH`. Model-run shell commands inherited that host runtime environment, so `python` and `pip` could unexpectedly resolve to Kolega Code's own development environment rather than the target project's normal shell environment.

## Fix

`build_child_env()` now assembles the environment for all model-facing local shells. It removes the runtime virtualenv only when `VIRTUAL_ENV` resolves to `sys.prefix`, including the corresponding `uv` metadata and matching `PATH` entry. A different user-activated virtualenv is preserved, and caller overrides are applied after scrubbing so deliberate values still work.

Both `PtySession.start()` and the legacy `execute_terminal_command` path now use the shared environment builder. Existing project-local `.venv` auto-activation remains unchanged.

## Tests

- `./run_tests.sh tests/agent/services/test_terminal.py tests/agent/tool_backend/test_terminal_tool.py -ra` (40 passed)
- `uv run ruff format --check` on changed files
- `uv run ruff check` on changed files
- `uv run pyright` on changed files
- full `tests/agent` suite previously run: 1507 passed
