### PR TITLE
fix(cli): eliminate Textual timing races

### DIFF
--- a/kolega_code/cli/tui/onboarding_screen.py
+++ b/kolega_code/cli/tui/onboarding_screen.py
@@ -127,7 +127,8 @@ class OnboardingScreen(ModalScreen[None]):
                         classes="onboarding-hint",
                     )
                     yield Static("", id="onboarding_test_status")
-            yield Static("", id="onboarding_status")
+            startup_error = getattr(self.owner, "startup_config_error", None)
+            yield Static(str(startup_error) if startup_error else "", id="onboarding_status")
             with Horizontal(id="onboarding_actions"):
                 yield Static("esc Skip", classes="dialog-hint")
                 yield Button("Skip for now", id="onboarding_skip", classes="quiet")

--- a/kolega_code/cli/tui/widgets.py
+++ b/kolega_code/cli/tui/widgets.py
@@ -575,10 +575,12 @@ class StickyRichLog(RichLog):
 
     bottom_tolerance = 1
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         kwargs["auto_scroll"] = False
         super().__init__(*args, **kwargs)
         self.auto_follow_bottom = True
+        self._follow_bottom_pending = False
+        self._follow_bottom_callback_scheduled = False
 
     def is_at_bottom(self) -> bool:
         """Return whether the current scroll position is effectively at the end."""
@@ -586,15 +588,53 @@ class StickyRichLog(RichLog):
 
     def watch_scroll_y(self, old_value: float, new_value: float) -> None:
         super().watch_scroll_y(old_value, new_value)
-        self.auto_follow_bottom = self.is_at_bottom()
+        at_bottom = self.is_at_bottom()
+        self.auto_follow_bottom = at_bottom
+        if not at_bottom:
+            self._follow_bottom_pending = False
+
+    def _schedule_follow_bottom(self) -> None:
+        """Coalesce a guarded sticky-bottom update after the next refresh."""
+        self._follow_bottom_pending = True
+        if self._follow_bottom_callback_scheduled or not self._size_known or not self.is_attached:
+            return
+        self._follow_bottom_callback_scheduled = True
+        self.call_after_refresh(self._apply_pending_follow_bottom)
+
+    def _apply_pending_follow_bottom(self) -> None:
+        self._follow_bottom_callback_scheduled = False
+        if not self._follow_bottom_pending:
+            return
+        if not self.is_attached:
+            self._follow_bottom_pending = False
+            return
+        if not self._size_known:
+            return
+        if not self.auto_follow_bottom:
+            self._follow_bottom_pending = False
+            return
+        self._follow_bottom_pending = False
+        super().scroll_end(animate=False, immediate=True, x_axis=False)
+
+    def on_resize(self, event: events.Resize) -> None:
+        super().on_resize(event)
+        if self._follow_bottom_pending:
+            self._schedule_follow_bottom()
 
     def write_sticky(self, content: object) -> None:
         """Append content, following only if the user was at the bottom."""
         should_follow = self.auto_follow_bottom or self.is_at_bottom()
-        self.write(content, scroll_end=should_follow)
+        if should_follow:
+            self.auto_follow_bottom = True
+        else:
+            self._follow_bottom_pending = False
+        self.write(content, scroll_end=False)
+        if should_follow:
+            self._schedule_follow_bottom()
 
     def clear_output(self) -> None:
         """Clear rendered output and restore sticky-follow defaults."""
+        self._follow_bottom_pending = False
         self.clear()
         self.auto_follow_bottom = True
 

--- a/tests/cli/_app_test_utils.py
+++ b/tests/cli/_app_test_utils.py
@@ -1,6 +1,7 @@
 # ruff: noqa: F401,F811,E402
 import time
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -148,27 +149,46 @@ def build_test_config(project: Path):
     )
 
 
-async def wait_for_onboarding_screen(app, pilot):
-    """Wait until the auto-opened onboarding wizard is up AND fully composed.
+async def wait_for_onboarding_screen(app: Any, pilot: Any, *, timeout: float = 6.0) -> Any:
+    """Wait until the auto-opened onboarding wizard is initialized and laid out."""
+    from textual.css.query import NoMatches
+    from textual.widgets import Button, Static
 
-    The app pushes OnboardingScreen via call_after_refresh and the screen's
-    children mount a further message-pump cycle later, so a single
-    pilot.pause() can lose the race on slow CI runners (NoMatches on
-    #onboarding_next). Pause until the widgets exist and the screen's mount
-    hook has initialized the owner's screen reference and startup status.
-    """
     from kolega_code.cli.tui.onboarding_screen import OnboardingScreen
 
-    for _ in range(20):
+    deadline = time.monotonic() + timeout
+    last_state: dict[str, object] = {}
+    while time.monotonic() < deadline:
+        screen = app._onboarding_screen
+        last_state = {
+            "screen_type": type(screen).__name__ if screen is not None else None,
+            "active": screen is not None and app.screen is screen,
+        }
+        if isinstance(screen, OnboardingScreen) and app.screen is screen:
+            try:
+                status = screen.query_one("#onboarding_status", Static)
+                key_status = screen.query_one("#onboarding_key_status", Static)
+                next_button = screen.query_one("#onboarding_next", Button)
+            except NoMatches as exc:
+                last_state["query_error"] = repr(exc)
+            else:
+                status_text = str(status.render())
+                key_status_text = str(key_status.render())
+                startup_error = getattr(app, "startup_config_error", None)
+                startup_status_ready = not startup_error or str(startup_error) in status_text
+                credentials_ready = key_status_text.startswith("Credential status:")
+                continue_laid_out = next_button.region.width > 0 and next_button.region.height > 0
+                last_state.update(
+                    {
+                        "status": status_text,
+                        "key_status": key_status_text,
+                        "continue_region": repr(next_button.region),
+                    }
+                )
+                if credentials_ready and startup_status_ready and continue_laid_out:
+                    return screen
         await pilot.pause()
-        screen = app.screen
-        if (
-            isinstance(screen, OnboardingScreen)
-            and app._onboarding_screen is screen
-            and screen.query("#onboarding_next")
-        ):
-            return screen
-    raise AssertionError("onboarding screen did not finish mounting")
+    raise AssertionError(f"onboarding screen did not become ready within {timeout:.1f}s: {last_state!r}")
 
 
 async def open_settings_screen(app, pilot, category: str = "model"):

--- a/tests/cli/test_app_rendering_terminal_logs.py
+++ b/tests/cli/test_app_rendering_terminal_logs.py
@@ -1,4 +1,5 @@
 # ruff: noqa: F401,F811,E402
+from collections.abc import Callable
 from pathlib import Path
 import asyncio
 import json
@@ -134,33 +135,131 @@ async def test_terminal_output_preserves_scrollback_when_user_scrolls_up(
 
     async with app.run_test(size=(100, 30)) as pilot:
         app.query_one("#events", TabbedContent).active = "terminal_pane"
-        await pilot.pause()
 
         terminal = app._terminal
+        await _wait_for_layout(pilot, lambda: terminal._size_known and terminal.region.height > 0)
         terminal.write_terminal("".join(f"line {index}\n" for index in range(120)))
-        await pilot.pause()
-        terminal.scroll_end(animate=False, immediate=True)
-        await pilot.pause()
-        assert terminal.max_scroll_y > 0
+        await _wait_for_layout(
+            pilot,
+            lambda: (
+                terminal.max_scroll_y > 0
+                and terminal.is_at_bottom()
+                and not terminal._follow_bottom_pending
+                and not terminal._follow_bottom_callback_scheduled
+            ),
+        )
 
         terminal.scroll_to(y=0, animate=False, immediate=True)
-        await pilot.pause()
+        await _wait_for_layout(pilot, lambda: terminal.scroll_y == 0 and not terminal.auto_follow_bottom)
         scroll_y = terminal.scroll_y
-        assert terminal.auto_follow_bottom is False
 
         app._render_event(AgentEvent(event_type="terminal_output", sender="coder", content={"output": "new line\n"}))
         app._flush_terminal_output()
-        await pilot.pause()
+        await _wait_for_layout(
+            pilot,
+            lambda: "new line" in "\n".join(strip.text for strip in terminal.lines),
+        )
 
         assert terminal.scroll_y == scroll_y
+        assert terminal.auto_follow_bottom is False
 
         terminal.scroll_end(animate=False, immediate=True)
-        await pilot.pause()
+        await _wait_for_layout(pilot, terminal.is_at_bottom)
         app._render_event(AgentEvent(event_type="terminal_output", sender="coder", content={"output": "tail line\n"}))
         app._flush_terminal_output()
-        await pilot.pause()
+        await _wait_for_layout(
+            pilot,
+            lambda: (
+                "tail line" in "\n".join(strip.text for strip in terminal.lines)
+                and terminal.is_at_bottom()
+                and not terminal._follow_bottom_pending
+                and not terminal._follow_bottom_callback_scheduled
+            ),
+        )
 
-        assert terminal.scroll_y >= terminal.max_scroll_y - terminal.bottom_tolerance
+        assert terminal.is_at_bottom()
+
+
+@pytest.mark.asyncio
+async def test_terminal_output_written_while_hidden_follows_when_shown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.widgets import TabbedContent
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        tabs = app.query_one("#events", TabbedContent)
+        assert tabs.active == "status_pane"
+        terminal = app._terminal
+
+        terminal.write_terminal("".join(f"hidden line {index}\n" for index in range(120)))
+        assert terminal._follow_bottom_pending is True
+
+        tabs.active = "terminal_pane"
+        await _wait_for_layout(
+            pilot,
+            lambda: (
+                "hidden line 119" in "\n".join(strip.text for strip in terminal.lines)
+                and terminal.max_scroll_y > 0
+                and terminal.is_at_bottom()
+                and not terminal._follow_bottom_pending
+                and not terminal._follow_bottom_callback_scheduled
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_terminal_clear_cancels_pending_follow_and_restores_following(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.widgets import TabbedContent
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.query_one("#events", TabbedContent).active = "terminal_pane"
+        terminal = app._terminal
+        await _wait_for_layout(pilot, lambda: terminal._size_known and terminal.region.height > 0)
+
+        scheduled_follow_count = 0
+        call_after_refresh = terminal.call_after_refresh
+
+        def track_call_after_refresh(callback: Callable[..., object], *args: object) -> None:
+            nonlocal scheduled_follow_count
+            if callback == terminal._apply_pending_follow_bottom:
+                scheduled_follow_count += 1
+            call_after_refresh(callback, *args)
+
+        monkeypatch.setattr(terminal, "call_after_refresh", track_call_after_refresh)
+        terminal.write_terminal("".join(f"stale line {index}\n" for index in range(120)))
+        terminal.write_terminal("another stale line\n")
+        assert terminal._follow_bottom_pending is True
+        assert scheduled_follow_count == 1
+        terminal.clear_output()
+
+        assert terminal._follow_bottom_pending is False
+        assert terminal.auto_follow_bottom is True
+        await _wait_for_layout(pilot, lambda: not terminal._follow_bottom_callback_scheduled)
+        assert terminal.lines == []
+        assert terminal.scroll_y == 0
+
+        terminal.write_terminal("".join(f"fresh line {index}\n" for index in range(120)))
+        await _wait_for_layout(
+            pilot,
+            lambda: (
+                "fresh line 119" in "\n".join(strip.text for strip in terminal.lines)
+                and terminal.max_scroll_y > 0
+                and terminal.is_at_bottom()
+                and not terminal._follow_bottom_pending
+                and not terminal._follow_bottom_callback_scheduled
+            ),
+        )
+        assert scheduled_follow_count == 2
 
 
 @pytest.mark.asyncio
@@ -690,12 +789,21 @@ async def test_terminal_selection_offsets_follow_vertical_scroll(
     async with app.run_test(size=(100, 30)) as pilot:
         app.query_one("#events", TabbedContent).active = "terminal_pane"
         terminal = app._terminal
+        await _wait_for_layout(pilot, lambda: terminal._size_known and terminal.region.height > 0)
         terminal.write_terminal("".join(f"scroll line {index}\n" for index in range(120)))
-        await pilot.pause()
-        assert terminal.max_scroll_y > 0
+        assert terminal._follow_bottom_pending is True
 
         terminal.scroll_to(y=10, animate=False, immediate=True)
-        await _wait_for_layout(pilot, lambda: terminal.scroll_offset.y == 10)
+        await _wait_for_layout(
+            pilot,
+            lambda: (
+                terminal.max_scroll_y > 10
+                and terminal.scroll_offset.y == 10
+                and not terminal._follow_bottom_pending
+                and not terminal._follow_bottom_callback_scheduled
+            ),
+        )
+        assert terminal.auto_follow_bottom is False
 
         # Viewport line 0 renders content line 10; stamped offsets must follow the scroll.
         strip = terminal.render_line(0)

--- a/tests/cli/test_app_sub_agents_workflows.py
+++ b/tests/cli/test_app_sub_agents_workflows.py
@@ -563,10 +563,19 @@ async def test_open_sub_agent_inspector_renders_trajectory(tmp_path: Path, monke
         app._render_event(_sub_agent_event(uuid="r1", text="some response"))
 
         app.action_open_sub_agent()
-        await pilot.pause()
 
         assert isinstance(app._sub_agent_inspector, SubAgentInspectorScreen)
         screen = app._sub_agent_inspector
+        activity_key, activity = next(iter(app._sub_agent_activities.items()))
+        expected_entry_ids = {step.entry_id for step in activity.steps}
+        await _wait_for_layout(
+            pilot,
+            lambda: (
+                screen._selected_key == activity_key
+                and set(screen._step_widgets) == expected_entry_ids
+                and all(widget.is_attached for widget in screen._step_widgets.values())
+            ),
+        )
         # One roster row per agent, and a trajectory widget per captured step.
         assert len(screen._rows) == 1
         # Seeded task step + tool_call + assistant response.
@@ -616,13 +625,29 @@ async def test_sub_agent_inspector_switches_agents(tmp_path: Path, monkeypatch: 
         )
 
         app.action_open_sub_agent("a1")
-        await pilot.pause()
         screen = app._sub_agent_inspector
         assert screen is not None
+        a1 = app._sub_agent_activities["a1"]
+        await _wait_for_layout(
+            pilot,
+            lambda: (
+                screen._selected_key == "a1"
+                and set(screen._step_widgets) == {step.entry_id for step in a1.steps}
+                and all(widget.is_attached for widget in screen._step_widgets.values())
+            ),
+        )
         assert screen._selected_key == "a1"
 
         screen.action_next_agent()
-        await pilot.pause()
+        a2 = app._sub_agent_activities["a2"]
+        await _wait_for_layout(
+            pilot,
+            lambda: (
+                screen._selected_key == "a2"
+                and set(screen._step_widgets) == {step.entry_id for step in a2.steps}
+                and all(widget.is_attached for widget in screen._step_widgets.values())
+            ),
+        )
         assert screen._selected_key == "a2"
 
 


### PR DESCRIPTION
## Summary
- replace `RichLog.write(..., scroll_end=True)` with a coalesced, cancelable sticky-follow intent that survives hidden-pane sizing
- seed onboarding startup errors during composition and wait for semantic mount/layout readiness in TUI tests
- wait for exact mounted sub-agent trajectory entries and add regressions for stale follow, scrollback, hidden panes, selection offsets, coalescing, and clear behavior

No timeouts were increased, no retries were added, and no public APIs changed.

## Validation
- five consecutive fresh invocations of the three formerly flaky tests
- `PYTHONDONTWRITEBYTECODE=1 ./run_tests.sh tests/cli/test_app_rendering_terminal_logs.py tests/cli/test_app_sub_agents_workflows.py tests/cli/test_tui_settings_screens.py -q` (68 passed)
- `PYTHONDONTWRITEBYTECODE=1 ./run_tests.sh` (2833 passed, 2 skipped, 104 deselected)
- `PYTHONDONTWRITEBYTECODE=1 uv run pre-commit run --all-files --show-diff-on-failure`