### PR TITLE
feat(cli): make sub-second event-loop chop visible in diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+### Changed
+
+- The responsiveness watchdog now captures stacks for event-loop stalls from ~1
+  second (was 5) and counts shorter gaps into a periodic `loop_gap_histogram`
+  diagnostics entry, so choppy-but-not-frozen UI leaves evidence instead of
+  nothing. Stack dumps are capped per session so a pathological session cannot
+  fill the timeline.
+
 ### Fixed
 
 - Stopped image-heavy sessions from freezing the TUI. Building request history

--- a/docs/src/content/docs/troubleshooting/diagnostics.md
+++ b/docs/src/content/docs/troubleshooting/diagnostics.md
@@ -42,11 +42,17 @@ loop being blocked, and there are two very different reasons it can happen. The
 watchdog tells them apart:
 
 - **Blocked by synchronous work (a true hang).** A background thread expects a
-  heartbeat roughly every second. If the heartbeat stops for ~5 seconds, the loop is
+  heartbeat several times a second. If the heartbeat stops for ~1 second, the loop is
   stuck inside some synchronous call — the watchdog records an `event_loop_stalled`
   entry and **dumps every thread's stack** to `stalls.log`. The main thread's frame
   in that dump is *exactly* the code that was blocking. When the heartbeat resumes it
-  records `event_loop_recovered` with how long the stall lasted.
+  records `event_loop_recovered` with how long the stall lasted. Stack dumps are
+  capped per session so a pathological session cannot fill the timeline; past the cap
+  the stall is still recorded, without stacks.
+- **Choppy rather than frozen.** Stalls too short to dump stacks for are counted into
+  a `loop_gap_histogram` entry (buckets from 100 ms up), written periodically and at
+  session end. It carries no stacks and costs a few bytes, but it answers the first
+  question about a "feels sluggish" report: whether the chop is real, and how big.
 - **Waiting on the network.** Here the loop is *not* blocked, so the watchdog stays
   quiet — but the timeline shows an LLM request that started and never finished. A
   request open for minutes with no matching completion points at a stalled network

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -457,7 +457,10 @@ class KolegaCodeApp(
             self._diag.record("session_start", **self._diagnostics_header())
             self._watchdog = ResponsivenessWatchdog(self._diag)
             self._watchdog.start()
-            self.set_interval(1.0, self._watchdog.beat)
+            # The beat doubles as the loop-latency probe, so it ticks several times a
+            # second: chop below the stack-capture threshold is only visible if a beat
+            # lands inside the stalled window. The callback is O(1).
+            self.set_interval(self._watchdog.beat_interval, self._watchdog.beat)
         except Exception:
             self._diag, self._watchdog = None, None
         # Register all themes and apply the persisted one before the first paint,

--- a/kolega_code/cli/diagnostics.py
+++ b/kolega_code/cli/diagnostics.py
@@ -205,34 +205,84 @@ class DiagnosticsLog:
 class ResponsivenessWatchdog:
     """Detect event-loop stalls from an off-loop thread and capture the blocking stack.
 
-    The Textual app calls :meth:`beat` on a ~1 s loop timer. If beats stop (the loop is
-    blocked by synchronous work), this daemon thread notices within ``check_interval`` and
-    records an ``event_loop_stalled`` line plus a full thread-stack dump — the main
-    thread's frame is exactly what is blocking the loop. When beats resume it records
-    ``event_loop_recovered``. (A blocked loop can't run the on-loop timer, so the
-    staleness *is* the signal; this thread keeps running regardless.)
+    The Textual app calls :meth:`beat` on a :attr:`beat_interval` loop timer. Two tiers
+    of evidence come out of that:
+
+    * **Stalls.** If beats stop (the loop is blocked by synchronous work), this daemon
+      thread notices within ``check_interval`` and records an ``event_loop_stalled``
+      line plus a full thread-stack dump — the main thread's frame is exactly what is
+      blocking the loop. When beats resume it records ``event_loop_recovered``. (A
+      blocked loop can't run the on-loop timer, so the staleness *is* the signal; this
+      thread keeps running regardless.) Stack capture is capped per session so a
+      pathological session cannot grow the diagnostics file without bound.
+    * **Sub-second chop.** Beats are late by exactly as much as the loop was blocked, so
+      :meth:`beat` histograms its own lateness. "Scrolling feels choppy" is produced by
+      stalls well under the stack-capture threshold, which would otherwise leave no
+      trace at all; the aggregate ``loop_gap_histogram`` line costs a few bytes and no
+      stacks, and says immediately whether the chop is real and how big it is.
+
+    Thresholds are constructor parameters for tests only — there is no user decision here.
     """
+
+    # Excess-over-nominal beat lateness, in seconds. The first edge is the floor of
+    # human-visible chop; the last is the stack-capture threshold.
+    _BUCKET_EDGES: tuple[float, ...] = (0.1, 0.25, 1.0, 5.0)
 
     def __init__(
         self,
         diag: DiagnosticsLog,
         *,
-        stall_seconds: float = 5.0,
-        check_interval: float = 1.0,
+        stall_seconds: float = 1.0,
+        check_interval: float = 0.25,
+        beat_interval: float = 0.2,
+        histogram_interval: float = 300.0,
+        max_stall_captures: int = 200,
     ) -> None:
         self._diag = diag
         self._stall = stall_seconds
         self._interval = check_interval
+        self.beat_interval = beat_interval
+        self._histogram_interval = histogram_interval
+        self._max_captures = max_stall_captures
+        self._captures = 0
         self._last_beat = time.monotonic()
         self._beat_lock = threading.Lock()
         self._thread: Optional[threading.Thread] = None
         self._stop = threading.Event()
         self._stalled_since: Optional[float] = None
         self._sig_file = None
+        self._beats = 0
+        self._max_excess = 0.0
+        self._labels = self._bucket_labels()
+        self._buckets: dict[str, int] = {label: 0 for label in self._labels}
+        self._window_start = time.monotonic()
+
+    @classmethod
+    def _bucket_labels(cls) -> list[str]:
+        edges = cls._BUCKET_EDGES
+        labels = [f"{edges[i]}-{edges[i + 1]}s" for i in range(len(edges) - 1)]
+        labels.append(f">={edges[-1]}s")
+        return labels
 
     def beat(self) -> None:
+        """Called on the event loop. Must stay O(1): it runs several times a second.
+
+        Lateness is measured against the nominal interval, so a stall shorter than
+        ``beat_interval`` can be under-reported by up to one interval (part of it is
+        absorbed by the beat's own wait). Bucket edges are therefore lower bounds.
+        """
+        now = time.monotonic()
         with self._beat_lock:
-            self._last_beat = time.monotonic()
+            excess = (now - self._last_beat) - self.beat_interval
+            self._last_beat = now
+            self._beats += 1
+            if excess < self._BUCKET_EDGES[0]:
+                return
+            self._max_excess = max(self._max_excess, excess)
+            for index in range(len(self._BUCKET_EDGES) - 1, -1, -1):
+                if excess >= self._BUCKET_EDGES[index]:
+                    self._buckets[self._labels[index]] += 1
+                    return
 
     def start(self) -> None:
         if not self._diag.enabled or self._thread is not None:
@@ -243,21 +293,56 @@ class ResponsivenessWatchdog:
 
     def stop(self) -> None:
         self._stop.set()
+        self.flush_histogram("session_end")
+
+    def flush_histogram(self, reason: str) -> None:
+        """Emit one aggregate line for the gaps seen since the last flush (no stacks)."""
+        with self._beat_lock:
+            counted = sum(self._buckets.values())
+            payload = {
+                "reason": reason,
+                "window_s": round(time.monotonic() - self._window_start, 1),
+                "beats": self._beats,
+                "max_gap_s": round(self._max_excess, 3),
+                "buckets": dict(self._buckets),
+            }
+            self._window_start = time.monotonic()
+            self._beats = 0
+            self._max_excess = 0.0
+            for label in self._buckets:
+                self._buckets[label] = 0
+        if counted:
+            self._diag.record("loop_gap_histogram", **payload)
 
     def _run(self) -> None:
+        last_flush = time.monotonic()
         while not self._stop.wait(self._interval):
             with self._beat_lock:
                 gap = time.monotonic() - self._last_beat
             if gap > self._stall and self._stalled_since is None:
                 self._stalled_since = time.monotonic()
-                stacks = format_all_thread_stacks()
-                self._diag.record("event_loop_stalled", stalled_for_s=round(gap, 1), stacks=stacks)
-                self._diag.write_sidecar("stalls.log", f"# stall at {_now_iso()} (gap {gap:.1f}s)\n{stacks}\n")
+                self._record_stall(gap)
             elif gap <= self._stall and self._stalled_since is not None:
                 self._diag.record(
                     "event_loop_recovered", stalled_for_s=round(time.monotonic() - self._stalled_since, 1)
                 )
                 self._stalled_since = None
+            now = time.monotonic()
+            if now - last_flush >= self._histogram_interval:
+                last_flush = now
+                self.flush_histogram("interval")
+
+    def _record_stall(self, gap: float) -> None:
+        # Stacks are the expensive part, and they only ever get written while the loop
+        # is already stalled — but cap them so one pathological session cannot fill the
+        # timeline. Past the cap the stall itself is still recorded, without stacks.
+        if self._captures >= self._max_captures:
+            self._diag.record("event_loop_stalled", stalled_for_s=round(gap, 1), stacks_omitted=True)
+            return
+        self._captures += 1
+        stacks = format_all_thread_stacks()
+        self._diag.record("event_loop_stalled", stalled_for_s=round(gap, 1), stacks=stacks)
+        self._diag.write_sidecar("stalls.log", f"# stall at {_now_iso()} (gap {gap:.1f}s)\n{stacks}\n")
 
     def _enable_faulthandler(self) -> None:
         # Hard-fault dumps + a manual escape hatch (`kill -USR1 <pid>`) for a wedged process.

--- a/tests/cli/test_diagnostics.py
+++ b/tests/cli/test_diagnostics.py
@@ -5,6 +5,7 @@ import json
 import time
 import zipfile
 from pathlib import Path
+from unittest.mock import patch
 
 from kolega_code.cli.diagnostics import (
     SECRET_PLACEHOLDER,
@@ -100,6 +101,56 @@ def test_watchdog_captures_loop_stall_with_blocking_stack(tmp_path: Path):
     assert recovered, "watchdog did not record recovery"
     # The stall dump is also written to a sidecar for the bug bundle.
     assert (diag.dir / "stalls.log").exists()
+
+
+def test_watchdog_histograms_sub_second_gaps(tmp_path: Path):
+    """Chop below the stack-capture threshold has to leave *some* trace."""
+    diag = DiagnosticsLog(tmp_path, "sess5")
+    watchdog = ResponsivenessWatchdog(diag, beat_interval=0.0, histogram_interval=3600.0)
+
+    # Drive beat() with controlled lateness instead of real sleeps.
+    now = [1000.0]
+    with patch("kolega_code.cli.diagnostics.time.monotonic", lambda: now[0]):
+        watchdog._last_beat = now[0]
+        for gap in (0.01, 0.15, 0.3, 2.0, 7.0):
+            now[0] += gap
+            watchdog.beat()
+        watchdog.flush_histogram("test")
+
+    rows = [r for r in _read(diag.path) if r["kind"] == "loop_gap_histogram"]
+    assert len(rows) == 1
+    assert rows[0]["buckets"] == {"0.1-0.25s": 1, "0.25-1.0s": 1, "1.0-5.0s": 1, ">=5.0s": 1}
+    assert rows[0]["beats"] == 5  # the 10ms gap is counted as a beat but bucketed nowhere
+    assert rows[0]["max_gap_s"] == 7.0
+
+    # Counters reset per window, and an empty window writes nothing.
+    watchdog.flush_histogram("test")
+    assert len([r for r in _read(diag.path) if r["kind"] == "loop_gap_histogram"]) == 1
+
+
+def test_watchdog_caps_stack_captures_but_keeps_recording_stalls(tmp_path: Path):
+    diag = DiagnosticsLog(tmp_path, "sess6")
+    watchdog = ResponsivenessWatchdog(diag, max_stall_captures=1)
+
+    watchdog._record_stall(2.0)
+    watchdog._record_stall(3.0)
+
+    stalls = [r for r in _read(diag.path) if r["kind"] == "event_loop_stalled"]
+    assert len(stalls) == 2
+    assert "stacks" in stalls[0] and "stacks_omitted" not in stalls[0]
+    assert stalls[1]["stacks_omitted"] is True and "stacks" not in stalls[1]
+
+
+def test_watchdog_stop_flushes_the_final_histogram(tmp_path: Path):
+    diag = DiagnosticsLog(tmp_path, "sess7")
+    watchdog = ResponsivenessWatchdog(diag, beat_interval=0.0, histogram_interval=3600.0)
+    watchdog._last_beat = time.monotonic() - 0.4
+    watchdog.beat()
+    watchdog.stop()
+
+    rows = [r for r in _read(diag.path) if r["kind"] == "loop_gap_histogram"]
+    assert len(rows) == 1
+    assert rows[0]["reason"] == "session_end"
 
 
 def test_write_crash_log_captures_scrubbed_traceback(tmp_path: Path):


### PR DESCRIPTION
Observability, not a speed fix — but it is what makes the next "choppy scrolling" report diagnosable from evidence instead of archaeology.

## Problem

The watchdog recorded a stall only past `stall_seconds = 5.0`. Choppy scrolling is produced by stalls in the 100 ms–5 s band, and today those leave **no trace whatsoever**. The history-image freeze (#364) was only caught because it happened to cross 5 s; the shorter stalls from the same cause — and anything like request serialization — were invisible.

## Fix

Two tiers in the watchdog:

1. **Stack capture from ~1 s** (was 5 s). Capturing stacks costs milliseconds and only ever happens while the loop is already stalled, so the old threshold was pure conservatism. Captures are capped per session (200); past the cap the stall is still recorded with `stacks_omitted: true` instead of a dump, so a pathological session cannot grow the timeline without bound.
2. **A histogram of the sub-second band.** `beat()` measures its own lateness and counts it into 0.1 / 0.25 / 1 / 5 s buckets; the watchdog flushes one aggregate `loop_gap_histogram` line every 5 minutes and at session end. Empty windows write nothing. No stacks, a few bytes per line, and the first question about a "feels sluggish" report — is the chop real, and how big — is answered directly.

The beat now doubles as the loop-latency probe, so it ticks every 0.2 s instead of every 1 s: a sub-second stall is only measurable if a beat lands inside the stalled window. All thresholds are constructor parameters for tests, not user config — there is no user decision here.

Lateness is measured against the nominal interval, so a stall shorter than one beat interval can be under-reported by up to that interval (part of it is absorbed by the beat's own wait). Bucket edges are therefore lower bounds; that is documented on `beat()`.

## Verification

Synthetic on-loop stalls of 0.3 s / 1.5 s / 6 s against a real loop:

| Stall | Before | After |
| --- | --- | --- |
| 0.3 s | nothing | counted in `loop_gap_histogram` |
| 1.5 s | nothing | `event_loop_stalled` + stack dump naming the blocking frame |
| 6 s | stall + stacks | unchanged |

Overhead: `beat()` costs **0.30 µs/call** — 1.5 µs per second of loop time at 5 beats/s.

Unit tests feed the watchdog controlled timestamps and assert bucket counts, per-window reset, the empty-window no-write, the stack-capture cap, and the session-end flush. `tests/cli/test_diagnostics.py` passes (17 tests), plus `ruff`, `pyright`, and the app bootstrap tests.

Docs updated (`troubleshooting/diagnostics.md`).

Note: touches the same `## Unreleased` changelog section as #364 and #365, so whichever merges last may need a trivial rebase.

