### PR TITLE
feat(models): add Claude Opus 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+### Added
+
+- Added Anthropic Claude Opus 5 (`claude-opus-5`) with a 1M-token context
+  window, 128K max output, vision input, and adaptive thinking with
+  `low`/`medium`/`high`/`xhigh`/`max` effort levels.
+
+### Changed
+
+- Made Claude Opus 5 the default Anthropic long-context and thinking model.
+
 ## 0.24.1 - 2026-07-26
 
 ### Changed

--- a/docs/src/content/docs/concepts/agents.md
+++ b/docs/src/content/docs/concepts/agents.md
@@ -51,7 +51,7 @@ An ordinary dispatch accepts one complete object under `model_override`:
   "task": "Review the authentication design for subtle security flaws.",
   "model_override": {
     "provider": "anthropic",
-    "model": "claude-opus-4-8",
+    "model": "claude-opus-5",
     "thinking_effort": "high"
   }
 }

--- a/docs/src/content/docs/configuration/providers-and-models.mdx
+++ b/docs/src/content/docs/configuration/providers-and-models.mdx
@@ -86,9 +86,9 @@ can match cost and capability to the job:
 
 | Role | Purpose | Default |
 | --- | --- | --- |
-| **Long context** | The main coding model — drives the conversation and most work | `anthropic` / `claude-opus-4-7` |
+| **Long context** | The main coding model — drives the conversation and most work | `anthropic` / `claude-opus-5` |
 | **Fast** | Quick, cheap utility calls | `anthropic` / `claude-haiku-4-5-20251001` |
-| **Thinking** | Extended-reasoning ("think hard") operations | `anthropic` / `claude-opus-4-7` (`medium` effort) |
+| **Thinking** | Extended-reasoning ("think hard") operations | `anthropic` / `claude-opus-5` (`medium` effort) |
 
 These built-in role defaults are used only when the corresponding provider or
 role is explicitly selected without a model. API key variables alone do not make
@@ -121,9 +121,9 @@ Override any role from the command line:
 
 ```bash
 kolega-code . \
-  --provider anthropic --model claude-opus-4-7 \
+  --provider anthropic --model claude-opus-5 \
   --fast-provider anthropic --fast-model claude-haiku-4-5-20251001 \
-  --thinking-provider anthropic --thinking-model claude-opus-4-7 \
+  --thinking-provider anthropic --thinking-model claude-opus-5 \
   --thinking-effort medium
 ```
 
@@ -185,8 +185,8 @@ models in the TUI.
 | Provider/model | Values | Kolega Code default |
 | --- | --- | --- |
 | Anthropic `claude-fable-5` | `low`, `medium`, `high`, `xhigh`, `max` | `medium` |
+| Anthropic `claude-opus-5` | `low`, `medium`, `high`, `xhigh`, `max` | `medium` |
 | Anthropic `claude-sonnet-5` | `low`, `medium`, `high`, `xhigh`, `max` | `medium` |
-| Anthropic `claude-opus-4-7` | `low`, `medium`, `high`, `xhigh`, `max` | `medium` |
 | DeepSeek `deepseek-v4-pro` | `none`, `high`, `max` | `high` |
 | Moonshot `kimi-k3` | `max` | `max` |
 | Moonshot `kimi-k2.7-code` | `auto` | `auto` |

--- a/docs/src/content/docs/gigacode.mdx
+++ b/docs/src/content/docs/gigacode.mdx
@@ -132,7 +132,7 @@ review = await agent(
     agent_type="investigation",
     model_override={
         "provider": "anthropic",
-        "model": "claude-opus-4-8",
+        "model": "claude-opus-5",
         "effort": "high",
     },
 )

--- a/kolega_code/agent/orchestration/guide.py
+++ b/kolega_code/agent/orchestration/guide.py
@@ -87,7 +87,7 @@ result = await agent(
     agent_type="investigation",
     model_override={
         "provider": "anthropic",
-        "model": "claude-opus-4-8",
+        "model": "claude-opus-5",
         "effort": "high",
     },
 )

--- a/kolega_code/cli/config.py
+++ b/kolega_code/cli/config.py
@@ -22,11 +22,11 @@ from .settings import CliSettings, SettingsStore
 OAUTH_PROVIDERS = frozenset({ModelProvider.OPENAI_CHATGPT})
 
 DEFAULT_LONG_PROVIDER = ModelProvider.ANTHROPIC
-DEFAULT_LONG_MODEL = "claude-opus-4-8"
+DEFAULT_LONG_MODEL = "claude-opus-5"
 DEFAULT_FAST_PROVIDER = ModelProvider.ANTHROPIC
 DEFAULT_FAST_MODEL = "claude-haiku-4-5-20251001"
 DEFAULT_THINKING_PROVIDER = ModelProvider.ANTHROPIC
-DEFAULT_THINKING_MODEL = "claude-opus-4-8"
+DEFAULT_THINKING_MODEL = "claude-opus-5"
 DEPRECATED_THINKING_TOKENS_MESSAGE = (
     "Thinking token budgets have been replaced by model-specific named effort. "
     "Use --thinking-effort or KOLEGA_CODE_THINKING_EFFORT."

--- a/kolega_code/cli/provider_registry.py
+++ b/kolega_code/cli/provider_registry.py
@@ -57,6 +57,7 @@ MODEL_LABELS: dict[str, str] = {
     "glm-5.1": "GLM-5.1",
     # Anthropic
     "claude-fable-5": "Claude Fable 5",
+    "claude-opus-5": "Claude Opus 5",
     "claude-opus-4-8": "Claude Opus 4.8",
     "claude-opus-4-7": "Claude Opus 4.7",
     "claude-opus-4-6": "Claude Opus 4.6",
@@ -134,7 +135,7 @@ PROVIDER_DEFAULT_MODEL: dict[ModelProvider, str] = {
     ModelProvider.DEEPSEEK: "deepseek-v4-pro",
     ModelProvider.ZAI: "glm-5.2",
     ModelProvider.KIMI_CODING: "kimi-for-coding",
-    ModelProvider.ANTHROPIC: "claude-opus-4-8",
+    ModelProvider.ANTHROPIC: "claude-opus-5",
     ModelProvider.OPENAI: "gpt-5.6-sol",
     ModelProvider.OPENAI_CHATGPT: "gpt-5.6-sol",
     ModelProvider.GOOGLE: "gemini-3.1-pro-preview",

--- a/kolega_code/config.py
+++ b/kolega_code/config.py
@@ -112,7 +112,7 @@ class AgentConfig(BaseModel):
             anthropic_api_key="your_anthropic_key",
             long_context_config=ModelConfig(
                 provider=ModelProvider.ANTHROPIC,
-                model="claude-opus-4-8"
+                model="claude-opus-5"
             )
         )
 
@@ -178,7 +178,7 @@ class AgentConfig(BaseModel):
     # Model configurations
     long_context_config: ModelConfig = Field(
         default_factory=lambda: ModelConfig(
-            provider=ModelProvider.ANTHROPIC, model="claude-opus-4-8", thinking_effort="medium"
+            provider=ModelProvider.ANTHROPIC, model="claude-opus-5", thinking_effort="medium"
         ),
         description="Configuration for long context operations",
     )
@@ -190,7 +190,7 @@ class AgentConfig(BaseModel):
 
     thinking_config: ModelConfig = Field(
         default_factory=lambda: ModelConfig(
-            provider=ModelProvider.ANTHROPIC, model="claude-opus-4-8", thinking_effort="medium"
+            provider=ModelProvider.ANTHROPIC, model="claude-opus-5", thinking_effort="medium"
         ),
         description="Configuration for thinking operations",
     )

--- a/kolega_code/llm/providers/anthropic.py
+++ b/kolega_code/llm/providers/anthropic.py
@@ -142,7 +142,7 @@ class AnthropicProvider(BaseLLMProvider):
     def _prepare_generation_params(self, params: Optional[GenerationParams] = None) -> Dict[str, Any]:
         """Convert common parameters to provider-specific format"""
         generation_params = {
-            "model": "claude-opus-4-8",  # Default model
+            "model": "claude-opus-5",  # Default model
             "max_tokens": 1024,  # Default max tokens
         }
 

--- a/kolega_code/llm/specs/catalog/anthropic.py
+++ b/kolega_code/llm/specs/catalog/anthropic.py
@@ -14,6 +14,18 @@ ANTHROPIC_SPECS = {
             mode="anthropic_adaptive_effort",
         ),
     },
+    ("anthropic", "claude-opus-5"): {
+        "context_length": 1000000,
+        "max_completion_tokens": 128000,
+        "default_temperature": 1.0,
+        "supports_temperature": False,
+        "supports_vision": True,
+        "thinking_effort": ThinkingEffortSpec(
+            options=("low", "medium", "high", "xhigh", "max"),
+            default="medium",
+            mode="anthropic_adaptive_effort",
+        ),
+    },
     ("anthropic", "claude-opus-4-8"): {
         "context_length": 1000000,
         "max_completion_tokens": 128000,

--- a/tests/agent/llm/test_model_specs.py
+++ b/tests/agent/llm/test_model_specs.py
@@ -168,6 +168,19 @@ def test_claude_fable_5_model_specs():
     assert specs["thinking_effort"].mode == "anthropic_adaptive_effort"
 
 
+def test_claude_opus_5_model_specs() -> None:
+    specs = get_model_specs("anthropic", "claude-opus-5")
+
+    assert specs["context_length"] == 1000000
+    assert specs["max_completion_tokens"] == 128000
+    assert specs["default_temperature"] == 1.0
+    assert specs["supports_temperature"] is False
+    assert specs["supports_vision"] is True
+    assert specs["thinking_effort"].options == ("low", "medium", "high", "xhigh", "max")
+    assert specs["thinking_effort"].default == "medium"
+    assert specs["thinking_effort"].mode == "anthropic_adaptive_effort"
+
+
 def test_claude_sonnet_5_model_specs():
     specs = get_model_specs("anthropic", "claude-sonnet-5")
 

--- a/tests/agent/llm/test_supports_vision.py
+++ b/tests/agent/llm/test_supports_vision.py
@@ -14,6 +14,7 @@ def test_supports_vision_flag_present_on_every_entry():
     "provider,model,expected",
     [
         ("anthropic", "claude-fable-5", True),
+        ("anthropic", "claude-opus-5", True),
         ("anthropic", "claude-sonnet-5", True),
         ("anthropic", "claude-opus-4-8", True),
         ("anthropic", "claude-haiku-4-5-20251001", True),

--- a/tests/agent/llm/test_thinking_effort.py
+++ b/tests/agent/llm/test_thinking_effort.py
@@ -11,6 +11,8 @@ from kolega_code.llm.specs import default_thinking_effort, thinking_effort_optio
 def test_model_specs_expose_provider_specific_thinking_efforts() -> None:
     assert thinking_effort_options("anthropic", "claude-fable-5") == ("low", "medium", "high", "xhigh", "max")
     assert default_thinking_effort("anthropic", "claude-fable-5") == "medium"
+    assert thinking_effort_options("anthropic", "claude-opus-5") == ("low", "medium", "high", "xhigh", "max")
+    assert default_thinking_effort("anthropic", "claude-opus-5") == "medium"
     assert thinking_effort_options("anthropic", "claude-sonnet-5") == ("low", "medium", "high", "xhigh", "max")
     assert default_thinking_effort("anthropic", "claude-sonnet-5") == "medium"
     assert thinking_effort_options("moonshot", "kimi-k3") == ("max",)
@@ -65,6 +67,20 @@ def test_anthropic_opus_effort_uses_adaptive_thinking_without_budget_tokens() ->
     assert generation_params["thinking"] == {"type": "adaptive"}
     assert generation_params["output_config"] == {"effort": "xhigh"}
     assert "budget_tokens" not in generation_params["thinking"]
+
+
+def test_anthropic_default_request_uses_opus_5_adaptive_thinking_without_temperature() -> None:
+    provider = AnthropicProvider(api_key="test-key", provider_name="anthropic")
+    params = GenerationParams(temperature=0.5, thinking="medium")
+    generation_params = provider._prepare_generation_params(params)
+
+    provider._apply_thinking_params(generation_params, params)
+    generation_params = provider._sanitize_generation_params(generation_params)
+
+    assert generation_params["model"] == "claude-opus-5"
+    assert generation_params["thinking"] == {"type": "adaptive"}
+    assert generation_params["output_config"] == {"effort": "medium"}
+    assert "temperature" not in generation_params
 
 
 def test_deepseek_routes_to_openai_v1_endpoint() -> None:

--- a/tests/cli/test_cli_config.py
+++ b/tests/cli/test_cli_config.py
@@ -69,6 +69,7 @@ def test_build_agent_config_explicit_provider_uses_provider_default_model(tmp_pa
     )
 
     assert config.long_context_config.provider == ModelProvider.ANTHROPIC
+    assert DEFAULT_LONG_MODEL == "claude-opus-5"
     assert config.long_context_config.model == DEFAULT_LONG_MODEL
     assert config.fast_config.model == DEFAULT_LONG_MODEL
     assert config.thinking_config.model == DEFAULT_LONG_MODEL

--- a/tests/cli/test_provider_registry.py
+++ b/tests/cli/test_provider_registry.py
@@ -1,4 +1,6 @@
 from kolega_code.cli.provider_registry import (
+    UI_DEFAULT_MODEL,
+    UI_DEFAULT_PROVIDER,
     default_model_for_provider,
     ui_model_options,
     ui_thinking_effort_options,
@@ -11,6 +13,25 @@ def test_kimi_k3_is_first_and_default_for_moonshot():
     assert ui_model_options(ModelProvider.MOONSHOT.value)[0] == ("Kimi K3", "kimi-k3")
     assert default_model_for_provider(ModelProvider.MOONSHOT) == "kimi-k3"
     assert ui_thinking_effort_options("moonshot", "kimi-k3") == [("Max", "max")]
+    assert (UI_DEFAULT_PROVIDER, UI_DEFAULT_MODEL) == ("moonshot", "kimi-k3")
+
+
+def test_opus_5_is_selectable_and_default_for_anthropic() -> None:
+    options = ui_model_options(ModelProvider.ANTHROPIC.value)
+
+    assert options[:3] == [
+        ("Claude Fable 5", "claude-fable-5"),
+        ("Claude Opus 5", "claude-opus-5"),
+        ("Claude Opus 4.8", "claude-opus-4-8"),
+    ]
+    assert default_model_for_provider(ModelProvider.ANTHROPIC) == "claude-opus-5"
+    assert ui_thinking_effort_options("anthropic", "claude-opus-5") == [
+        ("Low", "low"),
+        ("Medium", "medium"),
+        ("High", "high"),
+        ("Extra high", "xhigh"),
+        ("Max", "max"),
+    ]
 
 
 def test_kimi_coding_exposes_plan_specific_k3_models():

--- a/tests/test_agent_config_defaults.py
+++ b/tests/test_agent_config_defaults.py
@@ -1,0 +1,19 @@
+from kolega_code.config import AgentConfig, ModelProvider
+
+
+def test_agent_config_defaults_to_opus_5_for_long_and_thinking_slots() -> None:
+    config = AgentConfig(anthropic_api_key="test-key")
+
+    assert config.long_context_config.provider == ModelProvider.ANTHROPIC
+    assert config.long_context_config.model == "claude-opus-5"
+    assert config.long_context_config.thinking_effort == "medium"
+    assert config.thinking_config.provider == ModelProvider.ANTHROPIC
+    assert config.thinking_config.model == "claude-opus-5"
+    assert config.thinking_config.thinking_effort == "medium"
+
+
+def test_agent_config_keeps_haiku_as_the_fast_default() -> None:
+    config = AgentConfig(anthropic_api_key="test-key")
+
+    assert config.fast_config.provider == ModelProvider.ANTHROPIC
+    assert config.fast_config.model == "claude-haiku-4-5-20251001"


### PR DESCRIPTION
## Summary

- add `claude-opus-5` to the Anthropic model catalog with 1M context, 128K output, vision, and adaptive effort support
- make Opus 5 the Anthropic/core long-context and thinking default while preserving Haiku as the fast default and Moonshot Kimi K3 as the initial TUI selection
- update model examples, provider documentation, changelog, and regression coverage while retaining Opus 4.8 compatibility

## Testing

- `PYTHONDONTWRITEBYTECODE=1 ./run_tests.sh tests/agent/llm/test_model_specs.py tests/agent/llm/test_supports_vision.py tests/agent/llm/test_thinking_effort.py tests/cli/test_provider_registry.py tests/cli/test_cli_config.py tests/test_agent_config_defaults.py -ra` (152 passed)
- `PYTHONDONTWRITEBYTECODE=1 ./run_tests.sh` (2,839 passed, 2 skipped, 104 deselected)
- `uv run ruff check .`
- `uv run pyright`
- `cd docs && npm run build`