### PR TITLE
feat(models): add Gemini 3.6 Flash and 3.5 Flash-Lite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+### Added
+
+- Added stable Google Gemini 3.6 Flash and Gemini 3.5 Flash-Lite model support,
+  including model-specific thinking levels and omission of their deprecated
+  sampling temperature parameter.
+
 ## 0.22.1 - 2026-07-22
 
 ### Fixed

--- a/docs/src/content/docs/configuration/providers-and-models.mdx
+++ b/docs/src/content/docs/configuration/providers-and-models.mdx
@@ -198,7 +198,10 @@ models in the TUI.
 | Fireworks serverless reasoning models | `none`, `low`, `medium`, `high`, `max` | `medium` |
 | Ollama Cloud thinking models | `none`, `low`, `medium`, `high`, `max` | `medium` |
 | Ollama Cloud `gpt-oss:*` | `low`, `medium`, `high` | `medium` |
-| Google `gemini-2.5-pro` | `auto`, `low`, `medium`, `high` | `medium` |
+| Google `gemini-3.6-flash` | `minimal`, `low`, `medium`, `high` | `medium` |
+| Google `gemini-3.5-flash-lite` | `minimal`, `low`, `medium`, `high` | `minimal` |
+| Google `gemini-3.5-flash` | `minimal`, `low`, `medium`, `high` | `medium` |
+| Google `gemini-3.1-pro-preview` | `low`, `medium`, `high` | `high` |
 | OpenAI `gpt-5.6-*` | `none`, `low`, `medium`, `high`, `xhigh`, `max` | `medium` |
 | OpenAI `gpt-5.5` | `minimal`, `low`, `medium`, `high`, `xhigh` | `medium` |
 | OpenAI `gpt-5.4*` | `minimal`, `low`, `medium`, `high` | `medium` |

--- a/kolega_code/cli/provider_registry.py
+++ b/kolega_code/cli/provider_registry.py
@@ -74,6 +74,8 @@ MODEL_LABELS: dict[str, str] = {
     "gpt-5.4-mini": "GPT-5.4 Mini",
     "gpt-5.3-codex-spark": "GPT-5.3 Codex Spark",
     # Google
+    "gemini-3.6-flash": "Gemini 3.6 Flash",
+    "gemini-3.5-flash-lite": "Gemini 3.5 Flash-Lite",
     "gemini-3.1-pro-preview": "Gemini 3.1 Pro",
     "gemini-3.5-flash": "Gemini 3.5 Flash",
     # xAI

--- a/kolega_code/llm/providers/google.py
+++ b/kolega_code/llm/providers/google.py
@@ -4,7 +4,7 @@ from google.genai import Client as genai_client
 from google.genai import types as genai_types
 
 from ..models import Message, MessageChunk, MessageHistory, ToolDefinition
-from ..specs import build_thinking_request_params
+from ..specs import build_thinking_request_params, get_model_specs
 from ..tool_execution_ids import ToolExecutionIdRegistry
 from .base import BaseLLMProvider
 from .models import GenerationParams, TokenCount
@@ -119,6 +119,22 @@ class GoogleProvider(BaseLLMProvider):
             return None
         return genai_types.ThinkingConfig(**thinking_config)
 
+    def _prepare_generation_config(
+        self,
+        model: str,
+        system: Message,
+        params: GenerationParams,
+    ) -> genai_types.GenerateContentConfig:
+        config: dict[str, Any] = {
+            "system_instruction": cast(Any, system.content[0]).text,
+            "max_output_tokens": params.max_completion_tokens,
+            "tools": [tool.to_google() for tool in params.tools] if params.tools else None,
+            "thinking_config": self._prepare_thinking_config(model, params),
+        }
+        if get_model_specs("google", model).get("supports_temperature", True):
+            config["temperature"] = params.temperature
+        return genai_types.GenerateContentConfig(**config)
+
     async def count_tokens(
         self,
         messages: MessageHistory,
@@ -157,13 +173,7 @@ class GoogleProvider(BaseLLMProvider):
         """
         model = kwargs["model"]
         assert system is not None and params is not None
-        config = genai_types.GenerateContentConfig(
-            system_instruction=cast(Any, system.content[0]).text,
-            temperature=params.temperature,
-            max_output_tokens=params.max_completion_tokens,
-            tools=[t.to_google() for t in params.tools] if params.tools else None,
-            thinking_config=self._prepare_thinking_config(model, params),
-        )
+        config = self._prepare_generation_config(model, system, params)
 
         await self.rate_limiter.acquire()
 
@@ -188,13 +198,7 @@ class GoogleProvider(BaseLLMProvider):
     ) -> Message:
         model = kwargs["model"]
         assert system is not None and params is not None
-        config = genai_types.GenerateContentConfig(
-            system_instruction=cast(Any, system.content[0]).text,
-            temperature=params.temperature,
-            max_output_tokens=params.max_completion_tokens,
-            tools=[t.to_google() for t in params.tools] if params.tools else None,
-            thinking_config=self._prepare_thinking_config(model, params),
-        )
+        config = self._prepare_generation_config(model, system, params)
 
         await self.rate_limiter.acquire()
 

--- a/kolega_code/llm/specs/catalog/google.py
+++ b/kolega_code/llm/specs/catalog/google.py
@@ -2,6 +2,30 @@ from kolega_code.llm.specs.types import ThinkingEffortSpec
 
 # Google models
 GOOGLE_SPECS = {
+    ("google", "gemini-3.6-flash"): {
+        "context_length": 1048576,
+        "max_completion_tokens": 65536,
+        "default_temperature": 1.0,
+        "supports_temperature": False,
+        "supports_vision": True,
+        "thinking_effort": ThinkingEffortSpec(
+            options=("minimal", "low", "medium", "high"),
+            default="medium",
+            mode="google_thinking_level",
+        ),
+    },
+    ("google", "gemini-3.5-flash-lite"): {
+        "context_length": 1048576,
+        "max_completion_tokens": 65536,
+        "default_temperature": 1.0,
+        "supports_temperature": False,
+        "supports_vision": True,
+        "thinking_effort": ThinkingEffortSpec(
+            options=("minimal", "low", "medium", "high"),
+            default="minimal",
+            mode="google_thinking_level",
+        ),
+    },
     ("google", "gemini-3.1-pro-preview"): {
         "context_length": 1048576,
         "max_completion_tokens": 65536,

--- a/tests/agent/llm/test_google_provider.py
+++ b/tests/agent/llm/test_google_provider.py
@@ -1,0 +1,75 @@
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+from kolega_code.llm.models import Message, MessageHistory, TextBlock
+from kolega_code.llm.providers.google import GoogleProvider, GoogleStreamWrapper
+from kolega_code.llm.providers.models import GenerationParams
+
+
+class _FakeGoogleModels:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, object]] = []
+        self.response = object()
+        self.stream = SimpleNamespace()
+
+    async def generate_content(self, *, model: str, contents: object, config: object) -> object:
+        del contents
+        self.calls.append(("generate", model, config))
+        return self.response
+
+    async def generate_content_stream(self, *, model: str, contents: object, config: object) -> object:
+        del contents
+        self.calls.append(("stream", model, config))
+        return self.stream
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["generate", "stream"])
+@pytest.mark.parametrize(
+    "model,thinking,expected_temperature",
+    [
+        ("gemini-3.6-flash", "medium", None),
+        ("gemini-3.5-flash-lite", "minimal", None),
+        ("gemini-3.1-pro-preview", "high", 0.7),
+    ],
+)
+async def test_google_request_config_respects_model_temperature_support(
+    monkeypatch: pytest.MonkeyPatch,
+    method: str,
+    model: str,
+    thinking: str,
+    expected_temperature: float | None,
+) -> None:
+    provider = GoogleProvider(api_key="test-key")
+    fake_models = _FakeGoogleModels()
+    cast(Any, provider).async_client = SimpleNamespace(aio=SimpleNamespace(models=fake_models))
+    cast(Any, provider).rate_limiter = SimpleNamespace(acquire=AsyncMock())
+    monkeypatch.setattr(Message, "from_google", lambda response: response)
+
+    messages = MessageHistory([Message(role="user", content=[TextBlock(text="Hello")])])
+    system = Message(role="system", content=[TextBlock(text="Be concise")])
+    params = GenerationParams(
+        temperature=0.7,
+        max_completion_tokens=1024,
+        thinking=thinking,
+    )
+
+    result = await getattr(provider, method)(messages, system=system, params=params, model=model)
+
+    assert fake_models.calls[0][:2] == (method, model)
+    config = cast(Any, fake_models.calls[0][2])
+    serialized = config.model_dump(exclude_none=True)
+    if expected_temperature is None:
+        assert "temperature" not in serialized
+    else:
+        assert serialized["temperature"] == expected_temperature
+    assert serialized["thinking_config"]["thinking_level"].lower() == thinking
+
+    if method == "generate":
+        assert result is fake_models.response
+    else:
+        assert isinstance(result, GoogleStreamWrapper)
+        assert result.gemini_stream is fake_models.stream

--- a/tests/agent/llm/test_model_specs.py
+++ b/tests/agent/llm/test_model_specs.py
@@ -3,6 +3,30 @@ import pytest
 from kolega_code.llm.specs import get_model_specs, thinking_effort_options
 
 
+@pytest.mark.parametrize(
+    "model,thinking_options,default_thinking",
+    [
+        ("gemini-3.6-flash", ("minimal", "low", "medium", "high"), "medium"),
+        ("gemini-3.5-flash-lite", ("minimal", "low", "medium", "high"), "minimal"),
+    ],
+)
+def test_new_google_model_specs(
+    model: str,
+    thinking_options: tuple[str, ...],
+    default_thinking: str,
+) -> None:
+    specs = get_model_specs("google", model)
+
+    assert specs["context_length"] == 1048576
+    assert specs["max_completion_tokens"] == 65536
+    assert specs["default_temperature"] == 1.0
+    assert specs["supports_temperature"] is False
+    assert specs["supports_vision"] is True
+    assert specs["thinking_effort"].options == thinking_options
+    assert specs["thinking_effort"].default == default_thinking
+    assert specs["thinking_effort"].mode == "google_thinking_level"
+
+
 @pytest.mark.parametrize("model", ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"])
 @pytest.mark.parametrize("provider,context_length", [("openai", 1050000), ("openai_chatgpt", 272000)])
 def test_gpt56_model_specs(provider, context_length, model):

--- a/tests/agent/llm/test_thinking_effort.py
+++ b/tests/agent/llm/test_thinking_effort.py
@@ -21,6 +21,10 @@ def test_model_specs_expose_provider_specific_thinking_efforts() -> None:
     assert default_thinking_effort("moonshot", "kimi-k2.6") == "auto"
     assert thinking_effort_options("deepseek", "deepseek-v4-pro") == ("none", "high", "max")
     assert default_thinking_effort("deepseek", "deepseek-v4-pro") == "high"
+    assert thinking_effort_options("google", "gemini-3.6-flash") == ("minimal", "low", "medium", "high")
+    assert default_thinking_effort("google", "gemini-3.6-flash") == "medium"
+    assert thinking_effort_options("google", "gemini-3.5-flash-lite") == ("minimal", "low", "medium", "high")
+    assert default_thinking_effort("google", "gemini-3.5-flash-lite") == "minimal"
     assert thinking_effort_options("google", "gemini-3.1-pro-preview") == ("low", "medium", "high")
     assert default_thinking_effort("google", "gemini-3.1-pro-preview") == "high"
     assert thinking_effort_options("zai", "glm-5.2") == ("high", "max")
@@ -213,6 +217,44 @@ def test_google_gemini_3_pro_uses_thinking_level() -> None:
     assert high_config.thinking_level.value.lower() == "high"
     # thinking_level mode does not set an integer budget
     assert high_config.thinking_budget is None
+
+
+@pytest.mark.parametrize(
+    "model,effort",
+    [
+        ("gemini-3.6-flash", "minimal"),
+        ("gemini-3.6-flash", "low"),
+        ("gemini-3.6-flash", "medium"),
+        ("gemini-3.6-flash", "high"),
+        ("gemini-3.5-flash-lite", "minimal"),
+        ("gemini-3.5-flash-lite", "low"),
+        ("gemini-3.5-flash-lite", "medium"),
+        ("gemini-3.5-flash-lite", "high"),
+    ],
+)
+def test_new_google_models_use_supported_thinking_levels(model: str, effort: str) -> None:
+    provider = GoogleProvider(api_key="test-key")
+
+    config = provider._prepare_thinking_config(model, GenerationParams(thinking=effort))
+
+    assert config is not None
+    assert config.thinking_level is not None
+    assert config.thinking_level.value.lower() == effort
+    assert config.thinking_budget is None
+
+
+@pytest.mark.parametrize(
+    "model,effort",
+    [
+        ("gemini-3.6-flash", "xhigh"),
+        ("gemini-3.5-flash-lite", "xhigh"),
+    ],
+)
+def test_new_google_models_reject_unsupported_thinking_levels(model: str, effort: str) -> None:
+    client = LLMClient(provider="google", api_key="test-key")
+
+    with pytest.raises(ValueError, match="Unsupported thinking effort"):
+        client._prepare_thinking_param(effort, model=model)
 
 
 def test_openai_reasoning_effort_is_sent_for_reasoning_models() -> None:

--- a/tests/cli/test_provider_registry.py
+++ b/tests/cli/test_provider_registry.py
@@ -44,6 +44,32 @@ def test_gpt56_models_are_first_and_sol_is_default_for_openai_providers():
     ]
 
 
+def test_new_google_models_are_selectable_without_changing_default() -> None:
+    options = ui_model_options(ModelProvider.GOOGLE.value)
+
+    assert options[:2] == [
+        ("Gemini 3.6 Flash", "gemini-3.6-flash"),
+        ("Gemini 3.5 Flash-Lite", "gemini-3.5-flash-lite"),
+    ]
+    assert default_model_for_provider(ModelProvider.GOOGLE) == "gemini-3.1-pro-preview"
+    assert ui_thinking_effort_options("google", "gemini-3.6-flash") == [
+        ("Minimal", "minimal"),
+        ("Low", "low"),
+        ("Medium", "medium"),
+        ("High", "high"),
+    ]
+    assert ui_thinking_effort_options("google", "gemini-3.5-flash-lite") == [
+        ("Minimal", "minimal"),
+        ("Low", "low"),
+        ("Medium", "medium"),
+        ("High", "high"),
+    ]
+
+    vision_options = dict(ui_model_options(ModelProvider.GOOGLE.value, vision_only=True))
+    assert vision_options["Gemini 3.6 Flash"] == "gemini-3.6-flash"
+    assert vision_options["Gemini 3.5 Flash-Lite"] == "gemini-3.5-flash-lite"
+
+
 def test_fireworks_ui_model_options_include_serverless_catalog():
     options = dict(ui_model_options("fireworks"))
 


### PR DESCRIPTION
## Summary

- add stable `gemini-3.6-flash` and `gemini-3.5-flash-lite` catalog entries with 1M context, 64K output, multimodal support, and model-specific defaults
- expose both models in the Settings UI and `/model` picker while preserving Gemini 3.1 Pro as the Google default
- omit deprecated `temperature` from requests for the new models through a shared streaming/non-streaming Google config path
- document the supported thinking levels and add model, provider serialization, and registry coverage

## Live Gemini API verification

Verified using the repository's configured Google credentials:

- both stable model IDs resolve with API-reported limits of 1,048,576 input and 65,536 output tokens
- both models accept `minimal`, `low`, `medium`, and `high` thinking levels; defaults remain `medium` for 3.6 Flash and `minimal` for 3.5 Flash-Lite
- non-streaming tool calling succeeds with Gemini 3.6 Flash
- streaming tool calling succeeds with Gemini 3.5 Flash-Lite
- `temperature` is currently accepted but deprecated/ignored by Google, so Kolega Code omits it for forward compatibility

## Checks

- `PYTHONDONTWRITEBYTECODE=1 ./run_tests.sh tests/agent/llm/test_model_specs.py tests/agent/llm/test_thinking_effort.py tests/agent/llm/test_google_provider.py tests/cli/test_provider_registry.py -q` — 63 passed
- `uv run ruff check .` — passed
- `uv run pyright` — passed
- `uv run ruff format --check ...` — passed
- `cd docs && npm run build` — passed
- `PYTHONDONTWRITEBYTECODE=1 ./run_tests.sh` — 2691 passed, with two unrelated failures:
  - Fireworks live GLM-5.2 smoke test returned an empty response and reproduced independently
  - one TUI memory async race; it passed on focused rerun
