### PR TITLE
perf(llm): prepare LLM requests off the event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   sub-agent. Resized copies are now memoized per image and dimension cap
   (surviving the small byte-budget shifts a newly captured screenshot causes),
   and the repair/adapt pass runs in a worker thread.
+- Moved LLM request preparation off the event loop. Building a request body is
+  proportional to conversation size, and on the Anthropic streaming path it
+  blocked the UI for 0.4 s per request with an image-heavy history — multiplied
+  by every concurrently running sub-agent. The worst event-loop gap per request
+  drops from 111 ms to 19 ms with 6 MiB of images in history, and from 425 ms to
+  69 ms at 24 MiB.
 
 ## 0.25.2 - 2026-07-28
 

--- a/kolega_code/llm/providers/anthropic.py
+++ b/kolega_code/llm/providers/anthropic.py
@@ -204,8 +204,9 @@ class AnthropicProvider(BaseLLMProvider):
             # system message is supplied (the local branch tolerates None).
             assert system is not None
             await self.rate_limiter.acquire()
+            payload = await asyncio.to_thread(messages.to_anthropic)
             count = await self.async_client.messages.count_tokens(
-                messages=messages.to_anthropic(),
+                messages=payload,
                 system=cast(Any, [c.to_anthropic() for c in cast(List[ContentBlock], system.content)]),
                 model=cast(Any, model),
                 tools=cast(Any, [t.to_anthropic() for t in tools]),
@@ -458,18 +459,32 @@ class AnthropicProvider(BaseLLMProvider):
 
         await self.rate_limiter.acquire()
 
-        # Return the stream context manager. A per-request streaming timeout bounds the
-        # inter-chunk read wait (see kolega_code/llm/timeouts.py) so a stalled connection
-        # fails in minutes and is retried, instead of hanging on the SDK's 600s default.
-        return AnthropicStreamWrapper(
-            self.async_client.messages.stream(
+        system_blocks = [c.to_anthropic() for c in cast(List[ContentBlock], system.content)]
+
+        def open_stream():
+            # A per-request streaming timeout bounds the inter-chunk read wait (see
+            # kolega_code/llm/timeouts.py) so a stalled connection fails in minutes and
+            # is retried, instead of hanging on the SDK's 600s default.
+            return self.async_client.messages.stream(
                 messages=messages.to_anthropic(),
-                system=cast(Any, [c.to_anthropic() for c in cast(List[ContentBlock], system.content)]),
+                system=cast(Any, system_blocks),
                 timeout=streaming_timeout(),
                 **generation_params,
-            ),
-            provider_name=self.provider_name,
-        )
+            )
+
+        # `messages.stream()` is a *synchronous* SDK call: it builds the request body and
+        # runs the SDK's parameter transform over it, then returns a manager whose HTTP
+        # request is only awaited on `__aenter__`. That transform walks every node of the
+        # payload with per-node typing introspection — 0.4s of blocked event loop for a
+        # 24 MiB image history, per request and per concurrently running sub-agent — so
+        # build the manager in a worker thread. Sending the request, and every chunk
+        # after it, still happens on the loop.
+        #
+        # A turn cancelled inside this window drops the manager before it is entered: no
+        # request has been sent, and the SDK's unawaited request coroutine only logs a
+        # RuntimeWarning.
+        manager = await asyncio.to_thread(open_stream)
+        return AnthropicStreamWrapper(manager, provider_name=self.provider_name)
 
     async def generate(
         self,
@@ -485,8 +500,11 @@ class AnthropicProvider(BaseLLMProvider):
         generation_params = self._sanitize_generation_params(generation_params)
 
         await self.rate_limiter.acquire()
+        # `messages.create()` is async, so unlike the streaming path its parameter
+        # transform cannot be moved off the loop; only our own payload construction can.
+        payload = await asyncio.to_thread(messages.to_anthropic)
         response = await self.async_client.messages.create(
-            messages=messages.to_anthropic(),
+            messages=payload,
             system=cast(Any, [c.to_anthropic() for c in cast(List[ContentBlock], system.content)]),
             # Passing the configured timeout explicitly bypasses the Anthropic
             # SDK's Claude-specific max_tokens heuristic, which otherwise

--- a/kolega_code/llm/providers/openai.py
+++ b/kolega_code/llm/providers/openai.py
@@ -542,9 +542,16 @@ class OpenAIProvider(BaseLLMProvider):
         # Per-request streaming timeout bounds the inter-chunk read wait (see
         # kolega_code/llm/timeouts.py): a stalled connection fails in minutes and is
         # retried, instead of hanging on the SDK's 600s default.
+        # Only our own payload construction can leave the loop here: the SDK's
+        # `chat.completions.create()` is async, so its parameter transform (which walks
+        # every node of the request body) runs inline on the loop. See the Anthropic
+        # provider, whose `messages.stream()` is synchronous and can be built off-loop.
+        payload = await asyncio.to_thread(
+            messages.to_openai, provider=self.provider_name, model=generation_params["model"]
+        )
         return OpenAIStreamWrapper(
             await self.async_client.chat.completions.create(
-                messages=messages.to_openai(provider=self.provider_name, model=generation_params["model"]),
+                messages=payload,
                 timeout=streaming_timeout(),
                 **generation_params,
             ),
@@ -576,8 +583,11 @@ class OpenAIProvider(BaseLLMProvider):
             messages = MessageHistory([system] + messages)
 
         await self.rate_limiter.acquire()
+        payload = await asyncio.to_thread(
+            messages.to_openai, provider=self.provider_name, model=generation_params["model"]
+        )
         response = await self.async_client.chat.completions.create(
-            messages=messages.to_openai(provider=self.provider_name, model=generation_params["model"]),
+            messages=payload,
             **generation_params,
         )
 

--- a/tests/agent/llm/test_provider_request_offloading.py
+++ b/tests/agent/llm/test_provider_request_offloading.py
@@ -1,0 +1,164 @@
+"""Request preparation must not run on the event loop.
+
+Building a request body is O(history): for an image-heavy conversation the SDK's
+parameter transform blocks the loop for hundreds of milliseconds per request, once per
+concurrently running sub-agent. The Anthropic streaming path can move all of that off
+the loop because ``messages.stream()`` is a synchronous SDK call; everywhere else only
+our own payload construction can be offloaded, because the SDK method is async.
+"""
+
+import json
+import threading
+from typing import Any, cast
+
+import httpx
+import pytest
+from anthropic import AsyncAnthropic
+from openai import AsyncOpenAI
+
+from kolega_code.llm.models import Message, MessageHistory, TextBlock
+from kolega_code.llm.providers.anthropic import AnthropicProvider
+from kolega_code.llm.providers.openai import OpenAIProvider
+
+_ANTHROPIC_MESSAGE = {
+    "id": "msg_1",
+    "type": "message",
+    "role": "assistant",
+    "model": "claude-opus-5",
+    "content": [{"type": "text", "text": "ok"}],
+    "stop_reason": "end_turn",
+    "stop_sequence": None,
+    "usage": {"input_tokens": 10, "output_tokens": 2},
+}
+
+_ANTHROPIC_EVENTS = [
+    ("message_start", {"type": "message_start", "message": {**_ANTHROPIC_MESSAGE, "content": []}}),
+    (
+        "content_block_start",
+        {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+    ),
+    (
+        "content_block_delta",
+        {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "ok"}},
+    ),
+    ("content_block_stop", {"type": "content_block_stop", "index": 0}),
+    (
+        "message_delta",
+        {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 2}},
+    ),
+    ("message_stop", {"type": "message_stop"}),
+]
+
+_OPENAI_CHUNKS = [
+    {
+        "id": "chatcmpl-1",
+        "object": "chat.completion.chunk",
+        "created": 0,
+        "model": "gpt-5.6",
+        "choices": [{"index": 0, "delta": {"role": "assistant", "content": "ok"}, "finish_reason": None}],
+    },
+    {
+        "id": "chatcmpl-1",
+        "object": "chat.completion.chunk",
+        "created": 0,
+        "model": "gpt-5.6",
+        "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+    },
+]
+
+
+def _sse(events: list[tuple[str, dict[str, Any]]]) -> str:
+    return "".join(f"event: {name}\ndata: {json.dumps(body)}\n\n" for name, body in events)
+
+
+def _history() -> MessageHistory:
+    return MessageHistory([Message(role="user", content=[TextBlock(text="hello")])])
+
+
+def _record_conversion_thread(monkeypatch: pytest.MonkeyPatch, method: str) -> dict[str, int]:
+    """Note which thread builds the wire payload."""
+    seen: dict[str, int] = {}
+    original = getattr(MessageHistory, method)
+
+    def tracking(self, *args, **kwargs):
+        seen["thread"] = threading.get_ident()
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(MessageHistory, method, tracking)
+    return seen
+
+
+@pytest.mark.asyncio
+async def test_anthropic_stream_is_prepared_off_the_event_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        bodies.append(json.loads(request.content))
+        return httpx.Response(200, content=_sse(_ANTHROPIC_EVENTS), headers={"content-type": "text/event-stream"})
+
+    provider = AnthropicProvider(api_key="fake-key", max_retries=0)
+    provider.async_client = AsyncAnthropic(
+        api_key="fake-key",
+        max_retries=0,
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    seen = _record_conversion_thread(monkeypatch, "to_anthropic")
+    history = _history()
+
+    wrapper = cast(
+        Any, await provider.stream(history, system=Message(role="system", content=[TextBlock(text="system")]))
+    )
+    async with wrapper:
+        chunks = [chunk async for chunk in wrapper]
+
+    assert seen["thread"] != threading.get_ident()
+    # The whole request survived the thread hop: same body, same streamed content.
+    assert [chunk.text for chunk in chunks if chunk.type == "text"] == ["ok"]
+    assert bodies[0]["messages"] == [{"role": "user", "content": [{"type": "text", "text": "hello"}]}]
+    assert bodies[0]["system"] == [{"type": "text", "text": "system"}]
+    assert bodies[0]["stream"] is True
+
+
+@pytest.mark.asyncio
+async def test_anthropic_generate_builds_its_payload_off_the_event_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_ANTHROPIC_MESSAGE)
+
+    provider = AnthropicProvider(api_key="fake-key", max_retries=0)
+    provider.async_client = AsyncAnthropic(
+        api_key="fake-key",
+        max_retries=0,
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    seen = _record_conversion_thread(monkeypatch, "to_anthropic")
+
+    message = await provider.generate(_history(), system=Message(role="system", content=[TextBlock(text="system")]))
+
+    assert seen["thread"] != threading.get_ident()
+    assert message.get_text_content() == "ok"
+
+
+@pytest.mark.asyncio
+async def test_openai_builds_its_payload_off_the_event_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        bodies.append(json.loads(request.content))
+        payload = "".join(f"data: {json.dumps(chunk)}\n\n" for chunk in _OPENAI_CHUNKS) + "data: [DONE]\n\n"
+        return httpx.Response(200, content=payload, headers={"content-type": "text/event-stream"})
+
+    provider = OpenAIProvider(api_key="sk-test", max_retries=0)
+    provider.async_client = AsyncOpenAI(
+        api_key="sk-test",
+        max_retries=0,
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    seen = _record_conversion_thread(monkeypatch, "to_openai")
+
+    wrapper = cast(Any, await provider.stream(_history(), model="gpt-5.6"))
+    async with wrapper:
+        chunks = [chunk async for chunk in wrapper]
+
+    assert seen["thread"] != threading.get_ident()
+    assert [chunk.text for chunk in chunks if chunk.type == "text"] == ["ok"]
+    assert bodies[0]["messages"] == [{"role": "user", "content": [{"type": "text", "text": "hello"}]}]


### PR DESCRIPTION
The last piece of on-loop work found while auditing what the image-resize fix (#364) uncovered.

## Problem

Every LLM request builds its body on the event loop, and that work is proportional to conversation size:

1. our own `to_anthropic()` / `to_openai()` conversion, and
2. the SDK's parameter transform, which walks every node of the request body with per-node `typing` introspection (74k recursive calls for a 24 MiB history).

Profiling one request with 24 MiB of images in history: ~90% of the client-side cost is that transform; JSON encoding is a distant second. All of it blocks the loop, once per request and once more for every concurrently running sub-agent.

## Fix

**Anthropic streaming — all of it moves off the loop.** `messages.stream()` is a *synchronous* SDK call: it builds and transforms the body and returns a manager whose HTTP request is only awaited on `__aenter__`. So the whole call goes into a worker thread. Sending the request and every chunk after it still happens on the loop, and nothing about how the SDK is used changes — no private attributes, no internal helpers, no pre-serialized bodies.

**Everywhere else — payload construction only.** Anthropic `messages.create()` / `count_tokens()` and OpenAI `chat.completions.create()` are async, so their transform runs inline on the loop and can only be moved by driving the *sync* client from a thread, which would break cancellation (an aborted turn would keep the request running). Not worth it, so those paths offload just `to_anthropic()` / `to_openai()`, and the residual cost is documented in the code.

One trade-off is called out in a comment: a turn cancelled during the off-loop build drops the stream manager before it is entered. No request has been sent — the SDK's unawaited request coroutine only logs a `RuntimeWarning`.

## Measured

Worst event-loop gap per streaming request, through `AnthropicProvider.stream()` against an httpx `MockTransport` (no network, client-side cost only):

| Images in history | Before | After |
| --- | --- | --- |
| 6 MiB | 111 ms | 19 ms |
| 24 MiB (the aggregate cap) | 425 ms | 69 ms |

Wall time per request is unchanged (~131 ms / ~438 ms) — the work still happens, it just no longer blocks the UI. The remaining gap is the JSON encode and send, which the SDK does inside the awaited request.

Component costs at 24 MiB for reference: `to_anthropic()` 0.5 ms, `to_openai()` 4.3 ms, `json.dumps` 42 ms, UTF-8 encode 3 ms, SDK transform ~200 ms.

## Tests

New `tests/agent/llm/test_provider_request_offloading.py` drives both providers through a mock transport and asserts the payload is built on a non-loop thread while the request body and the streamed content survive the thread hop intact. `tests/agent/llm` passes (409 tests), plus `ruff` and `pyright`.

Note: touches the same `## Unreleased` changelog section as #365 and #366.
