### PR TITLE
chore: release v0.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.25.2 - 2026-07-28
+
 ### Fixed
 
 - Downscaled outbound image copies to satisfy Anthropic's per-image dimensions

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.25.1"
+__version__ = "0.25.2"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.25.1"
+__version__ = "0.25.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.25.1"
+version = "0.25.2"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-21T10:41:29.034392Z"
+exclude-newer = "2026-07-21T13:49:55.620956Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1522,7 +1522,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.25.1"
+version = "0.25.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- bump package and agent versions to `0.25.2`
- publish the Anthropic aggregate image request fix in the changelog
- refresh the lockfile release metadata

## Verification
- `UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" uv lock`
- `UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" uv sync --extra dev --frozen`
- `UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" uv run pre-commit run --all-files --show-diff-on-failure`
- `CI=1 UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" ./run_tests.sh` (`3348 passed, 29 skipped, 104 deselected`)
- `git diff --check`