### PR TITLE
perf(tools): measure fetched HTML once, off the event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   diagnostics entry, so choppy-but-not-frozen UI leaves evidence instead of
   nothing. Stack dumps are capped per session so a pathological session cannot
   fill the timeline.
+- `read_image` now refuses files above 20 MB (the limit image encoding already
+  applied elsewhere) instead of reading them and having the provider reject the
+  request.
 
 ### Fixed
 
@@ -28,6 +31,13 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   by every concurrently running sub-agent. The worst event-loop gap per request
   drops from 111 ms to 19 ms with 6 MiB of images in history, and from 425 ms to
   69 ms at 24 MiB.
+- Stopped `web_fetch` from freezing the UI on large pages. Scoring an extraction
+  re-parsed the entire raw document on the event loop, once per extractor
+  attempt plus once more for single-page-app detection; the document is now
+  measured once per fetch in a worker thread. On an 11.6 MB page the worst
+  event-loop gap drops from 774 ms to 219 ms, and on a pathological 13.8 MB page
+  from 48 s to 0.5 s.
+- Moved `read_image`'s file read and base64 encode off the event loop.
 
 ## 0.25.2 - 2026-07-28
 

--- a/kolega_code/agent/tool_backend/read_image_tool.py
+++ b/kolega_code/agent/tool_backend/read_image_tool.py
@@ -1,9 +1,10 @@
+import asyncio
 import base64
 from typing import List
 
 from .base_tool import BaseTool
 from kolega_code.llm.models import ContentBlock, ImageBlock
-from kolega_code.utils.images import IMAGE_MIME_TYPES
+from kolega_code.utils.images import IMAGE_MIME_TYPES, MAX_IMAGE_BYTES
 
 
 class ReadImageTool(BaseTool):
@@ -29,5 +30,18 @@ class ReadImageTool(BaseTool):
         media_type = IMAGE_MIME_TYPES.get(suffix)
         if media_type is None:
             raise ValueError(f"Unsupported image format '{suffix}'. Supported: " + ", ".join(sorted(IMAGE_MIME_TYPES)))
-        data = base64.b64encode(self.filesystem.read_bytes(path)).decode("ascii")
+        # Off the event loop: the read, the base64 encode, and the ASCII decode
+        # are each a full pass over the file, and this runs once per screenshot
+        # in a review loop. The size gate lives in the same hop so an oversized
+        # file is rejected before it is read rather than after.
+        data = await asyncio.to_thread(self._read_encoded, path)
         return [ImageBlock(image_type="base64", media_type=media_type, data=data)]
+
+    def _read_encoded(self, path: str) -> str:
+        size = self.filesystem.get_size(path)
+        if size > MAX_IMAGE_BYTES:
+            raise ValueError(
+                f"Image is too large to read: {size / (1024 * 1024):.1f} MB exceeds the "
+                f"{MAX_IMAGE_BYTES // (1024 * 1024)} MB limit. Resize or crop it first."
+            )
+        return base64.b64encode(self.filesystem.read_bytes(path)).decode("ascii")

--- a/kolega_code/agent/tool_backend/web_fetch/extractors.py
+++ b/kolega_code/agent/tool_backend/web_fetch/extractors.py
@@ -60,6 +60,38 @@ class ExtractedPage:
     attempts: tuple[ExtractorAttempt, ...] = field(default_factory=tuple)
 
 
+@dataclass(frozen=True)
+class HtmlSignals:
+    """Whole-document measurements shared by scoring and SPA detection.
+
+    Every field is O(len(html)) to compute — a full lxml parse plus regex
+    scans — and none of it changes between extractor attempts, so it is
+    computed exactly once per fetch, in a worker thread.
+    """
+
+    raw_visible_len: int
+    js_marker: bool
+    app_shell: bool
+    script_count: int
+
+
+def html_signals(html: str) -> HtmlSignals:
+    """Measure a document once. Call off the event loop: multi-MB pages take seconds."""
+    lower = html.lower()
+    try:
+        raw_visible_len = len(BeautifulSoup(html, "lxml").get_text(" ", strip=True))
+    except Exception:
+        # Trafilatura and Readability do not go through bs4, so a parser
+        # failure here must not fail the whole fetch. Strip tags instead.
+        raw_visible_len = len(re.sub(r"<[^>]+>", " ", html))
+    return HtmlSignals(
+        raw_visible_len=raw_visible_len,
+        js_marker=any(marker in lower for marker in _JS_MARKERS),
+        app_shell=any(re.search(pattern, html, re.IGNORECASE) for pattern in _APP_ROOT_PATTERNS),
+        script_count=len(re.findall(r"<script\b", html, re.IGNORECASE)),
+    )
+
+
 def _clean_markdown(value: str) -> str:
     lines = [line.rstrip() for line in (value or "").replace("\x00", "").splitlines()]
     cleaned = "\n".join(lines)
@@ -72,8 +104,13 @@ def _normalized_lines(content: str) -> list[str]:
     return [re.sub(r"\s+", " ", line).strip() for line in content.splitlines() if line.strip()]
 
 
-def quality_score(content: str, html: str) -> tuple[float, bool]:
-    """Score usefulness without making short-but-legitimate pages impossible."""
+def quality_score(content: str, raw_visible_len: int) -> tuple[float, bool]:
+    """Score usefulness without making short-but-legitimate pages impossible.
+
+    ``raw_visible_len`` is ``HtmlSignals.raw_visible_len`` for the source
+    document; it is passed in rather than measured here so the document is
+    parsed once per fetch instead of once per extractor attempt.
+    """
     cleaned = _clean_markdown(content)
     if not cleaned:
         return -100.0, False
@@ -99,10 +136,9 @@ def quality_score(content: str, html: str) -> tuple[float, bool]:
     if link_count / word_count > 0.18:
         score -= 12.0
 
-    raw_visible = BeautifulSoup(html, "lxml").get_text(" ", strip=True)
-    if chars < 80 and len(raw_visible) > 500:
+    if chars < 80 and raw_visible_len > 500:
         score -= 20.0
-    elif chars < 80 and len(raw_visible) <= 500:
+    elif chars < 80 and raw_visible_len <= 500:
         score += 8.0
 
     usable = chars >= 40 and score >= 8.0
@@ -201,14 +237,18 @@ def extractor_names() -> list[str]:
     return [DEFAULT_EXTRACTOR, *_EXTRACTORS]
 
 
-def _looks_like_spa(html: str, attempts: list[ExtractorAttempt]) -> bool:
-    lower = html.lower()
-    marker = any(marker in lower for marker in _JS_MARKERS)
-    app_shell = any(re.search(pattern, html, re.IGNORECASE) for pattern in _APP_ROOT_PATTERNS)
-    scripts = len(re.findall(r"<script\b", html, re.IGNORECASE))
-    visible = BeautifulSoup(html, "lxml").get_text(" ", strip=True)
+def _looks_like_spa(signals: HtmlSignals, attempts: list[ExtractorAttempt]) -> bool:
     unusable = not attempts or all(not attempt.usable for attempt in attempts)
-    return marker or (unusable and app_shell and (scripts >= 3 or len(visible) < 300))
+    return signals.js_marker or (
+        unusable and signals.app_shell and (signals.script_count >= 3 or signals.raw_visible_len < 300)
+    )
+
+
+def _extract_and_score(extractor: HtmlExtractor, html: str, url: str, raw_visible_len: int) -> tuple[str, float, bool]:
+    """Extract and score in one worker-thread hop (both passes are O(len(html)))."""
+    content = extractor.extract(html, url)
+    score, usable = quality_score(content, raw_visible_len)
+    return content, score, usable
 
 
 async def extract_html(html: str, url: str, preference: str = DEFAULT_EXTRACTOR) -> ExtractedPage:
@@ -221,13 +261,20 @@ async def extract_html(html: str, url: str, preference: str = DEFAULT_EXTRACTOR)
         else [preference, *[x for x in default_order if x != preference]]
     )
 
+    # One measurement pass for the whole fetch, off the event loop: parsing a
+    # multi-MB document here used to happen per attempt (and once more for SPA
+    # detection) on the loop, freezing the TUI for the duration.
+    signals = await asyncio.to_thread(html_signals, html)
+
     candidates: list[tuple[str, str, float, bool]] = []
     attempts: list[ExtractorAttempt] = []
     for name in order:
         extractor = _EXTRACTORS[name]
         try:
-            content = await asyncio.wait_for(asyncio.to_thread(extractor.extract, html, url), timeout=10.0)
-            score, usable = quality_score(content, html)
+            content, score, usable = await asyncio.wait_for(
+                asyncio.to_thread(_extract_and_score, extractor, html, url, signals.raw_visible_len),
+                timeout=10.0,
+            )
             attempts.append(ExtractorAttempt(name, score, len(content), usable))
             candidates.append((name, content, score, usable))
             if usable and score >= HIGH_QUALITY_SCORE:
@@ -237,7 +284,7 @@ async def extract_html(html: str, url: str, preference: str = DEFAULT_EXTRACTOR)
 
     usable_candidates = [candidate for candidate in candidates if candidate[3]]
     selected = max(usable_candidates or candidates, key=lambda item: item[2], default=None)
-    spa_detected = _looks_like_spa(html, attempts)
+    spa_detected = _looks_like_spa(signals, attempts)
     warnings: list[str] = []
     if spa_detected:
         warnings.append(

--- a/tests/agent/test_read_image_tool.py
+++ b/tests/agent/test_read_image_tool.py
@@ -1,4 +1,5 @@
 import base64
+import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
@@ -88,6 +89,45 @@ class TestReadImageToolBackend:
         tool = _make_tool(tmp_path)
         with pytest.raises(ValueError):
             await tool.read_image(str(path))
+
+    @pytest.mark.asyncio
+    async def test_oversized_image_is_rejected_before_it_is_read(self, tmp_path, monkeypatch):
+        import kolega_code.agent.tool_backend.read_image_tool as module
+
+        monkeypatch.setattr(module, "MAX_IMAGE_BYTES", 16)
+        path = tmp_path / "huge.png"
+        path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 64)
+
+        tool = _make_tool(tmp_path)
+        reads: list[str] = []
+
+        def refuse_to_read(target: str) -> bytes:
+            reads.append(target)
+            return b""
+
+        monkeypatch.setattr(tool.filesystem, "read_bytes", refuse_to_read)
+        with pytest.raises(ValueError, match="too large"):
+            await tool.read_image(str(path))
+        assert reads == []
+
+    @pytest.mark.asyncio
+    async def test_read_runs_off_the_event_loop(self, tmp_path):
+        """The read + base64 + ASCII decode are three full passes over the file."""
+        path = tmp_path / "shot.png"
+        path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 32)
+
+        tool = _make_tool(tmp_path)
+        loop_thread = threading.get_ident()
+        seen: dict[str, int] = {}
+        original = tool._read_encoded
+
+        def tracking(target: str) -> str:
+            seen["thread"] = threading.get_ident()
+            return original(target)
+
+        tool._read_encoded = tracking  # type: ignore[method-assign]
+        await tool.read_image(str(path))
+        assert seen["thread"] != loop_thread
 
 
 class TestReadImageWrapper:

--- a/tests/agent/tool_backend/test_web_fetch_pipeline.py
+++ b/tests/agent/tool_backend/test_web_fetch_pipeline.py
@@ -9,7 +9,11 @@ from pptx import Presentation
 from pptx.util import Inches
 
 from kolega_code.agent.tool_backend.web_fetch.documents import DocumentConverter
-from kolega_code.agent.tool_backend.web_fetch.extractors import extract_html, quality_score
+from kolega_code.agent.tool_backend.web_fetch.extractors import (
+    extract_html,
+    html_signals,
+    quality_score,
+)
 from kolega_code.agent.tool_backend.web_fetch.pipeline import LocalWebContentPipeline, WebContentError
 from kolega_code.agent.tool_backend.web_fetch.retrieval import (
     TEXT_MAX_BYTES,
@@ -129,9 +133,53 @@ async def test_spa_shell_is_detected_without_browser_fallback() -> None:
 
 def test_quality_gate_accepts_legitimate_short_page() -> None:
     html = "<html><body><main><p>Small but complete answer.</p></main></body></html>"
-    score, usable = quality_score("Small but complete answer with useful context for the reader.", html)
+    signals = html_signals(html)
+    score, usable = quality_score(
+        "Small but complete answer with useful context for the reader.", signals.raw_visible_len
+    )
     assert usable is True
     assert score > 8
+
+
+@pytest.mark.asyncio
+async def test_extract_html_measures_the_document_once_per_fetch() -> None:
+    """Scoring and SPA detection share one off-loop measurement pass.
+
+    Re-parsing the raw HTML per extractor attempt (plus once more for SPA
+    detection) on the event loop froze the TUI for seconds on large pages.
+    """
+    html = "<html><body><div><p>" + ("Short. " * 5) + "</p></div></body></html>"
+    calls: list[int] = []
+    real_signals = html_signals
+
+    def counting(source: str):
+        calls.append(len(source))
+        return real_signals(source)
+
+    with patch("kolega_code.agent.tool_backend.web_fetch.extractors.html_signals", counting):
+        result = await extract_html(html, "https://example.com")
+
+    # Four extractor attempts (none reaches HIGH_QUALITY_SCORE) plus SPA detection.
+    assert len(result.attempts) == 4
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_extract_html_survives_a_soup_parser_failure() -> None:
+    """A bs4 failure degrades the measurement instead of failing the whole fetch.
+
+    Trafilatura and Readability do not go through bs4, so they must still be
+    able to produce content.
+    """
+    html = "<html><body><main><h1>Title</h1><p>" + ("Useful article text. " * 40) + "</p></main></body></html>"
+    with patch(
+        "kolega_code.agent.tool_backend.web_fetch.extractors.BeautifulSoup",
+        side_effect=ValueError("parser exploded"),
+    ):
+        result = await extract_html(html, "https://example.com")
+
+    assert result.content
+    assert result.method in {"trafilatura", "readability"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Two more pieces of on-loop work found while auditing what the image-resize fix (#364) uncovered.

## Issue 1 — `web_fetch` re-parsed the raw HTML on the event loop

`quality_score()` parsed the **entire raw document** with BeautifulSoup/lxml just to compare the length of its visible text against two thresholds, and it ran on the event loop once per extractor attempt (up to four), plus a fifth parse in `_looks_like_spa()`. A recorded 5.2s stall (session `973185a2`, 2026-07-28T11:18:40) has exactly this stack: `extract_html → quality_score → bs4/builder/_lxml.py:494 feed`.

Fix:

- New `HtmlSignals` / `html_signals()` measures the document **once per fetch, in a worker thread**: visible-text length, JS marker, app-shell pattern, `<script` count — everything either caller needed from the raw HTML.
- `quality_score(content, raw_visible_len)` and `_looks_like_spa(signals, attempts)` take the measurements instead of the document. Extraction and scoring now share a single `to_thread` hop.
- A bs4 parser failure degrades to a tag-strip estimate instead of failing a fetch that trafilatura/readability could still serve (previously it errored every attempt *and* raised out of `extract_html`).

## Issue 4 — `read_image` did sync I/O + base64 on the event loop

The read, the base64 encode, and the ASCII decode are each a full pass over the file, all on the loop, once per screenshot in a review loop. They now run in a worker thread. **Behavior change:** the existing 20 MB `MAX_IMAGE_BYTES` cap (already enforced by `encode_image_file`) is now applied on this path too, evaluated before the read, so a huge file raises instead of being read, encoded, and then rejected by the provider. Noted in the changelog.

## Measured

11.6 MB article page (4 extractor attempts, none reaching `HIGH_QUALITY_SCORE`):

| Metric | Before | After |
| --- | --- | --- |
| Max event-loop gap during the fetch | 774 ms | 219 ms |
| `quality_score` on the loop | 126 ms × 4 attempts | 1 ms (no parse) |
| `_looks_like_spa` on the loop | 170 ms | 0 (off-loop) |
| Full-document measurement parses | 5 | 1 |

Pathological 13.8 MB table page (400k links, all extractors time out): max event-loop gap **48.0 s → 0.50 s**, total 88 s → 45 s.

Extractor choice, per-attempt scores, usability flags and the SPA verdict are byte-identical before and after on both pages — this is a pure scheduling/dedup change. The residual few-hundred-ms gaps are GIL contention from the parsers now running in worker threads, not on-loop work; that is inherent to CPython parsing and no longer a multi-second freeze.

## Tests

`tests/agent/tool_backend/test_web_fetch_pipeline.py` and `tests/agent/test_read_image_tool.py` pass, including four new cases: one measurement pass per fetch regardless of attempts, graceful degradation on a parser failure, the size cap rejecting before the read, and the encode running off the loop. Also `ruff check`, `ruff format`, `pyright`.

Note: touches the same `## Unreleased` changelog section as #364, so whichever merges second may need a trivial rebase.
