### PR TITLE
feat(cli): show sub-agent model routing

### DIFF
--- a/kolega_code/cli/tui/state.py
+++ b/kolega_code/cli/tui/state.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import itertools
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Optional
+from typing import Any, Optional
 
 from kolega_code.permissions import PermissionDecision, PermissionMode, PermissionRequest, PermissionRuleOption
 
@@ -126,6 +127,42 @@ class SessionFileChange:
     created_at: float = 0.0
 
 
+@dataclass(frozen=True)
+class SubAgentRouting:
+    """Effective provider/model/effort route for one dispatched sub-agent."""
+
+    provider: str
+    model: str
+    effort: Optional[str] = None
+    overridden: bool = False  # parent explicitly pinned this route via model_override
+
+    @classmethod
+    def from_info(cls, info: Optional[Mapping[str, Any]]) -> Optional["SubAgentRouting"]:
+        """Parse event sub_agent_info; tolerates old/partial shapes by returning None.
+
+        Ordinary dispatch keys effort as "thinking_effort"; workflow dispatch keys
+        it as "effort" — both are accepted here.
+        """
+        if not isinstance(info, Mapping):
+            return None
+        effective = info.get("effective_routing")
+        if not isinstance(effective, Mapping):
+            return None
+        provider = effective.get("provider")
+        model = effective.get("model")
+        if not isinstance(provider, str) or not provider.strip() or not isinstance(model, str) or not model.strip():
+            return None
+        effort = effective.get("thinking_effort", effective.get("effort"))
+        if not isinstance(effort, str) or not effort.strip():
+            effort = None
+        return cls(
+            provider=provider.strip(),
+            model=model.strip(),
+            effort=effort,
+            overridden=info.get("requested_routing") is not None,
+        )
+
+
 @dataclass
 class SubAgentActivity:
     """Live display state for one dispatched sub-agent."""
@@ -157,6 +194,7 @@ class SubAgentActivity:
     context_input_tokens: Optional[int] = None
     context_max_tokens: Optional[int] = None
     depth: int = 1
+    routing: Optional[SubAgentRouting] = None  # effective model route, None when unreported
     current_action: str = ""  # live "now:" action while running
     workflow_run_id: str = ""  # set when dispatched by a workflow, for card rollup
     workflow_phase: str = ""  # the workflow phase this agent runs under

--- a/kolega_code/cli/tui/sub_agent_screen.py
+++ b/kolega_code/cli/tui/sub_agent_screen.py
@@ -393,6 +393,12 @@ class SubAgentInspectorScreen(ModalScreen):
         full_task = activity.task_full or activity.task
         if full_task:
             lines.append(f"Task: {full_task}")
+        routing = activity.routing
+        if routing is not None:
+            sep = theme.g(Glyph.BULLET_SEP)
+            origin = "parent override" if routing.overridden else "inherited default"
+            effort = routing.effort or "none"
+            lines.append(f"Model: {routing.provider}/{routing.model} {sep} effort: {effort} {sep} {origin}")
         lines.append("")
         for step in activity.steps:
             # The full task is already printed above as the header Task line.

--- a/kolega_code/cli/tui/transcript.py
+++ b/kolega_code/cli/tui/transcript.py
@@ -24,6 +24,7 @@ from .state import (
     PhaseState,
     SessionFileChange,
     SubAgentActivity,
+    SubAgentRouting,
     TurnState,
     WorkflowActivity,
     TOOL_STATE_PRESENTATION,
@@ -576,9 +577,9 @@ class TranscriptRenderingMixin(tui_app_base.KolegaAppBase):
 
     def _ensure_sub_agent_activity(self, event: AgentEvent) -> SubAgentActivity:
         key = self._sub_agent_key(event)
+        info = event.sub_agent_info or {}
         activity = self._sub_agent_activities.get(key)
         if activity is None:
-            info = event.sub_agent_info or {}
             self._sub_agent_seq += 1
             entry = ConversationEntry(kind="sub_agent", content="", complete=False)
             task_full = str(info.get("task_full") or info.get("task") or "")
@@ -591,6 +592,7 @@ class TranscriptRenderingMixin(tui_app_base.KolegaAppBase):
                 task_full=task_full,
                 workflow_run_id=str(info.get("workflow_run_id") or ""),
                 workflow_phase=str(info.get("phase") or ""),
+                routing=SubAgentRouting.from_info(info),
                 started_at=self._now(),
             )
             self._sub_agent_activities[key] = activity
@@ -607,6 +609,10 @@ class TranscriptRenderingMixin(tui_app_base.KolegaAppBase):
             self._add_conversation_entry(entry)
             self._refresh_sub_agent_activity_status()
             self._note_workflow_sub_agent(activity)
+        elif activity.routing is None:
+            # Every child event carries sub_agent_info, so an activity whose first
+            # event lacked routing picks it up from any later one.
+            activity.routing = SubAgentRouting.from_info(info)
         return activity
 
     def _render_sub_agent_event(self, event: AgentEvent) -> None:
@@ -808,7 +814,27 @@ class TranscriptRenderingMixin(tui_app_base.KolegaAppBase):
             escape(activity.agent_name),
             color,
             state=f"#{activity.index} {theme.g(Glyph.BULLET_SEP)} {state}",
+            detail=self._format_sub_agent_routing(activity) or None,
         )
+
+    def _format_sub_agent_routing(self, activity: SubAgentActivity) -> str:
+        """Compact routing label: [provider/]model[ (effort)]; "" when unreported.
+
+        The provider prefix appears only when it differs from the session's own
+        provider; a parent-pinned override is tinted ACCENT (still dim in situ).
+        """
+        routing = activity.routing
+        if routing is None:
+            return ""
+        label = escape(routing.model)
+        session_provider = getattr(getattr(self, "_status_state", None), "provider", None)
+        if routing.provider != session_provider:
+            label = f"{escape(routing.provider)}/{label}"
+        if routing.effort:
+            label = f"{label} ({escape(routing.effort)})"
+        if routing.overridden:
+            label = f"[{Color.ACCENT}]{label}[/{Color.ACCENT}]"
+        return label
 
     def _sub_agent_body_lines(self, activity: SubAgentActivity) -> list[str]:
         sep = theme.g(Glyph.BULLET_SEP)

--- a/tests/cli/_app_test_utils.py
+++ b/tests/cli/_app_test_utils.py
@@ -210,22 +210,29 @@ def _sub_agent_event(
     parent_tool_call_id="tc-1",
     uuid=None,
     is_streaming=False,
+    effective_routing=None,
+    requested_routing=None,
     **content,
 ):
     kwargs = {"uuid": uuid} if uuid is not None else {}
+    sub_agent_info = {
+        "agent_id": agent_id,
+        "agent_name": agent_name,
+        "task": task,
+        "parent_tool_call_id": parent_tool_call_id,
+        "conversation_id": None,
+        "depth": 1,
+    }
+    # Opt-in so the default fixture doubles as missing-routing coverage.
+    if effective_routing is not None:
+        sub_agent_info["effective_routing"] = effective_routing
+        sub_agent_info["requested_routing"] = requested_routing
     return AgentEvent(
         event_type="chat_message",
         sender=agent_name,
         content=content,
         is_streaming=is_streaming,
-        sub_agent_info={
-            "agent_id": agent_id,
-            "agent_name": agent_name,
-            "task": task,
-            "parent_tool_call_id": parent_tool_call_id,
-            "conversation_id": None,
-            "depth": 1,
-        },
+        sub_agent_info=sub_agent_info,
         **kwargs,
     )
 

--- a/tests/cli/test_app_sub_agents_workflows.py
+++ b/tests/cli/test_app_sub_agents_workflows.py
@@ -423,6 +423,133 @@ async def test_sub_agent_completion_event_records_tokens(tmp_path: Path, monkeyp
         assert "3.1k tok" in activity.entry.content
 
 
+_ROUTING = {"provider": "anthropic", "model": "claude-opus-4-8", "thinking_effort": "high"}
+
+
+@pytest.mark.asyncio
+async def test_sub_agent_card_shows_effective_model(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        app._render_event(_sub_agent_event(status="GENERATING", message="Starting", effective_routing=_ROUTING))
+
+        activity = next(iter(app._sub_agent_activities.values()))
+        assert activity.routing is not None
+        assert activity.routing.overridden is False
+        # The session provider (anthropic) is elided; effort binds to the model.
+        assert "claude-opus-4-8 (high)" in activity.entry.content
+        assert "anthropic/" not in activity.entry.content
+
+
+@pytest.mark.asyncio
+async def test_sub_agent_card_shows_cross_provider_prefix(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        routing = {"provider": "deepseek", "model": "deepseek-r1", "thinking_effort": "high"}
+        app._render_event(_sub_agent_event(status="GENERATING", message="Starting", effective_routing=routing))
+
+        activity = next(iter(app._sub_agent_activities.values()))
+        assert "deepseek/deepseek-r1 (high)" in activity.entry.content
+
+
+@pytest.mark.asyncio
+async def test_sub_agent_routing_normalizes_workflow_effort_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        # Workflow dispatch spells the effort key "effort", not "thinking_effort".
+        routing = {"provider": "anthropic", "model": "claude-opus-4-8", "effort": "medium"}
+        app._render_event(_sub_agent_event(status="GENERATING", message="Starting", effective_routing=routing))
+
+        activity = next(iter(app._sub_agent_activities.values()))
+        assert activity.routing is not None
+        assert activity.routing.effort == "medium"
+        assert "claude-opus-4-8 (medium)" in activity.entry.content
+
+
+@pytest.mark.asyncio
+async def test_sub_agent_override_marks_routing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from kolega_code.cli.theme import Color
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        app._render_event(
+            _sub_agent_event(
+                status="GENERATING", message="Starting", effective_routing=_ROUTING, requested_routing=_ROUTING
+            )
+        )
+
+        activity = next(iter(app._sub_agent_activities.values()))
+        assert activity.routing is not None
+        assert activity.routing.overridden is True
+        # The header markup tints the overridden route; the plain card content keeps the bare label.
+        assert f"[{Color.ACCENT}]claude-opus-4-8 (high)[/{Color.ACCENT}]" in app._sub_agent_header(activity)
+        assert "claude-opus-4-8 (high)" in activity.entry.content
+
+
+@pytest.mark.asyncio
+async def test_sub_agent_routing_absent_renders_clean(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        app._render_event(_sub_agent_event(status="GENERATING", message="Starting"))
+
+        activity = next(iter(app._sub_agent_activities.values()))
+        assert activity.routing is None
+        header_line = activity.entry.content.splitlines()[0]
+        assert "(" not in header_line
+        assert not header_line.rstrip().endswith(("·", "-"))
+
+
+@pytest.mark.asyncio
+async def test_sub_agent_routing_late_arrival(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test():
+        app._render_event(_sub_agent_event(status="GENERATING", message="Starting"))
+        activity = next(iter(app._sub_agent_activities.values()))
+        assert activity.routing is None
+
+        app._render_event(
+            _sub_agent_event(status="STOPPED", message="Completed", total_tokens=100, effective_routing=_ROUTING)
+        )
+        assert activity.routing is not None
+        assert "claude-opus-4-8 (high)" in activity.entry.content
+
+
+@pytest.mark.asyncio
+async def test_sub_agent_inspector_header_and_copy_include_routing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        app._render_event(
+            _sub_agent_event(
+                message_type="tool_call",
+                text="Reading",
+                tool_description="read_file",
+                tool_call_id="t1",
+                effective_routing=_ROUTING,
+            )
+        )
+        app.action_open_sub_agent()
+        await pilot.pause()
+
+        screen = app._sub_agent_inspector
+        assert screen is not None
+        activity = next(iter(app._sub_agent_activities.values()))
+        assert "claude-opus-4-8 (high)" in screen._header_markup(activity)
+        copy_text = screen._trajectory_text(activity)
+        assert "Model: anthropic/claude-opus-4-8" in copy_text
+        assert "effort: high" in copy_text
+        assert "inherited default" in copy_text
+
+
 @pytest.mark.asyncio
 async def test_open_sub_agent_inspector_renders_trajectory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     from kolega_code.cli.tui.sub_agent_screen import SubAgentInspectorScreen

--- a/tests/cli/test_sub_agent_routing_state.py
+++ b/tests/cli/test_sub_agent_routing_state.py
@@ -1,0 +1,66 @@
+"""Unit tests for SubAgentRouting.from_info — no Textual app required."""
+
+from typing import Any, cast
+
+from kolega_code.cli.tui.state import SubAgentRouting
+
+
+def _info(effective=None, requested=None, **extra):
+    info = {"agent_id": "a1", "agent_name": "general-agent", **extra}
+    if effective is not None:
+        info["effective_routing"] = effective
+    if requested is not None:
+        info["requested_routing"] = requested
+    return info
+
+
+def test_from_info_none_and_non_mapping():
+    assert SubAgentRouting.from_info(None) is None
+    assert SubAgentRouting.from_info(cast(Any, "not a mapping")) is None
+
+
+def test_from_info_missing_or_malformed_effective_routing():
+    assert SubAgentRouting.from_info(_info()) is None
+    assert SubAgentRouting.from_info(_info(effective="anthropic/claude-opus-4-8")) is None
+    assert SubAgentRouting.from_info(_info(effective={"provider": "anthropic"})) is None
+    assert SubAgentRouting.from_info(_info(effective={"provider": "anthropic", "model": "  "})) is None
+    assert SubAgentRouting.from_info(_info(effective={"provider": None, "model": "claude-opus-4-8"})) is None
+
+
+def test_from_info_ordinary_dispatch_shape():
+    routing = SubAgentRouting.from_info(
+        _info(effective={"provider": "anthropic", "model": "claude-opus-4-8", "thinking_effort": "high"})
+    )
+    assert routing == SubAgentRouting(provider="anthropic", model="claude-opus-4-8", effort="high", overridden=False)
+
+
+def test_from_info_workflow_effort_key_spelling():
+    routing = SubAgentRouting.from_info(
+        _info(effective={"provider": "anthropic", "model": "claude-opus-4-8", "effort": "low"})
+    )
+    assert routing is not None
+    assert routing.effort == "low"
+
+
+def test_from_info_effort_none_or_blank():
+    for effort in (None, "", "   "):
+        routing = SubAgentRouting.from_info(
+            _info(effective={"provider": "anthropic", "model": "claude-opus-4-8", "thinking_effort": effort})
+        )
+        assert routing is not None
+        assert routing.effort is None
+
+
+def test_from_info_strips_whitespace():
+    routing = SubAgentRouting.from_info(
+        _info(effective={"provider": " anthropic ", "model": " claude-opus-4-8 ", "thinking_effort": "high"})
+    )
+    assert routing == SubAgentRouting(provider="anthropic", model="claude-opus-4-8", effort="high")
+
+
+def test_from_info_requested_routing_marks_override():
+    effective = {"provider": "deepseek", "model": "deepseek-r1", "thinking_effort": "high"}
+    inherited = SubAgentRouting.from_info(_info(effective=effective))
+    pinned = SubAgentRouting.from_info(_info(effective=effective, requested=effective))
+    assert inherited is not None and inherited.overridden is False
+    assert pinned is not None and pinned.overridden is True


### PR DESCRIPTION
## Summary

- parse effective and requested sub-agent routing metadata into TUI activity state
- show model, effort, cross-provider routing, and parent overrides in transcript and inspector headers
- include the full routing origin in inspector copy exports while safely omitting missing or malformed routing
- add parser and app-level coverage for routing display, normalization, overrides, late arrival, and legacy events

## Testing

- `PYTHONDONTWRITEBYTECODE=1 ./run_tests.sh tests/cli/test_sub_agent_routing_state.py tests/cli/test_app_sub_agents_workflows.py -ra` (44 passed)
- `uv run ruff check kolega_code/cli/tui/state.py kolega_code/cli/tui/sub_agent_screen.py kolega_code/cli/tui/transcript.py tests/cli/_app_test_utils.py tests/cli/test_app_sub_agents_workflows.py tests/cli/test_sub_agent_routing_state.py`
- `uv run ruff format --check kolega_code/cli/tui/state.py kolega_code/cli/tui/sub_agent_screen.py kolega_code/cli/tui/transcript.py tests/cli/_app_test_utils.py tests/cli/test_app_sub_agents_workflows.py tests/cli/test_sub_agent_routing_state.py`
- commit hooks, including Pyright
