### PR TITLE
chore: release v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,27 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.22.0 - 2026-07-22
+
 ### Added
 
 - Bundled the `docx`, `pdf`, `pptx`, `review`, `skill-authoring`, and `xlsx`
-  workflows from `kolega-skills` v0.1.0 so they are available out of the box.
+  workflows from `kolega-skills` v0.2.1 so they are available out of the box.
 - Added a top-level TUI `set_goal` tool so explicit user, Agent Skill, or host
   workflow instructions can enter the existing persistent autonomous goal loop
   without synthesizing a `/goal` command.
+- Added atomic per-dispatch model overrides for built-in, custom, and Gigacode
+  subagents, with credential-free model discovery and strict route validation.
+- Allowed file-editing and LSP tools to operate on explicitly requested absolute
+  and parent-relative paths outside the project while preserving permission and
+  policy gates.
+
+### Changed
+
+- Exposed the active model's vision capability to every bundled agent prompt and
+  prompt override.
+- Made saved-session listings easier to resume with labeled IDs, chronological
+  ordering, and a clear empty state.
 
 ### Fixed
 
@@ -27,6 +41,15 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   pre-failure output usage. Ordinary non-workflow extension and delegation behavior
   is unchanged, and no supported API, metadata schema, cache-key field, or artifact
   field was removed or renamed.
+- Resolved relative shell-command working directories against the target project
+  instead of the directory where Kolega Code was launched.
+- Prevented model-facing shells from inheriting Kolega Code's own `uv run`
+  virtualenv while preserving user-activated and project-local virtualenvs.
+
+### Security
+
+- Updated the documentation toolchain and `pyasn1` dependency to patched
+  releases, clearing the known dependency alerts.
 
 ## 0.21.1 - 2026-07-20
 

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.21.1"
+__version__ = "0.22.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -48,4 +48,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.21.1"
+__version__ = "0.22.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.21.1"
+version = "0.22.0"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-15T08:40:37.428975Z"
+exclude-newer = "2026-07-15T12:26:29.461955Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1497,7 +1497,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.21.1"
+version = "0.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- bump Kolega Code from `0.21.1` to `0.22.0` in all package version locations and `uv.lock`
- move the accumulated `Unreleased` changes into a dated `0.22.0` changelog section
- summarize user-facing additions, behavior changes, fixes, and security updates merged since `v0.21.1`

## Release verification

All commands used the isolated `.venv-release` environment required by `RELEASING.md`.

- `UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" uv sync --extra dev --frozen`
- `PYTHONDONTWRITEBYTECODE=1 UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" ./run_tests.sh` — 2653 passed, 103 deselected
- `PYTHONDONTWRITEBYTECODE=1 UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" uv run pre-commit run --all-files --show-diff-on-failure`
- release commit hooks passed
