### PR TITLE
chore: release v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.25.0 - 2026-07-28
+
 ### Added
 
 - **Scheduled loops.** `/loop 5m check whether CI went green` re-runs a prompt on
@@ -54,8 +56,6 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   string rather than a closed literal, and `timestamp` is timezone-aware UTC.
   `fastapi`, `uvicorn`, `websockets`, and `pygments` are now direct dependencies.
   See `MIGRATION.md` for host applications embedding this package.
-
-### Changed
 
 - Made Claude Opus 5 the default Anthropic long-context and thinking model.
 

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.24.1"
+__version__ = "0.25.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.24.1"
+__version__ = "0.25.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.24.1"
+version = "0.25.0"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-20T00:38:13.329257Z"
+exclude-newer = "2026-07-21T04:19:27.837066Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1522,7 +1522,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.24.1"
+version = "0.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- bump the package version to `0.25.0` in all release metadata
- roll accumulated Unreleased notes into the `0.25.0` changelog entry dated 2026-07-28
- regenerate `uv.lock` for the release

## Verification

- `UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" uv sync --extra dev --frozen`
- `UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" ./run_tests.sh` (`3354 passed, 1 skipped, 104 deselected`)
- `UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" uv run pre-commit run --all-files --show-diff-on-failure`
- `git diff --check`
