### PR TITLE
fix(llm): resize oversized Anthropic history images

### DIFF
--- a/kolega_code/agent/conversation.py
+++ b/kolega_code/agent/conversation.py
@@ -23,6 +23,7 @@ from kolega_code.llm.models import (
     ToolCall,
     ToolResult,
 )
+from kolega_code.utils import images as image_utils
 from kolega_code.agent.tool_backend.hashline_v2 import strip_hashline_read_output
 
 logger = logging.getLogger(__name__)
@@ -31,6 +32,66 @@ logger = logging.getLogger(__name__)
 def _image_placeholder(media_type: str, model_name: str) -> str:
     """Text substituted for an image block when the active model can't see images."""
     return f"[An image ({media_type}) was shared earlier in this thread but is not visible to {model_name}.]"
+
+
+def _oversized_image_placeholder(media_type: str, model_name: str) -> str:
+    """Text substituted when a provider-safe image derivative cannot be made."""
+    return (
+        f"[An earlier image ({media_type}) exceeded {model_name}'s request limit and could not be resized safely, "
+        "so it was omitted from this request.]"
+    )
+
+
+def _adapt_image_block_for_provider(
+    block: ImageBlock,
+    *,
+    target_provider: str,
+    target_model: str,
+    supports_vision: bool,
+) -> tuple[ContentBlock, bool]:
+    """Return a request-safe image block without mutating stored history."""
+    if not supports_vision:
+        return TextBlock(text=_image_placeholder(block.media_type, target_model)), True
+
+    if target_provider != "anthropic" or block.image_type != "base64":
+        return block, False
+
+    result = image_utils.resize_base64_image_to_limit(
+        block.data,
+        block.media_type,
+        max_base64_bytes=image_utils.ANTHROPIC_MAX_IMAGE_BASE64_BYTES,
+    )
+    if not result.succeeded:
+        logger.warning(
+            "Omitting oversized Anthropic history image that could not be resized: %s",
+            result.error or "unknown image conversion error",
+        )
+        return (
+            TextBlock(
+                text=_oversized_image_placeholder(block.media_type, target_model),
+                cache_checkpoint=block.cache_checkpoint,
+            ),
+            True,
+        )
+    if not result.resized:
+        return block, False
+
+    assert result.data is not None
+    assert result.media_type is not None
+    logger.info(
+        "Resized Anthropic history image from %d to %d base64 bytes",
+        len(block.data),
+        len(result.data),
+    )
+    return (
+        ImageBlock(
+            image_type="base64",
+            media_type=result.media_type,
+            data=result.data,
+            cache_checkpoint=block.cache_checkpoint,
+        ),
+        True,
+    )
 
 
 def count_image_blocks(messages: List[Message]) -> int:
@@ -209,9 +270,15 @@ def _adapt_content_blocks_for_provider(
     changed = False
 
     for block in blocks:
-        if isinstance(block, ImageBlock) and not supports_vision:
-            adapted.append(TextBlock(text=_image_placeholder(block.media_type, target_model)))
-            changed = True
+        if isinstance(block, ImageBlock):
+            adapted_block, image_changed = _adapt_image_block_for_provider(
+                block,
+                target_provider=target_provider,
+                target_model=target_model,
+                supports_vision=supports_vision,
+            )
+            adapted.append(adapted_block)
+            changed = changed or image_changed
         elif isinstance(block, (ThinkingBlock, RedactedThinkingBlock, ResponsesReasoningBlock)):
             if _preserve_reasoning_block(block, source_provider=source_provider, target_provider=target_provider):
                 adapted.append(block)
@@ -240,7 +307,24 @@ def _adapt_content_blocks_for_provider(
                 source_edit_protocol=call_protocol,
                 target_edit_protocol=target_edit_protocol,
             ):
-                adapted.append(block)
+                if isinstance(block.content, list):
+                    inner, inner_changed = _adapt_content_blocks_for_provider(
+                        block.content,
+                        source_provider=source_provider,
+                        target_provider=target_provider,
+                        target_model=target_model,
+                        supports_vision=supports_vision,
+                        target_edit_protocol=target_edit_protocol,
+                        tool_call_providers=tool_call_providers,
+                        tool_call_protocols=tool_call_protocols,
+                        source_usage_metadata=source_usage_metadata,
+                        # Nested tool-result content is tool output, never assistant prose.
+                        message_role=None,
+                    )
+                    adapted.append(_tool_result_with_content(block, inner) if inner_changed else block)
+                    changed = changed or inner_changed
+                else:
+                    adapted.append(block)
             else:
                 adapted.append(_freeform_result_placeholder(block, call_source))
                 changed = True
@@ -315,8 +399,9 @@ def adapt_history_for_provider(
     blocks — substituting model-visible text there gets echoed back by the model
     and then persisted as real history. Assistant text carrying placeholders
     echoed by earlier builds is scrubbed for the same reason. Image blocks are
-    preserved for vision models and replaced with placeholders for non-vision
-    models, matching the previous image compatibility behavior.
+    preserved for vision models, except that oversized base64 images get an
+    ephemeral provider-safe derivative for Anthropic. Non-vision models receive
+    placeholders, matching the previous image compatibility behavior.
 
     An assistant message left with no content blocks is omitted from the returned
     history. That orphans nothing: tool calls are never dropped by this pass, so

--- a/kolega_code/utils/images.py
+++ b/kolega_code/utils/images.py
@@ -14,10 +14,12 @@ from __future__ import annotations
 
 import base64
 import io
+import math
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
-from PIL import Image
+from PIL import Image, ImageOps
 
 # Supported image extensions -> MIME types. These are the common web image
 # formats accepted by all four provider backends (Anthropic, OpenAI, Google,
@@ -34,9 +36,150 @@ IMAGE_MIME_TYPES: Dict[str, str] = {
 # Skip images larger than this to avoid blowing the context budget.
 MAX_IMAGE_BYTES = 20 * 1024 * 1024
 
+# Anthropic validates the encoded ``source.base64`` field itself, not the
+# decoded image size. A raw image just under 10 MiB may therefore exceed this
+# limit after base64's 4/3 expansion.
+ANTHROPIC_MAX_IMAGE_BASE64_BYTES = 10 * 1024 * 1024
+
+# Leave headroom below the provider's hard boundary when producing a
+# derivative. This avoids repeatedly re-encoding an image for tiny accounting
+# differences and gives later request serialization a conservative margin.
+_IMAGE_RESIZE_SAFETY_RATIO = 0.95
+_IMAGE_RESIZE_MAX_ATTEMPTS = 12
+# Bound decoded working memory before Pillow copies/converts a provider
+# derivative. Forty megapixels can already require 160 MiB as RGBA.
+_IMAGE_RESIZE_MAX_PIXELS = 40_000_000
+
 # Dark -> light ramp for grayscale ASCII rendering. Index 0 (space) is the
 # darkest pixel; the last char (``@``) is the brightest.
 _ASCII_RAMP = " .:-=+*#%@"
+
+
+@dataclass(frozen=True)
+class ImageResizeResult:
+    """Result of fitting a base64 image to a provider payload limit."""
+
+    data: Optional[str]
+    media_type: Optional[str]
+    resized: bool
+    error: Optional[str] = None
+
+    @property
+    def succeeded(self) -> bool:
+        return self.data is not None and self.media_type is not None
+
+
+def base64_encoded_size(raw_size: int) -> int:
+    """Return the exact base64 length for ``raw_size`` bytes."""
+    if raw_size < 0:
+        raise ValueError("raw_size must be non-negative")
+    return 4 * ((raw_size + 2) // 3)
+
+
+def max_raw_size_for_base64_limit(encoded_limit: int) -> int:
+    """Return the largest raw byte count whose base64 fits ``encoded_limit``."""
+    if encoded_limit < 0:
+        raise ValueError("encoded_limit must be non-negative")
+    return 3 * (encoded_limit // 4)
+
+
+def resize_base64_image_to_limit(
+    data: str,
+    media_type: str,
+    *,
+    max_base64_bytes: int,
+) -> ImageResizeResult:
+    """Return a non-mutating provider-safe derivative of a base64 image.
+
+    Images already within the hard limit are returned byte-for-byte unchanged.
+    Oversized images are decoded and re-encoded as PNG when transparency must
+    be retained, or optimized JPEG otherwise. Dimensions are reduced
+    iteratively until the payload has a safety margin below the provider limit.
+    Animated images use their first frame for the ephemeral provider copy.
+    """
+    if max_base64_bytes <= 0:
+        raise ValueError("max_base64_bytes must be positive")
+
+    if not data.isascii():
+        return ImageResizeResult(None, None, resized=False, error="Image payload is not ASCII base64")
+    encoded_size = len(data)
+
+    if encoded_size <= max_base64_bytes:
+        return ImageResizeResult(data, media_type, resized=False)
+
+    try:
+        raw = base64.b64decode(data, validate=True)
+        with Image.open(io.BytesIO(raw)) as opened:
+            opened.seek(0)
+            width, height = opened.size
+            if width * height > _IMAGE_RESIZE_MAX_PIXELS:
+                return ImageResizeResult(
+                    None,
+                    None,
+                    resized=False,
+                    error=f"Image dimensions exceed the {_IMAGE_RESIZE_MAX_PIXELS:,}-pixel resize safety limit",
+                )
+            image = ImageOps.exif_transpose(opened).copy()
+    except Exception as exc:
+        return ImageResizeResult(None, None, resized=False, error=f"Could not decode image: {exc}")
+
+    has_transparency = "A" in image.getbands() or "transparency" in image.info
+    if has_transparency:
+        image = image.convert("RGBA")
+        output_format = "PNG"
+        output_media_type = "image/png"
+    else:
+        image = image.convert("RGB")
+        output_format = "JPEG"
+        output_media_type = "image/jpeg"
+
+    target_size = int(max_base64_bytes * _IMAGE_RESIZE_SAFETY_RATIO)
+    target_size -= target_size % 4
+    if target_size < 4:
+        return ImageResizeResult(
+            None,
+            None,
+            resized=False,
+            error=f"Could not fit image below the {max_base64_bytes}-byte base64 limit",
+        )
+
+    for _ in range(_IMAGE_RESIZE_MAX_ATTEMPTS):
+        output = io.BytesIO()
+        try:
+            if output_format == "PNG":
+                image.save(output, format=output_format, optimize=True, compress_level=9)
+            else:
+                image.save(output, format=output_format, quality=90, optimize=True, progressive=True)
+        except Exception as exc:
+            return ImageResizeResult(None, None, resized=False, error=f"Could not encode resized image: {exc}")
+
+        derivative = base64.b64encode(output.getvalue()).decode("ascii")
+        if len(derivative) <= target_size:
+            return ImageResizeResult(derivative, output_media_type, resized=True)
+
+        width, height = image.size
+        if width <= 1 and height <= 1:
+            break
+
+        # Encoded size trends with pixel area, so the square root estimates a
+        # useful one-step dimension ratio. The extra margin guarantees progress
+        # when compression ratios are nonlinear.
+        ratio = math.sqrt(target_size / len(derivative)) * 0.95
+        ratio = min(0.9, max(0.1, ratio))
+        next_width = max(1, int(width * ratio))
+        next_height = max(1, int(height * ratio))
+        if next_width == width and width > 1:
+            next_width -= 1
+        if next_height == height and height > 1:
+            next_height -= 1
+        image = image.resize((next_width, next_height), Image.Resampling.LANCZOS)
+
+    return ImageResizeResult(
+        None,
+        None,
+        resized=False,
+        error=f"Could not fit image below the {max_base64_bytes}-byte base64 limit",
+    )
 
 
 def image_media_type(path_or_suffix: Union[str, Path]) -> Optional[str]:

--- a/tests/agent/test_base_agent_effective_history.py
+++ b/tests/agent/test_base_agent_effective_history.py
@@ -1,4 +1,6 @@
 # ruff: noqa: F401,F811,E402
+import base64
+import io
 import os
 import uuid
 from types import SimpleNamespace
@@ -6,9 +8,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from dotenv import load_dotenv
+from PIL import Image
 
 from kolega_code.agent.baseagent import BaseAgent
 from kolega_code.agent.errors import MaxAgentIterationsExceeded
+from kolega_code.cli.session_store import SessionStore
 from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
 from kolega_code.events import AgentConnectionManager
 from kolega_code.llm.exceptions import (
@@ -146,6 +150,58 @@ class TestBaseAgent:
 
         assert history[0].content[1] is image
         assert history[1].content[0].content[0] is nested_image
+
+    def test_anthropic_history_resize_preserves_hydrated_history_and_artifact(
+        self,
+        base_agent,
+        tmp_path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        import kolega_code.utils.images as image_utils
+
+        image = Image.effect_noise((160, 120), 80).convert("RGB")
+        output = io.BytesIO()
+        image.save(output, format="JPEG")
+        original_bytes = output.getvalue()
+        original_base64 = base64.b64encode(original_bytes).decode("ascii")
+        limit = 1_600
+        assert len(original_base64) > limit
+
+        project = tmp_path / "project"
+        project.mkdir()
+        store = SessionStore(tmp_path / "state")
+        record = store.create(project, "code", {})
+        store.recorder(record.session_id).record_context_message(
+            Message(
+                role="user",
+                content=[ImageBlock(image_type="base64", media_type="image/jpeg", data=original_base64)],
+            )
+        )
+        journal = store.journal(record.session_id)
+        event = next(event for event in journal.read_events() if event.artifacts)
+        artifact_ref = event.artifacts[0]
+        artifact_before = journal.read_artifact(artifact_ref)
+        assert artifact_before == original_bytes
+
+        loaded = store.load(record.session_id)
+        base_agent.restore_message_history(loaded.history)
+        restored_image = base_agent.history[0].content[0]
+        assert isinstance(restored_image, ImageBlock)
+        assert restored_image.data == original_base64
+
+        monkeypatch.setattr(image_utils, "ANTHROPIC_MAX_IMAGE_BASE64_BYTES", limit)
+        base_agent.primary_model_config.provider = ModelProvider.ANTHROPIC
+        base_agent.primary_model_config.model = "claude-opus-4-8"
+        base_agent.supports_vision = True
+
+        outbound = base_agent._history_for_llm()
+
+        outbound_image = outbound[0].content[0]
+        assert isinstance(outbound_image, ImageBlock)
+        assert outbound_image.data != original_base64
+        assert len(outbound_image.data) < limit
+        assert restored_image.data == original_base64
+        assert journal.read_artifact(artifact_ref) == artifact_before
 
     def test_get_effective_history_falls_back_when_no_compression(self, base_agent):
         # With no compression, effective == full history

--- a/tests/agent/test_history_image_blocks.py
+++ b/tests/agent/test_history_image_blocks.py
@@ -7,6 +7,12 @@ request copy (stored history is never mutated), and the compaction-aware detecto
 only reports images that would actually be sent.
 """
 
+import base64
+import io
+
+import pytest
+from PIL import Image
+
 from kolega_code.agent.conversation import (
     Conversation,
     adapt_history_for_provider,
@@ -27,6 +33,17 @@ from kolega_code.llm.models import (
 
 def _image(media_type: str = "image/png") -> ImageBlock:
     return ImageBlock(image_type="base64", media_type=media_type, data="ZmFrZQ==")
+
+
+def _noise_jpeg() -> ImageBlock:
+    image = Image.effect_noise((160, 120), 80).convert("RGB")
+    output = io.BytesIO()
+    image.save(output, format="JPEG")
+    return ImageBlock(
+        image_type="base64",
+        media_type="image/jpeg",
+        data=base64.b64encode(output.getvalue()).decode("ascii"),
+    )
 
 
 def _user(*blocks) -> Message:
@@ -219,3 +236,149 @@ def test_replace_preserves_cache_checkpoint_on_tool_result():
     new_tr = out[0].content[0]
     assert isinstance(new_tr, ToolResult)
     assert new_tr.cache_checkpoint is True
+
+
+def test_adapt_resizes_top_level_and_nested_anthropic_images_without_mutating_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kolega_code.utils.images as image_utils
+
+    limit = 1_600
+    monkeypatch.setattr(image_utils, "ANTHROPIC_MAX_IMAGE_BASE64_BYTES", limit)
+    top_level = _noise_jpeg()
+    nested = _noise_jpeg()
+    result = ToolResult(
+        tool_use_id="image-call",
+        name="read_image",
+        content=[nested, TextBlock(text="caption")],
+        is_error=False,
+        cache_checkpoint=True,
+        execution_id="image-exec",
+    )
+    history = [_user(TextBlock(text="look"), top_level), _user(result)]
+
+    adapted = adapt_history_for_provider(
+        history,
+        target_provider="anthropic",
+        target_model="claude-opus-5",
+        supports_vision=True,
+    )
+
+    adapted_top = adapted[0].content[1]
+    assert isinstance(adapted_top, ImageBlock)
+    assert adapted_top is not top_level
+    assert adapted_top.media_type == "image/jpeg"
+    assert len(adapted_top.data) < limit
+    assert adapted_top.data != top_level.data
+
+    adapted_result = adapted[1].content[0]
+    assert isinstance(adapted_result, ToolResult)
+    assert adapted_result is not result
+    assert adapted_result.tool_use_id == "image-call"
+    assert adapted_result.name == "read_image"
+    assert adapted_result.is_error is False
+    assert adapted_result.cache_checkpoint is True
+    assert adapted_result.execution_id == "image-exec"
+    adapted_nested = adapted_result.content[0]
+    assert isinstance(adapted_nested, ImageBlock)
+    assert adapted_nested is not nested
+    assert len(adapted_nested.data) < limit
+    assert isinstance(adapted_result.content[1], TextBlock)
+    assert adapted_result.content[1].text == "caption"
+
+    # The canonical stored history remains full-resolution and untouched.
+    assert history[0].content[1] is top_level
+    assert history[1].content[0] is result
+    assert result.content[0] is nested
+
+
+def test_adapt_resizes_image_nested_in_compatible_freeform_tool_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    import kolega_code.utils.images as image_utils
+
+    limit = 1_600
+    monkeypatch.setattr(image_utils, "ANTHROPIC_MAX_IMAGE_BASE64_BYTES", limit)
+    nested = _noise_jpeg()
+    result = ToolResult(
+        tool_use_id="freeform-image-call",
+        name="read_image",
+        content=[nested],
+        is_error=False,
+        input_kind="freeform",
+    )
+    history = [
+        Message(
+            role="user",
+            content=[result],
+            usage_metadata={"provider": "anthropic"},
+        )
+    ]
+
+    adapted = adapt_history_for_provider(
+        history,
+        target_provider="anthropic",
+        target_model="claude-opus-5",
+        supports_vision=True,
+    )
+
+    adapted_result = adapted[0].content[0]
+    assert isinstance(adapted_result, ToolResult)
+    assert isinstance(adapted_result.content, list)
+    adapted_image = adapted_result.content[0]
+    assert isinstance(adapted_image, ImageBlock)
+    assert len(adapted_image.data) < limit
+    assert adapted_image.data != nested.data
+    assert result.content[0] is nested
+
+
+def test_adapt_leaves_valid_url_and_non_anthropic_images_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    import kolega_code.utils.images as image_utils
+
+    monkeypatch.setattr(image_utils, "ANTHROPIC_MAX_IMAGE_BASE64_BYTES", 64)
+    valid = _image()
+    url = ImageBlock(image_type="url", media_type="image/png", data="https://example.com/image.png")
+    oversized = _noise_jpeg()
+    history = [_user(valid, url, oversized)]
+
+    anthropic = adapt_history_for_provider(
+        history,
+        target_provider="anthropic",
+        target_model="claude-opus-5",
+        supports_vision=True,
+    )
+    assert anthropic[0].content[0] is valid
+    assert anthropic[0].content[1] is url
+
+    openai = adapt_history_for_provider(
+        history,
+        target_provider="openai",
+        target_model="gpt-5.4",
+        supports_vision=True,
+    )
+    assert openai is history
+    assert openai[0].content[2] is oversized
+
+
+def test_adapt_omits_oversized_anthropic_image_when_resize_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    import kolega_code.utils.images as image_utils
+
+    monkeypatch.setattr(image_utils, "ANTHROPIC_MAX_IMAGE_BASE64_BYTES", 64)
+    invalid = ImageBlock(
+        image_type="base64",
+        media_type="image/png",
+        data=base64.b64encode(b"not-an-image" * 100).decode("ascii"),
+        cache_checkpoint=True,
+    )
+    history = [_user(invalid)]
+
+    adapted = adapt_history_for_provider(
+        history,
+        target_provider="anthropic",
+        target_model="claude-opus-5",
+        supports_vision=True,
+    )
+
+    placeholder = adapted[0].content[0]
+    assert isinstance(placeholder, TextBlock)
+    assert "could not be resized safely" in placeholder.text
+    assert placeholder.cache_checkpoint is True
+    assert history[0].content[0] is invalid

--- a/tests/utils/test_images.py
+++ b/tests/utils/test_images.py
@@ -1,14 +1,21 @@
 """Tests for the shared image-encoding helpers."""
 
 import base64
+import io
 from pathlib import Path
 
+from PIL import Image
+
 from kolega_code.utils.images import (
+    ANTHROPIC_MAX_IMAGE_BASE64_BYTES,
     MAX_IMAGE_BYTES,
+    base64_encoded_size,
     encode_image_attachment,
     encode_image_file,
     image_media_type,
     is_supported_image,
+    max_raw_size_for_base64_limit,
+    resize_base64_image_to_limit,
 )
 
 
@@ -88,3 +95,149 @@ def test_encode_image_file_oversized_returns_none(tmp_path: Path, monkeypatch) -
 
 def test_encode_image_file_respects_real_max(tmp_path: Path) -> None:
     assert MAX_IMAGE_BYTES == 20 * 1024 * 1024
+
+
+def _encoded_image(
+    image: Image.Image,
+    image_format: str,
+    *,
+    exif: Image.Exif | None = None,
+) -> str:
+    output = io.BytesIO()
+    save_kwargs = {"exif": exif} if exif is not None else {}
+    image.save(output, format=image_format, **save_kwargs)
+    return base64.b64encode(output.getvalue()).decode("ascii")
+
+
+def test_base64_size_math_matches_anthropic_boundary_and_reported_session_image() -> None:
+    assert max_raw_size_for_base64_limit(ANTHROPIC_MAX_IMAGE_BASE64_BYTES) == 7_864_320
+    assert base64_encoded_size(7_864_320) == ANTHROPIC_MAX_IMAGE_BASE64_BYTES
+    assert base64_encoded_size(7_864_321) == ANTHROPIC_MAX_IMAGE_BASE64_BYTES + 4
+
+    # Session ef87fee1e3884ce3907157a352278a85: a 10,106,238-byte
+    # JPEG became the exact 13,474,984-byte field rejected by Anthropic.
+    assert base64_encoded_size(10_106_238) == 13_474_984
+
+
+def test_resize_base64_image_returns_fitting_image_unchanged() -> None:
+    data = _encoded_image(Image.new("RGB", (4, 4), "navy"), "PNG")
+
+    result = resize_base64_image_to_limit(data, "image/png", max_base64_bytes=len(data))
+
+    assert result.succeeded is True
+    assert result.resized is False
+    assert result.data == data
+    assert result.media_type == "image/png"
+
+
+def test_resize_base64_jpeg_produces_decodable_derivative_below_limit() -> None:
+    image = Image.effect_noise((160, 120), 80).convert("RGB")
+    data = _encoded_image(image, "JPEG")
+    limit = 1_600
+    assert len(data) > limit
+
+    result = resize_base64_image_to_limit(data, "image/jpeg", max_base64_bytes=limit)
+
+    assert result.succeeded is True
+    assert result.resized is True
+    assert result.data is not None
+    assert result.media_type == "image/jpeg"
+    assert len(result.data) < limit
+    with Image.open(io.BytesIO(base64.b64decode(result.data))) as derivative:
+        derivative.verify()
+
+
+def test_resize_base64_transparent_png_preserves_alpha() -> None:
+    image = Image.new("RGBA", (96, 96))
+    image.putdata(
+        [
+            ((x * 17) % 256, (y * 29) % 256, ((x + y) * 11) % 256, (x * y) % 256)
+            for y in range(image.height)
+            for x in range(image.width)
+        ]
+    )
+    data = _encoded_image(image, "PNG")
+    limit = 1_500
+    assert len(data) > limit
+
+    result = resize_base64_image_to_limit(data, "image/png", max_base64_bytes=limit)
+
+    assert result.succeeded is True
+    assert result.resized is True
+    assert result.data is not None
+    assert result.media_type == "image/png"
+    assert len(result.data) < limit
+    with Image.open(io.BytesIO(base64.b64decode(result.data))) as derivative:
+        assert "A" in derivative.getbands()
+
+
+def test_resize_base64_image_applies_exif_orientation() -> None:
+    image = Image.effect_noise((80, 40), 80).convert("RGB")
+    exif = Image.Exif()
+    exif[274] = 6  # Rotate 90 degrees clockwise.
+    data = _encoded_image(image, "JPEG", exif=exif)
+    limit = 1_200
+    assert len(data) > limit
+
+    result = resize_base64_image_to_limit(data, "image/jpeg", max_base64_bytes=limit)
+
+    assert result.succeeded is True
+    assert result.data is not None
+    with Image.open(io.BytesIO(base64.b64decode(result.data))) as derivative:
+        assert derivative.height > derivative.width
+
+
+def test_resize_base64_animated_image_uses_static_supported_frame() -> None:
+    first = Image.effect_noise((96, 96), 80).convert("RGB")
+    second = Image.new("RGB", (96, 96), "red")
+    output = io.BytesIO()
+    first.save(output, format="GIF", save_all=True, append_images=[second])
+    data = base64.b64encode(output.getvalue()).decode("ascii")
+    limit = 1_500
+    assert len(data) > limit
+
+    result = resize_base64_image_to_limit(data, "image/gif", max_base64_bytes=limit)
+
+    assert result.succeeded is True
+    assert result.resized is True
+    assert result.data is not None
+    assert result.media_type == "image/jpeg"
+    assert len(result.data) < limit
+    with Image.open(io.BytesIO(base64.b64decode(result.data))) as derivative:
+        assert getattr(derivative, "n_frames", 1) == 1
+
+
+def test_resize_base64_image_returns_safe_failure_for_invalid_image() -> None:
+    data = base64.b64encode(b"not-an-image" * 100).decode("ascii")
+
+    result = resize_base64_image_to_limit(data, "image/png", max_base64_bytes=64)
+
+    assert result.succeeded is False
+    assert result.data is None
+    assert result.media_type is None
+    assert result.error is not None
+    assert "decode image" in result.error
+
+
+def test_resize_base64_image_rejects_unsafe_decoded_pixel_count(monkeypatch) -> None:
+    import kolega_code.utils.images as images_mod
+
+    monkeypatch.setattr(images_mod, "_IMAGE_RESIZE_MAX_PIXELS", 32)
+    data = _encoded_image(Image.new("RGB", (8, 8), "red"), "PNG")
+
+    result = resize_base64_image_to_limit(data, "image/png", max_base64_bytes=64)
+
+    assert result.succeeded is False
+    assert result.data is None
+    assert result.error is not None
+    assert "pixel resize safety limit" in result.error
+
+
+def test_resize_base64_image_returns_safe_failure_when_limit_cannot_hold_base64() -> None:
+    data = _encoded_image(Image.new("RGB", (1, 1), "red"), "PNG")
+
+    result = resize_base64_image_to_limit(data, "image/png", max_base64_bytes=3)
+
+    assert result.succeeded is False
+    assert result.data is None
+    assert result.error is not None


### PR DESCRIPTION
## Summary

- add exact raw/base64 size arithmetic and Pillow-based image derivatives for Anthropic's 10 MiB encoded image-field limit
- recursively resize only ephemeral Anthropic provider-facing history copies, including images nested in regular and freeform tool results
- preserve full original image bytes in conversation history, session artifacts, replay, and export; use an actionable text fallback when safe conversion is impossible
- preserve EXIF orientation and transparency, reduce animated images to a supported static frame, and bound decoded resize working size

## Why

Anthropic enforces its image limit on the base64 field rather than the raw artifact. For the affected session shape, a 10,106,238-byte original projects to 13,474,984 base64 characters, exceeding the 10,485,760-character request limit. This change keeps that original canonical while generating a smaller derivative only for the outbound Anthropic request.

Goal-loop and scheduled-loop behavior are unchanged.

## Regression coverage

- exact boundary arithmetic and the reported original/base64 size distinction
- unchanged valid payloads plus resized JPEG, transparent PNG, EXIF-oriented, and animated fixtures
- safe failures for invalid, impossible, and unsafe decoded inputs
- top-level and nested request adaptation, URL/other-provider passthrough, metadata preservation, and non-mutation
- session artifact offload -> replay hydration -> Anthropic request-copy adaptation, asserting the artifact remains byte-for-byte unchanged
- existing `read_image` and session-store suites

## Verification

- `./run_tests.sh tests/utils/test_images.py tests/agent/test_history_image_blocks.py tests/agent/test_base_agent_effective_history.py tests/agent/test_read_image_tool.py tests/cli/test_session_store.py -q` (99 passed)
- `./run_tests.sh` (3368 passed, 1 skipped, 104 deselected)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pre-commit run --all-files --show-diff-on-failure`
