### PR TITLE
chore(deps): disable eval version update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
       day: monday
       time: "09:00"
       timezone: Europe/London
-    versioning-strategy: increase
-    groups:
-      eval-runtime:
-        patterns:
-          - "*"
+    # Eval pins mirror shared project dependencies and must be updated together.
+    # This disables version-update PRs without affecting security-update PRs.
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## Summary

- disable scheduled Dependabot version-update PRs for the standalone eval bundle
- remove the catch-all update group that independently upgraded pins coupled to `pyproject.toml`
- preserve Dependabot security-update PRs, which GitHub documents as unaffected by `open-pull-requests-limit`

This prevents grouped updates like #327, which attempted incompatible Matplotlib, NumPy, and pandas upgrades and failed the repository's `exclude-newer` audit. Security updates remain enabled; Pillow is already patched at 12.3.0 on `main` via #326.

## Testing

- parsed `.github/dependabot.yml` with PyYAML and asserted `open-pull-requests-limit: 0`
- `PYTHONDONTWRITEBYTECODE=1 uv run pre-commit run --all-files --show-diff-on-failure`
