### PR TITLE
feat(browser): viewport control and honest page coverage for the Chrome backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+### Added
+
+- `browser_scroll` on both browser backends, taking exactly one of a target, a
+  count of viewports, or an absolute offset. On a page too large to snapshot in
+  one call, scrolling is how the rest is reached, and until now nothing could
+  move the viewport on the Chrome backend at all.
+
 ### Changed
 
 - Project memory, repository guidance (`AGENTS.md`/`KOLEGA.md`), and the current
@@ -23,6 +30,34 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   could fail to match after a turn with many parallel tool calls, which discarded
   the whole conversation's cache; the second one bounds that loss to one turn.
 
+- The Chrome browser backend now works on large real-world pages. Selector
+  resolution, snapshots, text search and focus handling previously failed
+  outright on any page over about a thousand DOM nodes, so an ordinary
+  application page returned an empty snapshot and refused every selector. Work
+  is now bounded by a wall-clock budget with the browser's own APIs doing the
+  filtering, and a bound that is reached degrades with a report instead of
+  failing.
+- Snapshots emit the nodes nearest the viewport first and attach a `Coverage:`
+  line naming what was omitted, why, and where the viewport sits in the page, so
+  a partial snapshot reads as "narrow the scope" rather than "the page is
+  unreadable".
+- `browser_find` distinguishes three outcomes: absent from the page, present but
+  outside the region the snapshot covered, and undetermined because the search
+  was truncated. Only the first is a reliable absence.
+- Text waits that could not read the whole page now fail immediately with a
+  `search_truncated` explanation instead of polling to a timeout and implying the
+  text was not there.
+- `browser_press_key` scrolls for `PageDown`, `PageUp`, `Home`, `End`, arrow keys
+  and `Space`, matching the Playwright backend, unless the page handles the key
+  itself or focus is in a text field or select.
+- Chrome snapshot `depth` now counts emitted nodes rather than raw DOM nesting,
+  so it means roughly what it means on the Playwright backend.
+- Tall full-page screenshots on Chrome are clipped from the current scroll
+  position and report the omission, instead of being downscaled until unreadable.
+  Native Messaging envelopes are now bounded per direction, following Chrome's
+  own asymmetric limits.
+- Errors from the Chrome extension keep their error code, and codes that mean
+  "too large to cover in one call" carry the concrete next step.
 - The responsiveness watchdog now captures stacks for event-loop stalls from ~1
   second (was 5) and counts shorter gaps into a periodic `loop_gap_histogram`
   diagnostics entry, so choppy-but-not-frozen UI leaves evidence instead of

--- a/docs/src/content/docs/cli/browser.md
+++ b/docs/src/content/docs/cli/browser.md
@@ -80,18 +80,25 @@ response headers or bodies, file uploads or file/data drop, or console messages.
 ### Choosing which session controls the browser
 
 The extension connects to the native host on its own; you do not need to open it
-in normal use. When exactly one Kolega session is running it is selected
-automatically.
+in normal use.
 
-When two or more sessions are running, the extension will not guess which one
-may drive your browser, because selecting a session grants a local process
-access to pages in your ordinary profile. The toolbar badge shows `!` while a
-choice is pending — click the extension and pick a session. Run
+A Kolega session asks for the browser when it first runs a browser tool, and
+releases it again when it detaches — when a browser sub-agent finishes, or you run
+`browser_close`. Only sessions that currently want the browser are candidates, so
+having several Kolega sessions open costs you nothing: as long as one is browsing
+at a time it is selected automatically, with no clicking.
+
+The extension only involves you when two sessions want the browser *at the same
+time*. It will not guess between them, because selecting a session grants a local
+process access to pages in your ordinary profile. The toolbar badge shows `!` while
+a choice is pending — click the extension and pick a session. Waiting for the other
+session to finish browsing clears it too, since that releases its claim. Run
 `kolega-code browser doctor` to see the competing sessions and which runtime id
 belongs to the session you are using.
 
 Your choice is remembered for as long as Chrome stays open, including across
-service-worker restarts, and is cleared when Chrome restarts.
+service-worker restarts, and is cleared when Chrome restarts or the extension is
+reloaded. Losing it costs nothing when only one session is browsing.
 
 ### Regular expressions
 

--- a/docs/src/content/docs/cli/browser.md
+++ b/docs/src/content/docs/cli/browser.md
@@ -68,7 +68,7 @@ The Chrome integration exposes only these fixed protocol operations:
   `browser.wait_for`
 - Interaction: `browser.click`, `browser.type`, `browser.fill_form`,
   `browser.select_option`, `browser.hover`, `browser.drag`,
-  `browser.press_key`
+  `browser.press_key`, `browser.scroll`
 - Tabs and inspection: `browser.tabs`, `browser.network_requests`,
   `browser.screenshot`
 - Disconnect: `browser.detach`
@@ -109,12 +109,39 @@ ever repeat one atom, so catastrophic backtracking is impossible. Write
 The Playwright backend accepts full Python regular expressions, so a pattern that
 works there may be rejected on Chrome.
 
+### Very large pages
+
+A page can be far larger than one snapshot can carry, and the Chrome backend now
+says so instead of pretending otherwise. Snapshots emit the nodes nearest the
+viewport first and attach a `Coverage:` line naming how much was shown, why it
+stopped, and where the viewport sits in the page.
+
+Treat that line as an instruction, not a failure:
+
+- pass `target` to `browser_snapshot` to scope it to one subtree, or
+- `browser_scroll` and snapshot again to walk the page a screenful at a time.
+
+Two related guarantees follow from the same principle. A rendered-text search
+that could not read the whole page reports `search_truncated` rather than
+claiming the text is absent, and `browser_find` distinguishes text that is
+genuinely missing from text that lies outside the region the snapshot covered.
+A negative result you can trust is worth more than one that is merely short.
+
+Page work is bounded by a wall-clock budget rather than by a node count, so
+ordinary large pages are covered completely; only pathological documents run out
+of time, and they too report what they managed.
+
 ### Screenshots
 
 `browser.screenshot` returns the image inline. Neither the Chrome nor the
 Playwright backend writes screenshots to disk, so there is no artifact file path
 to report. Capture only the region you need: a full-page screenshot of a long
 page produces a large inline image.
+
+On Chrome, a page too tall to capture legibly is clipped from the current scroll
+position rather than downscaled, and the result reports what it omitted. Scroll
+and capture again to see the rest. Sticky headers repeat in each stitched band,
+which is inherent to how Chrome captures a visible tab.
 
 ## Native-host manifest location
 

--- a/docs/src/content/docs/concepts/tools.md
+++ b/docs/src/content/docs/concepts/tools.md
@@ -90,12 +90,18 @@ Drive a real browser (Playwright) for web tasks:
 
 - `browser_navigate`, `browser_snapshot`, `browser_find`, `browser_close`
 - `browser_click`, `browser_type`, `browser_fill_form`, `browser_select_option`
-- `browser_tabs`, `browser_wait_for`, `browser_handle_dialog`, `browser_file_upload`
+- `browser_scroll`, `browser_press_key`, `browser_wait_for`
+- `browser_tabs`, `browser_handle_dialog`, `browser_file_upload`
 - `browser_console_messages`, `browser_network_requests`, `browser_take_screenshot`
 
 The browser agent uses accessibility snapshots with element refs such as `e12`.
 Actions return an updated snapshot, so the agent can interact deterministically
 without inventing CSS selectors or relying on screenshots.
+
+On a page too large for one snapshot, the nodes nearest the viewport are emitted
+first and a `Coverage:` line states what was left out. Scope it with a `target`,
+or `browser_scroll` and snapshot again; see
+[the browser command reference](/cli/browser/#very-large-pages).
 
 Launch visible browser windows (instead of headless) with `--browser-visible` on
 the [TUI](../../cli/overview/) or [`ask`](../../cli/ask/).

--- a/kolega_code/agent/tool_backend/browser_tool.py
+++ b/kolega_code/agent/tool_backend/browser_tool.py
@@ -153,7 +153,33 @@ BROWSER_TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
         ["target"],
     ),
     "browser_press_key": _schema(
-        {"key": {"type": "string", "description": "Key name or character, such as ArrowLeft or a."}}, ["key"]
+        {
+            "key": {
+                "type": "string",
+                "description": (
+                    "Key name or character, such as ArrowLeft or a. PageDown, PageUp, Home, End, "
+                    "ArrowDown, ArrowUp and Space scroll the page unless focus is in a text field or "
+                    "the page handles the key itself."
+                ),
+            }
+        },
+        ["key"],
+    ),
+    "browser_scroll": _schema(
+        {
+            "target": {
+                "type": "string",
+                "description": "Scroll this element into view. Exact ref from browser_snapshot, or a unique selector.",
+            },
+            "x": {"type": "integer", "description": "Absolute horizontal offset in CSS pixels."},
+            "y": {"type": "integer", "description": "Absolute vertical offset in CSS pixels."},
+            "by_pages": {
+                "type": "number",
+                "description": (
+                    "Scroll by this many viewport heights; negative scrolls up. Fractions are allowed, range -10 to 10."
+                ),
+            },
+        }
     ),
     "browser_tabs": _schema(
         {
@@ -282,6 +308,13 @@ class BrowserTool(BaseTool):
     @staticmethod
     def _format_page(result: dict[str, Any]) -> str:
         parts = ["## Page", f"- URL: {result.get('url', 'about:blank')}", f"- Title: {result.get('title', '')}"]
+        scroll_y = result.get("scroll_y")
+        if isinstance(scroll_y, (int, float)):
+            # Where the viewport ended up, so a scroll-then-snapshot loop can tell
+            # progress from a scroll that hit the end of the page.
+            content_height = result.get("content_height")
+            extent = f" of {int(content_height)}" if isinstance(content_height, (int, float)) else ""
+            parts.append(f"- Scroll position: y={int(scroll_y)}{extent} px")
         if result.get("modal"):
             parts.extend(["", "## Modal state", "```json", json.dumps(result["modal"], indent=2), "```"])
         if "result" in result:
@@ -373,6 +406,15 @@ class BrowserTool(BaseTool):
 
     async def browser_press_key(self, key: str) -> str:
         return self._format_page(await self.browser_manager.press_key(key))
+
+    async def browser_scroll(
+        self,
+        target: Optional[str] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        by_pages: Optional[float] = None,
+    ) -> str:
+        return self._format_page(await self.browser_manager.scroll(target=target, x=x, y=y, by_pages=by_pages))
 
     async def browser_tabs(self, action: str, index: Optional[int] = None, url: Optional[str] = None) -> str:
         previous = self.browser_manager.session_id

--- a/kolega_code/agent/tool_backend/browser_tool.py
+++ b/kolega_code/agent/tool_backend/browser_tool.py
@@ -44,6 +44,83 @@ def _schema(properties: dict[str, Any], required: Optional[list[str]] = None) ->
     return result
 
 
+# Several models fill in *every* property a tool schema declares rather than
+# omitting the ones they are not using, so an unused string arrives as "" and an
+# unused number as 0. Neither can express a request, and the backends rightly
+# reject them — but rejecting is a dead end: the model has no way to stop padding,
+# so it retries the identical call until it gives up. (Observed: 13 consecutive
+# `browser_tabs {"action":"list","index":0,"url":""}` calls rejected with "url is
+# invalid", which ended the run at step one.) Treat a value that cannot express a
+# request as the omission it was meant to be, at this agent-facing boundary only:
+# the wire protocol below stays exact.
+def _text_or_none(value: Optional[str]) -> Optional[str]:
+    """Drop a string that carries no request, such as "" or "   "."""
+    if value is None or not value.strip():
+        return None
+    return value
+
+
+def _choice_or_default(value: Optional[str], default: str) -> str:
+    """Fall back to the documented default for an unset enum-valued argument."""
+    return value if value is not None and value.strip() else default
+
+
+def _resolve_scroll(
+    target: Optional[str],
+    x: Optional[int],
+    y: Optional[int],
+    by_pages: Optional[float],
+) -> tuple[Optional[str], Optional[int], Optional[int], Optional[float]]:
+    """Pick the one movement the caller asked for, ignoring padded-out arguments.
+
+    Both backends require exactly one of target, by_pages, or x/y, because three
+    different movements in one call cannot be resolved. Padding is not a fourth
+    movement though: a zero page count moves nothing, and zero offsets alongside a
+    real target say nothing the target does not already say. Only a genuine
+    conflict — two movements that would each go somewhere — is still rejected, and
+    the rejection names what arrived so it can be corrected.
+
+    ``x``/``y`` of 0 stay meaningful on their own: scrolling to the top of a page
+    is an ordinary request.
+    """
+    target = _text_or_none(target)
+    wants_target = target is not None
+    wants_pages = by_pages is not None and by_pages != 0
+    wants_offset = (x is not None and x != 0) or (y is not None and y != 0)
+    requested = sum((wants_target, wants_pages, wants_offset))
+    if requested > 1:
+        supplied = ", ".join(
+            part
+            for part in (
+                f"target={target!r}" if wants_target else "",
+                f"by_pages={by_pages}" if wants_pages else "",
+                f"x={x}, y={y}" if wants_offset else "",
+            )
+            if part
+        )
+        raise ValueError(
+            f"Provide exactly one of target, by_pages, or x/y; received {supplied}. "
+            "Pass only the movement you want and omit the others."
+        )
+    if requested == 1:
+        if wants_target:
+            return target, None, None, None
+        if wants_pages:
+            return None, None, None, by_pages
+        return None, x, y, None
+    # Nothing but zeros and blanks arrived. An explicit x/y still means "go to the
+    # top"; a lone by_pages=0 is a no-op the backends accept. Otherwise there is
+    # genuinely no movement to perform.
+    if x is not None or y is not None:
+        return None, x, y, None
+    if by_pages is not None:
+        return None, None, None, by_pages
+    raise ValueError(
+        "Provide exactly one of target, by_pages, or x/y: a selector or ref to scroll into view, "
+        "a signed number of viewport heights, or an absolute x/y offset in CSS pixels."
+    )
+
+
 BROWSER_TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
     "browser_navigate": _schema(
         {"url": {"type": "string", "description": "HTTP or HTTPS URL to navigate to."}}, ["url"]
@@ -193,16 +270,13 @@ BROWSER_TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
             "index": {
                 "type": "integer",
                 "description": (
-                    "Tab index for close or select. Required for select. Must be null for list and new; "
-                    "0 is a real tab index, not a stand-in for 'unset'."
+                    "Tab index, required for select and optional for close, where omitting it means the "
+                    "current tab. Ignored by list and new. 0 is a real tab index."
                 ),
             },
             "url": {
                 "type": "string",
-                "description": (
-                    "URL for a new tab. Accepted only with the new action; must be null otherwise. "
-                    "An empty string is rejected — use null."
-                ),
+                "description": "URL for a new tab. Ignored by every other action; omit it for a blank tab.",
             },
         },
         ["action"],
@@ -389,12 +463,15 @@ class BrowserTool(BaseTool):
         return self._format_page(await self.browser_manager.navigate_back())
 
     async def browser_snapshot(self, target: Optional[str] = None, depth: Optional[int] = None) -> str:
+        # depth is a positive maximum, so 0 can only be padding.
+        target, depth = _text_or_none(target), depth or None
         previous = self.browser_manager.session_id
         result = await self.browser_manager.snapshot(target=target, depth=depth)
         await self._broadcast_launched(previous, result)
         return self._format_page(result)
 
     async def browser_find(self, text: Optional[str] = None, regex: Optional[str] = None) -> str:
+        text, regex = _text_or_none(text), _text_or_none(regex)
         result = await self.browser_manager.find(text=text, regex=regex)
         query = result["query"]
         coverage = self._format_coverage(result.get("snapshot_coverage"))
@@ -419,6 +496,11 @@ class BrowserTool(BaseTool):
     async def browser_wait_for(
         self, time: Optional[float] = None, text: Optional[str] = None, text_gone: Optional[str] = None
     ) -> str:
+        text, text_gone = _text_or_none(text), _text_or_none(text_gone)
+        if time == 0 and (text is not None or text_gone is not None):
+            # A zero-second wait alongside a real condition is padding; on its own
+            # it stays a legitimate no-op wait.
+            time = None
         return self._format_page(await self.browser_manager.wait_for(time=time, text=text, text_gone=text_gone))
 
     async def browser_resize(self, width: int, height: int) -> str:
@@ -432,7 +514,12 @@ class BrowserTool(BaseTool):
         modifiers: Optional[list[str]] = None,
     ) -> str:
         return self._format_page(
-            await self.browser_manager.click(target, double_click=double_click, button=button, modifiers=modifiers)
+            await self.browser_manager.click(
+                target,
+                double_click=double_click,
+                button=_choice_or_default(button, "left"),
+                modifiers=modifiers,
+            )
         )
 
     async def browser_type(self, target: str, text: str, submit: bool = False, slowly: bool = False) -> str:
@@ -467,9 +554,17 @@ class BrowserTool(BaseTool):
         y: Optional[int] = None,
         by_pages: Optional[float] = None,
     ) -> str:
+        target, x, y, by_pages = _resolve_scroll(target, x, y, by_pages)
         return self._format_page(await self.browser_manager.scroll(target=target, x=x, y=y, by_pages=by_pages))
 
     async def browser_tabs(self, action: str, index: Optional[int] = None, url: Optional[str] = None) -> str:
+        # The action alone decides which of index and url applies, so anything
+        # supplied for the other one is padding and is dropped rather than
+        # rejected. list takes neither; new takes url ("" means a blank tab);
+        # close and select take index, where 0 is a real tab.
+        if action in {"list", "new"}:
+            index = None
+        url = _text_or_none(url) if action == "new" else None
         previous = self.browser_manager.session_id
         try:
             result = await self.browser_manager.tabs(action, index=index, url=url)
@@ -491,7 +586,9 @@ class BrowserTool(BaseTool):
         return self._format_page(await self.browser_manager.file_upload(self._file_payloads(paths)))
 
     async def browser_console_messages(self, level: str = "info", all_messages: bool = False) -> str:
-        result = await self.browser_manager.console_messages(level, all_messages=all_messages)
+        result = await self.browser_manager.console_messages(
+            _choice_or_default(level, "info"), all_messages=all_messages
+        )
         header = f"Total messages: {result['total']} (Errors: {result['errors']}, Warnings: {result['warnings']})"
         messages = []
         for message in result["messages"]:
@@ -502,7 +599,7 @@ class BrowserTool(BaseTool):
 
     async def browser_network_requests(self, include_static: bool = False, filter_pattern: Optional[str] = None) -> str:
         result = await self.browser_manager.network_requests(
-            include_static=include_static, filter_pattern=filter_pattern
+            include_static=include_static, filter_pattern=_text_or_none(filter_pattern)
         )
         if not result["requests"]:
             return "No matching network requests."
@@ -517,7 +614,7 @@ class BrowserTool(BaseTool):
     async def browser_network_request(self, index: int, part: Optional[str] = None) -> str:
         return (
             "```json\n"
-            + json.dumps(await self.browser_manager.network_request(index, part), indent=2, default=str)
+            + json.dumps(await self.browser_manager.network_request(index, _text_or_none(part)), indent=2, default=str)
             + "\n```"
         )
 
@@ -529,11 +626,14 @@ class BrowserTool(BaseTool):
         scale: str = "css",
     ) -> dict[str, Any]:
         return await self.browser_manager.screenshot(
-            target=target, image_type=image_type, full_page=full_page, scale=scale
+            target=_text_or_none(target),
+            image_type=_choice_or_default(image_type, "png"),
+            full_page=full_page,
+            scale=_choice_or_default(scale, "css"),
         )
 
     async def browser_evaluate(self, function: str, target: Optional[str] = None) -> str:
-        return self._format_page(await self.browser_manager.evaluate(function, target))
+        return self._format_page(await self.browser_manager.evaluate(function, _text_or_none(target)))
 
     async def browser_close(self) -> str:
         session_id = await self.browser_manager.close()

--- a/kolega_code/agent/tool_backend/browser_tool.py
+++ b/kolega_code/agent/tool_backend/browser_tool.py
@@ -52,7 +52,13 @@ BROWSER_TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
     "browser_snapshot": _schema(
         {
             "target": _TARGET,
-            "depth": {"type": "integer", "description": "Optional maximum accessibility-tree depth."},
+            "depth": {
+                "type": "integer",
+                "description": (
+                    "Optional maximum accessibility-tree depth. This counts emitted nodes, not raw DOM "
+                    "nesting, so ordinary deeply nested markup is not pruned."
+                ),
+            },
         }
     ),
     "browser_find": _schema(
@@ -254,7 +260,14 @@ BROWSER_TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
         {
             "target": _TARGET,
             "image_type": {"type": "string", "enum": ["png", "jpeg"]},
-            "full_page": {"type": "boolean", "description": "Capture the full scrollable page."},
+            "full_page": {
+                "type": "boolean",
+                "description": (
+                    "Capture the full scrollable page. A page too tall to capture legibly is clipped "
+                    "from the current scroll position and reports what it left out, so scroll and "
+                    "capture again to see the rest."
+                ),
+            },
             "scale": {"type": "string", "enum": ["css", "device"]},
         }
     ),
@@ -323,7 +336,33 @@ class BrowserTool(BaseTool):
             parts.append("Result truncated by size.")
         if result.get("snapshot") is not None:
             parts.extend(["", "## Snapshot", "```yaml", result["snapshot"], "```"])
+        coverage = BrowserTool._format_coverage(result.get("coverage"))
+        if coverage:
+            parts.extend(["", coverage])
         return "\n".join(parts)
+
+    @staticmethod
+    def _format_coverage(coverage: Any) -> str:
+        """Say what a partial snapshot left out, and what to do about it.
+
+        Only emitted when coverage is genuinely incomplete: a truncated snapshot
+        that looks complete is what made an agent conclude a page was unreadable.
+        """
+        if not isinstance(coverage, dict) or coverage.get("complete") is not False:
+            return ""
+        emitted = coverage.get("emitted")
+        candidates = coverage.get("candidates")
+        reason = coverage.get("reason") or "a size bound"
+        scope = f"Showing {emitted} of {candidates} page nodes" if emitted and candidates else "Snapshot truncated"
+        position = ""
+        scroll_y = coverage.get("scroll_y")
+        content_height = coverage.get("content_height")
+        if isinstance(scroll_y, (int, float)) and isinstance(content_height, (int, float)) and content_height:
+            position = f", at y={int(scroll_y)} of {int(content_height)} px"
+        return (
+            f"Coverage: {scope} ({reason}){position}. Nodes nearest the viewport are shown first. "
+            "Narrow the scope with browser_snapshot target=<selector>, or browser_scroll and snapshot again."
+        )
 
     def _file_payloads(self, paths: list[str]) -> list[dict[str, Any]]:
         payloads = []
@@ -357,11 +396,25 @@ class BrowserTool(BaseTool):
 
     async def browser_find(self, text: Optional[str] = None, regex: Optional[str] = None) -> str:
         result = await self.browser_manager.find(text=text, regex=regex)
+        query = result["query"]
+        coverage = self._format_coverage(result.get("snapshot_coverage"))
         if not result["matches"]:
-            return f"No matches found for {result['query']!r}."
-        return f"Found {result['match_count']} matches for {result['query']!r}:\n\n" + "\n\n---\n\n".join(
-            result["matches"]
-        )
+            # A bounded search must never be rendered as an absence. The three
+            # cases are: genuinely absent, present in the page but outside the
+            # region the snapshot covered, and undetermined because the search
+            # itself was truncated.
+            if result.get("page_text_match") is True:
+                return (
+                    f"No snapshot matches for {query!r}, but the page's rendered text does contain it, "
+                    "so it lies outside the region this snapshot covered." + (f"\n\n{coverage}" if coverage else "")
+                )
+            if result.get("page_text_match") is False:
+                return f"No matches found for {query!r}, and the page's rendered text does not contain it either."
+            return f"No matches found for {query!r} in the covered region; coverage was incomplete, so this is " + (
+                "not a reliable absence." + (f"\n\n{coverage}" if coverage else "")
+            )
+        found = f"Found {result['match_count']} matches for {query!r}:\n\n" + "\n\n---\n\n".join(result["matches"])
+        return f"{found}\n\n{coverage}" if coverage else found
 
     async def browser_wait_for(
         self, time: Optional[float] = None, text: Optional[str] = None, text_gone: Optional[str] = None

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -995,9 +995,15 @@ class ToolCollection(LogMixin):
         Prefer this over screenshots when deciding what to interact with. Interactive
         nodes include stable refs such as e12 that can be passed to action tools.
 
+        On a page too large to fit one snapshot, nodes nearest the viewport are shown
+        first and a Coverage line states what was left out. That is an instruction to
+        narrow the scope — pass a target, or browser_scroll and snapshot again — not a
+        sign the page is unreadable.
+
         Args:
             target: Optional snapshot ref or unique selector for a subtree.
-            depth: Optional maximum accessibility-tree depth.
+            depth: Optional maximum accessibility-tree depth. Counts emitted nodes
+                rather than raw DOM nesting.
         """
         return await self.browser_tool.browser_snapshot(target, depth)
 
@@ -1006,6 +1012,10 @@ class ToolCollection(LogMixin):
 
         Provide exactly one of text or regex. This is cheaper than requesting a
         full snapshot when locating a specific element.
+
+        A miss distinguishes three cases: absent from the page, present in the page
+        but outside the region the snapshot covered, and undetermined because the
+        search was truncated. Only the first is a reliable absence.
 
         Args:
             text: Case-insensitive text to find.

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -1163,14 +1163,15 @@ class ToolCollection(LogMixin):
     async def browser_tabs(self, action: str, index: Optional[int] = None, url: Optional[str] = None) -> str:
         """List, create, close, or select browser tabs.
 
-        Pass inapplicable parameters as null, never as 0 or an empty string:
-        list needs neither index nor url, new takes url with index null, and
-        select and close take index with url null.
+        The action decides which other argument applies, and anything supplied for
+        the rest is ignored: list uses neither, new uses url, and select and close
+        use index. Tab indices shift after a close, so re-list before acting again.
 
         Args:
             action: One of list, new, close, or select.
-            index: Tab index for close or select; must be null for list and new.
-            url: URL for a new tab; must be null for every other action.
+            index: Tab index, required for select. For close it defaults to the
+                current tab. 0 is a real tab index.
+            url: URL for a new tab; omit it for a blank tab.
         """
         return await self.browser_tool.browser_tabs(action, index, url)
 

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -508,6 +508,7 @@ class ToolCollection(LogMixin):
         "browser_drag",
         "browser_drop",
         "browser_press_key",
+        "browser_scroll",
         "browser_tabs",
         "browser_handle_dialog",
         "browser_file_upload",
@@ -1118,10 +1119,36 @@ class ToolCollection(LogMixin):
     async def browser_press_key(self, key: str) -> str:
         """Press a keyboard key in the current tab.
 
+        PageDown, PageUp, Home, End, ArrowDown, ArrowUp and Space also scroll the
+        page, unless focus is in a text field or select, or the page handles the
+        key itself. Use browser_scroll when you want to move the viewport
+        deliberately rather than as a side effect of a keystroke.
+
         Args:
             key: Key name or character, such as ArrowLeft or a.
         """
         return await self.browser_tool.browser_press_key(key)
+
+    async def browser_scroll(
+        self,
+        target: Optional[str] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        by_pages: Optional[float] = None,
+    ) -> str:
+        """Move the viewport, then return the updated page snapshot.
+
+        Supply exactly one movement. On a page too large to snapshot in one call,
+        scroll and re-snapshot: the snapshot prioritises what is near the viewport,
+        so moving the viewport is how you reach the rest.
+
+        Args:
+            target: Scroll this ref or unique selector into view.
+            x: Absolute horizontal offset in CSS pixels.
+            y: Absolute vertical offset in CSS pixels.
+            by_pages: Scroll by this many viewport heights; negative scrolls up.
+        """
+        return await self.browser_tool.browser_scroll(target, x, y, by_pages)
 
     async def browser_tabs(self, action: str, index: Optional[int] = None, url: Optional[str] = None) -> str:
         """List, create, close, or select browser tabs.
@@ -1335,9 +1362,15 @@ class ToolCollection(LogMixin):
         IMPORTANT: The browser agent specializes in these tools:
             - browser_navigate, browser_snapshot, and browser_find
             - browser_click, browser_type, browser_fill_form, and browser_select_option
-            - browser_tabs, browser_wait_for, browser_handle_dialog, and browser_file_upload
+            - browser_scroll, browser_press_key, and browser_wait_for
+            - browser_tabs, browser_handle_dialog, and browser_file_upload
             - browser_console_messages, browser_network_requests, and browser_take_screenshot
             - browser_close
+
+        On a page too large to snapshot in one call the snapshot is truncated and
+        says so, prioritising what is near the viewport. Treat that as an
+        instruction to narrow the scope: pass a target to browser_snapshot, or
+        browser_scroll and snapshot again. It does not mean the page is unreadable.
 
         Args:
             task: A detailed description of the browser task to perform

--- a/kolega_code/browser_extension/__init__.py
+++ b/kolega_code/browser_extension/__init__.py
@@ -1,6 +1,7 @@
 """Chrome Native Messaging browser backend."""
 
 from .framing import (
+    MAX_NATIVE_INBOUND_MESSAGE_BYTES,
     MAX_NATIVE_MESSAGE_BYTES,
     FramingError,
     MessageTooLargeError,
@@ -46,6 +47,7 @@ __all__ = [
     "ALLOWED_OPERATIONS",
     "CHROME_EXTENSION_CAPABILITIES",
     "CHROME_EXTENSION_SUPPORTED_TOOLS",
+    "MAX_NATIVE_INBOUND_MESSAGE_BYTES",
     "MAX_NATIVE_MESSAGE_BYTES",
     "PROTOCOL_VERSION",
     "ChromeExtensionBrowserManager",

--- a/kolega_code/browser_extension/framing.py
+++ b/kolega_code/browser_extension/framing.py
@@ -7,7 +7,13 @@ import json
 import struct
 from typing import Any, BinaryIO, Mapping, cast
 
+# Chrome's Native Messaging limits are asymmetric: a message *from* the host is
+# capped at 1 MB, while a message *to* the host may be far larger. Requests we
+# write toward Chrome must therefore respect the 1 MiB bound, but responses we
+# read back had no reason to share it, and that self-imposed symmetry is why a
+# full-page screenshot had to be downscaled into illegibility before it fitted.
 MAX_NATIVE_MESSAGE_BYTES = 1_048_576
+MAX_NATIVE_INBOUND_MESSAGE_BYTES = 67_108_864
 _HEADER = struct.Struct("<I")
 
 

--- a/kolega_code/browser_extension/manager.py
+++ b/kolega_code/browser_extension/manager.py
@@ -88,6 +88,7 @@ class ChromeExtensionBrowserManager(BrowserManager):
         self._peer: MultiplexedPeer | None = None
         self._state_changed = asyncio.Event()
         self._browser_session_id: str | None = None
+        self._route_epoch = 0
         self._peer_watch_tasks: set[asyncio.Task[None]] = set()
         self._lifecycle_lock = asyncio.Lock()
         self._operation_lock = asyncio.Lock()
@@ -182,7 +183,9 @@ class ChromeExtensionBrowserManager(BrowserManager):
         # Deliberately independent of peer state: this event is what makes the
         # native host dial the socket in the first place, so requiring a peer here
         # only reintroduces an ordering dependency between two views of the same
-        # fact.
+        # fact. Counting announcements lets a request that raced a rediscovery wait
+        # for the next one instead of failing (see _await_route_confirmation).
+        self._route_epoch += 1
         self._adopt_browser_session()
         self._state_changed.set()
 
@@ -200,25 +203,42 @@ class ChromeExtensionBrowserManager(BrowserManager):
             return []
 
     def _selection_detail(self) -> str:
-        """Ask the operator to grant this session the browser, naming the rivals.
+        """Say what is actually blocking the browser, and only then involve the operator.
 
-        The extension will not guess which local runtime may drive the browser when
-        several are advertised, because selecting one grants a local process access
-        to the operator's real Chrome profile.
+        Two completely different situations produce a selection refusal, and telling
+        the operator to click the extension is right in only one of them:
+
+        - **Contested.** Another Kolega session is claiming the browser at the same
+          time. The extension will not guess which local runtime may drive it,
+          because selecting one grants a local process access to the operator's real
+          Chrome profile, so only the operator can break the tie.
+        - **Uncontested.** This session holds the only claim. Then there is nothing
+          to choose and nothing to click: the extension auto-selects a lone runtime
+          on its next enumeration, which the native host triggers within about a
+          second of the claim appearing. Sending the operator to the popup here is
+          simply wrong, and it is what a claim that outlived its usefulness used to
+          make unavoidable.
         """
         mine = self.runtime_id
         runtimes = self._live_runtimes()
+        rivals = [descriptor for descriptor in runtimes if descriptor.runtime_id != mine]
+        if not rivals:
+            return (
+                "Chrome has not finished picking this session up yet — no other Kolega session is "
+                "competing for the browser, so there is nothing to select and nothing to click. The "
+                "companion enumerates sessions about a second after one asks for the browser, and it "
+                "selects a lone session automatically. Retry the operation."
+            )
         listed = ", ".join(
-            f"{descriptor.session_id} (runtime {descriptor.runtime_id}, pid {descriptor.pid})"
-            + (" <- this session" if descriptor.runtime_id == mine else "")
-            for descriptor in runtimes
+            f"{descriptor.session_id} (runtime {descriptor.runtime_id}, pid {descriptor.pid})" for descriptor in rivals
         )
-        census = f" {len(runtimes)} sessions are advertised: {listed}." if len(runtimes) > 1 else ""
+        plural = "sessions are" if len(rivals) > 1 else "session is"
         return (
-            "Kolega Browser Companion is waiting for you to choose which Kolega session may control the "
-            f"browser.{census} Click the extension and select this session"
+            f"Another Kolega {plural} currently using the browser, so Kolega Browser Companion needs you "
+            f"to choose which one may control it: {listed}. Click the extension and select this session"
             + (f" (runtime {mine})" if mine else "")
-            + ". The extension badge shows '!' while a choice is required."
+            + ". The extension badge shows '!' while a choice is required. A session releases its claim "
+            "when it finishes browsing, so waiting for the other one to finish also clears this."
         )
 
     def _unavailable_detail(self) -> str:
@@ -231,7 +251,8 @@ class ChromeExtensionBrowserManager(BrowserManager):
         count while holding a live connection used to blame the operator for a state
         the session was not actually in.
         """
-        if len(self._live_runtimes()) > 1:
+        mine = self.runtime_id
+        if any(descriptor.runtime_id != mine for descriptor in self._live_runtimes()):
             return self._selection_detail()
         return (
             "Kolega Browser Companion did not connect. Confirm the extension is installed and enabled in "
@@ -311,37 +332,80 @@ class ChromeExtensionBrowserManager(BrowserManager):
             result["state"] = "awaiting_selection"
         return result
 
+    async def _await_route_confirmation(self, since: int) -> bool:
+        """Wait for the extension to re-confirm that this runtime may drive Chrome.
+
+        Re-publishing a withdrawn claim reaches Chrome only through the native
+        host's registry watcher, so an operation issued right after a detach can
+        arrive before the rediscovery that re-selects us. The extension refuses it,
+        but announces ``browser.session_ready`` as soon as the rediscovery lands, so
+        that refusal is transient and worth waiting out once. Compares a
+        confirmation counter rather than clearing a flag, so an announcement that
+        races the refusal still counts.
+        """
+        loop = asyncio.get_running_loop()
+        expires = loop.time() + self.connection_timeout
+        while self._route_epoch == since:
+            self._state_changed.clear()
+            if self._route_epoch != since:
+                break
+            remaining = expires - loop.time()
+            if remaining <= 0:
+                return False
+            try:
+                await asyncio.wait_for(self._state_changed.wait(), timeout=remaining)
+            except TimeoutError:
+                return False
+        return True
+
     async def _request(self, operation: str, params: Mapping[str, JSONValue]) -> dict[str, Any]:
         async with self._operation_lock:
             try:
                 validated = validate_operation_request(operation, dict(params))
             except ProtocolValidationError as exc:
                 raise ChromeExtensionProtocolError(exc.message) from None
-            peer = await self._connected_peer()
-            try:
-                result = await peer.request(operation, validated, timeout=self.operation_timeout)
-            except (ConnectionClosedError, RequestTimeoutError) as exc:
-                if self._peer is peer and peer.closed:
-                    self._peer = None
-                    self._state_changed.set()
-                raise ChromeExtensionUnavailableError(str(exc)) from None
-            except RemoteRequestError as exc:
-                # The remote error code was previously discarded, leaving callers
-                # to string-match prose. Keep it, and append the concrete next
-                # step for the codes that mean "too big to cover in one call" or
-                # "the operator has not granted this session the browser".
-                remedy = _COVERAGE_REMEDIES.get(exc.code or "")
-                if exc.code in _SELECTION_CODES:
-                    remedy = self._selection_detail()
-                message = exc.message
-                if remedy:
-                    message = f"{message.rstrip('.')}. {remedy}"
-                raise ChromeExtensionUnavailableError(message, code=exc.code) from None
+            result = await self._send(operation, validated, allow_route_retry=True)
             if not isinstance(result, dict):
                 raise ChromeExtensionProtocolError("Chrome extension returned a non-object browser result.")
             response = cast(dict[str, Any], result)
             response.setdefault("session_id", self._browser_session_id)
             return response
+
+    async def _send(
+        self,
+        operation: str,
+        validated: dict[str, JSONValue],
+        *,
+        allow_route_retry: bool,
+    ) -> object:
+        epoch = self._route_epoch
+        peer = await self._connected_peer()
+        try:
+            return await peer.request(operation, validated, timeout=self.operation_timeout)
+        except (ConnectionClosedError, RequestTimeoutError) as exc:
+            if self._peer is peer and peer.closed:
+                self._peer = None
+                self._state_changed.set()
+            raise ChromeExtensionUnavailableError(str(exc)) from None
+        except RemoteRequestError as exc:
+            # A selection refusal is checked before the extension touches the page,
+            # so nothing happened and retrying once is safe.
+            if allow_route_retry and exc.code in _SELECTION_CODES and await self._await_route_confirmation(epoch):
+                return await self._send(operation, validated, allow_route_retry=False)
+            # The remote error code was previously discarded, leaving callers to
+            # string-match prose. Keep it, and append the concrete next step for the
+            # codes that mean "too big to cover in one call".
+            if exc.code in _SELECTION_CODES:
+                # Replace rather than append here: the extension cannot see how many
+                # sessions are competing, so its prose tells the operator to make a
+                # choice that usually is not theirs to make. Only this side knows
+                # whether anything is actually contending.
+                raise ChromeExtensionUnavailableError(self._selection_detail(), code=exc.code) from None
+            remedy = _COVERAGE_REMEDIES.get(exc.code or "")
+            message = exc.message
+            if remedy:
+                message = f"{message.rstrip('.')}. {remedy}"
+            raise ChromeExtensionUnavailableError(message, code=exc.code) from None
 
     async def navigate(self, url: str) -> dict[str, Any]:
         return await self._request("browser.navigate", {"url": url})

--- a/kolega_code/browser_extension/manager.py
+++ b/kolega_code/browser_extension/manager.py
@@ -17,7 +17,7 @@ from .runtime import RuntimeServer, RuntimeTransportError, UnsupportedRuntimeTra
 CHROME_EXTENSION_SUPPORTED_TOOLS = frozenset(
     "browser_navigate browser_navigate_back browser_snapshot browser_find browser_wait_for browser_click "
     "browser_type browser_fill_form browser_select_option browser_hover browser_drag browser_press_key "
-    "browser_tabs browser_network_requests browser_take_screenshot browser_close".split()
+    "browser_scroll browser_tabs browser_network_requests browser_take_screenshot browser_close".split()
 )
 CHROME_EXTENSION_CAPABILITIES = CHROME_EXTENSION_SUPPORTED_TOOLS
 DEFAULT_EXTENSION_CONNECTION_TIMEOUT_SECONDS = 12.0
@@ -357,6 +357,19 @@ class ChromeExtensionBrowserManager(BrowserManager):
 
     async def press_key(self, key: str) -> dict[str, Any]:
         return await self._request("browser.press_key", {"key": key})
+
+    async def scroll(
+        self,
+        *,
+        target: Optional[str] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        by_pages: Optional[float] = None,
+    ) -> dict[str, Any]:
+        return await self._request(
+            "browser.scroll",
+            {"by_pages": by_pages, "target": target, "x": x, "y": y},
+        )
 
     async def navigate_back(self) -> dict[str, Any]:
         return await self._request("browser.navigate_back", {})

--- a/kolega_code/browser_extension/manager.py
+++ b/kolega_code/browser_extension/manager.py
@@ -42,6 +42,12 @@ _COVERAGE_REMEDIES = {
     ),
 }
 
+# The extension refuses a request whenever the operator has not granted this
+# runtime the browser, or has since granted it to another session. It is the
+# authority on that, so these codes are answered with selection guidance rather
+# than inferred from anything on this side.
+_SELECTION_CODES = frozenset({"session_selection_required", "session_not_selected", "runtime_unavailable"})
+
 
 class ChromeExtensionUnavailableError(RuntimeError):
     """Chrome or the selected extension runtime is unavailable."""
@@ -81,7 +87,6 @@ class ChromeExtensionBrowserManager(BrowserManager):
         self._server: RuntimeServer | None = None
         self._peer: MultiplexedPeer | None = None
         self._state_changed = asyncio.Event()
-        self._ready = False
         self._browser_session_id: str | None = None
         self._peer_watch_tasks: set[asyncio.Task[None]] = set()
         self._lifecycle_lock = asyncio.Lock()
@@ -91,6 +96,23 @@ class ChromeExtensionBrowserManager(BrowserManager):
     @property
     def session_id(self) -> Optional[str]:
         return self._browser_session_id
+
+    @property
+    def _ready(self) -> bool:
+        """Whether this runtime may drive the browser right now.
+
+        Derived from having a live authenticated peer rather than latched by the
+        extension's ``browser.session_ready`` announcement. The native host dials
+        a runtime's socket only to relay a message the extension addressed to that
+        runtime, and the extension only ever addresses the runtime the operator
+        selected — so a live peer *is* the attachment, and nothing else needs to
+        agree. A separate latch was strictly worse: only an announcement the
+        extension makes once per discovery could set it, so every code path that
+        cleared it stranded the session at "connected but has not confirmed a
+        session" until the operator reopened the popup.
+        """
+        peer = self._peer
+        return peer is not None and not peer.closed
 
     @property
     def runtime_id(self) -> Optional[str]:
@@ -136,15 +158,11 @@ class ChromeExtensionBrowserManager(BrowserManager):
             await peer.close("Chrome integration is closed for this agent session.")
             return
         previous = self._peer
-        # Readiness belongs to this runtime session, not to a relay peer. The
-        # native host connects to a runtime's socket only to relay a message the
-        # extension addressed to that runtime, and the extension refuses to route
-        # anywhere but the selected runtime — so a peer existing at all already
-        # proves this runtime is selected. Clearing readiness on peer churn used to
-        # deadlock: the extension announces browser.session_ready once per native
-        # connection, so a reconnecting relay left the runtime permanently
-        # "connected but not confirmed" with no way to recover.
         self._peer = peer
+        # A peer proves selection (see _ready), so adopt the browsing session here
+        # rather than waiting for an announcement that only accompanies the *first*
+        # peer of a native connection.
+        self._adopt_browser_session()
         self._state_changed.set()
         watcher = asyncio.create_task(self._watch_peer(peer), name="chrome-extension-peer-lifecycle")
         self._peer_watch_tasks.add(watcher)
@@ -155,26 +173,23 @@ class ChromeExtensionBrowserManager(BrowserManager):
     async def _watch_peer(self, peer: MultiplexedPeer) -> None:
         await peer.wait_closed()
         if self._peer is peer:
-            # Keep readiness (see _handle_peer): operations still require a live
-            # peer, so losing one correctly blocks work without making recovery
-            # depend on a handshake the extension will not repeat.
             self._peer = None
             self._state_changed.set()
 
     async def _handle_event(self, envelope: Envelope) -> None:
         if envelope.payload["event"] != "browser.session_ready":
             return
-        peer = self._peer
-        server = self._server
-        if peer is None or peer.closed or server is None:
-            return
-        self._ready = True
-        self._browser_session_id = f"chrome:{server.runtime_id}"
+        # Deliberately independent of peer state: this event is what makes the
+        # native host dial the socket in the first place, so requiring a peer here
+        # only reintroduces an ordering dependency between two views of the same
+        # fact.
+        self._adopt_browser_session()
         self._state_changed.set()
 
-    def _clear_ready(self) -> None:
-        self._ready = False
-        self._browser_session_id = None
+    def _adopt_browser_session(self) -> None:
+        server = self._server
+        if self._browser_session_id is None and server is not None:
+            self._browser_session_id = f"chrome:{server.runtime_id}"
 
     def _live_runtimes(self) -> list[RuntimeDescriptor]:
         """List every runtime currently advertised to the extension picker."""
@@ -184,55 +199,66 @@ class ChromeExtensionBrowserManager(BrowserManager):
         except OSError:
             return []
 
-    def _unavailable_detail(self) -> str:
-        """Explain *why* the companion is not ready, naming competing runtimes.
+    def _selection_detail(self) -> str:
+        """Ask the operator to grant this session the browser, naming the rivals.
 
-        The extension connects automatically, but it will not guess which local
-        runtime may drive the browser when several are advertised. Distinguish
-        "nothing connected" from "awaiting your choice", because the remedies are
-        completely different. Note the choice is detected from the advertised
-        runtime count, not from having a peer: the extension only dials a
-        runtime's socket *after* it is selected, so a pending choice never has a
-        peer to observe.
+        The extension will not guess which local runtime may drive the browser when
+        several are advertised, because selecting one grants a local process access
+        to the operator's real Chrome profile.
         """
-        connected = self._peer is not None and not self._peer.closed
         mine = self.runtime_id
         runtimes = self._live_runtimes()
-        if len(runtimes) > 1:
-            listed = ", ".join(
-                f"{descriptor.session_id} (runtime {descriptor.runtime_id}, pid {descriptor.pid})"
-                + (" <- this session" if descriptor.runtime_id == mine else "")
-                for descriptor in runtimes
-            )
-            return (
-                "Kolega Browser Companion is connected but waiting for you to choose which Kolega session "
-                f"may control the browser. {len(runtimes)} sessions are advertised: {listed}. Click the "
-                "extension and select this session"
-                + (f" (runtime {mine})" if mine else "")
-                + ". The extension badge shows '!' while a choice is required."
-            )
-        if connected:
-            return (
-                "Kolega Browser Companion is connected but has not confirmed a session. Open the extension "
-                "and select this Kolega session, then retry."
-            )
+        listed = ", ".join(
+            f"{descriptor.session_id} (runtime {descriptor.runtime_id}, pid {descriptor.pid})"
+            + (" <- this session" if descriptor.runtime_id == mine else "")
+            for descriptor in runtimes
+        )
+        census = f" {len(runtimes)} sessions are advertised: {listed}." if len(runtimes) > 1 else ""
+        return (
+            "Kolega Browser Companion is waiting for you to choose which Kolega session may control the "
+            f"browser.{census} Click the extension and select this session"
+            + (f" (runtime {mine})" if mine else "")
+            + ". The extension badge shows '!' while a choice is required."
+        )
+
+    def _unavailable_detail(self) -> str:
+        """Explain why no companion connection exists, naming competing runtimes.
+
+        Only reached with no live peer, so this is "nothing reached us" — a peer
+        proves selection (see ``_ready``). A selection that is pending or has moved
+        to another session is reported by the extension itself when we ask, which is
+        both authoritative and immediate; guessing it from the advertised runtime
+        count while holding a live connection used to blame the operator for a state
+        the session was not actually in.
+        """
+        if len(self._live_runtimes()) > 1:
+            return self._selection_detail()
         return (
             "Kolega Browser Companion did not connect. Confirm the extension is installed and enabled in "
             "Chrome, that Chrome is running, and that `kolega-code browser status` reports a valid native "
-            "host, then retry."
+            "host, then retry. Opening the extension refreshes the connection."
         )
 
     async def _connected_peer(self) -> MultiplexedPeer:
-        await self._ensure_server()
+        server = await self._ensure_server()
+        # Driving the browser is a claim on it, so re-advertise if a previous
+        # detach withdrew ours. The native host notices the change and tells Chrome
+        # to re-enumerate, which is how a detached session asks for the browser back.
+        if not server.published:
+            server.publish()
         loop = asyncio.get_running_loop()
         expires = loop.time() + self.connection_timeout
         while True:
             peer = self._peer
-            if peer is not None and not peer.closed and self._ready:
+            if peer is not None and not peer.closed:
+                # Driving the browser starts a browsing session, so a detach that
+                # ended the previous one is followed by a fresh browser_launched.
+                self._adopt_browser_session()
                 return peer
             self._state_changed.clear()
             peer = self._peer
-            if peer is not None and not peer.closed and self._ready:
+            if peer is not None and not peer.closed:
+                self._adopt_browser_session()
                 return peer
             remaining = expires - loop.time()
             if remaining <= 0:
@@ -270,7 +296,7 @@ class ChromeExtensionBrowserManager(BrowserManager):
         else:
             result["state"] = "paired"
             result["detail"] = "Kolega Browser Companion is connected and this session is selected."
-        result["connected"] = self._peer is not None and not self._peer.closed
+        result["connected"] = self._ready
         result["ready"] = self._ready
         result["runtimes"] = [
             {
@@ -281,11 +307,8 @@ class ChromeExtensionBrowserManager(BrowserManager):
             }
             for descriptor in self._live_runtimes()
         ]
-        if result["state"] != "paired":
-            if len(result["runtimes"]) > 1:
-                result["state"] = "awaiting_selection"
-            elif result["connected"]:
-                result["state"] = "connected_not_selected"
+        if result["state"] != "paired" and len(result["runtimes"]) > 1:
+            result["state"] = "awaiting_selection"
         return result
 
     async def _request(self, operation: str, params: Mapping[str, JSONValue]) -> dict[str, Any]:
@@ -300,15 +323,19 @@ class ChromeExtensionBrowserManager(BrowserManager):
             except (ConnectionClosedError, RequestTimeoutError) as exc:
                 if self._peer is peer and peer.closed:
                     self._peer = None
-                    self._clear_ready()
                     self._state_changed.set()
                 raise ChromeExtensionUnavailableError(str(exc)) from None
             except RemoteRequestError as exc:
                 # The remote error code was previously discarded, leaving callers
                 # to string-match prose. Keep it, and append the concrete next
-                # step for the codes that mean "too big to cover in one call".
+                # step for the codes that mean "too big to cover in one call" or
+                # "the operator has not granted this session the browser".
                 remedy = _COVERAGE_REMEDIES.get(exc.code or "")
-                message = f"{exc.message} {remedy}" if remedy else exc.message
+                if exc.code in _SELECTION_CODES:
+                    remedy = self._selection_detail()
+                message = exc.message
+                if remedy:
+                    message = f"{message.rstrip('.')}. {remedy}"
                 raise ChromeExtensionUnavailableError(message, code=exc.code) from None
             if not isinstance(result, dict):
                 raise ChromeExtensionProtocolError("Chrome extension returned a non-object browser result.")
@@ -476,12 +503,31 @@ class ChromeExtensionBrowserManager(BrowserManager):
         raise ChromeExtensionProtocolError("Arbitrary JavaScript is not supported by the Chrome extension backend.")
 
     async def close(self) -> Optional[str]:
+        """End this browsing session without giving up the attachment.
+
+        ``browser_close`` on this backend means "stop driving the user's Chrome",
+        not "shut the browser down" — we never owned it. So it must stay possible
+        to drive it again afterwards: a browser sub-agent closes as a matter of
+        hygiene at the end of every dispatch, and making that irreversible bricked
+        Chrome for the rest of the Kolega session (every later operation waited out
+        the connection timeout and then told the operator to reopen the popup).
+        Only the browsing session id is dropped, so the next operation reports a
+        fresh browser_launched.
+
+        The advertisement *is* dropped, because it is a claim on the browser rather
+        than a fact about the process. A finished session that kept claiming forced
+        every other Kolega session to break the tie by hand in the extension, even
+        though nothing was competing for the browser any more.
+        """
         session_id = self._browser_session_id
         peer = self._peer
-        if peer is not None and not peer.closed and self._ready:
+        if peer is not None and not peer.closed:
             with contextlib.suppress(ChromeExtensionUnavailableError, ChromeExtensionProtocolError):
                 await self._request("browser.detach", {})
-        self._clear_ready()
+        self._browser_session_id = None
+        server = self._server
+        if server is not None:
+            server.withdraw()
         self._state_changed.set()
         return session_id
 
@@ -492,14 +538,13 @@ class ChromeExtensionBrowserManager(BrowserManager):
             self._closed = True
             server = self._server
             peer = self._peer
-            ready = self._ready
             self._server = None
             self._peer = None
-            self._clear_ready()
+            self._browser_session_id = None
             self._state_changed.set()
 
         async with self._operation_lock:
-            if peer is not None and not peer.closed and ready:
+            if peer is not None and not peer.closed:
                 with contextlib.suppress(Exception):
                     await peer.request("browser.detach", {}, timeout=self.operation_timeout)
             if server is not None:

--- a/kolega_code/browser_extension/manager.py
+++ b/kolega_code/browser_extension/manager.py
@@ -24,8 +24,31 @@ DEFAULT_EXTENSION_CONNECTION_TIMEOUT_SECONDS = 12.0
 DEFAULT_BROWSER_OPERATION_TIMEOUT_SECONDS = 30.0
 
 
+# Codes that mean "this page is larger than one call can cover", as opposed to
+# something being broken. Each one has a concrete next step, and saying so is what
+# stops an agent rediscovering the same wall from six directions.
+_COVERAGE_REMEDIES = {
+    "search_truncated": (
+        "Scope the search: snapshot a subtree with browser_snapshot target=<selector>, or check a "
+        "string that appears earlier in the page."
+    ),
+    "result_too_large": (
+        "The result did not fit its bound. Narrow it: pass a target to capture one element, or "
+        "browser_scroll and capture the region you need."
+    ),
+    "page_too_large": (
+        "The page exceeds what one call can cover. Pass a target to browser_snapshot to scope it, "
+        "or browser_scroll and snapshot again."
+    ),
+}
+
+
 class ChromeExtensionUnavailableError(RuntimeError):
     """Chrome or the selected extension runtime is unavailable."""
+
+    def __init__(self, message: str, *, code: str | None = None) -> None:
+        super().__init__(message)
+        self.code = code
 
 
 class ChromeExtensionProtocolError(RuntimeError):
@@ -281,7 +304,12 @@ class ChromeExtensionBrowserManager(BrowserManager):
                     self._state_changed.set()
                 raise ChromeExtensionUnavailableError(str(exc)) from None
             except RemoteRequestError as exc:
-                raise ChromeExtensionUnavailableError(exc.message) from None
+                # The remote error code was previously discarded, leaving callers
+                # to string-match prose. Keep it, and append the concrete next
+                # step for the codes that mean "too big to cover in one call".
+                remedy = _COVERAGE_REMEDIES.get(exc.code or "")
+                message = f"{exc.message} {remedy}" if remedy else exc.message
+                raise ChromeExtensionUnavailableError(message, code=exc.code) from None
             if not isinstance(result, dict):
                 raise ChromeExtensionProtocolError("Chrome extension returned a non-object browser result.")
             response = cast(dict[str, Any], result)

--- a/kolega_code/browser_extension/native_host.py
+++ b/kolega_code/browser_extension/native_host.py
@@ -16,7 +16,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, BinaryIO, Literal, Mapping, Sequence, TextIO, cast
 
-from .framing import MAX_NATIVE_MESSAGE_BYTES, FramingError, encode_message, read_message
+from .framing import (
+    MAX_NATIVE_INBOUND_MESSAGE_BYTES,
+    MAX_NATIVE_MESSAGE_BYTES,
+    FramingError,
+    encode_message,
+    read_message,
+)
 from .protocol import (
     MAX_DEADLINE_AHEAD_MS,
     PROTOCOL_VERSION,
@@ -42,6 +48,9 @@ DEFAULT_MAX_RUNTIMES = 16
 DEFAULT_MAX_RELAY_PENDING = 256
 RUNTIME_WATCH_INTERVAL_SECONDS = 1.0
 DEFAULT_MAX_NATIVE_PENDING_WRITES = 256
+# Writes toward Chrome stay bounded by its 1 MB message limit, so the backpressure
+# ceiling is expressed against that rather than against the much larger inbound
+# bound: a big response must not multiply into hundreds of megabytes of queue.
 DEFAULT_MAX_NATIVE_PENDING_WRITE_BYTES = 8 * MAX_NATIVE_MESSAGE_BYTES
 DEFAULT_NATIVE_WRITE_SHUTDOWN_SECONDS = 1.0
 _HOST_CONFIG_KEYS = frozenset({"extension_origin", "registry_dir", "max_runtimes", "max_pending_requests"})
@@ -190,15 +199,21 @@ class NativeMessageEndpoint:
         output_stream: BinaryIO,
         *,
         max_message_bytes: int = MAX_NATIVE_MESSAGE_BYTES,
+        max_inbound_message_bytes: int = MAX_NATIVE_INBOUND_MESSAGE_BYTES,
         max_pending_writes: int = DEFAULT_MAX_NATIVE_PENDING_WRITES,
         max_pending_write_bytes: int = DEFAULT_MAX_NATIVE_PENDING_WRITE_BYTES,
         shutdown_timeout: float = DEFAULT_NATIVE_WRITE_SHUTDOWN_SECONDS,
     ) -> None:
         if max_pending_writes <= 0 or max_pending_write_bytes <= 0 or shutdown_timeout <= 0:
             raise ValueError("native endpoint bounds must be positive")
+        if max_inbound_message_bytes <= 0:
+            raise ValueError("native endpoint bounds must be positive")
         self.input_stream = input_stream
         self.output_stream = output_stream
+        # Writes go to Chrome, which enforces a hard 1 MB limit; reads come from
+        # Chrome, which permits far more and carries screenshot payloads.
         self.max_message_bytes = max_message_bytes
+        self.max_inbound_message_bytes = max_inbound_message_bytes
         self.max_pending_writes = max_pending_writes
         self.max_pending_write_bytes = max_pending_write_bytes
         self.shutdown_timeout = shutdown_timeout
@@ -222,7 +237,7 @@ class NativeMessageEndpoint:
         return self._outstanding_write_bytes
 
     async def read(self) -> dict[str, Any] | None:
-        return await asyncio.to_thread(read_message, self.input_stream, max_bytes=self.max_message_bytes)
+        return await asyncio.to_thread(read_message, self.input_stream, max_bytes=self.max_inbound_message_bytes)
 
     async def write(self, envelope: Envelope) -> None:
         await self.write_mapping(envelope.to_mapping())

--- a/kolega_code/browser_extension/protocol.py
+++ b/kolega_code/browser_extension/protocol.py
@@ -140,6 +140,7 @@ ALLOWED_OPERATIONS = frozenset(
         "browser.hover",
         "browser.drag",
         "browser.press_key",
+        "browser.scroll",
         "browser.tabs",
         "browser.network_requests",
         "browser.screenshot",
@@ -489,6 +490,23 @@ def validate_operation_request(operation: object, params: object) -> dict[str, J
         assert key is not None
         if re.search(r"[\x00-\x1f\x7f]", key):
             raise _params_error("key is invalid")
+    elif operation == "browser.scroll":
+        _exact_params(values, frozenset({"by_pages", "target", "x", "y"}))
+        _target(values["target"], nullable=True)
+        _nullable_number(values["by_pages"], "by_pages", -10, 10)
+        _nullable_integer(values["x"], "x", 0, 10_000_000)
+        _nullable_integer(values["y"], "y", 0, 10_000_000)
+        # Exactly one request shape, so a caller can never leave it ambiguous
+        # which of three different movements was intended. Mirrors
+        # validateOperation in the extension's src/operations.js, including the
+        # message text; the two must keep accepting the same language.
+        modes = [
+            values["target"] is not None,
+            values["by_pages"] is not None,
+            values["x"] is not None or values["y"] is not None,
+        ]
+        if sum(1 for mode in modes if mode) != 1:
+            raise _params_error("Provide exactly one of target, by_pages, or x/y")
     elif operation == "browser.tabs":
         _exact_params(values, frozenset({"action", "index", "url"}))
         action = values["action"]

--- a/kolega_code/browser_extension/protocol.py
+++ b/kolega_code/browser_extension/protocol.py
@@ -18,7 +18,13 @@ PROTOCOL_VERSION = 1
 MAX_SAFE_INTEGER = (1 << 53) - 1
 MAX_IDENTIFIER_LENGTH = 128
 MAX_ERROR_MESSAGE_LENGTH = 240
+# Requests travel runtime -> extension and are bounded by their own parameter
+# schemas anyway, so they keep the conservative limit. Responses travel the other
+# way and carry screenshots; sharing the request bound with them is what forced a
+# full-page capture to be downscaled until it was unreadable. Chrome permits far
+# more in that direction, and every result still has its own explicit bound.
 MAX_PROTOCOL_JSON_BYTES = 1_048_576
+MAX_PROTOCOL_RESPONSE_JSON_BYTES = 67_108_864
 MAX_DISCOVERY_RUNTIMES = 64
 MAX_DEADLINE_AHEAD_MS = 300_000
 
@@ -668,6 +674,13 @@ class Envelope:
         object.__setattr__(self, "payload", validated.payload)
         self.to_json()
 
+    @property
+    def size_limit(self) -> int:
+        """The byte bound that applies to this envelope's direction."""
+        if self.direction is MessageDirection.EXTENSION_TO_RUNTIME:
+            return MAX_PROTOCOL_RESPONSE_JSON_BYTES
+        return MAX_PROTOCOL_JSON_BYTES
+
     @classmethod
     def from_mapping(cls, value: object) -> Envelope:
         envelope = _exact_mapping(value, _ENVELOPE_KEYS, "envelope")
@@ -701,9 +714,12 @@ class Envelope:
         return instance
 
     @classmethod
-    def from_json(cls, raw: str | bytes) -> Envelope:
+    def from_json(cls, raw: str | bytes, *, max_bytes: int = MAX_PROTOCOL_RESPONSE_JSON_BYTES) -> Envelope:
+        # The generous bound is the default here because the direction is only
+        # known after parsing; the per-direction limit is then enforced by
+        # __post_init__ through to_json.
         if isinstance(raw, bytes):
-            if len(raw) > MAX_PROTOCOL_JSON_BYTES:
+            if len(raw) > max_bytes:
                 raise _invalid("message_too_large", "protocol message exceeds the size limit")
             try:
                 text = raw.decode("utf-8")
@@ -715,7 +731,7 @@ class Envelope:
                 encoded_size = len(text.encode("utf-8"))
             except UnicodeEncodeError:
                 raise _invalid("invalid_json", "protocol message is not valid Unicode") from None
-            if encoded_size > MAX_PROTOCOL_JSON_BYTES:
+            if encoded_size > max_bytes:
                 raise _invalid("message_too_large", "protocol message exceeds the size limit")
         try:
             value = json.loads(text, object_pairs_hook=_reject_duplicate_keys, parse_constant=_reject_constant)
@@ -745,7 +761,7 @@ class Envelope:
             separators=(",", ":"),
             sort_keys=True,
         )
-        if len(encoded.encode("utf-8")) > MAX_PROTOCOL_JSON_BYTES:
+        if len(encoded.encode("utf-8")) > self.size_limit:
             raise _invalid("message_too_large", "protocol message exceeds the size limit")
         return encoded
 

--- a/kolega_code/browser_extension/runtime.py
+++ b/kolega_code/browser_extension/runtime.py
@@ -276,6 +276,7 @@ class RuntimeServer:
         self._refresh_task: asyncio.Task[None] | None = None
         self._close_lock = asyncio.Lock()
         self._closed = False
+        self._published = False
 
     def _select_endpoint(self) -> str:
         preferred = self.registry.root / f"{self.runtime_id}.sock"
@@ -305,6 +306,45 @@ class RuntimeServer:
             raise RuntimeTransportError("Runtime server has not started")
         return self._descriptor
 
+    @property
+    def published(self) -> bool:
+        """Whether this runtime is currently advertised to the extension picker."""
+        return self._published
+
+    def publish(self) -> None:
+        """Advertise this runtime, meaning "this session wants the browser now".
+
+        An advertisement is a claim on the browser, not a fact about the process:
+        the extension will not guess between several claims, so a session that has
+        finished browsing must stop making one. Re-advertising is also how a session
+        asks for the browser back — the native host watches the advertised set and
+        tells Chrome to re-enumerate whenever it changes, which is the only channel
+        a runtime has for speaking first.
+        """
+        descriptor = self._descriptor
+        if descriptor is None:
+            raise RuntimeTransportError("Runtime server has not started")
+        if self._closed:
+            raise RuntimeTransportError("Runtime server is closed")
+        now_ms = int(time.time() * 1000)
+        refreshed = replace(descriptor, expires_at_ms=now_ms + self.ttl_ms)
+        self.registry.register(refreshed)
+        self._descriptor = refreshed
+        self._published = True
+
+    def withdraw(self) -> None:
+        """Stop advertising, without giving up the socket or its connections.
+
+        Keeping the listener means an existing relay connection stays usable, so a
+        session that detaches and then browses again resumes immediately instead of
+        waiting out a fresh discovery.
+        """
+        if not self._published:
+            return
+        self._published = False
+        with contextlib.suppress(Exception):
+            self.registry.unregister(self.runtime_id, token=self.token)
+
     async def start(self) -> RuntimeDescriptor:
         if self._listener is not None:
             return self.descriptor
@@ -333,6 +373,7 @@ class RuntimeServer:
                 extension_origin=self.extension_origin,
             )
             self.registry.register(self._descriptor)
+            self._published = True
             self._refresh_task = asyncio.create_task(
                 self._refresh_descriptor(),
                 name=f"browser-extension-runtime-refresh-{self.runtime_id}",
@@ -359,6 +400,7 @@ class RuntimeServer:
             if self._closed:
                 return
             self._closed = True
+            self._published = False
             refresh = self._refresh_task
             self._refresh_task = None
             if refresh is not None:
@@ -382,13 +424,12 @@ class RuntimeServer:
         interval = max(0.05, self.ttl_ms / 3_000)
         while True:
             await asyncio.sleep(interval)
-            descriptor = self._descriptor
-            if descriptor is None or self._closed:
+            if self._descriptor is None or self._closed:
                 return
-            now_ms = int(time.time() * 1000)
-            refreshed = replace(descriptor, expires_at_ms=now_ms + self.ttl_ms)
-            self.registry.register(refreshed)
-            self._descriptor = refreshed
+            # Never resurrect a withdrawn advertisement: the lease refresh would
+            # otherwise reinstate a claim the session has explicitly given up.
+            if self._published:
+                self.publish()
 
     async def _close_listener(self) -> None:
         listener = self._listener

--- a/kolega_code/browser_extension/runtime.py
+++ b/kolega_code/browser_extension/runtime.py
@@ -17,7 +17,7 @@ from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 
-from .framing import FramingError, read_message_async, write_message_async
+from .framing import MAX_NATIVE_INBOUND_MESSAGE_BYTES, FramingError, read_message_async, write_message_async
 from .protocol import PROTOCOL_VERSION, Envelope, MessageDirection
 from .registry import (
     RuntimeDescriptor,
@@ -101,7 +101,9 @@ class RuntimeChannel:
     async def read(self) -> Envelope | None:
         if self._closed:
             return None
-        raw = await read_message_async(self._reader)
+        # This is our own local socket, not Chrome's stdio, so Chrome's 1 MB
+        # message limit does not apply to it. Screenshot responses cross here.
+        raw = await read_message_async(self._reader, max_bytes=MAX_NATIVE_INBOUND_MESSAGE_BYTES)
         if raw is None:
             return None
         envelope = Envelope.from_mapping(raw)
@@ -123,7 +125,11 @@ class RuntimeChannel:
                 async with self._write_lock:
                     if self.closed:
                         raise RuntimeDisconnectedError("Runtime channel is disconnected")
-                    await write_message_async(self._writer, envelope.to_mapping())
+                    await write_message_async(
+                        self._writer,
+                        envelope.to_mapping(),
+                        max_bytes=MAX_NATIVE_INBOUND_MESSAGE_BYTES,
+                    )
         except (TimeoutError, ConnectionError, BrokenPipeError, FramingError):
             raise RuntimeDisconnectedError("Runtime channel is disconnected") from None
 

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -727,13 +727,13 @@ def _run_browser(args: argparse.Namespace) -> int:
             if probe["state"] != "paired":
                 payload["remediation"] = probe["detail"]
             if probe["state"] == "awaiting_selection":
-                # doctor publishes its own temporary runtime, so with another Kolega
-                # session already running there are two and Chrome must be told which
-                # one may drive the browser. Say so rather than implying a fault.
+                # doctor publishes its own temporary runtime, so a choice is expected
+                # whenever another Kolega session is *actively* claiming the browser.
+                # Say so rather than implying a fault.
                 payload["remediation"] = (
                     f"{probe['detail']} This check publishes its own temporary runtime, so a choice is "
-                    "expected whenever another Kolega session is running; stop the other session to test "
-                    "pairing unattended."
+                    "expected whenever another Kolega session is currently using the browser; that session "
+                    "releases its claim when it detaches, or stop it to test pairing unattended."
                 )
 
         if args.json:

--- a/kolega_code/services/base.py
+++ b/kolega_code/services/base.py
@@ -153,6 +153,16 @@ class BrowserManager(ABC):
     async def press_key(self, key: str) -> Dict[str, Any]: ...
 
     @abstractmethod
+    async def scroll(
+        self,
+        *,
+        target: Optional[str] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        by_pages: Optional[float] = None,
+    ) -> Dict[str, Any]: ...
+
+    @abstractmethod
     async def navigate_back(self) -> Dict[str, Any]: ...
 
     @abstractmethod

--- a/kolega_code/services/browser.py
+++ b/kolega_code/services/browser.py
@@ -624,6 +624,61 @@ class PlaywrightBrowserManager(BrowserManager):
 
         return await self._perform_action(session, action)
 
+    async def scroll(
+        self,
+        *,
+        target: Optional[str] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        by_pages: Optional[float] = None,
+    ) -> dict[str, Any]:
+        """Move the viewport by target, by whole viewports, or to an absolute offset."""
+        supplied = [target is not None, by_pages is not None, x is not None or y is not None]
+        if sum(1 for mode in supplied if mode) != 1:
+            raise ValueError("Provide exactly one of target, by_pages, or x/y")
+        session = await self._ensure_session()
+        metrics: dict[str, Any] = {}
+
+        async def action(page: Any) -> None:
+            if target is not None:
+                locator = await self._target_locator(page, target)
+                await locator.scroll_into_view_if_needed(timeout=self.action_timeout)
+            elif by_pages is not None:
+                # mouse.wheel dispatches a wheel event without waiting for the
+                # scroll it triggers, so the position read back below raced it and
+                # reported no movement. Scrolling in the page is deterministic and
+                # does not depend on where the pointer happens to be.
+                await page.evaluate(
+                    "(pages) => window.scrollBy({ left: 0, top: pages * window.innerHeight, behavior: 'instant' })",
+                    by_pages,
+                )
+            else:
+                # Absolute positioning has no Playwright API either. Unlike the
+                # Chrome extension backend, this manager drives its own browser
+                # instance and already exposes browser_evaluate, so an in-page
+                # call here widens nothing.
+                await page.evaluate(
+                    "([left, top]) => window.scrollTo({ left, top, behavior: 'instant' })",
+                    [x or 0, y or 0],
+                )
+            metrics.update(
+                await page.evaluate(
+                    """() => ({
+                        content_height: Math.max(
+                            document.documentElement.scrollHeight,
+                            document.body ? document.body.scrollHeight : 0,
+                        ),
+                        scroll_x: window.scrollX,
+                        scroll_y: window.scrollY,
+                        viewport_height: window.innerHeight,
+                    })"""
+                )
+            )
+
+        result = await self._perform_action(session, action)
+        result.update(metrics)
+        return result
+
     async def navigate_back(self) -> dict[str, Any]:
         session = await self._ensure_session()
 

--- a/tests/agent/test_agent_tools_inventory.py
+++ b/tests/agent/test_agent_tools_inventory.py
@@ -95,6 +95,7 @@ def test_browser_agent_tools(project_path, mock_connection_manager, agent_config
         "browser_network_requests",
         "browser_press_key",
         "browser_resize",
+        "browser_scroll",
         "browser_select_option",
         "browser_snapshot",
         "browser_tabs",

--- a/tests/agent/tool_backend/test_browser_tool.py
+++ b/tests/agent/tool_backend/test_browser_tool.py
@@ -407,12 +407,119 @@ async def test_network_requests_omit_missing_resource_type(browser_tool, browser
     assert "[" not in output.split("\n")[-1]
 
 
-def test_regex_and_tabs_schemas_document_their_constraints():
-    """Two different models sent index=0/url="" because the schema never said otherwise."""
+def test_regex_schema_documents_its_constraints():
     find_regex = BROWSER_TOOL_SCHEMAS["browser_find"]["properties"]["regex"]["description"]
     assert "alternation" in find_regex
     assert "{n,m}" in find_regex
 
-    tabs = BROWSER_TOOL_SCHEMAS["browser_tabs"]["properties"]
-    assert "null" in tabs["index"]["description"]
-    assert "null" in tabs["url"]["description"]
+
+class TestPaddedArgumentsAreTreatedAsOmissions:
+    """Models that fill in every declared property must still be able to work.
+
+    Documenting "pass null, never 0 or an empty string" was tried and did not work:
+    a model that pads has no way to stop, so it retries the identical rejected call
+    until it gives up. One run lost its whole first phase to thirteen consecutive
+    `browser_tabs {"action":"list","index":0,"url":""}` calls answered with "url is
+    invalid". Padding that cannot express a request is therefore treated as the
+    omission it was meant to be, here at the agent-facing boundary; the wire
+    protocol stays exact.
+    """
+
+    @pytest.mark.asyncio
+    async def test_listing_tabs_ignores_padded_index_and_url(self, browser_tool, browser_manager):
+        browser_manager.tabs = AsyncMock(return_value={"tabs": []})
+
+        await browser_tool.browser_tabs("list", index=0, url="")
+
+        browser_manager.tabs.assert_awaited_once_with("list", index=None, url=None)
+
+    @pytest.mark.asyncio
+    async def test_a_new_tab_ignores_padded_index_and_reads_an_empty_url_as_blank(self, browser_tool, browser_manager):
+        browser_manager.tabs = AsyncMock(return_value={"tabs": []})
+
+        await browser_tool.browser_tabs("new", index=0, url="   ")
+
+        browser_manager.tabs.assert_awaited_once_with("new", index=None, url=None)
+
+    @pytest.mark.asyncio
+    async def test_selecting_a_tab_keeps_index_zero_and_drops_the_inapplicable_url(self, browser_tool, browser_manager):
+        """0 is a real tab index, so only url is inapplicable to select."""
+        browser_manager.tabs = AsyncMock(return_value={"tabs": []})
+
+        await browser_tool.browser_tabs("select", index=0, url="")
+
+        browser_manager.tabs.assert_awaited_once_with("select", index=0, url=None)
+
+    @pytest.mark.asyncio
+    async def test_scroll_by_pages_ignores_padded_offsets(self, browser_tool, browser_manager):
+        browser_manager.scroll = AsyncMock(return_value={"url": "https://example.com", "title": "Example"})
+
+        await browser_tool.browser_scroll(target="", x=0, y=0, by_pages=2)
+
+        browser_manager.scroll.assert_awaited_once_with(target=None, x=None, y=None, by_pages=2)
+
+    @pytest.mark.asyncio
+    async def test_scroll_to_a_target_ignores_padded_offsets_and_page_count(self, browser_tool, browser_manager):
+        browser_manager.scroll = AsyncMock(return_value={"url": "https://example.com", "title": "Example"})
+
+        await browser_tool.browser_scroll(target="#footer", x=0, y=0, by_pages=0)
+
+        browser_manager.scroll.assert_awaited_once_with(target="#footer", x=None, y=None, by_pages=None)
+
+    @pytest.mark.asyncio
+    async def test_scrolling_to_the_top_stays_a_real_request(self, browser_tool, browser_manager):
+        """x/y of 0 alone means the top of the page, so it must not be dropped."""
+        browser_manager.scroll = AsyncMock(return_value={"url": "https://example.com", "title": "Example"})
+
+        await browser_tool.browser_scroll(x=0, y=0)
+
+        browser_manager.scroll.assert_awaited_once_with(target=None, x=0, y=0, by_pages=None)
+
+    @pytest.mark.asyncio
+    async def test_two_real_movements_are_still_rejected_and_named(self, browser_tool, browser_manager):
+        browser_manager.scroll = AsyncMock()
+
+        with pytest.raises(ValueError, match=r"received target='#footer', by_pages=2"):
+            await browser_tool.browser_scroll(target="#footer", by_pages=2)
+        browser_manager.scroll.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_movement_at_all_explains_the_three_shapes(self, browser_tool, browser_manager):
+        browser_manager.scroll = AsyncMock()
+
+        with pytest.raises(ValueError, match="Provide exactly one of target, by_pages, or x/y"):
+            await browser_tool.browser_scroll(target="")
+        browser_manager.scroll.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_find_and_snapshot_drop_padded_strings_and_zero_depth(self, browser_tool, browser_manager):
+        browser_manager.find = AsyncMock(return_value={"query": "Sign in", "matches": [], "match_count": 0})
+        browser_manager.snapshot = AsyncMock(return_value={"url": "https://example.com", "title": "Example"})
+
+        await browser_tool.browser_find(text="Sign in", regex="")
+        await browser_tool.browser_snapshot(target="", depth=0)
+
+        browser_manager.find.assert_awaited_once_with(text="Sign in", regex=None)
+        browser_manager.snapshot.assert_awaited_once_with(target=None, depth=None)
+
+    @pytest.mark.asyncio
+    async def test_wait_for_drops_a_zero_timeout_beside_a_real_condition(self, browser_tool, browser_manager):
+        browser_manager.wait_for = AsyncMock(return_value={"url": "https://example.com", "title": "Example"})
+
+        await browser_tool.browser_wait_for(time=0, text="Ready", text_gone="")
+        browser_manager.wait_for.assert_awaited_once_with(time=None, text="Ready", text_gone=None)
+
+        # On its own a zero wait is a legitimate no-op and stays a request.
+        browser_manager.wait_for.reset_mock()
+        await browser_tool.browser_wait_for(time=0)
+        browser_manager.wait_for.assert_awaited_once_with(time=0, text=None, text_gone=None)
+
+    @pytest.mark.asyncio
+    async def test_screenshot_and_click_fall_back_to_documented_defaults(self, browser_tool, browser_manager):
+        browser_manager.click = AsyncMock(return_value={"url": "https://example.com", "title": "Example"})
+
+        await browser_tool.browser_take_screenshot(target="", image_type="", scale="")
+        await browser_tool.browser_click("e2", button="")
+
+        browser_manager.screenshot.assert_awaited_once_with(target=None, image_type="png", full_page=False, scale="css")
+        browser_manager.click.assert_awaited_once_with("e2", double_click=False, button="left", modifiers=None)

--- a/tests/agent/tool_backend/test_browser_tool.py
+++ b/tests/agent/tool_backend/test_browser_tool.py
@@ -79,6 +79,37 @@ async def test_click_forwards_snake_case_options(browser_tool, browser_manager):
 
 
 @pytest.mark.asyncio
+async def test_scroll_forwards_one_movement_and_reports_the_new_position(browser_tool, browser_manager):
+    browser_manager.scroll = AsyncMock(
+        return_value={
+            "session_id": "session-1",
+            "url": "https://example.com",
+            "title": "Example",
+            "snapshot": '- heading "Example" [ref=e2]',
+            "scroll_x": 0,
+            "scroll_y": 4_800,
+            "content_height": 20_176,
+            "viewport_height": 767,
+        }
+    )
+
+    result = await browser_tool.browser_scroll(by_pages=3)
+
+    browser_manager.scroll.assert_awaited_once_with(target=None, x=None, y=None, by_pages=3)
+    # Reporting where the viewport landed is what lets a scroll-then-snapshot
+    # loop tell progress from having reached the end of the page.
+    assert "- Scroll position: y=4800 of 20176 px" in result
+    assert '- heading "Example" [ref=e2]' in result
+
+
+@pytest.mark.asyncio
+async def test_page_format_omits_scroll_position_when_absent(browser_tool, browser_manager):
+    result = await browser_tool.browser_navigate("https://example.com")
+
+    assert "Scroll position" not in result
+
+
+@pytest.mark.asyncio
 async def test_file_upload_reads_only_through_workspace_filesystem(browser_tool, browser_manager, tmp_path):
     upload = tmp_path / "avatar.txt"
     upload.write_text("hello", encoding="utf-8")

--- a/tests/agent/tool_backend/test_browser_tool.py
+++ b/tests/agent/tool_backend/test_browser_tool.py
@@ -109,6 +109,106 @@ async def test_page_format_omits_scroll_position_when_absent(browser_tool, brows
     assert "Scroll position" not in result
 
 
+def _coverage(**overrides):
+    coverage = {
+        "candidates": 39_501,
+        "complete": False,
+        "content_height": 20_176,
+        "emitted": 639,
+        "reason": "char_cap",
+        "scroll_y": 588,
+        "viewport_height": 767,
+        "visited": 39_501,
+    }
+    coverage.update(overrides)
+    return coverage
+
+
+@pytest.mark.asyncio
+async def test_incomplete_coverage_is_reported_with_a_remedy(browser_tool, browser_manager):
+    browser_manager.navigate.return_value = {
+        "session_id": "session-1",
+        "url": "https://example.com",
+        "title": "Example",
+        "snapshot": '- heading "Example" [ref=e2]',
+        "coverage": _coverage(),
+    }
+
+    result = await browser_tool.browser_navigate("https://example.com")
+
+    assert "Coverage: Showing 639 of 39501 page nodes (char_cap), at y=588 of 20176 px" in result
+    assert "browser_scroll and snapshot again" in result
+
+
+@pytest.mark.asyncio
+async def test_complete_coverage_is_not_reported_at_all(browser_tool, browser_manager):
+    browser_manager.navigate.return_value = {
+        "session_id": "session-1",
+        "url": "https://example.com",
+        "title": "Example",
+        "snapshot": '- heading "Example" [ref=e2]',
+        "coverage": _coverage(complete=True, reason=None),
+    }
+
+    result = await browser_tool.browser_navigate("https://example.com")
+
+    assert "Coverage:" not in result
+
+
+@pytest.mark.asyncio
+async def test_find_distinguishes_absence_from_incomplete_coverage(browser_tool, browser_manager):
+    """A bounded search must never render as a flat absence.
+
+    Reporting "No matches found" for text plainly on the page is the wrong answer,
+    and it cost an earlier session most of its tool calls.
+    """
+    browser_manager.find = AsyncMock()
+
+    browser_manager.find.return_value = {
+        "query": "See more",
+        "match_count": 0,
+        "matches": [],
+        "page_text_match": True,
+        "snapshot_coverage": _coverage(),
+    }
+    outside = await browser_tool.browser_find(text="See more")
+    assert "outside the region this snapshot covered" in outside
+    assert "Coverage:" in outside
+
+    browser_manager.find.return_value = {
+        "query": "Nowhere",
+        "match_count": 0,
+        "matches": [],
+        "page_text_match": False,
+        "snapshot_coverage": _coverage(complete=True, reason=None),
+    }
+    absent = await browser_tool.browser_find(text="Nowhere")
+    assert "does not contain it either" in absent
+    assert "Coverage:" not in absent
+
+    browser_manager.find.return_value = {
+        "query": "Unknown",
+        "match_count": 0,
+        "matches": [],
+        "page_text_match": None,
+        "snapshot_coverage": _coverage(),
+    }
+    undetermined = await browser_tool.browser_find(text="Unknown")
+    assert "not a reliable absence" in undetermined
+
+    browser_manager.find.return_value = {
+        "query": "Save",
+        "match_count": 2,
+        "matches": ['- button "Save" [ref=e4]'],
+        "page_text_match": None,
+        "snapshot_coverage": _coverage(),
+    }
+    hit = await browser_tool.browser_find(text="Save")
+    assert "Found 2 matches" in hit
+    # A hit under partial coverage still warns, because there may be more.
+    assert "Coverage:" in hit
+
+
 @pytest.mark.asyncio
 async def test_file_upload_reads_only_through_workspace_filesystem(browser_tool, browser_manager, tmp_path):
     upload = tmp_path / "avatar.txt"

--- a/tests/browser_extension/test_manager.py
+++ b/tests/browser_extension/test_manager.py
@@ -13,7 +13,7 @@ from kolega_code.browser_extension.manager import (
     ChromeExtensionProtocolError,
     ChromeExtensionUnavailableError,
 )
-from kolega_code.browser_extension.multiplex import MultiplexedPeer
+from kolega_code.browser_extension.multiplex import MultiplexedPeer, RemoteRequestError
 from kolega_code.browser_extension.protocol import Envelope, MessageDirection
 from kolega_code.browser_extension.registry import RuntimeDescriptor
 from kolega_code.browser_extension.runtime import RuntimeServer
@@ -28,9 +28,12 @@ class FakePeer:
         self.requests: list[tuple[str, dict[str, Any]]] = []
         self.active = 0
         self.max_active = 0
+        self.error: RemoteRequestError | None = None
 
     async def request(self, operation: str, params: dict[str, Any], *, timeout: float) -> dict[str, Any]:
         self.requests.append((operation, params))
+        if self.error is not None:
+            raise self.error
         self.active += 1
         self.max_active = max(self.max_active, self.active)
         await asyncio.sleep(0.005)
@@ -170,6 +173,34 @@ async def test_manager_preserves_browser_result_shapes(tmp_path: Path) -> None:
 
 def test_scroll_is_part_of_the_supported_chrome_tool_surface() -> None:
     assert "browser_scroll" in CHROME_EXTENSION_SUPPORTED_TOOLS
+
+
+@pytest.mark.asyncio
+async def test_remote_error_codes_survive_and_coverage_codes_gain_a_remedy(tmp_path: Path) -> None:
+    """The remote code was being discarded, leaving callers to string-match prose."""
+    browser = manager(tmp_path)
+    browser._server = cast(RuntimeServer, FakeServer())
+    peer = FakePeer()
+    await browser._handle_peer(cast(MultiplexedPeer, peer))
+    await browser._handle_event(ready_event())
+
+    peer.error = RemoteRequestError(
+        "search_truncated",
+        "Page text search covered only the first 499998 characters.",
+        retryable=True,
+    )
+    with pytest.raises(ChromeExtensionUnavailableError) as truncated:
+        await browser.wait_for(text="anything")
+    assert truncated.value.code == "search_truncated"
+    assert "Scope the search" in str(truncated.value)
+
+    # A code with no coverage remedy keeps its message unchanged.
+    peer.error = RemoteRequestError("tab_closed", "The selected tab was closed", retryable=False)
+    with pytest.raises(ChromeExtensionUnavailableError) as closed:
+        await browser.snapshot()
+    assert closed.value.code == "tab_closed"
+    assert str(closed.value) == "The selected tab was closed"
+    await browser.cleanup_all_browsers()
 
 
 def _descriptor(runtime_id: str, session_id: str, pid: int = 4321) -> RuntimeDescriptor:

--- a/tests/browser_extension/test_manager.py
+++ b/tests/browser_extension/test_manager.py
@@ -153,7 +153,23 @@ async def test_manager_preserves_browser_result_shapes(tmp_path: Path) -> None:
         "browser.screenshot",
         {"target": None, "image_type": "png", "full_page": True, "scale": "device"},
     )
+    # Inapplicable scroll fields travel as explicit nulls, because the fixed
+    # schema requires every key and rejects 0 or "" as a stand-in for unset.
+    await browser.scroll(by_pages=1.5)
+    assert peer.requests[-1] == (
+        "browser.scroll",
+        {"by_pages": 1.5, "target": None, "x": None, "y": None},
+    )
+    await browser.scroll(target="#main")
+    assert peer.requests[-1] == (
+        "browser.scroll",
+        {"by_pages": None, "target": "#main", "x": None, "y": None},
+    )
     await browser.cleanup_all_browsers()
+
+
+def test_scroll_is_part_of_the_supported_chrome_tool_surface() -> None:
+    assert "browser_scroll" in CHROME_EXTENSION_SUPPORTED_TOOLS
 
 
 def _descriptor(runtime_id: str, session_id: str, pid: int = 4321) -> RuntimeDescriptor:

--- a/tests/browser_extension/test_manager.py
+++ b/tests/browser_extension/test_manager.py
@@ -312,6 +312,57 @@ async def test_detach_leaves_the_session_able_to_drive_the_browser_again(tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_an_operation_racing_a_rediscovery_waits_for_it_instead_of_failing(tmp_path: Path) -> None:
+    """Re-publishing a withdrawn claim reaches Chrome only via the host's watcher.
+
+    So the first operation after a detach can arrive before the rediscovery that
+    re-selects this runtime, and the extension refuses it. Observed live: the call
+    failed in under a second with a selection error, and an identical retry succeeded
+    with no operator action at all — a caller that believed the error would have
+    concluded the backend cannot re-attach, and the operator would have been sent to
+    the popup for nothing.
+    """
+    browser = manager(tmp_path)
+    browser._server = cast(RuntimeServer, FakeServer())
+    peer = FakePeer()
+    await browser._handle_peer(cast(MultiplexedPeer, peer))
+    await browser._handle_event(ready_event())
+    await browser.close()
+    peer.requests.clear()
+
+    refusal = RemoteRequestError(
+        "session_selection_required",
+        "Select a Kolega session before using browser operations",
+        retryable=False,
+    )
+    peer.error = refusal
+
+    async def rediscovery_lands() -> None:
+        """Stand in for the rediscovery the host watcher triggers ~1s after the claim
+        is re-published: the extension re-selects this runtime and announces it."""
+        for _ in range(1_000):
+            if peer.requests:
+                break
+            await asyncio.sleep(0)
+        peer.error = None
+        # Announcing after clearing is the point: the epoch comparison in
+        # _await_route_confirmation must cope with this landing either before or
+        # after the wait begins.
+        await browser._handle_event(ready_event())
+
+    rediscovery = asyncio.create_task(rediscovery_lands())
+    result = await browser.navigate("https://example.com")
+    await rediscovery
+
+    assert result["session_id"] == "chrome:runtime_1"
+    # Retried exactly once, and the caller never saw the transient refusal.
+    assert peer.requests == [
+        ("browser.navigate", {"url": "https://example.com/"}),
+        ("browser.navigate", {"url": "https://example.com/"}),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_a_selection_refused_by_the_extension_is_answered_with_guidance(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -342,9 +393,45 @@ async def test_a_selection_refused_by_the_extension_is_answered_with_guidance(
         await browser.navigate("https://example.com")
 
     assert refused.value.code == "session_not_selected"
-    assert "waiting for you to choose" in str(refused.value)
-    assert "session_2" in str(refused.value)
-    assert "this session" in str(refused.value)
+    detail = str(refused.value)
+    assert "Another Kolega session is currently using the browser" in detail
+    assert "session_2" in detail
+    assert "Click the extension and select this session" in detail
+    # The extension's own prose is replaced, not appended: it cannot see how many
+    # sessions are competing, so it tells the operator to make a choice that is
+    # usually not theirs to make.
+    assert "not routed to the selected" not in detail
+
+
+@pytest.mark.asyncio
+async def test_an_uncontested_refusal_never_sends_the_operator_to_the_popup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With no rival claim there is nothing to choose and nothing to click.
+
+    The extension auto-selects a lone runtime on its next enumeration, so this state
+    is transient. Telling the operator to open the popup here is simply wrong, and it
+    was the visible symptom of a claim that outlived its usefulness.
+    """
+    browser = manager(tmp_path)
+    browser._server = cast(RuntimeServer, FakeServer())
+    peer = FakePeer()
+    await browser._handle_peer(cast(MultiplexedPeer, peer))
+    _advertise(browser, monkeypatch, [_descriptor("runtime_1", "session_1")])
+    peer.error = RemoteRequestError(
+        "session_selection_required",
+        "No Kolega session is selected for browser operations yet",
+        retryable=False,
+    )
+
+    with pytest.raises(ChromeExtensionUnavailableError) as refused:
+        await browser.navigate("https://example.com")
+
+    detail = str(refused.value)
+    assert "nothing to select and nothing to click" in detail
+    assert "Retry the operation." in detail
+    for popup_instruction in ("Click the extension", "badge", "choose which"):
+        assert popup_instruction not in detail
 
 
 @pytest.mark.asyncio
@@ -380,9 +467,9 @@ async def test_probe_names_competing_runtimes_while_a_choice_is_pending(
     assert result["ready"] is False
     assert {entry["runtime_id"] for entry in result["runtimes"]} == {"runtime_1", "runtime_2"}
     assert [entry for entry in result["runtimes"] if entry["current"]][0]["runtime_id"] == "runtime_1"
-    assert "waiting for you to choose" in result["detail"]
+    assert "Another Kolega session is currently using the browser" in result["detail"]
     assert "session_2" in result["detail"]
-    assert "this session" in result["detail"]
+    assert "runtime_1" in result["detail"]
 
 
 @pytest.mark.asyncio
@@ -407,7 +494,7 @@ async def test_probe_reports_awaiting_selection_without_any_peer(
 
     assert result["state"] == "awaiting_selection"
     assert result["connected"] is False
-    assert "waiting for you to choose" in result["detail"]
+    assert "Another Kolega session is currently using the browser" in result["detail"]
 
 
 @pytest.mark.asyncio
@@ -436,5 +523,5 @@ async def test_unavailable_error_names_competing_runtimes(tmp_path: Path, monkey
         [_descriptor("runtime_1", "session_1"), _descriptor("runtime_2", "session_2")],
     )
 
-    with pytest.raises(ChromeExtensionUnavailableError, match="waiting for you to choose"):
+    with pytest.raises(ChromeExtensionUnavailableError, match="Another Kolega session is currently using"):
         await browser.navigate("https://example.com")

--- a/tests/browser_extension/test_manager.py
+++ b/tests/browser_extension/test_manager.py
@@ -53,6 +53,15 @@ class FakeServer:
 
     def __init__(self) -> None:
         self.close_count = 0
+        self.published = True
+        self.publish_count = 0
+
+    def publish(self) -> None:
+        self.published = True
+        self.publish_count += 1
+
+    def withdraw(self) -> None:
+        self.published = False
 
     async def close(self) -> None:
         self.close_count += 1
@@ -81,17 +90,21 @@ def ready_event(name: str = "browser.session_ready") -> Envelope:
 
 
 @pytest.mark.asyncio
-async def test_manager_waits_for_session_ready_then_serializes_calls(tmp_path: Path) -> None:
+async def test_manager_attaches_on_a_live_peer_then_serializes_calls(tmp_path: Path) -> None:
     browser = manager(tmp_path)
     server = FakeServer()
     peer = FakePeer()
     browser._server = cast(RuntimeServer, server)
-    await browser._handle_peer(cast(MultiplexedPeer, peer))
 
-    with pytest.raises(ChromeExtensionUnavailableError, match="connected but has not confirmed a session"):
+    with pytest.raises(ChromeExtensionUnavailableError, match="did not connect"):
         await browser.navigate("https://example.com")
+
+    # A live authenticated peer is the attachment: the native host dials a
+    # runtime's socket only to relay a message the extension addressed to it, and
+    # the extension only ever addresses the runtime the operator selected.
+    await browser._handle_peer(cast(MultiplexedPeer, peer))
+    assert browser.session_id == "chrome:runtime_1"
     await browser._handle_event(ready_event("browser.other"))
-    assert browser.session_id is None
     await browser._handle_event(ready_event())
     assert browser.session_id == "chrome:runtime_1"
 
@@ -234,15 +247,12 @@ def _advertise(
 
 
 @pytest.mark.asyncio
-async def test_readiness_survives_a_relay_peer_reconnecting(tmp_path: Path) -> None:
+async def test_a_reconnecting_relay_peer_is_usable_without_a_repeated_announcement(tmp_path: Path) -> None:
     """A reconnecting relay peer must not strand the session unconfirmed.
 
-    The extension announces browser.session_ready once per native connection, so
-    clearing readiness whenever the relay peer churned left the runtime stuck at
-    "connected but has not confirmed a session" with no way to recover short of
-    re-selecting in the popup. The native host only dials a runtime's socket to
-    relay a message the extension addressed to that runtime, so a peer existing at
-    all already proves this runtime is selected.
+    The extension announces browser.session_ready once per discovery, so anything
+    that requires a *fresh* announcement to work leaves the runtime stuck with no
+    way to recover short of re-selecting in the popup.
     """
     browser = manager(tmp_path)
     browser._server = cast(RuntimeServer, FakeServer())
@@ -251,11 +261,11 @@ async def test_readiness_survives_a_relay_peer_reconnecting(tmp_path: Path) -> N
     await browser._handle_event(ready_event())
     assert browser.session_id == "chrome:runtime_1"
 
-    # The relay drops; work must block, but the confirmation must not be lost.
+    # The relay drops; work must block while nothing is connected.
     await first.close()
     await asyncio.sleep(0)
     assert browser._peer is None
-    assert browser._ready is True
+    assert browser._ready is False
 
     # A fresh relay peer, with no repeated session_ready, must be usable at once.
     second = FakePeer()
@@ -266,17 +276,75 @@ async def test_readiness_survives_a_relay_peer_reconnecting(tmp_path: Path) -> N
 
 
 @pytest.mark.asyncio
-async def test_detach_still_clears_readiness(tmp_path: Path) -> None:
-    """Holding readiness across peer churn must not survive an explicit detach."""
+async def test_detach_leaves_the_session_able_to_drive_the_browser_again(tmp_path: Path) -> None:
+    """browser_close must not brick Chrome for the rest of the Kolega session.
+
+    Detaching means "stop driving the user's Chrome", not "shut it down" — we never
+    owned it — and every browser sub-agent detaches as cleanup at the end of its
+    dispatch. Latching attachment on an announcement the extension makes only once
+    per discovery meant the first detach was terminal: every later operation waited
+    out the connection timeout and then told the operator to reopen the popup.
+    """
     browser = manager(tmp_path)
     browser._server = cast(RuntimeServer, FakeServer())
-    await browser._handle_peer(cast(MultiplexedPeer, FakePeer()))
+    peer = FakePeer()
+    await browser._handle_peer(cast(MultiplexedPeer, peer))
     await browser._handle_event(ready_event())
 
-    await browser.close()
-
+    assert await browser.close() == "chrome:runtime_1"
+    assert peer.requests[-1] == ("browser.detach", {})
+    # The browsing session is over, so the next operation reports a fresh launch.
     assert browser.session_id is None
-    assert browser._ready is False
+    # An advertisement is a claim on the browser, so a finished session stops making
+    # one. Otherwise every other Kolega session had to break the tie by hand in the
+    # extension even though nothing was competing for the browser any more.
+    server = cast(FakeServer, browser._server)
+    assert server.published is False
+
+    result = await browser.navigate("https://example.com")
+
+    assert result["session_id"] == "chrome:runtime_1"
+    assert peer.requests[-1] == ("browser.navigate", {"url": "https://example.com/"})
+    # Browsing again re-asserts the claim, which is how a detached session asks for
+    # the browser back: the native host turns the change into a fresh discovery.
+    assert server.published is True
+    assert server.publish_count == 1
+
+
+@pytest.mark.asyncio
+async def test_a_selection_refused_by_the_extension_is_answered_with_guidance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The extension is the authority on whether this session may drive Chrome.
+
+    Holding a live peer no longer implies the grant cannot have moved: the operator
+    can switch to another Kolega session while our relay stays open. That refusal
+    arrives immediately and by code, which is strictly better than inferring it from
+    an advertised runtime count and waiting out a timeout — but it must still carry
+    the actionable remedy.
+    """
+    browser = manager(tmp_path)
+    browser._server = cast(RuntimeServer, FakeServer())
+    peer = FakePeer()
+    await browser._handle_peer(cast(MultiplexedPeer, peer))
+    _advertise(
+        browser,
+        monkeypatch,
+        [_descriptor("runtime_1", "session_1"), _descriptor("runtime_2", "session_2")],
+    )
+    peer.error = RemoteRequestError(
+        "session_not_selected",
+        "The request is not routed to the selected Kolega session",
+        retryable=False,
+    )
+
+    with pytest.raises(ChromeExtensionUnavailableError) as refused:
+        await browser.navigate("https://example.com")
+
+    assert refused.value.code == "session_not_selected"
+    assert "waiting for you to choose" in str(refused.value)
+    assert "session_2" in str(refused.value)
+    assert "this session" in str(refused.value)
 
 
 @pytest.mark.asyncio
@@ -293,14 +361,12 @@ async def test_probe_reports_unreachable_without_a_connection(tmp_path: Path) ->
 
 
 @pytest.mark.asyncio
-async def test_probe_reports_awaiting_selection_and_names_competing_runtimes(
+async def test_probe_names_competing_runtimes_while_a_choice_is_pending(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A connected-but-unselected companion is a different problem from an absent
-    one, and the operator needs to know which picker entry is theirs."""
+    """The operator needs to know which picker entry is theirs."""
     browser = manager(tmp_path)
     browser._server = cast(RuntimeServer, FakeServer())
-    await browser._handle_peer(cast(MultiplexedPeer, FakePeer()))
     _advertise(
         browser,
         monkeypatch,
@@ -310,7 +376,7 @@ async def test_probe_reports_awaiting_selection_and_names_competing_runtimes(
     result = await browser.probe()
 
     assert result["state"] == "awaiting_selection"
-    assert result["connected"] is True
+    assert result["connected"] is False
     assert result["ready"] is False
     assert {entry["runtime_id"] for entry in result["runtimes"]} == {"runtime_1", "runtime_2"}
     assert [entry for entry in result["runtimes"] if entry["current"]][0]["runtime_id"] == "runtime_1"
@@ -364,7 +430,6 @@ async def test_unavailable_error_names_competing_runtimes(tmp_path: Path, monkey
     """The operation error, not just doctor, must explain a blocked selection."""
     browser = manager(tmp_path)
     browser._server = cast(RuntimeServer, FakeServer())
-    await browser._handle_peer(cast(MultiplexedPeer, FakePeer()))
     _advertise(
         browser,
         monkeypatch,

--- a/tests/browser_extension/test_native_host.py
+++ b/tests/browser_extension/test_native_host.py
@@ -11,7 +11,13 @@ from typing import Any, cast
 
 import pytest
 
-from kolega_code.browser_extension.framing import read_message
+from kolega_code.browser_extension.framing import (
+    MAX_NATIVE_INBOUND_MESSAGE_BYTES,
+    MAX_NATIVE_MESSAGE_BYTES,
+    MessageTooLargeError,
+    encode_message,
+    read_message,
+)
 from kolega_code.browser_extension.native_host import (
     NativeHostBroker,
     NativeHostConfig,
@@ -141,6 +147,41 @@ async def test_native_endpoint_serializes_concurrent_complete_frames() -> None:
     assert second is not None
     assert {first["sequence"], second["sequence"]} == {1, 2}
     assert read_message(stream) is None
+
+
+@pytest.mark.asyncio
+async def test_native_endpoint_bounds_each_direction_by_what_chrome_enforces() -> None:
+    """Reads accept a screenshot-sized frame; writes stay inside Chrome's 1 MB cap.
+
+    Chrome caps a message *from* the host at 1 MB but allows far more *to* it, so
+    sharing one bound made the direction that carries screenshots pay for a limit
+    that never applied to it.
+    """
+    oversized_response = encode_message(
+        {"image": "a" * (MAX_NATIVE_MESSAGE_BYTES + 512_000)},
+        max_bytes=MAX_NATIVE_INBOUND_MESSAGE_BYTES,
+    )
+    endpoint = NativeMessageEndpoint(io.BytesIO(oversized_response), io.BytesIO())
+    inbound = await endpoint.read()
+    assert inbound is not None
+    assert len(inbound["image"]) == MAX_NATIVE_MESSAGE_BYTES + 512_000
+    await endpoint.close()
+
+    # The write direction is still refused past Chrome's hard limit.
+    writer = NativeMessageEndpoint(io.BytesIO(), io.BytesIO())
+    with pytest.raises(MessageTooLargeError):
+        await writer.write_mapping({"image": "a" * (MAX_NATIVE_MESSAGE_BYTES + 1)})
+    await writer.close()
+
+    # And the read direction is generous, not unbounded.
+    beyond = encode_message(
+        {"image": "a" * MAX_NATIVE_INBOUND_MESSAGE_BYTES},
+        max_bytes=MAX_NATIVE_INBOUND_MESSAGE_BYTES * 2,
+    )
+    guarded = NativeMessageEndpoint(io.BytesIO(beyond), io.BytesIO())
+    with pytest.raises(MessageTooLargeError):
+        await guarded.read()
+    await guarded.close()
 
 
 @pytest.mark.asyncio

--- a/tests/browser_extension/test_protocol.py
+++ b/tests/browser_extension/test_protocol.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import json
+import re
 import struct
 import time
 from typing import Any, cast
@@ -121,6 +122,7 @@ VALID_PARAMS: dict[str, dict[str, object]] = {
     "browser.hover": {"target": "e1"},
     "browser.drag": {"start_target": "e1", "end_target": "e2"},
     "browser.press_key": {"key": "ControlOrMeta+L"},
+    "browser.scroll": {"by_pages": 2, "target": None, "x": None, "y": None},
     "browser.tabs": {"action": "list", "index": None, "url": None},
     "browser.network_requests": {"include_static": False, "filter_pattern": None},
     "browser.screenshot": {"target": None, "image_type": "png", "full_page": True, "scale": "css"},
@@ -128,9 +130,9 @@ VALID_PARAMS: dict[str, dict[str, object]] = {
 }
 
 
-def test_fixed_operation_surface_has_exactly_sixteen_schemas() -> None:
+def test_fixed_operation_surface_has_exactly_seventeen_schemas() -> None:
     assert ALLOWED_OPERATIONS == frozenset(VALID_PARAMS)
-    assert len(ALLOWED_OPERATIONS) == 16
+    assert len(ALLOWED_OPERATIONS) == 17
 
 
 @pytest.mark.parametrize(("operation", "params"), VALID_PARAMS.items())
@@ -175,6 +177,32 @@ def test_invalid_operation_parameters_are_rejected(operation: str, params: dict[
     with pytest.raises(ProtocolValidationError) as error:
         validate_operation_request(operation, params)
     assert error.value.code == "invalid_params"
+
+
+def test_scroll_accepts_exactly_one_movement() -> None:
+    base: dict[str, object] = {"by_pages": None, "target": None, "x": None, "y": None}
+    for movement in ({"by_pages": 3}, {"by_pages": -1.5}, {"y": 15_000}, {"x": 0, "y": 0}, {"target": "#main"}):
+        params = {**base, **movement}
+        assert validate_operation_request("browser.scroll", params) == params
+
+    ambiguous = "Provide exactly one of target, by_pages, or x/y"
+    for params, expected in (
+        (base, ambiguous),
+        ({**base, "by_pages": 1, "y": 10}, ambiguous),
+        ({**base, "target": "#main", "by_pages": 1}, ambiguous),
+        ({**base, "by_pages": 11}, "by_pages is invalid"),
+        # Message text is mirrored character for character by nullableInteger in
+        # the extension's src/operations.js.
+        ({**base, "y": -1}, "y must be an integer between 0 and 10000000, or JSON null"),
+        ({**base, "y": 1.5}, "y must be an integer between 0 and 10000000, or JSON null"),
+        ({**base, "y": "null"}, "y must be an integer or JSON null, not the string 'null'"),
+        # Inapplicable fields must be null, never omitted.
+        ({"by_pages": 1}, "invalid schema"),
+        ({**base, "by_pages": 1, "extra": True}, "invalid schema"),
+    ):
+        with pytest.raises(ProtocolValidationError, match=re.escape(expected)) as error:
+            validate_operation_request("browser.scroll", params)
+        assert error.value.code == "invalid_params"
 
 
 def test_url_normalization_and_regex_escapes_match_the_extension_contract() -> None:

--- a/tests/browser_extension/test_protocol.py
+++ b/tests/browser_extension/test_protocol.py
@@ -20,6 +20,8 @@ from kolega_code.browser_extension.framing import (
 from kolega_code.browser_extension.protocol import (
     ALLOWED_OPERATIONS,
     MAX_ERROR_MESSAGE_LENGTH,
+    MAX_PROTOCOL_JSON_BYTES,
+    MAX_PROTOCOL_RESPONSE_JSON_BYTES,
     PROTOCOL_VERSION,
     Envelope,
     MessageDirection,
@@ -410,10 +412,28 @@ def test_native_framing_counts_utf8_bytes_without_ascii_escape_inflation() -> No
         encode_message(value, max_bytes=len(encoded) - 1)
 
 
-def test_generated_envelopes_cannot_exceed_the_protocol_frame_bound() -> None:
+def test_envelope_size_bounds_follow_the_direction_they_travel() -> None:
+    """Chrome caps host->extension at 1 MB but allows far more the other way.
+
+    Requests must respect the conservative bound; responses carry screenshots and
+    would otherwise have to be downscaled into illegibility to fit a limit that
+    was self-imposed rather than Chrome's.
+    """
+    # A response comfortably past the request bound is accepted.
+    large = Envelope.response_for(request(), {"image": "a" * 4_000_000})
+    assert large.direction is MessageDirection.EXTENSION_TO_RUNTIME
+    assert large.size_limit == MAX_PROTOCOL_RESPONSE_JSON_BYTES
+
+    # A request is still held to the limit Chrome actually enforces.
+    assert request().size_limit == MAX_PROTOCOL_JSON_BYTES
     with pytest.raises(ProtocolValidationError) as error:
-        Envelope.response_for(request(), {"text": "é" * 600_000})
-    assert error.value.code == "message_too_large"
+        request("browser.navigate", {"url": f"https://example.com/{'a' * 2_000_000}"})
+    assert error.value.code in {"invalid_params", "message_too_large"}
+
+    # The response bound is generous, not absent.
+    with pytest.raises(ProtocolValidationError) as too_big:
+        Envelope.response_for(request(), {"image": "a" * MAX_PROTOCOL_RESPONSE_JSON_BYTES})
+    assert too_big.value.code == "message_too_large"
 
 
 def test_protocol_json_rejects_non_finite_and_non_object_payloads() -> None:

--- a/tests/browser_extension/test_runtime.py
+++ b/tests/browser_extension/test_runtime.py
@@ -118,6 +118,70 @@ async def test_unix_runtime_auth_multiplex_timeout_disconnect_and_cleanup(tmp_pa
 
 
 @pytest.mark.asyncio
+async def test_withdrawing_drops_the_claim_but_keeps_the_socket_and_its_connections(tmp_path: Path) -> None:
+    """An advertisement is a claim on the browser, not a fact about the process.
+
+    The extension refuses to guess between several claims, so a session that has
+    finished browsing must stop making one — otherwise every other Kolega session
+    has to break the tie by hand in the extension even when nothing is competing.
+    Withdrawing must not cost the live connection though: a session that detaches
+    and then browses again has to resume without waiting out a fresh discovery.
+    """
+    registry = RuntimeDescriptorRegistry(tmp_path / "runtimes")
+    server = RuntimeServer(registry, session_id="session_1", extension_origin=ORIGIN, platform="darwin")
+    descriptor = await server.start()
+    assert server.published is True
+    assert [entry.runtime_id for entry in registry.list_active()] == [descriptor.runtime_id]
+
+    extension_peer = await connect_runtime_peer(descriptor, extension_origin=ORIGIN, platform="darwin")
+    runtime_peer = await server.wait_for_connection(timeout=1)
+
+    server.withdraw()
+    assert server.published is False
+    assert registry.list_active() == []
+    assert Path(descriptor.endpoint).exists()
+    assert runtime_peer.closed is False
+
+    # Re-advertising is how a detached session asks for the browser back, and the
+    # runtime id is unchanged so an operator's existing choice still matches.
+    server.publish()
+    assert server.published is True
+    republished = registry.list_active()
+    assert [entry.runtime_id for entry in republished] == [descriptor.runtime_id]
+    assert republished[0].created_at_ms == descriptor.created_at_ms
+    assert republished[0].expires_at_ms >= descriptor.expires_at_ms
+
+    await extension_peer.close()
+    await server.close()
+    assert registry.list_active() == []
+
+
+@pytest.mark.asyncio
+async def test_the_lease_refresh_never_resurrects_a_withdrawn_claim(tmp_path: Path) -> None:
+    """The refresh rewrites the descriptor to extend the lease, so left unguarded it
+    would reinstate a claim the session explicitly gave up."""
+    registry = RuntimeDescriptorRegistry(tmp_path / "runtimes")
+    # ttl_ms/3000 is the refresh interval, floored at 50ms.
+    server = RuntimeServer(
+        registry,
+        session_id="session_1",
+        extension_origin=ORIGIN,
+        ttl_ms=60_000,
+        platform="darwin",
+    )
+    await server.start()
+    server.withdraw()
+
+    for _ in range(6):
+        await asyncio.sleep(0.02)
+        assert registry.list_active() == []
+
+    server.publish()
+    assert len(registry.list_active()) == 1
+    await server.close()
+
+
+@pytest.mark.asyncio
 async def test_runtime_rejects_wrong_origin_and_registry_permissions(tmp_path: Path) -> None:
     registry = RuntimeDescriptorRegistry(tmp_path / "runtimes")
     server = RuntimeServer(registry, session_id="session_1", extension_origin=ORIGIN, platform="darwin")


### PR DESCRIPTION
Pairs with kolega-ai/kolega-chrome-extension#2, which fixes the extension side.
Both are needed: reload the extension after installing this.

## Why

An agent that cannot distinguish "I could not cover all of this" from "it is not
there" has to rediscover the same wall from every direction. On one large page that
cost roughly twenty-five tool calls and still produced a partial answer, because the
Chrome backend returned an empty snapshot, refused every selector, reported "no
matches" for visible text, and could not scroll.

## What changed here

**`browser_scroll`, on both backends.** A page too large to snapshot in one call can
only be read by moving the viewport, and nothing could move it: the Chrome backend's
scrolling keys did not scroll and neither backend exposed an explicit request. It
takes exactly one of a target, a count of viewports, or an absolute offset, and
reports where the viewport landed along with the content height, so a
scroll-then-snapshot loop can tell progress from having reached the end of the page.

The two validators mirror each other including message text, because the runtime
validates first and a caller should not see a different error depending on which side
caught it.

The Playwright implementation scrolls in the page rather than through `mouse.wheel`:
wheel dispatches an event without waiting for the scroll it triggers, so reading the
resulting position raced it and reported no movement. That manager drives its own
browser instance and already exposes `browser_evaluate`, so an in-page call widens
nothing here — unlike the extension backend, where the injected helper's surface is
the security boundary.

**Coverage that the agent can act on.** Remote error codes are no longer discarded on
the way out of the Chrome manager, and the codes meaning "larger than one call can
cover" carry the concrete next step. Snapshots gain a `Coverage:` line, emitted only
when coverage is genuinely incomplete, naming how much was shown, which bound stopped
it, and where the viewport sits. `browser_find` distinguishes four outcomes instead of
a flat "No matches found": a hit, a hit under partial coverage, text present in the
page but outside the covered region, and a genuine absence. Only the last is a
reliable negative.

**Direction-aware Native Messaging bounds.** Chrome caps a message from the host at
1 MB but allows far more toward it, and responses carry screenshots. The binding
constraint turned out to be `Envelope.__post_init__` calling `to_json()`, which
enforced the request bound on every envelope including responses. Requests keep the
hard limit; responses get 64 MiB. Request parameters remain bounded by their own
schemas, so the larger figure cannot be used to send a larger request.

Tool descriptions and the browser-agent dispatch guidance now state that a truncated
snapshot means "narrow the scope or scroll", that snapshot depth counts emitted nodes
rather than DOM nesting, and that a tall capture is clipped rather than shrunk.

## Verification

3551 tests pass, pre-commit clean, docs site builds with the new anchor.

Also exercised against a live Chrome, which is where the interesting failures were:
the Playwright wheel race above, and — on the extension side — a paragraph with
inline children being dropped entirely, which is the shape of most post bodies. On
the page that originally failed, the snapshot is now complete, "See more" carries a
usable ref, the feed scopes and scrolls, and `find` returns matches where it returned
none.

The capability boundary is unchanged and was re-verified fail-closed: restricted
hosts, `file://` and `chrome://` URLs, JavaScript evaluation, console, response
bodies, dialogs, uploads and resize all still refuse, with the page usable after each
rejection.
