### PR TITLE
fix(llm): upgrade Google and OpenAI SDK compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Skip coverage-badge-only change

--- a/kolega_code/llm/models.py
+++ b/kolega_code/llm/models.py
@@ -1783,7 +1783,7 @@ class MessageHistory(list):
                 processed_messages.append(message.to_google())
             else:
                 tool_response_message = genai_types.Content(
-                    role="tool", parts=[item.to_google() for item in message.content]
+                    role="user", parts=[item.to_google() for item in message.content]
                 )
 
                 processed_messages.append(tool_response_message)

--- a/kolega_code/llm/models.py
+++ b/kolega_code/llm/models.py
@@ -7,6 +7,7 @@ import base64
 import importlib
 import json
 import logging
+from functools import cache
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union, cast
 
 from kolega_code.utils.images import ascii_thumbnail_from_base64
@@ -48,6 +49,28 @@ CONTENT_BLOCK_CLASSES = {}
 logger = logging.getLogger(__name__)
 
 ToolInputKind = Literal["json", "freeform"]
+
+
+@cache
+def _google_function_declaration_type() -> type[Any]:
+    """Return the declaration adapter used at google-genai's wire boundary.
+
+    google-genai 2.12.1 normalizes tools while retaining their declaration
+    instances, then serializes each declaration with ``model_dump()`` without
+    ``by_alias=True``. For nested ``Schema`` models that emits Python field
+    names such as ``additional_properties`` instead of REST field aliases.
+
+    Define the subclass lazily to preserve this module's optional Google import.
+    This adapter can be removed only after a future SDK serializes nested
+    declarations by alias and the mldev regression test passes without it.
+    """
+
+    class _AliasFunctionDeclaration(genai_types.FunctionDeclaration):
+        def model_dump(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+            kwargs["by_alias"] = True
+            return super().model_dump(*args, **kwargs)
+
+    return _AliasFunctionDeclaration
 
 
 def _remove_trailing_commas(payload: str) -> str:
@@ -643,7 +666,7 @@ class ToolDefinition(ContentBlock):
                     required.append(parameter.name)
             parameters = genai_types.Schema(type=cast(Any, "OBJECT"), properties=properties, required=required)
 
-        function_declaration = genai_types.FunctionDeclaration(
+        function_declaration = _google_function_declaration_type()(
             name=self.name,
             description=self.description,
             parameters=parameters,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development",
     "Topic :: Utilities",
 ]
@@ -32,7 +34,7 @@ dependencies = [
     "firecrawl-py==4.28.2",
     # Project memory needs a persistent Unix lock file; unlink-on-release can split cooperating waiters.
     "filelock==3.20.3",
-    "google-genai==2.0.1",
+    "google-genai==2.12.1",
     "httpx==0.28.1",
     "jinja2==3.1.6",
     "langfuse==3.14.5",
@@ -41,7 +43,9 @@ dependencies = [
     "markitdown[docx,pdf,pptx,xls,xlsx]==0.1.6",
     "mcp==1.28.1",
     "nest-asyncio==1.6.0",
-    "openai==1.109.1",
+    # Magika's cross-platform resolution selects onnxruntime 1.20.1, which has no CPython 3.14 wheels.
+    "onnxruntime==1.27.0; python_version >= '3.14' and sys_platform != 'win32'",
+    "openai==2.46.0",
     "packaging==25.0",
     "pathspec==1.1.1",
     "pillow==12.3.0",

--- a/tests/agent/llm/test_freeform_tools.py
+++ b/tests/agent/llm/test_freeform_tools.py
@@ -219,7 +219,13 @@ def test_same_provider_fallback_history_remains_replayable(provider: str) -> Non
         assert payload[0]["content"][0]["input"] == {"input": "RAW"}
     elif provider == "google":
         payload = history.to_google()
+        assert [message.role for message in payload] == ["model", "user"]
         assert payload[0].parts[0].function_call.args == {"input": "RAW"}
+        function_response = payload[1].parts[0].function_response
+        assert function_response is not None
+        assert function_response.id == "call-1"
+        assert function_response.name == "apply_patch"
+        assert function_response.response == {"output": "Success"}
     else:
         payload = history.to_openai(provider=provider, model="model")
         assert payload[0]["tool_calls"][0]["function"]["arguments"] == '{"input": "RAW"}'

--- a/tests/agent/llm/test_google_provider.py
+++ b/tests/agent/llm/test_google_provider.py
@@ -3,8 +3,9 @@ from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
+from google.genai import types as genai_types
 
-from kolega_code.llm.models import Message, MessageHistory, TextBlock
+from kolega_code.llm.models import Message, MessageHistory, TextBlock, ToolDefinition, ToolParameter
 from kolega_code.llm.providers.google import GoogleProvider, GoogleStreamWrapper
 from kolega_code.llm.providers.models import GenerationParams
 
@@ -54,6 +55,13 @@ async def test_google_request_config_respects_model_temperature_support(
     params = GenerationParams(
         temperature=0.7,
         max_completion_tokens=1024,
+        tools=[
+            ToolDefinition(
+                name="lookup",
+                description="Look something up.",
+                parameters=[ToolParameter(name="query", type="string", description="Search query.", required=True)],
+            )
+        ],
         thinking=thinking,
     )
 
@@ -67,6 +75,13 @@ async def test_google_request_config_respects_model_temperature_support(
     else:
         assert serialized["temperature"] == expected_temperature
     assert serialized["thinking_config"]["thinking_level"].lower() == thinking
+    assert config.tools is not None
+    assert config.tools[0].function_declarations is not None
+    declaration = config.tools[0].function_declarations[0]
+    assert type(declaration) is not genai_types.FunctionDeclaration
+    assert isinstance(declaration.parameters, genai_types.Schema)
+    assert declaration.parameters.properties is not None
+    assert set(declaration.parameters.properties) == {"query"}
 
     if method == "generate":
         assert result is fake_models.response

--- a/tests/agent/llm/test_google_provider.py
+++ b/tests/agent/llm/test_google_provider.py
@@ -1,11 +1,21 @@
+import base64
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
+from google import genai
 from google.genai import types as genai_types
 
-from kolega_code.llm.models import Message, MessageHistory, TextBlock, ToolDefinition, ToolParameter
+from kolega_code.llm.models import (
+    Message,
+    MessageHistory,
+    TextBlock,
+    ToolCall,
+    ToolDefinition,
+    ToolParameter,
+    ToolResult,
+)
 from kolega_code.llm.providers.google import GoogleProvider, GoogleStreamWrapper
 from kolega_code.llm.providers.models import GenerationParams
 
@@ -88,3 +98,76 @@ async def test_google_request_config_respects_model_temperature_support(
     else:
         assert isinstance(result, GoogleStreamWrapper)
         assert result.gemini_stream is fake_models.stream
+
+
+@pytest.mark.asyncio
+async def test_google_mldev_serializes_function_response_as_user_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exercise the real 2.12.1 ML Dev request path for a complete tool-use round trip."""
+
+    thought_signature = b"\x01\x02gemini-signature"
+    history = MessageHistory(
+        [
+            Message(role="user", content=[TextBlock(text="Inspect the repository with gh.")]),
+            Message(
+                role="assistant",
+                content=[
+                    ToolCall(
+                        id="call-gh-1",
+                        name="gh",
+                        input={"args": ["repo", "view"]},
+                        thought_signature=thought_signature,
+                    )
+                ],
+                usage_metadata={"provider": "google"},
+            ),
+            Message(
+                role="user",
+                content=[
+                    ToolResult(
+                        tool_use_id="call-gh-1",
+                        content="kolega-ai/kolega-code",
+                        name="gh",
+                        is_error=False,
+                    )
+                ],
+            ),
+        ]
+    )
+
+    client = genai.Client(api_key="test-key")
+    request = AsyncMock(return_value=genai_types.HttpResponse(headers={}, body="{}"))
+    monkeypatch.setattr(client._api_client, "async_request", request)
+
+    try:
+        await client.aio.models.generate_content(
+            model="gemini-test",
+            contents=history.to_google(),
+        )
+    finally:
+        await client.aio.aclose()
+        client.close()
+
+    request_call = request.await_args
+    assert request_call is not None
+    request_payload = cast(dict[str, Any], request_call.args[2])
+    contents = cast(list[dict[str, Any]], request_payload["contents"])
+
+    assert [content["role"] for content in contents] == ["user", "model", "user"]
+    assert all(content["role"] != "tool" for content in contents)
+
+    function_call_part = contents[1]["parts"][0]
+    assert function_call_part["functionCall"] == {
+        "id": "call-gh-1",
+        "name": "gh",
+        "args": {"args": ["repo", "view"]},
+    }
+    assert function_call_part["thoughtSignature"] == base64.b64encode(thought_signature).decode("ascii")
+
+    function_response_part = contents[2]["parts"][0]
+    assert function_response_part["functionResponse"] == {
+        "id": "call-gh-1",
+        "name": "gh",
+        "response": {"output": "kolega-ai/kolega-code"},
+    }

--- a/tests/agent/llm/test_message_conversion.py
+++ b/tests/agent/llm/test_message_conversion.py
@@ -109,6 +109,74 @@ def test_tool_call_execution_id_is_internal_and_provider_id_is_preserved():
     assert restored.execution_id == first.execution_id
 
 
+def test_google_tool_results_use_user_role_and_preserve_structured_responses():
+    source = Message(
+        role="tool",
+        content=[
+            ToolResult(
+                tool_use_id="call-success",
+                content="repository details",
+                name="gh",
+                is_error=False,
+            ),
+            ToolResult(
+                tool_use_id="call-error",
+                content="permission denied",
+                name="read_file",
+                is_error=True,
+            ),
+        ],
+    )
+
+    converted = MessageHistory([source]).to_google()
+
+    assert source.role == "tool"
+    assert [content.role for content in converted] == ["user"]
+    assert all(content.role != "tool" for content in converted)
+    assert converted[0].parts is not None
+    responses = [part.function_response for part in converted[0].parts]
+    assert all(response is not None for response in responses)
+    assert [(response.id, response.name, response.response) for response in responses if response is not None] == [
+        ("call-success", "gh", {"output": "repository details"}),
+        ("call-error", "read_file", {"error": "permission denied"}),
+    ]
+
+
+def test_google_mixed_user_content_preserves_part_order_and_function_response():
+    source = Message(
+        role="user",
+        content=[
+            TextBlock(text="Before"),
+            ToolResult(
+                tool_use_id="call-1",
+                content="Success",
+                name="apply_patch",
+                is_error=False,
+            ),
+            TextBlock(text="After"),
+        ],
+    )
+
+    converted = MessageHistory(
+        [
+            source,
+            Message(role="assistant", content=[TextBlock(text="Done")]),
+        ]
+    ).to_google()
+
+    assert [content.role for content in converted] == ["user", "model"]
+    assert converted[0].parts is not None
+    before, function_response_part, after = converted[0].parts
+    assert before.text == "Before"
+    assert function_response_part.function_response is not None
+    assert function_response_part.function_response.id == "call-1"
+    assert function_response_part.function_response.name == "apply_patch"
+    assert function_response_part.function_response.response == {"output": "Success"}
+    assert after.text == "After"
+    assert converted[1].parts is not None
+    assert converted[1].parts[0].text == "Done"
+
+
 def test_local_anthropic_token_counting_includes_tool_result_content():
     provider = AnthropicProvider(api_key="test_key", provider_name="moonshot")
     large_tool_output = "unique_token " * 20_000

--- a/tests/agent/llm/test_openai_sdk_compatibility.py
+++ b/tests/agent/llm/test_openai_sdk_compatibility.py
@@ -1,0 +1,150 @@
+"""OpenAI Responses SDK-boundary compatibility regression tests."""
+
+import json
+from typing import Any, cast
+
+import httpx
+import pytest
+from openai import AsyncOpenAI
+from openai.types.responses import ResponseTextDeltaEvent
+from pydantic import ValidationError
+
+from kolega_code.llm.models import Message, MessageHistory, TextBlock, ToolDefinition
+from kolega_code.llm.providers.models import GenerationParams
+from kolega_code.llm.providers.openai_responses import OpenAIResponsesProvider
+
+
+@pytest.mark.asyncio
+async def test_responses_sdk_lenient_event_fallback_and_tool_serialization() -> None:
+    incomplete_delta: dict[str, Any] = {
+        "type": "response.output_text.delta",
+        "delta": "useful delta",
+    }
+    # This confirms the fixture cannot take the SDK's strict model-validation path:
+    # required event metadata is deliberately absent.
+    with pytest.raises(ValidationError):
+        ResponseTextDeltaEvent.model_validate(incomplete_delta)
+
+    completed_event = {
+        "type": "response.completed",
+        "sequence_number": 2,
+        "response": {
+            "id": "resp_mock",
+            "created_at": 0,
+            "model": "gpt-5.6-terra",
+            "object": "response",
+            "output": [],
+            "parallel_tool_calls": False,
+            "tool_choice": "auto",
+            "tools": [],
+            "status": "completed",
+        },
+    }
+    sse = (f"data: {json.dumps(incomplete_delta)}\n\ndata: {json.dumps(completed_event)}\n\ndata: [DONE]\n\n").encode()
+
+    request_bodies: list[dict[str, Any]] = []
+    request_urls: list[str] = []
+
+    async def handle_request(request: httpx.Request) -> httpx.Response:
+        request_urls.append(str(request.url))
+        request_bodies.append(cast(dict[str, Any], json.loads(await request.aread())))
+        return httpx.Response(
+            status_code=200,
+            headers={"content-type": "text/event-stream"},
+            content=sse,
+        )
+
+    nested_schema = {
+        "type": "object",
+        "properties": {
+            "task": {"type": "string", "minLength": 1},
+            "model_override": {
+                "type": "object",
+                "properties": {
+                    "provider": {"type": "string", "minLength": 1},
+                    "model": {"type": "string", "minLength": 1},
+                    "thinking_effort": {
+                        "anyOf": [
+                            {"type": "string", "enum": ["low", "medium", "high"]},
+                            {"type": "null"},
+                        ]
+                    },
+                },
+                "required": ["provider", "model"],
+                "additionalProperties": False,
+            },
+        },
+        "required": ["task"],
+        "additionalProperties": False,
+    }
+    function_tool = ToolDefinition(
+        name="dispatch_subagent",
+        description="Dispatch a focused task to a sub-agent.",
+        parameters=[],
+        input_schema=nested_schema,
+    )
+    freeform_tool = ToolDefinition(
+        name="apply_patch",
+        description="Apply a patch using the native freeform edit protocol.",
+        parameters=[],
+        input_kind="freeform",
+        freeform_format={
+            "type": "grammar",
+            "syntax": "lark",
+            "definition": "start: /.+/",
+        },
+    )
+
+    provider = OpenAIResponsesProvider(api_key="sk-test", max_retries=0)
+    original_client = provider.async_client
+    await original_client.close()
+    assert original_client.is_closed()
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handle_request))
+    sdk_client = AsyncOpenAI(
+        api_key="sk-test",
+        base_url="https://openai.test/v1",
+        max_retries=0,
+        http_client=http_client,
+    )
+    provider.async_client = sdk_client
+
+    try:
+        wrapper = await provider.stream(
+            MessageHistory([Message(role="user", content=[TextBlock(text="exercise the SDK boundary")])]),
+            params=GenerationParams(tools=[function_tool, freeform_tool]),
+            model="gpt-5.6-terra",
+        )
+        async with wrapper:
+            chunks = [chunk async for chunk in wrapper]
+        final_message = await wrapper.get_final_message()
+    finally:
+        await sdk_client.close()
+
+    assert sdk_client.is_closed()
+    assert http_client.is_closed
+    # Reaching these assertions means the SDK's discriminated-union fallback did
+    # not raise AttributeError, and the incomplete event retained its useful data.
+    assert [(chunk.type, chunk.text) for chunk in chunks if chunk.type == "text"] == [("text", "useful delta")]
+    assert final_message.get_text_content() == "useful delta"
+
+    assert request_urls == ["https://openai.test/v1/responses"]
+    assert len(request_bodies) == 1
+    assert request_bodies[0]["tools"] == [
+        {
+            "type": "function",
+            "name": "dispatch_subagent",
+            "description": "Dispatch a focused task to a sub-agent.",
+            "parameters": nested_schema,
+        },
+        {
+            "type": "custom",
+            "name": "apply_patch",
+            "description": "Apply a patch using the native freeform edit protocol.",
+            "format": {
+                "type": "grammar",
+                "syntax": "lark",
+                "definition": "start: /.+/",
+            },
+        },
+    ]

--- a/tests/tools/test_definitions.py
+++ b/tests/tools/test_definitions.py
@@ -5,6 +5,12 @@ shapes the callable introspector cannot express) across all three providers.
 No network calls.
 """
 
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+from google import genai
+from google.genai import _transformers
 from google.genai import types as genai_types
 
 from kolega_code.llm.models import ToolDefinition, ToolParameter
@@ -42,6 +48,29 @@ NESTED_SCHEMA = {
     "required": ["questions"],
 }
 
+DISPATCH_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "model_override": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "provider": {"type": "string", "minLength": 1},
+                "model": {"type": "string", "minLength": 1},
+                "thinking_effort": {
+                    "anyOf": [
+                        {"type": "string", "enum": ["low", "medium", "high"]},
+                        {"type": "null"},
+                    ]
+                },
+            },
+            "required": ["provider", "model", "thinking_effort"],
+        }
+    },
+    "required": ["model_override"],
+}
+
 
 def _nested_definition() -> ToolDefinition:
     return ToolDefinition(
@@ -49,6 +78,15 @@ def _nested_definition() -> ToolDefinition:
         description="Ask the user.",
         parameters=[ToolParameter(name="questions", type="array", description="", required=True)],
         input_schema=NESTED_SCHEMA,
+    )
+
+
+def _dispatch_definition() -> ToolDefinition:
+    return ToolDefinition(
+        name="dispatch_agent",
+        description="Dispatch an agent with an optional model override.",
+        parameters=[],
+        input_schema=DISPATCH_SCHEMA,
     )
 
 
@@ -92,6 +130,81 @@ def test_explicit_schema_converted_for_google():
     assert options.items.properties is not None
     assert "label" in options.items.properties
     assert options.items.properties["label"].type == genai_types.Type.STRING
+
+
+def test_strict_nested_google_schema_keeps_in_memory_schema_models() -> None:
+    tool = _dispatch_definition().to_google()
+    assert tool.function_declarations is not None
+    params = tool.function_declarations[0].parameters
+    assert isinstance(params, genai_types.Schema)
+    assert params.additional_properties is False
+    assert params.properties is not None
+
+    model_override = params.properties["model_override"]
+    assert isinstance(model_override, genai_types.Schema)
+    assert model_override.additional_properties is False
+    assert model_override.properties is not None
+    assert set(model_override.properties) == {"provider", "model", "thinking_effort"}
+    assert model_override.properties["provider"].min_length == 1
+    assert model_override.properties["model"].min_length == 1
+
+    thinking_effort = model_override.properties["thinking_effort"]
+    assert thinking_effort.nullable is True
+    assert thinking_effort.any_of is not None
+    assert thinking_effort.any_of[0].enum == ["low", "medium", "high"]
+
+
+@pytest.mark.asyncio
+async def test_google_mldev_serializes_nested_schema_aliases_without_renaming_properties(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exercise google-genai 2.12.1's real tool normalization and mldev request path."""
+
+    tool = _dispatch_definition().to_google()
+    assert tool.function_declarations is not None
+    declaration = tool.function_declarations[0]
+    assert type(declaration) is not genai_types.FunctionDeclaration
+
+    client = genai.Client(api_key="test-key")
+    request = AsyncMock(return_value=genai_types.HttpResponse(headers={}, body="{}"))
+    monkeypatch.setattr(client._api_client, "async_request", request)
+
+    try:
+        normalized = _transformers.t_tools(client._api_client, [tool])
+        assert normalized[-1].function_declarations is not None
+        normalized_declaration = normalized[-1].function_declarations[0]
+        assert normalized_declaration is declaration
+        assert type(normalized_declaration) is type(declaration)
+
+        await client.aio.models.generate_content(
+            model="gemini-test",
+            contents="Use the dispatch tool.",
+            config=genai_types.GenerateContentConfig(tools=[tool]),
+        )
+    finally:
+        await client.aio.aclose()
+        client.close()
+
+    request_call = request.await_args
+    assert request_call is not None
+    request_payload = cast(dict[str, Any], request_call.args[2])
+    parameters = request_payload["tools"][0]["functionDeclarations"][0]["parameters"]
+    model_override = parameters["properties"]["model_override"]
+    thinking_effort = model_override["properties"]["thinking_effort"]
+
+    assert parameters["additionalProperties"] is False
+    assert model_override["additionalProperties"] is False
+    assert model_override["properties"]["provider"]["minLength"] == 1
+    assert model_override["properties"]["model"]["minLength"] == 1
+    assert thinking_effort["anyOf"][0]["enum"] == ["low", "medium", "high"]
+    assert thinking_effort["nullable"] is True
+    assert set(parameters["properties"]) == {"model_override"}
+    assert set(model_override["properties"]) == {"provider", "model", "thinking_effort"}
+
+    serialized = repr(request_payload)
+    assert "additional_properties" not in serialized
+    assert "min_length" not in serialized
+    assert "any_of" not in serialized
 
 
 def test_flat_definition_still_serializes_without_input_schema():

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-17T15:09:27.213542Z"
+exclude-newer = "2026-07-19T02:11:04.403228Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -568,7 +568,7 @@ name = "coloredlogs"
 version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "humanfriendly" },
+    { name = "humanfriendly", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
 wheels = [
@@ -1035,7 +1035,7 @@ requests = [
 
 [[package]]
 name = "google-genai"
-version = "2.0.1"
+version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1049,9 +1049,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/ae/8504f6fa44aae887909c3fda1d49c6ffe129225b68f6f63b8904c49e7e90/google_genai-2.0.1.tar.gz", hash = "sha256:32cec7c07157c0e65e4dfc740e3288ff8e8bfc2d506cde49f884d79ed8377867", size = 537456, upload-time = "2026-05-09T01:37:12.693Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/59/9ea84cbeb8f09694564d3b0ee9dd59003551b308d47b61f251415df93982/google_genai-2.12.1.tar.gz", hash = "sha256:78c25217885d63dc430ca7c4526853512b164a25a93a8a0d0af5b85971aa1db0", size = 636710, upload-time = "2026-07-16T16:15:02.035Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/20/7f427041c3660fabd4c396e80b27dd40b7d89b121ba384d69005a764910d/google_genai-2.0.1-py3-none-any.whl", hash = "sha256:5cb61ff5b8d33129bb7f5df0b5384ed2e71e5dd06ccc012cdbad28b070f6ce99", size = 791449, upload-time = "2026-05-09T01:37:10.841Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/b4/1369fb413fc2ba7f78acace5590b6e9990c52ab5d1d166aafaa1ae2c28c8/google_genai-2.12.1-py3-none-any.whl", hash = "sha256:686d5ec39bda345151d3ed1bac3915f01f49138b1ea519af2eb98f11cc55ebc4", size = 1023403, upload-time = "2026-07-16T16:14:59.79Z" },
 ]
 
 [[package]]
@@ -1514,6 +1514,7 @@ dependencies = [
     { name = "markitdown", extra = ["docx", "pdf", "pptx", "xls", "xlsx"] },
     { name = "mcp" },
     { name = "nest-asyncio" },
+    { name = "onnxruntime", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
     { name = "openai" },
     { name = "packaging" },
     { name = "pathspec" },
@@ -1556,7 +1557,7 @@ requires-dist = [
     { name = "filelock", specifier = "==3.20.3" },
     { name = "firecrawl-py", specifier = "==4.28.2" },
     { name = "genbadge", extras = ["coverage"], marker = "extra == 'dev'", specifier = "==1.1.3" },
-    { name = "google-genai", specifier = "==2.0.1" },
+    { name = "google-genai", specifier = "==2.12.1" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "langfuse", specifier = "==3.14.5" },
@@ -1565,7 +1566,8 @@ requires-dist = [
     { name = "markitdown", extras = ["docx", "pdf", "pptx", "xls", "xlsx"], specifier = "==0.1.6" },
     { name = "mcp", specifier = "==1.28.1" },
     { name = "nest-asyncio", specifier = "==1.6.0" },
-    { name = "openai", specifier = "==1.109.1" },
+    { name = "onnxruntime", marker = "python_full_version >= '3.14' and sys_platform != 'win32'", specifier = "==1.27.0" },
+    { name = "openai", specifier = "==2.46.0" },
     { name = "packaging", specifier = "==25.0" },
     { name = "pathspec", specifier = "==1.1.1" },
     { name = "pillow", specifier = "==12.3.0" },
@@ -1753,7 +1755,8 @@ dependencies = [
     { name = "click" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "onnxruntime" },
+    { name = "onnxruntime", version = "1.20.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
+    { name = "onnxruntime", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
     { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/f3/3d1dcdd7b9c41d589f5cff252d32ed91cdf86ba84391cfc81d9d8773571d/magika-0.6.3.tar.gz", hash = "sha256:7cc52aa7359af861957043e2bf7265ed4741067251c104532765cd668c0c0cb1", size = 3042784, upload-time = "2025-10-30T15:22:34.499Z" }
@@ -2297,14 +2300,23 @@ wheels = [
 name = "onnxruntime"
 version = "1.20.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
 dependencies = [
-    { name = "coloredlogs" },
-    { name = "flatbuffers" },
+    { name = "coloredlogs", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
+    { name = "flatbuffers", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "sympy" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and python_full_version < '3.14') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
+    { name = "packaging", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
+    { name = "protobuf", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
+    { name = "sympy", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/8d/2634e2959b34aa8a0037989f4229e9abcfa484e9c228f99633b3241768a6/onnxruntime-1.20.1-cp311-cp311-macosx_13_0_universal2.whl", hash = "sha256:06bfbf02ca9ab5f28946e0f912a562a5f005301d0c419283dc57b3ed7969bb7b", size = 30998725, upload-time = "2024-11-21T00:48:51.013Z" },
@@ -2326,8 +2338,40 @@ wheels = [
 ]
 
 [[package]]
+name = "onnxruntime"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "flatbuffers", marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
+    { name = "packaging", marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
+    { name = "protobuf", marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/e4/5353d7e09ced4a8f473f843223fc75d726b2b5519dcefc12f22a6c92852d/onnxruntime-1.27.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:8ba14a38c570087f3cdb8cfba33f7a38a1e826c1e5b29e17c28ceda0cc910016", size = 18416484, upload-time = "2026-06-15T22:43:43.894Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1f/a2117aa3f144fce88774efa37440d0ca72d0c9144854dfc0961f2b04c6fc/onnxruntime-1.27.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2eb083321af8a236a84c7c140a7f4cecbfa2a987a18c07c78db471c20cd390ef", size = 16419330, upload-time = "2026-06-15T22:42:37.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/cd/74bb804170ceb622fda9111df31a07b3024f7491472256d3a90b5391a4d2/onnxruntime-1.27.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e4f7b0e90d2d212e2c2deaa6c8291616183ab815d3ec558ea12d3ac8b26d36f4", size = 18636930, upload-time = "2026-06-15T22:43:01.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/dd3a524ed93a820dff1af902d0412957ab12499953333e9daa01af5bc480/onnxruntime-1.27.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:a14c2ce45312def86b77aea651f46565e45960cf5f0721bfdff449165086ab76", size = 18433506, upload-time = "2026-06-15T22:43:47.026Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/c3b6b17745a1997d784dadc9bd88d713d2e6721139a5a0e885b28cfb79b1/onnxruntime-1.27.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c6fddce0539a4898c7bef35b052ffd37935b2190e35488eab99ce91887743ea1", size = 16438140, upload-time = "2026-06-15T22:42:40.666Z" },
+    { url = "https://files.pythonhosted.org/packages/26/81/24dd9b31b0fb912ee19ca53ac1c9764bfd79d58a2ccef564eb693be831a5/onnxruntime-1.27.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c65a7438632d55dfbc8a02ee60bd6cf7dd9d1ba05a43d4b851452f32338e194", size = 18658316, upload-time = "2026-06-15T22:43:04.012Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/2b/54208fd03ad410480bc17edf4869376362da8bbf46fe186ddf4cb5cc20fe/onnxruntime-1.27.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:b3e5b58b8c89c2b20e086e890aa9527377e5c240dc3ecc1640d18e07705eeb1c", size = 18432958, upload-time = "2026-06-15T22:42:53.105Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/24fc51fcbb126da6d032372314e47b55c3faad58f2aa78c0e199ccd20b9c/onnxruntime-1.27.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48b3d87eb560ff6a772240506f3c78d6d27c63cafedd5c775672e1194f968cfd", size = 16438180, upload-time = "2026-06-15T22:42:43.093Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/19/14929c3c2fe0b79b41cce24463062bf3afa4cdd3c19dccf00319caa92bff/onnxruntime-1.27.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6872443f236a554921cda6f318c900e2d0c226792cf3534d00e5057c6926e5d2", size = 18658445, upload-time = "2026-06-15T22:43:08.053Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/7d/e6bb1c6445c94f708c38cd8fbb7bf0264108c33498b9445c93e60fe6d329/onnxruntime-1.27.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:54c0c4e9202c36c4ecdb1f3443f5dfbfd5ee3b54d1362c4b4c6134110e74fb32", size = 16443331, upload-time = "2026-06-15T22:42:45.649Z" },
+    { url = "https://files.pythonhosted.org/packages/72/1b/b18b31e806eabc41077810199fbbb36fbc2d5f19912416e5ccfbf73053d1/onnxruntime-1.27.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1b215aa662c8f983f7d6dedafe65a9be72c26e5338e0fe98b3e0422c32c85428", size = 18670967, upload-time = "2026-06-15T22:43:10.621Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/37/48ab79c39b58a7c9f6f5aac1fa0ff2b993eb2643393d6ed9e839ddb6f347/onnxruntime-1.27.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:0874edc171f470fc4dd2bbb60bc0989612ed1a8b89b365cda016630a93227f13", size = 18433941, upload-time = "2026-06-15T22:42:58.867Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/24/d535ca8a09dbf697f853377c8dc0820dbcaae5f334316b400b953afbcba8/onnxruntime-1.27.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5b51c014cf1a4fcd93c29a97eac8071fa27710dae05a4d0380bb60a66d60a62c", size = 16439970, upload-time = "2026-06-15T22:42:48.023Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/b1/ea9ee80c0bdaa4efb13f29f8c236f3740f6655e8c092a2d119515a5a652c/onnxruntime-1.27.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:445fb702ea5241ba813a3ce2febe2e9408a64f6ad2eb610924322c536165f7cd", size = 18659240, upload-time = "2026-06-15T22:43:13.165Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7b/dca330a8397e9d816c976d7aed4e24a4a2d279bb1e551e3d0221d1389b1d/onnxruntime-1.27.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c6197a02e3f620c4dc13cff51b80672409fc1ffab3aa2593911b19fd322ff48b", size = 16443274, upload-time = "2026-06-15T22:42:50.467Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f6/2bac21f722aa45d876d4a51f26bd0ef30e704068a3cd5021a5a7cd784271/onnxruntime-1.27.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:370d211e1ceeac4cd5f45301655463ac59e27cdc74d9f7aeb2d19ff4b7a76715", size = 18670781, upload-time = "2026-06-15T22:43:17.151Z" },
+]
+
+[[package]]
 name = "openai"
-version = "1.109.1"
+version = "2.46.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2339,9 +2383,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/a1/a303104dc55fc546a3f6914c842d3da471c64eec92043aef8f652eb6c524/openai-1.109.1.tar.gz", hash = "sha256:d173ed8dbca665892a6db099b4a2dfac624f94d20a93f46eb0b56aae940ed869", size = 564133, upload-time = "2025-09-24T13:00:53.075Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/ac/f725c4efbda8657d02be684607e5a2e5ce362e4790fdbcbdfb7c15018647/openai-2.46.0.tar.gz", hash = "sha256:0421e0735ac41451cad894af4cddf0435bfbf8cbc538ac0e15b3c062f2ddc06a", size = 1114628, upload-time = "2026-07-17T02:48:06.05Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/2a/7dd3d207ec669cacc1f186fd856a0f61dbc255d24f6fdc1a6715d6051b0f/openai-1.109.1-py3-none-any.whl", hash = "sha256:6bcaf57086cf59159b8e27447e4e7dd019db5d29a438072fbd49c290c7e65315", size = 948627, upload-time = "2025-09-24T13:00:50.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/7b/206238ebcb50b235942b1c66dba4974776f2057402a8d91c399be587d66a/openai-2.46.0-py3-none-any.whl", hash = "sha256:672381db55efb3a1e2610f29304c130cccdd0b319bace4d492b2443cb64c1e7c", size = 1637556, upload-time = "2026-07-17T02:48:03.695Z" },
 ]
 
 [[package]]
@@ -3750,7 +3794,7 @@ name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mpmath" },
+    { name = "mpmath", marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- upgrade `google-genai` to 2.12.1 and `openai` to 2.46.0 under the existing one-week uv cutoff
- preserve strict Gemini schemas while forcing wire aliases at the `FunctionDeclaration` serialization boundary
- serialize Gemini `functionResponse` history as API-supported `user` turns instead of unsupported `tool` turns
- add real Google mldev and OpenAI SDK/SSE regression coverage
- extend CI and package classifiers through Python 3.14
- select `onnxruntime==1.27.0` on Python 3.14 non-Windows so the existing MarkItDown/Magika dependency chain can install and run there

## Details

The Gemini adapter keeps nested `google.genai.types.Schema` instances in memory but serializes schema keywords as `additionalProperties`, `minLength`, and `anyOf`. User-defined property names such as `model_override` and `thinking_effort` remain unchanged.

Gemini function responses remain structured, including their call IDs, function names, success/error payloads, batching order, and the preceding function call's thought signature. Only the Google wire content role changes from `tool` to `user`; Kolega's internal message roles and every other provider path are unchanged. An offline regression drives `google-genai==2.12.1`'s real ML Dev request serializer through an assistant function call, thought signature, and matching user function response.

The OpenAI regression uses a real `AsyncOpenAI` Responses stream over `httpx.MockTransport`, forces the SDK's lenient discriminated-union event fallback, and verifies nested function and native freeform tool payloads.

Magika 0.6.3 caps ONNX Runtime at 1.20.1 on Windows, so Python 3.14 Windows remains outside this non-Windows compatibility fix.

## Validation

- focused Google/message conversion suite on Python 3.11: 56 passed
- Google/OpenAI regression suite on Python 3.12: 26 passed
- Google/OpenAI regression suite on Python 3.13: 26 passed
- Google/OpenAI regression suite on Python 3.14: 26 passed
- Python 3.14 MarkItDown XLSX/DOCX conversion: 2 passed
- Ruff check and format: passed
- Pyright: passed
- pre-commit: passed
- `uv audit --locked`: no known vulnerabilities or adverse project statuses
- full fast suite: 2,831 passed, 1 skipped, 1 external live-provider failure
- live Google tool-signature round trips (streaming and non-streaming): passed

The single full-suite failure was the Ollama Cloud live smoke test returning HTTP 403 because the configured subscription payment is past due; it is unrelated to this change.
