### PR TITLE
fix(lsp): eliminate post-edit diagnostics delays

### DIFF
--- a/kolega_code/agent/tool_backend/edit_tool.py
+++ b/kolega_code/agent/tool_backend/edit_tool.py
@@ -579,12 +579,8 @@ class EditTool(BaseTool):
                 summaries.append(f"M {operation.path}")
 
         result = "Success. Updated the following files:\n" + "\n".join(summaries)
-        diagnostics: list[str] = []
-        for path in changed:
-            if working[path] is not None:
-                item = await self._maybe_append_lsp_diagnostics(path)
-                if item:
-                    diagnostics.append(item.strip())
+        diagnostic_paths = [path for path in changed if working[path] is not None]
+        diagnostics = await self._lsp_diagnostics_for_paths(diagnostic_paths)
         if diagnostics:
             result += "\n\n" + "\n\n".join(diagnostics)
         return result
@@ -929,3 +925,33 @@ class EditTool(BaseTool):
         # Blank-line separator so the diagnostics block reads as a distinct section
         # after the result line (e.g. "Edited foo.py\n\nLSP diagnostics (...)").
         return "\n\n" + format_diagnostics(diagnostics, path, source=server_name)
+
+    async def _lsp_diagnostics_for_paths(self, paths: list[str]) -> list[str]:
+        """Query and format post-edit diagnostics for multiple paths."""
+        if self._lsp_manager is None or not self._lsp_manager.enabled:
+            return []
+        if not self._lsp_manager._config.auto_diagnostics_on_edit:
+            return []
+        if not self._lsp_manager._initialized:
+            await self._lsp_manager.initialize()
+
+        servers = {
+            path: server_name
+            for path in dict.fromkeys(paths)
+            if (server_name := self._lsp_manager.server_for_path(path)) is not None
+        }
+        if not servers:
+            return []
+
+        try:
+            results = await self._lsp_manager.get_fresh_diagnostics_for_paths(servers)
+        except Exception:
+            return []
+
+        from kolega_code.services.lsp import format_diagnostics
+
+        return [
+            format_diagnostics(results[path], path, source=server_name)
+            for path, server_name in servers.items()
+            if results.get(path)
+        ]

--- a/kolega_code/agent/tool_backend/lsp_tool.py
+++ b/kolega_code/agent/tool_backend/lsp_tool.py
@@ -982,14 +982,20 @@ class LspEditTool(BaseTool):
         assert self._lsp_manager is not None
         if not self._lsp_manager._config.auto_diagnostics_on_edit:
             return ""
-        lines: list[str] = []
+        servers: dict[str, str] = {}
         for path in dict.fromkeys(paths):
             if not path or not self.filesystem.exists(path) or self.filesystem.is_dir(path):
                 continue
             server_name = self._lsp_manager.server_for_path(path)
-            if server_name is None:
-                continue
-            diagnostics = await self._lsp_manager.get_fresh_diagnostics(path)
+            if server_name is not None:
+                servers[path] = server_name
+        if not servers:
+            return ""
+
+        results = await self._lsp_manager.get_fresh_diagnostics_for_paths(servers)
+        lines: list[str] = []
+        for path, server_name in servers.items():
+            diagnostics = results.get(path, [])
             if diagnostics:
                 lines.append(format_diagnostics(diagnostics, path, source=server_name))
         return "\n\n".join(lines)

--- a/kolega_code/services/lsp/config.py
+++ b/kolega_code/services/lsp/config.py
@@ -74,7 +74,7 @@ class LspConfig:
     """Master kill-switch. Set ``False`` to disable all LSP activity."""
 
     auto_diagnostics_on_edit: bool = True
-    """Append LSP diagnostics to ``edit`` / ``multi_edit`` / ``write`` results."""
+    """Append LSP diagnostics to supported post-edit tool results."""
 
     max_diagnostics: int = 20
     """Maximum diagnostics returned per file per query."""

--- a/kolega_code/services/lsp/manager.py
+++ b/kolega_code/services/lsp/manager.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Callable, Optional
@@ -27,6 +28,8 @@ logger = logging.getLogger(__name__)
 
 # Maximum concurrent server starts to avoid thundering herd
 _MAX_CONCURRENT_STARTS = 4
+# Maximum concurrent diagnostics queries for a multi-file edit.
+_MAX_CONCURRENT_DIAGNOSTICS = 4
 
 # Client capabilities advertised in the initialize handshake.
 _CLIENT_CAPABILITIES: dict = {
@@ -126,8 +129,11 @@ class LspManager:
         self._open_files: dict[str, str] = {}
         # Latest diagnostics per URI (from publishDiagnostics notifications)
         self._diagnostics: dict[str, list[LspDiagnostic]] = {}
-        # Diagnostics events for non-blocking await, keyed by (session_key, uri)
-        self._diag_events: dict[tuple[str, str], asyncio.Event] = {}
+        # Diagnostics waiters and publish generations, keyed by (session_key, uri).
+        # Generations prevent a publish that arrives just before waiter registration
+        # from being missed and turning into an unnecessary timeout.
+        self._diag_waiters: dict[tuple[str, str], set[asyncio.Event]] = {}
+        self._diag_generations: dict[tuple[str, str], int] = {}
         # Detection report (populated by initialize)
         self.report: Optional[DetectionReport] = None
         # Initialization lock
@@ -272,6 +278,7 @@ class LspManager:
             return []
 
         uri = _path_to_uri(self._project_path, path)
+        push_generation = self._diagnostic_generation(effective_id, uri)
 
         # Open / change the document so the server knows about it
         try:
@@ -287,7 +294,12 @@ class LspManager:
             return dedupe_and_sort(primary + extra, self._config.max_diagnostics)
 
         # Fallback: wait briefly for publishDiagnostics
-        await self._wait_for_push_diagnostics(effective_id, uri, timeout=3.0)
+        await self._wait_for_push_diagnostics(
+            effective_id,
+            uri,
+            after_generation=push_generation,
+            timeout=3.0,
+        )
         return dedupe_and_sort(self._diagnostics_for(effective_id, uri) + extra, self._config.max_diagnostics)
 
     async def get_fresh_diagnostics(self, path: str) -> list[LspDiagnostic]:
@@ -313,6 +325,7 @@ class LspManager:
         # Snapshot pre-edit version for freshness comparison
         record = self._session_records.get(effective_id)
         pre_edit_version = record.diag_versions.get(uri) if record else self._diag_versions.get(uri)
+        push_generation = self._diagnostic_generation(effective_id, uri)
 
         # Sync new content (sends didChange with incremented version)
         try:
@@ -333,7 +346,12 @@ class LspManager:
             return dedupe_and_sort(primary + extra, self._config.max_diagnostics)
 
         # Fallback: wait for fresh push diagnostics
-        await self._wait_for_push_diagnostics(effective_id, uri, timeout=3.0)
+        await self._wait_for_push_diagnostics(
+            effective_id,
+            uri,
+            after_generation=push_generation,
+            timeout=3.0,
+        )
 
         # Accept push diagnostics only if the version is fresh (different from
         # pre-edit, or version tracking is not supported by the server)
@@ -346,6 +364,29 @@ class LspManager:
             return []
 
         return dedupe_and_sort(push_diags + extra, self._config.max_diagnostics)
+
+    async def get_fresh_diagnostics_for_paths(
+        self,
+        paths: Iterable[str],
+    ) -> dict[str, list[LspDiagnostic]]:
+        """Get fresh diagnostics for unique paths with bounded concurrency.
+
+        Results preserve first-seen path order. A failure for one path is isolated
+        to that path so post-edit diagnostics never fail an applied multi-file edit.
+        """
+        unique_paths = tuple(dict.fromkeys(paths))
+        semaphore = asyncio.Semaphore(_MAX_CONCURRENT_DIAGNOSTICS)
+
+        async def query(path: str) -> list[LspDiagnostic]:
+            async with semaphore:
+                try:
+                    return await self.get_fresh_diagnostics(path)
+                except Exception:
+                    logger.exception("Failed to get fresh LSP diagnostics for %s", path)
+                    return []
+
+        results = await asyncio.gather(*(query(path) for path in unique_paths))
+        return dict(zip(unique_paths, results))
 
     # -- code intelligence ---------------------------------------
 
@@ -932,7 +973,8 @@ class LspManager:
         self._session_records.clear()
         self._open_files.clear()
         self._diagnostics.clear()
-        self._diag_events.clear()
+        self._diag_waiters.clear()
+        self._diag_generations.clear()
         self._doc_versions.clear()
         self._diag_versions.clear()
         self._registered_capabilities.clear()
@@ -1078,6 +1120,8 @@ class LspManager:
     async def _pull_diagnostics(
         self, client: LspClient, uri: str, *, source: Optional[str] = None
     ) -> Optional[list[LspDiagnostic]]:
+        if not self._supports_method(client, ("diagnosticProvider",), "textDocument/diagnostic"):
+            return None
         try:
             result = await client.request(
                 "textDocument/diagnostic",
@@ -1093,15 +1137,36 @@ class LspManager:
             return None
         return self._parse_diagnostic_items(items, source=source)
 
-    async def _wait_for_push_diagnostics(self, session_key: str, uri: str, *, timeout: float) -> None:
+    def _diagnostic_generation(self, session_key: str, uri: str) -> int:
+        return self._diag_generations.get((session_key, uri), 0)
+
+    async def _wait_for_push_diagnostics(
+        self,
+        session_key: str,
+        uri: str,
+        *,
+        after_generation: int,
+        timeout: float,
+    ) -> None:
         event_key = (session_key, uri)
-        self._diag_events[event_key] = asyncio.Event()
+        if self._diagnostic_generation(session_key, uri) > after_generation:
+            return
+
+        event = asyncio.Event()
+        waiters = self._diag_waiters.setdefault(event_key, set())
+        waiters.add(event)
         try:
-            await asyncio.wait_for(self._diag_events[event_key].wait(), timeout=timeout)
+            # Recheck after registration so a publish at the registration boundary
+            # cannot be missed.
+            if self._diagnostic_generation(session_key, uri) > after_generation:
+                return
+            await asyncio.wait_for(event.wait(), timeout=timeout)
         except asyncio.TimeoutError:
             pass
         finally:
-            self._diag_events.pop(event_key, None)
+            waiters.discard(event)
+            if not waiters:
+                self._diag_waiters.pop(event_key, None)
 
     def _diagnostics_for(self, session_key: str, uri: str) -> list[LspDiagnostic]:
         record = self._session_records.get(session_key)
@@ -1226,6 +1291,8 @@ class LspManager:
                 logger.exception("Failed to start extra diagnostic server %s", extra_name)
                 continue
 
+            push_generation = self._diagnostic_generation(session_key, uri)
+
             # Ensure document is open in the extra server
             try:
                 await self._ensure_document_open(client, uri, path, lang_id, session_key=session_key)
@@ -1238,7 +1305,12 @@ class LspManager:
                 all_diagnostics.extend(pulled)
                 continue
 
-            await self._wait_for_push_diagnostics(session_key, uri, timeout=3.0)
+            await self._wait_for_push_diagnostics(
+                session_key,
+                uri,
+                after_generation=push_generation,
+                timeout=3.0,
+            )
             all_diagnostics.extend(self._diagnostics_for(session_key, uri))
 
         return all_diagnostics
@@ -1337,8 +1409,9 @@ class LspManager:
         if record is not None:
             record.diag_versions[parsed.uri] = version
         self._diag_versions[parsed.uri] = version
-        event = self._diag_events.get((session_key, parsed.uri))
-        if event:
+        event_key = (session_key, parsed.uri)
+        self._diag_generations[event_key] = self._diag_generations.get(event_key, 0) + 1
+        for event in tuple(self._diag_waiters.get(event_key, ())):
             event.set()
 
     # -- server→client request handlers ------------------------

--- a/tests/agent/tool_backend/test_codex_apply_patch.py
+++ b/tests/agent/tool_backend/test_codex_apply_patch.py
@@ -8,6 +8,7 @@ from kolega_code.agent.tool_backend.codex_patch import CodexPatchError, parse_co
 from kolega_code.agent.tool_backend.edit_tool import EditTool
 from kolega_code.agent.prompt_provider import AgentMode
 from kolega_code.config import AgentConfig, ModelConfig, ModelProvider
+from kolega_code.services.lsp import LspDiagnostic
 from kolega_code.services.snapshots import SnapshotService
 
 
@@ -264,3 +265,71 @@ async def test_apply_patch_snapshot_can_restore_multi_file_change(
 
     assert original.read_text() == "before\n"
     assert not (tmp_path / "created.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_batches_diagnostics_for_surviving_files_in_change_order(
+    tmp_path: Path,
+    caller: Mock,
+    config: AgentConfig,
+) -> None:
+    for path, content in (
+        ("first.py", "first = 1\n"),
+        ("second.py", "second = 1\n"),
+        ("deleted.py", "deleted = 1\n"),
+    ):
+        (tmp_path / path).write_text(content)
+
+    lsp_manager = Mock()
+    lsp_manager.enabled = True
+    lsp_manager._initialized = True
+    lsp_manager._config.auto_diagnostics_on_edit = True
+    lsp_manager.server_for_path.side_effect = lambda path: "pyright" if path.endswith(".py") else None
+    lsp_manager.get_fresh_diagnostics_for_paths = AsyncMock(
+        return_value={
+            "first.py": [
+                LspDiagnostic(
+                    range={"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 5}},
+                    severity=1,
+                    message="first issue",
+                    source="pyright",
+                )
+            ],
+            "second.py": [
+                LspDiagnostic(
+                    range={"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 6}},
+                    severity=2,
+                    message="second issue",
+                    source="pyright",
+                )
+            ],
+        }
+    )
+    tool = EditTool(
+        tmp_path,
+        "workspace",
+        str(uuid.uuid4()),
+        AsyncMock(),
+        config,
+        caller,
+        lsp_manager=lsp_manager,
+    )
+
+    result = await tool.apply_patch(
+        patch(
+            "*** Update File: first.py",
+            "@@",
+            "-first = 1",
+            "+first = 2",
+            "*** Update File: second.py",
+            "@@",
+            "-second = 1",
+            "+second = 2",
+            "*** Delete File: deleted.py",
+        )
+    )
+
+    lsp_manager.get_fresh_diagnostics_for_paths.assert_awaited_once_with(
+        {"first.py": "pyright", "second.py": "pyright"}
+    )
+    assert result.index("first issue") < result.index("second issue")

--- a/tests/agent/tool_backend/test_lsp_tool.py
+++ b/tests/agent/tool_backend/test_lsp_tool.py
@@ -466,6 +466,43 @@ class TestLspEditTool:
 
         assert f"{project_path.as_uri()}/link/../target.py" == uri
 
+    async def test_multi_path_diagnostics_uses_batch_and_preserves_order(
+        self,
+        lsp_edit_tool,
+        mock_lsp_manager,
+        project_path,
+    ):
+        for path in ("first.py", "second.py"):
+            (project_path / path).write_text("value = 1\n", encoding="utf-8")
+        mock_lsp_manager._config.auto_diagnostics_on_edit = True
+        mock_lsp_manager.get_fresh_diagnostics_for_paths = AsyncMock(
+            return_value={
+                "first.py": [
+                    LspDiagnostic(
+                        range={"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 5}},
+                        severity=1,
+                        message="first issue",
+                        source="pyright",
+                    )
+                ],
+                "second.py": [
+                    LspDiagnostic(
+                        range={"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 6}},
+                        severity=2,
+                        message="second issue",
+                        source="pyright",
+                    )
+                ],
+            }
+        )
+
+        result = await lsp_edit_tool._diagnostics_for_paths(("first.py", "second.py", "first.py"))
+
+        mock_lsp_manager.get_fresh_diagnostics_for_paths.assert_awaited_once_with(
+            {"first.py": "pyright", "second.py": "pyright"}
+        )
+        assert result.index("first issue") < result.index("second issue")
+
     async def test_rename_preview_does_not_write_file(self, lsp_edit_tool, mock_lsp_manager, project_path):
         path = project_path / "foo.py"
         path.write_text("old = 1\nprint(old)\n", encoding="utf-8")

--- a/tests/services/lsp/test_manager.py
+++ b/tests/services/lsp/test_manager.py
@@ -6,6 +6,7 @@ End-to-end tests with a fake server are in ``test_integration.py``.
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -387,3 +388,126 @@ def test_has_capability_absent_is_unsupported():
 
 def test_has_capability_none_client_is_unsupported():
     assert LspManager._has_capability(None, "definitionProvider") is False
+
+
+# ---------------------------------------------------------------------------
+# diagnostics routing and push waiters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pull_diagnostics_skips_server_without_capability(manager: LspManager):
+    client = MagicMock()
+    client.server_capabilities = {"hoverProvider": True}
+    client.request = AsyncMock()
+
+    result = await manager._pull_diagnostics(client, "file:///test.py")
+
+    assert result is None
+    client.request.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_push_wait_returns_when_publish_already_arrived(manager: LspManager):
+    uri = "file:///already.py"
+    generation = manager._diagnostic_generation("python", uri)
+    manager._on_publish_diagnostics(
+        "python",
+        {"uri": uri, "diagnostics": [], "version": None},
+    )
+
+    await asyncio.wait_for(
+        manager._wait_for_push_diagnostics(
+            "python",
+            uri,
+            after_generation=generation,
+            timeout=3.0,
+        ),
+        timeout=1.0,
+    )
+
+    assert manager._diag_waiters == {}
+
+
+@pytest.mark.asyncio
+async def test_push_wait_is_released_by_later_publish(manager: LspManager):
+    uri = "file:///later.py"
+    generation = manager._diagnostic_generation("python", uri)
+    waiting = asyncio.create_task(
+        manager._wait_for_push_diagnostics(
+            "python",
+            uri,
+            after_generation=generation,
+            timeout=3.0,
+        )
+    )
+    await asyncio.sleep(0)
+
+    assert len(manager._diag_waiters[("python", uri)]) == 1
+    manager._on_publish_diagnostics(
+        "python",
+        {"uri": uri, "diagnostics": [], "version": 1},
+    )
+    await asyncio.wait_for(waiting, timeout=1.0)
+
+    assert manager._diag_waiters == {}
+
+
+@pytest.mark.asyncio
+async def test_push_publish_releases_all_concurrent_waiters(manager: LspManager):
+    uri = "file:///concurrent.py"
+    generation = manager._diagnostic_generation("python", uri)
+    waiting = [
+        asyncio.create_task(
+            manager._wait_for_push_diagnostics(
+                "python",
+                uri,
+                after_generation=generation,
+                timeout=3.0,
+            )
+        )
+        for _ in range(2)
+    ]
+    await asyncio.sleep(0)
+
+    assert len(manager._diag_waiters[("python", uri)]) == 2
+    manager._on_publish_diagnostics(
+        "python",
+        {"uri": uri, "diagnostics": [], "version": 1},
+    )
+    await asyncio.wait_for(asyncio.gather(*waiting), timeout=1.0)
+
+    assert manager._diag_waiters == {}
+
+
+@pytest.mark.asyncio
+async def test_fresh_diagnostics_batch_is_ordered_unique_bounded_and_isolates_failures(
+    manager: LspManager,
+):
+    active = 0
+    max_active = 0
+    calls: list[str] = []
+
+    async def get_fresh(path: str) -> list[LspDiagnostic]:
+        nonlocal active, max_active
+        calls.append(path)
+        active += 1
+        max_active = max(max_active, active)
+        try:
+            await asyncio.sleep(0.01)
+            if path == "bad.py":
+                raise RuntimeError("broken server")
+            return [_make_diag(0, path)]
+        finally:
+            active -= 1
+
+    manager.get_fresh_diagnostics = get_fresh  # type: ignore[method-assign]
+    paths = ["a.py", "b.py", "c.py", "d.py", "e.py", "bad.py", "a.py"]
+
+    results = await manager.get_fresh_diagnostics_for_paths(paths)
+
+    assert list(results) == paths[:-1]
+    assert calls.count("a.py") == 1
+    assert max_active == 4
+    assert results["a.py"][0].message == "a.py"
+    assert results["bad.py"] == []


### PR DESCRIPTION
## Summary

- avoid unsupported `textDocument/diagnostic` requests when an LSP server does not advertise pull diagnostics
- make push-diagnostic waiting race-free with per-document generations and multi-waiter support
- batch multi-file post-edit diagnostics with bounded concurrency for `apply_patch` and LSP workspace edits
- preserve diagnostic freshness, ordering, deduplication, and non-fatal failure behavior

## Performance

- push-only diagnostics regressions dropped from roughly 3 seconds per query to about 0.02 seconds
- the reproduced second-query latency against `pyright-langserver` dropped from roughly 33 seconds to about 0.85 seconds

## Tests

- `./run_tests.sh tests/services/lsp/test_manager.py tests/services/lsp/test_integration.py::test_fresh_diagnostics_push_only_accepts_fresh tests/services/lsp/test_integration.py::test_fresh_diagnostics_push_only_suppresses_stale tests/agent/tool_backend/test_codex_apply_patch.py tests/agent/tool_backend/test_lsp_tool.py -q` (93 passed)
- `PYTHONDONTWRITEBYTECODE=1 ./run_tests.sh` (2660 passed, 103 deselected)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`