### PR TITLE
feat(agent): persistent eval kernels with loopback tool bridge

### DIFF
--- a/docs/src/content/docs/concepts/tools.md
+++ b/docs/src/content/docs/concepts/tools.md
@@ -55,13 +55,16 @@ calls, and across sub-agents in the session, so the agent works incrementally
 (imports → define → test → use) instead of re-running whole scripts.
 
 Inside a cell, either kernel can **call back into the agent's own tools** over
-an authenticated loopback bridge — `tool.read_file_section({"path": "data.csv"})`
-from Python, or `await tool.search_codebase({pattern: "TODO"})` from JavaScript.
+an authenticated loopback bridge — `tool.search_codebase({pattern: "TODO"})`
+from Python, or `await tool.read_image({path: "chart.png"})` from JavaScript.
 Bridge calls go through the same permission and hook pipeline as model-issued
-tool calls. In-kernel helpers include `display()` for rich outputs (matplotlib
-figures are returned as images to vision-capable models), `read`/`write`/`env`,
-`list_tools()` for tool discovery, `parallel()` for concurrent calls, and
-`pip_install()` / `npm_install()` for adding packages.
+tool calls, and results arrive in each tool's model-facing format (for example,
+`tool.read_file_section` wraps content in a markdown header and code fence).
+For raw file contents — CSV loads, JSON handoffs — use the in-kernel
+`read`/`write` helpers, which hit the filesystem directly. Other helpers include
+`display()` for rich outputs (matplotlib figures are returned as images to
+vision-capable models), `env`, `list_tools()` for tool discovery, `parallel()`
+for concurrent calls, and `pip_install()` / `npm_install()` for adding packages.
 
 The Python kernel runs in a **dedicated managed environment** (not your project
 venv, not the CLI's own interpreter): kolega-code provisions a CPython 3.12 with

--- a/docs/src/content/docs/concepts/tools.md
+++ b/docs/src/content/docs/concepts/tools.md
@@ -46,6 +46,41 @@ use) reports its real exit code and output. Processes started by the agent
 never outlive kolega-code: all sessions are terminated when the agent session
 ends, including on quit.
 
+### Code execution (eval)
+
+`eval` runs one step of code in a **persistent kernel** — `language="py"` for
+Python or `language="js"` for JavaScript (requires Bun or Node ≥ 18 on PATH).
+Imports, variables, and functions survive across `eval` calls, across tool
+calls, and across sub-agents in the session, so the agent works incrementally
+(imports → define → test → use) instead of re-running whole scripts.
+
+Inside a cell, either kernel can **call back into the agent's own tools** over
+an authenticated loopback bridge — `tool.read_file_section({"path": "data.csv"})`
+from Python, or `await tool.search_codebase({pattern: "TODO"})` from JavaScript.
+Bridge calls go through the same permission and hook pipeline as model-issued
+tool calls. In-kernel helpers include `display()` for rich outputs (matplotlib
+figures are returned as images to vision-capable models), `read`/`write`/`env`,
+`list_tools()` for tool discovery, `parallel()` for concurrent calls, and
+`pip_install()` / `npm_install()` for adding packages.
+
+The Python kernel runs in a **dedicated managed environment** (not your project
+venv, not the CLI's own interpreter): kolega-code provisions a CPython 3.12 with
+numpy, pandas, matplotlib, and pillow preinstalled on first use, so data and
+charting work everywhere without touching project or CLI dependencies. Executing
+your project's own code with its dependencies stays with `exec_command`, which
+auto-activates the project `.venv`.
+
+The environment lives at `eval-env/` under the [state directory](../troubleshooting/diagnostics/)
+(override with `KOLEGA_CODE_STATE_DIR`). It upgrades itself: if a Kolega Code
+update changes the bundled packages or Python version, the next `eval` call
+reprovisions automatically. Deleting the directory is always safe — it is simply
+recreated on demand. Updating the CLI with `kolega-code update` never touches it.
+
+Set `reset: true` to wipe a kernel's state; `timeout` bounds a cell (interrupts
+with `KeyboardInterrupt` on Python). Cells run locally with the same trust level
+as `exec_command` and are gated by command permissions in ask mode. Disable the
+feature with `"eval_enabled": false` in settings.
+
 ### Browser
 
 Drive a real browser (Playwright) for web tasks:

--- a/kolega_code/agent/eval/__init__.py
+++ b/kolega_code/agent/eval/__init__.py
@@ -1,0 +1,26 @@
+"""Persistent eval kernels (Python/JavaScript) with a loopback tool bridge.
+
+Internal package — not part of the supported ``kolega_code`` public API.
+"""
+
+from .bridge import BridgeRegistration, ToolBridge
+from .env import EvalEnvironmentManager, KernelEnvInfo
+from .kernel import (
+    BaseKernel,
+    EvalCellResult,
+    EvalKernelManager,
+    KernelErrorInfo,
+    KernelUnavailableError,
+)
+
+__all__ = [
+    "BaseKernel",
+    "BridgeRegistration",
+    "EvalCellResult",
+    "EvalEnvironmentManager",
+    "EvalKernelManager",
+    "KernelEnvInfo",
+    "KernelErrorInfo",
+    "KernelUnavailableError",
+    "ToolBridge",
+]

--- a/kolega_code/agent/eval/bridge.py
+++ b/kolega_code/agent/eval/bridge.py
@@ -1,0 +1,217 @@
+"""HTTP loopback bridge that lets eval kernels call back into agent tools.
+
+Kernels are separate processes; from inside a cell, ``tool.<name>(args)`` POSTs
+JSON to ``127.0.0.1`` on an ephemeral port with a per-process bearer token. The
+bridge looks up the registration for the cell's ``(session, run)`` pair and
+forwards the call to the executing agent's standard tool-execution path, so
+bridge-originated calls get the same permission prompts, hooks, and TUI
+visibility as model-issued tool calls.
+
+Registrations live only for the duration of one cell; in-flight bridge calls
+are cancelled when the owning cell is interrupted so nothing is orphaned.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import secrets
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Dict, Optional, Tuple
+
+# Special bridge op (not a session tool): list the executing agent's registry.
+LIST_TOOLS_OP = "__list_tools__"
+
+_MAX_HEADER_BYTES = 64 * 1024
+_MAX_BODY_BYTES = 64 * 1024 * 1024
+
+# (session_id, run_id) -> JSON-safe value returned to the kernel.
+ToolCaller = Callable[[str, Any], Awaitable[Any]]
+# () -> [{"name": ..., "summary": ...}]
+ToolLister = Callable[[], Any]
+
+
+@dataclass
+class BridgeRegistration:
+    """Routing entry for one executing cell."""
+
+    tool_caller: ToolCaller
+    tool_lister: Optional[ToolLister] = None
+    tasks: set[asyncio.Task] = field(default_factory=set)
+    cancelled: bool = False
+
+    def cancel_in_flight(self) -> None:
+        """Reject new calls and cancel in-flight ones (cell was interrupted)."""
+        self.cancelled = True
+        for task in list(self.tasks):
+            task.cancel()
+
+
+class ToolBridge:
+    """Asyncio loopback HTTP server dispatching kernel tool calls."""
+
+    _instances: Dict[int, "ToolBridge"] = {}
+
+    def __init__(self) -> None:
+        self._token = secrets.token_hex(24)
+        self._server: Optional[asyncio.AbstractServer] = None
+        self._registrations: Dict[Tuple[str, str], BridgeRegistration] = {}
+        self._port = 0
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self._port}"
+
+    @property
+    def token(self) -> str:
+        return self._token
+
+    @classmethod
+    async def ensure(cls) -> "ToolBridge":
+        """Return the bridge singleton for the current event loop, starting it lazily."""
+        loop = asyncio.get_running_loop()
+        key = id(loop)
+        instance = cls._instances.get(key)
+        if instance is None or instance._server is None:
+            instance = cls()
+            instance._loop = loop  # keep the loop alive for the id() key
+            await instance._start()
+            cls._instances[key] = instance
+        return instance
+
+    async def _start(self) -> None:
+        self._server = await asyncio.start_server(self._handle_client, host="127.0.0.1", port=0)
+        sock = self._server.sockets[0]
+        self._port = int(sock.getsockname()[1])
+
+    async def stop(self) -> None:
+        """Stop the server and cancel every in-flight call. Mainly for tests."""
+        for registration in self._registrations.values():
+            registration.cancel_in_flight()
+        self._registrations.clear()
+        if self._server is not None:
+            server = self._server
+            self._server = None
+            server.close()
+            await server.wait_closed()
+
+    def register(self, session_id: str, run_id: str, registration: BridgeRegistration) -> Callable[[], None]:
+        """Route calls for (session_id, run_id) for the duration of one cell."""
+        key = (session_id, run_id)
+        self._registrations[key] = registration
+
+        def unregister() -> None:
+            if self._registrations.get(key) is registration:
+                registration.cancel_in_flight()
+                del self._registrations[key]
+
+        return unregister
+
+    async def _handle_client(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            status, payload = await self._dispatch_request(reader)
+        except Exception as exc:  # never leak a stack into a kernel response
+            status, payload = 500, {"ok": False, "error": f"bridge error: {exc}"}
+        try:
+            body = json.dumps(payload).encode("utf-8", "replace")
+            reason = {200: "OK", 400: "Bad Request", 403: "Forbidden", 404: "Not Found", 413: "Too Large"}.get(
+                status, "Error"
+            )
+            head = (
+                f"HTTP/1.1 {status} {reason}\r\n"
+                "Content-Type: application/json\r\n"
+                f"Content-Length: {len(body)}\r\n"
+                "Connection: close\r\n\r\n"
+            )
+            writer.write(head.encode("ascii") + body)
+            await writer.drain()
+        except (ConnectionError, RuntimeError):
+            pass
+        finally:
+            try:
+                writer.close()
+            except Exception:
+                pass
+
+    async def _dispatch_request(self, reader: asyncio.StreamReader) -> Tuple[int, Dict[str, Any]]:
+        request_line = await reader.readline()
+        if len(request_line) > _MAX_HEADER_BYTES:
+            return 400, {"ok": False, "error": "request line too long"}
+        try:
+            method, target, _version = request_line.decode("ascii", "replace").strip().split(" ", 2)
+        except ValueError:
+            return 400, {"ok": False, "error": "malformed request line"}
+
+        headers: Dict[str, str] = {}
+        header_bytes = len(request_line)
+        while True:
+            line = await reader.readline()
+            header_bytes += len(line)
+            if header_bytes > _MAX_HEADER_BYTES:
+                return 400, {"ok": False, "error": "headers too large"}
+            if line in (b"\r\n", b"\n", b""):
+                break
+            name, sep, value = line.decode("ascii", "replace").partition(":")
+            if sep:
+                headers[name.strip().lower()] = value.strip()
+
+        if method != "POST" or target != "/v1/tool":
+            return 404, {"ok": False, "error": "not found"}
+        if headers.get("authorization") != f"Bearer {self._token}":
+            return 403, {"ok": False, "error": "forbidden"}
+
+        try:
+            length = int(headers.get("content-length") or "0")
+        except ValueError:
+            return 400, {"ok": False, "error": "invalid content-length"}
+        if length <= 0:
+            return 400, {"ok": False, "error": "missing body"}
+        if length > _MAX_BODY_BYTES:
+            return 413, {"ok": False, "error": "body too large"}
+        raw = await reader.readexactly(length)
+        try:
+            body = json.loads(raw)
+        except json.JSONDecodeError:
+            return 400, {"ok": False, "error": "invalid JSON body"}
+        if not isinstance(body, dict):
+            return 400, {"ok": False, "error": "body must be a JSON object"}
+
+        session_id = body.get("session")
+        run_id = body.get("run")
+        name = body.get("name")
+        if not isinstance(session_id, str) or not isinstance(run_id, str) or not isinstance(name, str) or not name:
+            return 400, {"ok": False, "error": "missing session/run/name"}
+        args = body.get("args")
+
+        registration = self._registrations.get((session_id, run_id))
+        if registration is None:
+            return 200, {"ok": False, "error": f"no active eval cell for session/run {session_id}/{run_id}"}
+        if registration.cancelled:
+            return 200, {"ok": False, "error": f"bridge call {name!r} rejected: eval cell was interrupted"}
+
+        if name == LIST_TOOLS_OP:
+            try:
+                tools = registration.tool_lister() if registration.tool_lister else []
+                return 200, {"ok": True, "value": tools}
+            except Exception as exc:
+                return 200, {"ok": False, "error": str(exc)}
+
+        task = asyncio.current_task()
+        if task is not None:
+            registration.tasks.add(task)
+        try:
+            value = await registration.tool_caller(name, args)
+            return 200, {"ok": True, "value": value}
+        except asyncio.CancelledError:
+            return 200, {"ok": False, "error": f"bridge call {name!r} cancelled: eval cell was interrupted"}
+        except Exception as exc:
+            return 200, {"ok": False, "error": str(exc) or exc.__class__.__name__}
+        finally:
+            if task is not None:
+                registration.tasks.discard(task)
+
+
+async def ensure_tool_bridge() -> ToolBridge:
+    """Module-level convenience matching ToolBridge.ensure()."""
+    return await ToolBridge.ensure()

--- a/kolega_code/agent/eval/bundle-requirements.txt
+++ b/kolega_code/agent/eval/bundle-requirements.txt
@@ -1,0 +1,4 @@
+numpy==2.2.6
+pandas==2.3.1
+matplotlib==3.10.3
+pillow==11.3.0

--- a/kolega_code/agent/eval/env.py
+++ b/kolega_code/agent/eval/env.py
@@ -1,0 +1,302 @@
+"""Dedicated, kolega-code-managed Python environment for eval kernels.
+
+The eval Python kernel deliberately runs neither on the project's venv nor on
+the kolega-code host interpreter. It gets its own managed environment under the
+user state dir so a curated library bundle (numpy/pandas/matplotlib/pillow) is
+always available and agent-driven ``pip_install`` calls can never break the
+CLI's own exactly-pinned dependency closure.
+
+Provisioning is lazy (first ``py`` cell), serialized across processes with a
+file lock, and self-healing: a manifest records the requested Python version
+and bundle hash, and any mismatch triggers a clean reprovision. When
+provisioning fails entirely (offline host, no compilers) the manager degrades
+to the host interpreter with a model-facing note instead of failing the cell.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from importlib.resources import files
+from pathlib import Path
+from typing import List, Optional
+
+import filelock
+
+BUNDLE_RESOURCE = "bundle-requirements.txt"
+ENV_DIR_NAME = "eval-env"
+LOCK_FILE_NAME = "eval-env.lock"
+MANIFEST_NAME = "kolega-eval-manifest.json"
+
+_INSTALL_TIMEOUT_S = 900
+_VENV_TIMEOUT_S = 300
+
+
+@dataclass
+class KernelEnvInfo:
+    """Resolved kernel interpreter and provisioning outcome."""
+
+    python: str
+    env_path: Optional[Path]
+    bundled: bool
+    degraded: bool
+    provisioned_now: bool
+    note: Optional[str] = None
+    # Command prefix for prelude pip_install(); empty when installs are not
+    # possible (degraded host interpreter or uv-managed env without uv).
+    pip_install_cmd: List[str] = field(default_factory=list)
+    bundle: List[str] = field(default_factory=list)
+
+
+def default_state_dir() -> Path:
+    """User state dir for kolega-code (mirrors cli.session_store.default_state_dir).
+
+    Mirrored here rather than imported so the agent layer does not depend on the
+    CLI layer. Keep the semantics in sync: KOLEGA_CODE_STATE_DIR override, then
+    the per-platform application-state location.
+    """
+    env = os.environ.get("KOLEGA_CODE_STATE_DIR")
+    if env:
+        return Path(env).expanduser()
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "kolega-code"
+    if sys.platform == "win32":
+        base = Path(os.environ.get("LOCALAPPDATA") or Path.home() / "AppData" / "Local")
+        return base / "kolega-code"
+    return Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local" / "state")) / "kolega-code"
+
+
+def _venv_python(env_path: Path) -> Path:
+    if sys.platform == "win32":
+        return env_path / "Scripts" / "python.exe"
+    return env_path / "bin" / "python"
+
+
+def _run(cmd: List[str], timeout: int) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, check=False)
+
+
+class EvalEnvironmentManager:
+    """Provisions and resolves the dedicated eval Python environment."""
+
+    def __init__(
+        self,
+        *,
+        state_dir: Optional[Path] = None,
+        env_path: Optional[Path] = None,
+        python_version: str = "3.12",
+        extra_packages: Optional[List[str]] = None,
+        override_python: Optional[str] = None,
+    ) -> None:
+        self._state_dir = Path(state_dir) if state_dir else default_state_dir()
+        self._env_path = Path(env_path) if env_path else self._state_dir / ENV_DIR_NAME
+        self._python_version = python_version
+        self._extra_packages = list(extra_packages or [])
+        self._override_python = override_python
+        self._cached: Optional[KernelEnvInfo] = None
+
+    @property
+    def env_path(self) -> Path:
+        return self._env_path
+
+    def _bundle_source(self) -> bytes:
+        return files("kolega_code.agent.eval").joinpath(BUNDLE_RESOURCE).read_bytes()
+
+    def _bundle_hash(self) -> str:
+        digest = hashlib.sha256()
+        digest.update(self._bundle_source())
+        for package in self._extra_packages:
+            digest.update(b"\0")
+            digest.update(package.encode("utf-8"))
+        return digest.hexdigest()
+
+    def _bundle_names(self) -> List[str]:
+        names: List[str] = []
+        for line in self._bundle_source().decode("utf-8").splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                names.append(line)
+        return names + self._extra_packages
+
+    def _materialize_bundle_file(self) -> Path:
+        """Write the bundle requirements to a real file installers can read."""
+        digest = self._bundle_hash()[:16]
+        target = self._state_dir / f"eval-bundle-{digest}.txt"
+        if not target.exists():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(self._bundle_source())
+            if self._extra_packages:
+                with target.open("a", encoding="utf-8") as handle:
+                    for package in self._extra_packages:
+                        handle.write(package + "\n")
+        return target
+
+    def _read_manifest(self) -> Optional[dict]:
+        manifest_path = self._env_path / MANIFEST_NAME
+        try:
+            data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        return data if isinstance(data, dict) else None
+
+    def _write_manifest(self, installer: str) -> None:
+        manifest = {
+            "python_version": self._python_version,
+            "bundle_hash": self._bundle_hash(),
+            "installer": installer,
+        }
+        (self._env_path / MANIFEST_NAME).write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    def _manifest_matches(self) -> bool:
+        manifest = self._read_manifest()
+        if manifest is None:
+            return False
+        if manifest.get("bundle_hash") != self._bundle_hash():
+            return False
+        if manifest.get("python_version") != self._python_version:
+            return False
+        return _venv_python(self._env_path).exists()
+
+    def _pip_install_cmd(self, installer: str, python: str) -> List[str]:
+        uv = shutil.which("uv")
+        if installer == "uv":
+            # uv-created venvs have no pip module; only uv can install into them.
+            return [uv, "pip", "install", "--python", python] if uv else []
+        return [python, "-m", "pip", "install"]
+
+    async def ensure(self) -> KernelEnvInfo:
+        """Resolve the kernel interpreter, provisioning the env on first use."""
+        if self._cached is not None:
+            return self._cached
+        import asyncio
+
+        info = await asyncio.to_thread(self._ensure_sync)
+        self._cached = info
+        return info
+
+    def _ensure_sync(self) -> KernelEnvInfo:
+        if self._override_python:
+            probe = _run([self._override_python, "--version"], timeout=30)
+            if probe.returncode == 0:
+                return KernelEnvInfo(
+                    python=self._override_python,
+                    env_path=None,
+                    bundled=False,
+                    degraded=False,
+                    provisioned_now=False,
+                    note=(
+                        "eval kernel is using the configured custom interpreter "
+                        f"({self._override_python}); the bundled libraries are not installed there. "
+                        "Use pip_install(package) to add packages."
+                    ),
+                    pip_install_cmd=[self._override_python, "-m", "pip", "install"],
+                )
+            # Fall through to normal provisioning if the override is broken.
+
+        if self._manifest_matches() and self._read_manifest() is not None:
+            python = str(_venv_python(self._env_path))
+            installer = str((self._read_manifest() or {}).get("installer") or "pip")
+            return KernelEnvInfo(
+                python=python,
+                env_path=self._env_path,
+                bundled=True,
+                degraded=False,
+                provisioned_now=False,
+                pip_install_cmd=self._pip_install_cmd(installer, python),
+                bundle=self._bundle_names(),
+            )
+
+        lock_path = self._state_dir / LOCK_FILE_NAME
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with filelock.FileLock(str(lock_path)):
+            # Another process may have provisioned while we waited on the lock.
+            if self._manifest_matches():
+                python = str(_venv_python(self._env_path))
+                installer = str((self._read_manifest() or {}).get("installer") or "pip")
+                return KernelEnvInfo(
+                    python=python,
+                    env_path=self._env_path,
+                    bundled=True,
+                    degraded=False,
+                    provisioned_now=False,
+                    pip_install_cmd=self._pip_install_cmd(installer, python),
+                    bundle=self._bundle_names(),
+                )
+            return self._provision_locked()
+
+    def _provision_locked(self) -> KernelEnvInfo:
+        """Create the env and install the bundle. Caller holds the file lock."""
+        try:
+            if self._env_path.exists():
+                shutil.rmtree(self._env_path, ignore_errors=True)
+            self._env_path.parent.mkdir(parents=True, exist_ok=True)
+            bundle_file = self._materialize_bundle_file()
+            uv = shutil.which("uv")
+            if uv:
+                step = _run(
+                    [uv, "venv", str(self._env_path), "--python", self._python_version], timeout=_VENV_TIMEOUT_S
+                )
+                if step.returncode != 0:
+                    raise RuntimeError(f"uv venv failed: {step.stderr[-500:]}")
+                python = str(_venv_python(self._env_path))
+                step = _run(
+                    [uv, "pip", "install", "--python", python, "-r", str(bundle_file)],
+                    timeout=_INSTALL_TIMEOUT_S,
+                )
+                if step.returncode != 0:
+                    raise RuntimeError(f"uv pip install failed: {step.stderr[-500:]}")
+                installer = "uv"
+            else:
+                step = _run([sys.executable, "-m", "venv", str(self._env_path)], timeout=_VENV_TIMEOUT_S)
+                if step.returncode != 0:
+                    raise RuntimeError(f"python -m venv failed: {step.stderr[-500:]}")
+                python = str(_venv_python(self._env_path))
+                step = _run(
+                    [python, "-m", "pip", "install", "-r", str(bundle_file)],
+                    timeout=_INSTALL_TIMEOUT_S,
+                )
+                if step.returncode != 0:
+                    raise RuntimeError(f"pip install failed: {step.stderr[-500:]}")
+                installer = "pip"
+            self._write_manifest(installer)
+            return KernelEnvInfo(
+                python=python,
+                env_path=self._env_path,
+                bundled=True,
+                degraded=False,
+                provisioned_now=True,
+                note=(
+                    "Provisioned the dedicated eval Python environment on first use "
+                    f"({self._python_version} with the bundled data libraries); this is a one-time setup."
+                ),
+                pip_install_cmd=self._pip_install_cmd(installer, python),
+                bundle=self._bundle_names(),
+            )
+        except Exception as exc:  # degrade rather than fail the cell
+            shutil.rmtree(self._env_path, ignore_errors=True)
+            return KernelEnvInfo(
+                python=sys.executable,
+                env_path=None,
+                bundled=False,
+                degraded=True,
+                provisioned_now=False,
+                note=(
+                    "Could not provision the dedicated eval Python environment "
+                    f"({exc}); running on the host interpreter {sys.executable} without the bundled "
+                    "libraries (numpy/pandas/matplotlib/pillow). pip_install is disabled."
+                ),
+                pip_install_cmd=[],
+            )
+
+
+def resolve_state_dir_from_config(config: object) -> Path:
+    """State dir override from AgentConfig (Mock-safe), else the default."""
+    raw = getattr(config, "eval_env_path", None)
+    if isinstance(raw, str) and raw.strip():
+        return Path(raw).expanduser()
+    return default_state_dir()

--- a/kolega_code/agent/eval/js_kernel.py
+++ b/kolega_code/agent/eval/js_kernel.py
@@ -1,0 +1,97 @@
+"""JavaScript eval kernel: a Bun/Node subprocess with a persistent vm context."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from importlib.resources import files
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from .kernel import BaseKernel, _cfg_str
+
+_RUNNER_RESOURCE = "runner.js"
+_PRELUDE_RESOURCE = "prelude.js"
+_MIN_NODE_MAJOR = 18
+
+
+@dataclass(frozen=True)
+class JsRuntime:
+    """A probed JavaScript runtime executable."""
+
+    name: str  # "bun" | "node"
+    path: str
+
+    def npm_install_cmd(self, home: Path) -> List[str]:
+        if self.name == "bun":
+            return [self.path, "add", "--cwd", str(home)]
+        npm = shutil.which("npm")
+        if not npm:
+            return []
+        return [npm, "install", "--prefix", str(home), "--no-audit", "--no-fund"]
+
+
+def _probe_node_version(path: str) -> bool:
+    try:
+        proc = subprocess.run([path, "--version"], capture_output=True, text=True, timeout=15, check=False)
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    version = (proc.stdout or "").strip().lstrip("v")
+    try:
+        major = int(version.split(".", 1)[0])
+    except (ValueError, IndexError):
+        return False
+    return major >= _MIN_NODE_MAJOR
+
+
+def probe_js_runtime(config: object) -> Optional[JsRuntime]:
+    """Find a JS runtime: explicit config, else bun preferred, then node >= 18."""
+    preferred = _cfg_str(config, "eval_js_runtime")
+    candidates = [preferred] if preferred else ["bun", "node"]
+    for candidate in candidates:
+        assert candidate is not None
+        if os.sep in candidate or (os.altsep and os.altsep in candidate):
+            path: Optional[str] = candidate if os.path.isfile(candidate) else None
+        else:
+            path = shutil.which(candidate)
+        if not path:
+            continue
+        name = "bun" if "bun" in os.path.basename(path).lower() else "node"
+        if name == "node" and not _probe_node_version(path):
+            continue
+        return JsRuntime(name=name, path=path)
+    return None
+
+
+def _resource_text(name: str) -> str:
+    return files("kolega_code.agent.eval").joinpath(name).read_text(encoding="utf-8")
+
+
+def materialize_runner(state_dir: Path) -> Path:
+    """Write the JS runner script next to the Python one (content-hash cached)."""
+    source = _resource_text(_RUNNER_RESOURCE)
+    digest = hashlib.sha256(source.encode("utf-8")).hexdigest()[:16]
+    target_dir = state_dir / "eval-kernels"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target = target_dir / f"runner-{digest}.js"
+    if not target.exists():
+        target.write_text(source, encoding="utf-8")
+    return target
+
+
+class JsKernel(BaseKernel):
+    """Persistent JavaScript kernel (one subprocess, NDJSON cell protocol)."""
+
+    def __init__(self, *, cwd: str, env: Dict[str, str], runtime: JsRuntime, state_dir: Path) -> None:
+        super().__init__(language="js", cwd=cwd, env=env)
+        self._runtime = runtime
+        self._runner_path = materialize_runner(state_dir)
+
+    def argv(self) -> List[str]:
+        return [self._runtime.path, str(self._runner_path)]
+
+    def init_cells(self) -> List[str]:
+        return [_resource_text(_PRELUDE_RESOURCE)]

--- a/kolega_code/agent/eval/kernel.py
+++ b/kolega_code/agent/eval/kernel.py
@@ -20,7 +20,7 @@ import json
 import signal
 import sys
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Callable, ClassVar, Coroutine, Dict, List, Optional, Tuple
 
@@ -449,7 +449,13 @@ class EvalKernelManager:
 
     async def _ensure_env(self) -> KernelEnvInfo:
         if self._env_info is None or self._env_info.degraded:
-            self._env_info = await self._env_manager_for_thread().ensure()
+            info = await self._env_manager_for_thread().ensure()
+            if info.provisioned_now:
+                # The one-time setup note belongs only to the kernel start that
+                # actually provisioned; later starts must reuse the env quietly.
+                self._env_info = replace(info, provisioned_now=False, note=None)
+                return info
+            self._env_info = info
         return self._env_info
 
     async def _start_python_kernel(self) -> Tuple[BaseKernel, List[str]]:

--- a/kolega_code/agent/eval/kernel.py
+++ b/kolega_code/agent/eval/kernel.py
@@ -1,0 +1,631 @@
+"""Host-side eval kernel lifecycle: subprocess management and the cell executor.
+
+``BaseKernel`` owns one kernel subprocess and speaks the NDJSON protocol from
+``protocol.py``: a background reader task routes frames to the currently
+executing cell, timeouts interrupt via SIGINT (escalating to SIGKILL, which
+costs the kernel its state), and shutdown drains gracefully.
+
+``EvalKernelManager`` owns one kernel per language for an agent session
+(workspace_id, thread_id). Managers are shared with sub-agents through a
+thread-keyed registry so kernel state persists across cells, tool calls, and
+sub-agent dispatches within the session. While a cell runs, the manager
+registers the executing agent on the loopback tool bridge so in-kernel
+``tool.<name>(args)`` calls route through that agent's standard tool path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import signal
+import sys
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, ClassVar, Coroutine, Dict, List, Optional, Tuple
+
+from kolega_code.llm.models import ImageBlock, TextBlock, ToolCall
+from kolega_code.services.terminal import build_child_env
+from kolega_code.tools import ToolError
+
+from .bridge import BridgeRegistration, ToolBridge
+from .env import EvalEnvironmentManager, KernelEnvInfo, default_state_dir
+from .protocol import (
+    FRAME_DISPLAY,
+    FRAME_DONE,
+    FRAME_ERROR,
+    FRAME_RESULT,
+    FRAME_STATUS,
+    FRAME_STDERR,
+    FRAME_STDOUT,
+    FRAME_STREAM_LIMIT,
+    STATUS_OK,
+    ProtocolError,
+    encode_frame,
+    parse_frame,
+)
+
+STARTUP_TIMEOUT_S = 30.0
+INTERRUPT_GRACE_S = 5.0
+SHUTDOWN_GRACE_S = 1.0
+CELL_PROTOCOL_VERSION = 1
+
+
+@dataclass
+class KernelErrorInfo:
+    ename: str
+    evalue: str
+    traceback: List[str]
+
+
+@dataclass
+class EvalCellResult:
+    """Accumulated outcome of one executed cell."""
+
+    status: str = "ok"
+    stdout: str = ""
+    stderr: str = ""
+    result_bundle: Dict[str, Any] = field(default_factory=dict)
+    displays: List[Dict[str, Any]] = field(default_factory=list)
+    statuses: List[Dict[str, Any]] = field(default_factory=list)
+    error: Optional[KernelErrorInfo] = None
+    interrupted: bool = False
+    restarted: bool = False
+    notes: List[str] = field(default_factory=list)
+
+
+class KernelUnavailableError(ToolError):
+    """The requested kernel language cannot run on this machine."""
+
+
+class _Execution:
+    """Accumulator for the frames of one in-flight cell."""
+
+    def __init__(self, msg_id: int, run_id: str) -> None:
+        self.msg_id = msg_id
+        self.run_id = run_id
+        self.done = asyncio.Event()
+        self.result = EvalCellResult()
+
+    def handle_frame(self, frame: Dict[str, Any]) -> None:
+        frame_type = frame.get("type")
+        result = self.result
+        if frame_type == FRAME_STDOUT:
+            result.stdout += str(frame.get("data") or "")
+        elif frame_type == FRAME_STDERR:
+            result.stderr += str(frame.get("data") or "")
+        elif frame_type == FRAME_DISPLAY:
+            bundle = frame.get("bundle")
+            if isinstance(bundle, dict):
+                result.displays.append(bundle)
+        elif frame_type == FRAME_RESULT:
+            bundle = frame.get("bundle")
+            if isinstance(bundle, dict):
+                result.result_bundle = bundle
+        elif frame_type == FRAME_STATUS:
+            event = frame.get("event")
+            if isinstance(event, dict):
+                result.statuses.append(event)
+        elif frame_type == FRAME_ERROR:
+            traceback = frame.get("traceback")
+            result.error = KernelErrorInfo(
+                ename=str(frame.get("ename") or "Error"),
+                evalue=str(frame.get("evalue") or ""),
+                traceback=[str(line) for line in traceback] if isinstance(traceback, list) else [],
+            )
+        elif frame_type == FRAME_DONE:
+            result.status = str(frame.get("status") or "error")
+            self.done.set()
+        # FRAME_STARTED needs no handling.
+
+
+class BaseKernel:
+    """One kernel subprocess speaking the NDJSON cell protocol."""
+
+    def __init__(self, *, language: str, cwd: str, env: Dict[str, str]) -> None:
+        self.language = language
+        self.cwd = cwd
+        self.env = env
+        self._proc: Optional[asyncio.subprocess.Process] = None
+        self._reader_task: Optional[asyncio.Task] = None
+        self._stderr_task: Optional[asyncio.Task] = None
+        self._stderr_tail: List[str] = []
+        self._current: Optional[_Execution] = None
+        self._msg_id = 0
+        self._alive = False
+        # Guards against overlapping execute() calls; the manager serializes per
+        # language, and a non-blocking check there turns re-entry into an error.
+        self._exec_lock = asyncio.Lock()
+
+    # -- subclass hooks -----------------------------------------------------
+
+    def argv(self) -> List[str]:
+        raise NotImplementedError
+
+    def init_cells(self) -> List[str]:
+        """Silent setup cells run once after spawn (prelude etc.)."""
+        return []
+
+    # -- lifecycle ----------------------------------------------------------
+
+    @property
+    def alive(self) -> bool:
+        return self._alive and self._proc is not None and self._proc.returncode is None
+
+    async def start(self) -> None:
+        if self.alive:
+            return
+        await self.shutdown()
+        self._stderr_tail.clear()
+        self._proc = await asyncio.create_subprocess_exec(
+            *self.argv(),
+            cwd=self.cwd,
+            env=self.env,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            limit=FRAME_STREAM_LIMIT,
+        )
+        self._alive = True
+        self._reader_task = asyncio.create_task(self._reader_loop())
+        self._stderr_task = asyncio.create_task(self._stderr_loop())
+        try:
+            for cell in self.init_cells():
+                await asyncio.wait_for(self._run_silent(cell), timeout=STARTUP_TIMEOUT_S)
+        except Exception:
+            await self.shutdown()
+            raise
+
+    async def shutdown(self, timeout: float = SHUTDOWN_GRACE_S) -> None:
+        self._alive = False
+        proc = self._proc
+        self._proc = None
+        if proc is not None and proc.returncode is None:
+            try:
+                if proc.stdin is not None:
+                    proc.stdin.write(encode_frame({"type": "exit"}))
+                    await proc.stdin.wait_closed()
+            except (BrokenPipeError, ConnectionError, RuntimeError):
+                pass
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=timeout)
+            except asyncio.TimeoutError:
+                self._kill_proc(proc)
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=timeout)
+                except asyncio.TimeoutError:
+                    pass
+        for task in (self._reader_task, self._stderr_task):
+            if task is not None:
+                task.cancel()
+        self._reader_task = None
+        self._stderr_task = None
+        current = self._current
+        if current is not None and not current.done.is_set():
+            current.result.status = "error"
+            current.result.notes.append("kernel was shut down mid-cell")
+            current.done.set()
+        self._current = None
+
+    def _kill_proc(self, proc: asyncio.subprocess.Process) -> None:
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
+
+    # -- protocol I/O -------------------------------------------------------
+
+    async def _reader_loop(self) -> None:
+        assert self._proc is not None and self._proc.stdout is not None
+        try:
+            while True:
+                line = await self._proc.stdout.readline()
+                if not line:
+                    break
+                try:
+                    frame = parse_frame(line)
+                except ProtocolError:
+                    # C-level writes bypass the kernel's stream capture and land
+                    # raw on fd 1; surface them as stdout rather than crashing.
+                    current = self._current
+                    if current is not None:
+                        current.result.stdout += line.decode("utf-8", "replace")
+                    continue
+                self._route_frame(frame)
+        except (ConnectionError, asyncio.IncompleteReadError, ValueError):
+            pass
+        finally:
+            self._alive = False
+            current = self._current
+            if current is not None and not current.done.is_set():
+                current.result.status = "error"
+                current.result.notes.append("kernel exited unexpectedly; its state was lost")
+                if self._stderr_tail:
+                    current.result.stderr += "".join(self._stderr_tail[-20:])
+                current.done.set()
+
+    async def _stderr_loop(self) -> None:
+        assert self._proc is not None and self._proc.stderr is not None
+        try:
+            while True:
+                chunk = await self._proc.stderr.read(4096)
+                if not chunk:
+                    break
+                self._stderr_tail.append(chunk.decode("utf-8", "replace"))
+                del self._stderr_tail[:-50]
+        except (ConnectionError, ValueError):
+            pass
+
+    def _route_frame(self, frame: Dict[str, Any]) -> None:
+        current = self._current
+        if current is None or frame.get("id") != current.msg_id:
+            return
+        current.handle_frame(frame)
+
+    async def _write_frame(self, frame: Dict[str, Any]) -> None:
+        if not self.alive or self._proc is None or self._proc.stdin is None:
+            raise KernelUnavailableError(f"{self.language} kernel is not running")
+        try:
+            self._proc.stdin.write(encode_frame(frame))
+            await self._proc.stdin.drain()
+        except (BrokenPipeError, ConnectionError, RuntimeError) as exc:
+            self._alive = False
+            raise KernelUnavailableError(f"{self.language} kernel pipe broke: {exc}") from exc
+
+    # -- execution ----------------------------------------------------------
+
+    async def _run_silent(self, code: str) -> None:
+        execution = await self._begin_execution(code, run_id="", silent=True)
+        await execution.done.wait()
+        if execution.result.status != STATUS_OK:
+            detail = ""
+            if execution.result.error is not None:
+                detail = f"{execution.result.error.ename}: {execution.result.error.evalue}"
+            raise KernelUnavailableError(f"{self.language} kernel init failed: {detail or 'unknown error'}")
+
+    async def _begin_execution(self, code: str, *, run_id: str, silent: bool) -> _Execution:
+        self._msg_id += 1
+        execution = _Execution(self._msg_id, run_id)
+        self._current = execution
+        await self._write_frame(
+            {
+                "type": "exec",
+                "id": execution.msg_id,
+                "run": run_id,
+                "code": code,
+                "cwd": self.cwd,
+                "silent": silent,
+            }
+        )
+        return execution
+
+    async def execute(self, code: str, *, run_id: str, timeout: Optional[float]) -> EvalCellResult:
+        """Run one cell, interrupting on timeout/cancellation."""
+        if self._exec_lock.locked():
+            raise ToolError(f"{self.language} kernel is busy with another cell")
+        async with self._exec_lock:
+            if not self.alive:
+                raise KernelUnavailableError(f"{self.language} kernel is not running")
+            execution = await self._begin_execution(code, run_id=run_id, silent=False)
+            try:
+                if timeout is not None and timeout > 0:
+                    await asyncio.wait_for(execution.done.wait(), timeout=timeout)
+                else:
+                    await execution.done.wait()
+            except asyncio.TimeoutError:
+                execution.result.interrupted = True
+                note = await self._interrupt(execution)
+                execution.result.status = "error"
+                execution.result.notes.append(f"cell timed out after {timeout}s; {note}")
+                return self._finish(execution)
+            except asyncio.CancelledError:
+                execution.result.interrupted = True
+                await self._interrupt(execution)
+                raise
+            finally:
+                if self._current is execution:
+                    self._current = None
+            return self._finish(execution)
+
+    async def _interrupt(self, execution: _Execution) -> str:
+        """SIGINT the cell; escalate to kill. Returns a human note."""
+        proc = self._proc
+        if proc is None or proc.returncode is not None:
+            return "kernel was already dead"
+        if sys.platform == "win32":
+            # No reliable per-process Ctrl-C for detached children here.
+            self._kill_proc(proc)
+        else:
+            try:
+                proc.send_signal(signal.SIGINT)
+            except ProcessLookupError:
+                return "kernel was already dead"
+        try:
+            await asyncio.wait_for(execution.done.wait(), timeout=INTERRUPT_GRACE_S)
+            return "interrupted (KeyboardInterrupt)"
+        except asyncio.TimeoutError:
+            self._kill_proc(proc)
+            try:
+                await asyncio.wait_for(execution.done.wait(), timeout=SHUTDOWN_GRACE_S)
+            except asyncio.TimeoutError:
+                pass
+            return "cell did not interrupt; the kernel was killed and its state was lost"
+
+    def _finish(self, execution: _Execution) -> EvalCellResult:
+        return execution.result
+
+
+# ---------------------------------------------------------------------------
+# Manager
+# ---------------------------------------------------------------------------
+
+
+def _cfg_str(config: object, name: str, default: Optional[str] = None) -> Optional[str]:
+    """Read a string AgentConfig field, tolerating Mock configs in tests."""
+    value = getattr(config, name, default)
+    return value if isinstance(value, str) and value.strip() else default
+
+
+def _cfg_str_list(config: object, name: str) -> List[str]:
+    value = getattr(config, name, None)
+    if isinstance(value, (list, tuple)):
+        return [str(item) for item in value if isinstance(item, str)]
+    return []
+
+
+def serialize_tool_result(result: Any) -> Dict[str, Any]:
+    """Flatten an agent ToolResult into the JSON value returned to kernels."""
+    content = getattr(result, "content", "")
+    texts: List[str] = []
+    images: List[Dict[str, str]] = []
+    if isinstance(content, str):
+        texts.append(content)
+    elif isinstance(content, list):
+        for block in content:
+            if isinstance(block, TextBlock):
+                texts.append(block.text)
+            elif isinstance(block, ImageBlock):
+                images.append({"mime_type": block.media_type, "data": block.data})
+            elif hasattr(block, "to_markdown"):
+                texts.append(str(block.to_markdown()))
+            else:
+                texts.append(str(block))
+    else:
+        texts.append(str(content))
+    value: Dict[str, Any] = {"text": "\n".join(texts)}
+    if images:
+        value["images"] = images
+    if getattr(result, "is_error", False):
+        raise ToolError(value["text"] or "tool call failed")
+    return value
+
+
+class EvalKernelManager:
+    """Owns the session's kernels (one per language) and bridge registrations."""
+
+    _registry: ClassVar[Dict[Tuple[str, str], "EvalKernelManager"]] = {}
+
+    @classmethod
+    def for_thread(
+        cls,
+        *,
+        workspace_id: str,
+        thread_id: str,
+        project_path: Path,
+        config: object,
+    ) -> "EvalKernelManager":
+        """Shared manager for an agent session; sub-agents join the same one."""
+        key = (workspace_id, thread_id)
+        manager = cls._registry.get(key)
+        if manager is None or manager._shutdown:
+            manager = cls(workspace_id=workspace_id, thread_id=thread_id, project_path=project_path, config=config)
+            cls._registry[key] = manager
+        return manager
+
+    def __init__(self, *, workspace_id: str, thread_id: str, project_path: Path, config: object) -> None:
+        self.workspace_id = workspace_id
+        self.thread_id = thread_id
+        self.project_path = Path(project_path)
+        self.config = config
+        self.session_id = uuid.uuid4().hex
+        self._kernels: Dict[str, BaseKernel] = {}
+        self._locks: Dict[str, asyncio.Lock] = {}
+        self._env_manager: Optional[EvalEnvironmentManager] = None
+        self._env_info: Optional[KernelEnvInfo] = None
+        self._shutdown = False
+
+    # -- kernels ------------------------------------------------------------
+
+    def _env_manager_for_thread(self) -> EvalEnvironmentManager:
+        if self._env_manager is None:
+            env_path_raw = _cfg_str(self.config, "eval_env_path")
+            self._env_manager = EvalEnvironmentManager(
+                env_path=Path(env_path_raw).expanduser() if env_path_raw else None,
+                python_version=_cfg_str(self.config, "eval_python_version", "3.12") or "3.12",
+                extra_packages=_cfg_str_list(self.config, "eval_kernel_packages"),
+                override_python=_cfg_str(self.config, "eval_python_path"),
+            )
+        return self._env_manager
+
+    async def _ensure_env(self) -> KernelEnvInfo:
+        if self._env_info is None or self._env_info.degraded:
+            self._env_info = await self._env_manager_for_thread().ensure()
+        return self._env_info
+
+    async def _start_python_kernel(self) -> Tuple[BaseKernel, List[str]]:
+        from .py_kernel import PythonKernel
+
+        env_info = await self._ensure_env()
+        bridge = await ToolBridge.ensure()
+        kernel_env = build_child_env()
+        kernel_env.update(
+            {
+                "KOLEGA_TOOL_BRIDGE_URL": bridge.url,
+                "KOLEGA_TOOL_BRIDGE_TOKEN": bridge.token,
+                "KOLEGA_TOOL_BRIDGE_SESSION": self.session_id,
+                "KOLEGA_EVAL_ENV_PATH": str(env_info.env_path or ""),
+                "KOLEGA_EVAL_BUNDLE": ",".join(env_info.bundle),
+                "KOLEGA_EVAL_PIP_INSTALL_CMD": json.dumps(env_info.pip_install_cmd),
+                "PYTHONUNBUFFERED": "1",
+                "PYTHONIOENCODING": "utf-8",
+            }
+        )
+        kernel = PythonKernel(
+            cwd=str(self.project_path),
+            env=kernel_env,
+            python_path=env_info.python,
+            state_dir=default_state_dir(),
+        )
+        await kernel.start()
+        notes = [env_info.note] if env_info.note else []
+        return kernel, notes
+
+    async def _start_js_kernel(self) -> Tuple[BaseKernel, List[str]]:
+        from .js_kernel import JsKernel, probe_js_runtime
+
+        runtime = probe_js_runtime(self.config)
+        if runtime is None:
+            raise KernelUnavailableError(
+                "JavaScript kernel unavailable: neither 'bun' nor 'node' (>= 18) was found on PATH. "
+                "Install Bun (https://bun.sh) or Node.js, or use language='py'."
+            )
+        bridge = await ToolBridge.ensure()
+        js_home = default_state_dir() / "eval-js"
+        js_home.mkdir(parents=True, exist_ok=True)
+        package_json = js_home / "package.json"
+        if not package_json.exists():
+            package_json.write_text("{}\n", encoding="utf-8")
+        kernel_env = build_child_env()
+        npm_cmd = runtime.npm_install_cmd(js_home)
+        kernel_env.update(
+            {
+                "KOLEGA_TOOL_BRIDGE_URL": bridge.url,
+                "KOLEGA_TOOL_BRIDGE_TOKEN": bridge.token,
+                "KOLEGA_TOOL_BRIDGE_SESSION": self.session_id,
+                "KOLEGA_EVAL_JS_HOME": str(js_home),
+                "KOLEGA_EVAL_NPM_INSTALL_CMD": json.dumps(npm_cmd),
+                "NODE_PATH": str(js_home / "node_modules"),
+            }
+        )
+        kernel = JsKernel(
+            cwd=str(self.project_path),
+            env=kernel_env,
+            runtime=runtime,
+            state_dir=default_state_dir(),
+        )
+        await kernel.start()
+        return kernel, [f"JavaScript kernel running on {runtime.name} ({runtime.path})."]
+
+    async def _get_or_start_kernel(self, language: str) -> Tuple[BaseKernel, List[str], bool]:
+        kernel = self._kernels.get(language)
+        if kernel is not None and kernel.alive:
+            return kernel, [], False
+        restarted = kernel is not None
+        if kernel is not None:
+            await kernel.shutdown()
+            self._kernels.pop(language, None)
+        if language == "py":
+            kernel, notes = await self._start_python_kernel()
+        elif language == "js":
+            kernel, notes = await self._start_js_kernel()
+        else:
+            raise ToolError(f"unsupported eval language {language!r}; use 'py' or 'js'")
+        self._kernels[language] = kernel
+        if restarted:
+            notes = list(notes) + ["The previous kernel died; restarted with fresh state."]
+        return kernel, notes, restarted
+
+    async def _stop_kernel(self, language: str) -> None:
+        kernel = self._kernels.pop(language, None)
+        if kernel is not None:
+            await kernel.shutdown()
+
+    # -- bridge -------------------------------------------------------------
+
+    def _make_tool_caller(self, agent: object) -> Callable[[str, Any], Coroutine[Any, Any, Any]]:
+        async def call(name: str, args: Any) -> Any:
+            if not isinstance(args, dict):
+                raise ToolError(f"tool {name!r} via the eval bridge needs an object of arguments")
+            if name == "eval":
+                language = str(args.get("language") or "")
+                if language in self._locks and self._locks[language].locked():
+                    raise ToolError(
+                        f"the {language} kernel is busy running this cell; call eval with another "
+                        "language or run it after this cell finishes"
+                    )
+            tool_call = ToolCall(id=f"eval-{uuid.uuid4().hex}", name=name, input=args)
+            result = await agent.execute_single_tool(tool_call)  # type: ignore[attr-defined]
+            return serialize_tool_result(result)
+
+        return call
+
+    def _make_tool_lister(self, agent: object) -> Callable[[], List[Dict[str, str]]]:
+        def list_tools() -> List[Dict[str, str]]:
+            collection = getattr(agent, "tool_collection", None)
+            if collection is None:
+                return []
+            tools: List[Dict[str, str]] = []
+            for definition in collection.get_tool_list():
+                summary = (definition.description or "").strip().splitlines()
+                tools.append({"name": definition.name, "summary": summary[0] if summary else ""})
+            return tools
+
+        return list_tools
+
+    # -- public API ---------------------------------------------------------
+
+    async def execute(
+        self,
+        *,
+        language: str,
+        code: str,
+        agent: object,
+        timeout: Optional[float],
+        reset: bool = False,
+    ) -> EvalCellResult:
+        """Run one cell on the session's kernel for ``language``."""
+        if self._shutdown:
+            raise ToolError("the eval kernel manager for this session has been shut down")
+        lock = self._locks.setdefault(language, asyncio.Lock())
+        if lock.locked():
+            raise ToolError(
+                f"the {language} kernel is busy with another cell. Wait for it to finish, "
+                "or pass reset=true to restart it."
+            )
+        async with lock:
+            if reset:
+                await self._stop_kernel(language)
+            kernel, notes, restarted = await self._get_or_start_kernel(language)
+            run_id = uuid.uuid4().hex
+            bridge = await ToolBridge.ensure()
+            registration = BridgeRegistration(
+                tool_caller=self._make_tool_caller(agent),
+                tool_lister=self._make_tool_lister(agent),
+            )
+            unregister = bridge.register(self.session_id, run_id, registration)
+            try:
+                try:
+                    result = await kernel.execute(code, run_id=run_id, timeout=timeout)
+                except KernelUnavailableError:
+                    # Kernel died between liveness check and write; retry once on
+                    # a fresh kernel so a crash does not fail the user's cell.
+                    await self._stop_kernel(language)
+                    kernel, notes, restarted = await self._get_or_start_kernel(language)
+                    notes = list(notes) + ["The kernel died at cell start; retried on a fresh kernel (state lost)."]
+                    result = await kernel.execute(code, run_id=run_id, timeout=timeout)
+            finally:
+                unregister()
+            result.notes = notes + result.notes
+            result.restarted = restarted
+            return result
+
+    async def shutdown(self) -> None:
+        """Shut down every kernel and unregister the manager (owner only)."""
+        if self._shutdown:
+            return
+        self._shutdown = True
+        for language in list(self._kernels):
+            await self._stop_kernel(language)
+        key = (self.workspace_id, self.thread_id)
+        if EvalKernelManager._registry.get(key) is self:
+            del EvalKernelManager._registry[key]

--- a/kolega_code/agent/eval/prelude.js
+++ b/kolega_code/agent/eval/prelude.js
@@ -1,0 +1,127 @@
+/**
+ * Kolega Code eval-kernel prelude (JavaScript).
+ *
+ * Executed once in the kernel's persistent vm context at startup (sent by the
+ * host as a silent init cell). Defines the model-facing in-kernel API:
+ * display(), read()/write()/env(), the tool.<name>(args) bridge proxy,
+ * listTools(), parallel(), npm_install(), setGlobal(), log()/phase().
+ *
+ * Style: async; helpers that hit the bridge return promises — use top-level
+ * await. The tool proxy takes ONE trailing object literal, never positional.
+ */
+
+const __kcFs = require("node:fs");
+const __kcPath = require("node:path");
+const __kcCp = require("node:child_process");
+
+async function __kolegaBridgeCall(name, args) {
+  const base = process.env.KOLEGA_TOOL_BRIDGE_URL;
+  const token = process.env.KOLEGA_TOOL_BRIDGE_TOKEN;
+  const session = process.env.KOLEGA_TOOL_BRIDGE_SESSION;
+  if (!base || !token || !session) throw new Error("tool bridge is unavailable in this kernel");
+  const run = globalThis.__kolega_run_id__ || "";
+  const response = await fetch(base.replace(/\/+$/, "") + "/v1/tool", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ session, run, name, args }),
+  });
+  let data;
+  try {
+    data = await response.json();
+  } catch {
+    throw new Error(`bridge call '${name}' failed: non-JSON response (HTTP ${response.status})`);
+  }
+  if (!data || data.ok !== true) {
+    throw new Error((data && data.error) || `bridge call '${name}' failed`);
+  }
+  const value = data.value;
+  if (
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.prototype.hasOwnProperty.call(value, "text") &&
+    Object.keys(value).every((key) => key === "text" || key === "images")
+  ) {
+    return value.images && value.images.length ? value : value.text;
+  }
+  return value;
+}
+
+const tool = new Proxy(
+  {},
+  {
+    get: (_target, name) => {
+      if (typeof name !== "string" || name.startsWith("_")) return undefined;
+      return (args) => __kolegaBridgeCall(name, args ?? {});
+    },
+  },
+);
+
+async function listTools() {
+  return __kolegaBridgeCall("__list_tools__", {});
+}
+
+function display(value) {
+  __kolega_display__(value);
+}
+
+function log(message) {
+  __kolega_status__("log", { message: String(message) });
+}
+
+function phase(title) {
+  __kolega_status__("phase", { title: String(title) });
+}
+
+function read(path, offset = 1, limit = undefined) {
+  let data = __kcFs.readFileSync(String(path), "utf-8");
+  if (offset > 1 || limit !== undefined) {
+    const lines = data.split(/(?<=\n)/);
+    const start = Math.max(0, offset - 1);
+    const end = limit ? start + limit : lines.length;
+    data = lines.slice(start, end).join("");
+  }
+  __kolega_status__("read", { path: String(path), chars: data.length });
+  return data;
+}
+
+function write(path, content) {
+  const target = __kcPath.resolve(String(path));
+  __kcFs.mkdirSync(__kcPath.dirname(target), { recursive: true });
+  __kcFs.writeFileSync(target, String(content), "utf-8");
+  __kolega_status__("write", { path: target, chars: String(content).length });
+  return target;
+}
+
+function env(key = undefined, value = undefined) {
+  if (key === undefined) return { ...process.env };
+  if (value !== undefined) {
+    process.env[String(key)] = String(value);
+    return value;
+  }
+  return process.env[String(key)];
+}
+
+function setGlobal(name, value) {
+  globalThis[name] = value;
+  return value;
+}
+
+function parallel(thunks) {
+  return Promise.all(thunks.map((thunk) => thunk()));
+}
+
+function npm_install(...packages) {
+  if (!packages.length) throw new Error("npm_install(...) needs at least one package name");
+  const cmd = JSON.parse(process.env.KOLEGA_EVAL_NPM_INSTALL_CMD || "[]");
+  if (!cmd.length) throw new Error("npm_install is unavailable in this kernel");
+  const result = __kcCp.spawnSync(cmd[0], [...cmd.slice(1), ...packages.map(String)], {
+    encoding: "utf-8",
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`npm_install failed (exit ${result.status}):\n${String(result.stderr).slice(-2000)}`);
+  }
+  __kolega_status__("npm_install", { packages });
+  return String(result.stdout).slice(-2000);
+}

--- a/kolega_code/agent/eval/prelude.py
+++ b/kolega_code/agent/eval/prelude.py
@@ -1,0 +1,210 @@
+"""Kolega Code eval-kernel prelude (Python).
+
+Executed once in the kernel's persistent namespace at startup (sent by the host
+as a silent init cell). Defines the model-facing in-kernel API: display(),
+read()/write()/env(), the tool.<name>(args) bridge proxy, list_tools(),
+parallel(), pip_install(), python_info(), log()/phase().
+
+Stdlib only. Runner provides __kolega_display__, __kolega_status__, and the
+__kolega_run_id__ global (updated per cell).
+"""
+
+from __future__ import annotations
+
+import json as _json
+import os as _os
+import subprocess as _subprocess
+import urllib.error as _urlerror
+import urllib.request as _urlrequest
+from concurrent.futures import ThreadPoolExecutor as _ThreadPoolExecutor
+from pathlib import Path as _Path
+
+
+def display(value):
+    """Render a value as a rich output (images, HTML, JSON) in the tool result."""
+    # __kolega_display__ is injected into the kernel namespace by the runner.
+    globals()["__kolega_display__"](value)
+
+
+def _emit_status(op, **data):
+    # __kolega_status__ is injected into the kernel namespace by the runner.
+    globals()["__kolega_status__"](op, **data)
+
+
+def log(message):
+    """Add a note to this cell's status output."""
+    _emit_status("log", message=str(message))
+
+
+def phase(title):
+    """Mark a named phase of this cell in its status output."""
+    _emit_status("phase", title=str(title))
+
+
+def env(key=None, value=None):
+    """Get or set kernel environment variables."""
+    if key is None:
+        return dict(sorted(_os.environ.items()))
+    if value is not None:
+        _os.environ[str(key)] = str(value)
+        return value
+    return _os.environ.get(str(key))
+
+
+def read(path, offset=1, limit=None):
+    """Read a file's contents. offset/limit are 1-indexed lines."""
+    p = _Path(path)
+    data = p.read_text(encoding="utf-8")
+    if offset > 1 or limit is not None:
+        lines = data.splitlines(keepends=True)
+        start = max(0, int(offset) - 1)
+        end = start + int(limit) if limit else len(lines)
+        data = "".join(lines[start:end])
+    _emit_status("read", path=str(p), chars=len(data))
+    return data
+
+
+def write(path, content):
+    """Write text to a file, creating parent directories. Returns the path."""
+    p = _Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(str(content), encoding="utf-8")
+    _emit_status("write", path=str(p), chars=len(str(content)))
+    return p
+
+
+def _bridge_config():
+    base = _os.environ.get("KOLEGA_TOOL_BRIDGE_URL")
+    token = _os.environ.get("KOLEGA_TOOL_BRIDGE_TOKEN")
+    session = _os.environ.get("KOLEGA_TOOL_BRIDGE_SESSION")
+    if not base or not token or not session:
+        raise RuntimeError("tool bridge is unavailable in this kernel")
+    return base.rstrip("/"), token, session
+
+
+def _bridge_call(name, args):
+    """POST one request to the host tool bridge and return its value."""
+    base, token, session = _bridge_config()
+    run_id = globals().get("__kolega_run_id__") or ""
+    payload = _json.dumps({"session": session, "run": run_id, "name": name, "args": args}).encode("utf-8")
+    request = _urlrequest.Request(
+        f"{base}/v1/tool",
+        data=payload,
+        method="POST",
+        headers={"Content-Type": "application/json", "Authorization": f"Bearer {token}"},
+    )
+    try:
+        with _urlrequest.urlopen(request) as response:
+            body = response.read()
+    except _urlerror.HTTPError as exc:
+        body = exc.read()
+    except _urlerror.URLError as exc:
+        raise RuntimeError(f"bridge call {name!r} failed: {exc}") from None
+    try:
+        data = _json.loads(body)
+    except _json.JSONDecodeError:
+        raise RuntimeError(f"bridge call {name!r}: non-JSON response: {body[:200]!r}") from None
+    if not isinstance(data, dict) or not data.get("ok"):
+        message = data.get("error") if isinstance(data, dict) else None
+        raise RuntimeError(message or f"bridge call {name!r} failed")
+    return data.get("value")
+
+
+def _unwrap_tool_value(value):
+    """Tool results are plain text unless images are attached."""
+    if isinstance(value, dict) and "text" in value and set(value) <= {"text", "images"}:
+        if value.get("images"):
+            return value
+        return value["text"]
+    return value
+
+
+class _ToolCallable:
+    """Invokes one host-side tool via the loopback bridge."""
+
+    __slots__ = ("_name",)
+
+    def __init__(self, name):
+        self._name = name
+
+    def __repr__(self):
+        return f"<tool.{self._name}>"
+
+    def __call__(self, args=None, /, **kwargs):
+        if args is None:
+            merged = {}
+        elif isinstance(args, dict):
+            merged = dict(args)
+        else:
+            raise TypeError(f"tool.{self._name}(...) expects a dict of arguments (got {type(args).__name__})")
+        merged.update(kwargs)
+        return _unwrap_tool_value(_bridge_call(self._name, merged))
+
+
+class _ToolProxy:
+    """``tool.<name>(args)`` proxy over the host's tool registry."""
+
+    __slots__ = ()
+
+    def __getattr__(self, name):
+        if name.startswith("_"):
+            raise AttributeError(name)
+        return _ToolCallable(name)
+
+    def __getitem__(self, name):
+        return _ToolCallable(name)
+
+    def __dir__(self):
+        try:
+            return sorted(entry.get("name", "") for entry in list_tools() or [])
+        except Exception:
+            return []
+
+    def __repr__(self):
+        return "<tool proxy: call list_tools() to discover available tools>"
+
+
+tool = _ToolProxy()
+
+
+def list_tools():
+    """List the tools available through `tool.<name>` as [{name, summary}]."""
+    return _bridge_call("__list_tools__", {})
+
+
+def parallel(thunks, max_workers=None):
+    """Run callables concurrently (threads) and return their results in order."""
+    thunks = list(thunks)
+    with _ThreadPoolExecutor(max_workers=max_workers or max(1, len(thunks))) as pool:
+        futures = [pool.submit(thunk) for thunk in thunks]
+        return [future.result() for future in futures]
+
+
+def pip_install(*packages):
+    """Install packages into the kernel's dedicated Python environment."""
+    if not packages:
+        raise ValueError("pip_install(...) needs at least one package name")
+    cmd = _json.loads(_os.environ.get("KOLEGA_EVAL_PIP_INSTALL_CMD") or "[]")
+    if not cmd:
+        raise RuntimeError(
+            "pip_install is unavailable: the kernel is not running in a managed environment "
+            "(custom interpreter or provisioning was skipped). Install packages into that "
+            "interpreter yourself, e.g. via tool.exec_command."
+        )
+    proc = _subprocess.run(list(cmd) + [str(p) for p in packages], capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        raise RuntimeError(f"pip_install failed (exit {proc.returncode}):\n{proc.stderr[-2000:]}")
+    _emit_status("pip_install", packages=list(packages))
+    return (proc.stdout or "")[-2000:]
+
+
+def python_info():
+    """Return interpreter version, env path, and bundled packages for this kernel."""
+    import sys as _sys
+
+    return {
+        "version": _sys.version.split()[0],
+        "executable": _sys.executable,
+        "env_path": _os.environ.get("KOLEGA_EVAL_ENV_PATH") or None,
+        "bundle": [p for p in (_os.environ.get("KOLEGA_EVAL_BUNDLE") or "").split(",") if p],
+    }

--- a/kolega_code/agent/eval/protocol.py
+++ b/kolega_code/agent/eval/protocol.py
@@ -1,0 +1,73 @@
+"""NDJSON wire protocol between the host and eval kernel subprocesses.
+
+One JSON object per line in each direction over the kernel's stdin/stdout.
+
+Host -> kernel frames:
+    {"type": "exec", "id": int, "run": str, "code": str, "cwd": str, "silent": bool}
+    {"type": "exit"}
+
+Kernel -> host frames:
+    {"type": "started", "id": int}
+    {"type": "stdout",  "id": int, "data": str}
+    {"type": "stderr",  "id": int, "data": str}
+    {"type": "display", "id": int, "bundle": {<mime>: <value>}}
+    {"type": "result",  "id": int, "bundle": {<mime>: <value>}}
+    {"type": "status",  "id": int, "event": {<op>: ...}}
+    {"type": "error",   "id": int, "ename": str, "evalue": str, "traceback": [str]}
+    {"type": "done",    "id": int, "status": "ok" | "error"}
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+# Frame type constants (host side; the kernels mirror these literals).
+FRAME_EXEC = "exec"
+FRAME_EXIT = "exit"
+
+FRAME_STARTED = "started"
+FRAME_STDOUT = "stdout"
+FRAME_STDERR = "stderr"
+FRAME_DISPLAY = "display"
+FRAME_RESULT = "result"
+FRAME_STATUS = "status"
+FRAME_ERROR = "error"
+FRAME_DONE = "done"
+
+STATUS_OK = "ok"
+STATUS_ERROR = "error"
+
+# StreamReader limit for kernel stdout. Display bundles carry base64 images, so
+# frames are routinely larger than the asyncio default of 64 KiB.
+FRAME_STREAM_LIMIT = 16 * 1024 * 1024
+
+# Largest single frame the host will parse. Generous because of images, but
+# bounded so a runaway kernel cannot exhaust host memory with one line.
+MAX_FRAME_BYTES = 64 * 1024 * 1024
+
+
+class ProtocolError(Exception):
+    """A kernel emitted a line that is not a well-formed protocol frame."""
+
+
+def encode_frame(frame: Dict[str, Any]) -> bytes:
+    """Serialize one frame as a single NDJSON line (UTF-8, newline terminated)."""
+    return (json.dumps(frame, ensure_ascii=False) + "\n").encode("utf-8", "replace")
+
+
+def parse_frame(line: bytes) -> Dict[str, Any]:
+    """Parse one NDJSON line from a kernel into a frame dict.
+
+    Raises:
+        ProtocolError: If the line is not valid JSON or not an object.
+    """
+    if len(line) > MAX_FRAME_BYTES:
+        raise ProtocolError(f"kernel frame exceeds {MAX_FRAME_BYTES} bytes")
+    try:
+        frame = json.loads(line)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ProtocolError(f"malformed kernel frame: {line[:200]!r}") from exc
+    if not isinstance(frame, dict) or not isinstance(frame.get("type"), str):
+        raise ProtocolError(f"kernel frame is not an object with a type: {line[:200]!r}")
+    return frame

--- a/kolega_code/agent/eval/py_kernel.py
+++ b/kolega_code/agent/eval/py_kernel.py
@@ -1,0 +1,56 @@
+"""Python eval kernel: a subprocess on the dedicated managed environment."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from importlib.resources import files
+from pathlib import Path
+from typing import Dict, List
+
+from .kernel import BaseKernel
+
+_RUNNER_RESOURCE = "runner.py"
+_PRELUDE_RESOURCE = "prelude.py"
+
+
+def _resource_text(name: str) -> str:
+    return files("kolega_code.agent.eval").joinpath(name).read_text(encoding="utf-8")
+
+
+def materialize_runner(state_dir: Path) -> Path:
+    """Write the runner script to a real file the subprocess can execute.
+
+    Cached by content hash under the user state dir so wheels/zip installs work
+    and repeated starts don't rewrite the file.
+    """
+    source = _resource_text(_RUNNER_RESOURCE)
+    digest = hashlib.sha256(source.encode("utf-8")).hexdigest()[:16]
+    target_dir = state_dir / "eval-kernels"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target = target_dir / f"runner-{digest}.py"
+    if not target.exists():
+        target.write_text(source, encoding="utf-8")
+    return target
+
+
+class PythonKernel(BaseKernel):
+    """Persistent Python kernel (one subprocess, NDJSON cell protocol)."""
+
+    def __init__(self, *, cwd: str, env: Dict[str, str], python_path: str, state_dir: Path) -> None:
+        super().__init__(language="py", cwd=cwd, env=env)
+        self._python_path = python_path
+        self._runner_path = materialize_runner(state_dir)
+
+    def argv(self) -> List[str]:
+        return [self._python_path, "-u", str(self._runner_path)]
+
+    def init_cells(self) -> List[str]:
+        init = (
+            "import os as _os, sys as _sys\n"
+            f"_cwd = {json.dumps(self.cwd)}\n"
+            "_os.chdir(_cwd)\n"
+            "if _cwd not in _sys.path:\n"
+            "    _sys.path.insert(0, _cwd)\n"
+        )
+        return [init, _resource_text(_PRELUDE_RESOURCE)]

--- a/kolega_code/agent/eval/runner.js
+++ b/kolega_code/agent/eval/runner.js
@@ -1,0 +1,311 @@
+/**
+ * Kolega Code eval-kernel runner (JavaScript, Node >= 18 or Bun).
+ *
+ * Spawned as `<runtime> runner.js` by the host. Speaks NDJSON over
+ * stdin/stdout, one JSON frame per line (see protocol.py in the same package).
+ *
+ * Cells run in a single persistent vm context: top-level let/const/function/
+ * class declarations survive across cells via the context's global lexical
+ * environment. Top-level await is supported by retrying the cell wrapped in an
+ * async IIFE (declarations inside wrapped cells do NOT persist — the prelude
+ * exposes setGlobal() for that case). The V8 script completion value of
+ * unwrapped cells is emitted as the result frame.
+ *
+ * Input uses a blocking fs.readSync(0) line reader rather than stream events:
+ * Bun (as of 1.2.x) does not deliver piped-stdin `data` events until more data
+ * or EOF arrives, which deadlocks the request/response protocol. Blocking while
+ * idle is safe because the host serializes frames — it sends the next cell only
+ * after reading the current cell's `done` frame — so at most one frame is ever
+ * in flight and the event loop is free for the duration of each cell.
+ */
+"use strict";
+
+const vm = require("node:vm");
+const util = require("node:util");
+const path = require("node:path");
+const fs = require("node:fs");
+const { createRequire } = require("node:module");
+
+const JS_HOME = process.env.KOLEGA_EVAL_JS_HOME || process.cwd();
+const CURRENT = { id: 0, run: "" };
+
+function emit(frame) {
+  process.stdout.write(JSON.stringify(frame) + "\n");
+}
+
+function formatArgs(args) {
+  return util.format(...args) + "\n";
+}
+
+const consoleShim = {
+  log: (...args) => emit({ type: "stdout", id: CURRENT.id, data: formatArgs(args) }),
+  info: (...args) => emit({ type: "stdout", id: CURRENT.id, data: formatArgs(args) }),
+  debug: (...args) => emit({ type: "stdout", id: CURRENT.id, data: formatArgs(args) }),
+  warn: (...args) => emit({ type: "stderr", id: CURRENT.id, data: formatArgs(args) }),
+  error: (...args) => emit({ type: "stderr", id: CURRENT.id, data: formatArgs(args) }),
+};
+
+function safeStringify(value) {
+  const seen = new WeakSet();
+  return JSON.stringify(value, (key, val) => {
+    if (typeof val === "bigint") return val.toString();
+    if (typeof val === "function") return `[Function ${val.name || "anonymous"}]`;
+    if (typeof val === "object" && val !== null) {
+      if (seen.has(val)) return "[Circular]";
+      seen.add(val);
+    }
+    return val;
+  });
+}
+
+function toBundle(value) {
+  const bundle = {};
+  if (typeof value === "string") {
+    bundle["text/plain"] = value;
+    return bundle;
+  }
+  try {
+    bundle["application/json"] = JSON.parse(safeStringify(value));
+  } catch {
+    /* not JSON-representable; text/plain below carries it */
+  }
+  let plain;
+  try {
+    plain = util.inspect(value, { depth: 4, maxStringLength: 4000, breakLength: 120 });
+  } catch {
+    plain = String(value);
+  }
+  bundle["text/plain"] = plain;
+  return bundle;
+}
+
+function emitError(id, err) {
+  const stack = typeof err?.stack === "string" ? err.stack.split("\n") : [String(err)];
+  emit({
+    type: "error",
+    id,
+    ename: (err && err.constructor && err.constructor.name) || "Error",
+    evalue: (err && err.message) || String(err),
+    traceback: stack,
+  });
+}
+
+// Errors raised inside the vm context belong to that realm, so `instanceof
+// SyntaxError` fails across realms (this is how Bun's parse errors arrive).
+function isSyntaxError(err) {
+  return (
+    err instanceof SyntaxError ||
+    Boolean(err && (err.name === "SyntaxError" || (err.constructor && err.constructor.name === "SyntaxError")))
+  );
+}
+
+function isRedeclaration(err) {
+  return isSyntaxError(err) && /already been declared|duplicate variable/i.test(err.message || "");
+}
+
+// Parse-level syntax failures (vs. runtime errors from code the cell itself
+// evals). Node reports them at `new vm.Script(...)`; Bun parses lazily, so they
+// surface from runInContext with an "at <parse>" stack frame instead.
+function isParseLevelSyntaxError(err) {
+  if (!isSyntaxError(err)) return false;
+  if (/await is only valid|await outside|Unexpected identifier|Unexpected token/i.test(err.message || "")) {
+    return true;
+  }
+  return String(err.stack || "").includes("at <parse>");
+}
+
+function augmentSyntaxError(err) {
+  if (isRedeclaration(err)) {
+    err.message +=
+      " (this name already exists in the persistent kernel — assign to it without " +
+      "redeclaring, pick a new name, or re-run with reset=true)";
+  }
+  return err;
+}
+
+const sandbox = {
+  console: consoleShim,
+  fetch: globalThis.fetch,
+  setTimeout,
+  clearTimeout,
+  setInterval,
+  clearInterval,
+  queueMicrotask,
+  structuredClone: globalThis.structuredClone,
+  TextEncoder,
+  TextDecoder,
+  URL,
+  URLSearchParams,
+  Buffer,
+  crypto: globalThis.crypto,
+  atob: globalThis.atob,
+  btoa: globalThis.btoa,
+  process: { env: process.env, cwd: () => process.cwd() },
+  require: createRequire(path.join(JS_HOME, "__kernel__.js")),
+  // Bridged by the prelude; defined here so cells can call them directly too.
+  __kolega_display__: (value) => emit({ type: "display", id: CURRENT.id, bundle: toBundle(value) }),
+  __kolega_status__: (op, data) =>
+    emit({ type: "status", id: CURRENT.id, event: { op, ...(data || {}) } }),
+};
+sandbox.globalThis = sandbox;
+const context = vm.createContext(sandbox);
+
+async function runCell(code, id, silent) {
+  const filename = `<cell-${id}>`;
+  // Top-level await (or return) needs an async wrapper. Declarations inside a
+  // wrapped cell do NOT persist across cells — the prelude's setGlobal() covers
+  // that case, and the tool description says so.
+  const wrappedSource = `(async () => {\n${code}\n})()`;
+
+  let script = null;
+  try {
+    script = new vm.Script(code, { filename });
+  } catch (err) {
+    if (isRedeclaration(err)) throw augmentSyntaxError(err);
+    if (isSyntaxError(err)) {
+      try {
+        script = new vm.Script(wrappedSource, { filename });
+      } catch {
+        throw augmentSyntaxError(err);
+      }
+    } else {
+      throw err;
+    }
+  }
+
+  let value;
+  try {
+    value = script.runInContext(context, { breakOnSigint: true });
+  } catch (err) {
+    if (isRedeclaration(err)) throw augmentSyntaxError(err);
+    if (isParseLevelSyntaxError(err)) {
+      // Bun parses lazily at runInContext time, so a top-level await only
+      // surfaces here. Retry once with the async wrapper.
+      let wrappedScript;
+      try {
+        wrappedScript = new vm.Script(wrappedSource, { filename });
+      } catch {
+        throw augmentSyntaxError(err);
+      }
+      try {
+        value = wrappedScript.runInContext(context, { breakOnSigint: true });
+      } catch (wrappedErr) {
+        if (isSyntaxError(wrappedErr)) throw augmentSyntaxError(err);
+        throw wrappedErr;
+      }
+    } else {
+      throw err;
+    }
+  }
+  if (value && typeof value.then === "function") {
+    value = await value;
+  }
+  return { value, emitResult: !silent };
+}
+
+// The cell currently executing, so SIGINT can finish it early when it is stuck
+// in a pending await (sync code is interrupted via breakOnSigint instead). The
+// handler only signals; handleExec owns all frame emission so `done` is sent
+// exactly once and the main loop resumes reading frames immediately.
+let activeCell = null;
+
+process.on("SIGINT", () => {
+  if (activeCell && !activeCell.settled) {
+    activeCell.settled = true;
+    activeCell.interrupt();
+  }
+});
+
+async function handleExec(msg) {
+  const id = Number(msg.id) || 0;
+  CURRENT.id = id;
+  CURRENT.run = typeof msg.run === "string" ? msg.run : "";
+  sandbox.__kolega_run_id__ = CURRENT.run;
+  if (typeof msg.cwd === "string" && msg.cwd) {
+    try {
+      process.chdir(msg.cwd);
+    } catch (err) {
+      emit({ type: "stderr", id, data: `[kernel] chdir failed: ${err.message}\n` });
+    }
+  }
+  emit({ type: "started", id });
+  const cell = { id, settled: false, interrupt: () => {} };
+  activeCell = cell;
+  const interrupted = new Promise((resolve) => {
+    cell.interrupt = () => resolve({ kind: "interrupted" });
+  });
+  // Guard both outcomes so a cell finished early by SIGINT cannot produce an
+  // unhandled rejection when its promise settles later.
+  const work = runCell(String(msg.code ?? ""), id, Boolean(msg.silent)).then(
+    (outcome) => ({ kind: "ok", outcome }),
+    (err) => ({ kind: "error", err }),
+  );
+  const verdict = await Promise.race([work, interrupted]);
+  cell.settled = true;
+  activeCell = null;
+
+  if (verdict.kind === "interrupted") {
+    emitError(id, new Error("cell interrupted (SIGINT)"));
+    emit({ type: "done", id, status: "error" });
+    return;
+  }
+  if (verdict.kind === "error") {
+    emitError(id, verdict.err);
+    emit({ type: "done", id, status: "error" });
+    return;
+  }
+  const { value, emitResult } = verdict.outcome;
+  if (emitResult && value !== undefined) {
+    emit({ type: "result", id, bundle: toBundle(value) });
+  }
+  emit({ type: "done", id, status: "ok" });
+}
+
+/**
+ * Read one newline-terminated frame from fd 0, blocking while idle. Returns
+ * null on EOF. Bytes after the first newline in a read chunk are dropped,
+ * which the host's strict request/response pacing makes unreachable.
+ */
+function readLineSync() {
+  const chunk = Buffer.alloc(65536);
+  let acc = "";
+  while (true) {
+    let n;
+    try {
+      n = fs.readSync(0, chunk, 0, chunk.length, null);
+    } catch (err) {
+      if (err && (err.code === "EAGAIN" || err.code === "EINTR")) continue;
+      throw err;
+    }
+    if (n === 0) return acc.length > 0 ? acc : null;
+    acc += chunk.toString("utf8", 0, n);
+    const newline = acc.indexOf("\n");
+    if (newline >= 0) return acc.slice(0, newline);
+  }
+}
+
+async function main() {
+  while (true) {
+    const line = readLineSync();
+    if (line === null) break;
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let msg;
+    try {
+      msg = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    if (!msg || typeof msg !== "object") continue;
+    if (msg.type === "exit") break;
+    if (msg.type === "exec") {
+      // The host serializes cells per kernel; no re-entry guard needed here.
+      await handleExec(msg);
+    }
+  }
+}
+
+main().catch((err) => {
+  emitError(CURRENT.id, err);
+  process.exit(1);
+});

--- a/kolega_code/agent/eval/runner.py
+++ b/kolega_code/agent/eval/runner.py
@@ -1,0 +1,310 @@
+"""Kolega Code eval-kernel runner (Python).
+
+Spawned as ``python -u runner.py`` by the host. Speaks NDJSON over stdin/stdout:
+one JSON frame per line. See protocol.py in the same package for the frame
+shapes. Stdlib only; requires Python 3.11+.
+
+Key behaviors:
+- Persistent global namespace across cells.
+- Top-level ``await`` via ast.PyCF_ALLOW_TOP_LEVEL_AWAIT; coroutine cells are
+  driven on one persistent event loop so loop-bound objects survive cells.
+- REPL echo: the last top-level expression is captured and emitted as a result
+  frame (when not None).
+- print()/logging are captured into stdout/stderr frames; protocol frames go to
+  the real fd 1 saved before streams are replaced.
+- SIGINT raises KeyboardInterrupt inside the running cell.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import base64
+import inspect
+import json
+import linecache
+import os
+import sys
+import traceback
+from typing import Any, Optional
+
+# The runner's own directory is added to sys.path[0] by the interpreter; remove
+# it so cell imports only see the project and normal site-packages.
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+if sys.path and os.path.abspath(sys.path[0]) == _SCRIPT_DIR:
+    sys.path.pop(0)
+
+_REAL_STDOUT = sys.stdout
+
+_CURRENT = {"id": 0, "run": ""}
+_LOOP: Optional[asyncio.AbstractEventLoop] = None
+_NS: dict = {}
+
+# Cap individual traceback payloads so a huge recursive failure cannot flood
+# the host with frames.
+_MAX_TRACEBACK_LINES = 60
+_MAX_REPR_CHARS = 4000
+
+
+def _emit(frame: dict) -> None:
+    data = json.dumps(frame, ensure_ascii=False, default=str).encode("utf-8", "replace") + b"\n"
+    _REAL_STDOUT.buffer.write(data)
+    _REAL_STDOUT.buffer.flush()
+
+
+def _current_id() -> int:
+    return _CURRENT["id"]
+
+
+class _FrameStream:
+    """sys.stdout/sys.stderr replacement emitting stdout/stderr frames."""
+
+    def __init__(self, kind: str) -> None:
+        self._kind = kind
+        self._buf = ""
+
+    def write(self, text: Any) -> int:
+        if not isinstance(text, str):
+            text = str(text)
+        self._buf += text
+        while "\n" in self._buf:
+            line, self._buf = self._buf.split("\n", 1)
+            _emit({"type": self._kind, "id": _current_id(), "data": line + "\n"})
+        return len(text)
+
+    def writelines(self, lines: Any) -> None:
+        for line in lines:
+            self.write(line)
+
+    def flush(self) -> None:
+        if self._buf:
+            _emit({"type": self._kind, "id": _current_id(), "data": self._buf})
+            self._buf = ""
+
+    def isatty(self) -> bool:
+        return False
+
+    def writable(self) -> bool:
+        return True
+
+    def fileno(self) -> int:
+        raise OSError("eval kernel streams have no file descriptor")
+
+
+def _safe_repr(value: Any) -> str:
+    try:
+        text = repr(value)
+    except Exception:
+        text = f"<{type(value).__name__} object>"
+    if len(text) > _MAX_REPR_CHARS:
+        text = text[:_MAX_REPR_CHARS] + f"\n[…{len(text) - _MAX_REPR_CHARS}ch elided…]"
+    return text
+
+
+def _try_b64(data: Any) -> Optional[str]:
+    if isinstance(data, str):
+        return data
+    if isinstance(data, (bytes, bytearray)):
+        return base64.b64encode(bytes(data)).decode("ascii")
+    return None
+
+
+def _mime_bundle(value: Any) -> dict:
+    """Best-effort IPython-style MIME bundle for a value."""
+    bundle: dict = {}
+
+    if isinstance(value, (dict, list, int, float, bool)):
+        try:
+            json.dumps(value)
+            bundle["application/json"] = value
+        except (TypeError, ValueError):
+            pass
+
+    repr_json = getattr(value, "_repr_json_", None)
+    if callable(repr_json):
+        try:
+            parsed = repr_json()
+            if isinstance(parsed, str):
+                parsed = json.loads(parsed)
+            json.dumps(parsed)
+            bundle.setdefault("application/json", parsed)
+        except Exception:
+            pass
+
+    for attr, mime in (
+        ("_repr_png_", "image/png"),
+        ("_repr_jpeg_", "image/jpeg"),
+        ("_repr_svg_", "image/svg+xml"),
+        ("_repr_html_", "text/html"),
+        ("_repr_markdown_", "text/markdown"),
+    ):
+        renderer = getattr(value, attr, None)
+        if not callable(renderer):
+            continue
+        try:
+            rendered = renderer()
+        except Exception:
+            continue
+        if mime in ("image/png", "image/jpeg"):
+            rendered = _try_b64(rendered)
+        if isinstance(rendered, str) and rendered:
+            bundle.setdefault(mime, rendered)
+
+    # matplotlib Figure (and lookalikes) without rich reprs: render via savefig.
+    savefig = getattr(value, "savefig", None)
+    if "image/png" not in bundle and callable(savefig):
+        try:
+            import io
+
+            buffer = io.BytesIO()
+            savefig(buffer, format="png", bbox_inches="tight")
+            bundle["image/png"] = base64.b64encode(buffer.getvalue()).decode("ascii")
+        except Exception:
+            pass
+
+    bundle.setdefault("text/plain", _safe_repr(value))
+    return bundle
+
+
+def _display(value: Any, raw: bool = False) -> None:
+    """Injected as __kolega_display__; the prelude's display() wraps it."""
+    if raw and isinstance(value, dict):
+        bundle = value
+    else:
+        bundle = _mime_bundle(value)
+    _emit({"type": "display", "id": _current_id(), "bundle": bundle})
+
+
+def _status(op: str, **data: Any) -> None:
+    """Injected as __kolega_status__ for prelude log()/phase()."""
+    _emit({"type": "status", "id": _current_id(), "event": {"op": op, **data}})
+
+
+def _emit_error(msg_id: int, exc: BaseException) -> None:
+    tb_lines = traceback.format_exception(type(exc), exc, exc.__traceback__)
+    if len(tb_lines) > _MAX_TRACEBACK_LINES:
+        tb_lines = tb_lines[:_MAX_TRACEBACK_LINES] + [f"[…{len(tb_lines) - _MAX_TRACEBACK_LINES} lines elided…]\n"]
+    _emit(
+        {
+            "type": "error",
+            "id": msg_id,
+            "ename": type(exc).__name__,
+            "evalue": str(exc),
+            "traceback": tb_lines,
+        }
+    )
+
+
+_RESULT_NAME = "__kolega_result__"
+
+
+def _compile_cell(code: str, msg_id: int, *, silent: bool):
+    filename = f"<cell-{msg_id}>"
+    # Register the source so tracebacks show cell code lines (like IPython).
+    linecache.cache[filename] = (len(code), None, code.splitlines(keepends=True), filename)
+    tree = ast.parse(code, filename=filename, mode="exec")
+    want_result = False
+    if not silent and tree.body and isinstance(tree.body[-1], ast.Expr):
+        last = tree.body.pop()
+        assert isinstance(last, ast.Expr)
+        assign = ast.Assign(
+            targets=[ast.Name(id=_RESULT_NAME, ctx=ast.Store())],
+            value=last.value,
+        )
+        ast.copy_location(assign, last)
+        tree.body.append(assign)
+        want_result = True
+    ast.fix_missing_locations(tree)
+    compiled = compile(tree, filename, "exec", flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT)
+    return compiled, want_result
+
+
+def _run_cell(code: str, msg_id: int, *, silent: bool) -> None:
+    if _LOOP is None:
+        raise RuntimeError("eval kernel event loop is not running")
+    _NS.pop(_RESULT_NAME, None)
+    compiled, want_result = _compile_cell(code, msg_id, silent=silent)
+    outcome = eval(compiled, _NS)
+    if inspect.iscoroutine(outcome):
+        _LOOP.run_until_complete(outcome)
+    if want_result:
+        value = _NS.get(_RESULT_NAME)
+        if value is not None:
+            _emit({"type": "result", "id": msg_id, "bundle": _mime_bundle(value)})
+
+
+def _execute(msg: dict) -> None:
+    msg_id = int(msg.get("id") or 0)
+    _CURRENT["id"] = msg_id
+    _CURRENT["run"] = str(msg.get("run") or "")
+    _NS["__kolega_run_id__"] = _CURRENT["run"]
+    cwd = msg.get("cwd")
+    if isinstance(cwd, str) and cwd:
+        try:
+            os.chdir(cwd)
+        except OSError as exc:
+            _emit({"type": "stderr", "id": msg_id, "data": f"[kernel] chdir failed: {exc}\n"})
+    silent = bool(msg.get("silent"))
+
+    _emit({"type": "started", "id": msg_id})
+    status = "ok"
+    try:
+        _run_cell(str(msg.get("code") or ""), msg_id, silent=silent)
+    except KeyboardInterrupt as exc:
+        status = "error"
+        _emit_error(msg_id, exc)
+    except BaseException as exc:  # every cell failure is a result, not a runner crash
+        status = "error"
+        _emit_error(msg_id, exc)
+    finally:
+        try:
+            sys.stdout.flush()
+            sys.stderr.flush()
+        except Exception:
+            pass
+        _emit({"type": "done", "id": msg_id, "status": status})
+        _CURRENT["run"] = ""
+        _NS["__kolega_run_id__"] = ""
+
+
+def main() -> None:
+    global _LOOP, _NS
+    _LOOP = asyncio.new_event_loop()
+    _NS = {
+        "__name__": "__eval__",
+        "__kolega_display__": _display,
+        "__kolega_status__": _status,
+        "__kolega_run_id__": "",
+    }
+    sys.stdout = _FrameStream("stdout")
+    sys.stderr = _FrameStream("stderr")
+
+    stdin = sys.stdin.buffer
+    while True:
+        line = stdin.readline()
+        if not line:
+            break
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(msg, dict):
+            continue
+        frame_type = msg.get("type")
+        if frame_type == "exit":
+            break
+        if frame_type == "exec":
+            _execute(msg)
+
+    try:
+        if _LOOP is not None:
+            _LOOP.close()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/kolega_code/agent/tool_backend/eval_tool.py
+++ b/kolega_code/agent/tool_backend/eval_tool.py
@@ -1,0 +1,223 @@
+"""Model-facing `eval` tool backend: persistent code kernels with tool callback.
+
+The heavy lifting lives in kolega_code.agent.eval (kernels, bridge, env); this
+backend resolves the session's shared EvalKernelManager, runs cells, and formats
+the outcome (stdout/stderr, REPL result, display outputs incl. images, status
+lines, errors) for the model.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from kolega_code.agent.eval.kernel import EvalCellResult, EvalKernelManager
+from kolega_code.llm.models import ContentBlock, ImageBlock, TextBlock
+from kolega_code.tools import ToolError
+
+from .base_tool import BaseTool
+
+EVAL_LANGUAGES = ("py", "js")
+
+DEFAULT_CELL_TIMEOUT_S = 120.0
+MAX_CELL_TIMEOUT_S = 600.0
+
+# Output budgets. stdout/stderr keep the tail (recent lines matter most);
+# display chunks are individually capped like oh-my-pi's 8 KB display limit.
+_STDOUT_TAIL_CHARS = 20_000
+_STDERR_TAIL_CHARS = 8_000
+_DISPLAY_CHUNK_CHARS = 8_000
+_RESULT_CHARS = 8_000
+
+_IMAGE_MIMES = ("image/png", "image/jpeg")
+
+
+def clamp_cell_timeout(timeout: object) -> Optional[float]:
+    """None -> default; 0 -> no timeout; otherwise clamp to (0, MAX].
+
+    Accepts ``object`` because model-emitted JSON can carry non-numeric values;
+    anything unparseable falls back to the default.
+    """
+    if timeout is None:
+        return DEFAULT_CELL_TIMEOUT_S
+    if not isinstance(timeout, (int, float, str)):
+        return DEFAULT_CELL_TIMEOUT_S
+    try:
+        value = float(timeout)
+    except (TypeError, ValueError):
+        return DEFAULT_CELL_TIMEOUT_S
+    if value == 0:
+        return None
+    return max(1.0, min(value, MAX_CELL_TIMEOUT_S))
+
+
+def _tail(text: str, limit: int) -> Tuple[str, bool]:
+    if len(text) <= limit:
+        return text, False
+    return text[-limit:], True
+
+
+def _bundle_text(bundle: Dict[str, Any], limit: int) -> str:
+    """Human-facing text for a MIME bundle (prefers plain text, then JSON)."""
+    plain = bundle.get("text/plain")
+    if isinstance(plain, str) and plain:
+        text = plain
+    else:
+        data: Any = bundle.get("application/json", None)
+        if data is not None:
+            try:
+                text = json.dumps(data, indent=2, ensure_ascii=False)
+            except (TypeError, ValueError):
+                text = str(data)
+        elif isinstance(bundle.get("text/html"), str):
+            text = f"[html output]\n{bundle['text/html']}"
+        elif isinstance(bundle.get("image/svg+xml"), str):
+            text = f"[svg image]\n{bundle['image/svg+xml']}"
+        else:
+            text = ""
+    if len(text) > limit:
+        text = text[:limit] + f"\n[…{len(text) - limit}ch elided…]"
+    return text
+
+
+def _bundle_images(bundle: Dict[str, Any]) -> List[Tuple[str, str]]:
+    """(mime, base64) pairs for image payloads in a bundle."""
+    images: List[Tuple[str, str]] = []
+    for mime in _IMAGE_MIMES:
+        data = bundle.get(mime)
+        if isinstance(data, str) and data:
+            images.append((mime, data))
+    return images
+
+
+class EvalTool(BaseTool):
+    """Runs code cells on the session's persistent kernels."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._manager: Optional[EvalKernelManager] = None
+
+    def _kernel_manager(self) -> EvalKernelManager:
+        if self._manager is None:
+            self._manager = EvalKernelManager.for_thread(
+                workspace_id=self.workspace_id,
+                thread_id=self.thread_id,
+                project_path=self.project_path,
+                config=self.config,
+            )
+        return self._manager
+
+    async def shutdown_if_owner(self) -> None:
+        """Shut down shared kernels. Only the top-level agent owns them."""
+        if getattr(self.caller, "sub_agent", False):
+            return
+        manager = self._manager
+        if manager is not None:
+            await manager.shutdown()
+            self._manager = None
+
+    async def eval(
+        self,
+        language: str,
+        code: str,
+        title: Optional[str] = None,
+        timeout: Optional[float] = None,
+        reset: bool = False,
+    ) -> Union[str, List[ContentBlock]]:
+        """Run one cell. See ToolCollection.eval for the model-facing contract."""
+        language = str(language).strip().lower()
+        if language not in EVAL_LANGUAGES:
+            raise ToolError(f"unsupported eval language {language!r}; use 'py' or 'js'")
+        if not isinstance(code, str) or not code.strip():
+            raise ToolError("eval requires non-empty code")
+
+        manager = self._kernel_manager()
+        result = await manager.execute(
+            language=language,
+            code=code,
+            agent=self.caller,
+            timeout=clamp_cell_timeout(timeout),
+            reset=bool(reset),
+        )
+        return self._format(result, title=title)
+
+    # -- result formatting ---------------------------------------------------
+
+    def _format(self, result: EvalCellResult, *, title: Optional[str]) -> Union[str, List[ContentBlock]]:
+        parts: List[str] = []
+        if title:
+            parts.append(f"## {title}")
+
+        for note in result.notes:
+            parts.append(f"> {note}")
+
+        stdout, stdout_cut = _tail(result.stdout, _STDOUT_TAIL_CHARS)
+        if stdout.strip():
+            if stdout_cut:
+                parts.append(f"[stdout truncated to the last {_STDOUT_TAIL_CHARS} chars]")
+            parts.append(f"### stdout\n{stdout.rstrip()}")
+
+        stderr, stderr_cut = _tail(result.stderr, _STDERR_TAIL_CHARS)
+        if stderr.strip():
+            if stderr_cut:
+                parts.append(f"[stderr truncated to the last {_STDERR_TAIL_CHARS} chars]")
+            parts.append(f"### stderr\n{stderr.rstrip()}")
+
+        status_lines = self._status_lines(result)
+        if status_lines:
+            parts.append("### status\n" + "\n".join(status_lines))
+
+        if result.result_bundle:
+            text = _bundle_text(result.result_bundle, _RESULT_CHARS)
+            if text:
+                parts.append(f"### result\n{text}")
+
+        display_parts: List[str] = []
+        for index, bundle in enumerate(result.displays, start=1):
+            text = _bundle_text(bundle, _DISPLAY_CHUNK_CHARS)
+            if text:
+                display_parts.append(f"display[{index}]:\n{text}")
+            elif _bundle_images(bundle):
+                display_parts.append(f"display[{index}]: [image]")
+        if display_parts:
+            parts.append("\n\n".join(display_parts))
+
+        if result.error is not None:
+            error = result.error
+            traceback_text = "".join(error.traceback).rstrip()
+            block = f"### error\n{error.ename}: {error.evalue}"
+            if traceback_text:
+                block += f"\n{traceback_text}"
+            parts.append(block)
+        elif result.status != "ok" and not result.interrupted:
+            parts.append(f"### error\ncell finished with status: {result.status}")
+
+        text_out = "\n\n".join(parts) if parts else "(cell completed with no output)"
+
+        images: List[Tuple[str, str]] = []
+        for bundle in result.displays:
+            images.extend(_bundle_images(bundle))
+        images.extend(_bundle_images(result.result_bundle))
+        if not images:
+            return text_out
+
+        if not bool(getattr(self.caller, "supports_vision", False)):
+            return text_out + f"\n\n[{len(images)} image output(s) not shown: model has no vision support]"
+
+        blocks: List[ContentBlock] = [TextBlock(text=text_out)]
+        blocks.extend(ImageBlock(image_type="base64", media_type=mime, data=data) for mime, data in images)
+        return blocks
+
+    @staticmethod
+    def _status_lines(result: EvalCellResult) -> List[str]:
+        lines: List[str] = []
+        for event in result.statuses:
+            op = event.get("op")
+            if op == "log":
+                lines.append(f"- log: {event.get('message', '')}")
+            elif op == "phase":
+                lines.append(f"- phase: {event.get('title', '')}")
+            elif op in ("read", "write", "pip_install", "npm_install"):
+                detail = event.get("path") or ", ".join(str(p) for p in event.get("packages", []) or [])
+                lines.append(f"- {op}: {detail}")
+        return lines

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -16,6 +16,7 @@ from kolega_code.services.browser import PlaywrightBrowserManager
 from .tool_backend.agent_tool import AgentTool
 from .tool_backend.browser_tool import BROWSER_TOOL_SCHEMAS, BrowserTool
 from .tool_backend.edit_tool import EditTool
+from .tool_backend.eval_tool import EvalTool
 from .tool_backend.codex_patch import CODEX_APPLY_PATCH_GRAMMAR
 from .tool_backend.glob_tool import GlobTool
 from .tool_backend.hashline_v2 import format_hash_lines, format_line_tag
@@ -551,12 +552,15 @@ class ToolCollection(LogMixin):
     # Shell execution + session management. Exposed to the planning and
     # investigation agents (via custom_tool_groups) so they can run investigative
     # commands even while read_only=True. Not read-only, so deliberately excluded
-    # from the parallel-safe set in _build_tool.
+    # from the parallel-safe set in _build_tool. `eval` (arbitrary code in the
+    # persistent kernels) carries the same power level as exec_command, so it
+    # shares this group.
     command_tools = [
         "exec_command",
         "write_stdin",
         "kill_command",
         "list_sessions",
+        "eval",
     ]
 
     def __init__(
@@ -805,6 +809,15 @@ class ToolCollection(LogMixin):
             self.caller,
             self.filesystem,
             terminal_manager=self.terminal_manager,
+        )
+        self.eval_tool = EvalTool(
+            self.project_path,
+            self.workspace_id,
+            self.thread_id,
+            self.connection_manager,
+            self.config,
+            self.caller,
+            self.filesystem,
         )
         memory_manager = getattr(self.caller, "memory_manager", None)
         if not isinstance(memory_manager, ProjectMemoryManager):
@@ -1854,6 +1867,50 @@ class ToolCollection(LogMixin):
         """
         return await self.terminal_tool.list_sessions()
 
+    async def eval(
+        self,
+        language: str,
+        code: str,
+        title: Optional[str] = None,
+        timeout: Optional[float] = None,
+        reset: bool = False,
+    ) -> Union[str, List[Any]]:
+        """Run one step of code in a persistent kernel. State (imports, variables, functions) persists across eval calls, across tool calls, and across sub-agents in this session — each call is one logical step.
+
+        language="py" runs Python in kolega-code's own managed environment (check python_info()): numpy, pandas, matplotlib, and pillow are preinstalled, and pip_install("scipy") adds more. Use tool.exec_command for anything that needs the project's own venv. language="js" runs JavaScript on Bun or Node (>= 18) when available.
+
+        Work incrementally: imports → define → test → use, each its own cell. Re-run setup ONLY after reset or a kernel crash. On error, fix and re-run just the failing step. Prior top-level names survive into the next cell — NEVER re-import or re-declare them.
+
+        Both kernels can call back into your own tools over a loopback bridge — load a CSV with tool.read_file_section({"path": "data.csv"}) inside Python, or loop tool.search_codebase over many patterns without leaving the cell. Bridge calls count as real tool calls (permissions and hooks apply). Use list_tools() in a cell to discover available tool names.
+
+        Python prelude (sync; pass kwargs):
+          display(value)                 rich output: dict/list → JSON, matplotlib Figure → image
+          print(value)                   shows in the cell's stdout
+          read(path, offset=1, limit=None)   write(path, content)   env(key=None, value=None)
+          tool.<name>(args_dict, **kwargs)   call any session tool (list_tools() shows names)
+          parallel([lambda: ..., ...])   run thunks concurrently, results in order
+          pip_install(*pkgs)   python_info()   log(msg)   phase(title)
+        Top-level await works; do NOT call asyncio.run() inside a coroutine cell.
+
+        JavaScript prelude (async; ONE trailing object literal, never positional args):
+          display(value)   read(path, offset, limit)   write(path, content)   env(key, value)
+          await tool.<name>({...})   await listTools()
+          await parallel([() => ..., ...])   npm_install("pkg")   setGlobal(name, value)
+          log(msg)   phase(title)
+        Top-level await works; declarations inside await-wrapped cells do NOT persist — use setGlobal(name, value) for cross-cell state there. Redeclaring an existing top-level name errors: assign without redeclaring, or pass reset=true.
+
+        Args:
+            language: "py" for the persistent Python kernel, "js" for the persistent JavaScript kernel (js needs bun or node >= 18 on PATH).
+            code: code to run in this eval call, verbatim. Top-level await is fine.
+            title: short label for this step shown in the transcript (e.g. "load csv", "chart by region").
+            timeout: timeout for this cell in seconds; 0 disables it. Default 120, max 600.
+            reset: wipe this language's kernel before running (fresh state). The other language is untouched.
+
+        Returns:
+            The cell's stdout/stderr, the last expression's value (REPL echo), display() outputs (images included when the model supports vision), log()/phase() status lines, and any error with its traceback.
+        """
+        return await self.eval_tool.eval(language, code, title=title, timeout=timeout, reset=reset)
+
     async def read_entire_file(self, path: str) -> str:
         """
         Read the contents of a file in the project.
@@ -2487,6 +2544,11 @@ class ToolCollection(LogMixin):
         if method_name == "read_image":
             return bool(getattr(self.caller, "supports_vision", False))
 
+        # Settings gate: eval can be disabled host-wide (AgentConfig.eval_enabled).
+        # Strict `is False` so Mock configs in tests keep the default (enabled).
+        if method_name == "eval" and getattr(self.config, "eval_enabled", True) is False:
+            return False
+
         # Check custom tool groups first
         if self.tool_config.custom_tool_groups:
             for group_name in self.tool_config.custom_tool_groups:
@@ -2594,6 +2656,12 @@ class ToolCollection(LogMixin):
             if hasattr(self, "terminal_tool") and hasattr(self.terminal_tool, "terminal_manager"):
                 await self.terminal_tool.terminal_manager.cleanup_all()
                 await self.log_info("Cleaned up terminal resources", sender="ToolCollection")
+
+            # Clean up eval kernel resources (only the top-level agent owns the
+            # session-shared kernel manager; EvalTool enforces that internally).
+            if hasattr(self, "eval_tool"):
+                await self.eval_tool.shutdown_if_owner()
+                await self.log_info("Cleaned up eval kernel resources", sender="ToolCollection")
 
             # Clean up any browser resources
             if hasattr(self, "browser_tool") and hasattr(self.browser_tool, "cleanup"):

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -1881,7 +1881,7 @@ class ToolCollection(LogMixin):
 
         Work incrementally: imports → define → test → use, each its own cell. Re-run setup ONLY after reset or a kernel crash. On error, fix and re-run just the failing step. Prior top-level names survive into the next cell — NEVER re-import or re-declare them.
 
-        Both kernels can call back into your own tools over a loopback bridge — load a CSV with tool.read_file_section({"path": "data.csv"}) inside Python, or loop tool.search_codebase over many patterns without leaving the cell. Bridge calls count as real tool calls (permissions and hooks apply). Use list_tools() in a cell to discover available tool names.
+        Both kernels can call back into your own tools over a loopback bridge — loop tool.search_codebase over many patterns, read images with tool.read_image, or dispatch sub-agents without leaving the cell. Bridge calls count as real tool calls (permissions and hooks apply). Use list_tools() in a cell to discover available tool names. tool.* results arrive in each tool's model-facing format (e.g. tool.read_file_section wraps content in a markdown header and code fence) — for raw file bytes like CSV/data loads, use the read()/write() helpers instead, which hit the filesystem directly.
 
         Python prelude (sync; pass kwargs):
           display(value)                 rich output: dict/list → JSON, matplotlib Figure → image

--- a/kolega_code/cli/config.py
+++ b/kolega_code/cli/config.py
@@ -512,6 +512,7 @@ def build_agent_config(
             mcp_config=mcp_config,
             lsp=LspConfig(enabled=True if settings is None or settings.lsp_enabled is None else settings.lsp_enabled),
             lsp_project_trusted=lsp_project_trusted,
+            eval_enabled=(True if settings is None or settings.eval_enabled is None else bool(settings.eval_enabled)),
         )
     except ValueError as exc:
         raise CliConfigError(str(exc)) from exc

--- a/kolega_code/cli/settings.py
+++ b/kolega_code/cli/settings.py
@@ -105,6 +105,9 @@ class CliSettings:
     # Additive optional field — absent in older files -> None -> use default
     # LSP config (enabled=True).
     lsp_enabled: Optional[bool] = None
+    # Additive optional field — absent in older files -> None -> eval tool
+    # enabled (persistent code kernels with the loopback tool bridge).
+    eval_enabled: Optional[bool] = None
     schema_version: int = SETTINGS_SCHEMA_VERSION
 
     @classmethod
@@ -139,6 +142,8 @@ class CliSettings:
             permission_mode=_coerce_permission_mode(data.get("permission_mode")),
             # Additive optional field; absent in older files -> None (use default).
             lsp_enabled=data.get("lsp_enabled"),
+            # Additive optional field; absent in older files -> None (enabled).
+            eval_enabled=data.get("eval_enabled"),
         )
 
     def to_dict(self) -> dict:
@@ -158,6 +163,7 @@ class CliSettings:
             "oauth_tokens": self.oauth_tokens,
             "permission_mode": _coerce_permission_mode(self.permission_mode),
             "lsp_enabled": self.lsp_enabled,
+            "eval_enabled": self.eval_enabled,
         }
 
     def get_api_key(self, provider: str) -> Optional[str]:

--- a/kolega_code/config.py
+++ b/kolega_code/config.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, PrivateAttr, model_validator
 
@@ -216,6 +216,28 @@ class AgentConfig(BaseModel):
     # servers. Excluded from serialization (parity with mcp_config) — it is a
     # runtime-resolved trust flag, not user-editable config.
     lsp_project_trusted: bool = Field(default=False, exclude=True, description="Project LSP config trust flag")
+
+    # eval tool (persistent code kernels with a loopback tool bridge). All fields
+    # are additive with defaults that enable the feature; excluded from
+    # serialization since they carry local paths (parity with lsp/mcp_config).
+    eval_enabled: bool = Field(default=True, exclude=True, description="Enable the eval tool and its kernels")
+    eval_python_version: str = Field(
+        default="3.12", exclude=True, description="Python version requested for the managed eval environment"
+    )
+    eval_env_path: Optional[str] = Field(
+        default=None, exclude=True, description="Override location of the managed eval environment directory"
+    )
+    eval_kernel_packages: Optional[List[str]] = Field(
+        default=None, exclude=True, description="Extra packages installed into the eval environment at provision time"
+    )
+    eval_python_path: Optional[str] = Field(
+        default=None,
+        exclude=True,
+        description="Full interpreter override for the eval Python kernel (skips managed-env provisioning)",
+    )
+    eval_js_runtime: Optional[str] = Field(
+        default=None, exclude=True, description="JS runtime for the eval JS kernel: 'bun', 'node', or a path"
+    )
 
     def model_config_for_agent(self, agent_name: Optional[str]) -> ModelConfig:
         """Return the model configuration an agent should use for its main loop.

--- a/kolega_code/permissions.py
+++ b/kolega_code/permissions.py
@@ -33,6 +33,7 @@ COMMAND_PERMISSION_TOOLS = frozenset(
     {
         "execute_terminal_command",
         "exec_command",
+        "eval",
     }
 )
 EDIT_PERMISSION_TOOLS = frozenset(
@@ -201,6 +202,19 @@ class ProjectPermissionStore:
 
 
 def permission_request_for_tool(tool_name: str, inputs: dict[str, Any]) -> Optional[PermissionRequest]:
+    if tool_name == "eval":
+        # Shape the cell as "[py] <code>" so the generic command rules work:
+        # the "executable" allow-rule option becomes "[py]" / "[js]", letting a
+        # user allow all cells for one language with a single rule.
+        language = str(inputs.get("language") or "").strip() or "?"
+        code = str(inputs.get("code") or "").strip()
+        return PermissionRequest(
+            kind=PermissionKind.COMMAND,
+            tool_name=tool_name,
+            inputs=inputs,
+            command=f"[{language}] {code}",
+        )
+
     if tool_name in COMMAND_PERMISSION_TOOLS:
         command = str(inputs.get("command") or "").strip()
         return PermissionRequest(

--- a/tests/agent/eval/test_bridge.py
+++ b/tests/agent/eval/test_bridge.py
@@ -1,0 +1,164 @@
+"""Tests for the loopback tool bridge (HTTP semantics, dispatch, cancellation)."""
+
+import asyncio
+import json
+
+import pytest
+import pytest_asyncio
+
+from kolega_code.agent.eval.bridge import LIST_TOOLS_OP, BridgeRegistration, ToolBridge
+from kolega_code.tools import ToolError
+
+
+async def _request(bridge: ToolBridge, body: dict | bytes | None, *, token: str | None = None, path: str = "/v1/tool"):
+    reader, writer = await asyncio.open_connection("127.0.0.1", bridge._port)
+    if isinstance(body, dict):
+        raw = json.dumps(body).encode()
+    else:
+        raw = body or b""
+    auth = f"Bearer {token}" if token is not None else f"Bearer {bridge.token}"
+    request = (
+        f"POST {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\n"
+        f"Authorization: {auth}\r\nContent-Length: {len(raw)}\r\nConnection: close\r\n\r\n"
+    ).encode() + raw
+    writer.write(request)
+    await writer.drain()
+    response = await reader.read()
+    writer.close()
+    head, _, payload = response.partition(b"\r\n\r\n")
+    status = int(head.split(b" ", 2)[1])
+    return status, json.loads(payload) if payload else {}
+
+
+@pytest_asyncio.fixture
+async def bridge():
+    instance = ToolBridge()
+    await instance._start()
+    yield instance
+    await instance.stop()
+
+
+@pytest.mark.asyncio
+async def test_rejects_wrong_token(bridge):
+    status, payload = await _request(bridge, {"session": "s", "run": "r", "name": "x"}, token="wrong")
+    assert status == 403
+    assert payload["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_rejects_unknown_path(bridge):
+    status, _ = await _request(bridge, {}, path="/nope")
+    assert status == 404
+
+
+@pytest.mark.asyncio
+async def test_rejects_malformed_body(bridge):
+    status, payload = await _request(bridge, b"{not json")
+    assert status == 400
+    assert payload["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_rejects_missing_fields(bridge):
+    status, payload = await _request(bridge, {"session": "s"})
+    assert status == 400
+    assert "missing" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_round_trip(bridge):
+    seen = []
+
+    async def caller(name, args):
+        seen.append((name, args))
+        return {"text": f"hello {args['who']}"}
+
+    unregister = bridge.register("sess", "run1", BridgeRegistration(tool_caller=caller))
+    try:
+        status, payload = await _request(
+            bridge, {"session": "sess", "run": "run1", "name": "greet", "args": {"who": "kernel"}}
+        )
+    finally:
+        unregister()
+    assert status == 200
+    assert payload == {"ok": True, "value": {"text": "hello kernel"}}
+    assert seen == [("greet", {"who": "kernel"})]
+
+
+@pytest.mark.asyncio
+async def test_unknown_registration_is_tool_level_error(bridge):
+    status, payload = await _request(bridge, {"session": "ghost", "run": "r", "name": "x", "args": {}})
+    assert status == 200
+    assert payload["ok"] is False
+    assert "no active eval cell" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_caller_exception_surfaces_as_error(bridge):
+    async def caller(name, args):
+        raise ToolError(f"{name} exploded")
+
+    unregister = bridge.register("s", "r", BridgeRegistration(tool_caller=caller))
+    try:
+        _, payload = await _request(bridge, {"session": "s", "run": "r", "name": "edit", "args": {}})
+    finally:
+        unregister()
+    assert payload["ok"] is False
+    assert "edit exploded" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_deregistration_rejects_late_calls(bridge):
+    async def caller(name, args):
+        return "late"
+
+    unregister = bridge.register("s", "r", BridgeRegistration(tool_caller=caller))
+    unregister()
+    _, payload = await _request(bridge, {"session": "s", "run": "r", "name": "x", "args": {}})
+    assert payload["ok"] is False
+    assert "no active eval cell" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_list_tools_op(bridge):
+    async def caller(name, args):
+        raise AssertionError("must not be called for __list_tools__")
+
+    registration = BridgeRegistration(
+        tool_caller=caller,
+        tool_lister=lambda: [{"name": "read", "summary": "Read a file"}],
+    )
+    unregister = bridge.register("s", "r", registration)
+    try:
+        _, payload = await _request(bridge, {"session": "s", "run": "r", "name": LIST_TOOLS_OP, "args": {}})
+    finally:
+        unregister()
+    assert payload == {"ok": True, "value": [{"name": "read", "summary": "Read a file"}]}
+
+
+@pytest.mark.asyncio
+async def test_interrupt_cancels_in_flight_calls(bridge):
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_caller(name, args):
+        started.set()
+        await release.wait()
+        return "done"
+
+    registration = BridgeRegistration(tool_caller=slow_caller)
+    bridge.register("s", "r", registration)
+
+    request_task = asyncio.create_task(_request(bridge, {"session": "s", "run": "r", "name": "slow", "args": {}}))
+    await asyncio.wait_for(started.wait(), timeout=5)
+
+    registration.cancel_in_flight()
+    _, payload = await asyncio.wait_for(request_task, timeout=5)
+    assert payload["ok"] is False
+    assert "interrupt" in payload["error"].lower() or "cancel" in payload["error"].lower()
+
+    # New calls are rejected too.
+    _, payload = await _request(bridge, {"session": "s", "run": "r", "name": "x", "args": {}})
+    assert payload["ok"] is False
+    assert "interrupted" in payload["error"]
+    release.set()

--- a/tests/agent/eval/test_env.py
+++ b/tests/agent/eval/test_env.py
@@ -1,0 +1,173 @@
+"""Unit tests for the dedicated eval environment manager (hermetic, mocked I/O)."""
+
+import asyncio
+import json
+import subprocess
+import sys
+
+import pytest
+
+from kolega_code.agent.eval import env as env_module
+from kolega_code.agent.eval.env import EvalEnvironmentManager
+
+
+def _ok(args, timeout):
+    return subprocess.CompletedProcess(args, 0, stdout="ok", stderr="")
+
+
+def _fail(args, timeout):
+    return subprocess.CompletedProcess(args, 1, stdout="", stderr="boom")
+
+
+def _fake_installer(env_path):
+    """A fake _run that 'creates' the venv python on the venv step."""
+
+    def run(cmd, timeout):
+        if "venv" in cmd:
+            python = env_module._venv_python(env_path)
+            python.parent.mkdir(parents=True, exist_ok=True)
+            python.write_text("#!/bin/sh\n")
+        return _ok(cmd, timeout)
+
+    return run
+
+
+def _ensure(manager):
+    return asyncio.run(manager.ensure())
+
+
+@pytest.fixture
+def state_dir(tmp_path):
+    return tmp_path / "state"
+
+
+def test_override_python_skips_provisioning(state_dir, monkeypatch):
+    calls = []
+    monkeypatch.setattr(env_module, "_run", lambda cmd, timeout: calls.append(cmd) or _ok(cmd, timeout))
+    monkeypatch.setattr(env_module.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    manager = EvalEnvironmentManager(state_dir=state_dir, override_python=sys.executable)
+    info = _ensure(manager)
+
+    assert info.python == sys.executable
+    assert info.degraded is False
+    assert info.bundled is False
+    assert "custom interpreter" in (info.note or "")
+    assert info.pip_install_cmd == [sys.executable, "-m", "pip", "install"]
+    # Only the --version probe ran; no venv/install commands.
+    assert calls == [[sys.executable, "--version"]]
+
+
+def test_provisions_with_uv_and_writes_manifest(state_dir, monkeypatch):
+    calls = []
+
+    manager = EvalEnvironmentManager(state_dir=state_dir, python_version="3.12")
+
+    def run(cmd, timeout):
+        calls.append(cmd)
+        return _fake_installer(manager.env_path)(cmd, timeout)
+
+    monkeypatch.setattr(env_module, "_run", run)
+    monkeypatch.setattr(env_module.shutil, "which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+    info = _ensure(manager)
+
+    assert info.bundled is True
+    assert info.degraded is False
+    assert info.provisioned_now is True
+    assert "one-time setup" in (info.note or "")
+    assert calls[0][:3] == ["/usr/bin/uv", "venv", str(manager.env_path)]
+    assert "--python" in calls[0]
+    assert calls[1][:3] == ["/usr/bin/uv", "pip", "install"]
+    assert info.pip_install_cmd[0] == "/usr/bin/uv"
+    assert "numpy" in " ".join(info.bundle)
+
+    manifest = json.loads((manager.env_path / env_module.MANIFEST_NAME).read_text())
+    assert manifest["installer"] == "uv"
+    assert manifest["python_version"] == "3.12"
+
+
+def test_provisions_with_venv_when_uv_missing(state_dir, monkeypatch):
+    calls = []
+
+    def run(cmd, timeout):
+        calls.append(cmd)
+        return _fake_installer(env_path)(cmd, timeout)
+
+    manager = EvalEnvironmentManager(state_dir=state_dir)
+    env_path = manager.env_path
+    monkeypatch.setattr(env_module, "_run", run)
+    monkeypatch.setattr(env_module.shutil, "which", lambda name: None)
+
+    info = _ensure(manager)
+
+    assert calls[0] == [sys.executable, "-m", "venv", str(manager.env_path)]
+    assert calls[1][1:4] == ["-m", "pip", "install"]
+    assert info.pip_install_cmd[1:] == ["-m", "pip", "install"]
+
+
+def test_degrades_to_host_interpreter_on_failure(state_dir, monkeypatch):
+    monkeypatch.setattr(env_module, "_run", _fail)
+    monkeypatch.setattr(env_module.shutil, "which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+    manager = EvalEnvironmentManager(state_dir=state_dir)
+    info = _ensure(manager)
+
+    assert info.degraded is True
+    assert info.python == sys.executable
+    assert info.pip_install_cmd == []
+    assert "host interpreter" in (info.note or "")
+    assert not manager.env_path.exists()
+
+
+def test_reuses_matching_manifest_without_provisioning(state_dir, monkeypatch):
+    monkeypatch.setattr(env_module.shutil, "which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    manager = EvalEnvironmentManager(state_dir=state_dir)
+
+    python = env_module._venv_python(manager.env_path)
+    python.parent.mkdir(parents=True)
+    python.write_text("#!/bin/sh\n")
+    manager._write_manifest("uv")
+
+    def no_run(cmd, timeout):
+        raise AssertionError("must not provision when the manifest matches")
+
+    monkeypatch.setattr(env_module, "_run", no_run)
+    info = _ensure(manager)
+
+    assert info.bundled is True
+    assert info.provisioned_now is False
+    assert info.python == str(python)
+
+
+def test_reprovisions_on_bundle_hash_change(state_dir, monkeypatch):
+    calls = []
+
+    manager = EvalEnvironmentManager(state_dir=state_dir)
+
+    def run(cmd, timeout):
+        calls.append(cmd)
+        return _fake_installer(manager.env_path)(cmd, timeout)
+
+    monkeypatch.setattr(env_module, "_run", run)
+    monkeypatch.setattr(env_module.shutil, "which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+    python = env_module._venv_python(manager.env_path)
+    python.parent.mkdir(parents=True)
+    python.write_text("#!/bin/sh\n")
+    # A manifest whose bundle hash does not match the current bundle.
+    (manager.env_path / env_module.MANIFEST_NAME).write_text(
+        json.dumps({"python_version": "3.12", "bundle_hash": "stale", "installer": "uv"})
+    )
+
+    info = _ensure(manager)
+    assert info.provisioned_now is True
+    assert any(cmd[:2] == ["/usr/bin/uv", "venv"] for cmd in calls)
+
+
+def test_extra_packages_extend_bundle_and_hash(state_dir):
+    base = EvalEnvironmentManager(state_dir=state_dir)
+    extended = EvalEnvironmentManager(state_dir=state_dir, extra_packages=["scipy==1.14.1"])
+
+    assert base._bundle_hash() != extended._bundle_hash()
+    assert "scipy==1.14.1" in extended._bundle_names()

--- a/tests/agent/eval/test_env_provisioning.py
+++ b/tests/agent/eval/test_env_provisioning.py
@@ -1,0 +1,67 @@
+"""Slow end-to-end test: provision a real managed env and run a cell in it.
+
+Uses an empty bundle so provisioning stays offline and fast (uv venv or
+python -m venv only). The full bundle install path is covered by unit tests in
+test_env.py with a mocked installer.
+"""
+
+import uuid
+from unittest.mock import Mock
+
+import pytest
+
+from kolega_code.agent.eval import env as env_module
+from kolega_code.agent.eval.kernel import EvalKernelManager
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.slow]
+
+
+class FakeAgent:
+    sub_agent = False
+    supports_vision = False
+    tool_collection = None
+
+    async def execute_single_tool(self, tool_call):
+        raise AssertionError("no bridge calls expected in this test")
+
+
+@pytest.fixture
+def config(tmp_path):
+    mock = Mock()
+    mock.eval_python_path = None
+    mock.eval_python_version = "3.12"
+    mock.eval_env_path = str(tmp_path / "eval-env")
+    mock.eval_kernel_packages = None
+    mock.eval_js_runtime = None
+    return mock
+
+
+async def test_provisions_real_env_and_runs_cell(tmp_path, config, isolated_cli_env, monkeypatch):
+    # Empty bundle: provision the venv without downloading packages.
+    monkeypatch.setattr(env_module.EvalEnvironmentManager, "_bundle_source", lambda self: b"")
+
+    manager = EvalKernelManager.for_thread(
+        workspace_id="test_ws",
+        thread_id=f"test-provision-{uuid.uuid4().hex}",
+        project_path=tmp_path,
+        config=config,
+    )
+    try:
+        result = await manager.execute(
+            language="py",
+            code="import sys\ninfo = python_info()\n[sys.version.split()[0], info['env_path']]",
+            agent=FakeAgent(),
+            timeout=120,
+        )
+        assert result.status == "ok", result.error
+        assert any("one-time setup" in note for note in result.notes)
+        version, env_path = result.result_bundle["application/json"]
+        assert version
+        assert env_path == str(tmp_path / "eval-env")
+
+        # Second cell reuses the env (no provisioning note).
+        again = await manager.execute(language="py", code="'warm'", agent=FakeAgent(), timeout=30)
+        assert again.status == "ok"
+        assert not any("one-time setup" in note for note in again.notes)
+    finally:
+        await manager.shutdown()

--- a/tests/agent/eval/test_env_provisioning.py
+++ b/tests/agent/eval/test_env_provisioning.py
@@ -63,5 +63,10 @@ async def test_provisions_real_env_and_runs_cell(tmp_path, config, isolated_cli_
         again = await manager.execute(language="py", code="'warm'", agent=FakeAgent(), timeout=30)
         assert again.status == "ok"
         assert not any("one-time setup" in note for note in again.notes)
+
+        # A kernel restart (reset) must not re-announce the one-time setup.
+        restarted = await manager.execute(language="py", code="'fresh'", agent=FakeAgent(), timeout=30, reset=True)
+        assert restarted.status == "ok"
+        assert not any("one-time setup" in note for note in restarted.notes)
     finally:
         await manager.shutdown()

--- a/tests/agent/eval/test_js_kernel.py
+++ b/tests/agent/eval/test_js_kernel.py
@@ -1,0 +1,170 @@
+"""Integration tests for the persistent JavaScript kernel (Bun/Node).
+
+Skipped when neither runtime is on PATH. Marked integration since they spawn
+external runtimes whose behavior can vary across versions.
+"""
+
+import sys
+import uuid
+from unittest.mock import Mock
+
+import pytest
+import pytest_asyncio
+
+from kolega_code.agent.eval.js_kernel import probe_js_runtime
+from kolega_code.agent.eval.kernel import EvalKernelManager
+from kolega_code.llm.models import ToolResult
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+
+def _runtime_or_skip(config):
+    runtime = probe_js_runtime(config)
+    if runtime is None:
+        pytest.skip("no JavaScript runtime (bun/node >= 18) on PATH")
+    return runtime
+
+
+class FakeAgent:
+    sub_agent = False
+    supports_vision = False
+
+    def __init__(self):
+        self.calls = []
+        self.tool_collection = None
+
+    async def execute_single_tool(self, tool_call):
+        self.calls.append((tool_call.name, tool_call.input))
+        if tool_call.name == "add":
+            total = tool_call.input["a"] + tool_call.input["b"]
+            return ToolResult(tool_use_id=tool_call.id, content=str(total), name=tool_call.name, is_error=False)
+        return ToolResult(
+            tool_use_id=tool_call.id, content=f"unknown tool: {tool_call.name}", name=tool_call.name, is_error=True
+        )
+
+
+@pytest.fixture
+def config():
+    mock = Mock()
+    mock.eval_python_path = sys.executable
+    mock.eval_python_version = None
+    mock.eval_env_path = None
+    mock.eval_kernel_packages = None
+    mock.eval_js_runtime = None
+    return mock
+
+
+@pytest_asyncio.fixture
+async def manager(tmp_path, config, isolated_cli_env):
+    _runtime_or_skip(config)
+    instance = EvalKernelManager.for_thread(
+        workspace_id="test_ws",
+        thread_id=f"test-js-{uuid.uuid4().hex}",
+        project_path=tmp_path,
+        config=config,
+    )
+    yield instance
+    await instance.shutdown()
+
+
+async def test_result_echo_and_console(manager):
+    agent = FakeAgent()
+    result = await manager.execute(language="js", code="console.log('hello js');\n40 + 2", agent=agent, timeout=30)
+    assert result.status == "ok"
+    assert result.stdout == "hello js\n"
+    assert result.result_bundle["application/json"] == 42
+
+
+async def test_declarations_persist_across_cells(manager):
+    agent = FakeAgent()
+    await manager.execute(language="js", code="let base = 40; const two = 2;", agent=agent, timeout=30)
+    result = await manager.execute(language="js", code="base + two", agent=agent, timeout=30)
+    assert result.result_bundle["application/json"] == 42
+
+
+async def test_redeclaration_error_is_actionable(manager):
+    agent = FakeAgent()
+    await manager.execute(language="js", code="let x = 1;", agent=agent, timeout=30)
+    result = await manager.execute(language="js", code="let x = 2;", agent=agent, timeout=30)
+    assert result.status == "error"
+    assert result.error is not None
+    assert result.error.ename == "SyntaxError"
+    assert "without" in result.error.evalue and "reset=true" in result.error.evalue
+
+
+async def test_top_level_await_and_set_global(manager):
+    agent = FakeAgent()
+    awaited = await manager.execute(
+        language="js",
+        code="const z = await Promise.resolve(7); setGlobal('z', z);",
+        agent=agent,
+        timeout=30,
+    )
+    assert awaited.status == "ok"
+    result = await manager.execute(language="js", code="z + 1", agent=agent, timeout=30)
+    assert result.result_bundle["application/json"] == 8
+
+
+async def test_throw_produces_error_frame(manager):
+    agent = FakeAgent()
+    result = await manager.execute(language="js", code="throw new Error('boom')", agent=agent, timeout=30)
+    assert result.status == "error"
+    assert result.error is not None
+    assert result.error.evalue == "boom"
+
+
+async def test_timeout_interrupts_and_kernel_survives(manager):
+    agent = FakeAgent()
+    result = await manager.execute(
+        language="js",
+        code="await new Promise((resolve) => setTimeout(resolve, 60000))",
+        agent=agent,
+        timeout=1,
+    )
+    assert result.status == "error"
+    assert result.interrupted is True
+
+    alive = await manager.execute(language="js", code="'still alive'", agent=agent, timeout=30)
+    assert alive.status == "ok"
+    assert alive.result_bundle["text/plain"] == "still alive"
+
+
+async def test_bridge_tool_call(manager):
+    agent = FakeAgent()
+    result = await manager.execute(
+        language="js",
+        code="return await tool.add({a: 5, b: 6});",
+        agent=agent,
+        timeout=30,
+    )
+    assert result.status == "ok"
+    assert agent.calls == [("add", {"a": 5, "b": 6})]
+    assert result.result_bundle["text/plain"] == "11"
+
+
+async def test_read_write_helpers(manager, tmp_path):
+    agent = FakeAgent()
+    result = await manager.execute(
+        language="js",
+        code="write('note.txt', 'some data');\nread('note.txt');",
+        agent=agent,
+        timeout=30,
+    )
+    assert result.status == "ok"
+    assert result.result_bundle["text/plain"] == "some data"
+    assert (tmp_path / "note.txt").read_text() == "some data"
+
+
+async def test_reset_wipes_state(manager):
+    agent = FakeAgent()
+    await manager.execute(language="js", code="var marker = 'x';", agent=agent, timeout=30)
+    await manager.execute(language="js", code="'reset'", agent=agent, timeout=30, reset=True)
+    result = await manager.execute(language="js", code="typeof marker", agent=agent, timeout=30)
+    assert result.result_bundle["text/plain"] == "undefined"
+
+
+async def test_json_values_in_results(manager):
+    agent = FakeAgent()
+    result = await manager.execute(language="js", code="({a: 1, b: [1, 2, 3]})", agent=agent, timeout=30)
+    assert result.status == "ok"
+    assert result.result_bundle["application/json"] == {"a": 1, "b": [1, 2, 3]}

--- a/tests/agent/eval/test_protocol.py
+++ b/tests/agent/eval/test_protocol.py
@@ -1,0 +1,38 @@
+"""Frame codec tests for the eval kernel NDJSON protocol."""
+
+import pytest
+
+from kolega_code.agent.eval.protocol import MAX_FRAME_BYTES, ProtocolError, encode_frame, parse_frame
+
+
+def test_round_trip_preserves_frame():
+    frame = {"type": "exec", "id": 7, "run": "abc", "code": "print('héllo')\n", "silent": False}
+    line = encode_frame(frame)
+    assert line.endswith(b"\n")
+    assert parse_frame(line) == frame
+
+
+def test_round_trip_large_image_bundle():
+    bundle = {"image/png": "a" * 200_000, "text/plain": "fig"}
+    frame = {"type": "display", "id": 3, "bundle": bundle}
+    assert parse_frame(encode_frame(frame)) == frame
+
+
+def test_parse_rejects_non_json():
+    with pytest.raises(ProtocolError, match="malformed"):
+        parse_frame(b"this is not json\n")
+
+
+def test_parse_rejects_non_object():
+    with pytest.raises(ProtocolError, match="not an object"):
+        parse_frame(b"[1, 2, 3]\n")
+
+
+def test_parse_rejects_missing_type():
+    with pytest.raises(ProtocolError, match="not an object with a type"):
+        parse_frame(b'{"id": 1}\n')
+
+
+def test_parse_rejects_oversized_frame():
+    with pytest.raises(ProtocolError, match="exceeds"):
+        parse_frame(b"x" * (MAX_FRAME_BYTES + 1))

--- a/tests/agent/eval/test_py_kernel.py
+++ b/tests/agent/eval/test_py_kernel.py
@@ -1,0 +1,246 @@
+"""Integration tests for the persistent Python kernel and the tool bridge path.
+
+These run a real kernel subprocess on the host interpreter (eval_python_path
+override skips managed-env provisioning). They stay fast and offline; the
+managed-env provisioning path is covered by unit tests in test_env.py.
+"""
+
+import json
+import sys
+import uuid
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+import pytest_asyncio
+
+from kolega_code.agent.eval.kernel import EvalKernelManager
+from kolega_code.llm.models import ToolResult
+
+pytestmark = pytest.mark.asyncio
+
+
+class FakeAgent:
+    """Minimal agent stand-in routing bridge calls through execute_single_tool."""
+
+    sub_agent = False
+    supports_vision = False
+
+    def __init__(self):
+        self.calls = []
+        self.tool_collection = None
+
+    async def execute_single_tool(self, tool_call):
+        self.calls.append((tool_call.name, tool_call.input))
+        if tool_call.name == "echo":
+            return ToolResult(
+                tool_use_id=tool_call.id,
+                content=json.dumps(tool_call.input, sort_keys=True),
+                name=tool_call.name,
+                is_error=False,
+            )
+        return ToolResult(
+            tool_use_id=tool_call.id,
+            content=f"unknown tool: {tool_call.name}",
+            name=tool_call.name,
+            is_error=True,
+        )
+
+
+@pytest.fixture
+def config():
+    mock = Mock()
+    mock.eval_python_path = sys.executable
+    mock.eval_python_version = None
+    mock.eval_env_path = None
+    mock.eval_kernel_packages = None
+    mock.eval_js_runtime = None
+    return mock
+
+
+@pytest_asyncio.fixture
+async def manager(tmp_path, config, isolated_cli_env):
+    instance = EvalKernelManager.for_thread(
+        workspace_id="test_ws",
+        thread_id=f"test-{uuid.uuid4().hex}",
+        project_path=tmp_path,
+        config=config,
+    )
+    yield instance
+    await instance.shutdown()
+
+
+async def test_result_echo_and_stdout(manager):
+    agent = FakeAgent()
+    result = await manager.execute(language="py", code="print('hello kernel')\n40 + 2", agent=agent, timeout=30)
+    assert result.status == "ok"
+    assert result.stdout == "hello kernel\n"
+    assert result.result_bundle["application/json"] == 42
+    # First start on the override interpreter carries the custom-interpreter note.
+    assert any("custom interpreter" in note for note in result.notes)
+
+
+async def test_state_persists_across_cells(manager):
+    agent = FakeAgent()
+    await manager.execute(language="py", code="counter = 10", agent=agent, timeout=30)
+    result = await manager.execute(language="py", code="counter += 5\ncounter", agent=agent, timeout=30)
+    assert result.result_bundle["application/json"] == 15
+
+
+async def test_reset_wipes_state(manager):
+    agent = FakeAgent()
+    await manager.execute(language="py", code="secret = 'x'", agent=agent, timeout=30)
+    await manager.execute(language="py", code="pass", agent=agent, timeout=30, reset=True)
+    result = await manager.execute(language="py", code="'secret' in globals()", agent=agent, timeout=30)
+    assert result.result_bundle["application/json"] is False
+
+
+async def test_top_level_await(manager):
+    agent = FakeAgent()
+    result = await manager.execute(
+        language="py",
+        code="import asyncio\nawait asyncio.sleep(0.05)\n'done'",
+        agent=agent,
+        timeout=30,
+    )
+    assert result.status == "ok"
+    assert result.result_bundle["text/plain"] == "'done'"
+
+
+async def test_error_traceback(manager):
+    agent = FakeAgent()
+    result = await manager.execute(language="py", code="def f():\n    return 1 / 0\nf()", agent=agent, timeout=30)
+    assert result.status == "error"
+    assert result.error is not None
+    assert result.error.ename == "ZeroDivisionError"
+    assert any("1 / 0" in line or "1/0" in line for line in result.error.traceback)
+
+
+async def test_timeout_interrupts_and_kernel_survives(manager):
+    agent = FakeAgent()
+    result = await manager.execute(language="py", code="import time\ntime.sleep(60)", agent=agent, timeout=1)
+    assert result.status == "error"
+    assert result.interrupted is True
+    assert any("timed out" in note for note in result.notes)
+    assert result.error is not None and result.error.ename == "KeyboardInterrupt"
+
+    alive = await manager.execute(language="py", code="'still alive'", agent=agent, timeout=30)
+    assert alive.status == "ok"
+    assert alive.result_bundle["text/plain"] == "'still alive'"
+
+
+async def test_display_json_and_status_lines(manager):
+    agent = FakeAgent()
+    result = await manager.execute(
+        language="py",
+        code="log('loading')\nphase('aggregate')\ndisplay({'rows': 3})",
+        agent=agent,
+        timeout=30,
+    )
+    assert result.status == "ok"
+    assert result.displays and result.displays[0]["application/json"] == {"rows": 3}
+    ops = [event["op"] for event in result.statuses]
+    assert ops[:2] == ["log", "phase"]
+
+
+async def test_bridge_tool_call_round_trip(manager):
+    agent = FakeAgent()
+    result = await manager.execute(
+        language="py",
+        code="tool.echo({'path': 'a.py', 'n': 2})",
+        agent=agent,
+        timeout=30,
+    )
+    assert result.status == "ok"
+    assert agent.calls == [("echo", {"path": "a.py", "n": 2})]
+    echoed = json.loads(result.result_bundle["text/plain"].strip("'"))
+    assert echoed == {"n": 2, "path": "a.py"}
+
+
+async def test_bridge_tool_error_raises_in_kernel(manager):
+    agent = FakeAgent()
+    result = await manager.execute(language="py", code="tool.nope({'x': 1})", agent=agent, timeout=30)
+    assert result.status == "error"
+    assert result.error is not None
+    assert result.error.ename == "RuntimeError"
+    assert "unknown tool: nope" in result.error.evalue
+
+
+async def test_parallel_bridge_calls(manager):
+    agent = FakeAgent()
+    result = await manager.execute(
+        language="py",
+        code="parallel([lambda i=i: tool.echo({'i': i}) for i in range(4)])",
+        agent=agent,
+        timeout=30,
+    )
+    assert result.status == "ok"
+    assert len(agent.calls) == 4
+    payloads = result.result_bundle["application/json"]
+    assert len(payloads) == 4
+    assert sorted(json.loads(item)["i"] for item in payloads) == [0, 1, 2, 3]
+
+
+async def test_list_tools_empty_without_tool_collection(manager):
+    agent = FakeAgent()
+    result = await manager.execute(language="py", code="list_tools()", agent=agent, timeout=30)
+    assert result.status == "ok"
+    assert result.result_bundle["application/json"] == []
+
+
+async def test_eval_via_bridge_into_busy_kernel_is_rejected(manager):
+    agent = FakeAgent()
+    result = await manager.execute(
+        language="py",
+        code="tool.eval({'language': 'py', 'code': '1'})",
+        agent=agent,
+        timeout=30,
+    )
+    assert result.status == "error"
+    assert result.error is not None
+    assert "busy" in result.error.evalue
+
+
+async def test_project_path_importable_and_cwd(manager, tmp_path):
+    (tmp_path / "myproj_mod.py").write_text("VALUE = 'from project'\n", encoding="utf-8")
+    agent = FakeAgent()
+    result = await manager.execute(
+        language="py",
+        code="import os, myproj_mod\n[os.getcwd(), myproj_mod.VALUE]",
+        agent=agent,
+        timeout=30,
+    )
+    assert result.status == "ok"
+    cwd, value = result.result_bundle["application/json"]
+    assert Path(cwd).resolve() == tmp_path.resolve()
+    assert value == "from project"
+
+
+async def test_read_write_env_helpers(manager, tmp_path):
+    agent = FakeAgent()
+    result = await manager.execute(
+        language="py",
+        code=("write('sub/out.txt', 'line1\\nline2\\nline3\\n')\nread('sub/out.txt', offset=2, limit=1)\n"),
+        agent=agent,
+        timeout=30,
+    )
+    assert result.status == "ok"
+    assert result.result_bundle["text/plain"] == "'line2\\n'"
+    assert (tmp_path / "sub" / "out.txt").read_text() == "line1\nline2\nline3\n"
+
+
+async def test_sub_agent_shares_kernel_but_does_not_own_it(tmp_path, config, isolated_cli_env):
+    thread_id = f"test-{uuid.uuid4().hex}"
+    parent = EvalKernelManager.for_thread(
+        workspace_id="test_ws", thread_id=thread_id, project_path=tmp_path, config=config
+    )
+    child = EvalKernelManager.for_thread(
+        workspace_id="test_ws", thread_id=thread_id, project_path=tmp_path, config=config
+    )
+    assert child is parent
+    agent = FakeAgent()
+    await parent.execute(language="py", code="shared = 99", agent=agent, timeout=30)
+    result = await child.execute(language="py", code="shared", agent=agent, timeout=30)
+    assert result.result_bundle["application/json"] == 99
+    await parent.shutdown()
+    assert ("test_ws", thread_id) not in EvalKernelManager._registry

--- a/tests/agent/test_agent_tools_inventory.py
+++ b/tests/agent/test_agent_tools_inventory.py
@@ -181,6 +181,7 @@ def test_investigation_agent_tools(project_path, mock_connection_manager, agent_
         "write_stdin",
         "kill_command",
         "list_sessions",
+        "eval",
         "find_files_by_pattern",
         "list_directory",
         "lsp",
@@ -369,6 +370,52 @@ def test_exec_command_exposes_optional_background_param(project_path, mock_conne
     assert params["background"].type == "boolean"
     assert params["background"].required is False
     assert params["background"].description
+
+
+def test_eval_tool_schema_carries_the_kernel_contract(project_path, mock_connection_manager, agent_config):
+    """The eval tool's docstring-derived schema teaches the model the feature."""
+    agent = CoderAgent(
+        project_path=project_path,
+        workspace_id="test_workspace",
+        thread_id=str(uuid.uuid4()),
+        connection_manager=mock_connection_manager,
+        config=agent_config,
+        agent_mode=AgentMode.CLI,
+    )
+
+    eval_tool = next(tool for tool in agent.tool_collection.get_tool_list() if tool.name == "eval")
+    description = eval_tool.description
+
+    # The contract: persistence, the prelude API, the bridge, and cell workflow.
+    assert "persistent" in description
+    assert "tool.<name>" in description
+    assert "list_tools()" in description
+    assert "pip_install" in description
+    assert "reset" in description
+    assert "parallel" in description
+
+    params = {param.name: param for param in eval_tool.parameters}
+    assert params["language"].required is True
+    assert params["code"].required is True
+    assert params["title"].required is False
+    assert params["timeout"].type == "number"
+    assert params["reset"].type == "boolean"
+
+
+def test_eval_tool_hidden_when_disabled(project_path, mock_connection_manager, agent_config):
+    """AgentConfig.eval_enabled=False removes the eval tool from the registry."""
+    agent_config.eval_enabled = False
+    agent = CoderAgent(
+        project_path=project_path,
+        workspace_id="test_workspace",
+        thread_id=str(uuid.uuid4()),
+        connection_manager=mock_connection_manager,
+        config=agent_config,
+        agent_mode=AgentMode.CLI,
+    )
+
+    tool_names = {tool.name for tool in agent.tool_collection.get_tool_list()}
+    assert "eval" not in tool_names
 
 
 def test_shared_tool_names_are_well_formed(project_path, mock_connection_manager, agent_config):

--- a/tests/agent/test_agent_tools_inventory.py
+++ b/tests/agent/test_agent_tools_inventory.py
@@ -393,6 +393,9 @@ def test_eval_tool_schema_carries_the_kernel_contract(project_path, mock_connect
     assert "pip_install" in description
     assert "reset" in description
     assert "parallel" in description
+    # The read()-vs-bridge guidance: raw bytes via read(), tool formats via tool.*.
+    assert "read()/write()" in description
+    assert "model-facing format" in description
 
     params = {param.name: param for param in eval_tool.parameters}
     assert params["language"].required is True

--- a/tests/agent/tool_backend/test_eval_tool.py
+++ b/tests/agent/tool_backend/test_eval_tool.py
@@ -1,0 +1,195 @@
+"""Tests for the model-facing eval tool backend (formatting, gating, wiring)."""
+
+import sys
+import uuid
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from kolega_code.agent.eval.kernel import EvalCellResult, KernelErrorInfo
+from kolega_code.agent.tool_backend.eval_tool import EvalTool, clamp_cell_timeout
+from kolega_code.llm.models import ImageBlock, TextBlock, ToolResult
+from kolega_code.permissions import PermissionKind, allow_rule_options, permission_request_for_tool
+from kolega_code.tools import ToolError
+
+PNG_1PX = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+
+pytestmark = pytest.mark.asyncio
+
+
+def make_tool(tmp_path, *, supports_vision=False, sub_agent=False, config=None):
+    caller = Mock()
+    caller.sub_agent = sub_agent
+    caller.supports_vision = supports_vision
+
+    async def execute_single_tool(tool_call):
+        return ToolResult(
+            tool_use_id=tool_call.id,
+            content=f"called {tool_call.name}",
+            name=tool_call.name,
+            is_error=False,
+        )
+
+    caller.execute_single_tool = execute_single_tool
+    if config is None:
+        config = Mock()
+        config.eval_python_path = sys.executable
+        config.eval_python_version = None
+        config.eval_env_path = None
+        config.eval_kernel_packages = None
+        config.eval_js_runtime = None
+    tool = EvalTool(tmp_path, "test_ws", f"eval-tool-{uuid.uuid4().hex}", AsyncMock(), config, caller)
+    return tool
+
+
+# -- timeout clamping ---------------------------------------------------------
+
+
+def test_clamp_timeout_defaults_and_bounds():
+    assert clamp_cell_timeout(None) == 120.0
+    assert clamp_cell_timeout(0) is None
+    assert clamp_cell_timeout(30) == 30.0
+    assert clamp_cell_timeout(99999) == 600.0
+    assert clamp_cell_timeout(0.1) == 1.0
+    assert clamp_cell_timeout("not-a-number") == 120.0
+
+
+# -- formatting ---------------------------------------------------------------
+
+
+def _format(tool, result, title=None):
+    return tool._format(result, title=title)
+
+
+async def test_format_stdout_result_and_title(tmp_path):
+    tool = make_tool(tmp_path)
+    result = EvalCellResult(stdout="hello\n", result_bundle={"text/plain": "42", "application/json": 42})
+    text = _format(tool, result, title="load data")
+    assert isinstance(text, str)
+    assert text.startswith("## load data")
+    assert "### stdout\nhello" in text
+    assert "### result\n42" in text
+
+
+async def test_format_error_with_traceback(tmp_path):
+    tool = make_tool(tmp_path)
+    result = EvalCellResult(
+        status="error",
+        error=KernelErrorInfo(ename="ValueError", evalue="bad", traceback=["Traceback...\n", "ValueError: bad\n"]),
+    )
+    text = _format(tool, result)
+    assert "### error" in text
+    assert "ValueError: bad" in text
+
+
+async def test_format_notes_and_status_lines(tmp_path):
+    tool = make_tool(tmp_path)
+    result = EvalCellResult(
+        notes=["Provisioned env (one-time setup)."],
+        statuses=[{"op": "log", "message": "loading"}, {"op": "phase", "title": "aggregate"}],
+        stdout="x\n",
+    )
+    text = _format(tool, result)
+    assert "> Provisioned env (one-time setup)." in text
+    assert "- log: loading" in text
+    assert "- phase: aggregate" in text
+
+
+async def test_format_truncates_long_stdout(tmp_path):
+    tool = make_tool(tmp_path)
+    result = EvalCellResult(stdout="y" * 30_000)
+    text = _format(tool, result)
+    assert "truncated" in text
+    assert "y" * 30_000 not in text
+
+
+async def test_format_display_json_chunk(tmp_path):
+    tool = make_tool(tmp_path)
+    result = EvalCellResult(displays=[{"application/json": {"a": 1}, "text/plain": "{'a': 1}"}])
+    text = _format(tool, result)
+    assert "display[1]:" in text
+    assert "'a': 1" in text
+
+
+async def test_format_images_hidden_without_vision(tmp_path):
+    tool = make_tool(tmp_path, supports_vision=False)
+    result = EvalCellResult(displays=[{"image/png": PNG_1PX, "text/plain": "<Figure>"}])
+    text = _format(tool, result)
+    assert isinstance(text, str)
+    assert "not shown: model has no vision support" in text
+
+
+async def test_format_images_returned_with_vision(tmp_path):
+    tool = make_tool(tmp_path, supports_vision=True)
+    result = EvalCellResult(stdout="plot done\n", displays=[{"image/png": PNG_1PX, "text/plain": "<Figure>"}])
+    blocks = _format(tool, result)
+    assert isinstance(blocks, list)
+    assert isinstance(blocks[0], TextBlock)
+    images = [block for block in blocks if isinstance(block, ImageBlock)]
+    assert len(images) == 1
+    assert images[0].media_type == "image/png"
+    assert images[0].data == PNG_1PX
+
+
+# -- validation + end-to-end ---------------------------------------------------
+
+
+async def test_rejects_unknown_language(tmp_path):
+    tool = make_tool(tmp_path)
+    with pytest.raises(ToolError, match="unsupported eval language"):
+        await tool.eval("ruby", "puts 1")
+
+
+async def test_rejects_empty_code(tmp_path):
+    tool = make_tool(tmp_path)
+    with pytest.raises(ToolError, match="non-empty code"):
+        await tool.eval("py", "   ")
+
+
+async def test_end_to_end_cell(tmp_path, isolated_cli_env):
+    tool = make_tool(tmp_path)
+    try:
+        text = await tool.eval("py", "total = 6 * 7\ntotal", title="compute")
+        assert "### result\n42" in text
+        assert "custom interpreter" in text  # eval_python_path override note
+        text = await tool.eval("py", "total + 1")
+        assert "### result\n43" in text
+    finally:
+        await tool.shutdown_if_owner()
+
+
+async def test_end_to_end_bridge_call_reaches_caller(tmp_path, isolated_cli_env):
+    tool = make_tool(tmp_path)
+    try:
+        text = await tool.eval("py", "tool.read_file_section({'path': 'x.py', 'start_line': 1, 'end_line': 2})")
+        assert "called read_file_section" in text
+    finally:
+        await tool.shutdown_if_owner()
+
+
+async def test_shutdown_skipped_for_sub_agents(tmp_path, isolated_cli_env):
+    tool = make_tool(tmp_path, sub_agent=True)
+    await tool.eval("py", "1 + 1")
+    manager = tool._manager
+    assert manager is not None and not manager._shutdown
+    await tool.shutdown_if_owner()
+    assert not manager._shutdown  # sub-agents must not kill shared kernels
+    await manager.shutdown()
+
+
+# -- permissions ---------------------------------------------------------------
+
+
+def test_permission_request_shapes_eval_command():
+    request = permission_request_for_tool("eval", {"language": "py", "code": "print(1)"})
+    assert request is not None
+    assert request.kind == PermissionKind.COMMAND
+    assert request.command == "[py] print(1)"
+
+
+def test_permission_rule_options_include_language_wide_allow():
+    request = permission_request_for_tool("eval", {"language": "js", "code": "console.log(1)"})
+    assert request is not None
+    options = allow_rule_options(request)
+    executable = [option for option in options if option.rule.match_type == "executable"]
+    assert executable and executable[0].rule.pattern == "[js]"

--- a/tests/cli/test_settings.py
+++ b/tests/cli/test_settings.py
@@ -57,6 +57,20 @@ def test_settings_store_missing_file_returns_empty_settings(tmp_path: Path) -> N
     assert settings.permission_mode == "ask"
     assert settings.api_keys == {}
     assert settings.agent_models == {}
+    assert settings.eval_enabled is None
+
+
+def test_settings_store_round_trips_eval_enabled(tmp_path: Path) -> None:
+    store = SettingsStore(tmp_path)
+    store.save(CliSettings(eval_enabled=False))
+
+    loaded = store.load()
+    assert loaded.eval_enabled is False
+    assert loaded.to_dict()["eval_enabled"] is False
+
+    # Absent in older files -> None -> the eval tool stays enabled downstream.
+    store.save(CliSettings())
+    assert SettingsStore(tmp_path).load().eval_enabled is None
 
 
 def test_settings_store_round_trips_agent_models(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Ports oh-my-pi's headline execution feature: a single **`eval` tool** that runs code cells in **persistent Python and JavaScript kernels**, where either kernel can **call back into the agent's own tools** (`read_file_section`, `search_codebase`, `dispatch_*_agent`, …) over an authenticated HTTP **loopback bridge**. State survives across cells, tool calls, and sub-agents within a session.

The Python kernel runs in a **dedicated, kolega-code-managed environment** — not the project venv, not the host interpreter — so a curated bundle (numpy/pandas/matplotlib/pillow) is always available and agent-driven `pip_install` can never break the CLI's pinned dependency closure.

## Design

- `kolega_code/agent/eval/`: NDJSON protocol, `BaseKernel` + thread-shared `EvalKernelManager` (sub-agents join the same session manager; owner-only shutdown), asyncio `ToolBridge` (127.0.0.1 + bearer token, run-scoped registrations, in-flight cancellation on interrupt), and `EvalEnvironmentManager` (uv-provisioned CPython 3.12 + pinned bundle, manifest-driven self-healing reprovision, graceful host-interpreter degradation offline).
- **Python kernel**: subprocess on the managed env; top-level `await` on a persistent loop; REPL echo via AST transform; `display()` MIME bundles (matplotlib figures → images for vision models); SIGINT → `KeyboardInterrupt` with SIGKILL escalation.
- **JS kernel**: Bun/Node subprocess with a persistent `vm` context (top-level `let/const` survive, verified on Node 22 + Bun 1.2); async-IIFE fallback for top-level await; blocking `readSync` stdin reader for Bun's pipe semantics.
- **Preludes**: `tool.<name>(args)`, `list_tools()`, `parallel()`, `pip_install`/`npm_install`, `read`/`write`/`env`, `display`, `log`/`phase`. Bridge calls re-enter `execute_single_tool`, so permission prompts, hooks, and TUI visibility are identical to model-issued calls.
- **Permissions**: `eval` gated like `exec_command` (`command_tools` group; ASK mode), with `[py]`/`[js]` language-wide allow-rules reusing command-prefix matching. `eval_enabled` settings flag + additive `AgentConfig` knobs.
- The `eval` docstring is the model-facing contract: persistence rules, prelude cheat-sheet, `read()` (raw bytes) vs `tool.*` (model-facing formats) guidance.

## Install/update impact

No new package dependencies (stdlib + already-pinned `filelock`); wheel and sdist both verified to carry the new package data. `kolega-code update` replaces the CLI venv while `eval-env/`, runner scripts, and settings live outside it; bundle/Python-version changes auto-reprovision via the manifest.

## Testing

- 66 new tests: protocol codec, env provisioning (mocked + real-venv slow test), bridge HTTP/dispatch/cancellation, both kernels end-to-end (persistence, TLA, bridge round-trips, interrupt survival, reset), tool formatting/vision gating, permissions, settings, inventory.
- Full fast suite green (2,809 passed; 2 pre-existing live-provider failures also fail on `main`). `ruff`, `pyright`, `pre-commit run --all-files` all pass.
- Live dogfood: ran a 12-stage acceptance gauntlet through the tool itself (managed-env provisioning, pandas CSV aggregation via bridge, matplotlib `display()`, `parallel()` fan-out, JS TLA + `setGlobal`, error recovery, reset isolation, sub-agent kernel sharing) — all pass; two small findings fixed in follow-up commits on this branch.

🤖 Generated with [Kolega Code](https://github.com/kolega-ai/kolega-code)