### PR TITLE
chore: release v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.24.0 - 2026-07-24
+
+### Added
+
+- Added persistent Python and JavaScript eval kernels whose state survives
+  between calls, with a loopback bridge for invoking agent tools from eval code.
+- Added managed background shell sessions for development servers and other
+  long-running processes.
+- Added a private per-session scratchpad for temporary agent files.
+
+### Changed
+
+- Kept agent-created Git worktrees in the project's `.kolega/worktrees/`
+  directory instead of using temporary system paths.
+
+### Fixed
+
+- Enabled mouse text selection and copying in the sidebar Terminal and Logs tabs.
+- Announced eval environment provisioning only when provisioning actually starts.
+- Corrected shell guidance for background processes so it no longer recommends
+  unsupported ways to outlive the agent session.
+
+### Security
+
+- Updated and constrained eval bundle dependencies to resolve known
+  vulnerabilities.
+
 ## 0.23.0 - 2026-07-23
 
 ### Added

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.23.0"
+__version__ = "0.24.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -48,4 +48,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.23.0"
+__version__ = "0.24.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.23.0"
+version = "0.24.0"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-16T10:08:36.781818Z"
+exclude-newer = "2026-07-17T15:09:27.213542Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1497,7 +1497,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.23.0"
+version = "0.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- bump package versions to 0.24.0
- update the lockfile cutoff and package metadata
- document user-visible changes since v0.23.0

## Validation

- `CI=1 PYTHONDONTWRITEBYTECODE=1 UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" ./run_tests.sh` (2798 passed, 29 skipped)
- `PYTHONDONTWRITEBYTECODE=1 UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" uv run pre-commit run --all-files --show-diff-on-failure`