### PR TITLE
fix(anthropic): resize many-image request history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ### Fixed
 
-- Downscaled outbound image copies in Anthropic conversations with more than 20
-  accumulated images to the provider's stricter dimension limit, preventing
-  later turns from failing while preserving full-resolution history and artifacts.
+- Downscaled outbound image copies to satisfy Anthropic's per-image dimensions
+  and aggregate request-size limit, preventing image-heavy conversations from
+  failing later turns while preserving full-resolution history and artifacts.
 
 ## 0.25.1 - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+### Fixed
+
+- Downscaled outbound image copies in Anthropic conversations with more than 20
+  accumulated images to the provider's stricter dimension limit, preventing
+  later turns from failing while preserving full-resolution history and artifacts.
+
 ## 0.25.1 - 2026-07-28
 
 ### Fixed

--- a/kolega_code/agent/conversation.py
+++ b/kolega_code/agent/conversation.py
@@ -48,6 +48,7 @@ def _adapt_image_block_for_provider(
     target_provider: str,
     target_model: str,
     supports_vision: bool,
+    max_image_dimension: Optional[int],
 ) -> tuple[ContentBlock, bool]:
     """Return a request-safe image block without mutating stored history."""
     if not supports_vision:
@@ -60,6 +61,7 @@ def _adapt_image_block_for_provider(
         block.data,
         block.media_type,
         max_base64_bytes=image_utils.ANTHROPIC_MAX_IMAGE_BASE64_BYTES,
+        max_dimension=max_image_dimension,
     )
     if not result.succeeded:
         logger.warning(
@@ -260,6 +262,7 @@ def _adapt_content_blocks_for_provider(
     target_provider: str,
     target_model: str,
     supports_vision: bool,
+    max_image_dimension: Optional[int] = None,
     target_edit_protocol: Optional[str] = None,
     tool_call_providers: Optional[Dict[str, str]] = None,
     tool_call_protocols: Optional[Dict[str, Optional[str]]] = None,
@@ -276,6 +279,7 @@ def _adapt_content_blocks_for_provider(
                 target_provider=target_provider,
                 target_model=target_model,
                 supports_vision=supports_vision,
+                max_image_dimension=max_image_dimension,
             )
             adapted.append(adapted_block)
             changed = changed or image_changed
@@ -314,6 +318,7 @@ def _adapt_content_blocks_for_provider(
                         target_provider=target_provider,
                         target_model=target_model,
                         supports_vision=supports_vision,
+                        max_image_dimension=max_image_dimension,
                         target_edit_protocol=target_edit_protocol,
                         tool_call_providers=tool_call_providers,
                         tool_call_protocols=tool_call_protocols,
@@ -355,6 +360,7 @@ def _adapt_content_blocks_for_provider(
                 target_provider=target_provider,
                 target_model=target_model,
                 supports_vision=supports_vision,
+                max_image_dimension=max_image_dimension,
                 target_edit_protocol=target_edit_protocol,
                 tool_call_providers=tool_call_providers,
                 tool_call_protocols=tool_call_protocols,
@@ -412,6 +418,14 @@ def adapt_history_for_provider(
     target_provider = _provider_value(target_provider)
     if target_edit_protocol is not None:
         target_edit_protocol = _provider_value(target_edit_protocol)
+    max_image_dimension: Optional[int] = None
+    if target_provider == "anthropic" and supports_vision:
+        image_count = count_image_blocks(messages)
+        max_image_dimension = (
+            image_utils.ANTHROPIC_MANY_IMAGE_MAX_DIMENSION
+            if image_count > image_utils.ANTHROPIC_MANY_IMAGE_THRESHOLD
+            else image_utils.ANTHROPIC_MAX_IMAGE_DIMENSION
+        )
     result: List[Message] = []
     changed_any = False
     tool_call_providers: Dict[str, str] = {}
@@ -436,6 +450,7 @@ def adapt_history_for_provider(
             target_provider=target_provider,
             target_model=target_model,
             supports_vision=supports_vision,
+            max_image_dimension=max_image_dimension,
             target_edit_protocol=target_edit_protocol,
             tool_call_providers=tool_call_providers,
             tool_call_protocols=tool_call_protocols,

--- a/kolega_code/agent/conversation.py
+++ b/kolega_code/agent/conversation.py
@@ -49,6 +49,7 @@ def _adapt_image_block_for_provider(
     target_model: str,
     supports_vision: bool,
     max_image_dimension: Optional[int],
+    max_image_base64_bytes: int,
 ) -> tuple[ContentBlock, bool]:
     """Return a request-safe image block without mutating stored history."""
     if not supports_vision:
@@ -60,7 +61,7 @@ def _adapt_image_block_for_provider(
     result = image_utils.resize_base64_image_to_limit(
         block.data,
         block.media_type,
-        max_base64_bytes=image_utils.ANTHROPIC_MAX_IMAGE_BASE64_BYTES,
+        max_base64_bytes=max_image_base64_bytes,
         max_dimension=max_image_dimension,
     )
     if not result.succeeded:
@@ -96,18 +97,54 @@ def _adapt_image_block_for_provider(
     )
 
 
-def count_image_blocks(messages: List[Message]) -> int:
-    """Count ``ImageBlock`` instances across messages, including ones nested in tool results."""
+def _image_block_stats(messages: List[Message]) -> tuple[int, List[int]]:
+    """Return total image count and base64 lengths, including nested tool results."""
     count = 0
+    base64_sizes: List[int] = []
     for message in messages:
         if not isinstance(message.content, list):
             continue
         for block in message.content:
             if isinstance(block, ImageBlock):
                 count += 1
+                if block.image_type == "base64":
+                    base64_sizes.append(len(block.data))
             elif isinstance(block, ToolResult) and isinstance(block.content, list):
-                count += sum(1 for inner in block.content if isinstance(inner, ImageBlock))
-    return count
+                for inner in block.content:
+                    if isinstance(inner, ImageBlock):
+                        count += 1
+                        if inner.image_type == "base64":
+                            base64_sizes.append(len(inner.data))
+    return count, base64_sizes
+
+
+def count_image_blocks(messages: List[Message]) -> int:
+    """Count ``ImageBlock`` instances across messages, including ones nested in tool results."""
+    return _image_block_stats(messages)[0]
+
+
+def _anthropic_image_base64_limit(base64_sizes: List[int]) -> int:
+    """Return a shared per-image cap that keeps aggregate image data request-safe.
+
+    Images already below the shared cap remain byte-for-byte unchanged. Larger
+    images divide the remaining aggregate budget evenly after accounting for
+    those smaller images, avoiding unnecessary reductions when the request
+    already fits.
+    """
+    per_image_limit = image_utils.ANTHROPIC_MAX_IMAGE_BASE64_BYTES
+    aggregate_limit = image_utils.ANTHROPIC_MAX_REQUEST_IMAGE_BASE64_BYTES
+    projected_sizes = sorted(min(size, per_image_limit) for size in base64_sizes)
+    if sum(projected_sizes) <= aggregate_limit:
+        return per_image_limit
+
+    remaining_budget = aggregate_limit
+    for index, size in enumerate(projected_sizes):
+        remaining_images = len(projected_sizes) - index
+        shared_limit = remaining_budget // remaining_images
+        if size > shared_limit:
+            return max(4, min(per_image_limit, shared_limit))
+        remaining_budget -= size
+    return per_image_limit
 
 
 def _provider_value(provider: Any) -> str:
@@ -263,6 +300,7 @@ def _adapt_content_blocks_for_provider(
     target_model: str,
     supports_vision: bool,
     max_image_dimension: Optional[int] = None,
+    max_image_base64_bytes: int = image_utils.ANTHROPIC_MAX_IMAGE_BASE64_BYTES,
     target_edit_protocol: Optional[str] = None,
     tool_call_providers: Optional[Dict[str, str]] = None,
     tool_call_protocols: Optional[Dict[str, Optional[str]]] = None,
@@ -280,6 +318,7 @@ def _adapt_content_blocks_for_provider(
                 target_model=target_model,
                 supports_vision=supports_vision,
                 max_image_dimension=max_image_dimension,
+                max_image_base64_bytes=max_image_base64_bytes,
             )
             adapted.append(adapted_block)
             changed = changed or image_changed
@@ -319,6 +358,7 @@ def _adapt_content_blocks_for_provider(
                         target_model=target_model,
                         supports_vision=supports_vision,
                         max_image_dimension=max_image_dimension,
+                        max_image_base64_bytes=max_image_base64_bytes,
                         target_edit_protocol=target_edit_protocol,
                         tool_call_providers=tool_call_providers,
                         tool_call_protocols=tool_call_protocols,
@@ -361,6 +401,7 @@ def _adapt_content_blocks_for_provider(
                 target_model=target_model,
                 supports_vision=supports_vision,
                 max_image_dimension=max_image_dimension,
+                max_image_base64_bytes=max_image_base64_bytes,
                 target_edit_protocol=target_edit_protocol,
                 tool_call_providers=tool_call_providers,
                 tool_call_protocols=tool_call_protocols,
@@ -419,13 +460,15 @@ def adapt_history_for_provider(
     if target_edit_protocol is not None:
         target_edit_protocol = _provider_value(target_edit_protocol)
     max_image_dimension: Optional[int] = None
+    max_image_base64_bytes = image_utils.ANTHROPIC_MAX_IMAGE_BASE64_BYTES
     if target_provider == "anthropic" and supports_vision:
-        image_count = count_image_blocks(messages)
+        image_count, base64_sizes = _image_block_stats(messages)
         max_image_dimension = (
             image_utils.ANTHROPIC_MANY_IMAGE_MAX_DIMENSION
             if image_count > image_utils.ANTHROPIC_MANY_IMAGE_THRESHOLD
             else image_utils.ANTHROPIC_MAX_IMAGE_DIMENSION
         )
+        max_image_base64_bytes = _anthropic_image_base64_limit(base64_sizes)
     result: List[Message] = []
     changed_any = False
     tool_call_providers: Dict[str, str] = {}
@@ -451,6 +494,7 @@ def adapt_history_for_provider(
             target_model=target_model,
             supports_vision=supports_vision,
             max_image_dimension=max_image_dimension,
+            max_image_base64_bytes=max_image_base64_bytes,
             target_edit_protocol=target_edit_protocol,
             tool_call_providers=tool_call_providers,
             tool_call_protocols=tool_call_protocols,

--- a/kolega_code/utils/images.py
+++ b/kolega_code/utils/images.py
@@ -46,6 +46,10 @@ ANTHROPIC_MAX_IMAGE_BASE64_BYTES = 10 * 1024 * 1024
 ANTHROPIC_MAX_IMAGE_DIMENSION = 8_000
 ANTHROPIC_MANY_IMAGE_THRESHOLD = 20
 ANTHROPIC_MANY_IMAGE_MAX_DIMENSION = 2_000
+# Anthropic rejects standard API requests above 32 MB. Keep aggregate base64
+# image data at 24 MiB so JSON, system prompts, tools, and text history retain
+# substantial request headroom.
+ANTHROPIC_MAX_REQUEST_IMAGE_BASE64_BYTES = 24 * 1024 * 1024
 
 # Leave headroom below the provider's hard boundary when producing a
 # derivative. This avoids repeatedly re-encoding an image for tiny accounting

--- a/kolega_code/utils/images.py
+++ b/kolega_code/utils/images.py
@@ -40,6 +40,12 @@ MAX_IMAGE_BYTES = 20 * 1024 * 1024
 # decoded image size. A raw image just under 10 MiB may therefore exceed this
 # limit after base64's 4/3 expansion.
 ANTHROPIC_MAX_IMAGE_BASE64_BYTES = 10 * 1024 * 1024
+# Anthropic accepts images up to 8,000 px on either axis for ordinary
+# requests. Once the request contains more than 20 images, every image must
+# instead fit within 2,000 x 2,000 px.
+ANTHROPIC_MAX_IMAGE_DIMENSION = 8_000
+ANTHROPIC_MANY_IMAGE_THRESHOLD = 20
+ANTHROPIC_MANY_IMAGE_MAX_DIMENSION = 2_000
 
 # Leave headroom below the provider's hard boundary when producing a
 # derivative. This avoids repeatedly re-encoding an image for tiny accounting
@@ -88,23 +94,30 @@ def resize_base64_image_to_limit(
     media_type: str,
     *,
     max_base64_bytes: int,
+    max_dimension: Optional[int] = None,
 ) -> ImageResizeResult:
     """Return a non-mutating provider-safe derivative of a base64 image.
 
-    Images already within the hard limit are returned byte-for-byte unchanged.
-    Oversized images are decoded and re-encoded as PNG when transparency must
-    be retained, or optimized JPEG otherwise. Dimensions are reduced
+    Images already within the byte and optional dimension limits are returned
+    byte-for-byte unchanged. Oversized images are decoded and re-encoded as PNG
+    when transparency must be retained, or optimized JPEG otherwise.
+    Dimensions are reduced proportionally to the requested maximum first, then
     iteratively until the payload has a safety margin below the provider limit.
     Animated images use their first frame for the ephemeral provider copy.
     """
     if max_base64_bytes <= 0:
         raise ValueError("max_base64_bytes must be positive")
+    if max_dimension is not None and max_dimension <= 0:
+        raise ValueError("max_dimension must be positive")
 
     if not data.isascii():
         return ImageResizeResult(None, None, resized=False, error="Image payload is not ASCII base64")
     encoded_size = len(data)
 
-    if encoded_size <= max_base64_bytes:
+    # Existing byte-only callers keep the cheap path and never decode a valid
+    # image that already fits. A dimension constraint requires reading the
+    # image header before the same unchanged decision can be made.
+    if encoded_size <= max_base64_bytes and max_dimension is None:
         return ImageResizeResult(data, media_type, resized=False)
 
     try:
@@ -112,6 +125,9 @@ def resize_base64_image_to_limit(
         with Image.open(io.BytesIO(raw)) as opened:
             opened.seek(0)
             width, height = opened.size
+            dimensions_fit = max_dimension is None or (width <= max_dimension and height <= max_dimension)
+            if encoded_size <= max_base64_bytes and dimensions_fit:
+                return ImageResizeResult(data, media_type, resized=False)
             if width * height > _IMAGE_RESIZE_MAX_PIXELS:
                 return ImageResizeResult(
                     None,
@@ -124,6 +140,9 @@ def resize_base64_image_to_limit(
         return ImageResizeResult(None, None, resized=False, error=f"Could not decode image: {exc}")
 
     has_transparency = "A" in image.getbands() or "transparency" in image.info
+    if max_dimension is not None and (image.width > max_dimension or image.height > max_dimension):
+        image.thumbnail((max_dimension, max_dimension), Image.Resampling.LANCZOS)
+
     if has_transparency:
         image = image.convert("RGBA")
         output_format = "PNG"

--- a/tests/agent/test_base_agent_effective_history.py
+++ b/tests/agent/test_base_agent_effective_history.py
@@ -124,8 +124,20 @@ class TestBaseAgent:
         assert history[0].content[1].text == "final answer"
 
     def test_history_for_llm_preserves_images_when_target_anthropic_supports_vision(self, base_agent):
-        image = ImageBlock(image_type="base64", media_type="image/png", data="BASE64")
-        nested_image = ImageBlock(image_type="base64", media_type="image/jpeg", data="BASE642")
+        png_output = io.BytesIO()
+        Image.new("RGB", (1, 1), "navy").save(png_output, format="PNG")
+        jpeg_output = io.BytesIO()
+        Image.new("RGB", (1, 1), "navy").save(jpeg_output, format="JPEG")
+        image = ImageBlock(
+            image_type="base64",
+            media_type="image/png",
+            data=base64.b64encode(png_output.getvalue()).decode("ascii"),
+        )
+        nested_image = ImageBlock(
+            image_type="base64",
+            media_type="image/jpeg",
+            data=base64.b64encode(jpeg_output.getvalue()).decode("ascii"),
+        )
         base_agent.primary_model_config.provider = ModelProvider.ANTHROPIC
         base_agent.primary_model_config.model = "claude-opus-4-8"
         base_agent.supports_vision = True
@@ -151,21 +163,16 @@ class TestBaseAgent:
         assert history[0].content[1] is image
         assert history[1].content[0].content[0] is nested_image
 
-    def test_anthropic_history_resize_preserves_hydrated_history_and_artifact(
+    def test_anthropic_many_image_resize_preserves_hydrated_history_and_artifact(
         self,
         base_agent,
         tmp_path,
-        monkeypatch: pytest.MonkeyPatch,
     ):
-        import kolega_code.utils.images as image_utils
-
-        image = Image.effect_noise((160, 120), 80).convert("RGB")
+        image = Image.new("RGB", (2_001, 100), "navy")
         output = io.BytesIO()
         image.save(output, format="JPEG")
         original_bytes = output.getvalue()
         original_base64 = base64.b64encode(original_bytes).decode("ascii")
-        limit = 1_600
-        assert len(original_base64) > limit
 
         project = tmp_path / "project"
         project.mkdir()
@@ -174,7 +181,9 @@ class TestBaseAgent:
         store.recorder(record.session_id).record_context_message(
             Message(
                 role="user",
-                content=[ImageBlock(image_type="base64", media_type="image/jpeg", data=original_base64)],
+                content=[
+                    ImageBlock(image_type="base64", media_type="image/jpeg", data=original_base64) for _ in range(21)
+                ],
             )
         )
         journal = store.journal(record.session_id)
@@ -185,22 +194,24 @@ class TestBaseAgent:
 
         loaded = store.load(record.session_id)
         base_agent.restore_message_history(loaded.history)
-        restored_image = base_agent.history[0].content[0]
-        assert isinstance(restored_image, ImageBlock)
-        assert restored_image.data == original_base64
+        restored_images = base_agent.history[0].content
+        assert len(restored_images) == 21
+        assert all(isinstance(block, ImageBlock) and block.data == original_base64 for block in restored_images)
 
-        monkeypatch.setattr(image_utils, "ANTHROPIC_MAX_IMAGE_BASE64_BYTES", limit)
         base_agent.primary_model_config.provider = ModelProvider.ANTHROPIC
-        base_agent.primary_model_config.model = "claude-opus-4-8"
+        base_agent.primary_model_config.model = "claude-opus-5"
         base_agent.supports_vision = True
 
         outbound = base_agent._history_for_llm()
 
-        outbound_image = outbound[0].content[0]
-        assert isinstance(outbound_image, ImageBlock)
-        assert outbound_image.data != original_base64
-        assert len(outbound_image.data) < limit
-        assert restored_image.data == original_base64
+        outbound_images = outbound[0].content
+        assert len(outbound_images) == 21
+        for outbound_image in outbound_images:
+            assert isinstance(outbound_image, ImageBlock)
+            assert outbound_image.data != original_base64
+            with Image.open(io.BytesIO(base64.b64decode(outbound_image.data))) as resized:
+                assert max(resized.size) <= 2_000
+        assert all(isinstance(block, ImageBlock) and block.data == original_base64 for block in restored_images)
         assert journal.read_artifact(artifact_ref) == artifact_before
 
     def test_get_effective_history_falls_back_when_no_compression(self, base_agent):

--- a/tests/agent/test_base_agent_effective_history.py
+++ b/tests/agent/test_base_agent_effective_history.py
@@ -167,7 +167,10 @@ class TestBaseAgent:
         self,
         base_agent,
         tmp_path,
+        monkeypatch: pytest.MonkeyPatch,
     ):
+        import kolega_code.utils.images as image_utils
+
         image = Image.new("RGB", (2_001, 100), "navy")
         output = io.BytesIO()
         image.save(output, format="JPEG")
@@ -201,11 +204,14 @@ class TestBaseAgent:
         base_agent.primary_model_config.provider = ModelProvider.ANTHROPIC
         base_agent.primary_model_config.model = "claude-opus-5"
         base_agent.supports_vision = True
+        aggregate_limit = 60_000
+        monkeypatch.setattr(image_utils, "ANTHROPIC_MAX_REQUEST_IMAGE_BASE64_BYTES", aggregate_limit)
 
         outbound = base_agent._history_for_llm()
 
         outbound_images = outbound[0].content
         assert len(outbound_images) == 21
+        assert sum(len(block.data) for block in outbound_images if isinstance(block, ImageBlock)) <= aggregate_limit
         for outbound_image in outbound_images:
             assert isinstance(outbound_image, ImageBlock)
             assert outbound_image.data != original_base64

--- a/tests/agent/test_coder_attachments.py
+++ b/tests/agent/test_coder_attachments.py
@@ -357,11 +357,12 @@ def _anthropic_config() -> AgentConfig:
 
 def _image_history_message() -> Message:
     """A user message carrying a text block and an image block from an earlier turn."""
+    one_pixel_png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
     return Message(
         role="user",
         content=[
             TextBlock(text="what is in this image?"),
-            ImageBlock(image_type="base64", media_type="image/png", data="ZmFrZQ=="),
+            ImageBlock(image_type="base64", media_type="image/png", data=one_pixel_png),
         ],
     )
 

--- a/tests/agent/test_history_adapter_thinking.py
+++ b/tests/agent/test_history_adapter_thinking.py
@@ -7,6 +7,11 @@ request copy (stored history is never mutated), and the compaction-aware detecto
 only reports images that would actually be sent.
 """
 
+import base64
+import io
+
+from PIL import Image
+
 from kolega_code.agent.conversation import (
     Conversation,
     adapt_history_for_provider,
@@ -26,7 +31,15 @@ from kolega_code.llm.models import (
 
 
 def _image(media_type: str = "image/png") -> ImageBlock:
-    return ImageBlock(image_type="base64", media_type=media_type, data="ZmFrZQ==")
+    image_format = "JPEG" if media_type == "image/jpeg" else "PNG"
+    image = Image.new("RGB", (1, 1), "navy")
+    output = io.BytesIO()
+    image.save(output, format=image_format)
+    return ImageBlock(
+        image_type="base64",
+        media_type=media_type,
+        data=base64.b64encode(output.getvalue()).decode("ascii"),
+    )
 
 
 def _user(*blocks) -> Message:

--- a/tests/agent/test_history_image_blocks.py
+++ b/tests/agent/test_history_image_blocks.py
@@ -32,7 +32,31 @@ from kolega_code.llm.models import (
 
 
 def _image(media_type: str = "image/png") -> ImageBlock:
-    return ImageBlock(image_type="base64", media_type=media_type, data="ZmFrZQ==")
+    image_format = "JPEG" if media_type == "image/jpeg" else "PNG"
+    image = Image.new("RGB", (1, 1), "navy")
+    output = io.BytesIO()
+    image.save(output, format=image_format)
+    return ImageBlock(
+        image_type="base64",
+        media_type=media_type,
+        data=base64.b64encode(output.getvalue()).decode("ascii"),
+    )
+
+
+def _solid_png(width: int, height: int) -> ImageBlock:
+    image = Image.new("RGB", (width, height), "navy")
+    output = io.BytesIO()
+    image.save(output, format="PNG")
+    return ImageBlock(
+        image_type="base64",
+        media_type="image/png",
+        data=base64.b64encode(output.getvalue()).decode("ascii"),
+    )
+
+
+def _image_dimensions(block: ImageBlock) -> tuple[int, int]:
+    with Image.open(io.BytesIO(base64.b64decode(block.data))) as image:
+        return image.size
 
 
 def _noise_jpeg() -> ImageBlock:
@@ -238,6 +262,92 @@ def test_replace_preserves_cache_checkpoint_on_tool_result():
     assert new_tr.cache_checkpoint is True
 
 
+def test_adapt_keeps_normal_anthropic_dimensions_at_exactly_twenty_images() -> None:
+    large = _solid_png(2_001, 100)
+    history = [_user(large, *[_image() for _ in range(19)])]
+
+    adapted = adapt_history_for_provider(
+        history,
+        target_provider="anthropic",
+        target_model="claude-opus-5",
+        supports_vision=True,
+    )
+
+    assert count_image_blocks(adapted) == 20
+    assert adapted is history
+    assert adapted[0].content[0] is large
+    assert _image_dimensions(large) == (2_001, 100)
+
+
+def test_adapt_constrains_direct_and_nested_images_when_request_has_more_than_twenty() -> None:
+    top_level = _solid_png(2_001, 100)
+    nested = _solid_png(100, 2_001)
+    valid = [_image() for _ in range(19)]
+    result = ToolResult(
+        tool_use_id="many-image-call",
+        name="browser_take_screenshot",
+        content=[nested, TextBlock(text="caption")],
+        is_error=False,
+        cache_checkpoint=True,
+        execution_id="many-image-exec",
+    )
+    history = [_user(top_level, *valid), _user(result)]
+
+    adapted = adapt_history_for_provider(
+        history,
+        target_provider="anthropic",
+        target_model="claude-opus-5",
+        supports_vision=True,
+    )
+
+    assert count_image_blocks(adapted) == 21
+    adapted_top = adapted[0].content[0]
+    assert isinstance(adapted_top, ImageBlock)
+    assert adapted_top is not top_level
+    assert max(_image_dimensions(adapted_top)) <= 2_000
+    assert all(adapted[0].content[index + 1] is block for index, block in enumerate(valid))
+
+    adapted_result = adapted[1].content[0]
+    assert isinstance(adapted_result, ToolResult)
+    assert adapted_result is not result
+    assert adapted_result.tool_use_id == "many-image-call"
+    assert adapted_result.name == "browser_take_screenshot"
+    assert adapted_result.cache_checkpoint is True
+    assert adapted_result.execution_id == "many-image-exec"
+    adapted_nested = adapted_result.content[0]
+    assert isinstance(adapted_nested, ImageBlock)
+    assert adapted_nested is not nested
+    assert max(_image_dimensions(adapted_nested)) <= 2_000
+    assert isinstance(adapted_result.content[1], TextBlock)
+    assert adapted_result.content[1].text == "caption"
+
+    # Only the outbound request receives derivatives.
+    assert history[0].content[0] is top_level
+    assert history[1].content[0] is result
+    assert result.content[0] is nested
+    assert _image_dimensions(top_level) == (2_001, 100)
+    assert _image_dimensions(nested) == (100, 2_001)
+
+
+def test_adapt_constrains_single_anthropic_image_to_normal_dimension_limit() -> None:
+    oversized = _solid_png(8_001, 2)
+    history = [_user(oversized)]
+
+    adapted = adapt_history_for_provider(
+        history,
+        target_provider="anthropic",
+        target_model="claude-opus-5",
+        supports_vision=True,
+    )
+
+    adapted_image = adapted[0].content[0]
+    assert isinstance(adapted_image, ImageBlock)
+    assert adapted_image is not oversized
+    assert max(_image_dimensions(adapted_image)) <= 8_000
+    assert history[0].content[0] is oversized
+    assert _image_dimensions(oversized) == (8_001, 2)
+
+
 def test_adapt_resizes_top_level_and_nested_anthropic_images_without_mutating_history(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -330,10 +440,44 @@ def test_adapt_resizes_image_nested_in_compatible_freeform_tool_result(monkeypat
     assert result.content[0] is nested
 
 
+def test_adapt_applies_many_image_dimension_to_compatible_freeform_tool_result() -> None:
+    nested = _solid_png(2_001, 100)
+    result = ToolResult(
+        tool_use_id="freeform-many-image-call",
+        name="browser_take_screenshot",
+        content=[nested],
+        is_error=False,
+        input_kind="freeform",
+    )
+    history = [
+        Message(
+            role="user",
+            content=[*[_image() for _ in range(20)], result],
+            usage_metadata={"provider": "anthropic"},
+        )
+    ]
+
+    adapted = adapt_history_for_provider(
+        history,
+        target_provider="anthropic",
+        target_model="claude-opus-5",
+        supports_vision=True,
+    )
+
+    adapted_result = adapted[0].content[-1]
+    assert isinstance(adapted_result, ToolResult)
+    assert isinstance(adapted_result.content, list)
+    adapted_image = adapted_result.content[0]
+    assert isinstance(adapted_image, ImageBlock)
+    assert max(_image_dimensions(adapted_image)) <= 2_000
+    assert result.content[0] is nested
+    assert _image_dimensions(nested) == (2_001, 100)
+
+
 def test_adapt_leaves_valid_url_and_non_anthropic_images_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
     import kolega_code.utils.images as image_utils
 
-    monkeypatch.setattr(image_utils, "ANTHROPIC_MAX_IMAGE_BASE64_BYTES", 64)
+    monkeypatch.setattr(image_utils, "ANTHROPIC_MAX_IMAGE_BASE64_BYTES", 128)
     valid = _image()
     url = ImageBlock(image_type="url", media_type="image/png", data="https://example.com/image.png")
     oversized = _noise_jpeg()

--- a/tests/agent/test_history_image_blocks.py
+++ b/tests/agent/test_history_image_blocks.py
@@ -348,6 +348,52 @@ def test_adapt_constrains_single_anthropic_image_to_normal_dimension_limit() -> 
     assert _image_dimensions(oversized) == (8_001, 2)
 
 
+def test_adapt_caps_aggregate_anthropic_image_payload_without_mutating_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kolega_code.utils.images as image_utils
+
+    aggregate_limit = 60_000
+    monkeypatch.setattr(image_utils, "ANTHROPIC_MAX_REQUEST_IMAGE_BASE64_BYTES", aggregate_limit)
+    valid = _image()
+    nested_images = [_noise_jpeg() for _ in range(14)]
+    results = [
+        ToolResult(
+            tool_use_id=f"aggregate-image-call-{index}",
+            name="read_image",
+            content=[image],
+            is_error=False,
+            cache_checkpoint=True,
+        )
+        for index, image in enumerate(nested_images)
+    ]
+    history = [_user(valid, *results)]
+    assert len(valid.data) + sum(len(image.data) for image in nested_images) > aggregate_limit
+
+    adapted = adapt_history_for_provider(
+        history,
+        target_provider="anthropic",
+        target_model="claude-opus-5",
+        supports_vision=True,
+    )
+
+    assert adapted is not history
+    assert adapted[0].content[0] is valid
+    adapted_results = adapted[0].content[1:]
+    adapted_images = []
+    for adapted_result in adapted_results:
+        assert isinstance(adapted_result, ToolResult)
+        assert adapted_result.cache_checkpoint is True
+        adapted_image = adapted_result.content[0]
+        assert isinstance(adapted_image, ImageBlock)
+        assert _image_dimensions(adapted_image)[0] > 0
+        adapted_images.append(adapted_image)
+    assert len(valid.data) + sum(len(image.data) for image in adapted_images) <= aggregate_limit
+
+    for original_result, original_image in zip(results, nested_images, strict=True):
+        assert original_result.content[0] is original_image
+
+
 def test_adapt_resizes_top_level_and_nested_anthropic_images_without_mutating_history(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/utils/test_images.py
+++ b/tests/utils/test_images.py
@@ -4,6 +4,7 @@ import base64
 import io
 from pathlib import Path
 
+import pytest
 from PIL import Image
 
 from kolega_code.utils.images import (
@@ -128,6 +129,64 @@ def test_resize_base64_image_returns_fitting_image_unchanged() -> None:
     assert result.resized is False
     assert result.data == data
     assert result.media_type == "image/png"
+
+
+def test_resize_base64_image_constrains_byte_small_image_dimensions() -> None:
+    data = _encoded_image(Image.new("RGB", (2_001, 100), "navy"), "PNG")
+    assert len(data) < ANTHROPIC_MAX_IMAGE_BASE64_BYTES
+
+    result = resize_base64_image_to_limit(
+        data,
+        "image/png",
+        max_base64_bytes=ANTHROPIC_MAX_IMAGE_BASE64_BYTES,
+        max_dimension=2_000,
+    )
+
+    assert result.succeeded is True
+    assert result.resized is True
+    assert result.data is not None
+    with Image.open(io.BytesIO(base64.b64decode(result.data))) as derivative:
+        assert derivative.width <= 2_000
+        assert derivative.height <= 2_000
+        assert derivative.width / derivative.height == pytest.approx(2_001 / 100, rel=0.02)
+
+
+def test_resize_base64_image_returns_dimension_boundary_unchanged() -> None:
+    data = _encoded_image(Image.new("RGB", (2_000, 100), "navy"), "PNG")
+
+    result = resize_base64_image_to_limit(
+        data,
+        "image/png",
+        max_base64_bytes=ANTHROPIC_MAX_IMAGE_BASE64_BYTES,
+        max_dimension=2_000,
+    )
+
+    assert result.succeeded is True
+    assert result.resized is False
+    assert result.data == data
+    assert result.media_type == "image/png"
+
+
+def test_resize_base64_image_satisfies_dimension_and_payload_limits() -> None:
+    image = Image.effect_noise((400, 300), 80).convert("RGB")
+    data = _encoded_image(image, "JPEG")
+    limit = 4_000
+    assert len(data) > limit
+
+    result = resize_base64_image_to_limit(
+        data,
+        "image/jpeg",
+        max_base64_bytes=limit,
+        max_dimension=200,
+    )
+
+    assert result.succeeded is True
+    assert result.resized is True
+    assert result.data is not None
+    assert len(result.data) < limit
+    with Image.open(io.BytesIO(base64.b64decode(result.data))) as derivative:
+        assert derivative.width <= 200
+        assert derivative.height <= 200
 
 
 def test_resize_base64_jpeg_produces_decodable_derivative_below_limit() -> None:


### PR DESCRIPTION
## Summary

- apply Anthropic's 8,000 px image dimension limit to normal outbound history and its stricter 2,000 px limit when a request contains more than 20 images
- retain the 10 MiB per-image cap and add a conservative 24 MiB aggregate base64 image budget, leaving headroom below Anthropic's 32 MB total request limit for JSON, system prompts, tools, and text history
- allocate the aggregate budget with a shared cap that preserves already-small images and resizes only larger request copies
- generate request-only derivatives for direct and nested base64 images while preserving canonical history, metadata, hydrated session data, and artifact bytes
- keep URL images and non-Anthropic providers unchanged; safely omit only images for which no valid provider-safe derivative can be produced
- add coverage for the reported 15-image aggregate-payload case below the dimension threshold, plus threshold, utility, freeform tool-result, hydration, and artifact regressions

## Verification

- focused image/history suites — 100 passed
- aggregate and hydrated-artifact regressions — 2 passed
- `./run_tests.sh` — 3,376 passed, 1 skipped, 104 deselected
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright` — 0 errors, 0 warnings
- `git diff --check`
- commit hooks passed