### PR TITLE
perf(agent): cache history image resizes and move them off the event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+### Fixed
+
+- Stopped image-heavy sessions from freezing the TUI. Building request history
+  re-encoded every screenshot in history on every LLM request, on the event
+  loop — dozens of multi-second stalls per session, multiplied by each running
+  sub-agent. Resized copies are now memoized per image and dimension cap
+  (surviving the small byte-budget shifts a newly captured screenshot causes),
+  and the repair/adapt pass runs in a worker thread.
+
 ## 0.25.2 - 2026-07-28
 
 ### Fixed

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -514,7 +514,21 @@ class BaseAgent(LogMixin):
         request copy only — the stored history is never mutated, so switching
         back to a vision-capable model restores the images.
         """
+        return self._finalize_history_for_llm(self.get_effective_history_for_llm())
+
+    async def _history_for_llm_async(self) -> MessageHistory:
+        """``_history_for_llm`` with the repair+adapt pass off the event loop.
+
+        Adapting history images for Anthropic decodes and re-encodes
+        screenshots with PIL. Run inline on the event loop this froze the TUI
+        for seconds per request, once per concurrently running (sub-)agent.
+        The effective-history snapshot is taken on the loop so the worker
+        thread never observes a concurrent history mutation.
+        """
         effective = self.get_effective_history_for_llm()
+        return await asyncio.to_thread(self._finalize_history_for_llm, effective)
+
+    def _finalize_history_for_llm(self, effective: MessageHistory) -> MessageHistory:
         fixed = self.fix_incomplete_tool_calls(list(effective))
         provider = getattr(self.primary_model_config.provider, "value", self.primary_model_config.provider)
         fixed = adapt_history_for_provider(
@@ -835,7 +849,7 @@ class BaseAgent(LogMixin):
             self._sanitize_oversized_tool_results()
             # History sent to the LLM (and to token counting): tool-call-repaired and,
             # for non-vision models, stripped of image blocks from earlier turns.
-            fixed_history = self._history_for_llm()
+            fixed_history = await self._history_for_llm_async()
         assert self.tool_collection is not None, "tool_collection must be initialized before counting context"
         token_count = await self.llm.count_tokens(
             system=self.system_prompt,
@@ -1793,7 +1807,7 @@ class BaseAgent(LogMixin):
                 # count and the request below — the repair+adapt+image-strip pass is
                 # O(history) and ran twice per iteration before.
                 self._sanitize_oversized_tool_results()
-                fixed_history = self._history_for_llm()
+                fixed_history = await self._history_for_llm_async()
                 token_count = await self.count_current_context(fixed_history)
                 logger.debug("Input token count: %s", token_count)
 
@@ -1813,7 +1827,7 @@ class BaseAgent(LogMixin):
                     # checkpoint before re-counting so the reused history reflects it.
                     self.mark_cache_checkpoint()
                     self._sanitize_oversized_tool_results()
-                    fixed_history = self._history_for_llm()
+                    fixed_history = await self._history_for_llm_async()
                     token_count = await self.count_current_context(fixed_history)
 
                     # PostCompact hooks (advisory): observe the outcome. There is no

--- a/kolega_code/agent/conversation.py
+++ b/kolega_code/agent/conversation.py
@@ -58,7 +58,7 @@ def _adapt_image_block_for_provider(
     if target_provider != "anthropic" or block.image_type != "base64":
         return block, False
 
-    result = image_utils.resize_base64_image_to_limit(
+    result = image_utils.resize_base64_image_to_limit_cached(
         block.data,
         block.media_type,
         max_base64_bytes=max_image_base64_bytes,
@@ -81,7 +81,9 @@ def _adapt_image_block_for_provider(
 
     assert result.data is not None
     assert result.media_type is not None
-    logger.info(
+    # Debug, not info: with the resize memo this fires on every request that
+    # replays the image, not just when the conversion work actually ran.
+    logger.debug(
         "Resized Anthropic history image from %d to %d base64 bytes",
         len(block.data),
         len(result.data),

--- a/kolega_code/utils/images.py
+++ b/kolega_code/utils/images.py
@@ -13,11 +13,14 @@ shows a small ASCII-art preview instead of a wall of base64.
 from __future__ import annotations
 
 import base64
+import hashlib
 import io
 import math
+import threading
+from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 from PIL import Image, ImageOps
 
@@ -203,6 +206,117 @@ def resize_base64_image_to_limit(
         resized=False,
         error=f"Could not fit image below the {max_base64_bytes}-byte base64 limit",
     )
+
+
+# History images are re-fitted for the provider on every LLM request, so the
+# same screenshot would otherwise be decoded and re-encoded once per request
+# for the rest of the session (multiplied by concurrent sub-agents). Memoize
+# per (content, dimension cap) rather than per exact byte cap: the shared
+# Anthropic byte cap shrinks a few percent every time a new screenshot lands
+# in history, and an exact-cap key would re-encode the entire history on each
+# shift. A stored derivative keeps serving every cap it still fits under (the
+# resize safety ratio provides the hysteresis); byte-fit of unchanged images
+# is a plain length check against the memoized dimensions-fit verdict. The
+# byte budget only counts stored derivatives; the entry cap bounds the rest.
+_RESIZE_CACHE_MAX_ENTRIES = 1024
+_RESIZE_CACHE_MAX_BYTES = 128 * 1024 * 1024
+
+_resize_cache: "OrderedDict[Tuple[str, str, Optional[int]], _ResizeMemo]" = OrderedDict()
+_resize_cache_bytes = 0
+_resize_cache_lock = threading.Lock()
+
+
+@dataclass
+class _ResizeMemo:
+    """Accumulated knowledge about one image under one dimension cap."""
+
+    # True once the original was seen to fit the dimension cap; None = unknown.
+    dims_fit: Optional[bool] = None
+    # Smallest derivative produced so far, reusable for any byte cap it fits.
+    derivative_data: Optional[str] = None
+    derivative_media_type: Optional[str] = None
+    # A failure verdict, valid for byte caps at or below the recorded limit
+    # (fit failures are monotone: what cannot fit N bytes cannot fit fewer).
+    error: Optional[str] = None
+    error_limit: int = 0
+
+
+def _derivative_target_size(max_base64_bytes: int) -> int:
+    """The byte target :func:`resize_base64_image_to_limit` fits derivatives to."""
+    target = int(max_base64_bytes * _IMAGE_RESIZE_SAFETY_RATIO)
+    return target - target % 4
+
+
+def _clear_resize_cache() -> None:
+    """Reset the resize memo (test isolation)."""
+    global _resize_cache_bytes
+    with _resize_cache_lock:
+        _resize_cache.clear()
+        _resize_cache_bytes = 0
+
+
+def resize_base64_image_to_limit_cached(
+    data: str,
+    media_type: str,
+    *,
+    max_base64_bytes: int,
+    max_dimension: Optional[int] = None,
+) -> ImageResizeResult:
+    """Memoized :func:`resize_base64_image_to_limit`.
+
+    The unchanged verdict hands back the caller's own payload so a cache entry
+    never pins a stale copy of the input string across session reloads.
+    Concurrent misses for the same image may duplicate work; the last result
+    wins.
+    """
+    key = (
+        hashlib.sha256(data.encode("utf-8", "surrogatepass")).hexdigest(),
+        media_type,
+        max_dimension,
+    )
+    with _resize_cache_lock:
+        memo = _resize_cache.get(key)
+        if memo is not None:
+            _resize_cache.move_to_end(key)
+            if memo.error is not None and max_base64_bytes <= memo.error_limit:
+                return ImageResizeResult(None, None, resized=False, error=memo.error)
+            if memo.dims_fit and len(data) <= max_base64_bytes:
+                return ImageResizeResult(data, media_type, resized=False)
+            if memo.derivative_data is not None and len(memo.derivative_data) <= _derivative_target_size(
+                max_base64_bytes
+            ):
+                return ImageResizeResult(memo.derivative_data, memo.derivative_media_type, resized=True)
+
+    result = resize_base64_image_to_limit(
+        data, media_type, max_base64_bytes=max_base64_bytes, max_dimension=max_dimension
+    )
+
+    global _resize_cache_bytes
+    with _resize_cache_lock:
+        memo = _resize_cache.get(key)
+        if memo is None:
+            memo = _ResizeMemo()
+            _resize_cache[key] = memo
+        _resize_cache.move_to_end(key)
+        if not result.succeeded:
+            memo.error = result.error
+            memo.error_limit = max(memo.error_limit, max_base64_bytes)
+        elif not result.resized:
+            memo.dims_fit = True
+        else:
+            assert result.data is not None
+            if memo.derivative_data is not None:
+                _resize_cache_bytes -= len(memo.derivative_data)
+            memo.derivative_data = result.data
+            memo.derivative_media_type = result.media_type
+            _resize_cache_bytes += len(result.data)
+        while _resize_cache and (
+            len(_resize_cache) > _RESIZE_CACHE_MAX_ENTRIES or _resize_cache_bytes > _RESIZE_CACHE_MAX_BYTES
+        ):
+            _, evicted = _resize_cache.popitem(last=False)
+            if evicted.derivative_data is not None:
+                _resize_cache_bytes -= len(evicted.derivative_data)
+    return result
 
 
 def image_media_type(path_or_suffix: Union[str, Path]) -> Optional[str]:

--- a/tests/agent/test_history_image_blocks.py
+++ b/tests/agent/test_history_image_blocks.py
@@ -572,3 +572,72 @@ def test_adapt_omits_oversized_anthropic_image_when_resize_fails(monkeypatch: py
     assert "could not be resized safely" in placeholder.text
     assert placeholder.cache_checkpoint is True
     assert history[0].content[0] is invalid
+
+
+@pytest.fixture(autouse=True)
+def _fresh_resize_cache():
+    import kolega_code.utils.images as image_utils
+
+    image_utils._clear_resize_cache()
+    yield
+    image_utils._clear_resize_cache()
+
+
+def test_adapt_reuses_cached_derivatives_when_new_images_shrink_the_shared_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A screenshot landing in history must not re-encode the ones already there.
+
+    The shared Anthropic byte cap shrinks a little with every additional image;
+    the resize memo must keep serving previously produced derivatives across
+    those shifts (the affected session re-encoded its entire screenshot history
+    on every request, freezing the TUI for the PIL time each time).
+    """
+    import kolega_code.utils.images as image_utils
+
+    def _noise_png(seed: int) -> ImageBlock:
+        import random
+
+        rng = random.Random(seed)
+        image = Image.new("RGB", (64, 64))
+        image.putdata([(rng.randrange(256), rng.randrange(256), rng.randrange(256)) for _ in range(64 * 64)])
+        output = io.BytesIO()
+        image.save(output, format="PNG")
+        return ImageBlock(
+            image_type="base64",
+            media_type="image/png",
+            data=base64.b64encode(output.getvalue()).decode("ascii"),
+        )
+
+    blocks = [_noise_png(seed) for seed in range(4)]
+    # Aggregate budget forces the shared per-image cap below every image's size,
+    # and the cap shrinks again when the fifth image lands.
+    per_image = max(len(block.data) for block in blocks)
+    monkeypatch.setattr(image_utils, "ANTHROPIC_MAX_IMAGE_BASE64_BYTES", per_image)
+    monkeypatch.setattr(image_utils, "ANTHROPIC_MAX_REQUEST_IMAGE_BASE64_BYTES", per_image * 3)
+
+    encodes = []
+    inner = image_utils.resize_base64_image_to_limit
+
+    def counting(*args, **kwargs):
+        encodes.append(1)
+        return inner(*args, **kwargs)
+
+    monkeypatch.setattr(image_utils, "resize_base64_image_to_limit", counting)
+
+    history = [_user(block) for block in blocks]
+    adapt_history_for_provider(history, target_provider="anthropic", target_model="claude-opus-5", supports_vision=True)
+    cold_encodes = len(encodes)
+    assert cold_encodes == len(blocks)
+
+    # Same request again: fully served from the memo.
+    adapt_history_for_provider(history, target_provider="anthropic", target_model="claude-opus-5", supports_vision=True)
+    assert len(encodes) == cold_encodes
+
+    # A new image landing shrinks the shared cap for everyone. Only the new
+    # image may pay for a resize call; the shifted cap must keep serving the
+    # existing derivatives. (Kept small so the shift stays within the reuse
+    # hysteresis, like one screenshot among dozens in a real session.)
+    history.append(_user(_image()))
+    adapt_history_for_provider(history, target_provider="anthropic", target_model="claude-opus-5", supports_vision=True)
+    assert len(encodes) == cold_encodes + 1

--- a/tests/utils/test_images.py
+++ b/tests/utils/test_images.py
@@ -300,3 +300,146 @@ def test_resize_base64_image_returns_safe_failure_when_limit_cannot_hold_base64(
     assert result.succeeded is False
     assert result.data is None
     assert result.error is not None
+
+
+@pytest.fixture(autouse=True)
+def _fresh_resize_cache():
+    import kolega_code.utils.images as images_mod
+
+    images_mod._clear_resize_cache()
+    yield
+    images_mod._clear_resize_cache()
+
+
+def test_resize_cached_computes_once_per_image_and_limits(monkeypatch) -> None:
+    import kolega_code.utils.images as images_mod
+
+    calls = []
+    inner = images_mod.resize_base64_image_to_limit
+
+    def counting(*args, **kwargs):
+        calls.append(1)
+        return inner(*args, **kwargs)
+
+    monkeypatch.setattr(images_mod, "resize_base64_image_to_limit", counting)
+    data = _encoded_image(Image.new("RGB", (2_001, 100), "navy"), "PNG")
+
+    first = images_mod.resize_base64_image_to_limit_cached(
+        data, "image/png", max_base64_bytes=ANTHROPIC_MAX_IMAGE_BASE64_BYTES, max_dimension=2_000
+    )
+    second = images_mod.resize_base64_image_to_limit_cached(
+        data, "image/png", max_base64_bytes=ANTHROPIC_MAX_IMAGE_BASE64_BYTES, max_dimension=2_000
+    )
+
+    assert len(calls) == 1
+    assert first.resized is True and second.resized is True
+    assert first.data == second.data
+    assert first.media_type == second.media_type
+
+    # A different dimension cap is a different key and recomputes.
+    images_mod.resize_base64_image_to_limit_cached(
+        data, "image/png", max_base64_bytes=ANTHROPIC_MAX_IMAGE_BASE64_BYTES, max_dimension=1_000
+    )
+    assert len(calls) == 2
+
+
+def test_resize_cached_reuses_derivative_across_smaller_byte_caps(monkeypatch) -> None:
+    import kolega_code.utils.images as images_mod
+
+    calls = []
+    inner = images_mod.resize_base64_image_to_limit
+
+    def counting(*args, **kwargs):
+        calls.append(1)
+        return inner(*args, **kwargs)
+
+    monkeypatch.setattr(images_mod, "resize_base64_image_to_limit", counting)
+    data = _encoded_image(Image.new("RGB", (2_001, 100), "navy"), "PNG")
+
+    first = images_mod.resize_base64_image_to_limit_cached(
+        data, "image/png", max_base64_bytes=ANTHROPIC_MAX_IMAGE_BASE64_BYTES, max_dimension=2_000
+    )
+    assert first.resized is True and first.data is not None
+    assert len(calls) == 1
+
+    # The shared Anthropic cap shrinks slightly as history grows; the stored
+    # derivative keeps serving every cap it still fits under.
+    smaller_cap = ANTHROPIC_MAX_IMAGE_BASE64_BYTES // 2
+    assert len(first.data) <= images_mod._derivative_target_size(smaller_cap)
+    reused = images_mod.resize_base64_image_to_limit_cached(
+        data, "image/png", max_base64_bytes=smaller_cap, max_dimension=2_000
+    )
+    assert reused.resized is True
+    assert reused.data == first.data
+    assert len(calls) == 1
+
+    # A cap the derivative genuinely exceeds forces one re-encode, whose
+    # smaller derivative replaces the stored one.
+    tiny_cap = len(first.data) // 2
+    recomputed = images_mod.resize_base64_image_to_limit_cached(
+        data, "image/png", max_base64_bytes=tiny_cap, max_dimension=2_000
+    )
+    assert len(calls) == 2
+    assert recomputed.resized is True and recomputed.data is not None
+    assert len(recomputed.data) < len(first.data)
+
+
+def test_resize_cached_unchanged_hit_returns_caller_payload_object() -> None:
+    import kolega_code.utils.images as images_mod
+
+    data = _encoded_image(Image.new("RGB", (4, 4), "navy"), "PNG")
+    first = images_mod.resize_base64_image_to_limit_cached(
+        data, "image/png", max_base64_bytes=len(data), max_dimension=2_000
+    )
+    assert first.resized is False
+
+    # A hit must hand back the caller's own string, not a pinned stale copy —
+    # session reloads rebuild history blocks with fresh string objects.
+    reloaded = "".join(data)
+    assert reloaded is not data
+    second = images_mod.resize_base64_image_to_limit_cached(
+        reloaded, "image/png", max_base64_bytes=len(data), max_dimension=2_000
+    )
+    assert second.resized is False
+    assert second.data is reloaded
+
+
+def test_resize_cached_failure_verdicts_are_memoized(monkeypatch) -> None:
+    import kolega_code.utils.images as images_mod
+
+    calls = []
+    inner = images_mod.resize_base64_image_to_limit
+
+    def counting(*args, **kwargs):
+        calls.append(1)
+        return inner(*args, **kwargs)
+
+    monkeypatch.setattr(images_mod, "resize_base64_image_to_limit", counting)
+    data = base64.b64encode(b"not-an-image" * 100).decode("ascii")
+
+    for _ in range(2):
+        result = images_mod.resize_base64_image_to_limit_cached(data, "image/png", max_base64_bytes=64)
+        assert result.succeeded is False
+        assert result.error is not None
+
+    assert len(calls) == 1
+
+
+def test_resize_cached_evicts_oldest_and_keeps_byte_accounting(monkeypatch) -> None:
+    import kolega_code.utils.images as images_mod
+
+    monkeypatch.setattr(images_mod, "_RESIZE_CACHE_MAX_ENTRIES", 1)
+    a = _encoded_image(Image.new("RGB", (2_001, 100), "navy"), "PNG")
+    b = _encoded_image(Image.new("RGB", (2_001, 100), "maroon"), "PNG")
+
+    images_mod.resize_base64_image_to_limit_cached(
+        a, "image/png", max_base64_bytes=ANTHROPIC_MAX_IMAGE_BASE64_BYTES, max_dimension=2_000
+    )
+    images_mod.resize_base64_image_to_limit_cached(
+        b, "image/png", max_base64_bytes=ANTHROPIC_MAX_IMAGE_BASE64_BYTES, max_dimension=2_000
+    )
+
+    assert len(images_mod._resize_cache) == 1
+    (memo,) = images_mod._resize_cache.values()
+    assert memo.derivative_data is not None
+    assert images_mod._resize_cache_bytes == len(memo.derivative_data)


### PR DESCRIPTION
## Problem

Image-heavy sessions froze the TUI for seconds at a time. One affected session's diagnostics recorded **65 event-loop stalls of 5–6s each (~360s of frozen UI)**, every one with the same main-thread stack: PIL re-encoding screenshots inside `resize_base64_image_to_limit`, called from `adapt_history_for_provider` while building request history.

Three compounding causes:

1. **It ran on the event loop.** `_history_for_llm()` is synchronous and was called directly from the agent turn loop, so every PIL decode/resample/encode froze the whole TUI. The watchdog only records stalls ≥5s — the shorter ones showed up as choppy scrolling.
2. **It redid all the work on every request.** Every image in history was re-processed per LLM request; with >20 images the 2000px Anthropic dimension cap forces a full re-encode of every Retina-sized screenshot. Nothing was cached.
3. **Sub-agents multiplied it.** Sub-agents share the event loop, and screenshot-review critic loops fill their histories with screenshots, so each concurrent sub-agent queued more PIL work on the loop — matching the report that it got worse with many sub-agents running.

## Fix

- **`kolega_code/utils/images.py`** — new `resize_base64_image_to_limit_cached()`: a bounded LRU memo (1024 entries / 128MiB of derivatives) keyed by content hash + dimension cap. It is deliberately **not** keyed by the byte cap, because the shared Anthropic byte budget shifts slightly every time a new screenshot lands; a stored derivative keeps serving every cap it still fits under, so a new screenshot no longer re-encodes the whole history.
- **`kolega_code/agent/baseagent.py`** — new `_history_for_llm_async()` runs the repair+adapt pass in a worker thread via `asyncio.to_thread` (PIL releases the GIL). All three request-path call sites use it. The history snapshot is taken on the loop, so the thread never races a mutation.
- **`kolega_code/agent/conversation.py`** — calls the cached variant; the per-resize log is demoted to `debug` since it now fires on cache hits too.

## Measured (24 Retina-sized RGBA screenshots in history)

| Scenario | Before | After |
| --- | --- | --- |
| Every LLM request (steady state) | 24.7s frozen | 0.013s (~1,900×) |
| Request after a new screenshot lands | 25.0s | 1.05s (only the new image pays) |
| Max event-loop gap during first-time processing | 24.5s (total freeze) | 16ms (off-loop) |

First-time processing of a given screenshot still costs the same CPU, but it happens once per session instead of once per request, and off the loop — so the TUI keeps scrolling smoothly even during cold processing with many sub-agents active.

## Tests

5 new tests cover cache hits, derivative reuse across shrinking caps, failure memoization, eviction accounting, and an end-to-end guard that a new screenshot doesn't re-encode existing history. Locally: `tests/agent`, `tests/utils`, and `tests/cli` pass (2,854 + the new cases), plus `ruff check`, `ruff format`, and `pyright`. Two pre-existing failures in `test_client_live.py` / `test_live_providers.py` are live-API tests that fail identically on clean `main` (one asserts the first Anthropic content block is text, but the model now returns thinking first) — unrelated to this change.