### PR TITLE
fix(cli): keep bug-bundle JSON valid when redacting secrets

### DIFF
--- a/kolega_code/cli/diagnostics.py
+++ b/kolega_code/cli/diagnostics.py
@@ -27,7 +27,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable, Optional
 
 from kolega_code.local_state import ensure_private_dir, ensure_private_file
-from kolega_code.security import SECRET_PLACEHOLDER as SECRET_PLACEHOLDER, redact_secrets
+from kolega_code.security import (
+    SECRET_PLACEHOLDER as SECRET_PLACEHOLDER,
+    redact_secrets,
+    redact_secrets_in_obj,
+)
 
 if TYPE_CHECKING:
     from .session_store import SessionBugExport
@@ -43,6 +47,48 @@ def scrub_secrets(text: str, extra_values: Optional[Iterable[str]] = None) -> st
     x-api-key, ``*_API_KEY=``, and ``sk-``/``xai-``/``AIza`` token shapes).
     """
     return redact_secrets(text, extra_values, include_environment=True)
+
+
+def scrub_secrets_in_obj(obj: Any, extra_values: Optional[Iterable[str]] = None) -> Any:
+    """Structural companion to ``scrub_secrets`` for JSON-compatible payloads.
+
+    Redacting serialized JSON can splice a replacement across an escape sequence
+    and leave a document that no longer parses, which is how a bug bundle's
+    ``session.json`` ended up unreadable. Redacting the decoded leaves and
+    re-serializing cannot do that.
+    """
+    return redact_secrets_in_obj(obj, extra_values, include_environment=True)
+
+
+def _scrub_json_document(
+    text: str,
+    extra_values: Optional[Iterable[str]] = None,
+    *,
+    indent: Optional[int] = None,
+    sort_keys: bool = False,
+) -> str:
+    """Redact one JSON document structurally, falling back to text scrubbing.
+
+    ``indent``/``sort_keys`` mirror how the document was written so re-serializing
+    does not flatten a human-readable export.
+    """
+    try:
+        parsed = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return scrub_secrets(text, extra_values)
+    scrubbed = scrub_secrets_in_obj(parsed, extra_values)
+    rendered = json.dumps(scrubbed, indent=indent, sort_keys=sort_keys, default=str)
+    return rendered + "\n" if text.endswith("\n") else rendered
+
+
+def _scrub_jsonl_document(text: str, extra_values: Optional[Iterable[str]] = None) -> str:
+    """Redact JSON Lines structurally, per line, so one bad line cannot poison the rest."""
+    out: list[str] = []
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        out.append(_scrub_json_document(line, extra_values))
+    return "\n".join(out) + ("\n" if out else "")
 
 
 def _now_iso() -> str:
@@ -97,7 +143,9 @@ class DiagnosticsLog:
             if value is not None:
                 payload[key] = self._bound(value)
         try:
-            line = scrub_secrets(json.dumps(payload, default=str), self._secret_values)
+            # Redact before serializing: scrubbing the encoded form can splice a
+            # replacement across a \" escape and emit a line that will not parse.
+            line = json.dumps(scrub_secrets_in_obj(payload, self._secret_values), default=str)
             with self._lock:
                 self._rotate_if_large()
                 # Write via os.open/os.write: Path/handle.write is modeled by CodeQL as a
@@ -285,14 +333,23 @@ def assemble_bug_bundle(
                 except OSError:
                     pass
             if session_export is not None:
-                zf.writestr("session.json", scrub_secrets(session_export.session_json, diag._secret_values))
+                # Structural redaction keeps these parseable; a document that does
+                # not parse to begin with degrades to plain-text scrubbing.
+                # SessionStore writes these two with indent=2/sort_keys=True; keep
+                # that so the bundle stays readable after redaction.
+                zf.writestr(
+                    "session.json",
+                    _scrub_json_document(session_export.session_json, diag._secret_values, indent=2, sort_keys=True),
+                )
                 zf.writestr(
                     "session-events.jsonl",
-                    scrub_secrets(session_export.events_jsonl, diag._secret_values),
+                    _scrub_jsonl_document(session_export.events_jsonl, diag._secret_values),
                 )
                 zf.writestr(
                     "session-artifacts.json",
-                    scrub_secrets(session_export.artifact_manifest_json, diag._secret_values),
+                    _scrub_json_document(
+                        session_export.artifact_manifest_json, diag._secret_values, indent=2, sort_keys=True
+                    ),
                 )
         ensure_private_file(zip_path)
         return zip_path

--- a/kolega_code/security/__init__.py
+++ b/kolega_code/security/__init__.py
@@ -5,6 +5,7 @@ from .secrets import (
     SecretFinding,
     detect_secrets,
     redact_secrets,
+    redact_secrets_in_obj,
 )
 
 __all__ = [
@@ -12,4 +13,5 @@ __all__ = [
     "SecretFinding",
     "detect_secrets",
     "redact_secrets",
+    "redact_secrets_in_obj",
 ]

--- a/kolega_code/security/secrets.py
+++ b/kolega_code/security/secrets.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import re
 from dataclasses import dataclass
-from typing import Iterable
+from typing import Any, Iterable
 
 SECRET_PLACEHOLDER = "‹secret›"
 
@@ -42,10 +42,16 @@ _PATTERNS: tuple[tuple[str, re.Pattern[str], str | None], ...] = (
     ("api-key-header", re.compile(r"(?i)x-api-key\s*[:=]\s*(?P<value>\S+)"), "value"),
     (
         "credential-assignment",
+        # The unquoted alternative excludes backslash as well as quotes. Without
+        # that, a secret sitting inside already-serialized JSON absorbs the
+        # leading backslash of the following \" escape; replacing the span then
+        # leaves a bare quote that terminates the JSON string and corrupts the
+        # document. Real credentials do not contain backslashes, so excluding it
+        # only ever shortens a match.
         re.compile(
             r"(?im)\b[A-Za-z0-9_]*(?:API_?KEY|ACCESS_?KEY|TOKEN|SECRET|"
             r"PASSWORD|PASSWD|PRIVATE_?KEY|CLIENT_?SECRET)[A-Za-z0-9_]*\s*[=:]\s*"
-            r"(?P<value>[^\s\"']+|\"[^\"]+\"|'[^']+')"
+            r"(?P<value>[^\s\"'\\]+|\"[^\"]+\"|'[^']+')"
         ),
         "value",
     ),
@@ -110,3 +116,39 @@ def redact_secrets(
     for finding in reversed(findings):
         text = text[: finding.start] + SECRET_PLACEHOLDER + text[finding.end :]
     return text
+
+
+def redact_secrets_in_obj(
+    obj: Any,
+    extra_values: Iterable[str] | None = None,
+    *,
+    include_environment: bool = False,
+) -> Any:
+    """Redact string leaves of a JSON-compatible structure, preserving its shape.
+
+    Prefer this over running ``redact_secrets`` on serialized JSON. Redacting the
+    encoded form can splice a replacement across an escape sequence and produce a
+    document that no longer parses; redacting the decoded leaves and re-serializing
+    is valid by construction, and the patterns match real text rather than escaped
+    text.
+
+    Leaves that are not JSON-native are coerced with ``str()`` and *then* redacted.
+    That closes a hole in the ``json.dumps(..., default=str)`` pattern, where an
+    object stringified during serialization would otherwise never be scrubbed.
+    Dict keys are left alone: they are structural, and rewriting them risks
+    collisions.
+    """
+    values = list(extra_values or [])
+
+    def walk(node: Any) -> Any:
+        if isinstance(node, str):
+            return redact_secrets(node, values, include_environment=include_environment)
+        if isinstance(node, bool) or node is None or isinstance(node, (int, float)):
+            return node
+        if isinstance(node, dict):
+            return {key: walk(value) for key, value in node.items()}
+        if isinstance(node, (list, tuple)):
+            return [walk(item) for item in node]
+        return redact_secrets(str(node), values, include_environment=include_environment)
+
+    return walk(obj)

--- a/tests/cli/test_diagnostics.py
+++ b/tests/cli/test_diagnostics.py
@@ -154,3 +154,127 @@ def test_assemble_bug_bundle_scrubs_secrets_keeps_content(tmp_path: Path):
     assert "fix my bug" in session
     assert "session-sess5.jsonl" in names
     assert "session-artifacts.json" in names
+
+
+# ---------------------------------------------------------------------------
+# JSON payloads must survive redaction intact
+# ---------------------------------------------------------------------------
+
+_FAKE_TOKEN = "apify_api_9RtQv3LmZx8KpWn2Yc7BdF4HsJ6Tg1Ae0Nu5"
+_SOURCE_LINE = f'api_url = f"https://api.example.com/v2/runs?token={_FAKE_TOKEN}"'
+
+
+def test_log_line_stays_parseable_when_a_secret_precedes_an_escaped_quote(tmp_path: Path):
+    """Scrubbing the serialized form used to splice across the \\" escape and break the line."""
+    diag = DiagnosticsLog(tmp_path, "sess-escape")
+    diag.record("tool", name="read_entire_file", output=_SOURCE_LINE)
+
+    records = _read(diag.path)
+
+    assert len(records) == 1
+    assert _FAKE_TOKEN not in records[0]["output"]
+    assert SECRET_PLACEHOLDER in records[0]["output"]
+
+
+def test_log_record_redacts_values_reached_only_via_str_coercion(tmp_path: Path):
+    """json.dumps(default=str) stringified after scrubbing, so these leaked."""
+
+    class Failure:
+        def __str__(self) -> str:
+            return f"boom token={_FAKE_TOKEN}"
+
+    diag = DiagnosticsLog(tmp_path, "sess-coerce")
+    diag.record("llm_error", error=Failure())
+
+    records = _read(diag.path)
+
+    assert _FAKE_TOKEN not in json.dumps(records[0])
+
+
+def test_bundle_session_json_stays_parseable_with_adversarial_content(tmp_path: Path):
+    diag = DiagnosticsLog(tmp_path, "sess-bundle-json")
+    session_export = SessionBugExport(
+        session_json=json.dumps({"history": [{"role": "assistant", "content": _SOURCE_LINE}]}),
+        events_jsonl=json.dumps({"type": "turn.started", "payload": {"text": _SOURCE_LINE}}) + "\n",
+        artifact_manifest_json=json.dumps({"artifacts_included": False, "artifacts": []}),
+    )
+
+    bundle = assemble_bug_bundle(diag, summary="kolega diag", session_export=session_export)
+
+    assert bundle is not None
+    with zipfile.ZipFile(bundle) as zf:
+        session = zf.read("session.json").decode("utf-8")
+        events = zf.read("session-events.jsonl").decode("utf-8")
+
+    parsed = json.loads(session)  # would raise before the fix
+    assert _FAKE_TOKEN not in session
+    assert SECRET_PLACEHOLDER in parsed["history"][0]["content"]
+    for line in events.splitlines():
+        assert json.loads(line)
+    assert _FAKE_TOKEN not in events
+
+
+def test_bundle_falls_back_to_text_scrubbing_for_unparseable_json(tmp_path: Path):
+    diag = DiagnosticsLog(tmp_path, "sess-bundle-bad")
+    session_export = SessionBugExport(
+        session_json="{not json at all, token=" + _FAKE_TOKEN,
+        events_jsonl="",
+        artifact_manifest_json="{}",
+    )
+
+    bundle = assemble_bug_bundle(diag, summary="kolega diag", session_export=session_export)
+
+    assert bundle is not None
+    with zipfile.ZipFile(bundle) as zf:
+        session = zf.read("session.json").decode("utf-8")
+
+    # Entry is still present and still scrubbed, just not reformatted.
+    assert _FAKE_TOKEN not in session
+    assert "not json at all" in session
+
+
+def test_bundle_keeps_good_jsonl_lines_when_one_line_is_malformed(tmp_path: Path):
+    diag = DiagnosticsLog(tmp_path, "sess-bundle-mixed")
+    session_export = SessionBugExport(
+        session_json="{}",
+        events_jsonl="\n".join(
+            [
+                json.dumps({"seq": 1, "text": "fine"}),
+                "{broken",
+                json.dumps({"seq": 3, "text": _SOURCE_LINE}),
+            ]
+        )
+        + "\n",
+        artifact_manifest_json="{}",
+    )
+
+    bundle = assemble_bug_bundle(diag, summary="kolega diag", session_export=session_export)
+
+    assert bundle is not None
+    with zipfile.ZipFile(bundle) as zf:
+        lines = zf.read("session-events.jsonl").decode("utf-8").splitlines()
+
+    assert len(lines) == 3
+    assert json.loads(lines[0])["seq"] == 1
+    assert json.loads(lines[2])["seq"] == 3
+    assert _FAKE_TOKEN not in "\n".join(lines)
+
+
+def test_bundle_preserves_readable_json_formatting(tmp_path: Path):
+    """SessionStore writes these with indent=2/sort_keys=True; redaction must not flatten them."""
+    diag = DiagnosticsLog(tmp_path, "sess-bundle-fmt")
+    session_export = SessionBugExport(
+        session_json=json.dumps({"b": 1, "a": {"nested": True}}, indent=2, sort_keys=True) + "\n",
+        events_jsonl="",
+        artifact_manifest_json=json.dumps({"artifacts_included": False}, indent=2, sort_keys=True) + "\n",
+    )
+
+    bundle = assemble_bug_bundle(diag, summary="kolega diag", session_export=session_export)
+
+    assert bundle is not None
+    with zipfile.ZipFile(bundle) as zf:
+        session = zf.read("session.json").decode("utf-8")
+
+    assert session.startswith("{\n")
+    assert '\n  "a": {' in session  # indented and key-sorted
+    assert session.endswith("\n")

--- a/tests/security/test_secrets.py
+++ b/tests/security/test_secrets.py
@@ -1,0 +1,100 @@
+"""Tests for probable-secret detection and redaction.
+
+Focus: redaction must never corrupt the document it is scrubbing. A bug bundle was
+shipped with an unparseable ``session.json`` because a match span absorbed the
+backslash of a JSON ``\\"`` escape, leaving a bare quote behind.
+"""
+
+import json
+
+from kolega_code.security import (
+    SECRET_PLACEHOLDER,
+    detect_secrets,
+    redact_secrets,
+    redact_secrets_in_obj,
+)
+
+# Obviously fake, but shaped like the real thing so the patterns fire.
+FAKE_TOKEN = "apify_api_9RtQv3LmZx8KpWn2Yc7BdF4HsJ6Tg1Ae0Nu5"
+SOURCE_LINE = f'api_url = f"https://api.example.com/v2/runs?token={FAKE_TOKEN}"'
+
+
+def test_redacting_serialized_json_keeps_it_parseable():
+    """The exact shape that corrupted a real bug bundle."""
+    encoded = json.dumps({"text": SOURCE_LINE})
+
+    out = redact_secrets(encoded)
+
+    assert json.loads(out)  # would raise before the fix
+    assert FAKE_TOKEN not in out
+    assert SECRET_PLACEHOLDER in out
+
+
+def test_detected_span_never_swallows_a_trailing_escape():
+    encoded = json.dumps({"text": SOURCE_LINE})
+
+    spans = [encoded[finding.start : finding.end] for finding in detect_secrets(encoded)]
+
+    assert spans == [FAKE_TOKEN]
+    assert not any(span.endswith("\\") for span in spans)
+
+
+def test_redact_in_obj_redacts_nested_strings_and_preserves_shape():
+    payload = {
+        "text": SOURCE_LINE,
+        "nested": {"deep": [SOURCE_LINE, "harmless"]},
+        "count": 3,
+        "ratio": 1.5,
+        "flag": True,
+        "missing": None,
+    }
+
+    out = redact_secrets_in_obj(payload)
+
+    assert FAKE_TOKEN not in json.dumps(out)
+    assert SECRET_PLACEHOLDER in out["text"]
+    assert out["nested"]["deep"][1] == "harmless"
+    assert out["count"] == 3
+    assert out["ratio"] == 1.5
+    assert out["flag"] is True
+    assert out["missing"] is None
+
+
+def test_redact_in_obj_output_is_json_serializable_and_parses():
+    out = redact_secrets_in_obj({"text": SOURCE_LINE})
+
+    assert json.loads(json.dumps(out))["text"].endswith("token=" + SECRET_PLACEHOLDER + '"')
+
+
+def test_redact_in_obj_coerces_and_redacts_non_json_leaves():
+    """``json.dumps(default=str)`` stringifies after scrubbing, so such leaves escaped redaction."""
+
+    class Failure:
+        def __str__(self) -> str:
+            return f"request failed: token={FAKE_TOKEN}"
+
+    out = redact_secrets_in_obj({"error": Failure()})
+
+    assert isinstance(out["error"], str)
+    assert FAKE_TOKEN not in out["error"]
+    assert SECRET_PLACEHOLDER in out["error"]
+
+
+def test_redact_in_obj_leaves_keys_alone():
+    out = redact_secrets_in_obj({"api_key_name": "harmless"})
+
+    assert "api_key_name" in out
+
+
+def test_redact_in_obj_applies_configured_extra_values():
+    out = redact_secrets_in_obj({"note": "value is hunter2hunter2"}, ["hunter2hunter2"])
+
+    assert "hunter2hunter2" not in out["note"]
+
+
+def test_quoted_credential_values_are_still_redacted():
+    text = 'DEEPSEEK_API_KEY="quotedsecretvalue123"'
+
+    out = redact_secrets(text)
+
+    assert "quotedsecretvalue123" not in out


### PR DESCRIPTION
## Problem

`redact_secrets` runs on **already-serialized** JSON. The `credential-assignment` pattern in
`kolega_code/security/secrets.py` captures its unquoted value as `[^\s"']+` — which excludes
whitespace and quotes, but not backslash. In encoded text it therefore matches the secret *plus the
trailing `\` of the following `\"` escape*. Replacing that span leaves a bare `"`, which closes the
JSON string early and corrupts the document.

In a user's `/bug` bundle this made `session.json` completely unparseable and destroyed 9 of 694
lines in `session-events.jsonl` — I had to reconstruct the session from the surviving JSONL to
diagnose their issue at all. Any source line of the form `f"...token={SECRET}"` that the agent read
will trigger it.

Reproduced on `main` before the fix, where the detected span was:

```
'apify_api_9RtQv3LmZx8KpWn2Yc7BdF4HsJ6Tg1Ae0Nu5\'
                                               ^ the JSON escape, swallowed
```

## Changes

**`redact_secrets_in_obj`** (new, exported from `kolega_code.security`) redacts the *decoded* string
leaves of a JSON-compatible structure and lets the caller re-serialize. Output is valid by
construction, and the patterns match real text instead of escaped text. Non-JSON leaves are coerced
with `str()` **and then** redacted — that closes a real hole, since `json.dumps(..., default=str)`
stringifies such objects *after* scrubbing, so a token inside e.g. an exception object was never
redacted at all. Dict keys are left alone; they are structural.

**Regex hardening:** the unquoted alternative becomes `[^\s"'\\]+`. Real credentials do not contain
backslashes, so this only ever shortens a match. It is defense in depth for the plain-text callers
(`summary.md`, crash sidecars) that cannot redact structurally.

**Wiring** in `kolega_code/cli/diagnostics.py`:

- `DiagnosticsLog.record` redacts the payload dict before `json.dumps`, so log lines are valid by
  construction.
- `assemble_bug_bundle` redacts `session.json`, `session-events.jsonl` and `session-artifacts.json`
  structurally — per line for the JSONL, so one bad line cannot poison the rest. It preserves the
  `indent=2` / `sort_keys=True` formatting `SessionStore` writes, so bundles stay readable, and falls
  back to the previous text scrubbing when input does not parse rather than dropping the entry.

## Tests

New `tests/security/test_secrets.py`:

- the exact repro — serialized JSON containing `token=<fake>` before an escaped quote still parses
  after redaction, with the secret gone
- the detected span never ends in a backslash
- `redact_secrets_in_obj` redacts nested strings, preserves shape and scalar types, honours
  configured extra values, leaves keys alone, and redacts secrets reachable only via `str()` coercion
- quoted credential values are still redacted

Extended `tests/cli/test_diagnostics.py`:

- a log line stays parseable when a secret precedes an escaped quote
- `record` redacts values reached only through `str()` coercion
- `assemble_bug_bundle` yields a parseable, secret-free `session.json` and `session-events.jsonl`
- unparseable input still produces a scrubbed entry via the fallback
- one malformed JSONL line does not lose the surrounding good lines
- `indent=2` / `sort_keys=True` formatting survives redaction

2463 passed; `pre-commit run --all-files` clean. All credentials in tests are obviously fake.
