### PR TITLE
fix(agent): stop injecting reasoning placeholders that models echo back

### DIFF
--- a/kolega_code/agent/conversation.py
+++ b/kolega_code/agent/conversation.py
@@ -138,11 +138,23 @@ def _preserve_reasoning_block(block: Any, *, source_provider: str, target_provid
     return _providers_replay_compatible(source_provider, target_provider)
 
 
-def _reasoning_placeholder(block: Any, source_provider: str) -> TextBlock:
-    source = source_provider or "unknown provider"
-    if isinstance(block, RedactedThinkingBlock):
-        return TextBlock(text=f"[Prior redacted reasoning from {source} omitted for compatibility.]")
-    return TextBlock(text=f"[Prior reasoning from {source} omitted for compatibility.]")
+# Foreign reasoning used to be replaced with a text placeholder here. Do not
+# reintroduce one: anything model-visible gets echoed. Models reproduced that
+# placeholder as the opening tokens of their own replies, the echo was persisted
+# by the session recorder, and it then re-primed every later turn. An omitted
+# -reasoning notice is not actionable for the model anyway, so the blocks are
+# simply dropped from the request copy.
+#
+# This pattern matches placeholders that earlier builds already echoed into
+# stored assistant text, so contaminated sessions stop re-priming themselves.
+_ECHOED_REASONING_PLACEHOLDER = re.compile(
+    r"\[Prior (?:redacted )?reasoning from [^\]\n]{1,64} omitted for compatibility\.\]"
+)
+
+
+def _scrub_echoed_reasoning_placeholder(text: str) -> str:
+    """Strip echoed reasoning placeholders from assistant prose, preserving the rest."""
+    return _ECHOED_REASONING_PLACEHOLDER.sub("", text).strip()
 
 
 def _preserve_freeform_exchange(
@@ -191,6 +203,7 @@ def _adapt_content_blocks_for_provider(
     tool_call_providers: Optional[Dict[str, str]] = None,
     tool_call_protocols: Optional[Dict[str, Optional[str]]] = None,
     source_usage_metadata: Optional[Dict[str, Any]] = None,
+    message_role: Optional[str] = None,
 ) -> tuple[List[Any], bool]:
     adapted: List[Any] = []
     changed = False
@@ -203,7 +216,7 @@ def _adapt_content_blocks_for_provider(
             if _preserve_reasoning_block(block, source_provider=source_provider, target_provider=target_provider):
                 adapted.append(block)
             else:
-                adapted.append(_reasoning_placeholder(block, source_provider))
+                # Dropped, never substituted — see _ECHOED_REASONING_PLACEHOLDER.
                 changed = True
         elif isinstance(block, ToolCall) and block.input_kind == "freeform":
             if _preserve_freeform_exchange(
@@ -262,12 +275,24 @@ def _adapt_content_blocks_for_provider(
                 tool_call_providers=tool_call_providers,
                 tool_call_protocols=tool_call_protocols,
                 source_usage_metadata=source_usage_metadata,
+                # Nested tool-result content is tool output, never assistant prose.
+                message_role=None,
             )
             if inner_changed:
                 adapted.append(_tool_result_with_content(block, inner))
                 changed = True
             else:
                 adapted.append(block)
+        elif isinstance(block, TextBlock) and message_role == "assistant":
+            cleaned = _scrub_echoed_reasoning_placeholder(block.text)
+            if cleaned == block.text:
+                adapted.append(block)
+            elif cleaned:
+                adapted.append(TextBlock(text=cleaned, cache_checkpoint=block.cache_checkpoint))
+                changed = True
+            else:
+                # The block was nothing but echoed placeholders.
+                changed = True
         else:
             adapted.append(block)
 
@@ -286,10 +311,18 @@ def adapt_history_for_provider(
 
     Provider-managed reasoning blocks are not portable across providers, but
     reasoning produced by a provider is safe to send back to the same provider.
-    Preserve same-provider reasoning; convert foreign or unknown reasoning
-    blocks to text placeholders. Image blocks are preserved for vision models
-    and replaced with placeholders for non-vision models, matching the previous
-    image compatibility behavior.
+    Preserve same-provider reasoning and **drop** foreign or unknown reasoning
+    blocks — substituting model-visible text there gets echoed back by the model
+    and then persisted as real history. Assistant text carrying placeholders
+    echoed by earlier builds is scrubbed for the same reason. Image blocks are
+    preserved for vision models and replaced with placeholders for non-vision
+    models, matching the previous image compatibility behavior.
+
+    An assistant message left with no content blocks is omitted from the returned
+    history. That orphans nothing: tool calls are never dropped by this pass, so
+    only reasoning-only or placeholder-only messages can empty out. A dropped
+    message could in principle carry a ``cache_checkpoint`` mark, but checkpoints
+    land on the trailing user/tool-result message, not on a reasoning-only turn.
     """
     target_provider = _provider_value(target_provider)
     if target_edit_protocol is not None:
@@ -322,7 +355,11 @@ def adapt_history_for_provider(
             tool_call_providers=tool_call_providers,
             tool_call_protocols=tool_call_protocols,
             source_usage_metadata=message.usage_metadata,
+            message_role=message.role,
         )
+        if changed and not adapted_content:
+            changed_any = True
+            continue
         if changed:
             result.append(_message_with_content(message, adapted_content))
             changed_any = True

--- a/kolega_code/llm/models.py
+++ b/kolega_code/llm/models.py
@@ -1183,9 +1183,9 @@ class Message:
         """
         # Native reasoning replay applies only when the target is a configured
         # reasoning model AND this assistant message was produced by that same
-        # provider. adapt_history_for_provider already converts foreign reasoning
-        # to text upstream; this source==target check is defense-in-depth so
-        # foreign reasoning can never serialize as native replay metadata.
+        # provider. adapt_history_for_provider already drops foreign reasoning
+        # upstream; this source==target check is defense-in-depth so foreign
+        # reasoning can never serialize as native replay metadata.
         reasoning_field: Optional[str] = None
         source_provider = (self.usage_metadata or {}).get("provider")
         if (

--- a/kolega_code/llm/providers/responses_common.py
+++ b/kolega_code/llm/providers/responses_common.py
@@ -177,7 +177,7 @@ def to_responses_input(messages: MessageHistory) -> List[Dict[str, Any]]:
                 text_parts.append(("image", _image_data_url(block)))
             # Foreign Anthropic thinking/redacted-thinking blocks (from a prior
             # provider) are skipped here; adapt_history_for_provider has already
-            # replaced them with text placeholders before this conversion runs.
+            # dropped them before this conversion runs.
         if text_parts:
             item = _role_message_item(message.role, text_parts)
             if item:

--- a/tests/agent/test_base_agent_effective_history.py
+++ b/tests/agent/test_base_agent_effective_history.py
@@ -65,7 +65,7 @@ class TestBaseAgent:
         assert effective[0].content[1].signature == "sig"
         assert effective[0].content[2].data == "encrypted-redacted-thinking"
 
-    def test_history_for_llm_converts_foreign_thinking_when_switching_to_anthropic(self, base_agent):
+    def test_history_for_llm_drops_foreign_thinking_when_switching_to_anthropic(self, base_agent):
         tool_call = ToolCall(id="tool1", name="read_file", input={"path": "README.md"})
         base_agent.primary_model_config.provider = ModelProvider.ANTHROPIC
         base_agent.primary_model_config.model = "claude-opus-4-8"
@@ -87,9 +87,10 @@ class TestBaseAgent:
         history = base_agent._history_for_llm()
 
         assert not any(isinstance(block, ThinkingBlock) for block in history[0].content)
-        assert isinstance(history[0].content[0], TextBlock)
-        assert "Prior reasoning from kimi_coding omitted" in history[0].content[0].text
-        assert isinstance(history[0].content[1], ToolCall)
+        # Dropped, not replaced: a text stand-in gets echoed back by the model.
+        assert not any(isinstance(block, TextBlock) for block in history[0].content)
+        assert len(history[0].content) == 1
+        assert isinstance(history[0].content[0], ToolCall)
         assert history[1].role == "user"
         assert isinstance(history[1].content[0], ToolResult)
         assert history[1].content[0].tool_use_id == "tool1"

--- a/tests/agent/test_history_adapter_thinking.py
+++ b/tests/agent/test_history_adapter_thinking.py
@@ -41,7 +41,7 @@ def _assistant(*blocks, provider: str | None = None) -> Message:
     )
 
 
-def test_adapt_converts_kimi_thinking_when_targeting_anthropic():
+def test_adapt_drops_kimi_thinking_when_targeting_anthropic():
     tool_call = ToolCall(id="tool1", name="read_image", input={"path": "a.png"})
     history = [
         _assistant(ThinkingBlock(thinking="foreign reasoning", signature="kimi-sig"), tool_call, provider="kimi_coding")
@@ -56,8 +56,8 @@ def test_adapt_converts_kimi_thinking_when_targeting_anthropic():
 
     assert out[0] is not history[0]
     assert not any(isinstance(block, ThinkingBlock) for block in out[0].content)
-    assert isinstance(out[0].content[0], TextBlock)
-    assert "Prior reasoning from kimi_coding omitted" in out[0].content[0].text
+    # Dropped outright: a text stand-in would be echoed back by the model.
+    assert not any(isinstance(block, TextBlock) for block in out[0].content)
     assert any(isinstance(block, ToolCall) and block.id == "tool1" for block in out[0].content)
 
 
@@ -136,7 +136,7 @@ def test_adapt_preserves_ollama_cloud_thinking_when_targeting_ollama_cloud():
     assert out[0].content[0].thinking == "ollama reasoning"
 
 
-def test_adapt_converts_ollama_cloud_thinking_when_targeting_foreign_provider():
+def test_adapt_drops_ollama_cloud_thinking_when_targeting_foreign_provider():
     history = [_assistant(ThinkingBlock(thinking="ollama reasoning"), provider="ollama_cloud")]
 
     out = adapt_history_for_provider(
@@ -146,12 +146,11 @@ def test_adapt_converts_ollama_cloud_thinking_when_targeting_foreign_provider():
         supports_vision=True,
     )
 
-    assert out[0] is not history[0]
-    assert isinstance(out[0].content[0], TextBlock)
-    assert "Prior reasoning from ollama_cloud omitted" in out[0].content[0].text
+    # Reasoning was the whole message, so the message itself goes away.
+    assert out == []
 
 
-def test_adapt_converts_ollama_cloud_thinking_without_source_provider():
+def test_adapt_drops_ollama_cloud_thinking_without_source_provider():
     history = [_assistant(ThinkingBlock(thinking="ollama reasoning"))]
 
     out = adapt_history_for_provider(
@@ -161,12 +160,10 @@ def test_adapt_converts_ollama_cloud_thinking_without_source_provider():
         supports_vision=False,
     )
 
-    assert out[0] is not history[0]
-    assert isinstance(out[0].content[0], TextBlock)
-    assert "Prior reasoning from unknown provider omitted" in out[0].content[0].text
+    assert out == []
 
 
-def test_adapt_converts_thinking_without_source_provider():
+def test_adapt_drops_thinking_without_source_provider():
     history = [_assistant(ThinkingBlock(thinking="unknown-source reasoning"))]
 
     out = adapt_history_for_provider(
@@ -176,12 +173,10 @@ def test_adapt_converts_thinking_without_source_provider():
         supports_vision=False,
     )
 
-    assert out[0] is not history[0]
-    assert isinstance(out[0].content[0], TextBlock)
-    assert "Prior reasoning from unknown provider omitted" in out[0].content[0].text
+    assert out == []
 
 
-def test_adapt_preserves_images_for_vision_target_while_converting_foreign_thinking():
+def test_adapt_preserves_images_for_vision_target_while_dropping_foreign_thinking():
     tr = ToolResult(tool_use_id="t1", name="read_image", content=[_image("image/jpeg")], is_error=False)
     history = [
         _user(TextBlock(text="look"), _image("image/png"), tr),
@@ -200,10 +195,11 @@ def test_adapt_preserves_images_for_vision_target_while_converting_foreign_think
     nested_tr = out[0].content[2]
     assert isinstance(nested_tr, ToolResult)
     assert isinstance(nested_tr.content[0], ImageBlock)
-    assert isinstance(out[1].content[0], TextBlock)
+    # The reasoning-only assistant message is dropped; the user message remains.
+    assert len(out) == 1
 
 
-def test_adapt_replaces_images_for_non_vision_target_and_converts_foreign_thinking():
+def test_adapt_replaces_images_for_non_vision_target_and_drops_foreign_thinking():
     tr = ToolResult(tool_use_id="t1", name="read_image", content=[_image("image/jpeg")], is_error=False)
     history = [
         _user(TextBlock(text="look"), _image("image/png"), tr),
@@ -223,8 +219,8 @@ def test_adapt_replaces_images_for_non_vision_target_and_converts_foreign_thinki
     nested_tr = out[0].content[2]
     assert isinstance(nested_tr, ToolResult)
     assert isinstance(nested_tr.content[0], TextBlock)
-    assert isinstance(out[1].content[0], TextBlock)
-    assert "redacted reasoning from kimi_coding omitted" in out[1].content[0].text
+    # Redacted reasoning is dropped too, taking its otherwise-empty message with it.
+    assert len(out) == 1
 
 
 def test_adapt_does_not_mutate_stored_history():
@@ -244,7 +240,9 @@ def test_adapt_does_not_mutate_stored_history():
     assert history[0].content[0] is image
     assert isinstance(history[1].content[0], ThinkingBlock)
     assert history[1].content[0] is thinking
-    assert isinstance(out[1].content[0], TextBlock)
+    # Storage keeps both messages; only the request copy loses the reasoning one.
+    assert len(history) == 2
+    assert len(out) == 1
 
 
 def test_repaired_preserves_usage_metadata_when_rebuilding_tool_result_message():
@@ -280,7 +278,9 @@ def test_adapted_kimi_thinking_is_not_serialized_as_anthropic_thinking():
 
     assert payload[0]["role"] == "assistant"
     assert all(block.get("type") != "thinking" for block in payload[0]["content"])
-    assert payload[0]["content"][1]["type"] == "tool_use"
+    # No text stand-in is emitted, so the tool call is the only remaining block.
+    assert len(payload[0]["content"]) == 1
+    assert payload[0]["content"][0]["type"] == "tool_use"
     assert payload[1]["role"] == "user"
     assert payload[1]["content"][0]["type"] == "tool_result"
     assert payload[1]["content"][0]["tool_use_id"] == "tool1"
@@ -325,7 +325,7 @@ def test_adapt_preserves_responses_reasoning_across_openai_backends():
         assert out[0].content[0].encrypted_content == "ENC"
 
 
-def test_adapt_converts_responses_reasoning_when_targeting_anthropic():
+def test_adapt_drops_responses_reasoning_when_targeting_anthropic():
     block = ResponsesReasoningBlock(encrypted_content="ENC", summary=[], item_id="rs_1")
     history = [_assistant(block, provider="openai_chatgpt")]
 
@@ -336,6 +336,124 @@ def test_adapt_converts_responses_reasoning_when_targeting_anthropic():
         supports_vision=True,
     )
 
-    assert out[0] is not history[0]
-    assert isinstance(out[0].content[0], TextBlock)
-    assert "Prior reasoning from openai_chatgpt omitted" in out[0].content[0].text
+    assert out == []
+    # Storage is untouched, so switching back to OpenAI restores continuity.
+    assert isinstance(history[0].content[0], ResponsesReasoningBlock)
+
+
+# ---------------------------------------------------------------------------
+# Scrubbing placeholders that earlier builds already echoed into stored history
+# ---------------------------------------------------------------------------
+
+
+def test_adapt_scrubs_echoed_placeholder_from_assistant_prose():
+    """Reproduces the shape seen in a real contaminated session.
+
+    The model reproduced the placeholder as the opening tokens of its own reply, so
+    it landed in stored history fused with genuine prose in a single text block.
+    """
+    text = "[Prior reasoning from openai_chatgpt omitted for compatibility.]I see what is happening."
+    stored = _assistant(TextBlock(text=text), provider="google")
+    history = [stored]
+
+    out = adapt_history_for_provider(
+        history,
+        target_provider="google",
+        target_model="gemini-3.1-pro-preview",
+        supports_vision=True,
+    )
+
+    adapted_block = out[0].content[0]
+    assert isinstance(adapted_block, TextBlock)
+    assert adapted_block.text == "I see what is happening."
+    # Request copy only: storage keeps what the model actually produced.
+    stored_block = stored.content[0]
+    assert isinstance(stored_block, TextBlock)
+    assert stored_block.text == text
+
+
+def test_adapt_scrubs_echoed_placeholder_before_a_tool_call():
+    tool_call = ToolCall(id="t1", name="exec_command", input={"command": "ls"})
+    history = [
+        _assistant(
+            TextBlock(text="[Prior reasoning from openai_chatgpt omitted for compatibility.]"),
+            tool_call,
+            provider="google",
+        )
+    ]
+
+    out = adapt_history_for_provider(
+        history,
+        target_provider="google",
+        target_model="gemini-3.1-pro-preview",
+        supports_vision=True,
+    )
+
+    # The text block held nothing else, so it goes; the tool call survives.
+    assert len(out[0].content) == 1
+    assert isinstance(out[0].content[0], ToolCall)
+    assert out[0].content[0].id == "t1"
+
+
+def test_adapt_drops_message_that_was_only_an_echoed_placeholder():
+    history = [_assistant(TextBlock(text="[Prior reasoning from kimi_coding omitted for compatibility.]"))]
+
+    out = adapt_history_for_provider(
+        history,
+        target_provider="google",
+        target_model="gemini-3.1-pro-preview",
+        supports_vision=True,
+    )
+
+    assert out == []
+
+
+def test_adapt_scrubs_redacted_placeholder_spelling():
+    history = [
+        _assistant(
+            TextBlock(text="[Prior redacted reasoning from anthropic omitted for compatibility.]done"),
+            provider="google",
+        )
+    ]
+
+    out = adapt_history_for_provider(
+        history,
+        target_provider="google",
+        target_model="gemini-3.1-pro-preview",
+        supports_vision=True,
+    )
+
+    adapted_block = out[0].content[0]
+    assert isinstance(adapted_block, TextBlock)
+    assert adapted_block.text == "done"
+
+
+def test_adapt_leaves_placeholder_text_in_user_messages_alone():
+    """A user quoting the phrase (e.g. pasting a transcript) must not be rewritten."""
+    text = "why does it say [Prior reasoning from openai_chatgpt omitted for compatibility.] ?"
+    history = [_user(TextBlock(text=text))]
+
+    out = adapt_history_for_provider(
+        history,
+        target_provider="google",
+        target_model="gemini-3.1-pro-preview",
+        supports_vision=True,
+    )
+
+    assert out is history
+    user_block = out[0].content[0]
+    assert isinstance(user_block, TextBlock)
+    assert user_block.text == text
+
+
+def test_adapt_leaves_ordinary_assistant_prose_untouched():
+    history = [_assistant(TextBlock(text="Here is the plan."), provider="google")]
+
+    out = adapt_history_for_provider(
+        history,
+        target_provider="google",
+        target_model="gemini-3.1-pro-preview",
+        supports_vision=True,
+    )
+
+    assert out is history


### PR DESCRIPTION
## Problem

`adapt_history_for_provider` replaced reasoning blocks from a non-replay-compatible provider with
the literal text `[Prior reasoning from <provider> omitted for compatibility.]`. Only
`{openai, openai_chatgpt}` are mutually compatible.

The rewrite is request-only and never mutated storage — but it is **model-visible**. Once every
prior assistant turn in the request opened with that bracketed line, the model reproduced it as the
opening tokens of its own response. `record_assistant` then persisted that generated text, so it
became real history and re-primed every later turn. Self-reinforcing.

## Evidence

From a user's 0.24.0 `/bug` bundle. A Settings override
`agent_models: {"planning": "google/gemini-3.1-pro-preview"}` alongside `openai_chatgpt` main
models made every `Shift+Tab` into plan mode a silent cross-provider switch — the user never touched
`/model`. All 53 plan-window requests ran on Google, and all 7 contaminated assistant messages were
produced there.

Two of the seven fuse the placeholder with 2.7 KB and 3.3 KB of freshly generated prose **in a
single text block**:

```
"[Prior reasoning from openai_chatgpt omitted for compatibility.]I see what is happening. Hermes is
running an ad-hoc Python script because…"
```

The adapter only ever rewrites *historical* messages, so it cannot concatenate a placeholder with
new output. The model generated it.

## Changes

All in `kolega_code/agent/conversation.py`:

- **Drop foreign reasoning** instead of substituting text. An omitted-reasoning notice is not
  actionable for the model, and anything model-visible is echoable. `_reasoning_placeholder` is
  deleted, with a comment recording why it must not come back.
- **Scrub already-echoed placeholders** from assistant text when building the request copy, so
  contaminated sessions stop re-priming themselves. Assistant role only, so a user quoting the
  phrase is never rewritten. Storage and the rendered transcript are untouched, exactly as before.
- **Omit assistant messages left with no content.** This orphans nothing: tool calls are never
  dropped by this pass, so only reasoning-only or placeholder-only messages can empty out.

Deliberately unchanged: image placeholders (an image you cannot see *is* actionable) and the
freeform tool-call/result placeholders (they describe an exchange the model needs to follow).

Also corrects two now-stale comments in `llm/providers/responses_common.py` and `llm/models.py` that
described the old substitute-with-text behavior. Both sites were already defensive; no logic change.

## Tests

Six assertions that pinned the placeholder text are rewritten to assert the drop, including the
messages that now disappear entirely. New coverage:

- foreign reasoning dropped with no `TextBlock` substituted, sibling tool call intact
- same-provider and `openai` ↔ `openai_chatgpt` reasoning still preserved
- the reporter's exact shape — placeholder fused with prose — yields just the prose
- placeholder-only text block dropped; message left empty omitted
- both spellings (`Prior reasoning`, `Prior redacted reasoning`) scrubbed
- the same text in a **user** message left alone
- ordinary assistant prose returns the original list object unchanged
- storage never mutated

2455 passed; `pre-commit run --all-files` clean.

## Follow-up, not in scope

The root trigger is that plan and build modes can silently sit on different providers with no
warning. A TUI warning for that mismatch is worth doing separately. The freeform placeholders carry
the same theoretical echo risk but convey information the model actually needs.
