### PR TITLE
chore: release v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.23.0 - 2026-07-23
+
 ### Added
 
 - Added stable Google Gemini 3.6 Flash and Gemini 3.5 Flash-Lite model support,
   including model-specific thinking levels and omission of their deprecated
   sampling temperature parameter.
+- Displayed each sub-agent's provider, model, and thinking effort in live status,
+  completed transcript summaries, and the sub-agent inspector.
 
 ## 0.22.1 - 2026-07-22
 

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.22.1"
+__version__ = "0.23.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -48,4 +48,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.22.1"
+__version__ = "0.23.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.22.1"
+version = "0.23.0"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-15T16:41:59.437982Z"
+exclude-newer = "2026-07-16T10:08:36.781818Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1497,7 +1497,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.22.1"
+version = "0.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- bump package version to 0.23.0
- add release notes for sub-agent model routing and Gemini 3.6 Flash / 3.5 Flash-Lite support
- refresh the uv lockfile release metadata

## Validation

- `UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" PYTHONDONTWRITEBYTECODE=1 ./run_tests.sh` (2,692 passed; one transient Browserless timeout)
- focused Browserless retry: 1 passed
- `UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" PYTHONDONTWRITEBYTECODE=1 uv run pre-commit run --all-files --show-diff-on-failure`