### PR TITLE
fix(agent): make failed model_override errors actionable

### DIFF
--- a/kolega_code/agent/model_routing.py
+++ b/kolega_code/agent/model_routing.py
@@ -57,6 +57,71 @@ def provider_is_configured(config: AgentConfig, provider: ModelProvider) -> bool
     return bool(config.get_api_key(provider))
 
 
+# The two OpenAI backends serve the same models, so a caller that names one when only
+# the other is configured is one word away from a valid route. Preference between them
+# is advice, never enforcement: a subscription can run out of quota, and the user may
+# have their own reason to direct a worker at a particular backend.
+_SIBLING_PROVIDERS: dict[ModelProvider, ModelProvider] = {
+    ModelProvider.OPENAI: ModelProvider.OPENAI_CHATGPT,
+    ModelProvider.OPENAI_CHATGPT: ModelProvider.OPENAI,
+}
+_PREFERRED_SIBLING = ModelProvider.OPENAI_CHATGPT
+
+SIBLING_PREFERENCE_ADVICE = (
+    f"`{ModelProvider.OPENAI.value}` and `{ModelProvider.OPENAI_CHATGPT.value}` serve the same models. "
+    f"Prefer `{_PREFERRED_SIBLING.value}` when configured."
+)
+
+
+def configured_provider_names(config: AgentConfig) -> list[str]:
+    """Configured providers that actually have dispatchable models, in catalog order.
+
+    Mirrors what ``subagent_model_catalog`` reports so an error message and the
+    discovery tool can never disagree about what is available.
+    """
+    names: list[str] = []
+    for provider_value, _model_name in MODEL_SPECS:
+        if provider_value in names:
+            continue
+        try:
+            provider = ModelProvider(provider_value)
+        except ValueError:
+            continue
+        if provider_is_configured(config, provider):
+            names.append(provider_value)
+    return names
+
+
+def _configured_providers_sentence(config: AgentConfig) -> str:
+    names = configured_provider_names(config)
+    if not names:
+        return "No providers are configured for sub-agent model overrides."
+    return f"Configured providers: {', '.join(names)}."
+
+
+def _sibling_sentence(config: AgentConfig, provider: Optional[ModelProvider]) -> str:
+    """Advice naming the configured sibling backend, when one is relevant."""
+    sibling = _SIBLING_PROVIDERS.get(provider) if provider is not None else None
+    if sibling is None or not provider_is_configured(config, sibling):
+        return ""
+    return (
+        f"'{ModelProvider.OPENAI.value}' and '{ModelProvider.OPENAI_CHATGPT.value}' serve the same models; "
+        f"prefer '{_PREFERRED_SIBLING.value}' when it is configured."
+    )
+
+
+def _omit_override_sentence(inherited: ModelConfig) -> str:
+    effort = inherited.thinking_effort if inherited.thinking_effort is not None else "null"
+    return (
+        "Omit model_override entirely to run with the default: "
+        f"{inherited.provider.value}/{inherited.model} ({effort})."
+    )
+
+
+def _override_error(*parts: str) -> ValueError:
+    return ValueError(" ".join(part for part in parts if part))
+
+
 def parse_atomic_model_override(
     value: Any,
     *,
@@ -99,21 +164,34 @@ def parse_atomic_model_override(
 def _validated_override_model(
     config: AgentConfig, override: AtomicModelOverride, inherited: ModelConfig
 ) -> ModelConfig:
+    # Every failure below names what *is* available and how to proceed without an
+    # override. Listing the supported enum instead of the configured providers sent
+    # callers straight into another unusable guess.
     try:
         provider = ModelProvider(override.provider)
     except ValueError as exc:
-        valid = ", ".join(item.value for item in ModelProvider)
-        raise ValueError(
-            f"Unsupported model_override provider '{override.provider}'. Valid providers: {valid}."
+        raise _override_error(
+            f"Unsupported model_override provider '{override.provider}'.",
+            _configured_providers_sentence(config),
+            _omit_override_sentence(inherited),
         ) from exc
 
     try:
         get_model_specs(provider, override.model)
     except ValueError as exc:
-        raise ValueError(str(exc)) from exc
+        raise _override_error(
+            str(exc),
+            _sibling_sentence(config, provider),
+            _omit_override_sentence(inherited),
+        ) from exc
 
     if not provider_is_configured(config, provider):
-        raise ValueError(f"Provider '{provider.value}' is not configured for sub-agent model overrides.")
+        raise _override_error(
+            f"Provider '{provider.value}' is not configured.",
+            _configured_providers_sentence(config),
+            _sibling_sentence(config, provider),
+            _omit_override_sentence(inherited),
+        )
 
     efforts = thinking_effort_options(provider, override.model)
     if efforts:
@@ -265,6 +343,7 @@ def subagent_model_catalog(config: AgentConfig, provider: Optional[str] = None) 
 def render_subagent_model_catalog(catalog: dict[str, Any]) -> str:
     """Render discovery data compactly for an LLM and the visible transcript."""
 
+    configured = {entry["provider"] for entry in catalog["providers"]}
     lines = [
         "# Available sub-agent models",
         "",
@@ -272,12 +351,18 @@ def render_subagent_model_catalog(catalog: dict[str, Any]) -> str:
         "- Ordinary dispatch: `provider`, `model`, `thinking_effort`",
         "- Gigacode: `provider`, `model`, `effort`",
         "- Effort must be an exact listed value; use `null` only where efforts are `null`.",
-        "",
-        "## Effective role defaults",
-        "",
-        "| Role | Provider/model | Effort |",
-        "| --- | --- | --- |",
     ]
+    if {ModelProvider.OPENAI.value, ModelProvider.OPENAI_CHATGPT.value} <= configured:
+        lines.append(f"- {SIBLING_PREFERENCE_ADVICE}")
+    lines.extend(
+        [
+            "",
+            "## Effective role defaults",
+            "",
+            "| Role | Provider/model | Effort |",
+            "| --- | --- | --- |",
+        ]
+    )
     for role, route in catalog["agent_defaults"].items():
         effort = route["thinking_effort"] if route["thinking_effort"] is not None else "null"
         lines.append(f"| {role} | `{route['provider']}/{route['model']}` | `{effort}` |")

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -51,7 +51,8 @@ _ORDINARY_MODEL_OVERRIDE_SCHEMA: dict[str, Any] = {
             "minLength": 1,
             "description": (
                 "Non-empty configured provider name returned by list_subagent_models. "
-                "Never infer it from the model name."
+                "Never infer it from the model name. "
+                "`openai` and `openai_chatgpt` serve the same models; prefer `openai_chatgpt` when configured."
             ),
         },
         "model": {

--- a/tests/agent/test_model_routing.py
+++ b/tests/agent/test_model_routing.py
@@ -5,6 +5,7 @@ import json
 import pytest
 
 from kolega_code.agent.model_routing import (
+    configured_provider_names,
     model_routing_fingerprint,
     render_subagent_model_catalog,
     resolve_subagent_model,
@@ -187,3 +188,127 @@ def test_routing_fingerprint_changes_without_including_secrets() -> None:
     )
     assert model_routing_fingerprint(first) != model_routing_fingerprint(second)
     assert "secret" not in model_routing_fingerprint(first)
+
+
+# ---------------------------------------------------------------------------
+# Failed overrides must name a way forward
+#
+# A real session produced 10 consecutive failed dispatches: the caller guessed
+# `openai` while running on `openai_chatgpt`, retried byte-identical input five
+# times, then invented `provider: "default"`. The old messages listed the
+# supported enum rather than what was configured, which just invited the next
+# unusable guess. It never called list_subagent_models.
+# ---------------------------------------------------------------------------
+
+
+def _override_error(config: AgentConfig, override: dict[str, object]) -> str:
+    with pytest.raises(ValueError) as excinfo:
+        resolve_subagent_model(config, "general-agent", override, effort_key="thinking_effort")
+    return str(excinfo.value)
+
+
+def test_unconfigured_provider_error_lists_configured_providers_not_the_enum() -> None:
+    message = _override_error(
+        _config(), {"provider": "google", "model": "gemini-3.1-pro-preview", "thinking_effort": "high"}
+    )
+
+    assert "Provider 'google' is not configured." in message
+    assert "Configured providers:" in message
+    assert "anthropic" in message and "openai_chatgpt" in message
+    # google is unconfigured here, so it must not be advertised back as a choice.
+    assert "Configured providers: " in message
+    listed = message.split("Configured providers: ", 1)[1].split(".", 1)[0]
+    assert "google" not in listed
+
+
+def test_unconfigured_provider_error_names_the_configured_sibling() -> None:
+    """The exact shape that failed five times in a row."""
+    message = _override_error(_config(), {"provider": "openai", "model": "gpt-5.4-mini", "thinking_effort": "low"})
+
+    assert "serve the same models" in message
+    assert "prefer 'openai_chatgpt' when it is configured" in message
+
+
+def test_sibling_advice_is_absent_for_unrelated_providers() -> None:
+    message = _override_error(
+        _config(), {"provider": "google", "model": "gemini-3.1-pro-preview", "thinking_effort": "high"}
+    )
+
+    assert "serve the same models" not in message
+
+
+def test_sibling_advice_is_absent_when_the_sibling_is_not_configured() -> None:
+    config = AgentConfig(anthropic_api_key="secret-anthropic-key")
+
+    message = _override_error(config, {"provider": "openai", "model": "gpt-5.4-mini", "thinking_effort": "low"})
+
+    assert "not configured" in message
+    assert "serve the same models" not in message
+
+
+def test_unsupported_provider_error_lists_configured_providers() -> None:
+    message = _override_error(_config(), {"provider": "default", "model": "default", "thinking_effort": None})
+
+    assert "Unsupported model_override provider 'default'." in message
+    assert "Configured providers:" in message
+    # The supported-enum dump used to advertise providers that were not usable.
+    assert "groq" not in message
+    assert "fireworks" not in message
+
+
+def test_unsupported_model_error_still_points_at_the_default() -> None:
+    message = _override_error(
+        _config(), {"provider": "anthropic", "model": "claude-imaginary-9", "thinking_effort": "high"}
+    )
+
+    assert "claude-imaginary-9" in message
+    assert "Omit model_override entirely" in message
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"provider": "google", "model": "gemini-3.1-pro-preview", "thinking_effort": "high"},
+        {"provider": "openai", "model": "gpt-5.4-mini", "thinking_effort": "low"},
+        {"provider": "default", "model": "default", "thinking_effort": None},
+    ],
+)
+def test_every_override_failure_offers_the_inherited_default(override: dict[str, object]) -> None:
+    """In all 10 real failures the caller did not need a specific model."""
+    config = _config()
+    inherited = config.model_config_for_agent("general-agent")
+
+    message = _override_error(config, override)
+
+    assert "Omit model_override entirely to run with the default:" in message
+    assert f"{inherited.provider.value}/{inherited.model}" in message
+
+
+def test_configured_provider_names_match_the_discovery_catalog() -> None:
+    """An error and list_subagent_models must never disagree about availability."""
+    config = _config()
+
+    names = configured_provider_names(config)
+    catalog = {entry["provider"] for entry in subagent_model_catalog(config)["providers"]}
+
+    assert set(names) == catalog
+
+
+def test_catalog_notes_the_sibling_preference_only_when_both_are_configured() -> None:
+    both = AgentConfig(
+        # anthropic keys the default role models so the config validates.
+        anthropic_api_key="secret-anthropic-key",
+        openai_api_key="secret-openai-key",
+        openai_chatgpt_tokens=OAuthTokens(
+            access_token="secret-access-token",
+            refresh_token="secret-refresh-token",
+            email="private@example.com",
+            account_id="acct-private",
+        ),
+    )
+
+    with_both = render_subagent_model_catalog(subagent_model_catalog(both))
+    with_one = render_subagent_model_catalog(subagent_model_catalog(_config()))
+
+    assert "Prefer `openai_chatgpt` when configured." in with_both
+    assert "Prefer `openai_chatgpt` when configured." not in with_one


### PR DESCRIPTION
## Problem

A real session produced **10 consecutive failed sub-agent dispatches**, from a caller that never
once called `list_subagent_models`:

| Attempts | `model_override` sent | Result |
| --- | --- | --- |
| 5× identical | `openai / gpt-5.4-mini / low` | `Provider 'openai' is not configured…` |
| 2× | `openai / gpt-5.6-terra / medium` | same |
| 1× | `openai / gpt-5.4 / high` | same |
| 1× | `anthropic / claude-sonnet-4-6 / high` | same |
| 1× | `default / default / null` | `Unsupported model_override provider 'default'…` |

The session was running on `openai_chatgpt`, and the caller kept guessing the sibling name `openai`.

The guidance it already had was emphatic — *"Never infer it from the model name"*, *"Only include it
after calling `list_subagent_models`"*, *"Usually omit this property entirely"* — and was ignored 11
times. More prose is not the lever. The **errors** are:

- `Provider 'openai' is not configured for sub-agent model overrides.` states the problem and offers
  no route forward. Hence the 5× identical retry.
- `Unsupported model_override provider 'default'. Valid providers: anthropic, openai, openai_chatgpt,
  google, groq, …` dumps the supported **enum**, not what is **configured** — so it advertises
  `openai` and `anthropic`, the two that had just failed as unconfigured. It invites the next
  unusable guess.

## Change

Failures now name what is available and how to proceed. Same config as the report (Google key +
ChatGPT subscription):

```
Provider 'openai' is not configured. Configured providers: openai_chatgpt, google.
'openai' and 'openai_chatgpt' serve the same models; prefer 'openai_chatgpt' when it is configured.
Omit model_override entirely to run with the default: google/gemini-3.1-pro-preview (high).
```

```
Unsupported model_override provider 'default'. Configured providers: openai_chatgpt, google.
Omit model_override entirely to run with the default: google/gemini-3.1-pro-preview (high).
```

Three parts:

- **Configured providers, not the enum.** Sourced from the same `MODEL_SPECS` walk as
  `subagent_model_catalog`, so an error and `list_subagent_models` can never disagree about what is
  available.
- **Sibling hint**, emitted only when the requested provider is one of the two OpenAI backends and
  the *other* one is configured.
- **The omit-it line**, always. In all 10 real failures no specific model was actually needed — the
  override was decoration.

All 10 failures would have been recoverable on the next attempt.

## The sibling preference is advice, not enforcement

I checked whether to remap `openai` → `openai_chatgpt` in code. It would be *technically* lossless —
`openai`'s 6 models are a strict subset of `openai_chatgpt`'s 7, with identical effort options and
vision support on every shared model — but it is wrong behaviourally: a subscription can run out of
quota, and a user may deliberately direct a worker at a particular backend. A hard redirect would
make the API-key route unreachable. So nothing is remapped; the route stays the caller's choice and
the preference is stated as a default.

The same sentence is added to the `provider` schema description (always in context, unlike the
catalog) and to the discovery catalog when both backends are configured.

## Tests

`tests/agent/test_model_routing.py`, 26 passing:

- unconfigured-provider error lists configured providers and does not list the unconfigured one
- the sibling hint appears for the exact `openai` shape that failed 5× in a row
- the hint is absent for unrelated providers, and absent when the sibling is not configured
- unsupported-provider error lists configured providers and no longer leaks `groq`/`fireworks`
- unsupported-model error still points at the default
- parametrised: every failure mode offers the inherited default route
- `configured_provider_names` matches the discovery catalog exactly
- the catalog notes the preference only when both backends are configured

Behaviour stays strict — an invalid override still fails rather than silently substituting a model
the caller did not ask for. Covers both override paths, since ordinary dispatch and gigacode share
`_validated_override_model`.

2478 passed; `pre-commit run --all-files` clean.
