### PR TITLE
feat(agent): keep worktrees project-local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ __pycache__/
 .env
 .env.*
 !.env.example
-.kolega/
 dist/
 build/
 *.egg-info/

--- a/docs/src/content/docs/tui/scratchpad.md
+++ b/docs/src/content/docs/tui/scratchpad.md
@@ -38,6 +38,8 @@ schedule (for example on reboot). The agent is instructed accordingly:
 
 - deliverables and anything you must keep belong in the working directory,
   never in the scratchpad;
+- Git worktrees are persistent developer-visible state, not scratchpad
+  content;
 - sub-agents share the session's scratchpad and use unique filenames to avoid
   collisions;
 - the agent must not delete scratchpad files it did not create.
@@ -47,6 +49,29 @@ agent may create files without asking. If the optional shell-command safety
 checker is enabled, commands that read, write, or delete files inside the
 scratchpad directory are treated as in-scope; other out-of-project paths are
 still flagged.
+
+## Git worktrees
+
+When an agent needs an auxiliary Git worktree, it creates it inside the
+project instead:
+
+```text
+<project>/.kolega/worktrees/<safe-unique-slug>/
+```
+
+Kolega Code automatically adds `/.kolega/worktrees/` to the clone's shared
+Git `info/exclude` file. This is local Git metadata, so the nested worktrees
+stay out of `git status` without adding or modifying a tracked `.gitignore`.
+Linked worktrees share the same Git common directory and therefore the same
+exclude rule.
+
+Only the `worktrees` subtree is excluded. Other `.kolega` content—such as
+project agents, prompts, hooks, and LSP settings—remains trackable. Each clone
+establishes its own exclude rule when a local top-level agent starts.
+
+The convention applies to newly created worktrees. Kolega Code does not move
+or delete existing worktrees, including worktrees previously created under a
+session scratchpad.
 
 ## Relation to other state
 

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -298,6 +298,14 @@ class BaseAgent(LogMixin):
             self.context.services.memory_manager = self.memory_manager
             self._owns_memory_manager = True
 
+        # Agent-created Git worktrees live under .kolega/worktrees. Keep that
+        # runtime-only subtree out of Git status through the clone-local shared
+        # info/exclude file; linked worktrees inherit the same rule.
+        if not sub_agent and isinstance(self.filesystem, LocalFileSystem):
+            from kolega_code.worktrees import ensure_worktree_dir_ignored
+
+            ensure_worktree_dir_ignored(self.project_path)
+
         # Session scratchpad: a per-session throwaway working directory under the
         # OS temp dir. The TUI injects the prompt extension itself (keyed by its
         # session id); other local hosts get it here, keyed by thread id.

--- a/kolega_code/agent/prompt_templates/extensions/cli/scratchpad.md.j2
+++ b/kolega_code/agent/prompt_templates/extensions/cli/scratchpad.md.j2
@@ -7,5 +7,6 @@ Use it for throwaway work that must not touch the user's working tree: one-off s
 Rules:
 
 - Never place deliverables in the scratchpad. It is a per-session temp directory that the OS may delete at any time; anything the user must keep belongs in the working directory.
+- Never create a Git worktree in the scratchpad. Worktrees are persistent developer-visible state; create new ones under the project-local `.kolega/worktrees/<safe-unique-slug>` path after verifying that subtree is ignored through the shared Git `info/exclude`.
 - The directory may already contain files from earlier turns of this session or from sub-agents that share it. Do not delete files you did not create.
 - Create uniquely named files; other agents may use the directory concurrently.

--- a/kolega_code/agent/prompt_templates/system/agents/coder_cli.md.j2
+++ b/kolega_code/agent/prompt_templates/system/agents/coder_cli.md.j2
@@ -51,6 +51,10 @@ When running tests or builds, choose the smallest command that gives confidence 
 
 When creating a branch or opening a pull request, follow repository or user conventions if provided; otherwise use Conventional Commits-style names. Use lowercase kebab-case branch names with a conventional type prefix, such as `feat/add-login-rate-limit` or `fix/navbar-overlap`. Use Conventional Commit PR titles, such as `feat(auth): add session timeout` or `fix: handle empty search results`. Keep names descriptive but not overly long.
 
+When creating an auxiliary Git worktree, place it at `{{ context.project_path }}/.kolega/worktrees/<slug>`, never in the OS temp directory or session scratchpad. Derive a descriptive filesystem-safe slug from the branch or purpose by replacing path separators, whitespace, and unsafe characters with hyphens; use `worktree` if nothing remains. Before creating it, inspect both the filesystem and `git worktree list`; if the name collides, add a suffix instead of overwriting, deleting, or silently reusing an existing worktree.
+
+Kolega Code normally excludes `.kolega/worktrees/` through the repository's shared Git `info/exclude`. Verify the path is ignored before running `git worktree add`. If automatic setup was ineffective, add only `/.kolega/worktrees/` to the shared `info/exclude`. Never ignore all of `.kolega/` or modify tracked ignore/config files solely for runtime worktree storage because other `.kolega` project configuration must remain trackable. Do not move or remove any existing worktree, including one under a session scratchpad, unless the user explicitly requests it.
+
 ## Development Servers
 
 When starting a local development server, use an available port and tell the user the URL. If a server is already running on the default port, use another suitable port. Stop servers you started when they are no longer needed unless the user is actively testing them.

--- a/kolega_code/memory/identity.py
+++ b/kolega_code/memory/identity.py
@@ -29,7 +29,7 @@ class ProjectIdentity:
 
 def resolve_project_identity(project_path: Path | str) -> ProjectIdentity:
     project = Path(project_path).expanduser().resolve()
-    common_dir = _git_common_dir(project)
+    common_dir = resolve_git_common_dir(project)
     if common_dir is not None:
         canonical = common_dir.resolve()
         return ProjectIdentity("git-common-dir", f"git:{canonical}", str(project))
@@ -66,7 +66,13 @@ def resolve_git_worktree_root(path: Path | str) -> Path | None:
     return None
 
 
-def _git_common_dir(project: Path) -> Path | None:
+def resolve_git_common_dir(path: Path | str) -> Path | None:
+    """Return the containing repository's shared Git directory, if any.
+
+    Linked worktrees resolve to the same common directory as their primary
+    checkout. The returned path is absolute but is not required to exist.
+    """
+    project = Path(path).expanduser().resolve()
     commands = (
         ["git", "-C", str(project), "rev-parse", "--path-format=absolute", "--git-common-dir"],
         ["git", "-C", str(project), "rev-parse", "--git-common-dir"],

--- a/kolega_code/worktrees.py
+++ b/kolega_code/worktrees.py
@@ -1,0 +1,63 @@
+"""Project-local paths and clone-local Git exclusion for agent worktrees."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from filelock import FileLock, Timeout
+
+from kolega_code.memory.identity import resolve_git_common_dir
+
+WORKTREE_RELATIVE_DIR = Path(".kolega") / "worktrees"
+WORKTREE_EXCLUDE_RULE = "/.kolega/worktrees/"
+
+_EXCLUDE_MARKER = "# kolega-code-runtime"
+_LOCK_TIMEOUT_SECONDS = 3
+
+
+def ensure_worktree_dir_ignored(project_path: Path | str) -> bool:
+    """Best-effort ensure the managed worktree subtree is ignored by Git.
+
+    The rule is stored in the clone-local shared ``info/exclude`` file rather
+    than a tracked ``.gitignore``. Linked worktrees therefore share the rule
+    while other ``.kolega`` project configuration remains trackable.
+
+    Returns ``True`` when the rule is present or was added, and ``False`` when
+    the path is not a Git repository or setup could not be completed.
+    """
+    try:
+        common_dir = resolve_git_common_dir(project_path)
+    except (OSError, RuntimeError):
+        return False
+    if common_dir is None:
+        return False
+
+    exclude_path = common_dir / "info" / "exclude"
+    lock_path = exclude_path.with_name("exclude.kolega-code.lock")
+    try:
+        exclude_path.parent.mkdir(parents=True, exist_ok=True)
+        with FileLock(str(lock_path), timeout=_LOCK_TIMEOUT_SECONDS, mode=0o600):
+            try:
+                content = exclude_path.read_bytes()
+            except FileNotFoundError:
+                content = b""
+
+            rule = WORKTREE_EXCLUDE_RULE.encode("utf-8")
+            if rule in content.splitlines():
+                return True
+
+            marker = _EXCLUDE_MARKER.encode("utf-8")
+            addition = bytearray()
+            if content and not content.endswith((b"\n", b"\r")):
+                addition.extend(b"\n")
+            if marker not in content.splitlines():
+                addition.extend(marker)
+                addition.extend(b"\n")
+            addition.extend(rule)
+            addition.extend(b"\n")
+
+            with exclude_path.open("ab") as exclude_file:
+                exclude_file.write(addition)
+            return True
+    except (OSError, Timeout):
+        return False

--- a/tests/agent/test_prompt_provider.py
+++ b/tests/agent/test_prompt_provider.py
@@ -55,6 +55,20 @@ class TestPromptProvider:
         assert "AGENTS.md" in prompt
         assert len(prompt) > 0
 
+    def test_coder_agent_cli_mode_keeps_worktrees_project_local(self, prompt_provider, prompt_context):
+        prompt = prompt_provider.get_system_prompt(
+            agent_type=AgentType.CODER, mode=AgentMode.CLI, context=prompt_context
+        )
+
+        assert "/test/project/.kolega/worktrees/<slug>" in prompt
+        assert "never in the OS temp directory or session scratchpad" in prompt
+        assert "inspect both the filesystem and `git worktree list`" in prompt
+        assert "use `worktree` if nothing remains" in prompt
+        assert "if the name collides, add a suffix" in prompt
+        assert "add only `/.kolega/worktrees/` to the shared `info/exclude`" in prompt
+        assert "Never ignore all of `.kolega/`" in prompt
+        assert "Do not move or remove any existing worktree" in prompt
+
     @pytest.mark.parametrize(
         ("agent_type", "mode"),
         [

--- a/tests/agent/test_prompts.py
+++ b/tests/agent/test_prompts.py
@@ -59,6 +59,9 @@ def test_scratchpad_prompt_renders_path_and_rules() -> None:
     assert "throwaway" in rendered
     assert "deliverables" in rendered
     assert "uniquely named files" in rendered
+    assert ".kolega/worktrees/<safe-unique-slug>" in rendered
+    assert "Never create a Git worktree in the scratchpad" in rendered
+    assert "shared Git `info/exclude`" in rendered
     assert "{{" not in rendered
 
 

--- a/tests/agent/test_scratchpad.py
+++ b/tests/agent/test_scratchpad.py
@@ -139,6 +139,10 @@ class TestScratchpadPrompt:
         assert "did not create" in rendered
         # Sanctioned out-of-worktree location.
         assert "outside the working directory" in rendered
+        # Persistent worktrees must remain project-local, not in temp.
+        assert ".kolega/worktrees/<safe-unique-slug>" in rendered
+        assert "Never create a Git worktree in the scratchpad" in rendered
+        assert "shared Git `info/exclude`" in rendered
 
     def test_template_is_fully_rendered(self, tmp_path: Path) -> None:
         rendered = build_scratchpad_prompt(tmp_path / "scratchpad")
@@ -254,11 +258,31 @@ class TestBaseAgentFallback:
         assert agent.scratchpad_dir == expected
         assert expected.is_dir()
 
+    def test_top_level_local_agent_ensures_worktree_exclusion(
+        self, tmp_path, agent_config, mock_connection_manager, monkeypatch
+    ) -> None:
+        ensure_ignored = MagicMock(return_value=True)
+        monkeypatch.setattr("kolega_code.worktrees.ensure_worktree_dir_ignored", ensure_ignored)
+
+        self._make_agent(tmp_path, agent_config, mock_connection_manager)
+
+        ensure_ignored.assert_called_once_with(tmp_path)
+
     def test_sub_agent_gets_no_fallback(self, tmp_path, agent_config, mock_connection_manager) -> None:
         agent = self._make_agent(tmp_path, agent_config, mock_connection_manager, sub_agent=True)
 
         assert self._scratchpad_extensions(agent) == []
         assert agent.scratchpad_dir is None
+
+    def test_sub_agent_does_not_repeat_worktree_exclusion(
+        self, tmp_path, agent_config, mock_connection_manager, monkeypatch
+    ) -> None:
+        ensure_ignored = MagicMock(return_value=True)
+        monkeypatch.setattr("kolega_code.worktrees.ensure_worktree_dir_ignored", ensure_ignored)
+
+        self._make_agent(tmp_path, agent_config, mock_connection_manager, sub_agent=True)
+
+        ensure_ignored.assert_not_called()
 
     def test_non_local_filesystem_gets_no_fallback(self, tmp_path, agent_config, mock_connection_manager) -> None:
         from kolega_code.services.file_system import FileSystem
@@ -268,6 +292,19 @@ class TestBaseAgentFallback:
 
         assert self._scratchpad_extensions(agent) == []
         assert agent.scratchpad_dir is None
+
+    def test_non_local_filesystem_does_not_setup_worktree_exclusion(
+        self, tmp_path, agent_config, mock_connection_manager, monkeypatch
+    ) -> None:
+        from kolega_code.services.file_system import FileSystem
+
+        ensure_ignored = MagicMock(return_value=True)
+        monkeypatch.setattr("kolega_code.worktrees.ensure_worktree_dir_ignored", ensure_ignored)
+        sandbox_fs = MagicMock(spec=FileSystem)
+
+        self._make_agent(tmp_path, agent_config, mock_connection_manager, filesystem=sandbox_fs)
+
+        ensure_ignored.assert_not_called()
 
     def test_host_injected_extension_is_not_duplicated(self, tmp_path, agent_config, mock_connection_manager) -> None:
         from kolega_code.agent.prompt_provider import PromptExtension

--- a/tests/agent/test_worktrees.py
+++ b/tests/agent/test_worktrees.py
@@ -1,0 +1,117 @@
+"""Tests for project-local agent worktree support."""
+
+from __future__ import annotations
+
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from kolega_code.memory.identity import resolve_git_common_dir
+from kolega_code.worktrees import WORKTREE_EXCLUDE_RULE, ensure_worktree_dir_ignored
+
+
+def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _git_init(repo: Path) -> None:
+    repo.mkdir()
+    _git(repo, "init", "-q")
+
+
+def _exclude_path(repo: Path) -> Path:
+    common_dir = resolve_git_common_dir(repo)
+    assert common_dir is not None
+    return common_dir / "info" / "exclude"
+
+
+def test_setup_preserves_existing_content_and_adds_exact_rule(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _git_init(repo)
+    exclude = _exclude_path(repo)
+    exclude.write_bytes(b"*.local")
+
+    assert ensure_worktree_dir_ignored(repo) is True
+
+    content = exclude.read_text(encoding="utf-8")
+    assert content.startswith("*.local\n")
+    assert "# kolega-code-runtime\n" in content
+    assert content.endswith(f"{WORKTREE_EXCLUDE_RULE}\n")
+    assert content.splitlines().count(WORKTREE_EXCLUDE_RULE) == 1
+
+
+def test_repeated_and_concurrent_setup_is_idempotent(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _git_init(repo)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(lambda _: ensure_worktree_dir_ignored(repo), range(16)))
+
+    assert all(results)
+    lines = _exclude_path(repo).read_text(encoding="utf-8").splitlines()
+    assert lines.count("# kolega-code-runtime") == 1
+    assert lines.count(WORKTREE_EXCLUDE_RULE) == 1
+    assert ensure_worktree_dir_ignored(repo) is True
+    assert _exclude_path(repo).read_text(encoding="utf-8").splitlines().count(WORKTREE_EXCLUDE_RULE) == 1
+
+
+def test_only_managed_worktree_subtree_is_ignored(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _git_init(repo)
+
+    assert ensure_worktree_dir_ignored(repo) is True
+
+    ignored = _git(repo, "check-ignore", "--no-index", "-q", ".kolega/worktrees/probe/file", check=False)
+    trackable = _git(repo, "check-ignore", "--no-index", "-q", ".kolega/lsp.json", check=False)
+    assert ignored.returncode == 0
+    assert trackable.returncode == 1
+
+
+def test_linked_worktree_updates_shared_common_exclude(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    linked = tmp_path / "linked"
+    _git_init(repo)
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test User")
+    (repo / "tracked.txt").write_text("tracked\n", encoding="utf-8")
+    _git(repo, "add", "tracked.txt")
+    _git(repo, "commit", "-qm", "initial")
+    _git(repo, "worktree", "add", "-qb", "test-linked", str(linked))
+
+    assert resolve_git_common_dir(linked) == resolve_git_common_dir(repo)
+    assert ensure_worktree_dir_ignored(linked) is True
+    assert WORKTREE_EXCLUDE_RULE in _exclude_path(repo).read_text(encoding="utf-8").splitlines()
+    assert _git(linked, "check-ignore", "--no-index", "-q", ".kolega/worktrees/probe", check=False).returncode == 0
+
+
+def test_non_git_path_is_unchanged(tmp_path: Path) -> None:
+    assert ensure_worktree_dir_ignored(tmp_path) is False
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_git_common_directory_resolution_failure_is_non_fatal(tmp_path: Path, monkeypatch) -> None:
+    def fail_resolution(path: Path | str) -> Path | None:
+        del path
+        raise OSError("git metadata unavailable")
+
+    monkeypatch.setattr("kolega_code.worktrees.resolve_git_common_dir", fail_resolution)
+
+    assert ensure_worktree_dir_ignored(tmp_path) is False
+
+
+def test_git_metadata_write_failure_is_non_fatal(tmp_path: Path, monkeypatch) -> None:
+    not_a_directory = tmp_path / "common"
+    not_a_directory.write_text("blocked", encoding="utf-8")
+
+    def resolve_to_file(path: Path | str) -> Path:
+        del path
+        return not_a_directory
+
+    monkeypatch.setattr("kolega_code.worktrees.resolve_git_common_dir", resolve_to_file)
+
+    assert ensure_worktree_dir_ignored(tmp_path) is False


### PR DESCRIPTION
## Summary

- place agent-created Git worktrees under `<project>/.kolega/worktrees/<safe-unique-slug>` instead of temporary scratchpads
- add the exact rooted `/.kolega/worktrees/` rule to the clone's shared Git `info/exclude` for top-level local agents, with locked idempotent and best-effort setup
- keep all other `.kolega` content trackable and update agent guidance and scratchpad documentation
- cover linked worktrees, concurrent setup, file preservation, failure handling, and startup/prompt wiring

## Testing

- `./run_tests.sh tests/agent/test_worktrees.py tests/agent/test_scratchpad.py tests/agent/test_prompts.py tests/agent/test_prompt_provider.py -ra` (82 passed)
- `PYTHONDONTWRITEBYTECODE=1 uv run pre-commit run --all-files --show-diff-on-failure`
- manual isolated-repository checks with `git check-ignore -v` and nested `git worktree add`
- fast suite: 2,823 passed and 1 skipped; the only failure was the configured Ollama Cloud live smoke test returning HTTP 403 for a past-due subscription
