### PR TITLE
chore: release v0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.22.1 - 2026-07-22
+
+### Fixed
+
+- Eliminated post-edit LSP diagnostics delays by invalidating cached diagnostics
+  immediately and avoiding redundant waits after successful edits.
+- Hardened subagent dispatch guidance and schemas so optional model overrides are
+  omitted by default and explicit overrides cannot contain blank route fields.
+- Clarified that contingent future work remains ordinary task execution and does
+  not authorize autonomous goal mode.
+
 ## 0.22.0 - 2026-07-22
 
 ### Added

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.22.0"
+__version__ = "0.22.1"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -48,4 +48,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.22.0"
+__version__ = "0.22.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.22.0"
+version = "0.22.1"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-15T12:26:29.461955Z"
+exclude-newer = "2026-07-15T16:41:59.437982Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1497,7 +1497,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.22.0"
+version = "0.22.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- bump Kolega Code from 0.22.0 to 0.22.1 in package metadata and the lockfile
- document the LSP diagnostics latency fix and hardened subagent/goal-mode guidance

## Verification
- `UV_PROJECT_ENVIRONMENT=/tmp/kolega-code-release-v0.22.1 uv sync --all-extras`
- `UV_PROJECT_ENVIRONMENT=/tmp/kolega-code-release-v0.22.1 PYTHONDONTWRITEBYTECODE=1 uv run pre-commit run --all-files --show-diff-on-failure`
- `UV_PROJECT_ENVIRONMENT=/tmp/kolega-code-release-v0.22.1 PYTHONDONTWRITEBYTECODE=1 ./run_tests.sh --coverage` (2660 passed, 103 deselected; 81.86% coverage)
- verified `pyproject.toml`, `kolega_code.__version__`, and `kolega_code.agent.__version__` all report `0.22.1`
