### PR TITLE
feat(models): add Fireworks Kimi K3 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 - Added Anthropic Claude Opus 5 (`claude-opus-5`) with a 1M-token context
   window, 128K max output, vision input, and adaptive thinking with
   `low`/`medium`/`high`/`xhigh`/`max` effort levels.
+- Added Fireworks Kimi K3 (`accounts/fireworks/models/kimi-k3`) with a 1M-token
+  context window, 131K configured output, vision and tool-calling support, and
+  max reasoning effort.
 
 ### Changed
 

--- a/docs/src/content/docs/configuration/providers-and-models.mdx
+++ b/docs/src/content/docs/configuration/providers-and-models.mdx
@@ -66,10 +66,11 @@ model catalog should be refreshed periodically from Ollama's model library/API.
 **Fireworks.ai.** The `fireworks` provider targets Fireworks' OpenAI-compatible
 serverless endpoint (`https://api.fireworks.ai/inference/v1`) with `FIREWORKS_API_KEY`.
 Fireworks model IDs use resource names such as `accounts/fireworks/models/glm-5p2`.
-Kolega Code exposes GLM-5.2, GLM-5.1, Kimi K2.7 Code, DeepSeek V4 Pro/Flash,
-MiniMax M3, and Qwen 3.7 Plus through the Settings UI and CLI. Fireworks reasoning
-models return `reasoning_content`; Kolega Code exposes `none`, `low`, `medium`,
-`high`, and `max` as `reasoning_effort` values for these models.
+Kolega Code exposes Kimi K3, GLM-5.2, GLM-5.1, Kimi K2.7 Code, DeepSeek V4
+Pro/Flash, MiniMax M3, and Qwen 3.7 Plus through the Settings UI and CLI.
+Fireworks reasoning models return `reasoning_content`. Kimi K3 always reasons and
+uses `max` effort; the other listed Fireworks models expose `none`, `low`, `medium`,
+`high`, and `max` as `reasoning_effort` values.
 </Aside>
 
 <Aside type="note">

--- a/kolega_code/cli/provider_registry.py
+++ b/kolega_code/cli/provider_registry.py
@@ -86,6 +86,7 @@ MODEL_LABELS: dict[str, str] = {
     # Fireworks
     "accounts/fireworks/models/glm-5p2": "GLM-5.2",
     "accounts/fireworks/models/glm-5p1": "GLM-5.1",
+    "accounts/fireworks/models/kimi-k3": "Kimi K3",
     "accounts/fireworks/models/kimi-k2p7-code": "Kimi K2.7 Code",
     "accounts/fireworks/models/deepseek-v4-pro": "DeepSeek V4 Pro",
     "accounts/fireworks/models/deepseek-v4-flash": "DeepSeek V4 Flash",

--- a/kolega_code/llm/specs/catalog/fireworks.py
+++ b/kolega_code/llm/specs/catalog/fireworks.py
@@ -2,8 +2,20 @@ from kolega_code.llm.specs.types import ThinkingEffortSpec
 
 # Fireworks models (OpenAI-compatible endpoint). Fireworks reasoning models
 # expose reasoning_content in responses and accept flat reasoning_effort
-# values on chat completions. "none" disables reasoning.
+# values on chat completions. "none" disables reasoning where supported; Kimi
+# K3 always reasons and exposes only its maximum effort.
 FIREWORKS_SPECS = {
+    ("fireworks", "accounts/fireworks/models/kimi-k3"): {
+        "context_length": 1048576,
+        "max_completion_tokens": 131072,
+        "default_temperature": 1.0,
+        "supports_vision": True,
+        "thinking_effort": ThinkingEffortSpec(
+            options=("max",),
+            default="max",
+            mode="openai_reasoning_effort",
+        ),
+    },
     ("fireworks", "accounts/fireworks/models/glm-5p2"): {
         "context_length": 1048576,
         "max_completion_tokens": 131072,

--- a/tests/agent/llm/test_model_specs.py
+++ b/tests/agent/llm/test_model_specs.py
@@ -155,6 +155,18 @@ def test_fireworks_serverless_model_specs():
         assert specs["thinking_effort"].default == "medium"
 
 
+def test_fireworks_kimi_k3_model_specs():
+    specs = get_model_specs("fireworks", "accounts/fireworks/models/kimi-k3")
+
+    assert specs["context_length"] == 1048576
+    assert specs["max_completion_tokens"] == 131072
+    assert specs["default_temperature"] == 1.0
+    assert specs["supports_vision"] is True
+    assert specs["thinking_effort"].options == ("max",)
+    assert specs["thinking_effort"].default == "max"
+    assert specs["thinking_effort"].mode == "openai_reasoning_effort"
+
+
 def test_claude_fable_5_model_specs():
     specs = get_model_specs("anthropic", "claude-fable-5")
 

--- a/tests/agent/llm/test_openai_reasoning_replay.py
+++ b/tests/agent/llm/test_openai_reasoning_replay.py
@@ -20,6 +20,7 @@ from kolega_code.llm.specs.thinking import reasoning_replay_field
 
 DEEPSEEK_MODEL = "deepseek-v4-pro"
 FIREWORKS_MODEL = "accounts/fireworks/models/glm-5p2"
+FIREWORKS_KIMI_K3_MODEL = "accounts/fireworks/models/kimi-k3"
 OLLAMA_MODEL = "deepseek-v3.2"
 
 
@@ -33,6 +34,7 @@ def _assistant(*blocks, provider):
 def test_reasoning_replay_field_deepseek_fireworks_xai_use_reasoning_content():
     assert reasoning_replay_field("deepseek", DEEPSEEK_MODEL) == "reasoning_content"
     assert reasoning_replay_field("fireworks", FIREWORKS_MODEL) == "reasoning_content"
+    assert reasoning_replay_field("fireworks", FIREWORKS_KIMI_K3_MODEL) == "reasoning_content"
     # xAI's Chat Completions endpoint returns/accepts reasoning_content (verified live).
     assert reasoning_replay_field("xai", "grok-4.3") == "reasoning_content"
     assert reasoning_replay_field("xai", "grok-4.5") == "reasoning_content"

--- a/tests/agent/llm/test_thinking_effort.py
+++ b/tests/agent/llm/test_thinking_effort.py
@@ -215,6 +215,26 @@ def test_fireworks_openai_reasoning_effort_serialization() -> None:
     }
 
 
+def test_fireworks_kimi_k3_reasoning_effort_serialization() -> None:
+    provider = OpenAIProvider(api_key="test-key", provider_name="fireworks")
+    params = {"model": "accounts/fireworks/models/kimi-k3"}
+
+    provider._apply_thinking_params(params, GenerationParams(thinking="max"))
+
+    assert params == {
+        "model": "accounts/fireworks/models/kimi-k3",
+        "reasoning_effort": "max",
+    }
+
+
+@pytest.mark.parametrize("effort", ["none", "high"])
+def test_fireworks_kimi_k3_rejects_unsupported_thinking_effort(effort: str) -> None:
+    client = LLMClient(provider="fireworks", api_key="test-key")
+
+    with pytest.raises(ValueError, match="Unsupported thinking effort"):
+        client._prepare_thinking_param(effort, model="accounts/fireworks/models/kimi-k3")
+
+
 def test_google_gemini_3_pro_uses_thinking_level() -> None:
     provider = GoogleProvider(api_key="test-key")
 

--- a/tests/cli/test_provider_registry.py
+++ b/tests/cli/test_provider_registry.py
@@ -94,6 +94,7 @@ def test_new_google_models_are_selectable_without_changing_default() -> None:
 def test_fireworks_ui_model_options_include_serverless_catalog():
     options = dict(ui_model_options("fireworks"))
 
+    assert options["Kimi K3"] == "accounts/fireworks/models/kimi-k3"
     assert options["GLM-5.2"] == "accounts/fireworks/models/glm-5p2"
     assert options["GLM-5.1"] == "accounts/fireworks/models/glm-5p1"
     assert options["Kimi K2.7 Code"] == "accounts/fireworks/models/kimi-k2p7-code"
@@ -112,6 +113,7 @@ def test_vision_only_model_options_follow_catalog_capabilities():
     fireworks = dict(ui_model_options("fireworks", vision_only=True))
 
     assert fireworks == {
+        "Kimi K3": "accounts/fireworks/models/kimi-k3",
         "Kimi K2.7 Code": "accounts/fireworks/models/kimi-k2p7-code",
         "MiniMax M3": "accounts/fireworks/models/minimax-m3",
     }


### PR DESCRIPTION
## Summary

- add Fireworks Kimi K3 (`accounts/fireworks/models/kimi-k3`) to the supported model catalog
- expose its 1M context, 131K configured completion ceiling, vision support, and max-only reasoning behavior
- preserve Fireworks `reasoning_content` across tool-call rounds and surface K3 in model/vision selectors
- document the model while keeping GLM-5.2 as the default Fireworks selection

## Verification

- `./run_tests.sh tests/agent/llm/test_model_specs.py tests/agent/llm/test_thinking_effort.py tests/agent/llm/test_openai_reasoning_replay.py tests/cli/test_provider_registry.py -ra` — 79 passed
- `./run_tests.sh` — 3,354 passed, 1 skipped, 104 deselected
- `uv run ruff check .`
- `uv run pyright` — 0 errors, 0 warnings
- pre-commit hooks passed

## Live smoke test

A real request through Kolega Code's `LLMClient` succeeded with:

- model: `accounts/fireworks/models/kimi-k3`
- `max_completion_tokens=131072`
- `reasoning_effort=max`
- exact response: `fireworks-kimi-k3-ok`
- one parsed thinking block
- usage: 120 prompt tokens, 50 completion tokens

No full 1M-token boundary request was made; the catalog limit is sourced from Fireworks' published model metadata.
