### PR TITLE
feat(browser): add macOS Chrome extension backend

### DIFF
--- a/docs/src/content/docs/cli/browser.md
+++ b/docs/src/content/docs/cli/browser.md
@@ -1,0 +1,94 @@
+---
+title: browser
+description: Install, verify, troubleshoot, and remove the Kolega Chrome integration.
+---
+
+The Kolega Chrome integration lets the browser agent work through the **Kolega
+Browser Companion** extension in your regular Chrome installation. Playwright
+remains the default browser backend. This integration currently supports macOS
+and Google Chrome Stable only.
+
+## Install
+
+Install the production native host and open the official Chrome Web Store listing:
+
+```bash
+kolega-code browser install
+```
+
+- **Chrome Web Store:** [Kolega Browser Companion](https://chromewebstore.google.com/detail/edihigldhbmimflgjkohkgnjefmhngdn)
+- **Production extension ID:** `edihigldhbmimflgjkohkgnjefmhngdn`
+
+Running `browser install` registers the per-user native-messaging host and opens
+the Web Store listing; it does not install the extension silently. Installing the
+extension through Chrome's **Add to Chrome** flow is the browser-access consent
+boundary. Review the listing and verify its extension ID before accepting Chrome's
+permission disclosure.
+
+If Chrome was open while the native host was registered, fully quit and restart
+Chrome before checking the connection.
+
+## Commands
+
+| Command | What it does |
+| --- | --- |
+| `kolega-code browser install` | Register or refresh the Kolega native host and open the production Web Store listing |
+| `kolega-code browser status` | Show whether the native host and Chrome extension configuration are installed and valid |
+| `kolega-code browser doctor` | Run detailed checks for manifest, executable, registration, and connection problems |
+| `kolega-code browser uninstall` | Remove Kolega-owned native-host registration and configuration files |
+
+Once `browser status` reports a valid configuration, the Chrome integration is
+available to the browser agent. Playwright is still selected by default; direct
+the agent in your prompt when you want it to use Chrome, for example:
+
+> Use Chrome to check the checkout flow.
+
+The agent chooses Chrome for that task. There is no `--chrome` switch and no saved
+browser-backend setting.
+
+## Fixed Chrome operations
+
+The Chrome integration exposes only these fixed protocol operations:
+
+- Navigation: `browser.navigate`, `browser.navigate_back`
+- Page inspection and waits: `browser.snapshot`, `browser.find`,
+  `browser.wait_for`
+- Interaction: `browser.click`, `browser.type`, `browser.fill_form`,
+  `browser.select_option`, `browser.hover`, `browser.drag`,
+  `browser.press_key`
+- Tabs and inspection: `browser.tabs`, `browser.network_requests`,
+  `browser.screenshot`
+- Disconnect: `browser.detach`
+
+This list is exhaustive. The integration does not expose arbitrary JavaScript,
+raw Chrome DevTools Protocol (CDP), cookies or browser storage, request or
+response headers or bodies, file uploads or file/data drop, or console messages.
+
+## Native-host manifest location
+
+On macOS, the installer writes the per-user manifest to:
+
+`~/Library/Application Support/Google/Chrome/NativeMessagingHosts/ai.kolega.browser.json`
+
+## Uninstall and troubleshoot
+
+Run:
+
+```bash
+kolega-code browser uninstall
+```
+
+This removes only Kolega-owned native-host files and registration. Remove the
+Chrome extension separately from `chrome://extensions`, then restart Chrome.
+
+If setup stops working:
+
+1. Run `kolega-code browser status` for the current state.
+2. Run `kolega-code browser doctor` for the failing path or registration check.
+3. After installing, reinstalling, or upgrading Kolega Code, run
+   `kolega-code browser install` again to refresh the executable path.
+4. Fully quit and restart Chrome so it reloads the native-host manifest.
+5. Confirm the installed extension ID is
+   `edihigldhbmimflgjkohkgnjefmhngdn`.
+6. If the agent still opens Playwright, explicitly direct it to use Chrome in
+   the task.

--- a/docs/src/content/docs/cli/browser.md
+++ b/docs/src/content/docs/cli/browser.md
@@ -33,11 +33,24 @@ Chrome before checking the connection.
 | Command | What it does |
 | --- | --- |
 | `kolega-code browser install` | Register or refresh the Kolega native host and open the production Web Store listing |
-| `kolega-code browser status` | Show whether the native host and Chrome extension configuration are installed and valid |
-| `kolega-code browser doctor` | Run detailed checks for manifest, executable, registration, and connection problems |
+| `kolega-code browser status` | Check the native-host manifest only — a fast, offline configuration check |
+| `kolega-code browser doctor` | Everything `status` checks, plus a real connection attempt to the extension |
 | `kolega-code browser uninstall` | Remove Kolega-owned native-host registration and configuration files |
 
-Once `browser status` reports a valid configuration, the Chrome integration is
+`status` deliberately does not talk to Chrome, so a valid manifest there does not
+mean the extension is reachable. Use `doctor` to test the connection; it reports
+one of:
+
+| `doctor` extension state | Meaning |
+| --- | --- |
+| `paired` | The extension is connected and this session may drive the browser |
+| `awaiting_selection` | Connected, but several Kolega sessions are advertised and you must pick one |
+| `connected_not_selected` | Connected, but no session is confirmed yet |
+| `unreachable` | No connection — check the extension is installed and enabled, and Chrome is running |
+
+`doctor` exits non-zero unless the state is `paired`.
+
+Once `browser doctor` reports `paired`, the Chrome integration is
 available to the browser agent. Playwright is still selected by default; direct
 the agent in your prompt when you want it to use Chrome, for example:
 
@@ -63,6 +76,45 @@ The Chrome integration exposes only these fixed protocol operations:
 This list is exhaustive. The integration does not expose arbitrary JavaScript,
 raw Chrome DevTools Protocol (CDP), cookies or browser storage, request or
 response headers or bodies, file uploads or file/data drop, or console messages.
+
+### Choosing which session controls the browser
+
+The extension connects to the native host on its own; you do not need to open it
+in normal use. When exactly one Kolega session is running it is selected
+automatically.
+
+When two or more sessions are running, the extension will not guess which one
+may drive your browser, because selecting a session grants a local process
+access to pages in your ordinary profile. The toolbar badge shows `!` while a
+choice is pending — click the extension and pick a session. Run
+`kolega-code browser doctor` to see the competing sessions and which runtime id
+belongs to the session you are using.
+
+Your choice is remembered for as long as Chrome stays open, including across
+service-worker restarts, and is cleared when Chrome restarts.
+
+### Regular expressions
+
+`browser.find` and the `filter_pattern` of `browser.network_requests` accept a
+restricted, linear-time subset of regular-expression syntax: literals, `.`,
+character classes, anchors, escapes, and the quantifiers `?`, `*`, `+` and
+`{n,m}` applied to a single character or class. At most four quantifiers are
+allowed and repetition counts may not exceed 1000.
+
+Groups `(` `)`, alternation `|`, and backreferences are rejected, which is what
+makes the quantifiers safe: with no grouping or alternation a quantifier can only
+ever repeat one atom, so catastrophic backtracking is impossible. Write
+`[0-9]{4}` rather than `(\d{4}|\d{2})`.
+
+The Playwright backend accepts full Python regular expressions, so a pattern that
+works there may be rejected on Chrome.
+
+### Screenshots
+
+`browser.screenshot` returns the image inline. Neither the Chrome nor the
+Playwright backend writes screenshots to disk, so there is no artifact file path
+to report. Capture only the region you need: a full-page screenshot of a long
+page produces a large inline image.
 
 ## Native-host manifest location
 

--- a/kolega_code/agent/orchestration/guide.py
+++ b/kolega_code/agent/orchestration/guide.py
@@ -114,14 +114,17 @@ fail with a migration error rather than running with partially inherited routing
 
 ### Primitives (all available as globals in the script)
 
-- `await agent(prompt, *, label=None, phase=None, schema=None, model_override=None, agent_type=None)`
+- `await agent(prompt, *, label=None, phase=None, schema=None, model_override=None, agent_type=None, browser_target=None)`
   Dispatch one sub-agent. Returns its report text, or a validated dict when `schema`
   (a JSON Schema) is given, or `None` if the agent failed/was skipped (so you can
   filter it out). `agent_type` is one of "general" (default, full toolset), "investigation"
   (read-only), "browser", or "coder". Omit `model_override` to inherit the requested
   role's configured defaults; otherwise supply the complete atomic object documented
-  above. In plan mode every sub-agent is forced read-only regardless of `agent_type`,
-  so use workflows there for parallel research and synthesis, not edits.
+  above. `browser_target` applies only to browser agents; omit it for isolated
+  Playwright, or use `"chrome"` only when the user directs the workflow to use the
+  configured Chrome extension. In plan mode every sub-agent is forced read-only
+  regardless of `agent_type`, so use workflows there for parallel research and
+  synthesis, not edits.
 - `await parallel(thunks)` — run zero-arg thunks concurrently and wait for ALL (a barrier).
   A thunk that raises resolves to `None`; the call never rejects. Filter `None` before use.
 - `await pipeline(items, *stages)` — run each item through all stages independently, with

--- a/kolega_code/agent/orchestration/runtime.py
+++ b/kolega_code/agent/orchestration/runtime.py
@@ -140,6 +140,7 @@ class WorkflowRuntime:
         schema: Optional[dict] = None,
         model_override: Any = None,
         agent_type: Optional[str] = None,
+        browser_target: Optional[str] = None,
         **legacy_kwargs: Any,
     ) -> Any:
         """Dispatch one sub-agent. Returns its recap text, or the validated dict
@@ -157,6 +158,10 @@ class WorkflowRuntime:
             raise WorkflowScriptError(f"agent() got unexpected keyword argument(s): {names}")
         if not isinstance(prompt, str) or not prompt.strip():
             raise WorkflowScriptError("agent() requires a non-empty prompt string")
+        if browser_target is not None and (not isinstance(browser_target, str) or not browser_target.strip()):
+            raise WorkflowScriptError("agent() browser_target must be a non-empty string when provided")
+        if browser_target is not None and (agent_type or "").lower() != "browser":
+            raise WorkflowScriptError("agent() browser_target is only valid with agent_type='browser'")
         try:
             parsed_override: Optional[AtomicModelOverride] = parse_atomic_model_override(
                 model_override,
@@ -176,6 +181,7 @@ class WorkflowRuntime:
             schema=schema,
             model_override=parsed_override,
             agent_type=agent_type,
+            browser_target=browser_target,
             routing_fingerprint=self._routing_fingerprint,
             actual_agent_type=(
                 self._actual_agent_type_resolver(agent_type) if self._actual_agent_type_resolver is not None else None

--- a/kolega_code/agent/orchestration/types.py
+++ b/kolega_code/agent/orchestration/types.py
@@ -26,6 +26,7 @@ class AgentRunSpec:
     schema: Optional[dict] = None
     model_override: Optional[AtomicModelOverride] = None
     agent_type: Optional[str] = None
+    browser_target: Optional[str] = None
     # Secret-free identity of inherited role routing. It participates in cache
     # identity only when model_override is absent.
     routing_fingerprint: Optional[str] = None
@@ -51,6 +52,7 @@ class AgentRunSpec:
             "model_override": (self.model_override.as_dict() if self.model_override is not None else None),
             "routing_fingerprint": (self.routing_fingerprint if self.model_override is None else None),
             "agent_type": self.agent_type,
+            "browser_target": self.browser_target,
             "actual_agent_type": self.actual_agent_type,
             "read_only_mode": self.read_only_mode,
             "max_agent_depth": self.max_agent_depth,

--- a/kolega_code/agent/prompt_templates/system/agents/browser.md.j2
+++ b/kolega_code/agent/prompt_templates/system/agents/browser.md.j2
@@ -54,7 +54,8 @@ If you are asked for links to assets such as images, do not answer from your mem
 6. On large pages, use `browser_find` to locate relevant snapshot nodes without loading the entire tree again.
 7. Use `browser_take_screenshot` only for visual inspection. Do not choose interaction targets from screenshots.
 8. Use explicit waits for visible or disappearing text when an application updates asynchronously.
-9. If an action reports a dialog or file chooser, handle that modal before attempting another browser action.
+9. If dialog or file-chooser tools are available and an action reports one, use the matching tool before attempting
+   another browser action.
 
 ## **CRITICAL: URL Navigation Guidelines**
 

--- a/kolega_code/agent/tool_backend/agent_tool.py
+++ b/kolega_code/agent/tool_backend/agent_tool.py
@@ -11,6 +11,7 @@ from kolega_code.events import AgentEvent
 from kolega_code.hooks import HookDispatcher, HookEvent
 from kolega_code.llm.specs import supports_vision
 from kolega_code.permissions import PermissionMode, auto_allow_permission_callback
+from kolega_code.services.base import BrowserManager, browser_manager_agent_lock
 from ..model_routing import render_subagent_model_catalog, resolve_subagent_model, subagent_model_catalog
 from ..orchestration.accounting import AgentReservation, WorkflowRunAccounting
 from ..orchestration.context import has_workflow_context_marker, validated_workflow_depth
@@ -188,6 +189,7 @@ class AgentTool(BaseTool):
         model_override: Any = None,
         routing_agent_name: Optional[str] = None,
         inherited_model: Optional[ModelConfig] = None,
+        browser_manager_override: BrowserManager | None = None,
     ) -> str:
         """
         Generic method to dispatch any agent type.
@@ -329,7 +331,9 @@ class AgentTool(BaseTool):
                 sub_agent=True,
                 filesystem=self.filesystem,
                 terminal_manager=self.terminal_manager,
-                browser_manager=self.browser_manager,
+                browser_manager=(
+                    browser_manager_override if browser_manager_override is not None else self.browser_manager
+                ),
                 langfuse_client=self.langfuse_client,
                 user_id=getattr(self.caller, "user_id", None) if self.caller else None,
                 user_email=getattr(self.caller, "user_email", None) if self.caller else None,
@@ -552,7 +556,26 @@ class AgentTool(BaseTool):
             model_override=model_override,
         )
 
-    async def dispatch_browser_agent(self, task: str, model_override: Any = None) -> str:
+    def _resolve_browser_manager(self, browser_target: Optional[str]) -> BrowserManager:
+        if self.browser_manager is None:
+            from kolega_code.services.browser import PlaywrightBrowserManager
+
+            self.browser_manager = PlaywrightBrowserManager()
+        resolver = getattr(self.browser_manager, "resolve_browser_target", None)
+        if browser_target is None:
+            if callable(resolver):
+                return cast(BrowserManager, resolver())
+            return cast(BrowserManager, self.browser_manager)
+        if not callable(resolver):
+            raise ValueError("browser_target is not available for this browser manager")
+        return cast(BrowserManager, resolver(browser_target))
+
+    async def dispatch_browser_agent(
+        self,
+        task: str,
+        model_override: Any = None,
+        browser_target: Optional[str] = None,
+    ) -> str:
         """
         Dispatch a browser agent to perform web-based tasks and interactions.
 
@@ -562,15 +585,20 @@ class AgentTool(BaseTool):
                 route from list_subagent_models. The selected catalog entry
                 must have supports_vision=true. All fields are required when
                 present, and invalid routes fail without fallback.
+            browser_target: Optional configured browser backend. Omit for
+                Playwright; choose Chrome only when directed by the user.
 
         Returns:
             A comprehensive report of the browser agent's findings and actions
         """
-        return await self._dispatch_agent(
-            agent_class_import="kolega_code.agent.browseragent.BrowserAgent",
-            task=task,
-            model_override=model_override,
-        )
+        browser_manager = self._resolve_browser_manager(browser_target)
+        async with browser_manager_agent_lock(browser_manager):
+            return await self._dispatch_agent(
+                agent_class_import="kolega_code.agent.browseragent.BrowserAgent",
+                task=task,
+                model_override=model_override,
+                browser_manager_override=browser_manager,
+            )
 
     async def dispatch_coding_agent(self, task: str, model_override: Any = None) -> str:
         """
@@ -735,7 +763,13 @@ class AgentTool(BaseTool):
             propagate_to_sub_agents=False,
         )
 
-    def _construct_workflow_sub_agent(self, agent_class, config, extra_tool_extensions):
+    def _construct_workflow_sub_agent(
+        self,
+        agent_class,
+        config,
+        extra_tool_extensions,
+        browser_manager_override: Optional[BrowserManager] = None,
+    ):
         """Construct a sub-agent the same way _dispatch_agent does, but allowing a
         config override and additional tool extensions.
         """
@@ -751,7 +785,9 @@ class AgentTool(BaseTool):
             sub_agent=True,
             filesystem=self.filesystem,
             terminal_manager=self.terminal_manager,
-            browser_manager=self.browser_manager,
+            browser_manager=(
+                browser_manager_override if browser_manager_override is not None else self.browser_manager
+            ),
             langfuse_client=self.langfuse_client,
             user_id=getattr(self.caller, "user_id", None) if self.caller else None,
             user_email=getattr(self.caller, "user_email", None) if self.caller else None,
@@ -903,6 +939,7 @@ class AgentTool(BaseTool):
         sub_agent_info_extra: Optional[dict] = None,
         artifact_paths: Optional[dict] = None,
         artifact_metadata: Optional[dict] = None,
+        browser_manager_override: Optional[BrowserManager] = None,
     ):
         """Dispatch one sub-agent for a gigacode workflow.
 
@@ -967,7 +1004,12 @@ class AgentTool(BaseTool):
         agent = None
 
         try:
-            agent = self._construct_workflow_sub_agent(agent_class, config, extra_extensions)
+            agent = self._construct_workflow_sub_agent(
+                agent_class,
+                config,
+                extra_extensions,
+                browser_manager_override=browser_manager_override,
+            )
             self.agents[agent_id] = agent
             agent.parent_tool_call_id = tool_call_id
             agent.conversation_id = conversation_id

--- a/kolega_code/agent/tool_backend/browser_tool.py
+++ b/kolega_code/agent/tool_backend/browser_tool.py
@@ -58,7 +58,16 @@ BROWSER_TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
     "browser_find": _schema(
         {
             "text": {"type": "string", "description": "Case-insensitive text to find in the snapshot."},
-            "regex": {"type": "string", "description": "Regular expression to find in the snapshot."},
+            "regex": {
+                "type": "string",
+                "description": (
+                    "Regular expression to find in the snapshot. On the Chrome backend a restricted, "
+                    "linear-time subset applies: literals, '.', character classes, anchors, escapes, and the "
+                    "quantifiers ?, *, + and {n,m} on a single character or class. Groups '(' ')', "
+                    "alternation '|', and backreferences are rejected; at most 4 quantifiers and repetition "
+                    "counts up to 1000."
+                ),
+            },
         }
     ),
     "browser_wait_for": _schema(
@@ -149,8 +158,20 @@ BROWSER_TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
     "browser_tabs": _schema(
         {
             "action": {"type": "string", "enum": ["list", "new", "close", "select"]},
-            "index": {"type": "integer", "description": "Tab index for close or select."},
-            "url": {"type": "string", "description": "Optional URL for a new tab."},
+            "index": {
+                "type": "integer",
+                "description": (
+                    "Tab index for close or select. Required for select. Must be null for list and new; "
+                    "0 is a real tab index, not a stand-in for 'unset'."
+                ),
+            },
+            "url": {
+                "type": "string",
+                "description": (
+                    "URL for a new tab. Accepted only with the new action; must be null otherwise. "
+                    "An empty string is rejected — use null."
+                ),
+            },
         },
         ["action"],
     ),
@@ -183,7 +204,14 @@ BROWSER_TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
     "browser_network_requests": _schema(
         {
             "include_static": {"type": "boolean", "description": "Include images, fonts, scripts, and styles."},
-            "filter_pattern": {"type": "string", "description": "Regular expression matched against request URLs."},
+            "filter_pattern": {
+                "type": "string",
+                "description": (
+                    "Regular expression matched against request URLs. On the Chrome backend the same "
+                    "restricted subset as browser_find applies: no groups, no alternation, at most 4 "
+                    "quantifiers."
+                ),
+            },
         }
     ),
     "browser_network_request": _schema(
@@ -386,7 +414,9 @@ class BrowserTool(BaseTool):
         lines = ["## Network requests"]
         for request in result["requests"]:
             status = request["status"] if request["status"] is not None else request["failure"] or "pending"
-            lines.append(f"- {request['index']}: {request['method']} {request['url']} => {status}")
+            resource_type = request.get("resource_type")
+            kind = f" [{resource_type}]" if resource_type else ""
+            lines.append(f"- {request['index']}: {request['method']} {request['url']}{kind} => {status}")
         return "\n".join(lines)
 
     async def browser_network_request(self, index: int, part: Optional[str] = None) -> str:

--- a/kolega_code/agent/tool_backend/workflow_tool.py
+++ b/kolega_code/agent/tool_backend/workflow_tool.py
@@ -17,6 +17,7 @@ from typing import Any, Optional
 
 from kolega_code.events import AgentEvent
 from kolega_code.llm.specs import supports_vision
+from kolega_code.services.base import browser_manager_agent_lock
 
 from ..model_routing import model_routing_fingerprint, resolve_subagent_model
 from ..orchestration import (
@@ -323,6 +324,7 @@ class WorkflowTool(BaseTool):
                 "requested_routing": requested_routing,
                 "effective_routing": effective_routing,
                 "actual_agent_type": actual_agent_type,
+                "browser_target": spec.browser_target,
             }
             label_for_path = spec.label or spec.agent_type or agent_class.__name__
             artifact_paths = journal.agent_artifact_paths(spec.call_index, label_for_path)
@@ -333,23 +335,37 @@ class WorkflowTool(BaseTool):
                 "agent_type": actual_agent_type,
                 "requested_agent_type": spec.agent_type,
                 "actual_agent_type": actual_agent_type,
+                "browser_target": spec.browser_target,
                 "agent_name": agent_name,
                 "max_agent_depth": spec.max_agent_depth,
                 "requested_routing": requested_routing,
                 "effective_routing": effective_routing,
             }
             try:
-                recap, tokens, structured = await self._agent_tool.dispatch_workflow_agent(
-                    agent_class,
-                    spec.prompt,
-                    workflow_accounting=accounting,
-                    reservation=reservation,
-                    config=config,
-                    schema=spec.schema,
-                    sub_agent_info_extra=sub_info_extra,
-                    artifact_paths=artifact_paths,
-                    artifact_metadata=artifact_metadata,
-                )
+                dispatch_kwargs = {
+                    "workflow_accounting": accounting,
+                    "reservation": reservation,
+                    "config": config,
+                    "schema": spec.schema,
+                    "sub_agent_info_extra": sub_info_extra,
+                    "artifact_paths": artifact_paths,
+                    "artifact_metadata": artifact_metadata,
+                }
+                if agent_name == "browser-agent":
+                    browser_manager = self._agent_tool._resolve_browser_manager(spec.browser_target)
+                    async with browser_manager_agent_lock(browser_manager):
+                        recap, tokens, structured = await self._agent_tool.dispatch_workflow_agent(
+                            agent_class,
+                            spec.prompt,
+                            browser_manager_override=browser_manager,
+                            **dispatch_kwargs,
+                        )
+                else:
+                    recap, tokens, structured = await self._agent_tool.dispatch_workflow_agent(
+                        agent_class,
+                        spec.prompt,
+                        **dispatch_kwargs,
+                    )
             except Exception as exc:  # noqa: BLE001 - a dead agent becomes a None result, not a crash
                 return AgentRunResult(
                     tokens=reservation.reported_tokens,

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -1008,7 +1008,15 @@ class ToolCollection(LogMixin):
 
         Args:
             text: Case-insensitive text to find.
-            regex: Regular expression to find.
+            regex: Regular expression to find. The Chrome backend accepts a
+                restricted, linear-time subset: literals, '.', character classes,
+                anchors, escapes, and the quantifiers ?, *, + and {n,m} applied to
+                a single character or class, with at most 4 quantifiers and
+                repetition counts up to 1000. Groups '(' ')', alternation '|', and
+                backreferences are rejected, so write [0-9]{4} rather than
+                (\\d{4}|\\d{2}). The Playwright backend accepts full Python
+                regular expressions, so a pattern that works there may be
+                rejected on Chrome.
         """
         return await self.browser_tool.browser_find(text, regex)
 
@@ -1118,10 +1126,14 @@ class ToolCollection(LogMixin):
     async def browser_tabs(self, action: str, index: Optional[int] = None, url: Optional[str] = None) -> str:
         """List, create, close, or select browser tabs.
 
+        Pass inapplicable parameters as null, never as 0 or an empty string:
+        list needs neither index nor url, new takes url with index null, and
+        select and close take index with url null.
+
         Args:
             action: One of list, new, close, or select.
-            index: Tab index for close or select.
-            url: Optional URL for a new tab.
+            index: Tab index for close or select; must be null for list and new.
+            url: URL for a new tab; must be null for every other action.
         """
         return await self.browser_tool.browser_tabs(action, index, url)
 

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -71,7 +71,11 @@ _ORDINARY_MODEL_OVERRIDE_SCHEMA: dict[str, Any] = {
 }
 
 
-def _dispatch_input_schema(*, custom: bool = False) -> dict[str, Any]:
+def _dispatch_input_schema(
+    *,
+    custom: bool = False,
+    browser_targets: tuple[str, ...] = (),
+) -> dict[str, Any]:
     properties: dict[str, Any] = {
         "task": {
             "type": "string",
@@ -88,6 +92,15 @@ def _dispatch_input_schema(*, custom: bool = False) -> dict[str, Any]:
         },
     }
     required = ["task"]
+    if browser_targets:
+        properties["browser_target"] = {
+            "type": "string",
+            "enum": list(browser_targets),
+            "description": (
+                "Browser backend for this task. Omit for Playwright; choose Chrome only when the user directs you "
+                "to use their configured Chrome browser."
+            ),
+        }
     if custom:
         properties = {
             "agent": {"type": "string", "description": "Name of the custom agent to run."},
@@ -914,6 +927,9 @@ class ToolCollection(LogMixin):
         self.extension_schemas["resolve"] = _RESOLVE_INPUT_SCHEMA
         self.extension_schemas.update(BROWSER_TOOL_SCHEMAS)
         self.extension_schemas.update(_AGENT_DISPATCH_INPUT_SCHEMAS)
+        browser_targets = tuple(getattr(self.browser_manager, "browser_targets", ()))
+        if len(browser_targets) > 1:
+            self.extension_schemas["dispatch_browser_agent"] = _dispatch_input_schema(browser_targets=browser_targets)
         self.browser_tool = BrowserTool(
             self.project_path,
             self.workspace_id,
@@ -1273,7 +1289,12 @@ class ToolCollection(LogMixin):
         """
         return await self.agent_tool.dispatch_investigation_agent(task, model_override)
 
-    async def dispatch_browser_agent(self, task: str, model_override: Any = None) -> str:
+    async def dispatch_browser_agent(
+        self,
+        task: str,
+        model_override: Any = None,
+        browser_target: Optional[str] = None,
+    ) -> str:
         """
         Dispatch a browser agent to perform web-based tasks and interactions.
 
@@ -1310,11 +1331,13 @@ class ToolCollection(LogMixin):
             task: A detailed description of the browser task to perform
             model_override: Optional complete provider/model/thinking_effort route. Call
                 list_subagent_models before selecting one; the model must support vision.
+            browser_target: Optional configured browser backend. Omit for Playwright;
+                choose Chrome only when the user asks to use their Chrome browser.
 
         Returns:
             A comprehensive report of the browser agent's findings and actions
         """
-        return await self.agent_tool.dispatch_browser_agent(task, model_override)
+        return await self.agent_tool.dispatch_browser_agent(task, model_override, browser_target)
 
     async def dispatch_coding_agent(self, task: str, model_override: Any = None) -> str:
         """
@@ -2465,7 +2488,9 @@ class ToolCollection(LogMixin):
             validated_workflow_depth(context) is not None or has_workflow_context_marker(context)
         )
         ordinary_parallel_dispatch = (
-            method_name in self.agent_dispatch_tools and method_name not in self._legacy_only_extension_dispatch_tools
+            method_name in self.agent_dispatch_tools
+            and method_name not in self._legacy_only_extension_dispatch_tools
+            and method_name != "dispatch_browser_agent"
         )
         return Tool(
             name=method_name,
@@ -2549,6 +2574,11 @@ class ToolCollection(LogMixin):
         # Strict `is False` so Mock configs in tests keep the default (enabled).
         if method_name == "eval" and getattr(self.config, "eval_enabled", True) is False:
             return False
+
+        if method_name in self.browser_tools:
+            supported_tools = getattr(self.browser_manager, "supported_tools", None)
+            if supported_tools is not None and method_name not in supported_tools:
+                return False
 
         # Check custom tool groups first
         if self.tool_config.custom_tool_groups:

--- a/kolega_code/browser_extension/__init__.py
+++ b/kolega_code/browser_extension/__init__.py
@@ -1,0 +1,78 @@
+"""Chrome Native Messaging browser backend."""
+
+from .framing import (
+    MAX_NATIVE_MESSAGE_BYTES,
+    FramingError,
+    MessageTooLargeError,
+    TruncatedMessageError,
+    read_message,
+    read_message_async,
+    write_message,
+    write_message_async,
+)
+from .manager import (
+    CHROME_EXTENSION_CAPABILITIES,
+    CHROME_EXTENSION_SUPPORTED_TOOLS,
+    ChromeExtensionBrowserManager,
+    ChromeExtensionProtocolError,
+    ChromeExtensionUnavailableError,
+)
+from .multiplex import (
+    ConnectionClosedError,
+    MultiplexedPeer,
+    PendingRequestLimitError,
+    RemoteRequestError,
+    RequestTimeoutError,
+)
+from .protocol import (
+    ALLOWED_OPERATIONS,
+    PROTOCOL_VERSION,
+    Envelope,
+    MessageDirection,
+    MessageType,
+    ProtocolValidationError,
+)
+from .registry import RuntimeDescriptor, RuntimeDescriptorRegistry
+from .runtime import (
+    RuntimeAuthenticationError,
+    RuntimeChannel,
+    RuntimeServer,
+    UnsupportedRuntimeTransportError,
+    connect_runtime_channel,
+    selected_runtime_transport,
+)
+
+__all__ = [
+    "ALLOWED_OPERATIONS",
+    "CHROME_EXTENSION_CAPABILITIES",
+    "CHROME_EXTENSION_SUPPORTED_TOOLS",
+    "MAX_NATIVE_MESSAGE_BYTES",
+    "PROTOCOL_VERSION",
+    "ChromeExtensionBrowserManager",
+    "ChromeExtensionProtocolError",
+    "ChromeExtensionUnavailableError",
+    "ConnectionClosedError",
+    "Envelope",
+    "FramingError",
+    "MessageDirection",
+    "MessageTooLargeError",
+    "MessageType",
+    "MultiplexedPeer",
+    "PendingRequestLimitError",
+    "ProtocolValidationError",
+    "RemoteRequestError",
+    "RequestTimeoutError",
+    "RuntimeAuthenticationError",
+    "RuntimeChannel",
+    "RuntimeDescriptor",
+    "RuntimeDescriptorRegistry",
+    "RuntimeServer",
+    "TruncatedMessageError",
+    "UnsupportedRuntimeTransportError",
+    "connect_runtime_channel",
+    "read_message",
+    "read_message_async",
+    "selected_runtime_transport",
+    "write_message",
+    "write_message_async",
+]

--- a/kolega_code/browser_extension/framing.py
+++ b/kolega_code/browser_extension/framing.py
@@ -1,0 +1,158 @@
+"""Chrome Native Messaging framing for bounded JSON objects."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import struct
+from typing import Any, BinaryIO, Mapping, cast
+
+MAX_NATIVE_MESSAGE_BYTES = 1_048_576
+_HEADER = struct.Struct("<I")
+
+
+class FramingError(ValueError):
+    """A safe-to-report native-message framing failure."""
+
+
+class MessageTooLargeError(FramingError):
+    """A frame exceeded the configured size bound."""
+
+
+class TruncatedMessageError(FramingError):
+    """EOF occurred in the middle of a frame."""
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise FramingError("Native message contains a duplicate object key")
+        result[key] = value
+    return result
+
+
+def _reject_constant(_: str) -> None:
+    raise FramingError("Native message contains a non-finite number")
+
+
+def _decode_object(data: bytes) -> dict[str, Any]:
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        raise FramingError("Native message is not valid UTF-8") from None
+    try:
+        value = json.loads(text, object_pairs_hook=_reject_duplicate_keys, parse_constant=_reject_constant)
+    except FramingError:
+        raise
+    except (json.JSONDecodeError, RecursionError):
+        raise FramingError("Native message is not valid JSON") from None
+    if not isinstance(value, dict):
+        raise FramingError("Native message must be a JSON object")
+    return cast(dict[str, Any], value)
+
+
+def encode_message(message: Mapping[str, object], *, max_bytes: int = MAX_NATIVE_MESSAGE_BYTES) -> bytes:
+    """Encode one mapping using Chrome's little-endian length framing."""
+    if max_bytes <= 0:
+        raise ValueError("max_bytes must be positive")
+    try:
+        payload = json.dumps(
+            dict(message),
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    except (TypeError, ValueError, RecursionError):
+        raise FramingError("Native message is not JSON serializable") from None
+    if len(payload) > max_bytes:
+        raise MessageTooLargeError("Native message exceeds the size limit")
+    return _HEADER.pack(len(payload)) + payload
+
+
+def _read_exact(stream: BinaryIO, size: int, *, allow_clean_eof: bool = False) -> bytes | None:
+    chunks = bytearray()
+    while len(chunks) < size:
+        chunk = stream.read(size - len(chunks))
+        if not chunk:
+            if not chunks and allow_clean_eof:
+                return None
+            raise TruncatedMessageError("Native message ended before the frame was complete")
+        chunks.extend(chunk)
+    return bytes(chunks)
+
+
+def read_message(stream: BinaryIO, *, max_bytes: int = MAX_NATIVE_MESSAGE_BYTES) -> dict[str, Any] | None:
+    """Read one message, returning ``None`` only for EOF between frames."""
+    if max_bytes <= 0:
+        raise ValueError("max_bytes must be positive")
+    header = _read_exact(stream, _HEADER.size, allow_clean_eof=True)
+    if header is None:
+        return None
+    (length,) = _HEADER.unpack(header)
+    if length > max_bytes:
+        raise MessageTooLargeError("Native message exceeds the size limit")
+    payload = _read_exact(stream, length)
+    assert payload is not None
+    return _decode_object(payload)
+
+
+def _write_all(stream: BinaryIO, data: bytes) -> None:
+    view = memoryview(data)
+    written = 0
+    while written < len(view):
+        count = stream.write(view[written:])
+        if count is None:
+            written = len(view)
+        elif count <= 0:
+            raise FramingError("Native message could not be written")
+        else:
+            written += count
+    flush = getattr(stream, "flush", None)
+    if flush is not None:
+        flush()
+
+
+def write_message(
+    stream: BinaryIO,
+    message: Mapping[str, object],
+    *,
+    max_bytes: int = MAX_NATIVE_MESSAGE_BYTES,
+) -> None:
+    """Write one complete native-message frame."""
+    _write_all(stream, encode_message(message, max_bytes=max_bytes))
+
+
+async def read_message_async(
+    reader: asyncio.StreamReader,
+    *,
+    max_bytes: int = MAX_NATIVE_MESSAGE_BYTES,
+) -> dict[str, Any] | None:
+    """Read one bounded native message from an asyncio byte stream."""
+    if max_bytes <= 0:
+        raise ValueError("max_bytes must be positive")
+    try:
+        header = await reader.readexactly(_HEADER.size)
+    except asyncio.IncompleteReadError as exc:
+        if not exc.partial:
+            return None
+        raise TruncatedMessageError("Native message ended before the frame was complete") from None
+    (length,) = _HEADER.unpack(header)
+    if length > max_bytes:
+        raise MessageTooLargeError("Native message exceeds the size limit")
+    try:
+        payload = await reader.readexactly(length)
+    except asyncio.IncompleteReadError:
+        raise TruncatedMessageError("Native message ended before the frame was complete") from None
+    return _decode_object(payload)
+
+
+async def write_message_async(
+    writer: asyncio.StreamWriter,
+    message: Mapping[str, object],
+    *,
+    max_bytes: int = MAX_NATIVE_MESSAGE_BYTES,
+) -> None:
+    """Write and drain one complete native-message frame."""
+    writer.write(encode_message(message, max_bytes=max_bytes))
+    await writer.drain()

--- a/kolega_code/browser_extension/installer.py
+++ b/kolega_code/browser_extension/installer.py
@@ -1,0 +1,533 @@
+"""Safe per-user Chrome Native Messaging host installation."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import stat
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final, Literal, Mapping, get_args
+
+from .native_host import (
+    DEFAULT_MAX_RELAY_PENDING,
+    DEFAULT_MAX_RUNTIMES,
+    NativeHostConfigurationError,
+    default_host_config_path,
+    load_host_config,
+)
+from .registry import validate_extension_origin
+from .runtime import UnsupportedRuntimeTransportError, ensure_runtime_transport_supported
+
+NATIVE_HOST_NAME = "ai.kolega.browser"
+CHROME_EXTENSION_ID = "edihigldhbmimflgjkohkgnjefmhngdn"
+CHROME_WEB_STORE_URL = f"https://chromewebstore.google.com/detail/{CHROME_EXTENSION_ID}"
+BrowserExtensionChannel = Literal["production", "beta", "dev"]
+BROWSER_EXTENSION_CHANNELS: Final[tuple[BrowserExtensionChannel, ...]] = get_args(BrowserExtensionChannel)
+DEFAULT_BROWSER_EXTENSION_CHANNEL: Final[BrowserExtensionChannel] = "production"
+CHANNEL_EXTENSION_IDS: Final[Mapping[BrowserExtensionChannel, str | None]] = {
+    "production": CHROME_EXTENSION_ID,
+    "beta": None,
+    "dev": None,
+}
+_EXTENSION_ID_RE = re.compile(r"^[a-p]{32}$")
+_MANIFEST_KEYS = frozenset({"name", "description", "path", "type", "allowed_origins"})
+
+
+class NativeHostInstallError(RuntimeError):
+    """The native host cannot be installed or removed safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class _FileSnapshot:
+    path: Path
+    content: bytes | None
+    mode: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class NativeHostStatus:
+    manifest_path: Path
+    installed: bool
+    valid: bool
+    host_path: Path | None
+    extension_id: str
+    detail: str
+    channel: BrowserExtensionChannel = DEFAULT_BROWSER_EXTENSION_CHANNEL
+    configured_extension_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "manifest_path": str(self.manifest_path),
+            "installed": self.installed,
+            "valid": self.valid,
+            "host_path": str(self.host_path) if self.host_path is not None else None,
+            "extension_id": self.extension_id,
+            "configured_extension_id": self.configured_extension_id,
+            "channel": self.channel,
+            "detail": self.detail,
+        }
+
+
+def validate_extension_id(extension_id: str) -> str:
+    if not _EXTENSION_ID_RE.fullmatch(extension_id):
+        raise NativeHostInstallError("Chrome extension ID must be 32 lowercase letters in the range a-p.")
+    return extension_id
+
+
+def resolve_channel_extension_id(
+    *,
+    channel: str = DEFAULT_BROWSER_EXTENSION_CHANNEL,
+    extension_id: str | None = None,
+) -> tuple[BrowserExtensionChannel, str]:
+    if channel not in BROWSER_EXTENSION_CHANNELS:
+        raise NativeHostInstallError(
+            f"Browser extension channel must be one of: {', '.join(BROWSER_EXTENSION_CHANNELS)}."
+        )
+    selected: BrowserExtensionChannel = channel
+    compiled = CHANNEL_EXTENSION_IDS[selected]
+    if compiled is not None:
+        if extension_id is not None and validate_extension_id(extension_id) != compiled:
+            raise NativeHostInstallError(
+                f"The {selected} channel uses extension ID {compiled}; a conflicting ID is not allowed."
+            )
+        return selected, compiled
+    if extension_id is None:
+        raise NativeHostInstallError(f"The {selected} channel requires an explicit extension ID.")
+    return selected, validate_extension_id(extension_id)
+
+
+def channel_web_store_url(channel: BrowserExtensionChannel) -> str | None:
+    return CHROME_WEB_STORE_URL if channel == "production" else None
+
+
+def chrome_extension_origin(extension_id: str = CHROME_EXTENSION_ID) -> str:
+    return validate_extension_origin(f"chrome-extension://{validate_extension_id(extension_id)}/")
+
+
+def default_state_dir(*, platform: str | None = None, env: Mapping[str, str] | None = None) -> Path:
+    selected = platform or sys.platform
+    if selected != "darwin":
+        raise UnsupportedRuntimeTransportError("Chrome browser integration is supported only on macOS.")
+    values = os.environ if env is None else env
+    configured = values.get("KOLEGA_CODE_STATE_DIR")
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / "Library" / "Application Support" / "kolega-code"
+
+
+def chrome_native_host_manifest_path(
+    *,
+    platform: str | None = None,
+    home: Path | None = None,
+) -> Path:
+    selected = platform or sys.platform
+    if selected != "darwin":
+        raise UnsupportedRuntimeTransportError("Chrome browser integration is supported only on macOS.")
+    user_home = (home or Path.home()).expanduser().resolve()
+    root = user_home / "Library" / "Application Support" / "Google" / "Chrome"
+    return root / "NativeMessagingHosts" / f"{NATIVE_HOST_NAME}.json"
+
+
+def _owner_id() -> int | None:
+    getuid = getattr(os, "getuid", None)
+    return getuid() if getuid is not None else None
+
+
+def _safe_owned_stat(file_stat: os.stat_result, *, directory: bool, require_private: bool) -> bool:
+    expected_type = stat.S_ISDIR if directory else stat.S_ISREG
+    if not expected_type(file_stat.st_mode):
+        return False
+    owner = _owner_id()
+    if owner is not None and file_stat.st_uid != owner:
+        return False
+    mask = 0o077 if require_private else 0o022
+    return not stat.S_IMODE(file_stat.st_mode) & mask
+
+
+def _ensure_safe_parent(path: Path) -> None:
+    parent = path.parent
+    try:
+        parent.mkdir(mode=0o700, parents=True, exist_ok=False)
+    except FileExistsError:
+        pass
+    try:
+        parent_stat = parent.lstat()
+    except OSError:
+        raise NativeHostInstallError("Native host destination directory is unavailable.") from None
+    if not _safe_owned_stat(parent_stat, directory=True, require_private=False):
+        raise NativeHostInstallError("Native host destination directory has unsafe ownership or permissions.")
+    if _owner_id() is not None:
+        os.chmod(parent, 0o700)
+
+
+def _assert_replaceable(path: Path) -> None:
+    try:
+        file_stat = path.lstat()
+    except FileNotFoundError:
+        return
+    if not _safe_owned_stat(file_stat, directory=False, require_private=False):
+        raise NativeHostInstallError("Refusing to replace a native host file with unsafe ownership or permissions.")
+
+
+def _write_private_json(path: Path, value: Mapping[str, object]) -> None:
+    destination = path.expanduser()
+    _ensure_safe_parent(destination)
+    _assert_replaceable(destination)
+    payload = json.dumps(dict(value), indent=2, allow_nan=False, sort_keys=True) + "\n"
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{destination.name}-", dir=destination.parent)
+    temporary = Path(temporary_name)
+    try:
+        if _owner_id() is not None:
+            os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8", closefd=True) as file:
+            fd = -1
+            file.write(payload)
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(temporary, destination)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _snapshot_file(path: Path) -> _FileSnapshot:
+    if not path.exists():
+        return _FileSnapshot(path=path, content=None, mode=None)
+    file_stat = path.lstat()
+    if not _safe_owned_stat(file_stat, directory=False, require_private=False):
+        raise NativeHostInstallError("Native host file has unsafe ownership or permissions.")
+    try:
+        content = path.read_bytes()
+    except OSError:
+        raise NativeHostInstallError("Native host file could not be read safely.") from None
+    return _FileSnapshot(path=path, content=content, mode=stat.S_IMODE(file_stat.st_mode))
+
+
+def _restore_snapshot(snapshot: _FileSnapshot) -> None:
+    if snapshot.content is None:
+        snapshot.path.unlink(missing_ok=True)
+        return
+    _ensure_safe_parent(snapshot.path)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{snapshot.path.name}-rollback-", dir=snapshot.path.parent)
+    temporary = Path(temporary_name)
+    try:
+        if snapshot.mode is not None:
+            os.fchmod(fd, snapshot.mode)
+        with os.fdopen(fd, "wb", closefd=True) as file:
+            fd = -1
+            file.write(snapshot.content)
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(temporary, snapshot.path)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        temporary.unlink(missing_ok=True)
+
+
+def _is_trusted_host_executable(path: Path) -> bool:
+    try:
+        file_stat = path.stat()
+    except OSError:
+        return False
+    owner = _owner_id()
+    return (
+        stat.S_ISREG(file_stat.st_mode)
+        and os.access(path, os.X_OK)
+        and not file_stat.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+        and (owner is None or file_stat.st_uid == owner)
+    )
+
+
+def resolve_native_host_executable(explicit_path: Path | None = None) -> Path:
+    candidates: list[Path] = []
+    if explicit_path is not None:
+        candidates.append(explicit_path)
+    else:
+        candidates.append(Path(sys.executable).parent / "kolega-code-browser-host")
+        discovered = shutil.which("kolega-code-browser-host")
+        if discovered:
+            candidates.append(Path(discovered))
+    for candidate in candidates:
+        try:
+            resolved = candidate.expanduser().resolve()
+        except (OSError, RuntimeError):
+            continue
+        if _is_trusted_host_executable(resolved):
+            return resolved
+    raise NativeHostInstallError(
+        "Native host executable must be a regular executable owned by the current user and not writable by others."
+    )
+
+
+def build_native_host_manifest(
+    host_path: Path,
+    *,
+    extension_id: str = CHROME_EXTENSION_ID,
+) -> dict[str, Any]:
+    origin = chrome_extension_origin(extension_id)
+    resolved = host_path.expanduser().resolve()
+    if not resolved.is_absolute():
+        raise NativeHostInstallError("Native host path must be absolute.")
+    return {
+        "name": NATIVE_HOST_NAME,
+        "description": "Kolega Code Chrome browser bridge",
+        "path": str(resolved),
+        "type": "stdio",
+        "allowed_origins": [origin],
+    }
+
+
+def install_native_host(
+    *,
+    host_path: Path | None = None,
+    channel: str = DEFAULT_BROWSER_EXTENSION_CHANNEL,
+    extension_id: str | None = None,
+    platform: str | None = None,
+    home: Path | None = None,
+    state_dir: Path | None = None,
+    host_config_path: Path | None = None,
+) -> NativeHostStatus:
+    selected_channel, selected_id = resolve_channel_extension_id(channel=channel, extension_id=extension_id)
+    ensure_runtime_transport_supported(platform=platform)
+    executable = resolve_native_host_executable(host_path)
+    manifest_path = chrome_native_host_manifest_path(platform=platform, home=home)
+    origin = chrome_extension_origin(selected_id)
+    registry_dir = (
+        (state_dir or default_state_dir(platform=platform)).expanduser().resolve() / "browser-extension" / "runtimes"
+    )
+    config_path = host_config_path or default_host_config_path(platform=platform)
+    if manifest_path.exists() or manifest_path.is_symlink():
+        existing_manifest = _read_private_mapping(manifest_path)
+        if existing_manifest is None or set(existing_manifest) != _MANIFEST_KEYS:
+            raise NativeHostInstallError("Refusing to replace an unsafe or foreign native host manifest.")
+        if existing_manifest.get("name") != NATIVE_HOST_NAME or existing_manifest.get("allowed_origins") != [origin]:
+            raise NativeHostInstallError("Refusing to replace an unsafe or foreign native host manifest.")
+    if config_path.exists() or config_path.is_symlink():
+        try:
+            existing_config = load_host_config(config_path)
+        except NativeHostConfigurationError:
+            raise NativeHostInstallError("Refusing to replace an unsafe or malformed host configuration.") from None
+        if (
+            existing_config.extension_origin != origin
+            or existing_config.registry_dir.expanduser().resolve() != registry_dir
+        ):
+            raise NativeHostInstallError(
+                "Refusing to replace host configuration owned by another runtime or extension."
+            )
+    config_snapshot = _snapshot_file(config_path)
+    manifest_snapshot = _snapshot_file(manifest_path)
+    try:
+        _write_private_json(
+            config_path,
+            {
+                "extension_origin": origin,
+                "registry_dir": str(registry_dir),
+                "max_runtimes": DEFAULT_MAX_RUNTIMES,
+                "max_pending_requests": DEFAULT_MAX_RELAY_PENDING,
+            },
+        )
+        _write_private_json(manifest_path, build_native_host_manifest(executable, extension_id=selected_id))
+        status = native_host_status(
+            channel=selected_channel,
+            extension_id=selected_id,
+            platform=platform,
+            home=home,
+            state_dir=state_dir,
+            host_config_path=host_config_path,
+            expected_host_path=executable,
+        )
+        if not status.valid:
+            raise NativeHostInstallError(status.detail)
+        return status
+    except BaseException:
+        _restore_snapshot(manifest_snapshot)
+        _restore_snapshot(config_snapshot)
+        raise
+
+
+def _read_private_mapping(path: Path, *, require_private: bool = True) -> Mapping[str, object] | None:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(path, flags)
+    except OSError:
+        return None
+    try:
+        file_stat = os.fstat(fd)
+        if not _safe_owned_stat(file_stat, directory=False, require_private=require_private):
+            return None
+        with os.fdopen(fd, "r", encoding="utf-8", closefd=True) as file:
+            fd = -1
+            raw = json.load(file)
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return None
+    finally:
+        if fd >= 0:
+            os.close(fd)
+    return raw if isinstance(raw, dict) else None
+
+
+def _extension_id_from_manifest(manifest: Mapping[str, object]) -> str | None:
+    origins = manifest.get("allowed_origins")
+    if not isinstance(origins, list) or len(origins) != 1 or not isinstance(origins[0], str):
+        return None
+    prefix = "chrome-extension://"
+    origin = origins[0]
+    if not origin.startswith(prefix) or not origin.endswith("/"):
+        return None
+    extension_id = origin[len(prefix) : -1]
+    return extension_id if _EXTENSION_ID_RE.fullmatch(extension_id) else None
+
+
+def native_host_status(
+    *,
+    channel: str = DEFAULT_BROWSER_EXTENSION_CHANNEL,
+    extension_id: str | None = None,
+    platform: str | None = None,
+    home: Path | None = None,
+    state_dir: Path | None = None,
+    host_config_path: Path | None = None,
+    expected_host_path: Path | None = None,
+) -> NativeHostStatus:
+    selected_channel, selected_id = resolve_channel_extension_id(channel=channel, extension_id=extension_id)
+    manifest_path = chrome_native_host_manifest_path(platform=platform, home=home)
+    if not manifest_path.is_file():
+        return NativeHostStatus(
+            manifest_path=manifest_path,
+            installed=False,
+            valid=False,
+            host_path=None,
+            extension_id=selected_id,
+            detail=f"Native host manifest is not installed for the {selected_channel} channel.",
+            channel=selected_channel,
+        )
+    manifest = _read_private_mapping(manifest_path)
+    if manifest is None:
+        return NativeHostStatus(
+            manifest_path=manifest_path,
+            installed=True,
+            valid=False,
+            host_path=None,
+            extension_id=selected_id,
+            detail="Native host manifest is unsafe or malformed.",
+            channel=selected_channel,
+        )
+    host_value = manifest.get("path")
+    host_path = Path(host_value).expanduser() if isinstance(host_value, str) and host_value else None
+    origin = chrome_extension_origin(selected_id)
+    configured_id = _extension_id_from_manifest(manifest)
+    shape_valid = (
+        set(manifest) == _MANIFEST_KEYS
+        and manifest.get("name") == NATIVE_HOST_NAME
+        and manifest.get("type") == "stdio"
+        and manifest.get("allowed_origins") == [origin]
+        and host_path is not None
+        and host_path.is_absolute()
+    )
+    try:
+        executable_valid = bool(
+            host_path and host_path == host_path.resolve() and _is_trusted_host_executable(host_path)
+        )
+    except (OSError, RuntimeError):
+        executable_valid = False
+    try:
+        expected_executable = resolve_native_host_executable(expected_host_path)
+        executable_valid = executable_valid and host_path == expected_executable
+    except NativeHostInstallError:
+        executable_valid = False
+    expected_registry = (
+        (state_dir or default_state_dir(platform=platform)).expanduser().resolve() / "browser-extension" / "runtimes"
+    )
+    try:
+        config = load_host_config(host_config_path or default_host_config_path(platform=platform))
+        config_valid = (
+            config.extension_origin == origin and config.registry_dir.expanduser().resolve() == expected_registry
+        )
+    except NativeHostConfigurationError:
+        config_valid = False
+    valid = shape_valid and executable_valid and config_valid
+    detail = (
+        f"Native host manifest is installed and valid for the {selected_channel} channel."
+        if valid
+        else "Native host files do not match the executable, extension origin, registry, or safety requirements."
+    )
+    return NativeHostStatus(
+        manifest_path=manifest_path,
+        installed=True,
+        valid=valid,
+        host_path=host_path,
+        extension_id=selected_id,
+        detail=detail,
+        channel=selected_channel,
+        configured_extension_id=configured_id,
+    )
+
+
+def configured_extension_origin(
+    *,
+    state_dir: Path | None = None,
+    host_config_path: Path | None = None,
+) -> str:
+    config = load_host_config(host_config_path or default_host_config_path())
+    expected_registry = (state_dir or default_state_dir()).expanduser().resolve() / "browser-extension" / "runtimes"
+    if config.registry_dir.expanduser().resolve() != expected_registry:
+        raise NativeHostConfigurationError("Native-host configuration points at a different runtime registry")
+    return config.extension_origin
+
+
+def uninstall_native_host(
+    *,
+    channel: str = DEFAULT_BROWSER_EXTENSION_CHANNEL,
+    extension_id: str | None = None,
+    platform: str | None = None,
+    home: Path | None = None,
+    host_config_path: Path | None = None,
+) -> bool:
+    _, selected_id = resolve_channel_extension_id(channel=channel, extension_id=extension_id)
+    origin = chrome_extension_origin(selected_id)
+    manifest_path = chrome_native_host_manifest_path(platform=platform, home=home)
+    config_path = host_config_path or default_host_config_path(platform=platform)
+    manifest_present = manifest_path.exists() or manifest_path.is_symlink()
+    config_present = config_path.exists() or config_path.is_symlink()
+    if manifest_present:
+        manifest = _read_private_mapping(manifest_path)
+        if (
+            manifest is None
+            or set(manifest) != _MANIFEST_KEYS
+            or manifest.get("name") != NATIVE_HOST_NAME
+            or manifest.get("allowed_origins") != [origin]
+        ):
+            raise NativeHostInstallError("Refusing to remove an unsafe or foreign native host manifest.")
+    if config_present:
+        try:
+            config = load_host_config(config_path)
+        except NativeHostConfigurationError:
+            raise NativeHostInstallError("Refusing to remove an unsafe or malformed host configuration.") from None
+        if config.extension_origin != origin:
+            raise NativeHostInstallError("Refusing to remove host configuration for a different extension.")
+    if not manifest_present and not config_present:
+        return False
+
+    manifest_snapshot = _snapshot_file(manifest_path)
+    config_snapshot = _snapshot_file(config_path)
+    try:
+        if manifest_present:
+            manifest_path.unlink()
+        if config_present:
+            config_path.unlink()
+    except BaseException:
+        _restore_snapshot(manifest_snapshot)
+        _restore_snapshot(config_snapshot)
+        raise
+    return True

--- a/kolega_code/browser_extension/manager.py
+++ b/kolega_code/browser_extension/manager.py
@@ -11,7 +11,7 @@ from kolega_code.services.base import BrowserManager
 
 from .multiplex import ConnectionClosedError, MultiplexedPeer, RemoteRequestError, RequestTimeoutError
 from .protocol import JSONValue, Envelope, ProtocolValidationError, validate_operation_request
-from .registry import RuntimeDescriptorRegistry, validate_extension_origin
+from .registry import RuntimeDescriptor, RuntimeDescriptorRegistry, validate_extension_origin
 from .runtime import RuntimeServer, RuntimeTransportError, UnsupportedRuntimeTransportError
 
 CHROME_EXTENSION_SUPPORTED_TOOLS = frozenset(
@@ -144,6 +144,52 @@ class ChromeExtensionBrowserManager(BrowserManager):
         self._ready = False
         self._browser_session_id = None
 
+    def _live_runtimes(self) -> list[RuntimeDescriptor]:
+        """List every runtime currently advertised to the extension picker."""
+        registry = RuntimeDescriptorRegistry(self.state_dir / "browser-extension" / "runtimes")
+        try:
+            return registry.list_active()
+        except OSError:
+            return []
+
+    def _unavailable_detail(self) -> str:
+        """Explain *why* the companion is not ready, naming competing runtimes.
+
+        The extension connects automatically, but it will not guess which local
+        runtime may drive the browser when several are advertised. Distinguish
+        "nothing connected" from "awaiting your choice", because the remedies are
+        completely different. Note the choice is detected from the advertised
+        runtime count, not from having a peer: the extension only dials a
+        runtime's socket *after* it is selected, so a pending choice never has a
+        peer to observe.
+        """
+        connected = self._peer is not None and not self._peer.closed
+        mine = self.runtime_id
+        runtimes = self._live_runtimes()
+        if len(runtimes) > 1:
+            listed = ", ".join(
+                f"{descriptor.session_id} (runtime {descriptor.runtime_id}, pid {descriptor.pid})"
+                + (" <- this session" if descriptor.runtime_id == mine else "")
+                for descriptor in runtimes
+            )
+            return (
+                "Kolega Browser Companion is connected but waiting for you to choose which Kolega session "
+                f"may control the browser. {len(runtimes)} sessions are advertised: {listed}. Click the "
+                "extension and select this session"
+                + (f" (runtime {mine})" if mine else "")
+                + ". The extension badge shows '!' while a choice is required."
+            )
+        if connected:
+            return (
+                "Kolega Browser Companion is connected but has not confirmed a session. Open the extension "
+                "and select this Kolega session, then retry."
+            )
+        return (
+            "Kolega Browser Companion did not connect. Confirm the extension is installed and enabled in "
+            "Chrome, that Chrome is running, and that `kolega-code browser status` reports a valid native "
+            "host, then retry."
+        )
+
     async def _connected_peer(self) -> MultiplexedPeer:
         await self._ensure_server()
         loop = asyncio.get_running_loop()
@@ -163,10 +209,52 @@ class ChromeExtensionBrowserManager(BrowserManager):
                 await asyncio.wait_for(self._state_changed.wait(), timeout=remaining)
             except TimeoutError:
                 break
-        raise ChromeExtensionUnavailableError(
-            "Kolega Browser Companion is not ready. Open Chrome, select this Kolega runtime in the extension, "
-            "and retry."
-        )
+        raise ChromeExtensionUnavailableError(self._unavailable_detail())
+
+    async def probe(self) -> dict[str, Any]:
+        """Attempt an attach and report the pairing state without raising.
+
+        Used by `kolega-code browser doctor`, which must distinguish a valid
+        native-host manifest from an extension that is actually reachable.
+        """
+        result: dict[str, Any] = {
+            "state": "unreachable",
+            "connected": False,
+            "ready": False,
+            "runtime_id": None,
+            "runtimes": [],
+            "detail": "",
+        }
+        try:
+            await self._ensure_server()
+        except ChromeExtensionUnavailableError as exc:
+            result["detail"] = str(exc)
+            return result
+        result["runtime_id"] = self.runtime_id
+        try:
+            await self._connected_peer()
+        except ChromeExtensionUnavailableError as exc:
+            result["detail"] = str(exc)
+        else:
+            result["state"] = "paired"
+            result["detail"] = "Kolega Browser Companion is connected and this session is selected."
+        result["connected"] = self._peer is not None and not self._peer.closed
+        result["ready"] = self._ready
+        result["runtimes"] = [
+            {
+                "runtime_id": descriptor.runtime_id,
+                "session_id": descriptor.session_id,
+                "pid": descriptor.pid,
+                "current": descriptor.runtime_id == self.runtime_id,
+            }
+            for descriptor in self._live_runtimes()
+        ]
+        if result["state"] != "paired":
+            if len(result["runtimes"]) > 1:
+                result["state"] = "awaiting_selection"
+            elif result["connected"]:
+                result["state"] = "connected_not_selected"
+        return result
 
     async def _request(self, operation: str, params: Mapping[str, JSONValue]) -> dict[str, Any]:
         async with self._operation_lock:

--- a/kolega_code/browser_extension/manager.py
+++ b/kolega_code/browser_extension/manager.py
@@ -1,0 +1,373 @@
+"""BrowserManager backed by a selected Chrome extension runtime."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from pathlib import Path
+from typing import Any, Mapping, Optional, cast
+
+from kolega_code.services.base import BrowserManager
+
+from .multiplex import ConnectionClosedError, MultiplexedPeer, RemoteRequestError, RequestTimeoutError
+from .protocol import JSONValue, Envelope, ProtocolValidationError, validate_operation_request
+from .registry import RuntimeDescriptorRegistry, validate_extension_origin
+from .runtime import RuntimeServer, RuntimeTransportError, UnsupportedRuntimeTransportError
+
+CHROME_EXTENSION_SUPPORTED_TOOLS = frozenset(
+    "browser_navigate browser_navigate_back browser_snapshot browser_find browser_wait_for browser_click "
+    "browser_type browser_fill_form browser_select_option browser_hover browser_drag browser_press_key "
+    "browser_tabs browser_network_requests browser_take_screenshot browser_close".split()
+)
+CHROME_EXTENSION_CAPABILITIES = CHROME_EXTENSION_SUPPORTED_TOOLS
+DEFAULT_EXTENSION_CONNECTION_TIMEOUT_SECONDS = 12.0
+DEFAULT_BROWSER_OPERATION_TIMEOUT_SECONDS = 30.0
+
+
+class ChromeExtensionUnavailableError(RuntimeError):
+    """Chrome or the selected extension runtime is unavailable."""
+
+
+class ChromeExtensionProtocolError(RuntimeError):
+    """A request or result violates the fixed browser contract."""
+
+
+class ChromeExtensionBrowserManager(BrowserManager):
+    """Drive Chrome through one extension-selected Kolega runtime."""
+
+    browser_target = "chrome"
+    supported_tools = CHROME_EXTENSION_SUPPORTED_TOOLS
+    capabilities = CHROME_EXTENSION_CAPABILITIES
+
+    def __init__(
+        self,
+        *,
+        state_dir: Path,
+        kolega_session_id: str,
+        extension_origin: str,
+        connection_timeout: float = DEFAULT_EXTENSION_CONNECTION_TIMEOUT_SECONDS,
+        operation_timeout: float = DEFAULT_BROWSER_OPERATION_TIMEOUT_SECONDS,
+    ) -> None:
+        if connection_timeout <= 0 or operation_timeout <= 0:
+            raise ValueError("Chrome extension timeouts must be positive.")
+        self.state_dir = state_dir.expanduser().resolve()
+        self.kolega_session_id = kolega_session_id
+        self.extension_origin = validate_extension_origin(extension_origin)
+        self.connection_timeout = connection_timeout
+        self.operation_timeout = operation_timeout
+        self._server: RuntimeServer | None = None
+        self._peer: MultiplexedPeer | None = None
+        self._state_changed = asyncio.Event()
+        self._ready = False
+        self._browser_session_id: str | None = None
+        self._peer_watch_tasks: set[asyncio.Task[None]] = set()
+        self._lifecycle_lock = asyncio.Lock()
+        self._operation_lock = asyncio.Lock()
+        self._closed = False
+
+    @property
+    def session_id(self) -> Optional[str]:
+        return self._browser_session_id
+
+    @property
+    def runtime_id(self) -> Optional[str]:
+        return self._server.runtime_id if self._server is not None else None
+
+    async def start(self) -> None:
+        """Publish this runtime for the extension picker."""
+        await self._ensure_server()
+
+    async def _ensure_server(self) -> RuntimeServer:
+        async with self._lifecycle_lock:
+            if self._closed:
+                raise ChromeExtensionUnavailableError("Chrome integration is closed for this agent session.")
+            if self._server is not None:
+                return self._server
+            registry = RuntimeDescriptorRegistry(self.state_dir / "browser-extension" / "runtimes")
+            try:
+                server = RuntimeServer(
+                    registry,
+                    session_id=self.kolega_session_id,
+                    extension_origin=self.extension_origin,
+                    event_handler=self._handle_event,
+                    on_peer=self._handle_peer,
+                )
+                await server.start()
+            except UnsupportedRuntimeTransportError as exc:
+                raise ChromeExtensionUnavailableError(str(exc)) from None
+            except RuntimeTransportError as exc:
+                if "server" in locals():
+                    with contextlib.suppress(Exception):
+                        await server.close()
+                raise ChromeExtensionUnavailableError(str(exc)) from None
+            except BaseException:
+                if "server" in locals():
+                    with contextlib.suppress(Exception):
+                        await server.close()
+                raise
+            self._server = server
+            return server
+
+    async def _handle_peer(self, peer: MultiplexedPeer) -> None:
+        if self._closed:
+            await peer.close("Chrome integration is closed for this agent session.")
+            return
+        previous = self._peer
+        self._clear_ready()
+        self._peer = peer
+        self._state_changed.set()
+        watcher = asyncio.create_task(self._watch_peer(peer), name="chrome-extension-peer-lifecycle")
+        self._peer_watch_tasks.add(watcher)
+        watcher.add_done_callback(self._peer_watch_tasks.discard)
+        if previous is not None and previous is not peer:
+            await previous.close("A newer Chrome extension connection replaced this connection.")
+
+    async def _watch_peer(self, peer: MultiplexedPeer) -> None:
+        await peer.wait_closed()
+        if self._peer is peer:
+            self._peer = None
+            self._clear_ready()
+            self._state_changed.set()
+
+    async def _handle_event(self, envelope: Envelope) -> None:
+        if envelope.payload["event"] != "browser.session_ready":
+            return
+        peer = self._peer
+        server = self._server
+        if peer is None or peer.closed or server is None:
+            return
+        self._ready = True
+        self._browser_session_id = f"chrome:{server.runtime_id}"
+        self._state_changed.set()
+
+    def _clear_ready(self) -> None:
+        self._ready = False
+        self._browser_session_id = None
+
+    async def _connected_peer(self) -> MultiplexedPeer:
+        await self._ensure_server()
+        loop = asyncio.get_running_loop()
+        expires = loop.time() + self.connection_timeout
+        while True:
+            peer = self._peer
+            if peer is not None and not peer.closed and self._ready:
+                return peer
+            self._state_changed.clear()
+            peer = self._peer
+            if peer is not None and not peer.closed and self._ready:
+                return peer
+            remaining = expires - loop.time()
+            if remaining <= 0:
+                break
+            try:
+                await asyncio.wait_for(self._state_changed.wait(), timeout=remaining)
+            except TimeoutError:
+                break
+        raise ChromeExtensionUnavailableError(
+            "Kolega Browser Companion is not ready. Open Chrome, select this Kolega runtime in the extension, "
+            "and retry."
+        )
+
+    async def _request(self, operation: str, params: Mapping[str, JSONValue]) -> dict[str, Any]:
+        async with self._operation_lock:
+            try:
+                validated = validate_operation_request(operation, dict(params))
+            except ProtocolValidationError as exc:
+                raise ChromeExtensionProtocolError(exc.message) from None
+            peer = await self._connected_peer()
+            try:
+                result = await peer.request(operation, validated, timeout=self.operation_timeout)
+            except (ConnectionClosedError, RequestTimeoutError) as exc:
+                if self._peer is peer and peer.closed:
+                    self._peer = None
+                    self._clear_ready()
+                    self._state_changed.set()
+                raise ChromeExtensionUnavailableError(str(exc)) from None
+            except RemoteRequestError as exc:
+                raise ChromeExtensionUnavailableError(exc.message) from None
+            if not isinstance(result, dict):
+                raise ChromeExtensionProtocolError("Chrome extension returned a non-object browser result.")
+            response = cast(dict[str, Any], result)
+            response.setdefault("session_id", self._browser_session_id)
+            return response
+
+    async def navigate(self, url: str) -> dict[str, Any]:
+        return await self._request("browser.navigate", {"url": url})
+
+    async def snapshot(self, target: Optional[str] = None, depth: Optional[int] = None) -> dict[str, Any]:
+        return await self._request("browser.snapshot", {"target": target, "depth": depth})
+
+    async def find(self, *, text: Optional[str] = None, regex: Optional[str] = None) -> dict[str, Any]:
+        return await self._request("browser.find", {"text": text, "regex": regex})
+
+    async def click(
+        self,
+        target: str,
+        *,
+        double_click: bool = False,
+        button: str = "left",
+        modifiers: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
+        return await self._request(
+            "browser.click",
+            {
+                "target": target,
+                "double_click": double_click,
+                "button": button,
+                "modifiers": cast(list[JSONValue], modifiers or []),
+            },
+        )
+
+    async def type_text(
+        self,
+        target: str,
+        text: str,
+        *,
+        submit: bool = False,
+        slowly: bool = False,
+    ) -> dict[str, Any]:
+        return await self._request(
+            "browser.type",
+            {"target": target, "text": text, "submit": submit, "slowly": slowly},
+        )
+
+    async def fill_form(self, fields: list[dict[str, Any]]) -> dict[str, Any]:
+        return await self._request("browser.fill_form", {"fields": cast(list[JSONValue], fields)})
+
+    async def select_option(self, target: str, values: list[str]) -> dict[str, Any]:
+        return await self._request(
+            "browser.select_option",
+            {"target": target, "values": cast(list[JSONValue], values)},
+        )
+
+    async def hover(self, target: str) -> dict[str, Any]:
+        return await self._request("browser.hover", {"target": target})
+
+    async def drag(self, start_target: str, end_target: str) -> dict[str, Any]:
+        return await self._request(
+            "browser.drag",
+            {"start_target": start_target, "end_target": end_target},
+        )
+
+    async def drop(
+        self,
+        target: str,
+        *,
+        files: Optional[list[dict[str, Any]]] = None,
+        data: Optional[dict[str, str]] = None,
+    ) -> dict[str, Any]:
+        raise ChromeExtensionProtocolError("File and data drop are not supported by the Chrome extension backend.")
+
+    async def press_key(self, key: str) -> dict[str, Any]:
+        return await self._request("browser.press_key", {"key": key})
+
+    async def navigate_back(self) -> dict[str, Any]:
+        return await self._request("browser.navigate_back", {})
+
+    async def wait_for(
+        self,
+        *,
+        time: Optional[float] = None,
+        text: Optional[str] = None,
+        text_gone: Optional[str] = None,
+    ) -> dict[str, Any]:
+        return await self._request(
+            "browser.wait_for",
+            {"time": time, "text": text, "text_gone": text_gone},
+        )
+
+    async def resize(self, width: int, height: int) -> dict[str, Any]:
+        raise ChromeExtensionProtocolError("Viewport resize is not supported by the Chrome extension backend.")
+
+    async def tabs(
+        self,
+        action: str,
+        *,
+        index: Optional[int] = None,
+        url: Optional[str] = None,
+    ) -> dict[str, Any]:
+        return await self._request(
+            "browser.tabs",
+            {"action": action, "index": index, "url": url},
+        )
+
+    async def handle_dialog(self, accept: bool, prompt_text: Optional[str] = None) -> dict[str, Any]:
+        raise ChromeExtensionProtocolError("Dialog automation is not supported by the Chrome extension backend.")
+
+    async def file_upload(self, files: list[dict[str, Any]]) -> dict[str, Any]:
+        raise ChromeExtensionProtocolError("File upload is not supported by the Chrome extension backend.")
+
+    async def console_messages(self, level: str = "info", *, all_messages: bool = False) -> dict[str, Any]:
+        raise ChromeExtensionProtocolError("Console messages are not supported by the Chrome extension backend.")
+
+    async def network_requests(
+        self,
+        *,
+        include_static: bool = False,
+        filter_pattern: Optional[str] = None,
+    ) -> dict[str, Any]:
+        return await self._request(
+            "browser.network_requests",
+            {"include_static": include_static, "filter_pattern": filter_pattern},
+        )
+
+    async def network_request(self, index: int, part: Optional[str] = None) -> dict[str, Any]:
+        raise ChromeExtensionProtocolError(
+            "Detailed network request inspection is not supported by the Chrome extension backend."
+        )
+
+    async def screenshot(
+        self,
+        *,
+        target: Optional[str] = None,
+        image_type: str = "png",
+        full_page: bool = False,
+        scale: str = "css",
+    ) -> dict[str, Any]:
+        return await self._request(
+            "browser.screenshot",
+            {
+                "target": target,
+                "image_type": image_type,
+                "full_page": full_page,
+                "scale": scale,
+            },
+        )
+
+    async def evaluate(self, function: str, target: Optional[str] = None) -> dict[str, Any]:
+        raise ChromeExtensionProtocolError("Arbitrary JavaScript is not supported by the Chrome extension backend.")
+
+    async def close(self) -> Optional[str]:
+        session_id = self._browser_session_id
+        peer = self._peer
+        if peer is not None and not peer.closed and self._ready:
+            with contextlib.suppress(ChromeExtensionUnavailableError, ChromeExtensionProtocolError):
+                await self._request("browser.detach", {})
+        self._clear_ready()
+        self._state_changed.set()
+        return session_id
+
+    async def cleanup_all_browsers(self) -> None:
+        async with self._lifecycle_lock:
+            if self._closed:
+                return
+            self._closed = True
+            server = self._server
+            peer = self._peer
+            ready = self._ready
+            self._server = None
+            self._peer = None
+            self._clear_ready()
+            self._state_changed.set()
+
+        async with self._operation_lock:
+            if peer is not None and not peer.closed and ready:
+                with contextlib.suppress(Exception):
+                    await peer.request("browser.detach", {}, timeout=self.operation_timeout)
+            if server is not None:
+                await server.close()
+            watchers = tuple(self._peer_watch_tasks)
+            for watcher in watchers:
+                watcher.cancel()
+            if watchers:
+                await asyncio.gather(*watchers, return_exceptions=True)

--- a/kolega_code/browser_extension/manager.py
+++ b/kolega_code/browser_extension/manager.py
@@ -113,7 +113,14 @@ class ChromeExtensionBrowserManager(BrowserManager):
             await peer.close("Chrome integration is closed for this agent session.")
             return
         previous = self._peer
-        self._clear_ready()
+        # Readiness belongs to this runtime session, not to a relay peer. The
+        # native host connects to a runtime's socket only to relay a message the
+        # extension addressed to that runtime, and the extension refuses to route
+        # anywhere but the selected runtime — so a peer existing at all already
+        # proves this runtime is selected. Clearing readiness on peer churn used to
+        # deadlock: the extension announces browser.session_ready once per native
+        # connection, so a reconnecting relay left the runtime permanently
+        # "connected but not confirmed" with no way to recover.
         self._peer = peer
         self._state_changed.set()
         watcher = asyncio.create_task(self._watch_peer(peer), name="chrome-extension-peer-lifecycle")
@@ -125,8 +132,10 @@ class ChromeExtensionBrowserManager(BrowserManager):
     async def _watch_peer(self, peer: MultiplexedPeer) -> None:
         await peer.wait_closed()
         if self._peer is peer:
+            # Keep readiness (see _handle_peer): operations still require a live
+            # peer, so losing one correctly blocks work without making recovery
+            # depend on a handshake the extension will not repeat.
             self._peer = None
-            self._clear_ready()
             self._state_changed.set()
 
     async def _handle_event(self, envelope: Envelope) -> None:

--- a/kolega_code/browser_extension/multiplex.py
+++ b/kolega_code/browser_extension/multiplex.py
@@ -1,0 +1,462 @@
+"""Bounded request correlation, deadlines, cancellation, and disconnects."""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+import time
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from typing import cast
+
+from .protocol import JSONValue, Envelope, MessageType, ProtocolValidationError
+from .runtime import RuntimeChannel, RuntimeTransportError
+
+DEFAULT_REQUEST_TIMEOUT_SECONDS = 30.0
+MAX_REQUEST_TIMEOUT_SECONDS = 300.0
+
+RequestHandler = Callable[[Envelope], Awaitable[JSONValue]]
+EventHandler = Callable[[Envelope], Awaitable[None]]
+
+
+class MultiplexError(RuntimeError):
+    """A safe-to-report multiplexing failure."""
+
+
+class ConnectionClosedError(MultiplexError):
+    """The peer disconnected before a request settled."""
+
+
+class PendingRequestLimitError(MultiplexError):
+    """The bounded outgoing request table is full."""
+
+
+class RequestTimeoutError(MultiplexError):
+    """A request deadline elapsed."""
+
+
+class RemoteRequestError(MultiplexError):
+    """A validated bounded error returned by the other endpoint."""
+
+    def __init__(self, code: str, message: str, *, retryable: bool) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.retryable = retryable
+
+
+@dataclass(slots=True)
+class _PendingRequest:
+    future: asyncio.Future[JSONValue]
+    request: Envelope
+    timeout_handle: asyncio.TimerHandle
+
+
+@dataclass(slots=True)
+class _InflightRequest:
+    request: Envelope
+    task: asyncio.Task[None]
+
+
+class MultiplexedPeer:
+    """Multiplex requests and events over one authenticated runtime channel."""
+
+    def __init__(
+        self,
+        channel: RuntimeChannel,
+        *,
+        request_handler: RequestHandler | None = None,
+        event_handler: EventHandler | None = None,
+        max_pending_requests: int = 128,
+        max_inflight_requests: int = 32,
+    ) -> None:
+        if max_pending_requests <= 0 or max_inflight_requests <= 0:
+            raise ValueError("request bounds must be positive")
+        self.channel = channel
+        self.request_handler = request_handler
+        self.event_handler = event_handler
+        self.max_pending_requests = max_pending_requests
+        self.max_inflight_requests = max_inflight_requests
+        self._pending: dict[str, _PendingRequest] = {}
+        self._inflight: dict[str, _InflightRequest] = {}
+        self._event_tasks: set[asyncio.Task[None]] = set()
+        self._reader_task: asyncio.Task[None] | None = None
+        self._closed_event = asyncio.Event()
+        self._closed_reason = "Runtime connection closed"
+        self._closing = False
+        self._close_lock = asyncio.Lock()
+
+    @property
+    def closed(self) -> bool:
+        return self._closing or self._closed_event.is_set() or self.channel.closed
+
+    @property
+    def pending_count(self) -> int:
+        return len(self._pending)
+
+    @property
+    def inflight_count(self) -> int:
+        return len(self._inflight)
+
+    async def start(self) -> None:
+        if self.closed:
+            raise ConnectionClosedError("Runtime connection is closed")
+        if self._reader_task is None:
+            self._reader_task = asyncio.create_task(
+                self._read_loop(),
+                name="browser-extension-runtime-reader",
+            )
+
+    async def wait_closed(self) -> None:
+        await self._closed_event.wait()
+
+    async def drain_events(self) -> None:
+        """Wait for event callbacks already admitted by the read loop."""
+        tasks = tuple(self._event_tasks)
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def request(
+        self,
+        operation: str,
+        params: Mapping[str, JSONValue],
+        *,
+        timeout: float = DEFAULT_REQUEST_TIMEOUT_SECONDS,
+        request_id: str | None = None,
+    ) -> JSONValue:
+        if not 0 < timeout <= MAX_REQUEST_TIMEOUT_SECONDS:
+            raise ValueError(f"timeout must be between 0 and {MAX_REQUEST_TIMEOUT_SECONDS} seconds")
+        if self.closed:
+            raise ConnectionClosedError(self._closed_reason)
+        if self._reader_task is None:
+            await self.start()
+        if len(self._pending) >= self.max_pending_requests:
+            raise PendingRequestLimitError("Pending request limit reached")
+
+        selected_id = request_id or f"request_{secrets.token_urlsafe(18)}"
+        if selected_id in self._pending:
+            raise MultiplexError("Request ID is already pending")
+        loop = asyncio.get_running_loop()
+        deadline_at = loop.time() + timeout
+        deadline_ms = int(time.time() * 1000 + timeout * 1000)
+        envelope = Envelope.request(
+            direction=self.channel.outbound_direction,
+            request_id=selected_id,
+            runtime_id=self.channel.runtime_id,
+            session_id=self.channel.session_id,
+            deadline_ms=deadline_ms,
+            operation=operation,
+            params=params,
+        )
+        future: asyncio.Future[JSONValue] = loop.create_future()
+        timeout_handle = loop.call_later(timeout, self._expire_request, selected_id)
+        self._pending[selected_id] = _PendingRequest(
+            future=future,
+            request=envelope,
+            timeout_handle=timeout_handle,
+        )
+        try:
+            async with asyncio.timeout_at(deadline_at):
+                await self.channel.write(envelope)
+        except TimeoutError:
+            pending = self._pop_pending(selected_id)
+            self._settle_abandoned_future(pending.future if pending is not None else future)
+            await self.close("Runtime request write exceeded its deadline")
+            raise RequestTimeoutError("Request deadline exceeded") from None
+        except asyncio.CancelledError:
+            pending = self._pop_pending(selected_id)
+            self._settle_abandoned_future(pending.future if pending is not None else future)
+            if pending is not None:
+                await self._send_cancel(pending.request, "caller_cancelled")
+            raise
+        except Exception:
+            pending = self._pop_pending(selected_id)
+            self._settle_abandoned_future(pending.future if pending is not None else future)
+            await self.close("Runtime connection is closed")
+            raise ConnectionClosedError("Runtime connection is closed") from None
+
+        try:
+            return await asyncio.shield(future)
+        except asyncio.CancelledError:
+            pending = self._pop_pending(selected_id)
+            if pending is not None:
+                pending.future.cancel()
+                await self._send_cancel(pending.request, "caller_cancelled")
+            raise
+
+    async def notify(
+        self,
+        event: str,
+        data: Mapping[str, JSONValue],
+        *,
+        deadline_ms: int | None = None,
+    ) -> None:
+        if self.closed:
+            raise ConnectionClosedError(self._closed_reason)
+        now_ms = int(time.time() * 1000)
+        envelope = Envelope.event(
+            direction=self.channel.outbound_direction,
+            request_id=f"event_{secrets.token_urlsafe(18)}",
+            runtime_id=self.channel.runtime_id,
+            session_id=self.channel.session_id,
+            deadline_ms=deadline_ms or now_ms + int(DEFAULT_REQUEST_TIMEOUT_SECONDS * 1000),
+            event=event,
+            data=data,
+        )
+        try:
+            await self.channel.write(envelope)
+        except RuntimeTransportError:
+            await self.close("Runtime connection is closed")
+            raise ConnectionClosedError("Runtime connection is closed") from None
+
+    async def close(self, reason: str = "Runtime connection closed") -> None:
+        async with self._close_lock:
+            if self._closed_event.is_set():
+                return
+            self._closing = True
+            self._closed_reason = reason
+            current = asyncio.current_task()
+            reader = self._reader_task
+            if reader is not None and reader is not current and not reader.done():
+                reader.cancel()
+
+            pending_items = tuple(self._pending.values())
+            self._pending.clear()
+            for pending in pending_items:
+                pending.timeout_handle.cancel()
+                if not pending.future.done():
+                    pending.future.set_exception(ConnectionClosedError(reason))
+
+            inflight = tuple(item.task for item in self._inflight.values())
+            self._inflight.clear()
+            events = tuple(self._event_tasks)
+            self._event_tasks.clear()
+            for task in (*inflight, *events):
+                if task is not current:
+                    task.cancel()
+
+            await self.channel.close()
+            waits = [
+                task
+                for task in (reader, *inflight, *events)
+                if task is not None and task is not current and not task.done()
+            ]
+            if waits:
+                await asyncio.gather(*waits, return_exceptions=True)
+            self._closed_event.set()
+
+    def _expire_request(self, request_id: str) -> None:
+        pending = self._pop_pending(request_id)
+        if pending is None:
+            return
+        if not pending.future.done():
+            pending.future.set_exception(RequestTimeoutError("Request deadline exceeded"))
+        asyncio.create_task(self._send_cancel(pending.request, "deadline_exceeded"))
+
+    def _pop_pending(self, request_id: str) -> _PendingRequest | None:
+        pending = self._pending.pop(request_id, None)
+        if pending is not None:
+            pending.timeout_handle.cancel()
+        return pending
+
+    @staticmethod
+    def _settle_abandoned_future(future: asyncio.Future[JSONValue]) -> None:
+        if not future.done():
+            future.cancel()
+        elif not future.cancelled():
+            future.exception()
+
+    async def _send_cancel(self, request: Envelope, reason: str) -> None:
+        if self.closed:
+            return
+        try:
+            await self.channel.write(Envelope.cancel_for(request, reason=reason))
+        except asyncio.CancelledError:
+            try:
+                await self.close("Runtime connection is closed")
+            finally:
+                raise
+        except Exception:
+            await self.close("Runtime connection is closed")
+
+    async def _read_loop(self) -> None:
+        reason = "Runtime connection closed"
+        try:
+            while True:
+                envelope = await self.channel.read()
+                if envelope is None:
+                    break
+                await self._dispatch(envelope)
+        except asyncio.CancelledError:
+            reason = self._closed_reason
+        except (ProtocolValidationError, RuntimeTransportError, ConnectionError):
+            reason = "Runtime connection protocol failed"
+        finally:
+            if not self._closing:
+                await self.close(reason)
+
+    async def _dispatch(self, envelope: Envelope) -> None:
+        if envelope.type is MessageType.RESPONSE:
+            self._handle_response(envelope)
+        elif envelope.type is MessageType.ERROR:
+            self._handle_error(envelope)
+        elif envelope.type is MessageType.REQUEST:
+            await self._start_incoming_request(envelope)
+        elif envelope.type is MessageType.CANCEL:
+            self._handle_cancel(envelope)
+        else:
+            self._handle_event(envelope)
+
+    def _handle_response(self, envelope: Envelope) -> None:
+        pending = self._pop_pending(envelope.request_id)
+        if pending is None:
+            return
+        if not self._response_matches(pending.request, envelope):
+            if not pending.future.done():
+                pending.future.set_exception(MultiplexError("Response metadata does not match the request"))
+            return
+        if pending.request.is_expired():
+            if not pending.future.done():
+                pending.future.set_exception(RequestTimeoutError("Request deadline exceeded"))
+            return
+        if not pending.future.done():
+            pending.future.set_result(envelope.payload["result"])
+
+    def _handle_error(self, envelope: Envelope) -> None:
+        pending = self._pop_pending(envelope.request_id)
+        if pending is None:
+            return
+        if not self._response_matches(pending.request, envelope):
+            if not pending.future.done():
+                pending.future.set_exception(MultiplexError("Response metadata does not match the request"))
+            return
+        if pending.request.is_expired():
+            if not pending.future.done():
+                pending.future.set_exception(RequestTimeoutError("Request deadline exceeded"))
+            return
+        payload = envelope.payload
+        if not pending.future.done():
+            pending.future.set_exception(
+                RemoteRequestError(
+                    cast(str, payload["code"]),
+                    cast(str, payload["message"]),
+                    retryable=cast(bool, payload["retryable"]),
+                )
+            )
+
+    @staticmethod
+    def _response_matches(request: Envelope, response: Envelope) -> bool:
+        return (
+            response.direction is request.direction.opposite
+            and response.runtime_id == request.runtime_id
+            and response.session_id == request.session_id
+            and response.request_id == request.request_id
+            and response.deadline_ms == request.deadline_ms
+        )
+
+    async def _start_incoming_request(self, envelope: Envelope) -> None:
+        if envelope.is_expired():
+            await self._send_error(envelope, "deadline_exceeded", "Request deadline exceeded", retryable=True)
+            return
+        if envelope.request_id in self._inflight:
+            return
+        if len(self._inflight) >= self.max_inflight_requests:
+            await self._send_error(envelope, "server_busy", "Runtime request limit reached", retryable=True)
+            return
+        task = asyncio.create_task(
+            self._run_handler(envelope),
+            name=f"browser-extension-request-{envelope.request_id}",
+        )
+        self._inflight[envelope.request_id] = _InflightRequest(request=envelope, task=task)
+
+    async def _run_handler(self, envelope: Envelope) -> None:
+        current = asyncio.current_task()
+        try:
+            if self.request_handler is None:
+                await self._send_error(envelope, "unsupported_operation", "Operation is not supported")
+                return
+            remaining = max(0.0, (envelope.deadline_ms - int(time.time() * 1000)) / 1000)
+            if remaining <= 0:
+                await self._send_error(envelope, "deadline_exceeded", "Request deadline exceeded", retryable=True)
+                return
+            try:
+                async with asyncio.timeout(remaining):
+                    result = await self.request_handler(envelope)
+            except TimeoutError:
+                await self._send_error(envelope, "deadline_exceeded", "Request deadline exceeded", retryable=True)
+                return
+            except asyncio.CancelledError:
+                return
+            except Exception:
+                await self._send_error(envelope, "internal_error", "Runtime operation failed")
+                return
+            item = self._inflight.get(envelope.request_id)
+            if item is not None and item.task is current:
+                if envelope.is_expired():
+                    await self._send_error(envelope, "deadline_exceeded", "Request deadline exceeded", retryable=True)
+                    return
+                try:
+                    response = Envelope.response_for(envelope, result)
+                except ProtocolValidationError:
+                    await self._send_error(envelope, "internal_error", "Runtime operation failed")
+                    return
+                remaining = max(0.0, (envelope.deadline_ms - int(time.time() * 1000)) / 1000)
+                if remaining <= 0:
+                    await self._send_error(envelope, "deadline_exceeded", "Request deadline exceeded", retryable=True)
+                    return
+                try:
+                    async with asyncio.timeout(remaining):
+                        await self.channel.write(response)
+                except TimeoutError:
+                    await self.close("Runtime response write exceeded its deadline")
+        except RuntimeTransportError:
+            await self.close("Runtime connection is closed")
+        finally:
+            item = self._inflight.get(envelope.request_id)
+            if item is not None and item.task is current:
+                self._inflight.pop(envelope.request_id, None)
+
+    async def _send_error(
+        self,
+        request: Envelope,
+        code: str,
+        message: str,
+        *,
+        retryable: bool = False,
+    ) -> None:
+        if self.closed:
+            return
+        try:
+            await self.channel.write(Envelope.error_for(request, code=code, message=message, retryable=retryable))
+        except RuntimeTransportError:
+            await self.close("Runtime connection is closed")
+
+    def _handle_cancel(self, envelope: Envelope) -> None:
+        item = self._inflight.get(envelope.request_id)
+        if item is None:
+            return
+        request = item.request
+        if (
+            envelope.direction is request.direction
+            and envelope.runtime_id == request.runtime_id
+            and envelope.session_id == request.session_id
+            and envelope.deadline_ms == request.deadline_ms
+        ):
+            self._inflight.pop(envelope.request_id, None)
+            item.task.cancel()
+
+    def _handle_event(self, envelope: Envelope) -> None:
+        if self.event_handler is None or envelope.is_expired():
+            return
+        if len(self._event_tasks) >= self.max_inflight_requests:
+            return
+        task = asyncio.create_task(self._run_event_handler(envelope), name="browser-extension-event")
+        self._event_tasks.add(task)
+        task.add_done_callback(self._event_tasks.discard)
+
+    async def _run_event_handler(self, envelope: Envelope) -> None:
+        assert self.event_handler is not None
+        try:
+            await self.event_handler(envelope)
+        except (asyncio.CancelledError, Exception):
+            return

--- a/kolega_code/browser_extension/native_host.py
+++ b/kolega_code/browser_extension/native_host.py
@@ -1,0 +1,888 @@
+"""Chrome Native Messaging broker for multiple authenticated runtimes."""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import contextlib
+import json
+import os
+import queue
+import stat
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, BinaryIO, Literal, Mapping, Sequence, TextIO, cast
+
+from .framing import MAX_NATIVE_MESSAGE_BYTES, FramingError, encode_message, read_message
+from .protocol import (
+    MAX_DEADLINE_AHEAD_MS,
+    PROTOCOL_VERSION,
+    Envelope,
+    MessageDirection,
+    MessageType,
+    ProtocolValidationError,
+    validate_discovery_request,
+    validate_operation_request,
+)
+from .registry import DescriptorError, RuntimeDescriptor, RuntimeDescriptorRegistry, validate_extension_origin
+from .runtime import (
+    RuntimeChannel,
+    RuntimeTransportError,
+    UnsupportedRuntimeTransportError,
+    connect_runtime_channel,
+    ensure_runtime_transport_supported,
+)
+
+MAX_HOST_CONFIG_BYTES = 65_536
+DEFAULT_MAX_RUNTIMES = 16
+DEFAULT_MAX_RELAY_PENDING = 256
+DEFAULT_MAX_NATIVE_PENDING_WRITES = 256
+DEFAULT_MAX_NATIVE_PENDING_WRITE_BYTES = 8 * MAX_NATIVE_MESSAGE_BYTES
+DEFAULT_NATIVE_WRITE_SHUTDOWN_SECONDS = 1.0
+_HOST_CONFIG_KEYS = frozenset({"extension_origin", "registry_dir", "max_runtimes", "max_pending_requests"})
+
+
+class NativeHostError(RuntimeError):
+    """A safe-to-report native-host failure."""
+
+
+class NativeHostConfigurationError(NativeHostError):
+    """Native-host configuration is absent, unsafe, or invalid."""
+
+
+class NativeMessageEndpointClosedError(NativeHostError):
+    """Native stdout is closing or unavailable."""
+
+
+@dataclass(frozen=True, slots=True)
+class NativeHostConfig:
+    """Non-secret native-host configuration."""
+
+    extension_origin: str
+    registry_dir: Path
+    max_runtimes: int = DEFAULT_MAX_RUNTIMES
+    max_pending_requests: int = DEFAULT_MAX_RELAY_PENDING
+
+    def __post_init__(self) -> None:
+        try:
+            origin = validate_extension_origin(self.extension_origin)
+        except DescriptorError:
+            raise NativeHostConfigurationError("Native-host extension origin is invalid") from None
+        if not self.registry_dir.is_absolute():
+            raise NativeHostConfigurationError("Native-host registry path must be absolute")
+        if not 0 < self.max_runtimes <= 64:
+            raise NativeHostConfigurationError("Native-host runtime limit is invalid")
+        if not 0 < self.max_pending_requests <= 4096:
+            raise NativeHostConfigurationError("Native-host pending-request limit is invalid")
+        object.__setattr__(self, "extension_origin", origin)
+
+    @classmethod
+    def from_mapping(cls, raw: object) -> NativeHostConfig:
+        if not isinstance(raw, dict) or set(raw) != _HOST_CONFIG_KEYS:
+            raise NativeHostConfigurationError("Native-host configuration has an invalid schema")
+        origin = raw["extension_origin"]
+        registry_dir = raw["registry_dir"]
+        max_runtimes = raw["max_runtimes"]
+        max_pending = raw["max_pending_requests"]
+        if not isinstance(origin, str):
+            raise NativeHostConfigurationError("Native-host extension origin is invalid")
+        if not isinstance(registry_dir, str) or "\0" in registry_dir:
+            raise NativeHostConfigurationError("Native-host registry path is invalid")
+        if (
+            not isinstance(max_runtimes, int)
+            or isinstance(max_runtimes, bool)
+            or not isinstance(max_pending, int)
+            or isinstance(max_pending, bool)
+        ):
+            raise NativeHostConfigurationError("Native-host limits are invalid")
+        return cls(
+            extension_origin=origin,
+            registry_dir=Path(registry_dir).expanduser(),
+            max_runtimes=max_runtimes,
+            max_pending_requests=max_pending,
+        )
+
+    def accepts_origin(self, origin: str) -> bool:
+        return self.extension_origin == origin
+
+
+def default_host_config_path(*, platform: str | None = None) -> Path:
+    if (platform or sys.platform) != "darwin":
+        raise UnsupportedRuntimeTransportError("Chrome browser integration is supported only on macOS")
+    configured = os.environ.get("KOLEGA_BROWSER_HOST_CONFIG")
+    if configured:
+        return Path(configured).expanduser()
+    root = Path.home() / "Library" / "Application Support"
+    return root / "kolega-code" / "browser-extension-host.json"
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise NativeHostConfigurationError("Native-host configuration is malformed")
+        result[key] = value
+    return result
+
+
+def _private_file_stat(file_stat: os.stat_result) -> bool:
+    if not stat.S_ISREG(file_stat.st_mode):
+        return False
+    getuid = getattr(os, "getuid", None)
+    if getuid is None:
+        return False
+    return file_stat.st_uid == getuid() and not stat.S_IMODE(file_stat.st_mode) & 0o077
+
+
+def load_host_config(path: Path) -> NativeHostConfig:
+    """Load a bounded per-user host configuration without following symlinks."""
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(path, flags)
+    except OSError:
+        raise NativeHostConfigurationError("Native-host configuration is unavailable") from None
+    try:
+        file_stat = os.fstat(fd)
+        if not _private_file_stat(file_stat):
+            raise NativeHostConfigurationError("Native-host configuration permissions are unsafe")
+        with os.fdopen(fd, "rb", closefd=True) as file:
+            fd = -1
+            payload = file.read(MAX_HOST_CONFIG_BYTES + 1)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+    if len(payload) > MAX_HOST_CONFIG_BYTES:
+        raise NativeHostConfigurationError("Native-host configuration exceeds the size limit")
+    try:
+        raw = json.loads(
+            payload.decode("utf-8"),
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=lambda _: (_ for _ in ()).throw(
+                NativeHostConfigurationError("Native-host configuration is malformed")
+            ),
+        )
+    except NativeHostConfigurationError:
+        raise
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError):
+        raise NativeHostConfigurationError("Native-host configuration is malformed") from None
+    return NativeHostConfig.from_mapping(raw)
+
+
+@dataclass(frozen=True, slots=True)
+class _NativeWrite:
+    frame: bytes
+    acknowledgement: concurrent.futures.Future[None]
+
+
+class NativeMessageEndpoint:
+    """Async endpoint with one bounded, uncancellable stdout owner."""
+
+    def __init__(
+        self,
+        input_stream: BinaryIO,
+        output_stream: BinaryIO,
+        *,
+        max_message_bytes: int = MAX_NATIVE_MESSAGE_BYTES,
+        max_pending_writes: int = DEFAULT_MAX_NATIVE_PENDING_WRITES,
+        max_pending_write_bytes: int = DEFAULT_MAX_NATIVE_PENDING_WRITE_BYTES,
+        shutdown_timeout: float = DEFAULT_NATIVE_WRITE_SHUTDOWN_SECONDS,
+    ) -> None:
+        if max_pending_writes <= 0 or max_pending_write_bytes <= 0 or shutdown_timeout <= 0:
+            raise ValueError("native endpoint bounds must be positive")
+        self.input_stream = input_stream
+        self.output_stream = output_stream
+        self.max_message_bytes = max_message_bytes
+        self.max_pending_writes = max_pending_writes
+        self.max_pending_write_bytes = max_pending_write_bytes
+        self.shutdown_timeout = shutdown_timeout
+        self._write_queue: queue.Queue[_NativeWrite] = queue.Queue(maxsize=max_pending_writes)
+        self._writer_thread: threading.Thread | None = None
+        self._writer_finished: concurrent.futures.Future[None] = concurrent.futures.Future()
+        self._writer_stop = threading.Event()
+        self._owner_loop: asyncio.AbstractEventLoop | None = None
+        self._slot_available: asyncio.Event | None = None
+        self._outstanding_writes = 0
+        self._outstanding_write_bytes = 0
+        self._closing = False
+        self._write_failure: BaseException | None = None
+
+    @property
+    def outstanding_write_count(self) -> int:
+        return self._outstanding_writes
+
+    @property
+    def outstanding_write_bytes(self) -> int:
+        return self._outstanding_write_bytes
+
+    async def read(self) -> dict[str, Any] | None:
+        return await asyncio.to_thread(read_message, self.input_stream, max_bytes=self.max_message_bytes)
+
+    async def write(self, envelope: Envelope) -> None:
+        await self.write_mapping(envelope.to_mapping())
+
+    async def write_mapping(self, message: Mapping[str, object]) -> None:
+        self._raise_if_unwritable()
+        frame = encode_message(message, max_bytes=self.max_message_bytes)
+        await self._reserve_write_slot(len(frame))
+        acknowledgement: concurrent.futures.Future[None] = concurrent.futures.Future()
+        item = _NativeWrite(frame=frame, acknowledgement=acknowledgement)
+        try:
+            self._ensure_writer()
+            self._write_queue.put_nowait(item)
+        except BaseException:
+            self._release_write_slot(len(frame))
+            raise
+        wrapped = asyncio.wrap_future(acknowledgement)
+        wrapped.add_done_callback(self._consume_abandoned_write_exception)
+        await asyncio.shield(wrapped)
+
+    async def close(self) -> None:
+        if self._closing:
+            return
+        self._closing = True
+        self._writer_stop.set()
+        if self._slot_available is not None:
+            self._slot_available.set()
+        if self._writer_thread is None:
+            if not self._writer_finished.done():
+                self._writer_finished.set_result(None)
+            return
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(asyncio.wrap_future(self._writer_finished)),
+                timeout=self.shutdown_timeout,
+            )
+        except TimeoutError:
+            self._write_failure = NativeMessageEndpointClosedError(
+                "Native stdout did not drain before the shutdown deadline"
+            )
+
+    def _raise_if_unwritable(self) -> None:
+        if self._write_failure is not None:
+            raise NativeMessageEndpointClosedError("Native stdout is unavailable") from self._write_failure
+        if self._closing:
+            raise NativeMessageEndpointClosedError("Native stdout is closed")
+
+    async def _reserve_write_slot(self, frame_bytes: int) -> None:
+        if frame_bytes > self.max_pending_write_bytes:
+            raise NativeMessageEndpointClosedError("Native message exceeds the pending stdout byte limit")
+        loop = asyncio.get_running_loop()
+        if self._owner_loop is None:
+            self._owner_loop = loop
+            self._slot_available = asyncio.Event()
+            self._slot_available.set()
+        elif self._owner_loop is not loop:
+            raise NativeMessageEndpointClosedError("Native stdout cannot be shared across event loops")
+        assert self._slot_available is not None
+        while (
+            self._outstanding_writes >= self.max_pending_writes
+            or self._outstanding_write_bytes + frame_bytes > self.max_pending_write_bytes
+        ):
+            self._raise_if_unwritable()
+            self._slot_available.clear()
+            if (
+                self._outstanding_writes < self.max_pending_writes
+                and self._outstanding_write_bytes + frame_bytes <= self.max_pending_write_bytes
+            ):
+                self._slot_available.set()
+                continue
+            await self._slot_available.wait()
+        self._raise_if_unwritable()
+        self._outstanding_writes += 1
+        self._outstanding_write_bytes += frame_bytes
+
+    def _release_write_slot(self, frame_bytes: int) -> None:
+        self._outstanding_writes = max(0, self._outstanding_writes - 1)
+        self._outstanding_write_bytes = max(0, self._outstanding_write_bytes - frame_bytes)
+        if self._slot_available is not None:
+            self._slot_available.set()
+
+    def _release_write_slot_from_thread(self, frame_bytes: int) -> None:
+        loop = self._owner_loop
+        if loop is not None:
+            with contextlib.suppress(RuntimeError):
+                loop.call_soon_threadsafe(self._release_write_slot, frame_bytes)
+
+    def _ensure_writer(self) -> None:
+        if self._writer_thread is not None:
+            return
+        self._writer_thread = threading.Thread(
+            target=self._writer_main,
+            name="kolega-native-message-writer",
+            daemon=True,
+        )
+        self._writer_thread.start()
+
+    def _writer_main(self) -> None:
+        try:
+            while True:
+                if self._writer_stop.is_set() and self._write_queue.empty():
+                    return
+                try:
+                    item = self._write_queue.get(timeout=0.05)
+                except queue.Empty:
+                    continue
+                try:
+                    self._write_frame(item.frame)
+                except BaseException as exc:
+                    self._write_failure = exc
+                    if not item.acknowledgement.done():
+                        item.acknowledgement.set_exception(exc)
+                    self._drain_queued_writes(exc)
+                    return
+                else:
+                    if not item.acknowledgement.done():
+                        item.acknowledgement.set_result(None)
+                finally:
+                    self._write_queue.task_done()
+                    self._release_write_slot_from_thread(len(item.frame))
+        finally:
+            if not self._writer_finished.done():
+                self._writer_finished.set_result(None)
+
+    def _write_frame(self, frame: bytes) -> None:
+        view = memoryview(frame)
+        written = 0
+        while written < len(view):
+            count = self.output_stream.write(view[written:])
+            if count is None:
+                written = len(view)
+            elif count <= 0:
+                raise FramingError("Native message could not be written")
+            else:
+                written += count
+        flush = getattr(self.output_stream, "flush", None)
+        if flush is not None:
+            flush()
+
+    def _drain_queued_writes(self, error: BaseException) -> None:
+        while True:
+            try:
+                item = self._write_queue.get_nowait()
+            except queue.Empty:
+                return
+            if not item.acknowledgement.done():
+                item.acknowledgement.set_exception(error)
+            self._write_queue.task_done()
+            self._release_write_slot_from_thread(len(item.frame))
+
+    @staticmethod
+    def _consume_abandoned_write_exception(future: asyncio.Future[None]) -> None:
+        if not future.cancelled():
+            with contextlib.suppress(BaseException):
+                future.exception()
+
+
+@dataclass(slots=True)
+class _RuntimeRelay:
+    descriptor: RuntimeDescriptor
+    channel: RuntimeChannel
+    reader_task: asyncio.Task[None] | None = None
+
+
+@dataclass(slots=True)
+class _RelayPending:
+    request: Envelope
+    timeout_task: asyncio.Task[None]
+
+
+class NativeHostBroker:
+    """Relay one Chrome native port across active runtimes."""
+
+    def __init__(
+        self,
+        *,
+        endpoint: NativeMessageEndpoint,
+        registry: RuntimeDescriptorRegistry,
+        extension_origin: str,
+        max_runtimes: int = DEFAULT_MAX_RUNTIMES,
+        max_pending_requests: int = DEFAULT_MAX_RELAY_PENDING,
+    ) -> None:
+        if max_runtimes <= 0 or max_pending_requests <= 0:
+            raise ValueError("broker bounds must be positive")
+        self.endpoint = endpoint
+        self.registry = registry
+        self.extension_origin = validate_extension_origin(extension_origin)
+        self.max_runtimes = max_runtimes
+        self.max_pending_requests = max_pending_requests
+        self._runtimes: dict[str, _RuntimeRelay] = {}
+        self._pending: dict[tuple[MessageDirection, str, str], _RelayPending] = {}
+        self._close_lock = asyncio.Lock()
+        self._closed = False
+
+    @property
+    def pending_count(self) -> int:
+        return len(self._pending)
+
+    async def run(self) -> None:
+        try:
+            while True:
+                raw = await self.endpoint.read()
+                if raw is None:
+                    break
+                if raw.get("kind") == "list_runtimes":
+                    await self._list_runtimes(raw)
+                    continue
+                envelope = Envelope.from_mapping(raw)
+                if envelope.direction is not MessageDirection.EXTENSION_TO_RUNTIME:
+                    raise NativeHostError("Chrome sent an envelope with an invalid direction")
+                self._validate_request(envelope)
+                await self._route_from_extension(envelope)
+        finally:
+            await self.close()
+
+    @staticmethod
+    def _validate_request(envelope: Envelope) -> None:
+        if envelope.type is MessageType.REQUEST:
+            validate_operation_request(envelope.payload["operation"], envelope.payload["params"])
+
+    async def _list_runtimes(self, raw: Mapping[str, object]) -> None:
+        try:
+            request = validate_discovery_request(dict(raw))
+        except ProtocolValidationError as exc:
+            raise NativeHostError("Chrome sent an invalid runtime discovery request") from exc
+        request_id = cast(str, request["request_id"])
+        matching = [
+            descriptor for descriptor in self.registry.list_active() if descriptor.accepts_origin(self.extension_origin)
+        ]
+        runtimes = [
+            {
+                "runtime_id": descriptor.runtime_id,
+                "session_id": descriptor.session_id,
+                "created_at_ms": descriptor.created_at_ms,
+                "expires_at_ms": descriptor.expires_at_ms,
+            }
+            for descriptor in matching[: self.max_runtimes]
+        ]
+        await self.endpoint.write_mapping(
+            {
+                "kind": "runtimes",
+                "protocol_version": PROTOCOL_VERSION,
+                "request_id": request_id,
+                "runtimes": runtimes,
+            }
+        )
+
+    async def close(self) -> None:
+        async with self._close_lock:
+            if self._closed:
+                return
+            self._closed = True
+            pending = tuple(self._pending.values())
+            self._pending.clear()
+            for item in pending:
+                item.timeout_task.cancel()
+                relay = self._runtimes.get(item.request.runtime_id)
+                if relay is None:
+                    continue
+                with contextlib.suppress(RuntimeTransportError):
+                    if item.request.direction is MessageDirection.RUNTIME_TO_EXTENSION:
+                        await relay.channel.write(
+                            Envelope.error_for(
+                                item.request,
+                                code="extension_disconnected",
+                                message="Chrome extension disconnected",
+                                retryable=True,
+                            )
+                        )
+                    else:
+                        await relay.channel.write(Envelope.cancel_for(item.request, reason="extension_disconnected"))
+
+            relays = tuple(self._runtimes.values())
+            self._runtimes.clear()
+            current = asyncio.current_task()
+            for relay in relays:
+                if relay.reader_task is not None and relay.reader_task is not current:
+                    relay.reader_task.cancel()
+            await asyncio.gather(*(relay.channel.close() for relay in relays), return_exceptions=True)
+            readers = [
+                relay.reader_task
+                for relay in relays
+                if relay.reader_task is not None and relay.reader_task is not current
+            ]
+            if readers:
+                await asyncio.gather(*readers, return_exceptions=True)
+
+    async def _route_from_extension(self, envelope: Envelope) -> None:
+        if envelope.type is MessageType.REQUEST:
+            now_ms = int(time.time() * 1000)
+            if envelope.deadline_ms > now_ms + MAX_DEADLINE_AHEAD_MS:
+                await self.endpoint.write(
+                    Envelope.error_for(
+                        envelope,
+                        code="invalid_deadline",
+                        message="Request deadline exceeds the protocol limit",
+                    )
+                )
+                return
+            if envelope.is_expired(now_ms=now_ms):
+                await self.endpoint.write(
+                    Envelope.error_for(
+                        envelope,
+                        code="deadline_exceeded",
+                        message="Request deadline exceeded",
+                        retryable=True,
+                    )
+                )
+                return
+        try:
+            relay = await self._runtime_for(envelope)
+        except (DescriptorError, RuntimeTransportError):
+            if envelope.type is MessageType.REQUEST:
+                expired = envelope.is_expired()
+                await self.endpoint.write(
+                    Envelope.error_for(
+                        envelope,
+                        code="deadline_exceeded" if expired else "runtime_unavailable",
+                        message="Request deadline exceeded" if expired else "Requested runtime is unavailable",
+                        retryable=True,
+                    )
+                )
+            return
+
+        if envelope.type is MessageType.REQUEST:
+            if envelope.is_expired():
+                await self.endpoint.write(
+                    Envelope.error_for(
+                        envelope,
+                        code="deadline_exceeded",
+                        message="Request deadline exceeded",
+                        retryable=True,
+                    )
+                )
+                return
+            registration = self._register_pending(envelope)
+            if registration == "duplicate":
+                return
+            if registration == "full":
+                await self.endpoint.write(
+                    Envelope.error_for(
+                        envelope,
+                        code="request_limit",
+                        message="Native-host request limit reached",
+                        retryable=True,
+                    )
+                )
+                return
+        elif envelope.type in {MessageType.RESPONSE, MessageType.ERROR}:
+            pending = self._settle_pending(envelope.direction.opposite, envelope.runtime_id, envelope.request_id)
+            if pending is None:
+                return
+            if not self._response_matches(pending.request, envelope):
+                await relay.channel.write(
+                    Envelope.error_for(
+                        pending.request,
+                        code="invalid_response",
+                        message="Extension response metadata is invalid",
+                    )
+                )
+                return
+            if pending.request.is_expired():
+                await relay.channel.write(
+                    Envelope.error_for(
+                        pending.request,
+                        code="deadline_exceeded",
+                        message="Request deadline exceeded",
+                        retryable=True,
+                    )
+                )
+                return
+        elif envelope.type is MessageType.CANCEL:
+            pending = self._settle_pending(envelope.direction, envelope.runtime_id, envelope.request_id)
+            if pending is None or not self._response_matches(pending.request, envelope):
+                return
+        try:
+            await relay.channel.write(envelope)
+        except RuntimeTransportError:
+            await self._runtime_disconnected(relay)
+
+    async def _runtime_for(self, envelope: Envelope) -> _RuntimeRelay:
+        existing = self._runtimes.get(envelope.runtime_id)
+        if existing is not None:
+            if existing.descriptor.session_id != envelope.session_id:
+                raise DescriptorError("Runtime session does not match")
+            return existing
+        if len(self._runtimes) >= self.max_runtimes:
+            raise RuntimeTransportError("Native-host runtime limit reached")
+        descriptor = self.registry.read(envelope.runtime_id)
+        if descriptor.session_id != envelope.session_id or not descriptor.accepts_origin(self.extension_origin):
+            raise DescriptorError("Runtime identity or extension origin does not match")
+        remaining = max(0.001, (envelope.deadline_ms - int(time.time() * 1000)) / 1000)
+        channel = await connect_runtime_channel(
+            descriptor,
+            extension_origin=self.extension_origin,
+            timeout=remaining,
+        )
+        relay = _RuntimeRelay(descriptor=descriptor, channel=channel)
+        self._runtimes[descriptor.runtime_id] = relay
+        relay.reader_task = asyncio.create_task(
+            self._read_runtime(relay),
+            name=f"browser-extension-broker-{descriptor.runtime_id}",
+        )
+        return relay
+
+    async def _read_runtime(self, relay: _RuntimeRelay) -> None:
+        try:
+            while True:
+                envelope = await relay.channel.read()
+                if envelope is None:
+                    break
+                self._validate_request(envelope)
+                await self._route_from_runtime(relay, envelope)
+        except (RuntimeTransportError, ProtocolValidationError, ConnectionError):
+            pass
+        finally:
+            await self._runtime_disconnected(relay)
+
+    async def _route_from_runtime(self, relay: _RuntimeRelay, envelope: Envelope) -> None:
+        if envelope.type is MessageType.REQUEST:
+            now_ms = int(time.time() * 1000)
+            if envelope.deadline_ms > now_ms + MAX_DEADLINE_AHEAD_MS:
+                await relay.channel.write(
+                    Envelope.error_for(
+                        envelope,
+                        code="invalid_deadline",
+                        message="Request deadline exceeds the protocol limit",
+                    )
+                )
+                return
+            if envelope.is_expired(now_ms=now_ms):
+                await relay.channel.write(
+                    Envelope.error_for(
+                        envelope,
+                        code="deadline_exceeded",
+                        message="Request deadline exceeded",
+                        retryable=True,
+                    )
+                )
+                return
+            registration = self._register_pending(envelope)
+            if registration == "duplicate":
+                return
+            if registration == "full":
+                await relay.channel.write(
+                    Envelope.error_for(
+                        envelope,
+                        code="request_limit",
+                        message="Native-host request limit reached",
+                        retryable=True,
+                    )
+                )
+                return
+        elif envelope.type in {MessageType.RESPONSE, MessageType.ERROR}:
+            pending = self._settle_pending(envelope.direction.opposite, envelope.runtime_id, envelope.request_id)
+            if pending is None:
+                return
+            if not self._response_matches(pending.request, envelope):
+                await self.endpoint.write(
+                    Envelope.error_for(
+                        pending.request,
+                        code="invalid_response",
+                        message="Runtime response metadata is invalid",
+                    )
+                )
+                return
+            if pending.request.is_expired():
+                await self.endpoint.write(
+                    Envelope.error_for(
+                        pending.request,
+                        code="deadline_exceeded",
+                        message="Request deadline exceeded",
+                        retryable=True,
+                    )
+                )
+                return
+        elif envelope.type is MessageType.CANCEL:
+            pending = self._settle_pending(envelope.direction, envelope.runtime_id, envelope.request_id)
+            if pending is None or not self._response_matches(pending.request, envelope):
+                return
+        await self.endpoint.write(envelope)
+
+    def _register_pending(self, request: Envelope) -> Literal["added", "duplicate", "full"]:
+        key = (request.direction, request.runtime_id, request.request_id)
+        if key in self._pending:
+            return "duplicate"
+        if len(self._pending) >= self.max_pending_requests:
+            return "full"
+        delay = max(0.0, (request.deadline_ms - int(time.time() * 1000)) / 1000)
+        timeout_task = asyncio.create_task(
+            self._expire_pending(key, delay),
+            name="browser-extension-broker-deadline",
+        )
+        self._pending[key] = _RelayPending(request=request, timeout_task=timeout_task)
+        return "added"
+
+    def _settle_pending(
+        self,
+        requester: MessageDirection,
+        runtime_id: str,
+        request_id: str,
+    ) -> _RelayPending | None:
+        pending = self._pending.pop((requester, runtime_id, request_id), None)
+        if pending is not None:
+            pending.timeout_task.cancel()
+        return pending
+
+    @staticmethod
+    def _response_matches(request: Envelope, response: Envelope) -> bool:
+        return (
+            response.runtime_id == request.runtime_id
+            and response.session_id == request.session_id
+            and response.request_id == request.request_id
+            and response.deadline_ms == request.deadline_ms
+        )
+
+    async def _expire_pending(self, key: tuple[MessageDirection, str, str], delay: float) -> None:
+        try:
+            await asyncio.sleep(delay)
+        except asyncio.CancelledError:
+            return
+        pending = self._pending.pop(key, None)
+        if pending is None:
+            return
+        relay = self._runtimes.get(pending.request.runtime_id)
+        if pending.request.direction is MessageDirection.EXTENSION_TO_RUNTIME:
+            with contextlib.suppress(FramingError, ConnectionError):
+                await self.endpoint.write(
+                    Envelope.error_for(
+                        pending.request,
+                        code="deadline_exceeded",
+                        message="Request deadline exceeded",
+                        retryable=True,
+                    )
+                )
+            if relay is not None:
+                with contextlib.suppress(RuntimeTransportError):
+                    await relay.channel.write(Envelope.cancel_for(pending.request, reason="deadline_exceeded"))
+        elif relay is not None:
+            with contextlib.suppress(RuntimeTransportError):
+                await relay.channel.write(
+                    Envelope.error_for(
+                        pending.request,
+                        code="deadline_exceeded",
+                        message="Request deadline exceeded",
+                        retryable=True,
+                    )
+                )
+            with contextlib.suppress(FramingError, ConnectionError):
+                await self.endpoint.write(Envelope.cancel_for(pending.request, reason="deadline_exceeded"))
+
+    async def _runtime_disconnected(self, relay: _RuntimeRelay) -> None:
+        if self._runtimes.get(relay.descriptor.runtime_id) is not relay:
+            return
+        self._runtimes.pop(relay.descriptor.runtime_id, None)
+        disconnected = [
+            (key, pending)
+            for key, pending in self._pending.items()
+            if pending.request.runtime_id == relay.descriptor.runtime_id
+        ]
+        try:
+            for key, pending in disconnected:
+                settled = self._settle_pending(*key)
+                if settled is not pending or self._closed:
+                    continue
+                if pending.request.direction is MessageDirection.EXTENSION_TO_RUNTIME:
+                    with contextlib.suppress(FramingError, ConnectionError):
+                        await self.endpoint.write(
+                            Envelope.error_for(
+                                pending.request,
+                                code="runtime_disconnected",
+                                message="Runtime disconnected",
+                                retryable=True,
+                            )
+                        )
+                else:
+                    with contextlib.suppress(FramingError, ConnectionError):
+                        await self.endpoint.write(Envelope.cancel_for(pending.request, reason="runtime_disconnected"))
+        finally:
+            await relay.channel.close()
+
+
+async def run_native_host(
+    *,
+    config: NativeHostConfig,
+    extension_origin: str,
+    input_stream: BinaryIO,
+    output_stream: BinaryIO,
+) -> None:
+    origin = validate_extension_origin(extension_origin)
+    if not config.accepts_origin(origin):
+        raise NativeHostConfigurationError("Chrome extension origin is not configured")
+    ensure_runtime_transport_supported()
+    registry = RuntimeDescriptorRegistry(config.registry_dir)
+    endpoint = NativeMessageEndpoint(
+        input_stream,
+        output_stream,
+        max_pending_writes=config.max_pending_requests,
+    )
+    broker = NativeHostBroker(
+        endpoint=endpoint,
+        registry=registry,
+        extension_origin=origin,
+        max_runtimes=config.max_runtimes,
+        max_pending_requests=config.max_pending_requests,
+    )
+    try:
+        await broker.run()
+    finally:
+        await endpoint.close()
+
+
+def _binary_stream(stream: object, label: str) -> BinaryIO:
+    binary = getattr(stream, "buffer", stream)
+    if label == "input" and not hasattr(binary, "read"):
+        raise NativeHostError("Native-host input stream is unavailable")
+    if label == "output" and not hasattr(binary, "write"):
+        raise NativeHostError("Native-host output stream is unavailable")
+    return cast(BinaryIO, binary)
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    config_path: Path | None = None,
+    input_stream: BinaryIO | None = None,
+    output_stream: BinaryIO | None = None,
+    error_stream: TextIO | None = None,
+) -> int:
+    """Console entry point launched by Chrome."""
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    errors = sys.stderr if error_stream is None else error_stream
+    if not arguments:
+        print("kolega browser host: Chrome extension origin is missing", file=errors)
+        return 2
+    try:
+        try:
+            origin = validate_extension_origin(arguments[0])
+        except DescriptorError:
+            raise NativeHostConfigurationError("Chrome extension origin is invalid") from None
+        config = load_host_config(config_path or default_host_config_path())
+        if not config.accepts_origin(origin):
+            raise NativeHostConfigurationError("Chrome extension origin is not configured")
+        native_input = _binary_stream(sys.stdin if input_stream is None else input_stream, "input")
+        native_output = _binary_stream(sys.stdout if output_stream is None else output_stream, "output")
+        asyncio.run(
+            run_native_host(
+                config=config,
+                extension_origin=origin,
+                input_stream=native_input,
+                output_stream=native_output,
+            )
+        )
+        return 0
+    except NativeHostConfigurationError:
+        print("kolega browser host: configuration or extension origin rejected", file=errors)
+        return 2
+    except UnsupportedRuntimeTransportError:
+        print("kolega browser host: secure platform transport is unavailable", file=errors)
+        return 3
+    except (NativeHostError, DescriptorError, RuntimeTransportError, FramingError, ProtocolValidationError, OSError):
+        print("kolega browser host: transport terminated", file=errors)
+        return 1
+    except KeyboardInterrupt:
+        return 130

--- a/kolega_code/browser_extension/native_host.py
+++ b/kolega_code/browser_extension/native_host.py
@@ -24,6 +24,7 @@ from .protocol import (
     MessageDirection,
     MessageType,
     ProtocolValidationError,
+    runtimes_changed_notification,
     validate_discovery_request,
     validate_operation_request,
 )
@@ -39,6 +40,7 @@ from .runtime import (
 MAX_HOST_CONFIG_BYTES = 65_536
 DEFAULT_MAX_RUNTIMES = 16
 DEFAULT_MAX_RELAY_PENDING = 256
+RUNTIME_WATCH_INTERVAL_SECONDS = 1.0
 DEFAULT_MAX_NATIVE_PENDING_WRITES = 256
 DEFAULT_MAX_NATIVE_PENDING_WRITE_BYTES = 8 * MAX_NATIVE_MESSAGE_BYTES
 DEFAULT_NATIVE_WRITE_SHUTDOWN_SECONDS = 1.0
@@ -414,12 +416,46 @@ class NativeHostBroker:
         self._pending: dict[tuple[MessageDirection, str, str], _RelayPending] = {}
         self._close_lock = asyncio.Lock()
         self._closed = False
+        self._watch_task: asyncio.Task[None] | None = None
+        self._advertised: frozenset[str] | None = None
 
     @property
     def pending_count(self) -> int:
         return len(self._pending)
 
+    def _advertised_runtime_ids(self) -> frozenset[str]:
+        try:
+            return frozenset(
+                descriptor.runtime_id
+                for descriptor in self.registry.list_active()
+                if descriptor.accepts_origin(self.extension_origin)
+            )
+        except OSError:
+            return self._advertised or frozenset()
+
+    async def _watch_runtimes(self) -> None:
+        """Tell Chrome to re-enumerate runtimes whenever the live set changes.
+
+        Compares runtime ids rather than file mtimes: each runtime rewrites its
+        descriptor every TTL/3 to extend the lease, so mtime-based watching would
+        notify continuously.
+        """
+        while True:
+            await asyncio.sleep(RUNTIME_WATCH_INTERVAL_SECONDS)
+            if self._closed:
+                return
+            current = self._advertised_runtime_ids()
+            if current == self._advertised:
+                continue
+            self._advertised = current
+            try:
+                await self.endpoint.write_mapping(runtimes_changed_notification())
+            except (NativeHostError, RuntimeTransportError, OSError):
+                return
+
     async def run(self) -> None:
+        self._advertised = self._advertised_runtime_ids()
+        self._watch_task = asyncio.create_task(self._watch_runtimes(), name="kolega-browser-runtime-watch")
         try:
             while True:
                 raw = await self.endpoint.read()
@@ -473,6 +509,12 @@ class NativeHostBroker:
             if self._closed:
                 return
             self._closed = True
+            watch = self._watch_task
+            self._watch_task = None
+            if watch is not None and watch is not asyncio.current_task():
+                watch.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await watch
             pending = tuple(self._pending.values())
             self._pending.clear()
             for item in pending:

--- a/kolega_code/browser_extension/protocol.py
+++ b/kolega_code/browser_extension/protocol.py
@@ -1,0 +1,715 @@
+"""Version 1 of the Kolega Chrome-extension protocol."""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import math
+import re
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping, TypeAlias, cast
+from urllib.parse import quote, urlsplit, urlunsplit
+
+import idna
+
+PROTOCOL_VERSION = 1
+MAX_SAFE_INTEGER = (1 << 53) - 1
+MAX_IDENTIFIER_LENGTH = 128
+MAX_ERROR_MESSAGE_LENGTH = 240
+MAX_PROTOCOL_JSON_BYTES = 1_048_576
+MAX_DISCOVERY_RUNTIMES = 64
+MAX_DEADLINE_AHEAD_MS = 300_000
+
+JSONValue: TypeAlias = None | bool | int | float | str | list["JSONValue"] | dict[str, "JSONValue"]
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._~-]{0,127}$")
+_NAME_RE = re.compile(r"^[a-z][a-z0-9_.-]{0,127}$")
+_ERROR_CODE_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+_ENVELOPE_KEYS = frozenset(
+    {
+        "version",
+        "direction",
+        "type",
+        "request_id",
+        "runtime_id",
+        "session_id",
+        "deadline_ms",
+        "payload",
+    }
+)
+_DISCOVERY_REQUEST_KEYS = frozenset({"kind", "protocol_version", "request_id"})
+_DISCOVERY_RESPONSE_KEYS = frozenset({"kind", "protocol_version", "request_id", "runtimes"})
+_DISCOVERY_RUNTIME_KEYS = frozenset({"runtime_id", "session_id", "created_at_ms", "expires_at_ms"})
+
+
+class MessageDirection(str, Enum):
+    """The endpoint that emitted an envelope."""
+
+    RUNTIME_TO_EXTENSION = "runtime_to_extension"
+    EXTENSION_TO_RUNTIME = "extension_to_runtime"
+
+    @property
+    def opposite(self) -> MessageDirection:
+        if self is MessageDirection.RUNTIME_TO_EXTENSION:
+            return MessageDirection.EXTENSION_TO_RUNTIME
+        return MessageDirection.RUNTIME_TO_EXTENSION
+
+
+class MessageType(str, Enum):
+    """Protocol message kinds."""
+
+    REQUEST = "request"
+    RESPONSE = "response"
+    ERROR = "error"
+    CANCEL = "cancel"
+    EVENT = "event"
+
+
+class ProtocolValidationError(ValueError):
+    """A bounded protocol validation failure."""
+
+    def __init__(self, code: str, message: str) -> None:
+        bounded = message[:MAX_ERROR_MESSAGE_LENGTH]
+        super().__init__(bounded)
+        self.code = code
+        self.message = bounded
+
+
+def _invalid(code: str, message: str) -> ProtocolValidationError:
+    return ProtocolValidationError(code, message)
+
+
+def _is_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _identifier(value: object, field: str) -> str:
+    if not isinstance(value, str) or not _IDENTIFIER_RE.fullmatch(value):
+        raise _invalid("invalid_identifier", f"{field} is invalid")
+    return value
+
+
+def _exact_mapping(value: object, keys: frozenset[str], label: str) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != keys or not all(isinstance(key, str) for key in value):
+        raise _invalid("invalid_schema", f"{label} has an invalid schema")
+    return cast(dict[str, Any], value)
+
+
+def _validate_json_value(value: object, *, depth: int = 0) -> JSONValue:
+    if depth > 64:
+        raise _invalid("invalid_json_value", "JSON nesting is too deep")
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        if any(0xD800 <= ord(character) <= 0xDFFF for character in value):
+            raise _invalid("invalid_json_value", "JSON strings must contain valid Unicode scalar values")
+        return value
+    if _is_int(value):
+        if abs(cast(int, value)) > MAX_SAFE_INTEGER:
+            raise _invalid("invalid_json_value", "JSON integer exceeds the safe range")
+        return cast(int, value)
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise _invalid("invalid_json_value", "JSON numbers must be finite")
+        return value
+    if isinstance(value, list):
+        return [_validate_json_value(item, depth=depth + 1) for item in value]
+    if isinstance(value, dict):
+        if not all(isinstance(key, str) for key in value):
+            raise _invalid("invalid_json_value", "JSON object keys must be strings")
+        if any(any(0xD800 <= ord(character) <= 0xDFFF for character in key) for key in value):
+            raise _invalid("invalid_json_value", "JSON strings must contain valid Unicode scalar values")
+        return {key: _validate_json_value(item, depth=depth + 1) for key, item in value.items()}
+    raise _invalid("invalid_json_value", "payload contains a non-JSON value")
+
+
+ALLOWED_OPERATIONS = frozenset(
+    {
+        "browser.navigate",
+        "browser.navigate_back",
+        "browser.snapshot",
+        "browser.find",
+        "browser.wait_for",
+        "browser.click",
+        "browser.type",
+        "browser.fill_form",
+        "browser.select_option",
+        "browser.hover",
+        "browser.drag",
+        "browser.press_key",
+        "browser.tabs",
+        "browser.network_requests",
+        "browser.screenshot",
+        "browser.detach",
+    }
+)
+_MODIFIERS = frozenset({"Alt", "Control", "ControlOrMeta", "Meta", "Shift"})
+_FORM_TYPES = frozenset({"textbox", "checkbox", "radio", "combobox", "slider"})
+_RESTRICTED_HOSTS = frozenset({"chrome.google.com", "chromewebstore.google.com"})
+
+
+def _params_error(message: str) -> ProtocolValidationError:
+    return _invalid("invalid_params", message)
+
+
+def _exact_params(params: dict[str, Any], keys: frozenset[str]) -> None:
+    if set(params) != keys:
+        raise _params_error("Operation parameters have an invalid schema")
+
+
+def _utf16_length(value: str) -> int:
+    return len(value.encode("utf-16-le", errors="surrogatepass")) // 2
+
+
+def _string_param(
+    value: object,
+    name: str,
+    *,
+    nullable: bool = False,
+    maximum: int = 20_000,
+    nonempty: bool = True,
+) -> str | None:
+    if nullable and value is None:
+        return None
+    if (
+        not isinstance(value, str)
+        or _utf16_length(value) > maximum
+        or (nonempty and not value.strip())
+        or "\0" in value
+    ):
+        raise _params_error(f"{name} is invalid")
+    return value
+
+
+def _target(value: object, name: str = "target", *, nullable: bool = False) -> str | None:
+    return _string_param(value, name, nullable=nullable, maximum=2_000)
+
+
+def _nullable_integer(value: object, name: str, minimum: int, maximum: int) -> None:
+    if value is not None and (not _is_int(value) or not minimum <= cast(int, value) <= maximum):
+        raise _params_error(f"{name} is invalid")
+
+
+def _nullable_number(value: object, name: str, minimum: float, maximum: float) -> None:
+    if value is not None and (
+        not isinstance(value, (int, float))
+        or isinstance(value, bool)
+        or not math.isfinite(value)
+        or not minimum <= value <= maximum
+    ):
+        raise _params_error(f"{name} is invalid")
+
+
+def _normalize_http_url(value: object, *, nullable: bool = False) -> str | None:
+    if nullable and value is None:
+        return None
+    raw = _string_param(value, "url", maximum=8_192)
+    assert raw is not None
+    candidate = raw.strip()
+    if "://" not in candidate:
+        local_address = re.match(r"^(?:localhost|127\.0\.0\.1|\[::1\])(?::|/|$)", candidate, re.IGNORECASE)
+        candidate = f"{'http' if local_address else 'https'}://{candidate}"
+    try:
+        parsed = urlsplit(candidate)
+        port = parsed.port
+    except ValueError:
+        raise _params_error("url must be a valid HTTP or HTTPS URL") from None
+    hostname = parsed.hostname
+    if (
+        parsed.scheme.lower() not in {"http", "https"}
+        or hostname is None
+        or parsed.username is not None
+        or parsed.password is not None
+    ):
+        raise _params_error("url must be a valid HTTP or HTTPS URL")
+    if any(character.isspace() or ord(character) < 0x20 or ord(character) == 0x7F for character in hostname):
+        raise _params_error("url must be a valid HTTP or HTTPS URL")
+    try:
+        if ":" in hostname:
+            ascii_hostname = ipaddress.IPv6Address(hostname).compressed
+        else:
+            ascii_hostname = (
+                idna.encode(
+                    hostname,
+                    uts46=True,
+                    transitional=False,
+                    std3_rules=True,
+                )
+                .decode("ascii")
+                .lower()
+            )
+    except (UnicodeError, ValueError, idna.IDNAError):
+        raise _params_error("url must be a valid HTTP or HTTPS URL") from None
+    if ascii_hostname.rstrip(".") in _RESTRICTED_HOSTS:
+        raise _params_error("url is restricted")
+    if ":" in ascii_hostname:
+        ascii_hostname = f"[{ascii_hostname}]"
+    scheme = parsed.scheme.lower()
+    if port is not None and not (scheme == "http" and port == 80) and not (scheme == "https" and port == 443):
+        ascii_hostname = f"{ascii_hostname}:{port}"
+    path = quote(parsed.path or "/", safe="/%:@!$&'()*+,;=-._~")
+    query = quote(parsed.query, safe="/?:@!$&'()*+,;=%-._~")
+    fragment = quote(parsed.fragment, safe="/?:@!$&'()*+,;=%-._~")
+    return urlunsplit((scheme, ascii_hostname, path, query, fragment))
+
+
+def _validate_safe_pattern(value: object, name: str = "regex") -> None:
+    expression = _string_param(value, name, maximum=200)
+    assert expression is not None
+    source = expression
+    flags = ""
+    literal = re.fullmatch(r"/(.*)/([a-z]*)", expression)
+    if literal is not None:
+        source, flags = literal.groups()
+    if flags and (not re.fullmatch(r"[imu]*", flags) or len(set(flags)) != len(flags)):
+        raise _params_error(f"{name} has unsupported flags")
+    in_class = False
+    escaped = False
+    unicode_mode = "u" in flags
+    simple_escapes = frozenset("bBdfnrsStvwW0")
+    syntax_escapes = frozenset("^$\\.*+?()[]{}|/")
+    for index, character in enumerate(source):
+        if escaped:
+            if re.fullmatch(r"[1-9kpP]", character) or (
+                character == "0" and index + 1 < len(source) and source[index + 1].isdigit()
+            ):
+                raise _params_error(f"{name} uses an unsafe expression")
+            if character == "x" and (
+                index + 2 >= len(source)
+                or not all(item in "0123456789abcdefABCDEF" for item in source[index + 1 : index + 3])
+            ):
+                raise _params_error(f"{name} uses an unsafe expression")
+            if character == "u" and (
+                index + 4 >= len(source)
+                or not all(item in "0123456789abcdefABCDEF" for item in source[index + 1 : index + 5])
+            ):
+                raise _params_error(f"{name} uses an unsafe expression")
+            if unicode_mode and (
+                character not in simple_escapes
+                and character not in syntax_escapes
+                and not (character == "-" and in_class)
+                and character not in {"x", "u"}
+            ):
+                raise _params_error(f"{name} uses an unsafe expression")
+            escaped = False
+        elif character == "\\":
+            escaped = True
+        elif character == "[":
+            if in_class:
+                raise _params_error(f"{name} uses an unsafe expression")
+            in_class = True
+        elif character == "]":
+            if not in_class:
+                raise _params_error(f"{name} uses an unsafe expression")
+            in_class = False
+        elif not in_class and character in "*+?{}()|":
+            raise _params_error(f"{name} uses an unsafe expression")
+    if escaped or in_class:
+        raise _params_error(f"{name} is invalid")
+
+
+def validate_operation_request(operation: object, params: object) -> dict[str, JSONValue]:
+    """Validate one fixed browser operation and its exact parameter schema."""
+    if not isinstance(operation, str) or not _NAME_RE.fullmatch(operation):
+        raise _invalid("invalid_operation", "request operation is invalid")
+    if operation not in ALLOWED_OPERATIONS:
+        raise _invalid("unsupported_operation", "Operation is not supported")
+    if not isinstance(params, dict):
+        raise _params_error("Operation params must be an object")
+    values = dict(cast(dict[str, Any], params))
+
+    if operation == "browser.navigate":
+        _exact_params(values, frozenset({"url"}))
+        values["url"] = _normalize_http_url(values["url"])
+    elif operation in {"browser.navigate_back", "browser.detach"}:
+        _exact_params(values, frozenset())
+    elif operation == "browser.snapshot":
+        _exact_params(values, frozenset({"depth", "target"}))
+        _target(values["target"], nullable=True)
+        _nullable_integer(values["depth"], "depth", 1, 20)
+    elif operation == "browser.find":
+        _exact_params(values, frozenset({"regex", "text"}))
+        _string_param(values["text"], "text", nullable=True, maximum=500)
+        _string_param(values["regex"], "regex", nullable=True, maximum=200)
+        if (values["text"] is None) == (values["regex"] is None):
+            raise _params_error("Provide exactly one of text or regex")
+        if values["regex"] is not None:
+            _validate_safe_pattern(values["regex"])
+    elif operation == "browser.wait_for":
+        _exact_params(values, frozenset({"text", "text_gone", "time"}))
+        _nullable_number(values["time"], "time", 0, 30)
+        _string_param(values["text"], "text", nullable=True, maximum=500)
+        _string_param(values["text_gone"], "text_gone", nullable=True, maximum=500)
+        if values["time"] is None and values["text"] is None and values["text_gone"] is None:
+            raise _params_error("Provide time, text, or text_gone")
+    elif operation == "browser.click":
+        _exact_params(values, frozenset({"button", "double_click", "modifiers", "target"}))
+        _target(values["target"])
+        modifiers = values["modifiers"]
+        if (
+            not isinstance(values["double_click"], bool)
+            or values["button"] not in {"left", "right", "middle"}
+            or not isinstance(modifiers, list)
+            or len(modifiers) > len(_MODIFIERS)
+            or any(not isinstance(item, str) or item not in _MODIFIERS for item in modifiers)
+            or len(set(cast(list[str], modifiers))) != len(modifiers)
+        ):
+            raise _params_error("click parameters are invalid")
+    elif operation == "browser.type":
+        _exact_params(values, frozenset({"slowly", "submit", "target", "text"}))
+        _target(values["target"])
+        _string_param(values["text"], "text", maximum=50_000, nonempty=False)
+        if not isinstance(values["submit"], bool) or not isinstance(values["slowly"], bool):
+            raise _params_error("type flags must be booleans")
+    elif operation == "browser.fill_form":
+        _exact_params(values, frozenset({"fields"}))
+        fields = values["fields"]
+        if not isinstance(fields, list) or not 1 <= len(fields) <= 50:
+            raise _params_error("fields must contain between 1 and 50 entries")
+        for field in fields:
+            if not isinstance(field, dict) or set(field) != {"name", "target", "type", "value"}:
+                raise _params_error("A form field has an invalid schema")
+            _string_param(field["name"], "field name", maximum=200)
+            _target(field["target"])
+            if field["type"] not in _FORM_TYPES:
+                raise _params_error("field type is invalid")
+            field_value = _string_param(field["value"], "field value", maximum=20_000, nonempty=False)
+            assert field_value is not None
+            if field["type"] in {"checkbox", "radio"} and field_value.lower() not in {"true", "false"}:
+                raise _params_error(f"{field['type']} value must be true or false")
+    elif operation == "browser.select_option":
+        _exact_params(values, frozenset({"target", "values"}))
+        _target(values["target"])
+        options = values["values"]
+        if not isinstance(options, list) or not 1 <= len(options) <= 100:
+            raise _params_error("values are invalid")
+        for option in options:
+            _string_param(option, "option value", maximum=2_000, nonempty=False)
+    elif operation == "browser.hover":
+        _exact_params(values, frozenset({"target"}))
+        _target(values["target"])
+    elif operation == "browser.drag":
+        _exact_params(values, frozenset({"end_target", "start_target"}))
+        _target(values["start_target"], "start_target")
+        _target(values["end_target"], "end_target")
+    elif operation == "browser.press_key":
+        _exact_params(values, frozenset({"key"}))
+        key = _string_param(values["key"], "key", maximum=64)
+        assert key is not None
+        if re.search(r"[\x00-\x1f\x7f]", key):
+            raise _params_error("key is invalid")
+    elif operation == "browser.tabs":
+        _exact_params(values, frozenset({"action", "index", "url"}))
+        action = values["action"]
+        if action not in {"list", "new", "close", "select"}:
+            raise _params_error("tab action is invalid")
+        _nullable_integer(values["index"], "index", 0, 1_000)
+        values["url"] = _normalize_http_url(values["url"], nullable=True)
+        if action == "select" and values["index"] is None:
+            raise _params_error("index is required when selecting a tab")
+        if action in {"list", "new"} and values["index"] is not None:
+            raise _params_error("index is not accepted for this tab action")
+        if action != "new" and values["url"] is not None:
+            raise _params_error("url is only accepted when creating a tab")
+    elif operation == "browser.network_requests":
+        _exact_params(values, frozenset({"filter_pattern", "include_static"}))
+        if not isinstance(values["include_static"], bool):
+            raise _params_error("include_static must be a boolean")
+        _string_param(values["filter_pattern"], "filter_pattern", nullable=True, maximum=200)
+        if values["filter_pattern"] is not None:
+            _validate_safe_pattern(values["filter_pattern"], "filter_pattern")
+    elif operation == "browser.screenshot":
+        _exact_params(values, frozenset({"full_page", "image_type", "scale", "target"}))
+        _target(values["target"], nullable=True)
+        if not isinstance(values["full_page"], bool):
+            raise _params_error("full_page must be a boolean")
+        if values["image_type"] not in {"png", "jpeg"} or values["scale"] not in {"css", "device"}:
+            raise _params_error("screenshot format or scale is invalid")
+        if values["target"] is not None and values["full_page"]:
+            raise _params_error("full_page cannot be combined with an element target")
+
+    validated = _validate_json_value(values)
+    assert isinstance(validated, dict)
+    return validated
+
+
+def _validate_payload(message_type: MessageType, value: object) -> dict[str, JSONValue]:
+    schemas = {
+        MessageType.REQUEST: frozenset({"operation", "params"}),
+        MessageType.RESPONSE: frozenset({"result"}),
+        MessageType.ERROR: frozenset({"code", "message", "retryable"}),
+        MessageType.CANCEL: frozenset({"reason"}),
+        MessageType.EVENT: frozenset({"event", "data"}),
+    }
+    payload = _exact_mapping(value, schemas[message_type], f"{message_type.value} payload")
+    if message_type is MessageType.REQUEST:
+        payload["params"] = validate_operation_request(payload["operation"], payload["params"])
+    elif message_type is MessageType.ERROR:
+        if not isinstance(payload["code"], str) or not _ERROR_CODE_RE.fullmatch(payload["code"]):
+            raise _invalid("invalid_error", "error code is invalid")
+        if (
+            not isinstance(payload["message"], str)
+            or not payload["message"]
+            or len(payload["message"]) > MAX_ERROR_MESSAGE_LENGTH
+        ):
+            raise _invalid("invalid_error", "error message is invalid")
+        if not isinstance(payload["retryable"], bool):
+            raise _invalid("invalid_error", "error retryable flag is invalid")
+    elif message_type is MessageType.CANCEL:
+        reason = payload["reason"]
+        if not isinstance(reason, str) or not reason or len(reason) > MAX_ERROR_MESSAGE_LENGTH:
+            raise _invalid("invalid_cancel", "cancel reason is invalid")
+    elif message_type is MessageType.EVENT:
+        if not isinstance(payload["event"], str) or not _NAME_RE.fullmatch(payload["event"]):
+            raise _invalid("invalid_event", "event name is invalid")
+        if not isinstance(payload["data"], dict):
+            raise _invalid("invalid_schema", "event data must be an object")
+    validated = _validate_json_value(payload)
+    assert isinstance(validated, dict)
+    return validated
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _invalid("duplicate_key", "JSON contains a duplicate object key")
+        result[key] = value
+    return result
+
+
+def _reject_constant(_: str) -> None:
+    raise _invalid("invalid_json", "JSON contains a non-finite number")
+
+
+def validate_discovery_request(value: object) -> dict[str, JSONValue]:
+    """Validate the exact extension-to-host runtime discovery request."""
+    request = _exact_mapping(value, _DISCOVERY_REQUEST_KEYS, "runtime discovery request")
+    if request["kind"] != "list_runtimes" or request["protocol_version"] != PROTOCOL_VERSION:
+        raise _invalid("invalid_discovery", "runtime discovery request is invalid")
+    _identifier(request["request_id"], "request_id")
+    return cast(dict[str, JSONValue], request)
+
+
+def validate_discovery_response(value: object, *, expected_request_id: str) -> dict[str, JSONValue]:
+    """Validate the exact host-to-extension runtime discovery response."""
+    response = _exact_mapping(value, _DISCOVERY_RESPONSE_KEYS, "runtime discovery response")
+    runtimes = response["runtimes"]
+    if (
+        response["kind"] != "runtimes"
+        or response["protocol_version"] != PROTOCOL_VERSION
+        or response["request_id"] != expected_request_id
+        or not isinstance(runtimes, list)
+        or len(runtimes) > MAX_DISCOVERY_RUNTIMES
+    ):
+        raise _invalid("invalid_discovery", "runtime discovery response is invalid")
+    for item in runtimes:
+        runtime = _exact_mapping(item, _DISCOVERY_RUNTIME_KEYS, "runtime descriptor")
+        _identifier(runtime["runtime_id"], "runtime_id")
+        _identifier(runtime["session_id"], "session_id")
+        created = runtime["created_at_ms"]
+        expires = runtime["expires_at_ms"]
+        if (
+            not _is_int(created)
+            or not _is_int(expires)
+            or created <= 0
+            or expires <= created
+            or expires > MAX_SAFE_INTEGER
+        ):
+            raise _invalid("invalid_discovery", "runtime descriptor is invalid")
+    validated = _validate_json_value(response)
+    assert isinstance(validated, dict)
+    return validated
+
+
+@dataclass(frozen=True, slots=True)
+class Envelope:
+    """A validated protocol v1 envelope."""
+
+    direction: MessageDirection
+    type: MessageType
+    request_id: str
+    runtime_id: str
+    session_id: str
+    deadline_ms: int
+    payload: dict[str, JSONValue]
+    version: int = PROTOCOL_VERSION
+
+    def __post_init__(self) -> None:
+        validated = Envelope.from_mapping(self.to_mapping())
+        object.__setattr__(self, "payload", validated.payload)
+        self.to_json()
+
+    @classmethod
+    def from_mapping(cls, value: object) -> Envelope:
+        envelope = _exact_mapping(value, _ENVELOPE_KEYS, "envelope")
+        if not _is_int(envelope["version"]) or envelope["version"] != PROTOCOL_VERSION:
+            raise _invalid("unsupported_version", "protocol version is unsupported")
+        try:
+            direction = MessageDirection(envelope["direction"])
+        except (TypeError, ValueError):
+            raise _invalid("invalid_direction", "message direction is invalid") from None
+        try:
+            message_type = MessageType(envelope["type"])
+        except (TypeError, ValueError):
+            raise _invalid("invalid_type", "message type is invalid") from None
+        request_id = _identifier(envelope["request_id"], "request_id")
+        runtime_id = _identifier(envelope["runtime_id"], "runtime_id")
+        session_id = _identifier(envelope["session_id"], "session_id")
+        deadline_ms = envelope["deadline_ms"]
+        if not _is_int(deadline_ms) or deadline_ms <= 0 or deadline_ms > MAX_SAFE_INTEGER:
+            raise _invalid("invalid_deadline", "deadline_ms is invalid")
+        payload = _validate_payload(message_type, envelope["payload"])
+
+        instance = object.__new__(cls)
+        object.__setattr__(instance, "direction", direction)
+        object.__setattr__(instance, "type", message_type)
+        object.__setattr__(instance, "request_id", request_id)
+        object.__setattr__(instance, "runtime_id", runtime_id)
+        object.__setattr__(instance, "session_id", session_id)
+        object.__setattr__(instance, "deadline_ms", deadline_ms)
+        object.__setattr__(instance, "payload", payload)
+        object.__setattr__(instance, "version", PROTOCOL_VERSION)
+        return instance
+
+    @classmethod
+    def from_json(cls, raw: str | bytes) -> Envelope:
+        if isinstance(raw, bytes):
+            if len(raw) > MAX_PROTOCOL_JSON_BYTES:
+                raise _invalid("message_too_large", "protocol message exceeds the size limit")
+            try:
+                text = raw.decode("utf-8")
+            except UnicodeDecodeError:
+                raise _invalid("invalid_json", "protocol message is not valid UTF-8") from None
+        else:
+            text = raw
+            try:
+                encoded_size = len(text.encode("utf-8"))
+            except UnicodeEncodeError:
+                raise _invalid("invalid_json", "protocol message is not valid Unicode") from None
+            if encoded_size > MAX_PROTOCOL_JSON_BYTES:
+                raise _invalid("message_too_large", "protocol message exceeds the size limit")
+        try:
+            value = json.loads(text, object_pairs_hook=_reject_duplicate_keys, parse_constant=_reject_constant)
+        except ProtocolValidationError:
+            raise
+        except (json.JSONDecodeError, RecursionError):
+            raise _invalid("invalid_json", "protocol message is not valid JSON") from None
+        return cls.from_mapping(value)
+
+    def to_mapping(self) -> dict[str, JSONValue]:
+        return {
+            "version": self.version,
+            "direction": self.direction.value,
+            "type": self.type.value,
+            "request_id": self.request_id,
+            "runtime_id": self.runtime_id,
+            "session_id": self.session_id,
+            "deadline_ms": self.deadline_ms,
+            "payload": self.payload,
+        }
+
+    def to_json(self) -> str:
+        encoded = json.dumps(
+            self.to_mapping(),
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        if len(encoded.encode("utf-8")) > MAX_PROTOCOL_JSON_BYTES:
+            raise _invalid("message_too_large", "protocol message exceeds the size limit")
+        return encoded
+
+    def is_expired(self, *, now_ms: int | None = None) -> bool:
+        current = int(time.time() * 1000) if now_ms is None else now_ms
+        return self.deadline_ms <= current
+
+    @classmethod
+    def request(
+        cls,
+        *,
+        direction: MessageDirection,
+        request_id: str,
+        runtime_id: str,
+        session_id: str,
+        deadline_ms: int,
+        operation: str,
+        params: Mapping[str, JSONValue],
+    ) -> Envelope:
+        return cls(
+            direction=direction,
+            type=MessageType.REQUEST,
+            request_id=request_id,
+            runtime_id=runtime_id,
+            session_id=session_id,
+            deadline_ms=deadline_ms,
+            payload={"operation": operation, "params": dict(params)},
+        )
+
+    @classmethod
+    def response_for(cls, request: Envelope, result: JSONValue) -> Envelope:
+        return cls(
+            direction=request.direction.opposite,
+            type=MessageType.RESPONSE,
+            request_id=request.request_id,
+            runtime_id=request.runtime_id,
+            session_id=request.session_id,
+            deadline_ms=request.deadline_ms,
+            payload={"result": result},
+        )
+
+    @classmethod
+    def error_for(
+        cls,
+        request: Envelope,
+        *,
+        code: str,
+        message: str,
+        retryable: bool = False,
+    ) -> Envelope:
+        return cls(
+            direction=request.direction.opposite,
+            type=MessageType.ERROR,
+            request_id=request.request_id,
+            runtime_id=request.runtime_id,
+            session_id=request.session_id,
+            deadline_ms=request.deadline_ms,
+            payload={"code": code, "message": message[:MAX_ERROR_MESSAGE_LENGTH], "retryable": retryable},
+        )
+
+    @classmethod
+    def cancel_for(cls, request: Envelope, *, reason: str) -> Envelope:
+        return cls(
+            direction=request.direction,
+            type=MessageType.CANCEL,
+            request_id=request.request_id,
+            runtime_id=request.runtime_id,
+            session_id=request.session_id,
+            deadline_ms=request.deadline_ms,
+            payload={"reason": reason[:MAX_ERROR_MESSAGE_LENGTH]},
+        )
+
+    @classmethod
+    def event(
+        cls,
+        *,
+        direction: MessageDirection,
+        request_id: str,
+        runtime_id: str,
+        session_id: str,
+        deadline_ms: int,
+        event: str,
+        data: Mapping[str, JSONValue],
+    ) -> Envelope:
+        return cls(
+            direction=direction,
+            type=MessageType.EVENT,
+            request_id=request_id,
+            runtime_id=runtime_id,
+            session_id=session_id,
+            deadline_ms=deadline_ms,
+            payload={"event": event, "data": dict(data)},
+        )

--- a/kolega_code/browser_extension/protocol.py
+++ b/kolega_code/browser_extension/protocol.py
@@ -42,6 +42,7 @@ _ENVELOPE_KEYS = frozenset(
 _DISCOVERY_REQUEST_KEYS = frozenset({"kind", "protocol_version", "request_id"})
 _DISCOVERY_RESPONSE_KEYS = frozenset({"kind", "protocol_version", "request_id", "runtimes"})
 _DISCOVERY_RUNTIME_KEYS = frozenset({"runtime_id", "session_id", "created_at_ms", "expires_at_ms"})
+_RUNTIMES_CHANGED_KEYS = frozenset({"kind", "protocol_version"})
 
 
 class MessageDirection(str, Enum):
@@ -155,8 +156,19 @@ def _params_error(message: str) -> ProtocolValidationError:
 
 
 def _exact_params(params: dict[str, Any], keys: frozenset[str]) -> None:
-    if set(params) != keys:
-        raise _params_error("Operation parameters have an invalid schema")
+    present = set(params)
+    if present == keys:
+        return
+    # Name the offending keys: every parameter must be present, with inapplicable
+    # ones passed as JSON null rather than omitted or defaulted to 0 / "".
+    missing = sorted(keys - present)
+    unexpected = sorted(present - keys)
+    details: list[str] = []
+    if missing:
+        details.append(f"missing {', '.join(missing)} (pass null when not applicable)")
+    if unexpected:
+        details.append(f"unexpected {', '.join(unexpected)}")
+    raise _params_error(f"Operation parameters have an invalid schema: {'; '.join(details)}")
 
 
 def _utf16_length(value: str) -> int:
@@ -188,8 +200,13 @@ def _target(value: object, name: str = "target", *, nullable: bool = False) -> s
 
 
 def _nullable_integer(value: object, name: str, minimum: int, maximum: int) -> None:
-    if value is not None and (not _is_int(value) or not minimum <= cast(int, value) <= maximum):
-        raise _params_error(f"{name} is invalid")
+    if value is None or (_is_int(value) and minimum <= cast(int, value) <= maximum):
+        return
+    # A string "null" is a common serialization slip; say so rather than leaving
+    # the caller to guess what "invalid" means.
+    if isinstance(value, str):
+        raise _params_error(f"{name} must be an integer or JSON null, not the string {value!r}")
+    raise _params_error(f"{name} must be an integer between {minimum} and {maximum}, or JSON null")
 
 
 def _nullable_number(value: object, name: str, minimum: float, maximum: float) -> None:
@@ -255,7 +272,26 @@ def _normalize_http_url(value: object, *, nullable: bool = False) -> str | None:
     return urlunsplit((scheme, ascii_hostname, path, query, fragment))
 
 
+_MAX_PATTERN_QUANTIFIERS = 4
+_MAX_PATTERN_REPETITION = 1_000
+_HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
+_PATTERN_SUBSET_HINT = (
+    "supported: literals, '.', character classes, anchors, escapes, and the quantifiers ?, *, + and "
+    "{n,m} applied to a single character or class; not supported: groups, alternation, backreferences"
+)
+
+
 def _validate_safe_pattern(value: object, name: str = "regex") -> None:
+    """Validate a pattern against the restricted, linear-time regex subset.
+
+    Grouping and alternation stay forbidden, so a quantifier can only ever apply
+    to a single atom (a literal, ``.``, an escape, or a character class). That
+    makes catastrophic exponential backtracking impossible by construction, and
+    the quantifier-count and repetition-bound caps below bound the remaining
+    polynomial cost. This grammar is mirrored character-for-character by
+    ``validateSafeRegex`` in the Chrome extension's ``src/operations.js``; change
+    both together or the two backends will accept different languages.
+    """
     expression = _string_param(value, name, maximum=200)
     assert expression is not None
     source = expression
@@ -265,49 +301,102 @@ def _validate_safe_pattern(value: object, name: str = "regex") -> None:
         source, flags = literal.groups()
     if flags and (not re.fullmatch(r"[imu]*", flags) or len(set(flags)) != len(flags)):
         raise _params_error(f"{name} has unsupported flags")
-    in_class = False
-    escaped = False
     unicode_mode = "u" in flags
     simple_escapes = frozenset("bBdfnrsStvwW0")
     syntax_escapes = frozenset("^$\\.*+?()[]{}|/")
-    for index, character in enumerate(source):
-        if escaped:
-            if re.fullmatch(r"[1-9kpP]", character) or (
-                character == "0" and index + 1 < len(source) and source[index + 1].isdigit()
-            ):
-                raise _params_error(f"{name} uses an unsafe expression")
-            if character == "x" and (
-                index + 2 >= len(source)
-                or not all(item in "0123456789abcdefABCDEF" for item in source[index + 1 : index + 3])
-            ):
-                raise _params_error(f"{name} uses an unsafe expression")
-            if character == "u" and (
-                index + 4 >= len(source)
-                or not all(item in "0123456789abcdefABCDEF" for item in source[index + 1 : index + 5])
-            ):
-                raise _params_error(f"{name} uses an unsafe expression")
-            if unicode_mode and (
-                character not in simple_escapes
-                and character not in syntax_escapes
-                and not (character == "-" and in_class)
-                and character not in {"x", "u"}
-            ):
-                raise _params_error(f"{name} uses an unsafe expression")
-            escaped = False
-        elif character == "\\":
-            escaped = True
-        elif character == "[":
-            if in_class:
-                raise _params_error(f"{name} uses an unsafe expression")
-            in_class = True
-        elif character == "]":
-            if not in_class:
-                raise _params_error(f"{name} uses an unsafe expression")
-            in_class = False
-        elif not in_class and character in "*+?{}()|":
-            raise _params_error(f"{name} uses an unsafe expression")
-    if escaped or in_class:
-        raise _params_error(f"{name} is invalid")
+
+    def unsupported() -> ProtocolValidationError:
+        return _params_error(f"{name} uses unsupported syntax; {_PATTERN_SUBSET_HINT}")
+
+    def read_escape(position: int, in_class: bool) -> int:
+        if position + 1 >= len(source):
+            raise _params_error(f"{name} is invalid")
+        character = source[position + 1]
+        if re.fullmatch(r"[1-9kpP]", character) or (
+            character == "0" and position + 2 < len(source) and source[position + 2].isdigit()
+        ):
+            raise _params_error(f"{name} does not support backreferences or unicode property escapes")
+        if character == "x":
+            digits = source[position + 2 : position + 4]
+            if len(digits) != 2 or not all(item in _HEX_DIGITS for item in digits):
+                raise unsupported()
+            return position + 4
+        if character == "u":
+            digits = source[position + 2 : position + 6]
+            if len(digits) != 4 or not all(item in _HEX_DIGITS for item in digits):
+                raise unsupported()
+            return position + 6
+        if unicode_mode and (
+            character not in simple_escapes and character not in syntax_escapes and not (character == "-" and in_class)
+        ):
+            raise unsupported()
+        return position + 2
+
+    quantifiers = 0
+    quantifiable = False
+    index = 0
+    while index < len(source):
+        character = source[index]
+        if character == "\\":
+            index = read_escape(index, False)
+            quantifiable = True
+            continue
+        if character == "[":
+            index += 1
+            closed = False
+            while index < len(source):
+                inner = source[index]
+                if inner == "\\":
+                    index = read_escape(index, True)
+                    continue
+                if inner == "[":
+                    raise unsupported()
+                if inner == "]":
+                    closed = True
+                    index += 1
+                    break
+                index += 1
+            if not closed:
+                raise _params_error(f"{name} is invalid")
+            quantifiable = True
+            continue
+        if character in "()":
+            raise _params_error(f"{name} does not support groups; remove '(' and ')'")
+        if character == "|":
+            raise _params_error(f"{name} does not support alternation; remove '|'")
+        if character in "*+?":
+            if not quantifiable:
+                raise _params_error(f"{name} has a quantifier with nothing to repeat")
+            quantifiers += 1
+            quantifiable = False
+            index += 1
+            continue
+        if character == "{":
+            closing = source.find("}", index + 1)
+            if closing < 0:
+                raise _params_error(f"{name} has an unterminated repetition bound")
+            bound = re.fullmatch(r"(\d{1,4})(?:,(\d{0,4}))?", source[index + 1 : closing])
+            if bound is None:
+                raise _params_error(f"{name} has an invalid repetition bound")
+            if not quantifiable:
+                raise _params_error(f"{name} has a quantifier with nothing to repeat")
+            minimum = int(bound.group(1))
+            maximum_text = bound.group(2)
+            maximum = minimum if maximum_text is None else (None if maximum_text == "" else int(maximum_text))
+            if maximum is not None and maximum < minimum:
+                raise _params_error(f"{name} has an invalid repetition bound")
+            if max(minimum, maximum or 0) > _MAX_PATTERN_REPETITION:
+                raise _params_error(f"{name} allows repetition counts up to {_MAX_PATTERN_REPETITION}")
+            quantifiers += 1
+            quantifiable = False
+            index = closing + 1
+            continue
+        if character in "]}":
+            raise unsupported()
+        quantifiable = character not in "^$"
+        index += 1
+    if quantifiers > _MAX_PATTERN_QUANTIFIERS:
+        raise _params_error(f"{name} allows at most {_MAX_PATTERN_QUANTIFIERS} quantifiers")
 
 
 def validate_operation_request(operation: object, params: object) -> dict[str, JSONValue]:
@@ -408,11 +497,11 @@ def validate_operation_request(operation: object, params: object) -> dict[str, J
         _nullable_integer(values["index"], "index", 0, 1_000)
         values["url"] = _normalize_http_url(values["url"], nullable=True)
         if action == "select" and values["index"] is None:
-            raise _params_error("index is required when selecting a tab")
+            raise _params_error("index is required when selecting a tab; pass index: <tab index>, url: null")
         if action in {"list", "new"} and values["index"] is not None:
-            raise _params_error("index is not accepted for this tab action")
+            raise _params_error(f"index is not accepted for the {action} tab action; pass index: null")
         if action != "new" and values["url"] is not None:
-            raise _params_error("url is only accepted when creating a tab")
+            raise _params_error(f"url is only accepted when creating a tab; pass url: null for the {action} action")
     elif operation == "browser.network_requests":
         _exact_params(values, frozenset({"filter_pattern", "include_static"}))
         if not isinstance(values["include_static"], bool):
@@ -491,6 +580,25 @@ def validate_discovery_request(value: object) -> dict[str, JSONValue]:
         raise _invalid("invalid_discovery", "runtime discovery request is invalid")
     _identifier(request["request_id"], "request_id")
     return cast(dict[str, JSONValue], request)
+
+
+def runtimes_changed_notification() -> dict[str, JSONValue]:
+    """Build the unsolicited host-to-extension "rediscover runtimes" notification.
+
+    The extension only enumerates runtimes when it opens the native port, when the
+    popup is used, or on install. Without this notification a Kolega session that
+    starts later stays invisible until the operator clicks the extension, which is
+    exactly the behaviour this notification removes.
+    """
+    return {"kind": "runtimes_changed", "protocol_version": PROTOCOL_VERSION}
+
+
+def validate_runtimes_changed(value: object) -> dict[str, JSONValue]:
+    """Validate the exact host-to-extension runtime-change notification."""
+    message = _exact_mapping(value, _RUNTIMES_CHANGED_KEYS, "runtime change notification")
+    if message["kind"] != "runtimes_changed" or message["protocol_version"] != PROTOCOL_VERSION:
+        raise _invalid("invalid_discovery", "runtime change notification is invalid")
+    return cast(dict[str, JSONValue], message)
 
 
 def validate_discovery_response(value: object, *, expected_request_id: str) -> dict[str, JSONValue]:

--- a/kolega_code/browser_extension/registry.py
+++ b/kolega_code/browser_extension/registry.py
@@ -1,0 +1,346 @@
+"""Owner-private discovery registry for active browser runtimes."""
+
+from __future__ import annotations
+
+import errno
+import contextlib
+import hmac
+import json
+import os
+import re
+import stat
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, cast
+
+from .protocol import MAX_SAFE_INTEGER, PROTOCOL_VERSION
+
+MAX_DESCRIPTOR_BYTES = 65_536
+RuntimeTransport = Literal["unix"]
+
+_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._~-]{0,127}$")
+_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]{32,256}$")
+_ORIGIN_RE = re.compile(r"^chrome-extension://[a-p]{32}/$")
+_DESCRIPTOR_KEYS = frozenset(
+    {
+        "protocol_version",
+        "runtime_id",
+        "session_id",
+        "transport",
+        "endpoint",
+        "token",
+        "pid",
+        "created_at_ms",
+        "expires_at_ms",
+        "extension_origin",
+    }
+)
+
+
+class DescriptorError(RuntimeError):
+    """A safe-to-report runtime descriptor failure."""
+
+
+class DescriptorSecurityError(DescriptorError):
+    """Descriptor ownership, type, or permissions are unsafe."""
+
+
+class DescriptorNotFoundError(DescriptorError):
+    """No descriptor exists for the requested runtime."""
+
+
+class StaleDescriptorError(DescriptorError):
+    """A descriptor no longer identifies a live runtime."""
+
+
+def validate_extension_origin(origin: object) -> str:
+    """Return one exact Chrome extension origin."""
+    if not isinstance(origin, str) or not _ORIGIN_RE.fullmatch(origin):
+        raise DescriptorError("Chrome extension origin is invalid")
+    return origin
+
+
+def validate_identifier(value: object, label: str) -> str:
+    if not isinstance(value, str) or not _ID_RE.fullmatch(value):
+        raise DescriptorError(f"{label} is invalid")
+    return value
+
+
+def _is_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _validate_endpoint(transport: object, endpoint: object) -> tuple[RuntimeTransport, str]:
+    if transport != "unix":
+        raise DescriptorError("Runtime descriptor transport is unsupported")
+    if not isinstance(endpoint, str) or not endpoint or "\0" in endpoint:
+        raise DescriptorError("Runtime descriptor endpoint is invalid")
+    if not Path(endpoint).is_absolute():
+        raise DescriptorError("Runtime descriptor endpoint is invalid")
+    return cast(RuntimeTransport, transport), endpoint
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeDescriptor:
+    """Private connection data for one active runtime."""
+
+    runtime_id: str
+    session_id: str
+    transport: RuntimeTransport
+    endpoint: str
+    token: str
+    pid: int
+    created_at_ms: int
+    expires_at_ms: int
+    extension_origin: str
+    protocol_version: int = PROTOCOL_VERSION
+
+    def __post_init__(self) -> None:
+        RuntimeDescriptor.from_mapping(self.to_mapping())
+
+    @classmethod
+    def from_mapping(cls, value: object) -> RuntimeDescriptor:
+        if not isinstance(value, dict) or set(value) != _DESCRIPTOR_KEYS:
+            raise DescriptorError("Runtime descriptor has an invalid schema")
+        raw = cast(dict[str, Any], value)
+        if not _is_int(raw["protocol_version"]) or raw["protocol_version"] != PROTOCOL_VERSION:
+            raise DescriptorError("Runtime descriptor protocol is unsupported")
+        runtime_id = validate_identifier(raw["runtime_id"], "runtime ID")
+        session_id = validate_identifier(raw["session_id"], "session ID")
+        transport, endpoint = _validate_endpoint(raw["transport"], raw["endpoint"])
+        token = raw["token"]
+        if not isinstance(token, str) or not _TOKEN_RE.fullmatch(token):
+            raise DescriptorError("Runtime descriptor credential is invalid")
+        pid = raw["pid"]
+        created = raw["created_at_ms"]
+        expires = raw["expires_at_ms"]
+        if not _is_int(pid) or pid <= 0:
+            raise DescriptorError("Runtime descriptor process ID is invalid")
+        if (
+            not _is_int(created)
+            or not _is_int(expires)
+            or created <= 0
+            or expires <= created
+            or expires > MAX_SAFE_INTEGER
+        ):
+            raise DescriptorError("Runtime descriptor lifetime is invalid")
+        origin = validate_extension_origin(raw["extension_origin"])
+
+        instance = object.__new__(cls)
+        object.__setattr__(instance, "runtime_id", runtime_id)
+        object.__setattr__(instance, "session_id", session_id)
+        object.__setattr__(instance, "transport", transport)
+        object.__setattr__(instance, "endpoint", endpoint)
+        object.__setattr__(instance, "token", token)
+        object.__setattr__(instance, "pid", pid)
+        object.__setattr__(instance, "created_at_ms", created)
+        object.__setattr__(instance, "expires_at_ms", expires)
+        object.__setattr__(instance, "extension_origin", origin)
+        object.__setattr__(instance, "protocol_version", PROTOCOL_VERSION)
+        return instance
+
+    def to_mapping(self) -> dict[str, object]:
+        return {
+            "protocol_version": self.protocol_version,
+            "runtime_id": self.runtime_id,
+            "session_id": self.session_id,
+            "transport": self.transport,
+            "endpoint": self.endpoint,
+            "token": self.token,
+            "pid": self.pid,
+            "created_at_ms": self.created_at_ms,
+            "expires_at_ms": self.expires_at_ms,
+            "extension_origin": self.extension_origin,
+        }
+
+    def accepts_origin(self, origin: str) -> bool:
+        return hmac.compare_digest(self.extension_origin, origin)
+
+
+def _owner_uid() -> int:
+    getuid = getattr(os, "getuid", None)
+    if getuid is None:
+        raise DescriptorSecurityError("POSIX descriptor ownership checks are unavailable")
+    return cast(int, getuid())
+
+
+def _verify_private_stat(file_stat: os.stat_result, *, directory: bool) -> None:
+    expected_type = stat.S_ISDIR if directory else stat.S_ISREG
+    if not expected_type(file_stat.st_mode):
+        raise DescriptorSecurityError("Runtime registry object has an unsafe type")
+    if file_stat.st_uid != _owner_uid() or stat.S_IMODE(file_stat.st_mode) & 0o077:
+        raise DescriptorSecurityError("Runtime registry ownership or permissions are unsafe")
+
+
+def _pid_is_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError as exc:
+        return exc.errno == errno.EPERM
+    return True
+
+
+class RuntimeDescriptorRegistry:
+    """Atomic per-user runtime descriptor storage."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root.expanduser().resolve()
+        self._ensure_private_root()
+
+    def _ensure_private_root(self) -> None:
+        try:
+            self.root.mkdir(mode=0o700, parents=True, exist_ok=False)
+        except FileExistsError:
+            pass
+        _verify_private_stat(self.root.lstat(), directory=True)
+        os.chmod(self.root, 0o700)
+
+    def _path_for(self, runtime_id: str) -> Path:
+        return self.root / f"{validate_identifier(runtime_id, 'runtime ID')}.json"
+
+    def register(self, descriptor: RuntimeDescriptor) -> Path:
+        if descriptor.expires_at_ms <= int(time.time() * 1000):
+            raise StaleDescriptorError("Runtime descriptor is stale")
+        payload = json.dumps(
+            descriptor.to_mapping(),
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        if len(payload) > MAX_DESCRIPTOR_BYTES:
+            raise DescriptorError("Runtime descriptor exceeds the size limit")
+        destination = self._path_for(descriptor.runtime_id)
+        fd, temporary_name = tempfile.mkstemp(prefix=".runtime-", dir=self.root)
+        temporary = Path(temporary_name)
+        try:
+            os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "wb", closefd=True) as file:
+                fd = -1
+                file.write(payload)
+                file.flush()
+                os.fsync(file.fileno())
+            os.replace(temporary, destination)
+            self._fsync_root()
+        finally:
+            if fd >= 0:
+                os.close(fd)
+            with contextlib.suppress(FileNotFoundError):
+                temporary.unlink()
+        return destination
+
+    def read(
+        self,
+        runtime_id: str,
+        *,
+        check_stale: bool = True,
+        now_ms: int | None = None,
+    ) -> RuntimeDescriptor:
+        path = self._path_for(runtime_id)
+        flags = os.O_RDONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        try:
+            fd = os.open(path, flags)
+        except FileNotFoundError:
+            raise DescriptorNotFoundError("Runtime descriptor was not found") from None
+        except OSError:
+            raise DescriptorSecurityError("Runtime descriptor could not be opened safely") from None
+        try:
+            file_stat = os.fstat(fd)
+            _verify_private_stat(file_stat, directory=False)
+            with os.fdopen(fd, "rb", closefd=True) as file:
+                fd = -1
+                payload = file.read(MAX_DESCRIPTOR_BYTES + 1)
+        finally:
+            if fd >= 0:
+                os.close(fd)
+        if len(payload) > MAX_DESCRIPTOR_BYTES:
+            raise DescriptorError("Runtime descriptor exceeds the size limit")
+        try:
+            raw = json.loads(payload.decode("utf-8"), object_pairs_hook=self._reject_duplicate_keys)
+        except DescriptorError:
+            raise
+        except (UnicodeDecodeError, json.JSONDecodeError, RecursionError):
+            raise DescriptorError("Runtime descriptor is malformed") from None
+        descriptor = RuntimeDescriptor.from_mapping(raw)
+        if descriptor.runtime_id != runtime_id:
+            raise DescriptorError("Runtime descriptor identity does not match its filename")
+        if check_stale and self._is_stale(descriptor, now_ms=now_ms):
+            self._unlink_if_same(path, file_stat)
+            raise StaleDescriptorError("Runtime descriptor is stale")
+        return descriptor
+
+    def unregister(self, runtime_id: str, *, token: str) -> bool:
+        try:
+            descriptor = self.read(runtime_id, check_stale=False)
+        except DescriptorNotFoundError:
+            return False
+        if not hmac.compare_digest(descriptor.token, token):
+            return False
+        path = self._path_for(runtime_id)
+        try:
+            file_stat = path.stat(follow_symlinks=False)
+        except FileNotFoundError:
+            return False
+        self._unlink_if_same(path, file_stat)
+        return True
+
+    def list_active(self) -> list[RuntimeDescriptor]:
+        active: list[RuntimeDescriptor] = []
+        for path in sorted(self.root.glob("*.json")):
+            try:
+                active.append(self.read(path.stem))
+            except DescriptorError:
+                continue
+        return active
+
+    @staticmethod
+    def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        value: dict[str, object] = {}
+        for key, item in pairs:
+            if key in value:
+                raise DescriptorError("Runtime descriptor is malformed")
+            value[key] = item
+        return value
+
+    def _is_stale(self, descriptor: RuntimeDescriptor, *, now_ms: int | None = None) -> bool:
+        current = int(time.time() * 1000) if now_ms is None else now_ms
+        if descriptor.expires_at_ms <= current or not _pid_is_alive(descriptor.pid):
+            return True
+        try:
+            endpoint_stat = Path(descriptor.endpoint).stat(follow_symlinks=False)
+        except OSError:
+            return True
+        return (
+            not stat.S_ISSOCK(endpoint_stat.st_mode)
+            or endpoint_stat.st_uid != _owner_uid()
+            or bool(stat.S_IMODE(endpoint_stat.st_mode) & 0o077)
+        )
+
+    @staticmethod
+    def _unlink_if_same(path: Path, expected_stat: os.stat_result) -> None:
+        try:
+            current = path.stat(follow_symlinks=False)
+            if current.st_dev == expected_stat.st_dev and current.st_ino == expected_stat.st_ino:
+                path.unlink()
+        except FileNotFoundError:
+            return
+
+    def _fsync_root(self) -> None:
+        try:
+            directory_fd = os.open(self.root, os.O_RDONLY)
+        except OSError:
+            return
+        try:
+            os.fsync(directory_fd)
+        except OSError:
+            pass
+        finally:
+            os.close(directory_fd)

--- a/kolega_code/browser_extension/runtime.py
+++ b/kolega_code/browser_extension/runtime.py
@@ -1,0 +1,491 @@
+"""Authenticated local channels over owner-private macOS Unix sockets."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import hashlib
+import hmac
+import inspect
+import os
+import secrets
+import stat
+import sys
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import replace
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+from .framing import FramingError, read_message_async, write_message_async
+from .protocol import PROTOCOL_VERSION, Envelope, MessageDirection
+from .registry import (
+    RuntimeDescriptor,
+    RuntimeDescriptorRegistry,
+    RuntimeTransport,
+    validate_extension_origin,
+    validate_identifier,
+)
+
+if TYPE_CHECKING:
+    from .multiplex import EventHandler, MultiplexedPeer, RequestHandler
+
+AUTH_TIMEOUT_SECONDS = 5.0
+RUNTIME_WRITE_TIMEOUT_SECONDS = 5.0
+DEFAULT_RUNTIME_TTL_MS = 12 * 60 * 60 * 1000
+_AUTH_KEYS = frozenset({"kind", "protocol_version", "runtime_id", "token", "extension_origin"})
+_AUTH_OK_KEYS = frozenset({"kind", "protocol_version", "runtime_id"})
+
+
+class RuntimeTransportError(RuntimeError):
+    """A safe-to-report local transport failure."""
+
+
+class UnsupportedRuntimeTransportError(RuntimeTransportError):
+    """The selected secure platform transport cannot execute."""
+
+
+class RuntimeAuthenticationError(RuntimeTransportError):
+    """Runtime-channel authentication failed."""
+
+
+class RuntimeDisconnectedError(RuntimeTransportError):
+    """An authenticated runtime channel disconnected."""
+
+
+def selected_runtime_transport(*, platform: str | None = None) -> RuntimeTransport:
+    """Select the macOS transport without a network-socket fallback."""
+    if (platform or sys.platform) != "darwin":
+        raise UnsupportedRuntimeTransportError("Chrome browser integration is supported only on macOS")
+    return "unix"
+
+
+def ensure_runtime_transport_supported(*, platform: str | None = None) -> RuntimeTransport:
+    """Verify that the selected transport can execute in this interpreter."""
+    transport = selected_runtime_transport(platform=platform)
+    if not hasattr(asyncio, "start_unix_server"):
+        raise UnsupportedRuntimeTransportError("Unix-domain-socket runtime transport is unavailable")
+    return transport
+
+
+class _Listener(Protocol):
+    def close(self) -> None: ...
+
+    async def wait_closed(self) -> None: ...
+
+
+class RuntimeChannel:
+    """A framed, authenticated protocol-envelope channel."""
+
+    def __init__(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        *,
+        runtime_id: str,
+        session_id: str,
+        outbound_direction: MessageDirection,
+    ) -> None:
+        self._reader = reader
+        self._writer = writer
+        self.runtime_id = runtime_id
+        self.session_id = session_id
+        self.outbound_direction = outbound_direction
+        self._write_lock = asyncio.Lock()
+        self._closed = False
+
+    @property
+    def closed(self) -> bool:
+        return self._closed or self._writer.is_closing()
+
+    async def read(self) -> Envelope | None:
+        if self._closed:
+            return None
+        raw = await read_message_async(self._reader)
+        if raw is None:
+            return None
+        envelope = Envelope.from_mapping(raw)
+        if envelope.runtime_id != self.runtime_id or envelope.session_id != self.session_id:
+            raise RuntimeTransportError("Runtime channel received a mismatched envelope")
+        if envelope.direction is not self.outbound_direction.opposite:
+            raise RuntimeTransportError("Runtime channel received an invalid direction")
+        return envelope
+
+    async def write(self, envelope: Envelope) -> None:
+        if self.closed:
+            raise RuntimeDisconnectedError("Runtime channel is disconnected")
+        if envelope.runtime_id != self.runtime_id or envelope.session_id != self.session_id:
+            raise RuntimeTransportError("Runtime channel cannot send a mismatched envelope")
+        if envelope.direction is not self.outbound_direction:
+            raise RuntimeTransportError("Runtime channel cannot send an invalid direction")
+        try:
+            async with asyncio.timeout(RUNTIME_WRITE_TIMEOUT_SECONDS):
+                async with self._write_lock:
+                    if self.closed:
+                        raise RuntimeDisconnectedError("Runtime channel is disconnected")
+                    await write_message_async(self._writer, envelope.to_mapping())
+        except (TimeoutError, ConnectionError, BrokenPipeError, FramingError):
+            raise RuntimeDisconnectedError("Runtime channel is disconnected") from None
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._writer.close()
+        with contextlib.suppress(ConnectionError, OSError):
+            await self._writer.wait_closed()
+
+
+def _validate_auth_request(raw: object) -> tuple[str, str, str]:
+    if not isinstance(raw, dict) or set(raw) != _AUTH_KEYS:
+        raise RuntimeAuthenticationError("Runtime authentication failed")
+    if raw["kind"] != "authenticate" or raw["protocol_version"] != PROTOCOL_VERSION:
+        raise RuntimeAuthenticationError("Runtime authentication failed")
+    try:
+        runtime_id = validate_identifier(raw["runtime_id"], "runtime ID")
+        origin = validate_extension_origin(raw["extension_origin"])
+    except Exception:
+        raise RuntimeAuthenticationError("Runtime authentication failed") from None
+    token = raw["token"]
+    if not isinstance(token, str):
+        raise RuntimeAuthenticationError("Runtime authentication failed")
+    return runtime_id, token, origin
+
+
+async def _open_local_connection(
+    descriptor: RuntimeDescriptor,
+    *,
+    platform: str | None = None,
+) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+    selected = selected_runtime_transport(platform=platform)
+    if descriptor.transport != selected:
+        raise UnsupportedRuntimeTransportError("Runtime descriptor uses a different platform transport")
+    try:
+        return await asyncio.open_unix_connection(descriptor.endpoint)
+    except OSError:
+        raise RuntimeDisconnectedError("Runtime endpoint is unavailable") from None
+
+
+async def connect_runtime_channel(
+    descriptor: RuntimeDescriptor,
+    *,
+    extension_origin: str,
+    timeout: float = AUTH_TIMEOUT_SECONDS,
+    platform: str | None = None,
+) -> RuntimeChannel:
+    """Connect and authenticate to one runtime as the native-host side."""
+    if timeout <= 0:
+        raise ValueError("timeout must be positive")
+    ensure_runtime_transport_supported(platform=platform)
+    origin = validate_extension_origin(extension_origin)
+    if not descriptor.accepts_origin(origin):
+        raise RuntimeAuthenticationError("Runtime authentication failed")
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    try:
+        async with asyncio.timeout_at(deadline):
+            reader, writer = await _open_local_connection(descriptor, platform=platform)
+    except TimeoutError:
+        raise RuntimeDisconnectedError("Runtime endpoint is unavailable") from None
+    try:
+        async with asyncio.timeout_at(deadline):
+            await write_message_async(
+                writer,
+                {
+                    "kind": "authenticate",
+                    "protocol_version": PROTOCOL_VERSION,
+                    "runtime_id": descriptor.runtime_id,
+                    "token": descriptor.token,
+                    "extension_origin": origin,
+                },
+            )
+            response = await read_message_async(reader)
+        if (
+            not isinstance(response, dict)
+            or set(response) != _AUTH_OK_KEYS
+            or response["kind"] != "authenticated"
+            or response["protocol_version"] != PROTOCOL_VERSION
+            or response["runtime_id"] != descriptor.runtime_id
+        ):
+            raise RuntimeAuthenticationError("Runtime authentication failed")
+    except (TimeoutError, ConnectionError, FramingError, RuntimeAuthenticationError):
+        writer.close()
+        with contextlib.suppress(ConnectionError, OSError):
+            await writer.wait_closed()
+        raise RuntimeAuthenticationError("Runtime authentication failed") from None
+    return RuntimeChannel(
+        reader,
+        writer,
+        runtime_id=descriptor.runtime_id,
+        session_id=descriptor.session_id,
+        outbound_direction=MessageDirection.EXTENSION_TO_RUNTIME,
+    )
+
+
+PeerCallback = Callable[["MultiplexedPeer"], Awaitable[None] | None]
+
+
+class RuntimeServer:
+    """Authenticated per-runtime server selected for the current platform."""
+
+    def __init__(
+        self,
+        registry: RuntimeDescriptorRegistry,
+        *,
+        session_id: str,
+        extension_origin: str,
+        request_handler: RequestHandler | None = None,
+        event_handler: EventHandler | None = None,
+        on_peer: PeerCallback | None = None,
+        runtime_id: str | None = None,
+        ttl_ms: int = DEFAULT_RUNTIME_TTL_MS,
+        max_pending_requests: int = 128,
+        max_inflight_requests: int = 32,
+        platform: str | None = None,
+    ) -> None:
+        self.transport: RuntimeTransport = ensure_runtime_transport_supported(platform=platform)
+        if ttl_ms <= 0:
+            raise ValueError("ttl_ms must be positive")
+        self.registry = registry
+        self.platform = platform
+        self.session_id = validate_identifier(session_id, "session ID")
+        self.extension_origin = validate_extension_origin(extension_origin)
+        self.runtime_id = validate_identifier(
+            runtime_id or f"runtime_{secrets.token_urlsafe(18)}",
+            "runtime ID",
+        )
+        self.token = secrets.token_urlsafe(32)
+        self.ttl_ms = ttl_ms
+        self.request_handler = request_handler
+        self.event_handler = event_handler
+        self.on_peer = on_peer
+        self.max_pending_requests = max_pending_requests
+        self.max_inflight_requests = max_inflight_requests
+        self.endpoint = self._select_endpoint()
+        self._listener: _Listener | None = None
+        self._descriptor: RuntimeDescriptor | None = None
+        self._socket_identity: tuple[int, int] | None = None
+        self._peers: set[MultiplexedPeer] = set()
+        self._peer_queue: asyncio.Queue[MultiplexedPeer] = asyncio.Queue(maxsize=8)
+        self._refresh_task: asyncio.Task[None] | None = None
+        self._close_lock = asyncio.Lock()
+        self._closed = False
+
+    def _select_endpoint(self) -> str:
+        preferred = self.registry.root / f"{self.runtime_id}.sock"
+        if len(os.fsencode(preferred)) <= 100:
+            return str(preferred)
+        getuid = getattr(os, "getuid", None)
+        if getuid is None:
+            raise UnsupportedRuntimeTransportError("Owner-private Unix runtime endpoints are unavailable")
+        short_root = Path("/tmp") / f"kb-{getuid()}"
+        try:
+            short_root.mkdir(mode=0o700, exist_ok=False)
+        except FileExistsError:
+            pass
+        root_stat = short_root.lstat()
+        if (
+            not stat.S_ISDIR(root_stat.st_mode)
+            or root_stat.st_uid != getuid()
+            or stat.S_IMODE(root_stat.st_mode) & 0o077
+        ):
+            raise RuntimeTransportError("Short runtime socket directory is unsafe")
+        digest = hashlib.sha256(f"{self.registry.root}\0{self.runtime_id}".encode()).hexdigest()[:16]
+        return str(short_root / f"{digest}.sock")
+
+    @property
+    def descriptor(self) -> RuntimeDescriptor:
+        if self._descriptor is None:
+            raise RuntimeTransportError("Runtime server has not started")
+        return self._descriptor
+
+    async def start(self) -> RuntimeDescriptor:
+        if self._listener is not None:
+            return self.descriptor
+        if self._closed:
+            raise RuntimeTransportError("Runtime server is closed")
+        if Path(self.endpoint).exists() or Path(self.endpoint).is_symlink():
+            raise RuntimeTransportError("Runtime endpoint already exists")
+        try:
+            listener = await asyncio.start_unix_server(self._accept_client, path=self.endpoint)
+            os.chmod(self.endpoint, 0o600)
+            socket_stat = Path(self.endpoint).lstat()
+            if not stat.S_ISSOCK(socket_stat.st_mode):
+                raise RuntimeTransportError("Runtime endpoint is not a Unix socket")
+            self._socket_identity = (socket_stat.st_dev, socket_stat.st_ino)
+            self._listener = listener
+            now_ms = int(time.time() * 1000)
+            self._descriptor = RuntimeDescriptor(
+                runtime_id=self.runtime_id,
+                session_id=self.session_id,
+                transport=self.transport,
+                endpoint=self.endpoint,
+                token=self.token,
+                pid=os.getpid(),
+                created_at_ms=now_ms,
+                expires_at_ms=now_ms + self.ttl_ms,
+                extension_origin=self.extension_origin,
+            )
+            self.registry.register(self._descriptor)
+            self._refresh_task = asyncio.create_task(
+                self._refresh_descriptor(),
+                name=f"browser-extension-runtime-refresh-{self.runtime_id}",
+            )
+            return self._descriptor
+        except Exception:
+            await self._close_listener()
+            self._unlink_owned_socket()
+            raise
+
+    async def wait_for_connection(self, *, timeout: float | None = None) -> MultiplexedPeer:
+        async def next_open_peer() -> MultiplexedPeer:
+            while True:
+                peer = await self._peer_queue.get()
+                if not peer.closed:
+                    return peer
+
+        if timeout is None:
+            return await next_open_peer()
+        return await asyncio.wait_for(next_open_peer(), timeout=timeout)
+
+    async def close(self) -> None:
+        async with self._close_lock:
+            if self._closed:
+                return
+            self._closed = True
+            refresh = self._refresh_task
+            self._refresh_task = None
+            if refresh is not None:
+                refresh.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await refresh
+            with contextlib.suppress(Exception):
+                await self._close_listener()
+            peers = tuple(self._peers)
+            self._peers.clear()
+            if peers:
+                await asyncio.gather(
+                    *(peer.close("Runtime server closed") for peer in peers),
+                    return_exceptions=True,
+                )
+            with contextlib.suppress(Exception):
+                self.registry.unregister(self.runtime_id, token=self.token)
+            self._unlink_owned_socket()
+
+    async def _refresh_descriptor(self) -> None:
+        interval = max(0.05, self.ttl_ms / 3_000)
+        while True:
+            await asyncio.sleep(interval)
+            descriptor = self._descriptor
+            if descriptor is None or self._closed:
+                return
+            now_ms = int(time.time() * 1000)
+            refreshed = replace(descriptor, expires_at_ms=now_ms + self.ttl_ms)
+            self.registry.register(refreshed)
+            self._descriptor = refreshed
+
+    async def _close_listener(self) -> None:
+        listener = self._listener
+        self._listener = None
+        if listener is not None:
+            listener.close()
+            await listener.wait_closed()
+
+    def _unlink_owned_socket(self) -> None:
+        if self._socket_identity is None:
+            return
+        try:
+            endpoint_stat = Path(self.endpoint).lstat()
+            if (endpoint_stat.st_dev, endpoint_stat.st_ino) == self._socket_identity and stat.S_ISSOCK(
+                endpoint_stat.st_mode
+            ):
+                Path(self.endpoint).unlink()
+        except FileNotFoundError:
+            pass
+        self._socket_identity = None
+
+    async def _accept_client(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        from .multiplex import MultiplexedPeer
+
+        peer: MultiplexedPeer | None = None
+        try:
+            raw = await asyncio.wait_for(read_message_async(reader), timeout=AUTH_TIMEOUT_SECONDS)
+            runtime_id, token, origin = _validate_auth_request(raw)
+            if (
+                runtime_id != self.runtime_id
+                or not hmac.compare_digest(token, self.token)
+                or not hmac.compare_digest(origin, self.extension_origin)
+            ):
+                raise RuntimeAuthenticationError("Runtime authentication failed")
+            await write_message_async(
+                writer,
+                {
+                    "kind": "authenticated",
+                    "protocol_version": PROTOCOL_VERSION,
+                    "runtime_id": self.runtime_id,
+                },
+            )
+            channel = RuntimeChannel(
+                reader,
+                writer,
+                runtime_id=self.runtime_id,
+                session_id=self.session_id,
+                outbound_direction=MessageDirection.RUNTIME_TO_EXTENSION,
+            )
+            peer = MultiplexedPeer(
+                channel,
+                request_handler=self.request_handler,
+                event_handler=self.event_handler,
+                max_pending_requests=self.max_pending_requests,
+                max_inflight_requests=self.max_inflight_requests,
+            )
+            assert peer is not None
+            self._peers.add(peer)
+            await peer.start()
+            if self.on_peer is None:
+                try:
+                    self._peer_queue.put_nowait(peer)
+                except asyncio.QueueFull:
+                    await peer.close("Runtime connection limit reached")
+                    return
+            else:
+                callback_result = self.on_peer(peer)
+                if inspect.isawaitable(callback_result):
+                    await callback_result
+            await peer.wait_closed()
+        except (TimeoutError, FramingError, RuntimeAuthenticationError, ConnectionError):
+            writer.close()
+            with contextlib.suppress(ConnectionError, OSError):
+                await writer.wait_closed()
+        finally:
+            if peer is not None:
+                self._peers.discard(peer)
+
+
+async def connect_runtime_peer(
+    descriptor: RuntimeDescriptor,
+    *,
+    extension_origin: str,
+    request_handler: RequestHandler | None = None,
+    event_handler: EventHandler | None = None,
+    max_pending_requests: int = 128,
+    max_inflight_requests: int = 32,
+    platform: str | None = None,
+) -> MultiplexedPeer:
+    """Connect a multiplexed peer as the extension/native-host side."""
+    from .multiplex import MultiplexedPeer
+
+    channel = await connect_runtime_channel(
+        descriptor,
+        extension_origin=extension_origin,
+        platform=platform,
+    )
+    peer = MultiplexedPeer(
+        channel,
+        request_handler=request_handler,
+        event_handler=event_handler,
+        max_pending_requests=max_pending_requests,
+        max_inflight_requests=max_inflight_requests,
+    )
+    await peer.start()
+    return peer

--- a/kolega_code/cli/browser_backend.py
+++ b/kolega_code/cli/browser_backend.py
@@ -1,0 +1,101 @@
+"""Ordinary-host browser backend selection for the CLI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import ClassVar
+
+from kolega_code.browser_extension.installer import (
+    CHROME_EXTENSION_ID,
+    configured_extension_origin,
+    native_host_status,
+)
+from kolega_code.browser_extension.manager import ChromeExtensionBrowserManager, ChromeExtensionUnavailableError
+from kolega_code.browser_extension.native_host import NativeHostConfigurationError
+from kolega_code.browser_extension.runtime import UnsupportedRuntimeTransportError
+from kolega_code.services.base import BrowserManager
+from kolega_code.services.browser import PlaywrightBrowserManager
+
+
+def _configured_extension_origin(state_dir: Path) -> str:
+    try:
+        origin = configured_extension_origin(state_dir=state_dir)
+        extension_id = origin.removeprefix("chrome-extension://").removesuffix("/")
+        channel = "production" if extension_id == CHROME_EXTENSION_ID else "dev"
+        status = native_host_status(
+            channel=channel,
+            extension_id=None if channel == "production" else extension_id,
+            state_dir=state_dir,
+        )
+    except UnsupportedRuntimeTransportError as exc:
+        raise NativeHostConfigurationError(str(exc)) from None
+    if not status.valid:
+        raise NativeHostConfigurationError(status.detail)
+    return origin
+
+
+class OrdinaryHostBrowserManager(PlaywrightBrowserManager):
+    """Keep Playwright as the default while exposing configured host backends."""
+
+    browser_target: ClassVar[str] = "playwright"
+
+    def __init__(
+        self,
+        *,
+        state_dir: Path,
+        kolega_session_id: str,
+        browser_visible: bool = False,
+    ) -> None:
+        super().__init__()
+        self.state_dir = state_dir
+        self.kolega_session_id = kolega_session_id
+        self.headless = not browser_visible
+        self._chrome_manager: ChromeExtensionBrowserManager | None = None
+
+    @property
+    def browser_targets(self) -> tuple[str, ...]:
+        try:
+            _configured_extension_origin(self.state_dir)
+        except NativeHostConfigurationError:
+            return ("playwright",)
+        return ("playwright", "chrome")
+
+    def resolve_browser_target(self, browser_target: str | None = None) -> BrowserManager:
+        if browser_target is None or browser_target == "playwright":
+            return self
+        if browser_target != "chrome":
+            raise ValueError(f"Unknown browser target {browser_target!r}. Expected 'playwright' or 'chrome'.")
+        if self._chrome_manager is not None:
+            return self._chrome_manager
+        try:
+            extension_origin = _configured_extension_origin(self.state_dir)
+        except NativeHostConfigurationError:
+            raise ChromeExtensionUnavailableError(
+                "Chrome browser integration is not configured. Run `kolega-code browser install` and retry."
+            ) from None
+        self._chrome_manager = ChromeExtensionBrowserManager(
+            state_dir=self.state_dir,
+            kolega_session_id=self.kolega_session_id,
+            extension_origin=extension_origin,
+        )
+        return self._chrome_manager
+
+    async def cleanup_all_browsers(self) -> None:
+        try:
+            if self._chrome_manager is not None:
+                await self._chrome_manager.cleanup_all_browsers()
+        finally:
+            await super().cleanup_all_browsers()
+
+
+def build_browser_manager(
+    state_dir: Path,
+    kolega_session_id: str,
+    browser_visible: bool = False,
+) -> OrdinaryHostBrowserManager:
+    """Build the default ordinary-host Playwright manager."""
+    return OrdinaryHostBrowserManager(
+        state_dir=state_dir,
+        kolega_session_id=kolega_session_id,
+        browser_visible=browser_visible,
+    )

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import contextlib
 import faulthandler
 import importlib.util
 import json
@@ -53,6 +54,7 @@ from kolega_code.browser_extension.installer import (
     BROWSER_EXTENSION_CHANNELS,
     DEFAULT_BROWSER_EXTENSION_CHANNEL,
     channel_web_store_url,
+    default_state_dir,
     install_native_host,
     native_host_status,
     uninstall_native_host,
@@ -649,6 +651,34 @@ def _run_update() -> int:
     return result.returncode
 
 
+def _probe_chrome_extension(state_dir: Path | None, extension_id: str) -> dict[str, Any]:
+    """Attempt a real attach so `doctor` cannot report green while unreachable."""
+    from kolega_code.browser_extension.manager import (
+        ChromeExtensionBrowserManager,
+        ChromeExtensionUnavailableError,
+    )
+
+    resolved_state_dir = state_dir or default_state_dir()
+
+    async def run() -> dict[str, Any]:
+        manager = ChromeExtensionBrowserManager(
+            state_dir=resolved_state_dir,
+            kolega_session_id="browser-doctor",
+            extension_origin=f"chrome-extension://{extension_id}/",
+            connection_timeout=5.0,
+        )
+        try:
+            return await manager.probe()
+        finally:
+            with contextlib.suppress(Exception):
+                await manager.cleanup_all_browsers()
+
+    try:
+        return asyncio.run(run())
+    except ChromeExtensionUnavailableError as exc:
+        return {"state": "unreachable", "connected": False, "ready": False, "runtimes": [], "detail": str(exc)}
+
+
 def _run_browser(args: argparse.Namespace) -> int:
     command = args.browser_command
     common = {
@@ -687,13 +717,43 @@ def _run_browser(args: argparse.Namespace) -> int:
         if command == "doctor" and not status.valid:
             payload["remediation"] = "Run `kolega-code browser install` with the same channel and extension ID."
 
+        # `status` is a cheap manifest check; only `doctor` attempts a real
+        # attach, because a valid manifest says nothing about whether the
+        # extension is installed, enabled, or paired with this session.
+        probe: dict[str, Any] | None = None
+        if command == "doctor" and status.valid:
+            probe = _probe_chrome_extension(args.state_dir, status.extension_id)
+            payload["extension"] = probe
+            if probe["state"] != "paired":
+                payload["remediation"] = probe["detail"]
+            if probe["state"] == "awaiting_selection":
+                # doctor publishes its own temporary runtime, so with another Kolega
+                # session already running there are two and Chrome must be told which
+                # one may drive the browser. Say so rather than implying a fault.
+                payload["remediation"] = (
+                    f"{probe['detail']} This check publishes its own temporary runtime, so a choice is "
+                    "expected whenever another Kolega session is running; stop the other session to test "
+                    "pairing unattended."
+                )
+
         if args.json:
             print(json.dumps(payload, sort_keys=True))
         else:
             print(status.detail)
+            if command == "status":
+                print("Checked the native-host manifest only; run `kolega-code browser doctor` to test the extension.")
             print(f"Manifest: {status.manifest_path}")
             if status.host_path is not None:
                 print(f"Native host: {status.host_path}")
+            if probe is not None:
+                print(f"Extension: {probe['state']}")
+                if probe.get("runtime_id"):
+                    print(f"This session's runtime: {probe['runtime_id']}")
+                for runtime in probe["runtimes"]:
+                    marker = " (this session)" if runtime["current"] else ""
+                    print(
+                        f"  - {runtime['session_id']} — runtime {runtime['runtime_id']}, pid {runtime['pid']}{marker}"
+                    )
             if payload.get("remediation"):
                 print(payload["remediation"])
             if store_url:
@@ -701,6 +761,8 @@ def _run_browser(args: argparse.Namespace) -> int:
 
         if command == "install" and store_url:
             webbrowser.open(store_url)
+        if probe is not None and probe["state"] != "paired":
+            return 1
         return 0 if status.valid else 1
     except (RuntimeError, OSError) as exc:
         if getattr(args, "json", False):

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -8,6 +8,7 @@ import faulthandler
 import importlib.util
 import json
 import sys
+import webbrowser
 from pathlib import Path
 from typing import Any, Iterable, Optional
 
@@ -48,10 +49,18 @@ from kolega_code.permissions import (
     allow_rule_options,
     normalize_permission_mode,
 )
-from kolega_code.services.browser import PlaywrightBrowserManager
+from kolega_code.browser_extension.installer import (
+    BROWSER_EXTENSION_CHANNELS,
+    DEFAULT_BROWSER_EXTENSION_CHANNEL,
+    channel_web_store_url,
+    install_native_host,
+    native_host_status,
+    uninstall_native_host,
+)
 from kolega_code.utils.images import encode_image_file
 
 from . import messages
+from .browser_backend import build_browser_manager
 from .diagnostics import write_crash_log
 from .config import (
     DEPRECATED_THINKING_TOKENS_MESSAGE,
@@ -98,7 +107,7 @@ from .skills import (
 )
 from .updater import check_for_update, run_self_update, update_status_message
 
-SUBCOMMANDS = {"ask", "sessions", "doctor", "update", "prompts", "agents", "mcp", "tui", "share"}
+SUBCOMMANDS = {"ask", "sessions", "doctor", "update", "prompts", "agents", "browser", "mcp", "tui", "share"}
 RESUME_LATEST = "__latest__"
 CLI_AGENT_MODE = AgentMode.CLI.value
 ASK_DEFAULT_PERMISSION_MODE = PermissionMode.AUTO.value
@@ -138,6 +147,8 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
             return _run_prompts(args)
         if args.command == "agents":
             return _run_agents(args)
+        if args.command == "browser":
+            return _run_browser(args)
         if args.command == "mcp":
             return asyncio.run(_run_mcp(args))
         if args.command == "update":
@@ -420,6 +431,31 @@ def _build_subcommand_parser() -> argparse.ArgumentParser:
     agents_validate.add_argument("--project", default=".", type=Path, help="Project directory to inspect.")
     agents_validate.add_argument("--state-dir", type=Path, help="Directory containing user-level custom agents.")
 
+    browser = subparsers.add_parser("browser", help="Manage the Chrome native-messaging integration.")
+    browser_sub = browser.add_subparsers(dest="browser_command", required=True)
+
+    def add_browser_registration_args(command: argparse.ArgumentParser, *, include_host_path: bool = False) -> None:
+        command.add_argument(
+            "--channel",
+            choices=BROWSER_EXTENSION_CHANNELS,
+            default=DEFAULT_BROWSER_EXTENSION_CHANNEL,
+            help="Extension release channel.",
+        )
+        command.add_argument("--extension-id", help="Required explicit extension ID for beta and dev channels.")
+        command.add_argument("--state-dir", type=Path, help="Directory for CLI and browser runtime state.")
+        command.add_argument("--json", action="store_true", help="Print machine-readable status.")
+        if include_host_path:
+            command.add_argument("--host-path", type=Path, help="Explicit native-host executable path.")
+
+    browser_install = browser_sub.add_parser("install", help="Install or refresh the Chrome native host.")
+    add_browser_registration_args(browser_install, include_host_path=True)
+    browser_status = browser_sub.add_parser("status", help="Check the Chrome native-host configuration.")
+    add_browser_registration_args(browser_status)
+    browser_doctor = browser_sub.add_parser("doctor", help="Diagnose the Chrome native-host configuration.")
+    add_browser_registration_args(browser_doctor)
+    browser_uninstall = browser_sub.add_parser("uninstall", help="Remove the Chrome native host.")
+    add_browser_registration_args(browser_uninstall)
+
     mcp = subparsers.add_parser("mcp", help="Manage MCP servers and verification state.")
     mcp.add_argument(
         "--project", default=".", type=Path, help="Project directory to use for trusted project MCP config."
@@ -611,6 +647,67 @@ def _run_update() -> int:
     elif not result.error:
         _print_styled("Kolega Code update failed.", style="error", stderr=True)
     return result.returncode
+
+
+def _run_browser(args: argparse.Namespace) -> int:
+    command = args.browser_command
+    common = {
+        "channel": args.channel,
+        "extension_id": args.extension_id,
+    }
+    try:
+        if command == "uninstall":
+            removed = uninstall_native_host(**common)
+            payload = {
+                "command": command,
+                "removed": removed,
+                "detail": "Chrome native host removed." if removed else "Chrome native host was not installed.",
+            }
+            if args.json:
+                print(json.dumps(payload, sort_keys=True))
+            else:
+                print(payload["detail"])
+            return 0
+
+        status_kwargs = {
+            **common,
+            "state_dir": args.state_dir,
+        }
+        if command == "install":
+            status = install_native_host(host_path=args.host_path, **status_kwargs)
+        else:
+            status = native_host_status(**status_kwargs)
+
+        store_url = channel_web_store_url(status.channel)
+        payload = {
+            "command": command,
+            **status.to_dict(),
+            "web_store_url": store_url,
+        }
+        if command == "doctor" and not status.valid:
+            payload["remediation"] = "Run `kolega-code browser install` with the same channel and extension ID."
+
+        if args.json:
+            print(json.dumps(payload, sort_keys=True))
+        else:
+            print(status.detail)
+            print(f"Manifest: {status.manifest_path}")
+            if status.host_path is not None:
+                print(f"Native host: {status.host_path}")
+            if payload.get("remediation"):
+                print(payload["remediation"])
+            if store_url:
+                print(f"Chrome Web Store: {store_url}")
+
+        if command == "install" and store_url:
+            webbrowser.open(store_url)
+        return 0 if status.valid else 1
+    except (RuntimeError, OSError) as exc:
+        if getattr(args, "json", False):
+            print(json.dumps({"command": command, "error": str(exc)}, sort_keys=True))
+        else:
+            _print_styled(f"kolega-code browser: {exc}", style="error", stderr=True)
+        return 2
 
 
 def _run_tui(args: argparse.Namespace) -> int:
@@ -992,8 +1089,11 @@ async def _run_ask(args: argparse.Namespace) -> int:
         session = store.load(session.session_id)
 
     manager = CliConnectionManager()
-    browser_manager = PlaywrightBrowserManager()
-    browser_manager.headless = not args.browser_visible
+    browser_manager = build_browser_manager(
+        store.root,
+        session.session_id,
+        browser_visible=args.browser_visible,
+    )
     agent_ref: dict[str, CoderAgent] = {}
     prompt_extensions = []
     tool_extensions = []

--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -23,11 +23,11 @@ from kolega_code.llm.exceptions import LLMError, llm_error_message
 from kolega_code.mcp.tools import build_mcp_tool_extension
 from kolega_code.permissions import PermissionDecision
 from kolega_code.session.runtime import deserialize_permission_request
-from kolega_code.services.browser import PlaywrightBrowserManager
 from kolega_code.tools import ToolError
 from textual.widgets import Static
 
 from .. import messages
+from ..browser_backend import build_browser_manager
 from ..config import CliConfigError, build_agent_config, config_summary
 from ..goal import (
     GoalState,
@@ -974,8 +974,11 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
             if rebuild:
                 await self.agent.cleanup()
 
-        browser_manager = PlaywrightBrowserManager()
-        browser_manager.headless = not self.browser_visible
+        browser_manager = build_browser_manager(
+            self.store.root,
+            self.session.session_id,
+            browser_visible=self.browser_visible,
+        )
         agent_class = PlanningAgent if self.interaction_mode == tui_constants.PLAN_INTERACTION_MODE else CoderAgent
         self.skill_catalog = discover_skills(self.project_path)
         self.custom_agent_catalog = validate_custom_agent_models(

--- a/kolega_code/services/base.py
+++ b/kolega_code/services/base.py
@@ -1,3 +1,4 @@
+import asyncio
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
@@ -99,6 +100,10 @@ class TerminalManager(ABC):
 class BrowserManager(ABC):
     """Abstract single-session browser interface used by the browser agent."""
 
+    # ``None`` preserves the complete legacy browser tool surface. Backends with
+    # a fixed subset advertise model-facing tool names here.
+    supported_tools: frozenset[str] | None = None
+
     @abstractmethod
     async def navigate(self, url: str) -> Dict[str, Any]: ...
 
@@ -197,3 +202,12 @@ class BrowserManager(ABC):
     async def cleanup_all_browsers(self) -> None:
         """Close the current browser session during agent teardown."""
         await self.close()
+
+
+def browser_manager_agent_lock(manager: BrowserManager) -> asyncio.Lock:
+    """Return the manager-scoped lock used to serialize whole browser-agent runs."""
+    lock = getattr(manager, "_kolega_browser_agent_lock", None)
+    if not isinstance(lock, asyncio.Lock):
+        lock = asyncio.Lock()
+        setattr(manager, "_kolega_browser_agent_lock", lock)
+    return lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ dependencies = [
     "filelock==3.20.3",
     "google-genai==2.12.1",
     "httpx==0.28.1",
+    # Protocol-v1 URLs follow WHATWG-compatible non-transitional UTS-46 host normalization.
+    "idna==3.18",
     "jinja2==3.1.6",
     "langfuse==3.14.5",
     "lxml-html-clean==0.4.5",
@@ -98,9 +100,24 @@ dev = [
 
 [project.scripts]
 kolega-code = "kolega_code.cli.main:main"
+kolega-code-browser-host = "kolega_code.browser_extension.native_host:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["kolega_code"]
+
+[tool.hatch.build.targets.sdist]
+exclude = ["/.kolega/worktrees/**"]
+include = [
+    "/CHANGELOG.md",
+    "/CONTRIBUTING.md",
+    "/LICENSE",
+    "/MIGRATION.md",
+    "/README.md",
+    "/RELEASING.md",
+    "/kolega_code/**",
+    "/pyproject.toml",
+]
+skip-excluded-dirs = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/agent/orchestration/test_orchestration.py
+++ b/tests/agent/orchestration/test_orchestration.py
@@ -456,6 +456,30 @@ def test_cache_key_includes_actual_execution_class_and_read_only_mode() -> None:
     assert writable.cache_key() != forced_plan.cache_key()
 
 
+def test_cache_key_includes_browser_target() -> None:
+    playwright = AgentRunSpec(prompt="same", agent_type="browser")
+    chrome = AgentRunSpec(prompt="same", agent_type="browser", browser_target="chrome")
+
+    assert playwright.cache_key() != chrome.cache_key()
+
+
+@pytest.mark.asyncio
+async def test_runtime_passes_browser_target_to_dispatch(tmp_path: Path) -> None:
+    runtime, calls, _, _ = make_runtime(tmp_path)
+
+    await runtime.agent("browse", agent_type="browser", browser_target="chrome")
+
+    assert calls[0].browser_target == "chrome"
+
+
+@pytest.mark.asyncio
+async def test_runtime_rejects_browser_target_for_non_browser_agent(tmp_path: Path) -> None:
+    runtime, _, _, _ = make_runtime(tmp_path)
+
+    with pytest.raises(WorkflowScriptError, match="only valid"):
+        await runtime.agent("investigate", agent_type="investigation", browser_target="chrome")
+
+
 @pytest.mark.asyncio
 async def test_runtime_records_dispatch_routing_metadata(tmp_path: Path) -> None:
     async def dispatch(_spec: AgentRunSpec) -> AgentRunResult:

--- a/tests/agent/test_browser_capabilities.py
+++ b/tests/agent/test_browser_capabilities.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from kolega_code.agent.tools import ToolCollection, ToolCollectionConfig
+from kolega_code.browser_extension.manager import (
+    CHROME_EXTENSION_SUPPORTED_TOOLS,
+    ChromeExtensionBrowserManager,
+)
+from kolega_code.cli.browser_backend import build_browser_manager
+from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
+from kolega_code.services.base import browser_manager_agent_lock
+from kolega_code.services.browser import PlaywrightBrowserManager
+
+_EXTENSION_ORIGIN = "chrome-extension://edihigldhbmimflgjkohkgnjefmhngdn/"
+
+
+def _agent_config() -> AgentConfig:
+    model = ModelConfig(provider=ModelProvider.ANTHROPIC, model="test-model", rate_limits=RateLimitConfig())
+    return AgentConfig(
+        anthropic_api_key="test-key",
+        long_context_config=model,
+        fast_config=model,
+        thinking_config=model,
+    )
+
+
+def _caller() -> Mock:
+    caller = Mock()
+    caller.agent_name = "test-agent"
+    caller.sub_agent = False
+    caller.gigacode_enabled = False
+    caller.supports_vision = True
+    caller.custom_agent_catalog = None
+    caller.sub_agent_context = None
+    return caller
+
+
+def _collection(
+    tmp_path: Path,
+    browser_manager: PlaywrightBrowserManager | ChromeExtensionBrowserManager,
+    *,
+    browser_only: bool = False,
+    dispatch: bool = False,
+) -> ToolCollection:
+    return ToolCollection(
+        tmp_path,
+        "workspace",
+        str(uuid.uuid4()),
+        AsyncMock(),
+        _agent_config(),
+        _caller(),
+        browser_manager=browser_manager,
+        tool_config=ToolCollectionConfig(
+            browser_only=browser_only,
+            include_agent_dispatch_tools=dispatch,
+        ),
+    )
+
+
+def test_playwright_retains_the_complete_browser_tool_inventory(tmp_path: Path) -> None:
+    collection = _collection(tmp_path, PlaywrightBrowserManager(), browser_only=True)
+
+    assert set(collection.registry().names()) == set(ToolCollection.browser_tools) | {"read_image"}
+
+
+def test_chrome_exposes_only_its_fixed_browser_tool_inventory(tmp_path: Path) -> None:
+    manager = ChromeExtensionBrowserManager(
+        state_dir=tmp_path,
+        kolega_session_id="session-1",
+        extension_origin=_EXTENSION_ORIGIN,
+    )
+    collection = _collection(tmp_path, manager, browser_only=True)
+
+    assert set(collection.registry().names()) == CHROME_EXTENSION_SUPPORTED_TOOLS | {"read_image"}
+
+
+def test_configured_chrome_target_is_offered_on_browser_dispatch(tmp_path: Path) -> None:
+    with patch("kolega_code.cli.browser_backend._configured_extension_origin", return_value=_EXTENSION_ORIGIN):
+        manager = build_browser_manager(tmp_path, "session-1")
+        collection = _collection(tmp_path, manager, dispatch=True)
+
+    dispatch = collection.registry().get("dispatch_browser_agent")
+    assert dispatch.definition.input_schema is not None
+    assert dispatch.definition.input_schema["required"] == ["task"]
+    assert dispatch.definition.input_schema["properties"]["browser_target"]["enum"] == [
+        "playwright",
+        "chrome",
+    ]
+    assert dispatch.parallel_safe is False
+    assert collection.registry().get("dispatch_investigation_agent").parallel_safe is True
+
+
+@pytest.mark.asyncio
+async def test_browser_dispatch_injects_the_selected_concrete_manager(tmp_path: Path) -> None:
+    manager = build_browser_manager(tmp_path, "session-1")
+    selected = PlaywrightBrowserManager()
+    manager.resolve_browser_target = Mock(return_value=selected)  # type: ignore[method-assign]
+    collection = _collection(tmp_path, manager, dispatch=True)
+    dispatch = AsyncMock(return_value="done")
+    collection.agent_tool._dispatch_agent = dispatch  # type: ignore[method-assign]
+
+    assert await collection.agent_tool.dispatch_browser_agent("Use Chrome", browser_target="chrome") == "done"
+    manager.resolve_browser_target.assert_called_once_with("chrome")
+    assert dispatch.await_args is not None
+    assert dispatch.await_args.kwargs["browser_manager_override"] is selected
+
+
+@pytest.mark.asyncio
+async def test_browser_agent_runs_are_serialized_per_concrete_manager(tmp_path: Path) -> None:
+    manager = build_browser_manager(tmp_path, "session-1")
+    selected = PlaywrightBrowserManager()
+    manager.resolve_browser_target = Mock(return_value=selected)  # type: ignore[method-assign]
+    collection = _collection(tmp_path, manager, dispatch=True)
+    active = 0
+    maximum_active = 0
+
+    async def dispatch(**_: object) -> str:
+        nonlocal active, maximum_active
+        active += 1
+        maximum_active = max(maximum_active, active)
+        await asyncio.sleep(0)
+        active -= 1
+        return "done"
+
+    collection.agent_tool._dispatch_agent = dispatch  # type: ignore[method-assign]
+
+    await asyncio.gather(
+        collection.agent_tool.dispatch_browser_agent("first", browser_target="chrome"),
+        collection.agent_tool.dispatch_browser_agent("second", browser_target="chrome"),
+    )
+
+    assert maximum_active == 1
+    assert browser_manager_agent_lock(selected) is browser_manager_agent_lock(selected)
+    assert browser_manager_agent_lock(selected) is not browser_manager_agent_lock(manager)
+
+
+@pytest.mark.asyncio
+async def test_legacy_browser_manager_rejects_an_explicit_target(tmp_path: Path) -> None:
+    collection = _collection(tmp_path, PlaywrightBrowserManager(), dispatch=True)
+
+    with pytest.raises(ValueError, match="browser_target"):
+        await collection.agent_tool.dispatch_browser_agent("task", browser_target="chrome")

--- a/tests/agent/tool_backend/test_agent_tool.py
+++ b/tests/agent/tool_backend/test_agent_tool.py
@@ -2,7 +2,7 @@
 
 import pytest
 from typing import Any, ClassVar, Optional
-from unittest.mock import AsyncMock, Mock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, Mock, MagicMock, patch
 import uuid
 import builtins
 
@@ -490,8 +490,22 @@ class TestAgentTool:
                 agent_class_import="kolega_code.agent.browseragent.BrowserAgent",
                 task="Browse the web",
                 model_override=None,
+                browser_manager_override=ANY,
             )
+            assert agent_tool.browser_manager is mock_dispatch.call_args.kwargs["browser_manager_override"]
             assert result == "Browser task completed"
+
+    async def test_workflow_agent_receives_concrete_browser_manager(self, agent_tool):
+        browser_manager = Mock()
+
+        agent = agent_tool._construct_workflow_sub_agent(
+            MockAgent,
+            config=None,
+            extra_tool_extensions=None,
+            browser_manager_override=browser_manager,
+        )
+
+        assert agent.init_kwargs["browser_manager"] is browser_manager
 
     async def test_dispatch_coding_agent(self, agent_tool):
         """Test coding agent dispatch."""

--- a/tests/agent/tool_backend/test_browser_tool.py
+++ b/tests/agent/tool_backend/test_browser_tool.py
@@ -224,3 +224,64 @@ def test_browser_schema_enums_serialize_for_google():
         "Meta",
         "Shift",
     ]
+
+
+@pytest.mark.asyncio
+async def test_network_requests_report_resource_type(browser_tool, browser_manager):
+    """The Chrome and Playwright backends both supply resource_type; the shared
+    formatter used to drop it, so callers could not tell a fetch from a stylesheet."""
+    browser_manager.network_requests = AsyncMock(
+        return_value={
+            "requests": [
+                {
+                    "index": 1,
+                    "method": "GET",
+                    "url": "http://127.0.0.1:8931/api/ping",
+                    "status": 200,
+                    "failure": None,
+                    "resource_type": "xmlhttprequest",
+                },
+                {
+                    "index": 2,
+                    "method": "GET",
+                    "url": "http://127.0.0.1:8931/fixture.css",
+                    "status": 200,
+                    "failure": None,
+                    "resource_type": "stylesheet",
+                },
+            ]
+        }
+    )
+
+    output = await browser_tool.browser_network_requests(include_static=True)
+
+    assert "1: GET http://127.0.0.1:8931/api/ping [xmlhttprequest] => 200" in output
+    assert "2: GET http://127.0.0.1:8931/fixture.css [stylesheet] => 200" in output
+
+
+@pytest.mark.asyncio
+async def test_network_requests_omit_missing_resource_type(browser_tool, browser_manager):
+    """A backend that omits the field must still produce a clean line."""
+    browser_manager.network_requests = AsyncMock(
+        return_value={
+            "requests": [
+                {"index": 1, "method": "POST", "url": "https://example.com/x", "status": None, "failure": "blocked"}
+            ]
+        }
+    )
+
+    output = await browser_tool.browser_network_requests()
+
+    assert "1: POST https://example.com/x => blocked" in output
+    assert "[" not in output.split("\n")[-1]
+
+
+def test_regex_and_tabs_schemas_document_their_constraints():
+    """Two different models sent index=0/url="" because the schema never said otherwise."""
+    find_regex = BROWSER_TOOL_SCHEMAS["browser_find"]["properties"]["regex"]["description"]
+    assert "alternation" in find_regex
+    assert "{n,m}" in find_regex
+
+    tabs = BROWSER_TOOL_SCHEMAS["browser_tabs"]["properties"]
+    assert "null" in tabs["index"]["description"]
+    assert "null" in tabs["url"]["description"]

--- a/tests/agent/tool_backend/test_workflow_tool.py
+++ b/tests/agent/tool_backend/test_workflow_tool.py
@@ -4,6 +4,7 @@ The sub-agent dispatch is stubbed, so these run without the LLM stack but exerci
 the real run_workflow code path (state-dir resolution, journal, emit, summary).
 """
 
+import asyncio
 import json
 from pathlib import Path
 from typing import Any
@@ -73,6 +74,7 @@ def _stub_dispatch() -> tuple[Any, list[tuple[Any, ...]]]:
         sub_agent_info_extra: Any = None,
         artifact_paths: Any = None,
         artifact_metadata: Any = None,
+        browser_manager_override: Any = None,
     ) -> tuple[str, int, Any]:
         calls.append((task, schema, sub_agent_info_extra, artifact_paths, artifact_metadata))
         if artifact_paths:
@@ -83,6 +85,72 @@ def _stub_dispatch() -> tuple[Any, list[tuple[Any, ...]]]:
         return (f"recap:{task}", 3, None)
 
     return dispatch_workflow_agent, calls
+
+
+@pytest.mark.asyncio
+async def test_browser_workflow_resolves_target_and_injects_concrete_manager(workflow_tool) -> None:
+    tool, _ = workflow_tool
+    concrete_manager = Mock()
+    selector = Mock()
+    selector.resolve_browser_target.return_value = concrete_manager
+    tool._agent_tool.browser_manager = selector
+    captured: list[Any] = []
+
+    async def stub(
+        agent_class: type[Any],
+        task: str,
+        *,
+        browser_manager_override: Any = None,
+        **kwargs: Any,
+    ) -> tuple[str, int, Any]:
+        captured.append((agent_class, task, browser_manager_override, kwargs))
+        return ("done", 1, None)
+
+    tool._agent_tool.dispatch_workflow_agent = stub
+    script = (
+        'meta = {"name": "browser-target", "description": "d"}\n'
+        'return await agent("browse", agent_type="browser", browser_target="chrome")\n'
+    )
+
+    await tool.run_workflow(script=script)
+
+    selector.resolve_browser_target.assert_called_once_with("chrome")
+    agent_class, task, browser_manager, kwargs = captured[0]
+    assert agent_class.__name__ == "BrowserAgent"
+    assert task == "browse"
+    assert browser_manager is concrete_manager
+    assert kwargs["sub_agent_info_extra"]["browser_target"] == "chrome"
+    assert kwargs["artifact_metadata"]["browser_target"] == "chrome"
+
+
+@pytest.mark.asyncio
+async def test_browser_workflow_serializes_runs_on_the_concrete_manager(workflow_tool) -> None:
+    tool, _ = workflow_tool
+    concrete_manager = Mock()
+    selector = Mock()
+    selector.resolve_browser_target.return_value = concrete_manager
+    tool._agent_tool.browser_manager = selector
+    running = 0
+    max_running = 0
+
+    async def stub(*args: Any, **kwargs: Any) -> tuple[str, int, Any]:
+        nonlocal running, max_running
+        assert kwargs["browser_manager_override"] is concrete_manager
+        running += 1
+        max_running = max(max_running, running)
+        await asyncio.sleep(0.01)
+        running -= 1
+        return ("done", 1, None)
+
+    tool._agent_tool.dispatch_workflow_agent = stub
+    script = (
+        'meta = {"name": "browser-lock", "description": "d"}\n'
+        'return await parallel([(lambda: agent("browse", agent_type="browser")) for _ in range(2)])\n'
+    )
+
+    await tool.run_workflow(script=script)
+
+    assert max_running == 1
 
 
 SCRIPT = """\

--- a/tests/benchmarks/test_edit_benchmark_providers.py
+++ b/tests/benchmarks/test_edit_benchmark_providers.py
@@ -141,4 +141,4 @@ def test_benchmark_is_not_part_of_installed_package_or_console_scripts() -> None
     pyproject = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
 
     assert pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]["packages"] == ["kolega_code"]
-    assert set(pyproject["project"]["scripts"]) == {"kolega-code"}
+    assert set(pyproject["project"]["scripts"]) == {"kolega-code", "kolega-code-browser-host"}

--- a/tests/browser_extension/__init__.py
+++ b/tests/browser_extension/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Chrome Native Messaging backend."""

--- a/tests/browser_extension/test_installer.py
+++ b/tests/browser_extension/test_installer.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+import kolega_code.browser_extension.installer as installer_module
+from kolega_code.browser_extension.installer import (
+    CHROME_EXTENSION_ID,
+    NATIVE_HOST_NAME,
+    NativeHostInstallError,
+    build_native_host_manifest,
+    chrome_extension_origin,
+    chrome_native_host_manifest_path,
+    install_native_host,
+    native_host_status,
+    resolve_channel_extension_id,
+    uninstall_native_host,
+)
+from kolega_code.browser_extension.runtime import UnsupportedRuntimeTransportError
+
+
+def executable(tmp_path: Path) -> Path:
+    path = tmp_path / "bin" / "kolega-code-browser-host"
+    path.parent.mkdir(parents=True)
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(0o700)
+    return path
+
+
+def install_paths(tmp_path: Path) -> tuple[Path, Path, Path]:
+    host = executable(tmp_path)
+    config = tmp_path / "state" / "native-host.json"
+    manifest = chrome_native_host_manifest_path(platform="darwin", home=tmp_path)
+    return host, config, manifest
+
+
+def test_install_status_and_uninstall_manage_owned_private_files(tmp_path: Path) -> None:
+    host, config, manifest_path = install_paths(tmp_path)
+    state_dir = tmp_path / "runtime-state"
+    status = install_native_host(
+        host_path=host,
+        platform="darwin",
+        home=tmp_path,
+        state_dir=state_dir,
+        host_config_path=config,
+    )
+    assert status.installed is True
+    assert status.valid is True
+    assert status.host_path == host.resolve()
+    assert status.extension_id == CHROME_EXTENSION_ID
+    assert json.loads(manifest_path.read_text(encoding="utf-8")) == build_native_host_manifest(host)
+    assert json.loads(config.read_text(encoding="utf-8")) == {
+        "extension_origin": chrome_extension_origin(),
+        "registry_dir": str((state_dir / "browser-extension" / "runtimes").resolve()),
+        "max_pending_requests": 256,
+        "max_runtimes": 16,
+    }
+    assert os.stat(manifest_path).st_mode & 0o077 == 0
+    assert os.stat(config).st_mode & 0o077 == 0
+    assert native_host_status(
+        platform="darwin",
+        home=tmp_path,
+        state_dir=state_dir,
+        host_config_path=config,
+        expected_host_path=host,
+    ).valid
+
+    assert uninstall_native_host(platform="darwin", home=tmp_path, host_config_path=config) is True
+    assert not manifest_path.exists()
+    assert not config.exists()
+    assert uninstall_native_host(platform="darwin", home=tmp_path, host_config_path=config) is False
+
+
+def test_status_rejects_a_manifest_pointing_to_a_different_executable(tmp_path: Path) -> None:
+    host, config, _ = install_paths(tmp_path)
+    state_dir = tmp_path / "runtime-state"
+    install_native_host(
+        host_path=host,
+        platform="darwin",
+        home=tmp_path,
+        state_dir=state_dir,
+        host_config_path=config,
+    )
+    unrelated = executable(tmp_path / "unrelated")
+    status = native_host_status(
+        platform="darwin",
+        home=tmp_path,
+        state_dir=state_dir,
+        host_config_path=config,
+        expected_host_path=unrelated,
+    )
+    assert status.installed is True
+    assert status.valid is False
+
+
+def test_install_refuses_foreign_manifest_without_modifying_config(tmp_path: Path) -> None:
+    host, config, manifest_path = install_paths(tmp_path)
+    manifest_path.parent.mkdir(parents=True)
+    original = '{"name":"some.other.host"}\n'
+    manifest_path.write_text(original, encoding="utf-8")
+    manifest_path.chmod(0o600)
+    with pytest.raises(NativeHostInstallError, match="foreign"):
+        install_native_host(
+            host_path=host,
+            platform="darwin",
+            home=tmp_path,
+            state_dir=tmp_path / "runtime-state",
+            host_config_path=config,
+        )
+    assert manifest_path.read_text(encoding="utf-8") == original
+    assert not config.exists()
+
+
+def test_install_refuses_foreign_config_without_modifying_manifest(tmp_path: Path) -> None:
+    host, config, manifest_path = install_paths(tmp_path)
+    config.parent.mkdir(parents=True)
+    config.write_text(
+        json.dumps(
+            {
+                "extension_origin": chrome_extension_origin(),
+                "registry_dir": str(tmp_path / "other-runtime"),
+                "max_runtimes": 16,
+                "max_pending_requests": 256,
+            }
+        ),
+        encoding="utf-8",
+    )
+    config.chmod(0o600)
+    with pytest.raises(NativeHostInstallError, match="another runtime"):
+        install_native_host(
+            host_path=host,
+            platform="darwin",
+            home=tmp_path,
+            state_dir=tmp_path / "runtime-state",
+            host_config_path=config,
+        )
+    assert not manifest_path.exists()
+
+
+def test_install_rolls_back_both_owned_files_after_a_mid_transaction_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host, config, manifest_path = install_paths(tmp_path)
+    state_dir = tmp_path / "runtime-state"
+    install_native_host(
+        host_path=host,
+        platform="darwin",
+        home=tmp_path,
+        state_dir=state_dir,
+        host_config_path=config,
+    )
+    original_config = config.read_bytes()
+    original_manifest = manifest_path.read_bytes()
+    real_write = installer_module._write_private_json
+
+    def fail_manifest(path: Path, value: dict[str, object]) -> None:
+        if path == manifest_path:
+            raise OSError("simulated manifest write failure")
+        real_write(path, value)
+
+    monkeypatch.setattr(installer_module, "_write_private_json", fail_manifest)
+    with pytest.raises(OSError, match="simulated"):
+        install_native_host(
+            host_path=host,
+            platform="darwin",
+            home=tmp_path,
+            state_dir=state_dir,
+            host_config_path=config,
+        )
+    assert config.read_bytes() == original_config
+    assert manifest_path.read_bytes() == original_manifest
+
+
+def test_uninstall_refuses_foreign_artifacts(tmp_path: Path) -> None:
+    _, config, manifest_path = install_paths(tmp_path)
+    manifest_path.parent.mkdir(parents=True)
+    original = '{"name":"some.other.host"}\n'
+    manifest_path.write_text(original, encoding="utf-8")
+    manifest_path.chmod(0o600)
+    with pytest.raises(NativeHostInstallError, match="foreign"):
+        uninstall_native_host(platform="darwin", home=tmp_path, host_config_path=config)
+    assert manifest_path.read_text(encoding="utf-8") == original
+
+
+def test_uninstall_validates_all_artifacts_before_removing_any(tmp_path: Path) -> None:
+    host, config, manifest_path = install_paths(tmp_path)
+    install_native_host(
+        host_path=host,
+        platform="darwin",
+        home=tmp_path,
+        state_dir=tmp_path / "runtime-state",
+        host_config_path=config,
+    )
+    original_manifest = manifest_path.read_bytes()
+    config.write_text("{malformed", encoding="utf-8")
+    with pytest.raises(NativeHostInstallError, match="malformed"):
+        uninstall_native_host(platform="darwin", home=tmp_path, host_config_path=config)
+    assert manifest_path.read_bytes() == original_manifest
+    assert config.read_text(encoding="utf-8") == "{malformed"
+
+
+def test_uninstall_restores_files_after_a_mid_transaction_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host, config, manifest_path = install_paths(tmp_path)
+    install_native_host(
+        host_path=host,
+        platform="darwin",
+        home=tmp_path,
+        state_dir=tmp_path / "runtime-state",
+        host_config_path=config,
+    )
+    original_config = config.read_bytes()
+    original_manifest = manifest_path.read_bytes()
+    real_unlink = Path.unlink
+    failed = False
+
+    def fail_config_unlink(path: Path, missing_ok: bool = False) -> None:
+        nonlocal failed
+        if path == config and not failed:
+            failed = True
+            raise OSError("simulated config removal failure")
+        real_unlink(path, missing_ok=missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", fail_config_unlink)
+    with pytest.raises(OSError, match="simulated"):
+        uninstall_native_host(platform="darwin", home=tmp_path, host_config_path=config)
+    assert config.read_bytes() == original_config
+    assert manifest_path.read_bytes() == original_manifest
+
+
+def test_manifest_path_is_macos_only_and_channel_ids_are_exact(tmp_path: Path) -> None:
+    darwin = chrome_native_host_manifest_path(platform="darwin", home=tmp_path)
+    assert darwin == (
+        tmp_path
+        / "Library"
+        / "Application Support"
+        / "Google"
+        / "Chrome"
+        / "NativeMessagingHosts"
+        / f"{NATIVE_HOST_NAME}.json"
+    )
+    for platform in ("linux", "win32"):
+        with pytest.raises(UnsupportedRuntimeTransportError, match="only on macOS"):
+            chrome_native_host_manifest_path(platform=platform, home=tmp_path)
+    assert resolve_channel_extension_id() == ("production", CHROME_EXTENSION_ID)
+    with pytest.raises(NativeHostInstallError, match="conflicting"):
+        resolve_channel_extension_id(extension_id="b" * 32)
+    with pytest.raises(NativeHostInstallError, match="explicit"):
+        resolve_channel_extension_id(channel="dev")
+    assert resolve_channel_extension_id(channel="dev", extension_id="b" * 32) == ("dev", "b" * 32)
+
+
+@pytest.mark.parametrize("platform", ["linux", "win32"])
+def test_install_rejects_non_macos_without_writing_files(tmp_path: Path, platform: str) -> None:
+    host = executable(tmp_path)
+    state_dir = tmp_path / "state"
+    config = tmp_path / "native-host.json"
+
+    with pytest.raises(UnsupportedRuntimeTransportError, match="only on macOS"):
+        install_native_host(
+            host_path=host,
+            platform=platform,
+            home=tmp_path,
+            state_dir=state_dir,
+            host_config_path=config,
+        )
+
+    assert not state_dir.exists()
+    assert not config.exists()

--- a/tests/browser_extension/test_manager.py
+++ b/tests/browser_extension/test_manager.py
@@ -15,6 +15,7 @@ from kolega_code.browser_extension.manager import (
 )
 from kolega_code.browser_extension.multiplex import MultiplexedPeer
 from kolega_code.browser_extension.protocol import Envelope, MessageDirection
+from kolega_code.browser_extension.registry import RuntimeDescriptor
 from kolega_code.browser_extension.runtime import RuntimeServer
 
 ORIGIN = f"chrome-extension://{'a' * 32}/"
@@ -84,7 +85,7 @@ async def test_manager_waits_for_session_ready_then_serializes_calls(tmp_path: P
     browser._server = cast(RuntimeServer, server)
     await browser._handle_peer(cast(MultiplexedPeer, peer))
 
-    with pytest.raises(ChromeExtensionUnavailableError, match="not ready"):
+    with pytest.raises(ChromeExtensionUnavailableError, match="connected but has not confirmed a session"):
         await browser.navigate("https://example.com")
     await browser._handle_event(ready_event("browser.other"))
     assert browser.session_id is None
@@ -153,3 +154,129 @@ async def test_manager_preserves_browser_result_shapes(tmp_path: Path) -> None:
         {"target": None, "image_type": "png", "full_page": True, "scale": "device"},
     )
     await browser.cleanup_all_browsers()
+
+
+def _descriptor(runtime_id: str, session_id: str, pid: int = 4321) -> RuntimeDescriptor:
+    """Build an advertised runtime, as a second Kolega session would publish."""
+    now_ms = int(time.time() * 1000)
+    return RuntimeDescriptor(
+        runtime_id=runtime_id,
+        session_id=session_id,
+        transport="unix",
+        endpoint=f"/tmp/{runtime_id}.sock",
+        token="t" * 43,
+        pid=pid,
+        created_at_ms=now_ms,
+        expires_at_ms=now_ms + 60_000,
+        extension_origin=ORIGIN,
+    )
+
+
+def _advertise(
+    browser: ChromeExtensionBrowserManager,
+    monkeypatch: pytest.MonkeyPatch,
+    descriptors: list[RuntimeDescriptor],
+) -> None:
+    """Inject the advertised runtime list.
+
+    The registry's own liveness rules (TTL, live pid, owner-private socket) are
+    covered by the registry tests; here we only care about how the manager
+    reports pairing state.
+    """
+    monkeypatch.setattr(browser, "_live_runtimes", lambda: descriptors)
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_unreachable_without_a_connection(tmp_path: Path) -> None:
+    browser = manager(tmp_path)
+    browser._server = cast(RuntimeServer, FakeServer())
+
+    result = await browser.probe()
+
+    assert result["state"] == "unreachable"
+    assert result["connected"] is False
+    assert result["ready"] is False
+    assert "did not connect" in result["detail"]
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_awaiting_selection_and_names_competing_runtimes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A connected-but-unselected companion is a different problem from an absent
+    one, and the operator needs to know which picker entry is theirs."""
+    browser = manager(tmp_path)
+    browser._server = cast(RuntimeServer, FakeServer())
+    await browser._handle_peer(cast(MultiplexedPeer, FakePeer()))
+    _advertise(
+        browser,
+        monkeypatch,
+        [_descriptor("runtime_1", "session_1"), _descriptor("runtime_2", "session_2")],
+    )
+
+    result = await browser.probe()
+
+    assert result["state"] == "awaiting_selection"
+    assert result["connected"] is True
+    assert result["ready"] is False
+    assert {entry["runtime_id"] for entry in result["runtimes"]} == {"runtime_1", "runtime_2"}
+    assert [entry for entry in result["runtimes"] if entry["current"]][0]["runtime_id"] == "runtime_1"
+    assert "waiting for you to choose" in result["detail"]
+    assert "session_2" in result["detail"]
+    assert "this session" in result["detail"]
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_awaiting_selection_without_any_peer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The realistic pending-choice case has no peer at all.
+
+    The extension only dials a runtime's socket once that runtime is selected, so
+    keying "awaiting selection" off a connected peer made the state unreachable in
+    practice and every pending choice looked like a dead connection.
+    """
+    browser = manager(tmp_path)
+    browser._server = cast(RuntimeServer, FakeServer())
+    _advertise(
+        browser,
+        monkeypatch,
+        [_descriptor("runtime_1", "session_1"), _descriptor("runtime_2", "session_2")],
+    )
+
+    result = await browser.probe()
+
+    assert result["state"] == "awaiting_selection"
+    assert result["connected"] is False
+    assert "waiting for you to choose" in result["detail"]
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_paired_once_the_session_is_ready(tmp_path: Path) -> None:
+    browser = manager(tmp_path)
+    browser._server = cast(RuntimeServer, FakeServer())
+    await browser._handle_peer(cast(MultiplexedPeer, FakePeer()))
+    await browser._handle_event(ready_event())
+
+    result = await browser.probe()
+
+    assert result["state"] == "paired"
+    assert result["connected"] is True
+    assert result["ready"] is True
+    assert result["runtime_id"] == "runtime_1"
+
+
+@pytest.mark.asyncio
+async def test_unavailable_error_names_competing_runtimes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The operation error, not just doctor, must explain a blocked selection."""
+    browser = manager(tmp_path)
+    browser._server = cast(RuntimeServer, FakeServer())
+    await browser._handle_peer(cast(MultiplexedPeer, FakePeer()))
+    _advertise(
+        browser,
+        monkeypatch,
+        [_descriptor("runtime_1", "session_1"), _descriptor("runtime_2", "session_2")],
+    )
+
+    with pytest.raises(ChromeExtensionUnavailableError, match="waiting for you to choose"):
+        await browser.navigate("https://example.com")

--- a/tests/browser_extension/test_manager.py
+++ b/tests/browser_extension/test_manager.py
@@ -187,6 +187,52 @@ def _advertise(
 
 
 @pytest.mark.asyncio
+async def test_readiness_survives_a_relay_peer_reconnecting(tmp_path: Path) -> None:
+    """A reconnecting relay peer must not strand the session unconfirmed.
+
+    The extension announces browser.session_ready once per native connection, so
+    clearing readiness whenever the relay peer churned left the runtime stuck at
+    "connected but has not confirmed a session" with no way to recover short of
+    re-selecting in the popup. The native host only dials a runtime's socket to
+    relay a message the extension addressed to that runtime, so a peer existing at
+    all already proves this runtime is selected.
+    """
+    browser = manager(tmp_path)
+    browser._server = cast(RuntimeServer, FakeServer())
+    first = FakePeer()
+    await browser._handle_peer(cast(MultiplexedPeer, first))
+    await browser._handle_event(ready_event())
+    assert browser.session_id == "chrome:runtime_1"
+
+    # The relay drops; work must block, but the confirmation must not be lost.
+    await first.close()
+    await asyncio.sleep(0)
+    assert browser._peer is None
+    assert browser._ready is True
+
+    # A fresh relay peer, with no repeated session_ready, must be usable at once.
+    second = FakePeer()
+    await browser._handle_peer(cast(MultiplexedPeer, second))
+    result = await browser.navigate("https://example.com")
+    assert result["session_id"] == "chrome:runtime_1"
+    assert second.requests == [("browser.navigate", {"url": "https://example.com/"})]
+
+
+@pytest.mark.asyncio
+async def test_detach_still_clears_readiness(tmp_path: Path) -> None:
+    """Holding readiness across peer churn must not survive an explicit detach."""
+    browser = manager(tmp_path)
+    browser._server = cast(RuntimeServer, FakeServer())
+    await browser._handle_peer(cast(MultiplexedPeer, FakePeer()))
+    await browser._handle_event(ready_event())
+
+    await browser.close()
+
+    assert browser.session_id is None
+    assert browser._ready is False
+
+
+@pytest.mark.asyncio
 async def test_probe_reports_unreachable_without_a_connection(tmp_path: Path) -> None:
     browser = manager(tmp_path)
     browser._server = cast(RuntimeServer, FakeServer())

--- a/tests/browser_extension/test_manager.py
+++ b/tests/browser_extension/test_manager.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from kolega_code.browser_extension.manager import (
+    CHROME_EXTENSION_SUPPORTED_TOOLS,
+    ChromeExtensionBrowserManager,
+    ChromeExtensionProtocolError,
+    ChromeExtensionUnavailableError,
+)
+from kolega_code.browser_extension.multiplex import MultiplexedPeer
+from kolega_code.browser_extension.protocol import Envelope, MessageDirection
+from kolega_code.browser_extension.runtime import RuntimeServer
+
+ORIGIN = f"chrome-extension://{'a' * 32}/"
+
+
+class FakePeer:
+    def __init__(self) -> None:
+        self.closed = False
+        self.closed_event = asyncio.Event()
+        self.requests: list[tuple[str, dict[str, Any]]] = []
+        self.active = 0
+        self.max_active = 0
+
+    async def request(self, operation: str, params: dict[str, Any], *, timeout: float) -> dict[str, Any]:
+        self.requests.append((operation, params))
+        self.active += 1
+        self.max_active = max(self.max_active, self.active)
+        await asyncio.sleep(0.005)
+        self.active -= 1
+        return {"url": "https://example.com", "title": "Example", "result": {"operation": operation}}
+
+    async def close(self, reason: str = "") -> None:
+        self.closed = True
+        self.closed_event.set()
+
+    async def wait_closed(self) -> None:
+        await self.closed_event.wait()
+
+
+class FakeServer:
+    runtime_id = "runtime_1"
+
+    def __init__(self) -> None:
+        self.close_count = 0
+
+    async def close(self) -> None:
+        self.close_count += 1
+
+
+def manager(tmp_path: Path) -> ChromeExtensionBrowserManager:
+    return ChromeExtensionBrowserManager(
+        state_dir=tmp_path,
+        kolega_session_id="session_1",
+        extension_origin=ORIGIN,
+        connection_timeout=0.02,
+        operation_timeout=1,
+    )
+
+
+def ready_event(name: str = "browser.session_ready") -> Envelope:
+    return Envelope.event(
+        direction=MessageDirection.EXTENSION_TO_RUNTIME,
+        request_id="event_1",
+        runtime_id="runtime_1",
+        session_id="session_1",
+        deadline_ms=int(time.time() * 1000) + 1_000,
+        event=name,
+        data={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_manager_waits_for_session_ready_then_serializes_calls(tmp_path: Path) -> None:
+    browser = manager(tmp_path)
+    server = FakeServer()
+    peer = FakePeer()
+    browser._server = cast(RuntimeServer, server)
+    await browser._handle_peer(cast(MultiplexedPeer, peer))
+
+    with pytest.raises(ChromeExtensionUnavailableError, match="not ready"):
+        await browser.navigate("https://example.com")
+    await browser._handle_event(ready_event("browser.other"))
+    assert browser.session_id is None
+    await browser._handle_event(ready_event())
+    assert browser.session_id == "chrome:runtime_1"
+
+    first, second = await asyncio.gather(
+        browser.navigate("https://example.com"),
+        browser.press_key("A"),
+    )
+    assert first["result"] == {"operation": "browser.navigate"}
+    assert second["result"] == {"operation": "browser.press_key"}
+    assert first["session_id"] == "chrome:runtime_1"
+    assert peer.max_active == 1
+    assert peer.requests[:2] == [
+        ("browser.navigate", {"url": "https://example.com/"}),
+        ("browser.press_key", {"key": "A"}),
+    ]
+
+    closed_id = await browser.close()
+    assert closed_id == "chrome:runtime_1"
+    assert peer.requests[-1] == ("browser.detach", {})
+    assert browser.session_id is None
+    await browser.cleanup_all_browsers()
+    await browser.cleanup_all_browsers()
+    assert server.close_count == 1
+
+
+@pytest.mark.asyncio
+async def test_manager_validates_locally_and_fails_fast_for_unsupported_methods(tmp_path: Path) -> None:
+    browser = manager(tmp_path)
+    assert browser.browser_target == "chrome"
+    assert browser.supported_tools == CHROME_EXTENSION_SUPPORTED_TOOLS
+    with pytest.raises(ChromeExtensionProtocolError, match="index is required"):
+        await browser.tabs("select")
+    with pytest.raises(ChromeExtensionProtocolError, match="exactly one"):
+        await browser.find(text="x", regex="x")
+
+    unsupported = [
+        browser.resize(800, 600),
+        browser.drop("e1", data={"text/plain": "x"}),
+        browser.handle_dialog(True),
+        browser.file_upload([]),
+        browser.console_messages(),
+        browser.network_request(1),
+        browser.evaluate("() => 1"),
+    ]
+    for call in unsupported:
+        with pytest.raises(ChromeExtensionProtocolError):
+            await call
+    assert browser._server is None
+
+
+@pytest.mark.asyncio
+async def test_manager_preserves_browser_result_shapes(tmp_path: Path) -> None:
+    browser = manager(tmp_path)
+    browser._server = cast(RuntimeServer, FakeServer())
+    peer = FakePeer()
+    await browser._handle_peer(cast(MultiplexedPeer, peer))
+    await browser._handle_event(ready_event())
+    result = await browser.screenshot(target=None, image_type="png", full_page=True, scale="device")
+    assert result["url"] == "https://example.com"
+    assert result["result"] == {"operation": "browser.screenshot"}
+    assert peer.requests[-1] == (
+        "browser.screenshot",
+        {"target": None, "image_type": "png", "full_page": True, "scale": "device"},
+    )
+    await browser.cleanup_all_browsers()

--- a/tests/browser_extension/test_native_host.py
+++ b/tests/browser_extension/test_native_host.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import io
 import json
 import os
@@ -366,3 +367,79 @@ def test_broker_revalidates_fixed_operation_requests() -> None:
     with pytest.raises(ProtocolValidationError) as error:
         NativeHostBroker._validate_request(envelope)
     assert error.value.code == "unsupported_operation"
+
+
+@pytest.mark.asyncio
+async def test_broker_notifies_chrome_when_the_live_runtime_set_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Chrome only enumerates runtimes when it is prompted.
+
+    Without this notification a Kolega session that starts after the native port
+    opened stays invisible until the operator clicks the extension.
+    """
+    monkeypatch.setattr(
+        "kolega_code.browser_extension.native_host.RUNTIME_WATCH_INTERVAL_SECONDS",
+        0.01,
+    )
+    endpoint = FakeEndpoint()
+    registry = FakeRegistry([descriptor("runtime_1")])
+    broker = NativeHostBroker(
+        endpoint=cast(NativeMessageEndpoint, endpoint),
+        registry=cast(RuntimeDescriptorRegistry, registry),
+        extension_origin=ORIGIN,
+    )
+    broker._advertised = broker._advertised_runtime_ids()
+    watch = asyncio.create_task(broker._watch_runtimes())
+    try:
+        # A steady set must stay quiet, including across descriptor lease renewals
+        # that only advance expires_at_ms.
+        await asyncio.sleep(0.05)
+        assert endpoint.messages == []
+        renewed = descriptor("runtime_1")
+        object.__setattr__(renewed, "expires_at_ms", renewed.expires_at_ms + 30_000)
+        registry.descriptors["runtime_1"] = renewed
+        await asyncio.sleep(0.05)
+        assert endpoint.messages == []
+
+        # A newly registered runtime must prompt exactly one rediscovery.
+        registry.descriptors["runtime_2"] = descriptor("runtime_2")
+        for _ in range(200):
+            if endpoint.messages:
+                break
+            await asyncio.sleep(0.01)
+        assert endpoint.messages == [{"kind": "runtimes_changed", "protocol_version": 1}]
+
+        # A runtime going away also changes the set.
+        del registry.descriptors["runtime_1"]
+        for _ in range(200):
+            if len(endpoint.messages) > 1:
+                break
+            await asyncio.sleep(0.01)
+        assert endpoint.messages[-1] == {"kind": "runtimes_changed", "protocol_version": 1}
+        assert len(endpoint.messages) == 2
+    finally:
+        watch.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await watch
+        await broker.close()
+
+
+@pytest.mark.asyncio
+async def test_broker_close_stops_the_runtime_watcher(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "kolega_code.browser_extension.native_host.RUNTIME_WATCH_INTERVAL_SECONDS",
+        0.01,
+    )
+    endpoint = FakeEndpoint()
+    broker = NativeHostBroker(
+        endpoint=cast(NativeMessageEndpoint, endpoint),
+        registry=cast(RuntimeDescriptorRegistry, FakeRegistry([descriptor("runtime_1")])),
+        extension_origin=ORIGIN,
+    )
+    broker._watch_task = asyncio.create_task(broker._watch_runtimes())
+    await asyncio.sleep(0.02)
+
+    await broker.close()
+
+    assert broker._watch_task is None

--- a/tests/browser_extension/test_native_host.py
+++ b/tests/browser_extension/test_native_host.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from kolega_code.browser_extension.framing import read_message
+from kolega_code.browser_extension.native_host import (
+    NativeHostBroker,
+    NativeHostConfig,
+    NativeHostConfigurationError,
+    NativeMessageEndpoint,
+    load_host_config,
+)
+from kolega_code.browser_extension.multiplex import MultiplexedPeer, RequestTimeoutError
+from kolega_code.browser_extension.protocol import Envelope, MessageDirection, ProtocolValidationError
+from kolega_code.browser_extension.registry import RuntimeDescriptor, RuntimeDescriptorRegistry
+from kolega_code.browser_extension.runtime import RuntimeChannel
+
+ORIGIN = f"chrome-extension://{'a' * 32}/"
+OTHER_ORIGIN = f"chrome-extension://{'b' * 32}/"
+NOW = int(time.time() * 1000)
+
+
+def descriptor(runtime_id: str, origin: str = ORIGIN) -> RuntimeDescriptor:
+    return RuntimeDescriptor(
+        runtime_id=runtime_id,
+        session_id=f"session_{runtime_id[-1]}",
+        transport="unix",
+        endpoint=f"/tmp/{runtime_id}.sock",
+        token="x" * 32,
+        pid=os.getpid(),
+        created_at_ms=NOW,
+        expires_at_ms=NOW + 10_000,
+        extension_origin=origin,
+    )
+
+
+class FakeEndpoint:
+    def __init__(self) -> None:
+        self.messages: list[dict[str, Any]] = []
+
+    async def write(self, envelope: Envelope) -> None:
+        self.messages.append(cast(dict[str, Any], envelope.to_mapping()))
+
+    async def write_mapping(self, message: dict[str, object]) -> None:
+        self.messages.append(dict(message))
+
+
+class FakeRegistry:
+    def __init__(self, descriptors: list[RuntimeDescriptor]) -> None:
+        self.descriptors = {item.runtime_id: item for item in descriptors}
+
+    def list_active(self) -> list[RuntimeDescriptor]:
+        return list(self.descriptors.values())
+
+    def read(self, runtime_id: str) -> RuntimeDescriptor:
+        return self.descriptors[runtime_id]
+
+
+class FakeChannel:
+    outbound_direction = MessageDirection.RUNTIME_TO_EXTENSION
+    runtime_id = "runtime_1"
+    session_id = "session_1"
+
+    def __init__(self) -> None:
+        self.writes: list[Envelope] = []
+        self.closed = False
+        self.block = asyncio.Event()
+
+    async def write(self, envelope: Envelope) -> None:
+        self.writes.append(envelope)
+
+    async def read(self) -> Envelope | None:
+        await self.block.wait()
+        return None
+
+    async def close(self) -> None:
+        self.closed = True
+        self.block.set()
+
+
+def event_for(item: RuntimeDescriptor) -> Envelope:
+    return Envelope.event(
+        direction=MessageDirection.EXTENSION_TO_RUNTIME,
+        request_id=f"event_{item.runtime_id}",
+        runtime_id=item.runtime_id,
+        session_id=item.session_id,
+        deadline_ms=NOW + 10_000,
+        event="browser.session_ready",
+        data={},
+    )
+
+
+def test_host_config_is_exact_private_and_origin_bound(tmp_path: Path) -> None:
+    path = tmp_path / "host.json"
+    value = {
+        "extension_origin": ORIGIN,
+        "registry_dir": str(tmp_path / "runtimes"),
+        "max_runtimes": 4,
+        "max_pending_requests": 8,
+    }
+    path.write_text(json.dumps(value), encoding="utf-8")
+    path.chmod(0o600)
+    assert load_host_config(path) == NativeHostConfig(
+        extension_origin=ORIGIN,
+        registry_dir=tmp_path / "runtimes",
+        max_runtimes=4,
+        max_pending_requests=8,
+    )
+    path.write_text(json.dumps({**value, "extra": True}), encoding="utf-8")
+    with pytest.raises(NativeHostConfigurationError, match="invalid schema"):
+        load_host_config(path)
+    path.write_text(json.dumps(value), encoding="utf-8")
+    if hasattr(os, "getuid"):
+        path.chmod(0o644)
+        with pytest.raises(NativeHostConfigurationError, match="permissions"):
+            load_host_config(path)
+
+
+@pytest.mark.asyncio
+async def test_native_endpoint_serializes_concurrent_complete_frames() -> None:
+    output = io.BytesIO()
+    endpoint = NativeMessageEndpoint(io.BytesIO(), output, max_pending_writes=2)
+    await asyncio.gather(
+        endpoint.write_mapping({"sequence": 1}),
+        endpoint.write_mapping({"sequence": 2}),
+    )
+    await endpoint.close()
+    stream = io.BytesIO(output.getvalue())
+    first = read_message(stream)
+    second = read_message(stream)
+    assert first is not None
+    assert second is not None
+    assert {first["sequence"], second["sequence"]} == {1, 2}
+    assert read_message(stream) is None
+
+
+@pytest.mark.asyncio
+async def test_broker_discovers_only_exact_origin_and_routes_multiple_runtimes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = descriptor("runtime_1")
+    second = descriptor("runtime_2")
+    foreign = descriptor("runtime_3", OTHER_ORIGIN)
+    endpoint = FakeEndpoint()
+    registry = FakeRegistry([first, second, foreign])
+    channels: dict[str, FakeChannel] = {}
+
+    async def connect(item: RuntimeDescriptor, *, extension_origin: str, timeout: float) -> RuntimeChannel:
+        assert extension_origin == ORIGIN
+        assert timeout > 0
+        channel = channels.setdefault(item.runtime_id, FakeChannel())
+        return cast(RuntimeChannel, channel)
+
+    monkeypatch.setattr("kolega_code.browser_extension.native_host.connect_runtime_channel", connect)
+    broker = NativeHostBroker(
+        endpoint=cast(NativeMessageEndpoint, endpoint),
+        registry=cast(RuntimeDescriptorRegistry, registry),
+        extension_origin=ORIGIN,
+    )
+    await broker._list_runtimes({"kind": "list_runtimes", "protocol_version": 1, "request_id": "discover_1"})
+    assert endpoint.messages[0]["kind"] == "runtimes"
+    assert [item["runtime_id"] for item in endpoint.messages[0]["runtimes"]] == ["runtime_1", "runtime_2"]
+
+    await broker._route_from_extension(event_for(first))
+    await broker._route_from_extension(event_for(second))
+    assert channels["runtime_1"].writes == [event_for(first)]
+    assert channels["runtime_2"].writes == [event_for(second)]
+    await broker.close()
+    await broker.close()
+    assert all(channel.closed for channel in channels.values())
+
+
+@pytest.mark.asyncio
+async def test_broker_correlates_both_directions_and_enforces_deadlines(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    item = descriptor("runtime_1")
+    endpoint = FakeEndpoint()
+    channel = FakeChannel()
+
+    async def connect(runtime: RuntimeDescriptor, *, extension_origin: str, timeout: float) -> RuntimeChannel:
+        assert runtime == item
+        assert extension_origin == ORIGIN
+        assert timeout > 0
+        return cast(RuntimeChannel, channel)
+
+    monkeypatch.setattr("kolega_code.browser_extension.native_host.connect_runtime_channel", connect)
+    broker = NativeHostBroker(
+        endpoint=cast(NativeMessageEndpoint, endpoint),
+        registry=cast(RuntimeDescriptorRegistry, FakeRegistry([item])),
+        extension_origin=ORIGIN,
+    )
+    await broker._route_from_extension(event_for(item))
+    relay = broker._runtimes[item.runtime_id]
+
+    far_future_extension_request = Envelope.request(
+        direction=MessageDirection.EXTENSION_TO_RUNTIME,
+        request_id="far_future_extension_request",
+        runtime_id=item.runtime_id,
+        session_id=item.session_id,
+        deadline_ms=int(time.time() * 1000) + 301_000,
+        operation="browser.snapshot",
+        params={"target": None, "depth": None},
+    )
+    writes_before = len(channel.writes)
+    await broker._route_from_extension(far_future_extension_request)
+    assert endpoint.messages[-1]["payload"]["code"] == "invalid_deadline"
+    assert len(channel.writes) == writes_before
+    assert broker.pending_count == 0
+
+    far_future_runtime_request = Envelope.request(
+        direction=MessageDirection.RUNTIME_TO_EXTENSION,
+        request_id="far_future_runtime_request",
+        runtime_id=item.runtime_id,
+        session_id=item.session_id,
+        deadline_ms=int(time.time() * 1000) + 301_000,
+        operation="browser.snapshot",
+        params={"target": None, "depth": None},
+    )
+    endpoint_writes_before = len(endpoint.messages)
+    await broker._route_from_runtime(relay, far_future_runtime_request)
+    assert channel.writes[-1].payload["code"] == "invalid_deadline"
+    assert len(endpoint.messages) == endpoint_writes_before
+    assert broker.pending_count == 0
+
+    runtime_request = Envelope.request(
+        direction=MessageDirection.RUNTIME_TO_EXTENSION,
+        request_id="runtime_request",
+        runtime_id=item.runtime_id,
+        session_id=item.session_id,
+        deadline_ms=int(time.time() * 1000) + 1_000,
+        operation="browser.snapshot",
+        params={"target": None, "depth": None},
+    )
+    await broker._route_from_runtime(relay, runtime_request)
+    assert endpoint.messages[-1] == runtime_request.to_mapping()
+    response = Envelope.response_for(runtime_request, {"url": "https://example.com", "snapshot": "page"})
+    await broker._route_from_extension(response)
+    assert channel.writes[-1] == response
+    assert broker.pending_count == 0
+
+    expiring_request = Envelope.request(
+        direction=MessageDirection.EXTENSION_TO_RUNTIME,
+        request_id="expiring_request",
+        runtime_id=item.runtime_id,
+        session_id=item.session_id,
+        deadline_ms=int(time.time() * 1000) + 10,
+        operation="browser.snapshot",
+        params={"target": None, "depth": None},
+    )
+    await broker._route_from_extension(expiring_request)
+    assert channel.writes[-1] == expiring_request
+    await asyncio.sleep(0.03)
+    assert endpoint.messages[-1]["payload"]["code"] == "deadline_exceeded"
+    assert channel.writes[-1].type.value == "cancel"
+    assert broker.pending_count == 0
+    await broker.close()
+
+
+@pytest.mark.asyncio
+async def test_multiplex_rejects_a_response_delivered_after_its_absolute_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel = FakeChannel()
+    peer = MultiplexedPeer(cast(RuntimeChannel, channel))
+    pending = asyncio.create_task(
+        peer.request(
+            "browser.snapshot",
+            {"target": None, "depth": None},
+            timeout=1,
+            request_id="late_response",
+        )
+    )
+    while not channel.writes:
+        await asyncio.sleep(0)
+    sent = channel.writes[-1]
+    monkeypatch.setattr(
+        "kolega_code.browser_extension.multiplex.time.time",
+        lambda: (sent.deadline_ms + 1) / 1_000,
+    )
+    peer._handle_response(Envelope.response_for(sent, {"snapshot": "too late"}))
+    with pytest.raises(RequestTimeoutError, match="deadline"):
+        await pending
+    await peer.close()
+
+
+@pytest.mark.asyncio
+async def test_multiplex_request_deadline_includes_a_blocked_write() -> None:
+    class BlockingWriteChannel(FakeChannel):
+        async def write(self, envelope: Envelope) -> None:
+            self.writes.append(envelope)
+            await asyncio.Event().wait()
+
+    channel = BlockingWriteChannel()
+    peer = MultiplexedPeer(cast(RuntimeChannel, channel))
+    started = time.monotonic()
+    with pytest.raises(RequestTimeoutError, match="deadline"):
+        await peer.request(
+            "browser.snapshot",
+            {"target": None, "depth": None},
+            timeout=0.02,
+            request_id="blocked_write",
+        )
+    assert time.monotonic() - started < 0.15
+    assert peer.closed
+
+
+@pytest.mark.asyncio
+async def test_broker_rejects_a_response_after_the_absolute_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    item = descriptor("runtime_1")
+    endpoint = FakeEndpoint()
+    channel = FakeChannel()
+
+    async def connect(runtime: RuntimeDescriptor, *, extension_origin: str, timeout: float) -> RuntimeChannel:
+        assert runtime == item
+        assert extension_origin == ORIGIN
+        assert timeout > 0
+        return cast(RuntimeChannel, channel)
+
+    monkeypatch.setattr("kolega_code.browser_extension.native_host.connect_runtime_channel", connect)
+    broker = NativeHostBroker(
+        endpoint=cast(NativeMessageEndpoint, endpoint),
+        registry=cast(RuntimeDescriptorRegistry, FakeRegistry([item])),
+        extension_origin=ORIGIN,
+    )
+    await broker._route_from_extension(event_for(item))
+    relay = broker._runtimes[item.runtime_id]
+    pending_request = Envelope.request(
+        direction=MessageDirection.RUNTIME_TO_EXTENSION,
+        request_id="late_broker_response",
+        runtime_id=item.runtime_id,
+        session_id=item.session_id,
+        deadline_ms=int(time.time() * 1000) + 1_000,
+        operation="browser.snapshot",
+        params={"target": None, "depth": None},
+    )
+    await broker._route_from_runtime(relay, pending_request)
+    object.__setattr__(pending_request, "deadline_ms", int(time.time() * 1000) - 1)
+    late_response = Envelope.response_for(pending_request, {"snapshot": "late"})
+    await broker._route_from_extension(late_response)
+    assert channel.writes[-1].payload["code"] == "deadline_exceeded"
+    await broker.close()
+
+
+def test_broker_revalidates_fixed_operation_requests() -> None:
+    envelope = Envelope.request(
+        direction=MessageDirection.RUNTIME_TO_EXTENSION,
+        request_id="request_1",
+        runtime_id="runtime_1",
+        session_id="session_1",
+        deadline_ms=NOW + 10_000,
+        operation="browser.navigate",
+        params={"url": "https://example.com"},
+    )
+    object.__setattr__(envelope, "payload", {"operation": "browser.evaluate", "params": {}})
+    with pytest.raises(ProtocolValidationError) as error:
+        NativeHostBroker._validate_request(envelope)
+    assert error.value.code == "unsupported_operation"

--- a/tests/browser_extension/test_protocol.py
+++ b/tests/browser_extension/test_protocol.py
@@ -202,11 +202,124 @@ def test_url_normalization_and_regex_escapes_match_the_extension_contract() -> N
         with pytest.raises(ProtocolValidationError, match="restricted"):
             validate_operation_request("browser.navigate", {"url": f"https://{hostname}/detail/example"})
     for expression in (r"\xGG", r"\x0", r"\u123", r"\uZZZZ"):
-        with pytest.raises(ProtocolValidationError, match="unsafe expression"):
+        with pytest.raises(ProtocolValidationError, match="unsupported syntax"):
             validate_operation_request("browser.find", {"text": None, "regex": expression})
     for expression in (r"/\q/u", r"/\c/u", r"/\_/u"):
-        with pytest.raises(ProtocolValidationError, match="unsafe expression"):
+        with pytest.raises(ProtocolValidationError, match="unsupported syntax"):
             validate_operation_request("browser.find", {"text": None, "regex": expression})
+
+
+# Mirrors tests/operations.test.js in kolega-chrome-extension. The grammar is
+# duplicated across the two repos, so these cases must stay in lockstep or the
+# backends will accept different regex languages.
+ACCEPTED_PATTERNS = (
+    "QX-[0-9]{4}-ZT",
+    r"QX-\d{4}-ZT",
+    "QX-[0-9]+-ZT",
+    "QX-48.1-ZT",
+    "QX-[0-9][0-9][0-9][0-9]-ZT",
+    "a?b",
+    "a*b",
+    "[a-z]{2,5}",
+    "x{3,}",
+    "^abc$",
+    r"\x41+",
+    "/abc[0-9]+/i",
+    "a{1000}",
+    "a.{1,3}b",
+    "[0-9]{4}[a-z]{2}x*y+",
+    r"[a\-z]+",
+    "/x{2}/u",
+    r"\u0041{2}",
+)
+
+REJECTED_PATTERNS = (
+    ("(abc)+", "does not support groups"),
+    ("(?=a)", "does not support groups"),
+    ("(a+)+$", "does not support groups"),
+    ("[a](?:b)", "does not support groups"),
+    (r"(a)\1", "does not support groups"),
+    ("a|b", "does not support alternation"),
+    (r"\p{L}", "backreferences or unicode property escapes"),
+    (r"\k<x>", "backreferences or unicode property escapes"),
+    ("a*b*c*d*e*", "at most 4 quantifiers"),
+    ("a{1001}", "repetition counts up to 1000"),
+    ("*abc", "nothing to repeat"),
+    ("^*", "nothing to repeat"),
+    ("a**", "nothing to repeat"),
+    ("a{2,1}", "invalid repetition bound"),
+    ("a{abc}", "invalid repetition bound"),
+    ("a{", "unterminated repetition bound"),
+    ("[[a]]", "unsupported syntax"),
+    ("]", "unsupported syntax"),
+    ("}", "unsupported syntax"),
+    ("[abc", "is invalid"),
+    ("abc\\", "is invalid"),
+    ("/abc/z", "unsupported flags"),
+    ("/abc/ii", "unsupported flags"),
+)
+
+
+@pytest.mark.parametrize("expression", ACCEPTED_PATTERNS)
+def test_find_accepts_single_atom_quantifiers(expression: str) -> None:
+    """Quantifiers bound to one atom are linear-time, so they are supported."""
+    validated = validate_operation_request("browser.find", {"text": None, "regex": expression})
+    assert validated["regex"] == expression
+
+
+@pytest.mark.parametrize(("expression", "message"), REJECTED_PATTERNS)
+def test_find_rejects_unsupported_regex_constructs(expression: str, message: str) -> None:
+    """Grouping and alternation stay banned: they are what make backtracking blow up."""
+    with pytest.raises(ProtocolValidationError, match=message):
+        validate_operation_request("browser.find", {"text": None, "regex": expression})
+
+
+def test_network_filter_pattern_shares_the_find_grammar() -> None:
+    validated = validate_operation_request(
+        "browser.network_requests",
+        {"include_static": False, "filter_pattern": "/api/v[0-9]{1,2}/"},
+    )
+    assert validated["filter_pattern"] == "/api/v[0-9]{1,2}/"
+    with pytest.raises(ProtocolValidationError, match="does not support alternation"):
+        validate_operation_request(
+            "browser.network_requests",
+            {"include_static": False, "filter_pattern": "api|cdn"},
+        )
+
+
+def test_wait_for_accepts_text_and_text_gone_conditions() -> None:
+    """The text branches had no coverage, which is how a null deref shipped."""
+    for params in (
+        {"time": None, "text": "Ready", "text_gone": None},
+        {"time": None, "text": None, "text_gone": "Loading"},
+        {"time": None, "text": "Ready", "text_gone": "Loading"},
+        {"time": 1.5, "text": "Ready", "text_gone": "Loading"},
+    ):
+        assert validate_operation_request("browser.wait_for", dict(params)) == params
+    with pytest.raises(ProtocolValidationError, match="Provide time, text, or text_gone"):
+        validate_operation_request("browser.wait_for", {"time": None, "text": None, "text_gone": None})
+
+
+def test_tabs_parameter_errors_name_the_correct_shape() -> None:
+    """A bare 0 or "" for an inapplicable field burned a whole acceptance run."""
+    with pytest.raises(ProtocolValidationError, match=r"index is not accepted for the list tab action"):
+        validate_operation_request("browser.tabs", {"action": "list", "index": 0, "url": None})
+    with pytest.raises(ProtocolValidationError, match="pass index: null"):
+        validate_operation_request("browser.tabs", {"action": "new", "index": 0, "url": "https://example.com/"})
+    with pytest.raises(ProtocolValidationError, match="url is invalid"):
+        validate_operation_request("browser.tabs", {"action": "list", "index": None, "url": ""})
+    with pytest.raises(ProtocolValidationError, match="index is required when selecting a tab"):
+        validate_operation_request("browser.tabs", {"action": "select", "index": None, "url": None})
+    with pytest.raises(ProtocolValidationError, match="url is only accepted when creating a tab"):
+        validate_operation_request("browser.tabs", {"action": "select", "index": 2, "url": "https://example.com/"})
+    # A missing key must name itself rather than say "invalid schema".
+    with pytest.raises(ProtocolValidationError, match=r"missing index, url \(pass null when not applicable\)"):
+        validate_operation_request("browser.tabs", {"action": "list"})
+    with pytest.raises(ProtocolValidationError, match="unexpected extra"):
+        validate_operation_request(
+            "browser.tabs",
+            {"action": "list", "index": None, "url": None, "extra": 1},
+        )
 
 
 def test_discovery_messages_are_exact_v1_shapes() -> None:

--- a/tests/browser_extension/test_protocol.py
+++ b/tests/browser_extension/test_protocol.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import io
+import json
+import struct
+import time
+from typing import Any, cast
+
+import pytest
+
+from kolega_code.browser_extension.framing import (
+    FramingError,
+    MessageTooLargeError,
+    TruncatedMessageError,
+    encode_message,
+    read_message,
+    write_message,
+)
+from kolega_code.browser_extension.protocol import (
+    ALLOWED_OPERATIONS,
+    MAX_ERROR_MESSAGE_LENGTH,
+    PROTOCOL_VERSION,
+    Envelope,
+    MessageDirection,
+    MessageType,
+    ProtocolValidationError,
+    validate_discovery_request,
+    validate_discovery_response,
+    validate_operation_request,
+)
+
+NOW = int(time.time() * 1000)
+
+
+def request(operation: str = "browser.navigate", params: dict[str, Any] | None = None) -> Envelope:
+    return Envelope.request(
+        direction=MessageDirection.RUNTIME_TO_EXTENSION,
+        request_id="request_1",
+        runtime_id="runtime_1",
+        session_id="session_1",
+        deadline_ms=NOW + 10_000,
+        operation=operation,
+        params=params if params is not None else {"url": "https://example.com"},
+    )
+
+
+def test_v1_envelope_is_strict_and_round_trips() -> None:
+    envelope = request()
+    assert PROTOCOL_VERSION == 1
+    assert set(envelope.to_mapping()) == {
+        "version",
+        "direction",
+        "type",
+        "request_id",
+        "runtime_id",
+        "session_id",
+        "deadline_ms",
+        "payload",
+    }
+    assert Envelope.from_json(envelope.to_json()) == envelope
+    mapping = envelope.to_mapping()
+    mapping["extra"] = None
+    with pytest.raises(ProtocolValidationError, match="invalid schema"):
+        Envelope.from_mapping(mapping)
+    raw = envelope.to_json().replace('"version":1', '"version":1,"version":1')
+    with pytest.raises(ProtocolValidationError) as duplicate:
+        Envelope.from_json(raw)
+    assert duplicate.value.code == "duplicate_key"
+
+
+def test_payload_types_and_bounded_errors() -> None:
+    original = request()
+    result = {"page": {"html": "<main>normal browser data</main>"}, "items": [1, True, None]}
+    assert Envelope.response_for(original, result).payload["result"] == result
+    bounded = Envelope.error_for(original, code="failed", message="x" * 500)
+    assert len(cast(str, bounded.payload["message"])) == MAX_ERROR_MESSAGE_LENGTH
+    invalid = bounded.to_mapping()
+    invalid["payload"] = {"code": "failed", "message": "x" * 241, "retryable": False}
+    with pytest.raises(ProtocolValidationError, match="error message"):
+        Envelope.from_mapping(invalid)
+    assert Envelope.cancel_for(original, reason="done").direction is original.direction
+    event = Envelope.event(
+        direction=MessageDirection.EXTENSION_TO_RUNTIME,
+        request_id="event_1",
+        runtime_id="runtime_1",
+        session_id="session_1",
+        deadline_ms=NOW + 10_000,
+        event="browser.session_ready",
+        data={},
+    )
+    assert event.type is MessageType.EVENT
+
+
+def test_protocol_rejects_lone_surrogates_before_utf8_serialization() -> None:
+    original = request()
+    with pytest.raises(ProtocolValidationError, match="Unicode scalar"):
+        Envelope.response_for(original, {"text": "\ud800"})
+
+    escaped = json.dumps(
+        {
+            **Envelope.response_for(original, {"text": "safe"}).to_mapping(),
+            "payload": {"result": {"text": "\udfff"}},
+        }
+    ).encode()
+    with pytest.raises(ProtocolValidationError, match="Unicode scalar"):
+        Envelope.from_json(escaped)
+    with pytest.raises(ProtocolValidationError, match="valid Unicode"):
+        Envelope.from_json("\ud800")
+
+
+VALID_PARAMS: dict[str, dict[str, object]] = {
+    "browser.navigate": {"url": "https://example.com/"},
+    "browser.navigate_back": {},
+    "browser.snapshot": {"target": None, "depth": 3},
+    "browser.find": {"text": "Save", "regex": None},
+    "browser.wait_for": {"time": 0.1, "text": None, "text_gone": None},
+    "browser.click": {"target": "e1", "double_click": False, "button": "left", "modifiers": ["Shift"]},
+    "browser.type": {"target": "e1", "text": "hello", "submit": True, "slowly": False},
+    "browser.fill_form": {"fields": [{"name": "Email", "target": "e1", "type": "textbox", "value": "a@example.com"}]},
+    "browser.select_option": {"target": "e1", "values": ["blue"]},
+    "browser.hover": {"target": "e1"},
+    "browser.drag": {"start_target": "e1", "end_target": "e2"},
+    "browser.press_key": {"key": "ControlOrMeta+L"},
+    "browser.tabs": {"action": "list", "index": None, "url": None},
+    "browser.network_requests": {"include_static": False, "filter_pattern": None},
+    "browser.screenshot": {"target": None, "image_type": "png", "full_page": True, "scale": "css"},
+    "browser.detach": {},
+}
+
+
+def test_fixed_operation_surface_has_exactly_sixteen_schemas() -> None:
+    assert ALLOWED_OPERATIONS == frozenset(VALID_PARAMS)
+    assert len(ALLOWED_OPERATIONS) == 16
+
+
+@pytest.mark.parametrize(("operation", "params"), VALID_PARAMS.items())
+def test_fixed_operation_schemas(operation: str, params: dict[str, object]) -> None:
+    assert operation in ALLOWED_OPERATIONS
+    assert validate_operation_request(operation, params) == params
+    assert request(operation, params).payload["operation"] == operation
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        "browser.evaluate",
+        "browser.cdp",
+        "browser.cookies",
+        "browser.storage",
+        "browser.network_request",
+        "browser.file_upload",
+        "browser.drop",
+        "browser.console_messages",
+    ],
+)
+def test_dangerous_or_unknown_operations_are_rejected(operation: str) -> None:
+    with pytest.raises(ProtocolValidationError) as error:
+        validate_operation_request(operation, {})
+    assert error.value.code == "unsupported_operation"
+
+
+@pytest.mark.parametrize(
+    ("operation", "params"),
+    [
+        ("browser.navigate", {"url": "file:///tmp/a"}),
+        ("browser.find", {"text": "x", "regex": "x"}),
+        ("browser.wait_for", {"time": None, "text": None, "text_gone": None}),
+        ("browser.click", {"target": "e1", "double_click": False, "button": "left", "modifiers": ["Shift", "Shift"]}),
+        ("browser.fill_form", {"fields": []}),
+        ("browser.tabs", {"action": "select", "index": None, "url": None}),
+        ("browser.screenshot", {"target": "e1", "image_type": "png", "full_page": True, "scale": "css"}),
+    ],
+)
+def test_invalid_operation_parameters_are_rejected(operation: str, params: dict[str, object]) -> None:
+    with pytest.raises(ProtocolValidationError) as error:
+        validate_operation_request(operation, params)
+    assert error.value.code == "invalid_params"
+
+
+def test_url_normalization_and_regex_escapes_match_the_extension_contract() -> None:
+    assert validate_operation_request("browser.navigate", {"url": "localhost:3000/path"}) == {
+        "url": "http://localhost:3000/path"
+    }
+    assert validate_operation_request("browser.navigate", {"url": "example.com"}) == {"url": "https://example.com/"}
+    assert validate_operation_request("browser.navigate", {"url": "https://faß.de/"}) == {
+        "url": "https://xn--fa-hia.de/"
+    }
+    assert validate_operation_request("browser.navigate", {"url": "https://[0:0:0:0:0:0:0:1]/"}) == {
+        "url": "https://[::1]/"
+    }
+    with pytest.raises(ProtocolValidationError):
+        validate_operation_request("browser.navigate", {"url": "https://exa mple.com"})
+    for hostname in ("foo..bar", ".example.com", "-foo.com", "foo_.com"):
+        with pytest.raises(ProtocolValidationError, match="valid HTTP"):
+            validate_operation_request("browser.navigate", {"url": f"https://{hostname}/"})
+    for hostname in (
+        "chrome.google.com",
+        "chrome.google.com.",
+        "CHROMEWEBSTORE.GOOGLE.COM",
+        "chromewebstore.google.com.",
+    ):
+        with pytest.raises(ProtocolValidationError, match="restricted"):
+            validate_operation_request("browser.navigate", {"url": f"https://{hostname}/detail/example"})
+    for expression in (r"\xGG", r"\x0", r"\u123", r"\uZZZZ"):
+        with pytest.raises(ProtocolValidationError, match="unsafe expression"):
+            validate_operation_request("browser.find", {"text": None, "regex": expression})
+    for expression in (r"/\q/u", r"/\c/u", r"/\_/u"):
+        with pytest.raises(ProtocolValidationError, match="unsafe expression"):
+            validate_operation_request("browser.find", {"text": None, "regex": expression})
+
+
+def test_discovery_messages_are_exact_v1_shapes() -> None:
+    discovery = {"kind": "list_runtimes", "protocol_version": 1, "request_id": "discover_1"}
+    assert validate_discovery_request(discovery) == discovery
+    response = {
+        "kind": "runtimes",
+        "protocol_version": 1,
+        "request_id": "discover_1",
+        "runtimes": [
+            {
+                "runtime_id": "runtime_1",
+                "session_id": "session_1",
+                "created_at_ms": NOW,
+                "expires_at_ms": NOW + 1_000,
+            }
+        ],
+    }
+    assert validate_discovery_response(response, expected_request_id="discover_1") == response
+    for malformed in ({**discovery, "extra": True}, {**discovery, "protocol_version": 999}):
+        with pytest.raises(ProtocolValidationError):
+            validate_discovery_request(malformed)
+
+
+class _ChunkedBytesIO(io.BytesIO):
+    def read(self, size: int = -1) -> bytes:
+        return super().read(min(size, 1))
+
+
+class _PartialWriter(io.BytesIO):
+    def write(self, value: bytes | bytearray | memoryview) -> int:
+        return super().write(bytes(value[:2]))
+
+
+def test_native_framing_handles_partial_io_and_strict_json() -> None:
+    frame = encode_message({"hello": "world"})
+    assert read_message(_ChunkedBytesIO(frame)) == {"hello": "world"}
+    output = _PartialWriter()
+    write_message(output, {"hello": "world"})
+    assert read_message(io.BytesIO(output.getvalue())) == {"hello": "world"}
+    with pytest.raises(TruncatedMessageError):
+        read_message(io.BytesIO(struct.pack("<I", 4) + b"{}"))
+    duplicate = b'{"a":1,"a":2}'
+    with pytest.raises(FramingError, match="duplicate"):
+        read_message(io.BytesIO(struct.pack("<I", len(duplicate)) + duplicate))
+    with pytest.raises(MessageTooLargeError):
+        encode_message({"x": "large"}, max_bytes=2)
+    assert read_message(io.BytesIO()) is None
+    with pytest.raises(FramingError):
+        encode_message({"bad": float("nan")})
+
+
+def test_native_framing_counts_utf8_bytes_without_ascii_escape_inflation() -> None:
+    value = {"text": "é" * 10}
+    encoded = json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    frame = encode_message(value, max_bytes=len(encoded))
+    assert struct.unpack("<I", frame[:4]) == (len(encoded),)
+    assert frame[4:] == encoded
+    with pytest.raises(MessageTooLargeError):
+        encode_message(value, max_bytes=len(encoded) - 1)
+
+
+def test_generated_envelopes_cannot_exceed_the_protocol_frame_bound() -> None:
+    with pytest.raises(ProtocolValidationError) as error:
+        Envelope.response_for(request(), {"text": "é" * 600_000})
+    assert error.value.code == "message_too_large"
+
+
+def test_protocol_json_rejects_non_finite_and_non_object_payloads() -> None:
+    raw = request().to_mapping()
+    raw["payload"] = {"result": float("inf")}
+    raw["type"] = "response"
+    with pytest.raises(ProtocolValidationError):
+        Envelope.from_mapping(raw)
+    encoded = json.dumps(request().to_mapping()).encode()
+    assert Envelope.from_json(encoded) == request()
+    with pytest.raises(ProtocolValidationError) as error:
+        Envelope.from_json(b'{"version":NaN}')
+    assert error.value.code == "invalid_json"

--- a/tests/browser_extension/test_runtime.py
+++ b/tests/browser_extension/test_runtime.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from kolega_code.browser_extension.multiplex import ConnectionClosedError, RequestTimeoutError
+from kolega_code.browser_extension.protocol import JSONValue, Envelope
+from kolega_code.browser_extension.registry import (
+    DescriptorSecurityError,
+    RuntimeDescriptor,
+    RuntimeDescriptorRegistry,
+)
+from kolega_code.browser_extension.runtime import (
+    RuntimeAuthenticationError,
+    RuntimeServer,
+    UnsupportedRuntimeTransportError,
+    connect_runtime_channel,
+    connect_runtime_peer,
+    ensure_runtime_transport_supported,
+    selected_runtime_transport,
+)
+
+ORIGIN = f"chrome-extension://{'a' * 32}/"
+OTHER_ORIGIN = f"chrome-extension://{'b' * 32}/"
+
+
+def test_runtime_descriptor_is_exact_and_macos_only() -> None:
+    now = int(time.time() * 1000)
+    descriptor = RuntimeDescriptor(
+        runtime_id="runtime_1",
+        session_id="session_1",
+        transport="unix",
+        endpoint="/tmp/runtime_1.sock",
+        token="x" * 32,
+        pid=os.getpid(),
+        created_at_ms=now,
+        expires_at_ms=now + 1_000,
+        extension_origin=ORIGIN,
+    )
+    assert descriptor.endpoint == "/tmp/runtime_1.sock"
+    assert set(descriptor.to_mapping()) == {
+        "protocol_version",
+        "runtime_id",
+        "session_id",
+        "transport",
+        "endpoint",
+        "token",
+        "pid",
+        "created_at_ms",
+        "expires_at_ms",
+        "extension_origin",
+    }
+    assert selected_runtime_transport(platform="darwin") == "unix"
+    for platform in ("linux", "win32"):
+        with pytest.raises(UnsupportedRuntimeTransportError, match="only on macOS"):
+            ensure_runtime_transport_supported(platform=platform)
+
+
+@pytest.mark.asyncio
+async def test_unix_runtime_auth_multiplex_timeout_disconnect_and_cleanup(tmp_path: Path) -> None:
+    registry = RuntimeDescriptorRegistry(tmp_path / "runtimes")
+    cancelled = asyncio.Event()
+    blocked = asyncio.Event()
+
+    async def handle(envelope: Envelope) -> JSONValue:
+        operation = envelope.payload["operation"]
+        if operation == "browser.snapshot":
+            return {"url": "https://example.com", "snapshot": "- button: Save"}
+        if operation == "browser.navigate_back":
+            try:
+                await asyncio.Event().wait()
+            finally:
+                cancelled.set()
+        await blocked.wait()
+        return {}
+
+    server = RuntimeServer(
+        registry,
+        session_id="session_1",
+        extension_origin=ORIGIN,
+        request_handler=None,
+        platform="darwin",
+    )
+    descriptor = await server.start()
+    extension_peer = await connect_runtime_peer(
+        descriptor,
+        extension_origin=ORIGIN,
+        request_handler=handle,
+        platform="darwin",
+    )
+    runtime_peer = await server.wait_for_connection(timeout=1)
+    assert await runtime_peer.request(
+        "browser.snapshot",
+        {"target": None, "depth": None},
+        timeout=1,
+    ) == {"url": "https://example.com", "snapshot": "- button: Save"}
+
+    with pytest.raises(RequestTimeoutError):
+        await runtime_peer.request("browser.navigate_back", {}, timeout=0.02)
+    await asyncio.wait_for(cancelled.wait(), timeout=1)
+    assert runtime_peer.pending_count == 0
+
+    pending = asyncio.create_task(runtime_peer.request("browser.press_key", {"key": "A"}, timeout=1))
+    while extension_peer.inflight_count == 0:
+        await asyncio.sleep(0)
+    await extension_peer.close()
+    with pytest.raises(ConnectionClosedError):
+        await pending
+
+    await server.close()
+    await server.close()
+    assert not Path(descriptor.endpoint).exists()
+    assert not (registry.root / f"{descriptor.runtime_id}.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_runtime_rejects_wrong_origin_and_registry_permissions(tmp_path: Path) -> None:
+    registry = RuntimeDescriptorRegistry(tmp_path / "runtimes")
+    server = RuntimeServer(registry, session_id="session_1", extension_origin=ORIGIN, platform="darwin")
+    descriptor = await server.start()
+    with pytest.raises(RuntimeAuthenticationError):
+        await connect_runtime_channel(descriptor, extension_origin=OTHER_ORIGIN, platform="darwin")
+    descriptor_path = registry.root / f"{descriptor.runtime_id}.json"
+    if hasattr(os, "getuid"):
+        descriptor_path.chmod(0o644)
+        with pytest.raises(DescriptorSecurityError):
+            registry.read(descriptor.runtime_id)
+        descriptor_path.chmod(0o600)
+    assert registry.unregister(descriptor.runtime_id, token="wrong") is False
+    assert registry.read(descriptor.runtime_id) == descriptor
+    await server.close()

--- a/tests/cli/test_app_agent_wiring.py
+++ b/tests/cli/test_app_agent_wiring.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import asyncio
 import json
 import time
+from unittest.mock import Mock
 
 import pytest
 
@@ -47,6 +48,47 @@ from ._app_test_utils import (
 
 class FakePlanningAgent(FakeCoderAgent):
     pass
+
+
+@pytest.mark.asyncio
+async def test_textual_app_builds_the_configured_browser_manager(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.app import KolegaCodeApp
+
+    install_fake_agents(monkeypatch, planning_cls=FakePlanningAgent)
+    browser_manager = Mock()
+    build_browser_manager = Mock(return_value=browser_manager)
+    monkeypatch.setattr(
+        "kolega_code.cli.tui.agent_runtime.build_browser_manager",
+        build_browser_manager,
+    )
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(
+        project_path=project,
+        config=config,
+        mode="code",
+        store=store,
+        session=session,
+        browser_visible=True,
+    )
+
+    async with app.run_test():
+        assert isinstance(app.agent, FakeCoderAgent)
+        assert app.agent.kwargs["browser_manager"] is browser_manager
+        build_browser_manager.assert_called_once_with(
+            store.root,
+            session.session_id,
+            browser_visible=True,
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_browser_backend.py
+++ b/tests/cli/test_browser_backend.py
@@ -1,0 +1,138 @@
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from kolega_code.browser_extension.installer import CHROME_EXTENSION_ID, NativeHostStatus
+from kolega_code.browser_extension.manager import ChromeExtensionUnavailableError
+from kolega_code.browser_extension.native_host import NativeHostConfigurationError
+from kolega_code.cli.browser_backend import _configured_extension_origin, build_browser_manager
+from kolega_code.services.browser import PlaywrightBrowserManager
+
+_EXTENSION_ORIGIN = "chrome-extension://edihigldhbmimflgjkohkgnjefmhngdn/"
+
+
+def test_configuration_requires_a_valid_native_host(tmp_path: Path) -> None:
+    status = NativeHostStatus(
+        manifest_path=tmp_path / "manifest.json",
+        installed=True,
+        valid=True,
+        host_path=tmp_path / "host",
+        extension_id=CHROME_EXTENSION_ID,
+        detail="valid",
+    )
+    with (
+        patch(
+            "kolega_code.cli.browser_backend.configured_extension_origin",
+            return_value=_EXTENSION_ORIGIN,
+        ),
+        patch("kolega_code.cli.browser_backend.native_host_status", return_value=status) as host_status,
+    ):
+        assert _configured_extension_origin(tmp_path) == _EXTENSION_ORIGIN
+
+    host_status.assert_called_once_with(
+        channel="production",
+        extension_id=None,
+        state_dir=tmp_path,
+    )
+
+
+def test_configured_chrome_target_is_advertised(tmp_path: Path) -> None:
+    with patch(
+        "kolega_code.cli.browser_backend._configured_extension_origin",
+        return_value=_EXTENSION_ORIGIN,
+    ):
+        manager = build_browser_manager(tmp_path, "session-1")
+
+        assert manager.browser_targets == ("playwright", "chrome")
+
+
+def test_default_and_playwright_targets_resolve_to_default_manager(tmp_path: Path) -> None:
+    manager = build_browser_manager(tmp_path, "session-1")
+
+    assert manager.resolve_browser_target() is manager
+    assert manager.resolve_browser_target("playwright") is manager
+
+
+def test_chrome_target_is_created_lazily_and_cached(tmp_path: Path) -> None:
+    chrome = Mock()
+    with (
+        patch(
+            "kolega_code.cli.browser_backend._configured_extension_origin",
+            return_value=_EXTENSION_ORIGIN,
+        ) as configured_origin,
+        patch(
+            "kolega_code.cli.browser_backend.ChromeExtensionBrowserManager",
+            return_value=chrome,
+        ) as chrome_manager,
+    ):
+        manager = build_browser_manager(tmp_path, "session-1")
+
+        chrome_manager.assert_not_called()
+        assert manager.resolve_browser_target("chrome") is chrome
+        assert manager.resolve_browser_target("chrome") is chrome
+
+    configured_origin.assert_called_once_with(tmp_path)
+    chrome_manager.assert_called_once_with(
+        state_dir=tmp_path,
+        kolega_session_id="session-1",
+        extension_origin=_EXTENSION_ORIGIN,
+    )
+
+
+def test_unconfigured_chrome_target_is_not_advertised_or_fallback(tmp_path: Path) -> None:
+    with patch(
+        "kolega_code.cli.browser_backend._configured_extension_origin",
+        side_effect=NativeHostConfigurationError("not configured"),
+    ):
+        manager = build_browser_manager(tmp_path, "session-1")
+
+        assert manager.browser_targets == ("playwright",)
+        with pytest.raises(ChromeExtensionUnavailableError, match=r"kolega-code browser install"):
+            manager.resolve_browser_target("chrome")
+
+
+@pytest.mark.parametrize(
+    ("browser_visible", "expected_headless"),
+    [(False, True), (True, False)],
+)
+def test_factory_sets_cli_fields_and_playwright_visibility(
+    tmp_path: Path,
+    browser_visible: bool,
+    expected_headless: bool,
+) -> None:
+    manager = build_browser_manager(tmp_path, "session-1", browser_visible)
+
+    assert isinstance(manager, PlaywrightBrowserManager)
+    assert manager.state_dir == tmp_path
+    assert manager.kolega_session_id == "session-1"
+    assert manager.headless is expected_headless
+
+
+@pytest.mark.asyncio
+async def test_cleanup_attempts_chrome_and_playwright_cleanup(tmp_path: Path) -> None:
+    chrome = Mock()
+    chrome.cleanup_all_browsers = AsyncMock(side_effect=RuntimeError("chrome cleanup failed"))
+    with (
+        patch(
+            "kolega_code.cli.browser_backend._configured_extension_origin",
+            return_value=_EXTENSION_ORIGIN,
+        ),
+        patch(
+            "kolega_code.cli.browser_backend.ChromeExtensionBrowserManager",
+            return_value=chrome,
+        ),
+        patch.object(
+            PlaywrightBrowserManager,
+            "cleanup_all_browsers",
+            new_callable=AsyncMock,
+        ) as playwright_cleanup,
+    ):
+        manager = build_browser_manager(tmp_path, "session-1")
+        manager.resolve_browser_target("chrome")
+
+        with pytest.raises(RuntimeError, match="chrome cleanup failed"):
+            await manager.cleanup_all_browsers()
+
+    chrome.cleanup_all_browsers.assert_awaited_once_with()
+    playwright_cleanup.assert_awaited_once_with()

--- a/tests/cli/test_browser_cli.py
+++ b/tests/cli/test_browser_cli.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import argparse
+import json
+import tomllib
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kolega_code.browser_extension.installer import (
+    CHROME_EXTENSION_ID,
+    CHROME_WEB_STORE_URL,
+    NativeHostStatus,
+)
+from kolega_code.cli.main import _run_browser, parse_args
+
+
+def _args(command: str, tmp_path: Path, *, json_output: bool = True) -> argparse.Namespace:
+    return argparse.Namespace(
+        browser_command=command,
+        channel="production",
+        extension_id=None,
+        state_dir=tmp_path,
+        host_path=None,
+        json=json_output,
+    )
+
+
+def _status(tmp_path: Path, *, valid: bool = True) -> NativeHostStatus:
+    return NativeHostStatus(
+        manifest_path=tmp_path / "ai.kolega.browser.json",
+        installed=True,
+        valid=valid,
+        host_path=tmp_path / "kolega-code-browser-host",
+        extension_id=CHROME_EXTENSION_ID,
+        detail="valid" if valid else "stale",
+    )
+
+
+def test_browser_subcommands_parse_registration_options(tmp_path: Path) -> None:
+    args = parse_args(
+        [
+            "browser",
+            "install",
+            "--state-dir",
+            str(tmp_path),
+            "--host-path",
+            str(tmp_path / "host"),
+            "--channel",
+            "dev",
+            "--extension-id",
+            "a" * 32,
+            "--json",
+        ]
+    )
+
+    assert args.command == "browser"
+    assert args.browser_command == "install"
+    assert args.state_dir == tmp_path
+    assert args.host_path == tmp_path / "host"
+    assert args.channel == "dev"
+    assert args.extension_id == "a" * 32
+    assert args.json is True
+
+
+def test_browser_install_reports_status_and_opens_the_production_listing(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = _status(tmp_path)
+    with (
+        patch("kolega_code.cli.main.install_native_host", return_value=status) as install,
+        patch("kolega_code.cli.main.webbrowser.open") as open_browser,
+    ):
+        result = _run_browser(_args("install", tmp_path))
+
+    assert result == 0
+    install.assert_called_once_with(
+        host_path=None,
+        channel="production",
+        extension_id=None,
+        state_dir=tmp_path,
+    )
+    open_browser.assert_called_once_with(CHROME_WEB_STORE_URL)
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["valid"] is True
+    assert payload["web_store_url"] == CHROME_WEB_STORE_URL
+
+
+def test_browser_status_and_doctor_return_one_for_invalid_configuration(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with patch("kolega_code.cli.main.native_host_status", return_value=_status(tmp_path, valid=False)):
+        assert _run_browser(_args("status", tmp_path)) == 1
+        status_payload = json.loads(capsys.readouterr().out)
+        assert status_payload["valid"] is False
+
+        assert _run_browser(_args("doctor", tmp_path)) == 1
+        doctor_payload = json.loads(capsys.readouterr().out)
+        assert "browser install" in doctor_payload["remediation"]
+
+
+def test_browser_uninstall_is_a_successful_noop_when_not_installed(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with patch("kolega_code.cli.main.uninstall_native_host", return_value=False) as uninstall:
+        assert _run_browser(_args("uninstall", tmp_path)) == 0
+
+    uninstall.assert_called_once_with(channel="production", extension_id=None)
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["removed"] is False
+
+
+def test_browser_command_errors_return_two(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    with patch("kolega_code.cli.main.native_host_status", side_effect=RuntimeError("unsafe manifest")):
+        assert _run_browser(_args("status", tmp_path)) == 2
+
+    assert json.loads(capsys.readouterr().out)["error"] == "unsafe manifest"
+
+
+def test_native_host_console_entry_point_is_packaged() -> None:
+    metadata = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+
+    assert (
+        metadata["project"]["scripts"]["kolega-code-browser-host"] == "kolega_code.browser_extension.native_host:main"
+    )

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
@@ -437,6 +438,9 @@ def test_ask_skill_with_prompt_activates_before_dispatch(
     monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
     monkeypatch.setenv("KOLEGA_CODE_PROVIDER", "anthropic")
     monkeypatch.setattr(main_module, "CoderAgent", FakeCoderAgent)
+    browser_manager = object()
+    build_browser_manager = Mock(return_value=browser_manager)
+    monkeypatch.setattr(main_module, "build_browser_manager", build_browser_manager)
 
     exit_code = main_module.main(["ask", "/demo-skill do the task", "--project", str(project)])
 
@@ -444,6 +448,8 @@ def test_ask_skill_with_prompt_activates_before_dispatch(
     output = capsys.readouterr().out
     assert "ok" in output
     agent = FakeCoderAgent.instances[0]
+    assert agent.kwargs["browser_manager"] is browser_manager
+    assert build_browser_manager.call_args.kwargs["browser_visible"] is False
     assert agent.messages == ["do the task"]
     assert '<skill_content name="demo-skill">' in agent.history[0].get_text_content()
     assert any(extension.name == "cli-agent-skills" for extension in agent.kwargs["tool_extensions"])

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-21T13:49:55.620956Z"
+exclude-newer = "2026-07-22T09:56:40.449154Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1533,6 +1533,7 @@ dependencies = [
     { name = "firecrawl-py" },
     { name = "google-genai" },
     { name = "httpx" },
+    { name = "idna" },
     { name = "jinja2" },
     { name = "langfuse" },
     { name = "lxml-html-clean" },
@@ -1589,6 +1590,7 @@ requires-dist = [
     { name = "genbadge", extras = ["coverage"], marker = "extra == 'dev'", specifier = "==1.1.3" },
     { name = "google-genai", specifier = "==2.12.1" },
     { name = "httpx", specifier = "==0.28.1" },
+    { name = "idna", specifier = "==3.18" },
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "langfuse", specifier = "==3.14.5" },
     { name = "lxml-html-clean", specifier = "==0.4.5" },


### PR DESCRIPTION
## Summary

- add an opt-in, macOS-only Chrome backend using Native Messaging while retaining Playwright as the default
- preserve Playwright and sandbox-provider isolation through explicit backend routing and capability filtering
- implement strict protocol v1 with exactly 16 typed browser operations
- add CLI setup/status/removal flows, TUI and agent wiring, lifecycle management, packaging, tests, and user documentation
- exclude arbitrary JavaScript execution and raw CDP access by design

Companion extension PR: https://github.com/kolega-ai/kolega-chrome-extension/pull/1

## Security boundaries

- Chrome control is opt-in; existing Playwright and sandbox paths remain separate and unchanged by default
- the native host accepts only the fixed protocol-v1 operation set and validates typed request/response payloads
- browser access remains constrained by the companion extension's install-time origin consent and eligible-tab tracking
- deterministic navigation destinations are preflighted by the companion and fail closed for restricted targets
- agent-created `about:blank` tabs do not become eligible control targets
- no generic script evaluation, generic CDP passthrough, cookies/storage access, response bodies, or raw authorization headers

## Repository split

This PR contains the Kolega Code host backend and integration. The separately installable extension, its package validation, and its browser-side security boundary are reviewed in companion PR https://github.com/kolega-ai/kolega-chrome-extension/pull/1.

## Verification

- focused host regression suite — 63 passed
- full fast host suite — 3469 passed, 1 skipped, 104 deselected
- `uv run pre-commit run --all-files --show-diff-on-failure`
- built wheel and sdist inspected for the expected backend files and absence of unrelated/private files
- companion extension `npm run check` — 41/41 tests, static security scan, package validation, and deterministic production ZIP

## Scope notes

- macOS is the only supported Chrome Native Messaging platform in this change
- Playwright remains the default browser backend
- network URL redaction behavior is unchanged
