### PR TITLE
fix(cli): enable text selection in sidebar terminal and logs tabs

### DIFF
--- a/kolega_code/cli/tui/widgets.py
+++ b/kolega_code/cli/tui/widgets.py
@@ -598,6 +598,31 @@ class StickyRichLog(RichLog):
         self.clear()
         self.auto_follow_bottom = True
 
+    def render_line(self, y: int) -> Strip:
+        # RichLog does not participate in Textual text selection: its strips carry no
+        # "offset" meta, so drags never start a selection. Stamp content coordinates so
+        # the compositor can map mouse positions back into `self.lines`, and overlay the
+        # selection highlight. Both happen after super().render_line, i.e. outside
+        # RichLog's _line_cache, so the base selection_updated() refresh is enough to
+        # repaint highlight changes without cache invalidation.
+        strip = super().render_line(y)
+        content_y = self.scroll_offset.y + y
+        # #logs/#terminal set `overflow-x: hidden`, so scroll_x stays 0 and x-offsets
+        # may start at 0; y must still be translated by the vertical scroll offset.
+        strip = _with_selection_style(strip, self.text_selection, content_y, self.selection_style)
+        return _with_selection_offsets(strip, content_y)
+
+    def get_selection(self, selection: Selection) -> tuple[str, str] | None:
+        # Extract from `self.lines` (one Strip per visual line, indexed by content y)
+        # so coordinates match what is on screen. Strips are padded to render width,
+        # so rstrip each line to keep copied text clean.
+        if not self.lines:
+            return None
+        text = "\n".join(strip.text.rstrip() for strip in self.lines)
+        if not text.strip():
+            return None
+        return selection.extract(text), "\n"
+
 
 class TerminalOutputLog(StickyRichLog):
     """Sticky log for terminal output."""

--- a/tests/cli/test_app_rendering_terminal_logs.py
+++ b/tests/cli/test_app_rendering_terminal_logs.py
@@ -546,3 +546,206 @@ async def test_log_output_is_batched_until_flush(tmp_path: Path, monkeypatch: py
         rendered = renderable_text(written[0])
         assert "line 0" in rendered
         assert "line 4" in rendered
+
+
+async def _wait_for_layout(pilot, predicate, *, timeout: float = 6.0) -> None:
+    """Poll until ``predicate()`` is truthy or the layout deadline expires."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        await pilot.pause(0.02)
+        if predicate():
+            return
+    raise AssertionError(f"layout did not settle within {timeout}s")
+
+
+@pytest.mark.asyncio
+async def test_terminal_output_extracts_selected_text(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("textual")
+
+    from textual.geometry import Offset
+    from textual.selection import Selection
+    from textual.widgets import TabbedContent
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        # RichLog defers writes until its size is known; the pane must be visible first.
+        app.query_one("#events", TabbedContent).active = "terminal_pane"
+        await pilot.pause()
+
+        terminal = app._terminal
+        terminal.write_terminal("alpha\nbeta\ngamma\n")
+        await pilot.pause()
+
+        selected = terminal.get_selection(Selection(None, None))
+        assert selected is not None
+        text, ending = selected
+        assert ending == "\n"
+        assert "alpha" in text
+        assert "beta" in text
+        assert "gamma" in text
+        assert "\x1b" not in text
+        assert not any(line != line.rstrip() for line in text.split("\n"))
+
+        # Coordinates are content (line, column) pairs across visual lines.
+        partial = terminal.get_selection(Selection(Offset(1, 0), Offset(3, 2)))
+        assert partial is not None
+        assert partial[0] == "lpha\nbeta\ngam"
+
+
+@pytest.mark.asyncio
+async def test_terminal_render_line_marks_selection_offsets_and_highlight(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.geometry import Offset
+    from textual.selection import Selection
+    from textual.widgets import TabbedContent
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.query_one("#events", TabbedContent).active = "terminal_pane"
+        terminal = app._terminal
+        terminal.write_terminal("highlight this line\n")
+        await pilot.pause()
+
+        app.screen.selections = {terminal: Selection(Offset(0, 0), Offset(9, 0))}
+        strip = terminal.render_line(0)
+        selection_bg = terminal.selection_style.bgcolor
+
+        assert any(
+            segment.style is not None
+            and segment.style.bgcolor == selection_bg
+            and segment.style.meta.get("offset") is not None
+            for segment in strip
+        )
+
+        # Unscrolled log: selection coordinates start at the content origin.
+        tagged_offsets = [
+            segment.style.meta["offset"]
+            for segment in strip
+            if segment.style is not None and segment.style.meta.get("offset") is not None
+        ]
+        assert tagged_offsets
+        assert min(tagged_offsets) == (0, 0)
+
+        app.screen.selections = {}
+
+
+@pytest.mark.asyncio
+async def test_terminal_output_supports_mouse_drag_selection(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("textual")
+
+    from textual import events
+    from textual.widgets import TabbedContent
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.query_one("#events", TabbedContent).active = "terminal_pane"
+        terminal = app._terminal
+        terminal.write_terminal("select this terminal text\nsecond line\n")
+        await pilot.pause()
+
+        def selection_targets_are_ready() -> bool:
+            for x in (0, 24):
+                hit_widget, select_offset = app.screen.get_widget_and_offset_at(
+                    terminal.region.x + x, terminal.region.y
+                )
+                if hit_widget is not terminal or select_offset is None:
+                    return False
+            return True
+
+        # The widget can be queryable before the compositor's hit map reflects its
+        # region. Mouse selection requires both to agree.
+        await _wait_for_layout(pilot, selection_targets_are_ready)
+
+        await pilot.mouse_down(terminal, offset=(0, 0))
+        await pilot._post_mouse_events([events.MouseMove], terminal, offset=(24, 0), button=1)
+        await pilot.mouse_up(terminal, offset=(24, 0))
+
+        def selection_copied_text() -> bool:
+            return (app.screen.get_selected_text() or "").strip() == "select this terminal text"
+
+        await _wait_for_layout(pilot, selection_copied_text)
+        selected_text = app.screen.get_selected_text()
+        assert selected_text is not None
+        assert selected_text.strip() == "select this terminal text"
+
+
+@pytest.mark.asyncio
+async def test_terminal_selection_offsets_follow_vertical_scroll(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.geometry import Offset
+    from textual.selection import Selection
+    from textual.widgets import TabbedContent
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.query_one("#events", TabbedContent).active = "terminal_pane"
+        terminal = app._terminal
+        terminal.write_terminal("".join(f"scroll line {index}\n" for index in range(120)))
+        await pilot.pause()
+        assert terminal.max_scroll_y > 0
+
+        terminal.scroll_to(y=10, animate=False, immediate=True)
+        await pilot.pause()
+        assert terminal.scroll_offset.y == 10
+
+        # Viewport line 0 renders content line 10; stamped offsets must follow the scroll.
+        strip = terminal.render_line(0)
+        offset_meta = [
+            segment.style.meta["offset"]
+            for segment in strip
+            if segment.style is not None and segment.style.meta.get("offset") is not None
+        ]
+        assert offset_meta
+        assert all(y == 10 for _x, y in offset_meta)
+
+        # Extraction uses the same content coordinates as the stamped offsets.
+        selected = terminal.get_selection(Selection(Offset(0, 10), Offset(len("scroll line 10"), 10)))
+        assert selected is not None
+        assert selected[0] == "scroll line 10"
+
+
+@pytest.mark.asyncio
+async def test_logs_output_supports_mouse_drag_selection(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("textual")
+
+    from textual import events
+    from textual.widgets import TabbedContent
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch, show_logs=True)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.query_one("#events", TabbedContent).active = "logs_pane"
+        logs = app._logs
+        logs.write_log("select this log text\n")
+        await pilot.pause()
+
+        def selection_targets_are_ready() -> bool:
+            for x in (0, 19):
+                hit_widget, select_offset = app.screen.get_widget_and_offset_at(logs.region.x + x, logs.region.y)
+                if hit_widget is not logs or select_offset is None:
+                    return False
+            return True
+
+        await _wait_for_layout(pilot, selection_targets_are_ready)
+
+        await pilot.mouse_down(logs, offset=(0, 0))
+        await pilot._post_mouse_events([events.MouseMove], logs, offset=(19, 0), button=1)
+        await pilot.mouse_up(logs, offset=(19, 0))
+
+        def selection_copied_text() -> bool:
+            return (app.screen.get_selected_text() or "").strip() == "select this log text"
+
+        await _wait_for_layout(pilot, selection_copied_text)
+        selected_text = app.screen.get_selected_text()
+        assert selected_text is not None
+        assert selected_text.strip() == "select this log text"


### PR DESCRIPTION
## Summary

Mouse-drag selection (and therefore copy) did not work in the sidebar **Terminal** tab (`#terminal`) or **Logs** tab (`#logs`). Both extend `StickyRichLog` → Textual's `RichLog`, which does not participate in Textual's text-selection protocol:

1. Its rendered strips carry no `"offset"` style meta, so the compositor can't map a mouse position to a content offset — drags never start a selection.
2. It doesn't implement `get_selection()`, so there would be nothing to extract on copy anyway.

The transcript (`ConversationEntryWidget`) and Plan/Status sidebar (`PlanningMarkdown`) already solved this with the `_with_selection_offsets` / `_with_selection_style` helpers; the sidebar logs never got the same treatment.

## Fix

`StickyRichLog` now:

- **`render_line()`** — translates the viewport line to content coordinates (`scroll_offset.y + y`), overlays the selection highlight, and stamps `"offset"` meta so mouse drags resolve to `self.lines` positions. Both steps run after `super().render_line()`, outside RichLog's `_line_cache`, so the base `selection_updated()` refresh handles highlight repaints.
- **`get_selection()`** — extracts from `self.lines` (one `Strip` per visual line, indexed by content y), rstripping render-width padding so copied text is clean.

No changes to `app.py`, CSS, or keybindings — the copy pipeline (`ctrl+c`/`super+c` → `copy_text` → OSC 52 + `pbcopy`) already existed; selection just couldn't be created before.

## Tests

Five new tests in `tests/cli/test_app_rendering_terminal_logs.py`:

- `test_terminal_output_extracts_selected_text` — full + partial-span `get_selection` extraction
- `test_terminal_render_line_marks_selection_offsets_and_highlight` — selection bgcolor + offset meta on rendered strips
- `test_terminal_output_supports_mouse_drag_selection` — end-to-end pilot drag → `get_selected_text()`
- `test_terminal_selection_offsets_follow_vertical_scroll` — offset/extraction mapping when scrolled
- `test_logs_output_supports_mouse_drag_selection` — same coverage for the Logs tab

Full fast suite: 2728 passed, 1 skipped (pre-existing env-gated). Ruff and pyright clean.