### PR TITLE
feat(terminal): add background exec mode and localhost dev-server guidance

### DIFF
--- a/docs/src/content/docs/concepts/tools.md
+++ b/docs/src/content/docs/concepts/tools.md
@@ -33,6 +33,17 @@ pending action—rerun it with `apply: true`.
 
 Run shell commands in the project and stream their output to the **Terminal** tab.
 
+**Background processes & dev servers:** pass `background=true` to `exec_command`
+for dev servers, watchers, and long builds you want to keep running. It returns
+after a short startup window (~2s) with a `session_id`; the process keeps
+running until stopped. Poll output with `write_stdin`, stop it with
+`kill_command`, and see all running shells with `list_sessions` (background
+sessions are marked `background: true`). Avoid shell `&` instead — processes
+backgrounded that way are killed when the command that started them ends, and
+the result prints a warning when that happens. A command passed with
+`background=true` that exits within the startup window (e.g. port already in
+use) reports its real exit code and output.
+
 ### Browser
 
 Drive a real browser (Playwright) for web tasks:

--- a/docs/src/content/docs/concepts/tools.md
+++ b/docs/src/content/docs/concepts/tools.md
@@ -42,7 +42,9 @@ sessions are marked `background: true`). Avoid shell `&` instead — processes
 backgrounded that way are killed when the command that started them ends, and
 the result prints a warning when that happens. A command passed with
 `background=true` that exits within the startup window (e.g. port already in
-use) reports its real exit code and output.
+use) reports its real exit code and output. Processes started by the agent
+never outlive kolega-code: all sessions are terminated when the agent session
+ends, including on quit.
 
 ### Browser
 

--- a/kolega_code/agent/prompt_templates/system/agents/browser.md.j2
+++ b/kolega_code/agent/prompt_templates/system/agents/browser.md.j2
@@ -68,25 +68,27 @@ If you are asked for links to assets such as images, do not answer from your mem
   - Navigate to the server URL (e.g., `http://localhost:9001`)
   - Use proper HTTP/HTTPS protocols only
 
-**⚠️ ALWAYS GET THE CORRECT HOSTNAME BEFORE NAVIGATION ⚠️**
+**⚠️ LOCAL DEVELOPMENT SERVERS ⚠️**
 
-Before navigating to any local development server:
-1. Use the `get_host` tool with the port number
-2. Construct the full URL using the returned hostname
-3. Navigate to the constructed URL
+The browser runs on the same machine as the agent's terminal, so `localhost` and `127.0.0.1`
+URLs refer to services running on your own machine:
+
+1. Navigate directly to the server URL you were given (e.g., `http://localhost:9001`).
+2. If your environment provides a `get_host` tool, call it with the port number and use the
+   returned hostname instead (cloud sandboxes expose services on generated hostnames).
+3. If a loopback URL fails with `net::ERR_CONNECTION_REFUSED`, the server is genuinely not
+   listening. Do not assume network isolation or a sandboxed browser — report that the
+   connection was refused and suggest checking whether the server is still running.
 
 **Examples of INCORRECT usage:**
 - `file:///path/to/index.html` ❌
 - Loading HTML files directly from filesystem ❌
 - Opening local files in browser ❌
-- Navigating directly to `http://localhost:9001` without checking host ❌
 
 **Examples of CORRECT usage:**
-- Call get_host(9001), then navigate to `http://{{result}}` ✅
-- `https://example.com` (external sites don't need get_host) ✅
-- Call get_host(8000), then navigate to `http://{{result}}/api` ✅
-
-This ensures compatibility with both local and cloud sandbox environments.
+- `http://localhost:9001` (a dev server URL you were given) ✅
+- `https://example.com` (external sites) ✅
+- Call get_host(8000), then navigate to `http://{{result}}/api` (only when get_host is available) ✅
 
 ## **Communication Guidelines**
 

--- a/kolega_code/agent/tool_backend/browser_tool.py
+++ b/kolega_code/agent/tool_backend/browser_tool.py
@@ -17,8 +17,8 @@ _TARGET = {
 _LOOPBACK_REFUSED_HINT = (
     "The connection was refused — no server is listening on that port. The browser runs on the "
     "same machine as the terminal; if the server was started backgrounded (`&`) in an earlier "
-    "terminal command it has since exited. Restart it with exec_command background=true (or "
-    "`nohup`), confirm it answers with curl, then retry."
+    "terminal command it has since exited. Restart it with exec_command background=true, "
+    "confirm it answers with curl, then retry."
 )
 
 

--- a/kolega_code/agent/tool_backend/browser_tool.py
+++ b/kolega_code/agent/tool_backend/browser_tool.py
@@ -1,4 +1,5 @@
 import json
+import urllib.parse
 from pathlib import Path
 from typing import Any, Optional, Union
 
@@ -12,6 +13,28 @@ _TARGET = {
     "type": "string",
     "description": "Exact element ref from browser_snapshot (for example e12), or a unique selector.",
 }
+
+_LOOPBACK_REFUSED_HINT = (
+    "The connection was refused — no server is listening on that port. The browser runs on the "
+    "same machine as the terminal; if the server was started backgrounded (`&`) in an earlier "
+    "terminal command it has since exited. Restart it with exec_command background=true (or "
+    "`nohup`), confirm it answers with curl, then retry."
+)
+
+
+def _is_loopback_url(url: str) -> bool:
+    candidate = url.strip()
+    if "://" not in candidate:
+        candidate = f"http://{candidate}"
+    host = (urllib.parse.urlsplit(candidate).hostname or "").lower()
+    return host == "localhost" or host.endswith(".localhost") or host == "::1" or host.startswith("127.")
+
+
+def _augment_loopback_refused(url: Optional[str], exc: Exception) -> Exception:
+    """Append localhost troubleshooting guidance to loopback connection refusals."""
+    if url and "ERR_CONNECTION_REFUSED" in str(exc) and _is_loopback_url(url):
+        return RuntimeError(f"{exc}\n\n{_LOOPBACK_REFUSED_HINT}")
+    return exc
 
 
 def _schema(properties: dict[str, Any], required: Optional[list[str]] = None) -> dict[str, Any]:
@@ -255,7 +278,10 @@ class BrowserTool(BaseTool):
 
     async def browser_navigate(self, url: str) -> str:
         previous = self.browser_manager.session_id
-        result = await self.browser_manager.navigate(url)
+        try:
+            result = await self.browser_manager.navigate(url)
+        except Exception as exc:
+            raise _augment_loopback_refused(url, exc) from exc
         await self._broadcast_launched(previous, result)
         return self._format_page(result)
 
@@ -322,7 +348,10 @@ class BrowserTool(BaseTool):
 
     async def browser_tabs(self, action: str, index: Optional[int] = None, url: Optional[str] = None) -> str:
         previous = self.browser_manager.session_id
-        result = await self.browser_manager.tabs(action, index=index, url=url)
+        try:
+            result = await self.browser_manager.tabs(action, index=index, url=url)
+        except Exception as exc:
+            raise _augment_loopback_refused(url if action == "new" else None, exc) from exc
         await self._broadcast_launched(previous, result)
         lines = ["## Open tabs"]
         for tab in result["tabs"]:

--- a/kolega_code/agent/tool_backend/terminal_tool.py
+++ b/kolega_code/agent/tool_backend/terminal_tool.py
@@ -15,6 +15,17 @@ from kolega_code.services.base import ExecResult
 from kolega_code.services.terminal import LocalTerminalManager, build_child_env
 from .base_tool import BaseTool
 
+# Startup window for background=true launches: long enough to capture a dev
+# server's "ready" line or an early crash (port in use, missing env), short
+# enough that the agent is not blocked on a process meant to outlive the call.
+BACKGROUND_SETTLE_MS = 2000
+
+_BACKGROUND_NOTE = (
+    "Running in background. Poll output with write_stdin(session_id), stop with "
+    "kill_command(session_id), and see all running shells with list_sessions. "
+    "The session keeps running until killed or the agent session ends."
+)
+
 
 class TerminalTool(BaseTool):
     def __init__(
@@ -43,6 +54,10 @@ class TerminalTool(BaseTool):
         self.venv_activation_command = None
         self.initialized = False
         self.security_check_enabled = False
+        # Ids of sessions started with background=true that are still running.
+        # Best-effort annotation metadata for list_sessions; the sessions
+        # themselves are always tracked manager-wide.
+        self._background_sessions: set[str] = set()
 
         # Use injected terminal_manager if provided, otherwise create local one
         if self.terminal_manager is None:
@@ -104,18 +119,20 @@ class TerminalTool(BaseTool):
 
     # -- model-facing unified-exec tools -----------------------------------
 
-    def _format_result(self, result: ExecResult) -> str:
-        return json.dumps(
-            {
-                "status": result.status,
-                "exit_code": result.exit_code,
-                "session_id": result.session_id,
-                "output": result.output,
-                "truncated": result.truncated,
-                "original_token_count": result.original_token_count,
-                "duration_ms": result.duration_ms,
-            }
-        )
+    def _format_result(self, result: ExecResult, *, background: bool = False) -> str:
+        payload = {
+            "status": result.status,
+            "exit_code": result.exit_code,
+            "session_id": result.session_id,
+            "output": result.output,
+            "truncated": result.truncated,
+            "original_token_count": result.original_token_count,
+            "duration_ms": result.duration_ms,
+        }
+        if background and result.status == "running" and result.session_id is not None:
+            payload["background"] = True
+            payload["note"] = _BACKGROUND_NOTE
+        return json.dumps(payload)
 
     async def exec_command(
         self,
@@ -124,6 +141,7 @@ class TerminalTool(BaseTool):
         yield_time_ms: int = 10000,
         max_output_tokens: int = 10000,
         login: bool = False,
+        background: bool = False,
     ) -> str:
         """Run a shell command as a fresh process and return its output.
 
@@ -138,6 +156,16 @@ class TerminalTool(BaseTool):
         chain commands in one call with `cd path && ...`. Defaults to the
         project root.
 
+        Running long-lived processes: pass background=true for dev servers,
+        watchers, and long builds you want to keep running while you do other
+        work. It returns after a short startup window with a session_id; the
+        process keeps running until you stop it with kill_command or the agent
+        session ends. Do NOT use shell `&` for this — processes backgrounded
+        that way are killed when the command that started them ends. Manage
+        background sessions with write_stdin (poll output), kill_command
+        (stop), and list_sessions (see all running shells). Always verify a
+        server answers (e.g. curl) before handing its URL to the browser agent.
+
         Args:
             command: Shell command line, executed via `bash -c`.
             workdir: Working directory for the command. Relative paths resolve
@@ -146,11 +174,15 @@ class TerminalTool(BaseTool):
                            in milliseconds (clamped to 250–30000).
             max_output_tokens: Maximum tokens of output to return in this call.
             login: Run the shell as a login shell (sources profile). Default false.
+            background: Keep the command running and return after a short
+                        startup window (~2s) with a session_id. Commands that
+                        exit within that window report their real exit code.
 
         Returns:
             A JSON object: {"status": "exited"|"running", "exit_code",
             "session_id", "output", "truncated", "original_token_count",
-            "duration_ms"}.
+            "duration_ms"}. Background launches that are still running also
+            include "background": true and a "note" with management hints.
         """
         if self.security_check_enabled:
             allowed, denied_reason = await self._run_command_security_check(command)
@@ -164,13 +196,15 @@ class TerminalTool(BaseTool):
             result = await self.terminal_manager.exec_command(
                 command,
                 workdir=wd,
-                yield_time_ms=yield_time_ms,
+                yield_time_ms=min(yield_time_ms, BACKGROUND_SETTLE_MS) if background else yield_time_ms,
                 max_output_tokens=max_output_tokens,
                 login=login,
             )
         except Exception as exc:
             return json.dumps({"status": "error", "error": str(exc)})
-        return self._format_result(result)
+        if background and result.status == "running" and result.session_id is not None:
+            self._background_sessions.add(result.session_id)
+        return self._format_result(result, background=background)
 
     async def write_stdin(
         self,
@@ -222,16 +256,23 @@ class TerminalTool(BaseTool):
             result = await self.terminal_manager.kill_session(session_id, signal)
         except KeyError as exc:
             return json.dumps({"status": "error", "error": str(exc)})
+        self._background_sessions.discard(session_id)
         return self._format_result(result)
 
     async def list_sessions(self) -> str:
         """List currently running exec sessions.
 
+        Includes sessions started with exec_command background=true, annotated
+        with "background": true.
+
         Returns:
             A JSON object mapping each running session id to its command,
-            working directory, and runtime in seconds.
+            working directory, runtime in seconds, and background flag.
         """
         sessions = await self.terminal_manager.list_sessions()
+        self._background_sessions.intersection_update(sessions)
+        for session_id, info in sessions.items():
+            info["background"] = session_id in self._background_sessions
         return json.dumps({"sessions": sessions})
 
     # -- internal one-shot helper (not exposed to the model) ---------------

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -1747,6 +1747,7 @@ class ToolCollection(LogMixin):
         yield_time_ms: int = 10000,
         max_output_tokens: int = 10000,
         login: bool = False,
+        background: bool = False,
     ) -> str:
         """Run a shell command as a fresh process and return its output.
 
@@ -1761,6 +1762,16 @@ class ToolCollection(LogMixin):
         chain commands in one call with `cd path && ...`. Defaults to the
         project root.
 
+        Running long-lived processes: pass background=true for dev servers,
+        watchers, and long builds you want to keep running while you do other
+        work. It returns after a short startup window with a session_id; the
+        process keeps running until you stop it with kill_command or the agent
+        session ends. Do NOT use shell `&` for this — processes backgrounded
+        that way are killed when the command that started them ends. Manage
+        background sessions with write_stdin (poll output), kill_command
+        (stop), and list_sessions (see all running shells). Always verify a
+        server answers (e.g. curl) before handing its URL to the browser agent.
+
         Args:
             command: Shell command line, executed via `bash -c`.
             workdir: Working directory for the command. Defaults to project root.
@@ -1768,11 +1779,15 @@ class ToolCollection(LogMixin):
                            milliseconds (clamped to 250–30000).
             max_output_tokens: Maximum tokens of output to return in this call.
             login: Run the shell as a login shell (sources profile). Default false.
+            background: Keep the command running and return after a short
+                        startup window (~2s) with a session_id. Commands that
+                        exit within that window report their real exit code.
 
         Returns:
             A JSON object: {"status": "exited"|"running", "exit_code",
             "session_id", "output", "truncated", "original_token_count",
-            "duration_ms"}.
+            "duration_ms"}. Background launches that are still running also
+            include "background": true and a "note" with management hints.
         """
         return await self.terminal_tool.exec_command(
             command,
@@ -1780,6 +1795,7 @@ class ToolCollection(LogMixin):
             yield_time_ms=yield_time_ms,
             max_output_tokens=max_output_tokens,
             login=login,
+            background=background,
         )
 
     async def write_stdin(
@@ -1829,9 +1845,12 @@ class ToolCollection(LogMixin):
     async def list_sessions(self) -> str:
         """List currently running exec sessions.
 
+        Includes sessions started with exec_command background=true, annotated
+        with "background": true.
+
         Returns:
             A JSON object mapping each running session id to its command,
-            working directory, and runtime in seconds.
+            working directory, runtime in seconds, and background flag.
         """
         return await self.terminal_tool.list_sessions()
 

--- a/kolega_code/services/terminal.py
+++ b/kolega_code/services/terminal.py
@@ -82,9 +82,8 @@ _BACKGROUND_JOB_TRAP = (
     'kill -0 $p 2>/dev/null && pids="$pids $p"; done; '
     'pids="${pids# }"; if [ -n "$pids" ]; then '
     'printf "\\n[kolega-code] WARNING: background process(es) (%s) backgrounded with & were terminated when this '
-    "command ended. To keep a process running, re-run it with exec_command background=true. "
-    'To detach a process so it outlives this session, use: trap \\"\\" HUP; nohup cmd >log 2>&1 & disown.\\n" '
-    '"$pids" >&2; fi; fi\' EXIT; '
+    "command ended. To keep a process running between commands, re-run it with exec_command background=true; "
+    'it will still be stopped when the kolega-code session ends.\\n" "$pids" >&2; fi; fi\' EXIT; '
 )
 
 

--- a/kolega_code/services/terminal.py
+++ b/kolega_code/services/terminal.py
@@ -82,8 +82,9 @@ _BACKGROUND_JOB_TRAP = (
     'kill -0 $p 2>/dev/null && pids="$pids $p"; done; '
     'pids="${pids# }"; if [ -n "$pids" ]; then '
     'printf "\\n[kolega-code] WARNING: background process(es) (%s) backgrounded with & were terminated when this '
-    "command ended. To keep a process running, re-run it with exec_command background=true, "
-    'or detach it with: nohup cmd >log 2>&1 &.\\n" "$pids" >&2; fi; fi\' EXIT; '
+    "command ended. To keep a process running, re-run it with exec_command background=true. "
+    'To detach a process so it outlives this session, use: trap \\"\\" HUP; nohup cmd >log 2>&1 & disown.\\n" '
+    '"$pids" >&2; fi; fi\' EXIT; '
 )
 
 

--- a/kolega_code/services/terminal.py
+++ b/kolega_code/services/terminal.py
@@ -54,6 +54,38 @@ _VENV_ACTIVATE_REL = os.path.join(".venv", "bin", "activate")
 # Env vars `uv run` injects when launching this app from a source checkout.
 _RUNTIME_VENV_VARS = ("VIRTUAL_ENV", "VIRTUAL_ENV_PROMPT", "UV", "UV_RUN_RECURSION_DEPTH")
 
+# Shell preamble installed ahead of every command. Each exec runs as a pty
+# session leader, so when its shell exits the kernel SIGHUPs the whole
+# foreground process group — silently killing anything the command left
+# backgrounded with `&`. The EXIT trap turns that silent kill into an explicit
+# warning that names the surviving-till-exit pids and the supported patterns.
+# (`jobs -p` is empty when no background jobs linger, so quiet commands stay
+# quiet; bash and sh both evaluate the trap the same way. The message avoids
+# backticks and extra `%` specifiers: the trap body is re-evaluated when it
+# fires, and printf reuses its format for surplus arguments.)
+#
+# Two guards keep the warning accurate:
+# - The TERM/INT/HUP traps record signal-driven exits (kill_command) in
+#   `_kolega_signaled` and re-exit with the equivalent 128+signal status. A
+#   killed foreground command lingers in the job table when the EXIT trap
+#   fires, so without this flag kill_command would warn as if `&` had been
+#   misused. (Checking job state or pid liveness alone races under load —
+#   the doomed child may not have been reaped yet.)
+# - `kill -0` liveness filters jobs that already died on their own before a
+#   normal exit, so the warning only names processes the shell exit actually
+#   kills.
+_BACKGROUND_JOB_TRAP = (
+    "trap '_kolega_signaled=1; exit 143' TERM; "
+    "trap '_kolega_signaled=1; exit 130' INT; "
+    "trap '_kolega_signaled=1; exit 129' HUP; "
+    'trap \'if [ -z "${_kolega_signaled:-}" ]; then pids=""; for p in $(jobs -p); do '
+    'kill -0 $p 2>/dev/null && pids="$pids $p"; done; '
+    'pids="${pids# }"; if [ -n "$pids" ]; then '
+    'printf "\\n[kolega-code] WARNING: background process(es) (%s) backgrounded with & were terminated when this '
+    "command ended. To keep a process running, re-run it with exec_command background=true, "
+    'or detach it with: nohup cmd >log 2>&1 &.\\n" "$pids" >&2; fi; fi\' EXIT; '
+)
+
 
 def _strip_runtime_venv(env: Dict[str, str], runtime_prefix: Optional[str] = None) -> Dict[str, str]:
     """Remove this process's own venv from ``env`` (mutating and returning it).
@@ -160,6 +192,11 @@ class PtySession:
             activate = os.path.join(str(self.workdir), _VENV_ACTIVATE_REL)
             if os.path.isfile(activate):
                 command = f"source {shlex.quote(activate)} 2>/dev/null; {command}"
+        # Install the background-job warning ahead of everything else so it
+        # survives venv activation and still fires if the command backgrounds
+        # processes and exits (the trap is overwritten only if the command
+        # sets its own EXIT trap).
+        command = _BACKGROUND_JOB_TRAP + command
 
         shell = _pick_shell()
         shell_args = ["-lc", command] if self.login else ["-c", command]

--- a/tests/agent/services/test_terminal.py
+++ b/tests/agent/services/test_terminal.py
@@ -1,5 +1,7 @@
 import asyncio
 import os
+import re
+import signal
 import sys
 from unittest.mock import patch
 
@@ -254,6 +256,27 @@ async def test_no_background_warning_when_foreground_session_killed(manager):
     killed = await manager.kill_session(result.session_id, "TERM")
     assert killed.status == "exited"
     assert "WARNING" not in killed.output
+
+
+@pytest.mark.asyncio
+async def test_documented_detach_pattern_survives_without_warning(manager):
+    # The warning message recommends `trap "" HUP; nohup cmd & disown` as the
+    # full-detach pattern. That pattern must actually survive the shell exit
+    # (plain `nohup ... &` races the session-leader-exit SIGHUP and dies) and
+    # must not trip the warning (disown removes it from the job table).
+    result = await manager.exec_command(
+        'trap "" HUP; nohup sleep 30 >/dev/null 2>&1 & disown; echo pid=$!',
+        yield_time_ms=8000,
+    )
+    assert result.status == "exited"
+    assert "WARNING" not in result.output
+    match = re.search(r"pid=(\d+)", result.output)
+    assert match is not None
+    pid = int(match.group(1))
+    try:
+        os.kill(pid, 0)  # detached process is still alive
+    finally:
+        os.kill(pid, signal.SIGKILL)
 
 
 @pytest.mark.asyncio

--- a/tests/agent/services/test_terminal.py
+++ b/tests/agent/services/test_terminal.py
@@ -1,7 +1,5 @@
 import asyncio
 import os
-import re
-import signal
 import sys
 from unittest.mock import patch
 
@@ -224,12 +222,15 @@ async def test_close_all_terminates_sessions(manager):
 async def test_warns_when_command_leaves_background_jobs(manager):
     # Backgrounded (`&`) processes die with the shell that started them; the
     # result must say so loudly instead of letting the agent believe a server
-    # it launched is still listening.
+    # it launched is still listening. By policy the warning must NOT teach
+    # detach recipes (nohup/disown): nothing should outlive kolega-code.
     result = await manager.exec_command("sleep 30 & echo main-done", yield_time_ms=8000)
     assert result.status == "exited"
     assert "main-done" in result.output
     assert "[kolega-code] WARNING: background process(es)" in result.output
     assert "exec_command background=true" in result.output
+    assert "nohup" not in result.output
+    assert "disown" not in result.output
 
 
 @pytest.mark.asyncio
@@ -256,27 +257,6 @@ async def test_no_background_warning_when_foreground_session_killed(manager):
     killed = await manager.kill_session(result.session_id, "TERM")
     assert killed.status == "exited"
     assert "WARNING" not in killed.output
-
-
-@pytest.mark.asyncio
-async def test_documented_detach_pattern_survives_without_warning(manager):
-    # The warning message recommends `trap "" HUP; nohup cmd & disown` as the
-    # full-detach pattern. That pattern must actually survive the shell exit
-    # (plain `nohup ... &` races the session-leader-exit SIGHUP and dies) and
-    # must not trip the warning (disown removes it from the job table).
-    result = await manager.exec_command(
-        'trap "" HUP; nohup sleep 30 >/dev/null 2>&1 & disown; echo pid=$!',
-        yield_time_ms=8000,
-    )
-    assert result.status == "exited"
-    assert "WARNING" not in result.output
-    match = re.search(r"pid=(\d+)", result.output)
-    assert match is not None
-    pid = int(match.group(1))
-    try:
-        os.kill(pid, 0)  # detached process is still alive
-    finally:
-        os.kill(pid, signal.SIGKILL)
 
 
 @pytest.mark.asyncio

--- a/tests/agent/services/test_terminal.py
+++ b/tests/agent/services/test_terminal.py
@@ -219,6 +219,44 @@ async def test_close_all_terminates_sessions(manager):
 
 
 @pytest.mark.asyncio
+async def test_warns_when_command_leaves_background_jobs(manager):
+    # Backgrounded (`&`) processes die with the shell that started them; the
+    # result must say so loudly instead of letting the agent believe a server
+    # it launched is still listening.
+    result = await manager.exec_command("sleep 30 & echo main-done", yield_time_ms=8000)
+    assert result.status == "exited"
+    assert "main-done" in result.output
+    assert "[kolega-code] WARNING: background process(es)" in result.output
+    assert "exec_command background=true" in result.output
+
+
+@pytest.mark.asyncio
+async def test_no_background_warning_for_quiet_commands(manager):
+    result = await manager.exec_command("echo plain-done", yield_time_ms=5000)
+    assert result.status == "exited"
+    assert "WARNING" not in result.output
+
+
+@pytest.mark.asyncio
+async def test_no_background_warning_when_jobs_finished(manager):
+    result = await manager.exec_command("sleep 0.2 & wait; echo waited-done", yield_time_ms=5000)
+    assert result.status == "exited"
+    assert "waited-done" in result.output
+    assert "WARNING" not in result.output
+
+
+@pytest.mark.asyncio
+async def test_no_background_warning_when_foreground_session_killed(manager):
+    # kill_command on a foreground process leaves a stale job-table entry when
+    # the EXIT trap fires; the liveness filter must keep that from warning.
+    result = await manager.exec_command("sleep 30", yield_time_ms=300)
+    assert result.status == "running"
+    killed = await manager.kill_session(result.session_id, "TERM")
+    assert killed.status == "exited"
+    assert "WARNING" not in killed.output
+
+
+@pytest.mark.asyncio
 async def test_pty_display_broadcast_decodes_split_utf8_without_replacement(tmp_path):
     connection = _RecordingConnectionManager()
     session = PtySession("s_test", "echo", str(tmp_path), connection, "workspace", "thread")

--- a/tests/agent/test_agent_tools_inventory.py
+++ b/tests/agent/test_agent_tools_inventory.py
@@ -351,6 +351,26 @@ def test_planning_agent_exposes_read_only_and_planning_tools(project_path, mock_
     )
 
 
+def test_exec_command_exposes_optional_background_param(project_path, mock_connection_manager, agent_config):
+    """The model-facing exec_command schema includes the optional background flag."""
+    agent = CoderAgent(
+        project_path=project_path,
+        workspace_id="test_workspace",
+        thread_id=str(uuid.uuid4()),
+        connection_manager=mock_connection_manager,
+        config=agent_config,
+        agent_mode=AgentMode.CLI,
+    )
+
+    exec_tool = next(tool for tool in agent.tool_collection.get_tool_list() if tool.name == "exec_command")
+    params = {param.name: param for param in exec_tool.parameters}
+
+    assert "background" in params
+    assert params["background"].type == "boolean"
+    assert params["background"].required is False
+    assert params["background"].description
+
+
 def test_shared_tool_names_are_well_formed(project_path, mock_connection_manager, agent_config):
     """Shared agent tool definitions have valid names and descriptions."""
     agents = [

--- a/tests/agent/tool_backend/test_browser_tool.py
+++ b/tests/agent/tool_backend/test_browser_tool.py
@@ -128,6 +128,65 @@ def test_browser_tool_schemas_use_snake_case_and_exclude_legacy_contract():
     assert "text_gone" in BROWSER_TOOL_SCHEMAS["browser_wait_for"]["properties"]
     assert "doubleClick" not in BROWSER_TOOL_SCHEMAS["browser_click"]["properties"]
 
+
+class TestLoopbackRefusedHint:
+    """Loopback connection refusals get guidance instead of a bare net error."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://localhost:9999/",
+            "http://127.0.0.1:9999/",
+            "http://[::1]:9999/",
+            "http://app.localhost:9999/",
+            "localhost:9999",
+        ],
+    )
+    async def test_refused_loopback_navigate_includes_hint(self, browser_tool, browser_manager, url):
+        browser_manager.navigate = AsyncMock(
+            side_effect=RuntimeError(f"Page.goto: net::ERR_CONNECTION_REFUSED at {url}")
+        )
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await browser_tool.browser_navigate(url)
+
+        message = str(exc_info.value)
+        assert "ERR_CONNECTION_REFUSED" in message
+        assert "no server is listening on that port" in message
+        assert "same machine as the terminal" in message
+
+    @pytest.mark.asyncio
+    async def test_refused_remote_navigate_passes_through(self, browser_tool, browser_manager):
+        error = RuntimeError("Page.goto: net::ERR_CONNECTION_REFUSED at https://example.com/")
+        browser_manager.navigate = AsyncMock(side_effect=error)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await browser_tool.browser_navigate("https://example.com/")
+
+        assert exc_info.value is error
+        assert "no server is listening" not in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_loopback_other_errors_pass_through(self, browser_tool, browser_manager):
+        error = RuntimeError("Page.goto: Timeout 30000ms exceeded")
+        browser_manager.navigate = AsyncMock(side_effect=error)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await browser_tool.browser_navigate("http://localhost:9999/")
+
+        assert exc_info.value is error
+        assert "no server is listening" not in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_refused_loopback_new_tab_includes_hint(self, browser_tool, browser_manager):
+        browser_manager.tabs = AsyncMock(
+            side_effect=RuntimeError("Page.goto: net::ERR_CONNECTION_REFUSED at http://127.0.0.1:9999/")
+        )
+
+        with pytest.raises(RuntimeError, match="no server is listening on that port"):
+            await browser_tool.browser_tabs("new", url="http://127.0.0.1:9999/")
+
     legacy = {
         "launch_browser",
         "list_browsers",

--- a/tests/agent/tool_backend/test_terminal_tool.py
+++ b/tests/agent/tool_backend/test_terminal_tool.py
@@ -10,7 +10,7 @@ import uuid
 from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
 from kolega_code.events import AgentEvent
 from kolega_code.services.base import ExecResult
-from kolega_code.agent.tool_backend.terminal_tool import TerminalTool
+from kolega_code.agent.tool_backend.terminal_tool import BACKGROUND_SETTLE_MS, TerminalTool
 
 # Check if running in CI environment
 SKIP_IN_CI = bool(os.getenv("CI")) or bool(os.getenv("GITLAB_CI"))
@@ -298,3 +298,99 @@ class TestUnifiedExecTools:
         result = await terminal_tool.exec_command("rm -rf /")
         assert "blocked" in result
         terminal_tool.terminal_manager.exec_command.assert_not_awaited()
+
+
+class TestBackgroundExec:
+    """Tests for exec_command(background=True) dev-server style launches."""
+
+    @pytest.mark.asyncio
+    async def test_background_running_caps_yield_and_annotates_result(self, terminal_tool):
+        terminal_tool.terminal_manager = Mock()
+        terminal_tool.terminal_manager.exec_command = AsyncMock(
+            return_value=ExecResult(status="running", session_id="s_1", output="ready", duration_ms=2000)
+        )
+
+        data = json.loads(await terminal_tool.exec_command("npm run dev", background=True, yield_time_ms=30000))
+
+        assert data["status"] == "running"
+        assert data["session_id"] == "s_1"
+        assert data["background"] is True
+        assert "kill_command" in data["note"]
+        kwargs = terminal_tool.terminal_manager.exec_command.call_args.kwargs
+        assert kwargs["yield_time_ms"] == BACKGROUND_SETTLE_MS
+        assert "s_1" in terminal_tool._background_sessions
+
+    @pytest.mark.asyncio
+    async def test_background_early_exit_returns_real_exit_code(self, terminal_tool):
+        terminal_tool.terminal_manager = Mock()
+        terminal_tool.terminal_manager.exec_command = AsyncMock(
+            return_value=ExecResult(status="exited", exit_code=1, output="EADDRINUSE", duration_ms=300)
+        )
+
+        data = json.loads(await terminal_tool.exec_command("npm run dev", background=True))
+
+        assert data["status"] == "exited"
+        assert data["exit_code"] == 1
+        assert "background" not in data
+        assert terminal_tool._background_sessions == set()
+
+    @pytest.mark.asyncio
+    async def test_default_exec_is_not_annotated_as_background(self, terminal_tool):
+        terminal_tool.terminal_manager = Mock()
+        terminal_tool.terminal_manager.exec_command = AsyncMock(
+            return_value=ExecResult(status="running", session_id="s_2", output="", duration_ms=10000)
+        )
+
+        data = json.loads(await terminal_tool.exec_command("sleep 5", yield_time_ms=30000))
+
+        assert data["status"] == "running"
+        assert "background" not in data
+        kwargs = terminal_tool.terminal_manager.exec_command.call_args.kwargs
+        assert kwargs["yield_time_ms"] == 30000
+        assert terminal_tool._background_sessions == set()
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_marks_background_and_prunes_dead(self, terminal_tool):
+        terminal_tool.terminal_manager = Mock()
+        terminal_tool.terminal_manager.exec_command = AsyncMock(
+            return_value=ExecResult(status="running", session_id="s_1", output="", duration_ms=2000)
+        )
+        await terminal_tool.exec_command("npm run dev", background=True)
+        terminal_tool._background_sessions.add("s_stale")
+
+        terminal_tool.terminal_manager.list_sessions = AsyncMock(
+            return_value={"s_1": {"command": "npm run dev", "running": True}}
+        )
+        data = json.loads(await terminal_tool.list_sessions())
+
+        assert data["sessions"]["s_1"]["background"] is True
+        # Ids no longer running are pruned from the tracking set.
+        assert terminal_tool._background_sessions == {"s_1"}
+
+    @pytest.mark.asyncio
+    async def test_kill_command_forgets_background_session(self, terminal_tool):
+        terminal_tool.terminal_manager = Mock()
+        terminal_tool.terminal_manager.kill_session = AsyncMock(return_value=ExecResult(status="exited", exit_code=143))
+        terminal_tool._background_sessions.add("s_1")
+
+        await terminal_tool.kill_command("s_1", "TERM")
+
+        assert terminal_tool._background_sessions == set()
+
+    @pytest.mark.asyncio
+    async def test_background_end_to_end_dev_server_pattern(self, terminal_tool):
+        # Real PTY through the default manager: a backgrounded server process
+        # stays alive across later tool calls, appears in list_sessions, and
+        # dies via kill_command — the dev-server flow the browser agent needs.
+        data = json.loads(await terminal_tool.exec_command("sleep 30", background=True))
+        assert data["status"] == "running"
+        assert data["background"] is True
+        session_id = data["session_id"]
+
+        sessions = json.loads(await terminal_tool.list_sessions())["sessions"]
+        assert session_id in sessions
+        assert sessions[session_id]["background"] is True
+
+        killed = json.loads(await terminal_tool.kill_command(session_id))
+        assert killed["status"] == "exited"
+        assert session_id not in json.loads(await terminal_tool.list_sessions())["sessions"]


### PR DESCRIPTION
## Why

Agents routinely start dev servers backgrounded with `&` inside `exec_command` (e.g. `npm run dev & sleep 5; curl ...`). `PtySession` runs each command as a pty session leader, so when the shell exits the kernel SIGHUPs the whole foreground process group — **the server dies the instant the call returns**. Curl checks inside the same call pass; the browser sub-agent dispatched seconds later gets `net::ERR_CONNECTION_REFUSED` on `localhost` and (primed by stale "cloud sandbox" wording in the browser prompt) misdiagnoses it as network isolation, even though the browser is a local Chromium on the same host.

## What

- **`exec_command(background=true)`** — first-class background mode. Returns after a 2s settle window with a `session_id`; early startup failures (e.g. `EADDRINUSE`) come back with their real exit code and output. Sessions started this way are marked `background: true` in `list_sessions`, stream via `write_stdin`, and stop via `kill_command`. Tool description teaches the lifecycle: never use shell `&` for servers, verify with curl before browser testing.
- **Loud warning on `&` misuse** — `PtySession` installs an EXIT trap that prints a warning naming the pids and the supported patterns when a command exits leaving live background jobs. Guards keep it accurate:
  - TERM/INT/HUP traps record signal-driven exits (`_kolega_signaled`) and re-exit `143/130/129`, so `kill_command` on a foreground session does **not** warn (a killed foreground child lingers in the job table at trap time — verified this races under load, so the flag is deterministic).
  - A `kill -0` liveness filter skips jobs that already died on their own before a normal exit.
- **Loopback refusal hint** — `browser_navigate`/`browser_tabs` append troubleshooting guidance to `ERR_CONNECTION_REFUSED` on loopback URLs: the browser runs on the same machine; restart the server with `background=true` and confirm with curl.
- **Browser prompt fix** — drop the stale mandatory `get_host` step (the tool isn't in the browser agent's `browser_only` toolset), state the browser shares the agent's machine, and instruct plain "not listening" reporting instead of assuming a sandboxed browser. Wording stays environment-neutral for hosted deployments.
- **Docs** — terminal tool section covers background processes & dev servers.

## Compatibility

Additive optional tool param; `ExecResult` and the `TerminalManager` interface are unchanged (background is a tool-layer contract), so sandbox/e2b backends and hosts are unaffected. No public API changes.

## Test plan

- New tests: 6 background-exec (mock + real-PTY end-to-end), 4 trap-warning incl. the kill-foreground regression, 8 loopback-hint (parametrized loopback forms + passthrough cases), 1 schema-inventory assertion for the optional `background` boolean.
- `tests/agent/services` + `tests/agent/tool_backend`: 522 passed; prompt suites pass; pre-commit (ruff + pyright) clean.
- Verified live in a TUI session: `background=true` server → visible in `list_sessions` → real `BrowserTool` navigate to `localhost` succeeds → `kill_command` stops it quietly (no false warning); `&` misuse warns and the server is indeed gone.
