### PR TITLE
feat(agent): add per-session scratchpad working directory

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -95,6 +95,7 @@ export default defineConfig({
             { label: "Chat Composer", slug: "tui/composer" },
             { label: "Slash Commands", slug: "tui/slash-commands" },
             { label: "Project Memory", slug: "tui/project-memory" },
+            { label: "Session Scratchpad", slug: "tui/scratchpad" },
             { label: "Sessions & Resuming", slug: "tui/sessions-and-resume" },
           ],
         },

--- a/docs/src/content/docs/tui/project-memory.md
+++ b/docs/src/content/docs/tui/project-memory.md
@@ -168,8 +168,9 @@ Project memory is distinct from:
   instructions;
 - host-provided `workspace_memories`: a separately labelled host context;
 - session history: the messages and tool results used to resume a conversation;
-  and
-- the Planning tab's task list: current work state, not durable knowledge.
+- the Planning tab's task list: current work state, not durable knowledge; and
+- the [session scratchpad](../scratchpad/): a per-session throwaway working
+  directory in OS temp for scripts, downloads, and other transient files.
 
 ## Pluggable backends
 

--- a/docs/src/content/docs/tui/scratchpad.md
+++ b/docs/src/content/docs/tui/scratchpad.md
@@ -1,0 +1,63 @@
+---
+title: Session Scratchpad
+description: A per-session throwaway working directory in OS temp for scripts, venvs, and downloads.
+---
+
+Every session gets a private **scratchpad working directory** under the OS
+temp dir. The agent is told its path in the system prompt and uses it for
+throwaway work that should not touch your repository: one-off scripts, ad-hoc
+virtual environments, downloaded files, extracted archives, generated
+intermediates, and log captures.
+
+Nothing is written to your repository, so `git status` stays clean.
+
+## Where it lives
+
+The path is shaped like:
+
+```text
+<os-temp>/kolega-code-<user>/<project-key>/<session-id>/scratchpad/
+```
+
+- `<os-temp>` is the platform temp dir (`$TMPDIR` on macOS, `%TEMP%` on
+  Windows, `/tmp` on most Linux).
+- `<user>` is the numeric user id on POSIX (temp dirs can be shared there) or
+  the login name elsewhere.
+- `<project-key>` is the same stable project identity used by
+  [project memory](../project-memory/): linked Git worktrees share a key,
+  separate clones do not.
+- `<session-id>` scopes the directory to one conversation. Resuming a session
+  — including across plan/build mode switches — advertises the same path, so
+  earlier scratchpad files are still there until the OS cleans them.
+
+## What belongs there (and what does not)
+
+The scratchpad is **throwaway by design**. It is not swept, migrated, or
+backed up by Kolega Code — the operating system reclaims temp on its own
+schedule (for example on reboot). The agent is instructed accordingly:
+
+- deliverables and anything you must keep belong in the working directory,
+  never in the scratchpad;
+- sub-agents share the session's scratchpad and use unique filenames to avoid
+  collisions;
+- the agent must not delete scratchpad files it did not create.
+
+The scratchpad is the only location outside the working directory where the
+agent may create files without asking. If the optional shell-command safety
+checker is enabled, commands that read, write, or delete files inside the
+scratchpad directory are treated as in-scope; other out-of-project paths are
+still flagged.
+
+## Relation to other state
+
+The scratchpad is distinct from:
+
+- [project memory](../project-memory/): durable, curated knowledge that
+  persists across sessions — never transient progress or task state;
+- the current plan artifact: the approved implementation plan preserved
+  across compaction;
+- session history: the messages and tool results used to resume a
+  conversation.
+
+If the temp directory cannot be created, the session simply runs without a
+scratchpad section; nothing else changes.

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -298,6 +298,36 @@ class BaseAgent(LogMixin):
             self.context.services.memory_manager = self.memory_manager
             self._owns_memory_manager = True
 
+        # Session scratchpad: a per-session throwaway working directory under the
+        # OS temp dir. The TUI injects the prompt extension itself (keyed by its
+        # session id); other local hosts get it here, keyed by thread id.
+        # Sandbox/E2B hosts are unchanged, as are sub-agents, which inherit the
+        # section and the resolved directory from their parent.
+        self.scratchpad_dir: Optional[Path] = None
+        if not sub_agent and isinstance(self.filesystem, LocalFileSystem):
+            from kolega_code.scratchpad import SCRATCHPAD_PROMPT_EXTENSION_ID, ensure_scratchpad_dir
+
+            extensions = self.prompt_extensions or []
+            if not any(getattr(ext, "id", None) == SCRATCHPAD_PROMPT_EXTENSION_ID for ext in extensions):
+                try:
+                    scratchpad_path = ensure_scratchpad_dir(self.project_path, self.thread_id)
+                except (OSError, ValueError):
+                    scratchpad_path = None
+                if scratchpad_path is not None:
+                    from .prompts import build_scratchpad_prompt
+
+                    self.prompt_extensions = [
+                        *extensions,
+                        PromptExtension(
+                            id=SCRATCHPAD_PROMPT_EXTENSION_ID,
+                            title="Session Scratchpad",
+                            markdown=build_scratchpad_prompt(scratchpad_path),
+                            # No mode restriction: the fallback serves any local host.
+                            propagate_to_sub_agents=True,
+                        ),
+                    ]
+                    self.scratchpad_dir = scratchpad_path
+
         # gigacode (workflow orchestration) opt-in. Off by default; the host toggles
         # it via apply_gigacode(). The run_workflow tool gate reads this live, so
         # toggling takes effect on the next turn without rebuilding the agent.

--- a/kolega_code/agent/prompt_templates/auxiliary/terminal/safety.system.md
+++ b/kolega_code/agent/prompt_templates/auxiliary/terminal/safety.system.md
@@ -3,6 +3,7 @@ You are a security expert evaluating shell commands for safety. Your task is to 
 Rules for safe commands:
 - Commands that modify files within the project's working directory (e.g. git, npm, pip, file operations)
 - Commands to delete files within the project's working directory
+- Commands that read, write, or delete files inside the session scratchpad directory provided in the command context
 - Basic directory navigation (cd, ls, pwd)
 - Reading file contents (cat, less, head, tail)
 - Package management within the project scope

--- a/kolega_code/agent/prompt_templates/extensions/cli/scratchpad.md.j2
+++ b/kolega_code/agent/prompt_templates/extensions/cli/scratchpad.md.j2
@@ -1,0 +1,11 @@
+You have a private scratchpad working directory for this session at:
+
+`{{ scratchpad_path }}`
+
+Use it for throwaway work that must not touch the user's working tree: one-off scripts, ad-hoc virtual environments, downloaded files, extracted archives, generated intermediates, and log captures. This is the only location outside the working directory where you may create files without asking.
+
+Rules:
+
+- Never place deliverables in the scratchpad. It is a per-session temp directory that the OS may delete at any time; anything the user must keep belongs in the working directory.
+- The directory may already contain files from earlier turns of this session or from sub-agents that share it. Do not delete files you did not create.
+- Create uniquely named files; other agents may use the directory concurrently.

--- a/kolega_code/agent/prompt_templates/system/agents/coder_cli.md.j2
+++ b/kolega_code/agent/prompt_templates/system/agents/coder_cli.md.j2
@@ -82,7 +82,7 @@ Use dependencies and external APIs that fit the repository and the user's reques
 
 ## Tool Calling Guidelines
 
-Use the available tools according to their schemas and scope. Before meaningful file edits or long-running checks, briefly state what you are about to do. Keep all file operations inside the working directory unless the user explicitly authorizes broader access.
+Use the available tools according to their schemas and scope. Before meaningful file edits or long-running checks, briefly state what you are about to do. Keep all file operations inside the working directory (or the session scratchpad directory, when one is provided) unless the user explicitly authorizes broader access.
 
 ## Delegating to Sub-Agents
 

--- a/kolega_code/agent/prompts.py
+++ b/kolega_code/agent/prompts.py
@@ -87,6 +87,13 @@ def build_current_plan_artifact_prompt(plan_artifact_path: str | Path) -> str:
     )
 
 
+def build_scratchpad_prompt(scratchpad_path: str | Path) -> str:
+    return render_prompt_template(
+        "extensions/cli/scratchpad.md.j2",
+        scratchpad_path=str(scratchpad_path),
+    )
+
+
 def build_init_agents_prompt(arguments: str) -> str:
     return render_prompt_template("user_tasks/cli/init_agents.md.j2", arguments=arguments.strip())
 

--- a/kolega_code/agent/tool_backend/agent_tool.py
+++ b/kolega_code/agent/tool_backend/agent_tool.py
@@ -351,6 +351,10 @@ class AgentTool(BaseTool):
             # Store agent reference
             self.agents[agent_id] = agent
 
+            # Sub-agents share the parent's scratchpad directory (the model-facing
+            # section is inherited separately via propagate_to_sub_agents).
+            agent.scratchpad_dir = getattr(self.caller, "scratchpad_dir", None)
+
             # Set parent context so the agent's own events carry sub_agent_info
             agent.parent_tool_call_id = tool_call_id
             agent.conversation_id = conversation_id
@@ -733,7 +737,7 @@ class AgentTool(BaseTool):
         tool_extensions = self._sub_agent_extensions(getattr(self.caller, "tool_extensions", None))
         if extra_tool_extensions:
             tool_extensions = list(tool_extensions or []) + list(extra_tool_extensions)
-        return agent_class(
+        agent = agent_class(
             project_path=self.project_path,
             workspace_id=self.workspace_id,
             thread_id=self.thread_id,
@@ -768,6 +772,9 @@ class AgentTool(BaseTool):
             hook_dispatcher=getattr(self.caller, "hook_dispatcher", None) if self.caller else None,
             max_iterations=getattr(self.caller, "max_iterations", None),
         )
+        # Workflow sub-agents share the parent's scratchpad directory too.
+        agent.scratchpad_dir = getattr(self.caller, "scratchpad_dir", None)
+        return agent
 
     @staticmethod
     def _write_jsonl_message(path: Optional[Path], message: dict) -> None:

--- a/kolega_code/agent/tool_backend/terminal_tool.py
+++ b/kolega_code/agent/tool_backend/terminal_tool.py
@@ -72,13 +72,15 @@ class TerminalTool(BaseTool):
 
             system_message = Message(role="system", content=[TextBlock(text=prompts.SHELL_SAFETY_SYSTEM_PROMPT)])
 
+            scratchpad_dir = getattr(self.caller, "scratchpad_dir", None)
+            directory_context = f"Project directory:\n{str(self.caller.project_path)}"
+            if isinstance(scratchpad_dir, (str, Path)) and scratchpad_dir:
+                directory_context += f"\nScratchpad directory (session-writable):\n{scratchpad_dir}"
             messages = MessageHistory(
                 [
                     Message(
                         role="user",
-                        content=[
-                            TextBlock(text=f"Project directory:\n{str(self.caller.project_path)}\nCommand:\n{command}")
-                        ],
+                        content=[TextBlock(text=f"{directory_context}\nCommand:\n{command}")],
                     )
                 ]
             )

--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -8,8 +8,9 @@ from kolega_code.agent import AgentConfig, AgentEvent, CoderAgent, PlanningAgent
 from kolega_code.agent.baseagent import QueuedUserInput
 from kolega_code.agent.prompt_provider import AgentMode
 from kolega_code.agent.custom_agents import discover_custom_agents, validate_custom_agent_models
-from kolega_code.agent.prompts import build_current_plan_artifact_prompt
+from kolega_code.agent.prompts import build_current_plan_artifact_prompt, build_scratchpad_prompt
 from kolega_code.hooks import HookDispatcher, HookEvent, load_hook_config, project_hooks_present
+from kolega_code.scratchpad import SCRATCHPAD_PROMPT_EXTENSION_ID, ensure_scratchpad_dir, scratchpad_dir_for
 from kolega_code.llm.exceptions import LLMError, llm_error_message
 from kolega_code.mcp.tools import build_mcp_tool_extension
 from kolega_code.services.browser import PlaywrightBrowserManager
@@ -759,6 +760,35 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
             propagate_to_sub_agents=True,
         )
 
+    def _scratchpad_prompt_extension(self) -> PromptExtension | None:
+        """Return prompt context advertising this session's scratchpad directory.
+
+        Applies to both interaction modes and is stable across resumes and
+        plan/build switches because it is keyed by ``session.session_id``.
+        Best-effort: if the temp directory cannot be created the agent simply
+        runs without a scratchpad section.
+        """
+        try:
+            scratchpad_path = ensure_scratchpad_dir(self.project_path, self.session.session_id)
+        except (OSError, ValueError) as exc:
+            try:
+                self._notify_user(
+                    f"Could not prepare the session scratchpad: {exc}",
+                    severity="warning",
+                )
+            except Exception:
+                pass
+            return None
+        return PromptExtension(
+            id=SCRATCHPAD_PROMPT_EXTENSION_ID,
+            title="Session Scratchpad",
+            markdown=build_scratchpad_prompt(scratchpad_path),
+            modes=[AgentMode.CLI],
+            # Delegated agents share the parent's scratchpad; the prompt text
+            # tells them to use unique filenames for concurrent safety.
+            propagate_to_sub_agents=True,
+        )
+
     async def _build_agent(
         self,
         config: AgentConfig,
@@ -799,6 +829,11 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
         # callback stay on the top-level agent and are never inherited by delegates.
         prompt_extensions.append(self._goal_control_prompt_extension())
         tool_extensions.append(self._goal_control_tool_extension())
+        # Both interaction modes get the scratchpad: plan-mode research and
+        # build-mode execution both produce throwaway files.
+        scratchpad_extension = self._scratchpad_prompt_extension()
+        if scratchpad_extension is not None:
+            prompt_extensions.append(scratchpad_extension)
         skill_prompt_extension = build_skill_prompt_extension(
             self.skill_catalog,
             context_window_tokens=context_window_tokens_for_skill_budget(
@@ -861,6 +896,10 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
             custom_agent_catalog=self.custom_agent_catalog,
         )
         assert self.agent is not None
+        if scratchpad_extension is not None:
+            # Expose the resolved directory for the terminal safety checker; the
+            # prompt extension above is what the model sees.
+            self.agent.scratchpad_dir = scratchpad_dir_for(self.project_path, self.session.session_id)
         # Mid-turn queue delivery: the running turn drains composer messages
         # queued while it works (main agent only; sub-agents never get this).
         self.agent.set_queued_input_provider(self._provide_queued_user_inputs)

--- a/kolega_code/scratchpad.py
+++ b/kolega_code/scratchpad.py
@@ -1,0 +1,81 @@
+"""Per-session scratchpad working directories under the OS temp dir.
+
+The scratchpad is the one sanctioned location outside the project working
+directory where agents may create files without asking: throwaway scripts,
+ad-hoc virtual environments, downloads, extracted archives, and intermediate
+outputs that must not pollute the user's working tree.
+
+Scratchpads are deliberately *not* durable state. They live under the OS temp
+dir keyed by user, project identity, and session id, and the OS reclaims them
+on its own schedule. Kolega Code never sweeps or migrates them, and agents are
+told (via the prompt extension) not to place deliverables there.
+"""
+
+from __future__ import annotations
+
+import getpass
+import os
+import re
+import tempfile
+from pathlib import Path
+
+from kolega_code.local_state import ensure_private_dir
+from kolega_code.memory.identity import resolve_project_identity
+
+# Reserved prompt-extension id. Hosts and the BaseAgent fallback check for this
+# id so the section is never injected twice.
+SCRATCHPAD_PROMPT_EXTENSION_ID = "kolega-session-scratchpad"
+
+_SCRATCHPAD_DIRNAME = "scratchpad"
+
+
+def _user_suffix() -> str:
+    """Return a per-user path suffix for shared temp dirs."""
+    getuid = getattr(os, "getuid", None)
+    if callable(getuid):
+        return str(getuid())
+    # Windows has no getuid; its temp dir is already per-user, but keep the
+    # path shape uniform across platforms.
+    try:
+        name = getpass.getuser()
+    except Exception:  # pragma: no cover - getuser rarely fails, but never break a session over it
+        name = ""
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "-", name).strip(".-")
+    return slug or "user"
+
+
+def scratchpad_root() -> Path:
+    """Return the per-user root under the OS temp dir for all scratchpads."""
+    return Path(tempfile.gettempdir()) / f"kolega-code-{_user_suffix()}"
+
+
+def _validate_session_id(session_id: str) -> str:
+    """Return ``session_id`` stripped, or raise when unsafe as a path component."""
+    normalized = (session_id or "").strip()
+    if not normalized or normalized in {".", ".."} or "/" in normalized or "\\" in normalized or "\0" in normalized:
+        raise ValueError(f"session_id is not a safe path component: {session_id!r}")
+    return normalized
+
+
+def scratchpad_dir_for(project_path: Path | str, session_id: str) -> Path:
+    """Return the deterministic per-session scratchpad directory for a project.
+
+    The project component reuses the project-memory identity key, so linked
+    Git worktrees share one namespace while separate clones do not; the
+    session id provides the per-session scope. The same project + session id
+    always maps to the same directory, including across session resumes.
+    """
+    identity = resolve_project_identity(project_path)
+    return scratchpad_root() / identity.directory_key / _validate_session_id(session_id) / _SCRATCHPAD_DIRNAME
+
+
+def ensure_scratchpad_dir(project_path: Path | str, session_id: str) -> Path:
+    """Create the session scratchpad directory (owner-only) and return its path.
+
+    Idempotent and cheap; intended to run whenever the scratchpad prompt
+    extension is (re)built. Callers treat this as best-effort and catch
+    ``OSError`` to run without a scratchpad.
+    """
+    path = scratchpad_dir_for(project_path, session_id)
+    ensure_private_dir(path)
+    return path

--- a/tests/agent/test_prompts.py
+++ b/tests/agent/test_prompts.py
@@ -52,6 +52,22 @@ def test_current_plan_artifact_prompt_renders_path() -> None:
     assert "read-only" in rendered
 
 
+def test_scratchpad_prompt_renders_path_and_rules() -> None:
+    rendered = prompts.build_scratchpad_prompt("/tmp/kolega-code-501/project-key/session-1/scratchpad")
+
+    assert "/tmp/kolega-code-501/project-key/session-1/scratchpad" in rendered
+    assert "throwaway" in rendered
+    assert "deliverables" in rendered
+    assert "uniquely named files" in rendered
+    assert "{{" not in rendered
+
+
+def test_coder_cli_prompt_allows_scratchpad_file_operations() -> None:
+    source = prompts.prompt_template_source("system/agents/coder_cli.md.j2")
+
+    assert "session scratchpad directory" in source
+
+
 def test_implement_plan_prompt_omits_gigacode_nudge_by_default() -> None:
     rendered = prompts.build_implement_plan_prompt("- [ ] update docs")
 

--- a/tests/agent/test_scratchpad.py
+++ b/tests/agent/test_scratchpad.py
@@ -1,0 +1,300 @@
+# ruff: noqa: F401,F811,E402
+"""Tests for the per-session scratchpad directory (kolega_code.scratchpad)."""
+
+import os
+import stat
+import subprocess
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from kolega_code.agent.prompts import build_scratchpad_prompt
+from kolega_code.agent.tool_backend.terminal_tool import TerminalTool
+from kolega_code.scratchpad import (
+    SCRATCHPAD_PROMPT_EXTENSION_ID,
+    _user_suffix,
+    ensure_scratchpad_dir,
+    scratchpad_dir_for,
+    scratchpad_root,
+)
+
+
+def _git_init(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", str(path)], check=True)
+
+
+class TestScratchpadPaths:
+    def test_root_is_per_user_under_temp_dir(self, tmp_path: Path) -> None:
+        root = scratchpad_root()
+
+        # tests/conftest.py redirects tempfile.tempdir to the test tmp_path.
+        assert root.parent == tmp_path
+        assert root.name == f"kolega-code-{_user_suffix()}"
+        assert root.name.startswith("kolega-code-")
+        assert root.name != "kolega-code-"
+
+    def test_dir_shape_uses_project_key_session_and_scratchpad(self, tmp_path: Path) -> None:
+        project = tmp_path / "my-project"
+        project.mkdir()
+
+        path = scratchpad_dir_for(project, "session-abc")
+
+        assert path.name == "scratchpad"
+        assert path.parent.name == "session-abc"
+        assert path.parent.parent.parent == scratchpad_root()
+        # The project component is the project-memory directory key: name slug + digest.
+        assert path.parent.parent.name.startswith("my-project-")
+
+    def test_same_project_and_session_is_stable(self, tmp_path: Path) -> None:
+        project = tmp_path / "project"
+        project.mkdir()
+
+        assert scratchpad_dir_for(project, "s1") == scratchpad_dir_for(project, "s1")
+        assert scratchpad_dir_for(str(project), "s1") == scratchpad_dir_for(project, "s1")
+
+    def test_different_sessions_are_isolated(self, tmp_path: Path) -> None:
+        project = tmp_path / "project"
+        project.mkdir()
+
+        first = scratchpad_dir_for(project, "s1")
+        second = scratchpad_dir_for(project, "s2")
+
+        assert first != second
+        assert first.parent.parent == second.parent.parent  # same project namespace
+
+    def test_directories_in_one_git_repo_share_project_namespace(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        _git_init(repo)
+        sub_a = repo / "a"
+        sub_b = repo / "b"
+        sub_a.mkdir()
+        sub_b.mkdir()
+
+        path_a = scratchpad_dir_for(sub_a, "s1")
+        path_b = scratchpad_dir_for(sub_b, "s1")
+
+        assert path_a.parent.parent == path_b.parent.parent
+
+    def test_separate_git_clones_do_not_share_project_namespace(self, tmp_path: Path) -> None:
+        repo_one = tmp_path / "one"
+        repo_two = tmp_path / "two"
+        _git_init(repo_one)
+        _git_init(repo_two)
+
+        assert scratchpad_dir_for(repo_one, "s1").parent.parent != scratchpad_dir_for(repo_two, "s1").parent.parent
+
+    @pytest.mark.parametrize("bad_id", ["", "   ", ".", "..", "a/b", "a\\b", "a\0b"])
+    def test_invalid_session_id_rejected(self, tmp_path: Path, bad_id: str) -> None:
+        with pytest.raises(ValueError):
+            scratchpad_dir_for(tmp_path, bad_id)
+
+    def test_session_id_is_stripped(self, tmp_path: Path) -> None:
+        assert scratchpad_dir_for(tmp_path, "  s1  ") == scratchpad_dir_for(tmp_path, "s1")
+
+
+class TestEnsureScratchpadDir:
+    def test_creates_owner_only_chain(self, tmp_path: Path) -> None:
+        project = tmp_path / "project"
+        project.mkdir()
+
+        old_umask = os.umask(0)
+        try:
+            path = ensure_scratchpad_dir(project, "session-xyz")
+        finally:
+            os.umask(old_umask)
+
+        assert path == scratchpad_dir_for(project, "session-xyz")
+        assert path.is_dir()
+        if os.name != "nt":
+            assert stat.S_IMODE(path.stat().st_mode) == 0o700
+            assert stat.S_IMODE(path.parent.stat().st_mode) == 0o700
+            assert stat.S_IMODE(scratchpad_root().stat().st_mode) == 0o700
+
+    def test_second_call_is_noop(self, tmp_path: Path) -> None:
+        project = tmp_path / "project"
+        project.mkdir()
+
+        first = ensure_scratchpad_dir(project, "s1")
+        marker = first / "keep.txt"
+        marker.write_text("still here", encoding="utf-8")
+        second = ensure_scratchpad_dir(project, "s1")
+
+        assert first == second
+        assert marker.read_text(encoding="utf-8") == "still here"
+
+
+class TestScratchpadPrompt:
+    def test_renders_path_and_core_rules(self, tmp_path: Path) -> None:
+        rendered = build_scratchpad_prompt(tmp_path / "scratchpad")
+
+        assert str(tmp_path / "scratchpad") in rendered
+        # Throwaway-only: no deliverables, OS may delete at any time.
+        assert "deliverables" in rendered
+        assert "throwaway" in rendered
+        # Shared-directory etiquette for sub-agents.
+        assert "uniquely named files" in rendered
+        assert "did not create" in rendered
+        # Sanctioned out-of-worktree location.
+        assert "outside the working directory" in rendered
+
+    def test_template_is_fully_rendered(self, tmp_path: Path) -> None:
+        rendered = build_scratchpad_prompt(tmp_path / "scratchpad")
+
+        assert "{{" not in rendered
+        assert "}}" not in rendered
+
+
+class _FakeResponse:
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def get_text_content(self) -> str:
+        return self._text
+
+
+@pytest.fixture
+def terminal_tool(tmp_path, mock_connection_manager, agent_config):
+    caller = Mock()
+    caller.agent_name = "test_agent"
+    caller.scratchpad_dir = None
+    tool = TerminalTool(tmp_path, "test_workspace", str(uuid.uuid4()), mock_connection_manager, agent_config, caller)
+    tool.initialized = True
+    return tool
+
+
+class TestTerminalSafetyCheck:
+    @staticmethod
+    def _patch_security_llm(monkeypatch: pytest.MonkeyPatch, captured: dict, verdict: str = "safe") -> None:
+        class _FakeClient:
+            def __init__(self, **kwargs) -> None:
+                pass
+
+            async def generate(self, **kwargs):
+                captured.update(kwargs)
+                return _FakeResponse(verdict)
+
+        monkeypatch.setattr("kolega_code.agent.tool_backend.terminal_tool.LLMClient", _FakeClient)
+        monkeypatch.setattr(
+            "kolega_code.agent.tool_backend.terminal_tool.get_model_specs",
+            lambda *args, **kwargs: {"max_completion_tokens": 16},
+        )
+
+    @staticmethod
+    def _user_text(captured: dict) -> str:
+        message = captured["messages"][0]
+        return "\n".join(block.text for block in message.content)
+
+    @pytest.mark.asyncio
+    async def test_security_check_includes_scratchpad_directory(self, terminal_tool, monkeypatch) -> None:
+        scratchpad = Path("/tmp/kolega-code-test/key/session/scratchpad")
+        terminal_tool.caller.scratchpad_dir = scratchpad
+        captured: dict = {}
+        self._patch_security_llm(monkeypatch, captured)
+
+        ok, _ = await terminal_tool._run_command_security_check("echo hi > scratchpad/script.py")
+
+        assert ok is True
+        text = self._user_text(captured)
+        assert "Project directory:" in text
+        assert f"Scratchpad directory (session-writable):\n{scratchpad}" in text
+        assert "echo hi > scratchpad/script.py" in text
+
+    @pytest.mark.asyncio
+    async def test_security_check_omits_scratchpad_when_unavailable(self, terminal_tool, monkeypatch) -> None:
+        terminal_tool.caller.scratchpad_dir = None
+        captured: dict = {}
+        self._patch_security_llm(monkeypatch, captured)
+
+        ok, _ = await terminal_tool._run_command_security_check("echo hi")
+
+        assert ok is True
+        assert "Scratchpad directory" not in self._user_text(captured)
+
+    def test_safety_prompt_whitelists_scratchpad(self) -> None:
+        from kolega_code.agent import prompts
+
+        assert "scratchpad" in prompts.SHELL_SAFETY_SYSTEM_PROMPT
+        assert "session scratchpad directory" in prompts.SHELL_SAFETY_SYSTEM_PROMPT
+
+
+class TestBaseAgentFallback:
+    """The BaseAgent fallback gives non-TUI local hosts a scratchpad for free."""
+
+    @staticmethod
+    def _make_agent(tmp_path: Path, agent_config, mock_connection_manager, **overrides):
+        from kolega_code.agent.baseagent import BaseAgent
+
+        kwargs = {
+            "project_path": tmp_path,
+            "workspace_id": "test_workspace",
+            "thread_id": "thread-abc123",
+            "connection_manager": mock_connection_manager,
+            "config": agent_config,
+        }
+        kwargs.update(overrides)
+        return BaseAgent(**kwargs)
+
+    @staticmethod
+    def _scratchpad_extensions(agent) -> list:
+        return [ext for ext in agent.prompt_extensions if getattr(ext, "id", None) == SCRATCHPAD_PROMPT_EXTENSION_ID]
+
+    def test_top_level_local_agent_gets_scratchpad(self, tmp_path, agent_config, mock_connection_manager) -> None:
+        agent = self._make_agent(tmp_path, agent_config, mock_connection_manager)
+
+        extensions = self._scratchpad_extensions(agent)
+        assert len(extensions) == 1
+        extension = extensions[0]
+        expected = scratchpad_dir_for(tmp_path, "thread-abc123")
+        assert str(expected) in extension.markdown
+        assert extension.propagate_to_sub_agents is True
+        assert extension.modes is None  # fallback serves any host mode
+        assert agent.scratchpad_dir == expected
+        assert expected.is_dir()
+
+    def test_sub_agent_gets_no_fallback(self, tmp_path, agent_config, mock_connection_manager) -> None:
+        agent = self._make_agent(tmp_path, agent_config, mock_connection_manager, sub_agent=True)
+
+        assert self._scratchpad_extensions(agent) == []
+        assert agent.scratchpad_dir is None
+
+    def test_non_local_filesystem_gets_no_fallback(self, tmp_path, agent_config, mock_connection_manager) -> None:
+        from kolega_code.services.file_system import FileSystem
+
+        sandbox_fs = MagicMock(spec=FileSystem)
+        agent = self._make_agent(tmp_path, agent_config, mock_connection_manager, filesystem=sandbox_fs)
+
+        assert self._scratchpad_extensions(agent) == []
+        assert agent.scratchpad_dir is None
+
+    def test_host_injected_extension_is_not_duplicated(self, tmp_path, agent_config, mock_connection_manager) -> None:
+        from kolega_code.agent.prompt_provider import PromptExtension
+
+        injected = PromptExtension(
+            id=SCRATCHPAD_PROMPT_EXTENSION_ID,
+            title="Session Scratchpad",
+            markdown="host-managed scratchpad",
+        )
+        agent = self._make_agent(tmp_path, agent_config, mock_connection_manager, prompt_extensions=[injected])
+
+        extensions = self._scratchpad_extensions(agent)
+        assert len(extensions) == 1
+        assert extensions[0].markdown == "host-managed scratchpad"
+        # The host owns the extension; the fallback does not resolve a directory.
+        assert agent.scratchpad_dir is None
+
+    def test_scratchpad_creation_failure_is_non_fatal(
+        self, tmp_path, agent_config, mock_connection_manager, monkeypatch
+    ) -> None:
+        def _boom(*args, **kwargs):
+            raise OSError("temp dir unavailable")
+
+        monkeypatch.setattr("kolega_code.scratchpad.ensure_scratchpad_dir", _boom)
+        # baseagent imports ensure_scratchpad_dir lazily inside __init__, so patch
+        # the symbol it looks up on the module.
+        agent = self._make_agent(tmp_path, agent_config, mock_connection_manager)
+
+        assert self._scratchpad_extensions(agent) == []
+        assert agent.scratchpad_dir is None

--- a/tests/cli/_app_test_utils.py
+++ b/tests/cli/_app_test_utils.py
@@ -43,6 +43,8 @@ class FakeCoderAgent:
         self.active_goal_condition = None
         self.session_recorder = kwargs.get("session_recorder")
         self.queued_input_provider = None
+        # Set by _build_agent when the scratchpad prompt extension is active.
+        self.scratchpad_dir = None
 
     def apply_goal(self, condition, prompt_extension=None):
         self.active_goal_condition = condition

--- a/tests/cli/test_app_scratchpad.py
+++ b/tests/cli/test_app_scratchpad.py
@@ -1,0 +1,110 @@
+# ruff: noqa: F401,F811,E402
+"""TUI wiring for the per-session scratchpad prompt extension."""
+
+from pathlib import Path
+
+import pytest
+
+from kolega_code.cli.config import config_summary
+from kolega_code.cli.session_store import SessionStore
+from kolega_code.scratchpad import SCRATCHPAD_PROMPT_EXTENSION_ID, scratchpad_dir_for
+
+from ._app_test_utils import (
+    FakeCoderAgent,
+    build_test_config,
+    extension_by_name,
+    install_fake_agents,
+)
+
+
+def _build_app(tmp_path: Path):
+    from kolega_code.cli.app import KolegaCodeApp
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+    return app, project, store, session
+
+
+@pytest.mark.asyncio
+async def test_textual_app_agent_gets_scratchpad_extension(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("textual")
+
+    install_fake_agents(monkeypatch, planning_cls=FakeCoderAgent)
+    app, project, store, session = _build_app(tmp_path)
+
+    async with app.run_test():
+        assert isinstance(app.agent, FakeCoderAgent)
+        extension = extension_by_name(app.agent.kwargs["prompt_extensions"], SCRATCHPAD_PROMPT_EXTENSION_ID)
+        expected = scratchpad_dir_for(project, session.session_id)
+
+        assert extension.title == "Session Scratchpad"
+        assert str(expected) in extension.markdown
+        assert extension.propagate_to_sub_agents is True
+        assert app.agent.scratchpad_dir == expected
+        assert expected.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_textual_app_scratchpad_path_is_stable_across_modes_and_rebuilds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    install_fake_agents(monkeypatch, planning_cls=FakeCoderAgent)
+    app, project, store, session = _build_app(tmp_path)
+
+    async with app.run_test():
+        assert isinstance(app.agent, FakeCoderAgent)
+        build_path = app.agent.scratchpad_dir
+        assert build_path == scratchpad_dir_for(project, session.session_id)
+
+        # Plan mode rebuilds the agent with the same session id, so the
+        # scratchpad path must not change.
+        await app.action_toggle_interaction_mode()
+        assert app.interaction_mode == "plan"
+        assert isinstance(app.agent, FakeCoderAgent)
+        plan_extension = extension_by_name(app.agent.kwargs["prompt_extensions"], SCRATCHPAD_PROMPT_EXTENSION_ID)
+        assert app.agent.scratchpad_dir == build_path
+        assert str(build_path) in plan_extension.markdown
+        assert plan_extension.propagate_to_sub_agents is True
+
+        # Switching back to build mode keeps the same path again.
+        await app.action_toggle_interaction_mode()
+        assert app.interaction_mode == "build"
+        assert isinstance(app.agent, FakeCoderAgent)
+        assert app.agent.scratchpad_dir == build_path
+        extension_by_name(app.agent.kwargs["prompt_extensions"], SCRATCHPAD_PROMPT_EXTENSION_ID)
+
+
+@pytest.mark.asyncio
+async def test_textual_app_resumed_session_keeps_scratchpad_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    install_fake_agents(monkeypatch, planning_cls=FakeCoderAgent)
+    app, project, store, session = _build_app(tmp_path)
+
+    async with app.run_test():
+        assert isinstance(app.agent, FakeCoderAgent)
+        original_path = app.agent.scratchpad_dir
+
+    # A second app instance bound to the same session record (resume) resolves
+    # the identical scratchpad directory.
+    from kolega_code.cli.app import KolegaCodeApp
+
+    resumed = KolegaCodeApp(
+        project_path=project,
+        config=app.config,
+        mode="code",
+        store=store,
+        session=store.load(session.session_id),
+    )
+    async with resumed.run_test():
+        assert isinstance(resumed.agent, FakeCoderAgent)
+        assert resumed.agent.scratchpad_dir == original_path
+        extension_by_name(resumed.agent.kwargs["prompt_extensions"], SCRATCHPAD_PROMPT_EXTENSION_ID)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared pytest configuration for the repository."""
 
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -34,3 +35,15 @@ def isolated_cli_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     for key in {*API_KEY_ENV.values(), *CLI_CONFIG_ENV_KEYS}:
         monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("KOLEGA_CODE_STATE_DIR", str(tmp_path / "state"))
+
+
+@pytest.fixture(autouse=True)
+def isolated_temp_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Point the process temp dir at the test's tmp_path for full isolation.
+
+    tempfile caches its probe in ``tempfile.tempdir``; pre-seeding the cache
+    redirects gettempdir/mkstemp/mkdtemp without env vars. Session scratchpads
+    (kolega_code.scratchpad) resolve under it, so agent and TUI tests never
+    touch the developer's real temp dir.
+    """
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))


### PR DESCRIPTION
## Summary

Give every agent session a private, per-session **scratchpad working directory** under the OS temp dir, advertised to the model through a system-prompt section (Claude Code model). Agents use it for throwaway work — one-off scripts, ad-hoc venvs, downloads, extracted archives, intermediates — instead of polluting the user's working tree.

```text
<os-temp>/kolega-code-<uid>/<project-key>/<session-id>/scratchpad/
```

- `<project-key>` reuses the project-memory identity, so linked Git worktrees share a namespace
- `<session-id>` keeps the path stable across resumes and plan/build mode switches
- No kolega-side cleanup: the OS owns temp reclamation

## Changes

- **`kolega_code/scratchpad.py`** (new): path derivation, owner-only (0700) creation, reserved prompt-extension id, session-id validation
- **Prompt**: new `scratchpad.md.j2` extension section (`build_scratchpad_prompt`); `coder_cli.md.j2` guidelines permit the scratchpad as the one sanctioned out-of-worktree write location
- **TUI** (`agent_runtime.py`): inject the extension in both plan and build modes; expose the resolved path on the agent as `scratchpad_dir`
- **BaseAgent fallback**: non-TUI local hosts get the extension automatically (keyed by `thread_id`); sandbox/E2B hosts and sub-agents are unchanged; hosts that inject the reserved id are never double-injected
- **Sub-agents**: share the parent's scratchpad — prompt inheritance via `propagate_to_sub_agents` plus explicit `scratchpad_dir` propagation at both construction sites in `agent_tool.py`
- **Terminal safety checker**: the check context includes the scratchpad directory and `safety.system.md` whitelists file ops inside it (previously any out-of-project access was flagged)
- **Docs**: new `tui/scratchpad` page + sidebar entry; `project-memory` page lists it as a distinct kind of state

## Test plan

- New `tests/agent/test_scratchpad.py` (26 tests): path shape/stability/isolation, git common-dir sharing vs separate clones, owner-only creation, session-id validation, prompt rendering, safety-check context, BaseAgent fallback (incl. creation failure is non-fatal)
- New `tests/cli/test_app_scratchpad.py`: extension present in build and plan modes, stable across rebuilds and resumes, `scratchpad_dir` set on the agent
- New autouse `tests/conftest.py` fixture redirects the process temp dir (`tempfile.tempdir`) into each test's `tmp_path` so agent/TUI constructions never touch the developer's real temp
- `tests/agent/test_prompts.py`: scratchpad prompt rendering + coder_cli guideline text
- ✅ Full fast suite: 2724 passed
- ✅ `pre-commit run --all-files` (ruff check/format, pyright)
- ✅ Docs `npm run build` (new page renders, sidebar entry valid)