### PR TITLE
fix(worktrees): flag prunable entries in registered worktree inventory

### DIFF
--- a/kolega_code/worktrees.py
+++ b/kolega_code/worktrees.py
@@ -443,7 +443,11 @@ def _git_error_detail(completed: subprocess.CompletedProcess[str]) -> str:
 
 
 def _with_registered(message: str, worktrees: Sequence[WorktreeInfo]) -> str:
-    entries = ", ".join(f"{info.path} [{info.branch or 'detached'}]" for info in worktrees)
+    """Suffix the registered inventory, flagging stale entries with git's own
+    ``prunable`` term so a model is not offered a target that cannot resolve."""
+    entries = ", ".join(
+        f"{info.path} [{info.branch or 'detached'}{'' if info.path.is_dir() else ', prunable'}]" for info in worktrees
+    )
     return f"{message}. Registered worktrees: {entries}"
 
 

--- a/tests/agent/test_tool_collection_config.py
+++ b/tests/agent/test_tool_collection_config.py
@@ -276,6 +276,40 @@ class TestToolCollection:
         names_at_limit = set(tool_collection.registry().names())
         assert not names_at_limit.intersection(ToolCollection.agent_dispatch_tools)
 
+    async def test_registration_collects_exclusive_tools_from_extensions(
+        self,
+        project_path: Path,
+        mock_connection_manager: AgentConnectionManager,
+        agent_config: AgentConfig,
+        mock_base_agent: BaseAgent,
+    ) -> None:
+        """The batch-rejection guard reads ``exclusive_tools`` off the live
+        collection; registration must derive it from extension declarations."""
+
+        async def switch_workspace(path: str) -> str:
+            return path
+
+        async def plain_tool(task: str) -> str:
+            return task
+
+        extension = ToolExtension(
+            name="host-session-control",
+            tools={"switch_workspace": switch_workspace, "plain_tool": plain_tool},
+            exclusive_tools=frozenset({"switch_workspace"}),
+        )
+        tool_collection = ToolCollection(
+            project_path,
+            "test_workspace",
+            str(uuid.uuid4()),
+            mock_connection_manager,
+            agent_config,
+            mock_base_agent,
+            tool_extensions=[extension],
+        )
+
+        assert tool_collection.exclusive_tools == frozenset({"switch_workspace"})
+        assert "switch_workspace" in tool_collection.registry()
+
     async def test_model_discovery_is_exposed_to_workflow_authors_but_hidden_from_leaves(
         self,
         project_path: Path,

--- a/tests/agent/test_worktrees.py
+++ b/tests/agent/test_worktrees.py
@@ -249,6 +249,9 @@ def test_resolve_rejects_registered_worktree_whose_checkout_is_missing(tmp_path:
 
     assert error.value.code is WorktreeErrorCode.UNKNOWN_WORKTREE
     assert "missing or invalid" in str(error.value)
+    # The registered inventory must not advertise the stale checkout as a
+    # usable target; git's own term marks it.
+    assert f"{linked} [stale-branch, prunable]" in str(error.value)
 
 
 def test_resolve_rejects_ambiguous_branch_and_path(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #361, from an end-to-end exercise of the worktree-aware workspace features.

The `Registered worktrees:` inventory appended to worktree-resolution errors listed every registered entry as though it were selectable — including entries whose checkout directory no longer exists. Picking one already failed safely (`Registered worktree is missing or invalid`), so the only harm was misleading the caller into retrying a target that can never resolve. This surfaced in practice: a real unknown-target error advertised a stale worktree left behind by an earlier session.

Stale entries are still listed, because they *are* registered, but they now carry git's own `prunable` term:

```
/path/to/worktree [some-branch, prunable]
```

## Changes

- `kolega_code/worktrees.py` — `_with_registered` annotates entries whose checkout directory is missing.
- `tests/agent/test_worktrees.py` — the existing stale-checkout test now asserts the annotation.
- `tests/agent/test_tool_collection_config.py` — unrelated but adjacent: pins that a real `ToolCollection` derives `exclusive_tools` from extension declarations, completing the unit chain behind the exclusive-tool batch guard (extension declares -> collection collects -> batch rejected).

## Verification

- `tests/agent/test_worktrees.py` + `tests/agent/test_tool_collection_config.py`: 33 passed.
- Full fast suite: 3666 passed, 1 skipped.
- `ruff check`, `ruff format --check`, `pyright`: clean. Pre-commit hooks passed on both commits.
- Behaviour also confirmed live end-to-end: the exclusive-batch guard rejects a co-called tool with nothing executed, the busy-terminal guard refuses while a session runs, and switching main -> linked worktree -> main retargets terminal cwd, git branch, and relative-path file tools while leaving the other checkout untouched.

No user-facing docs change: this only refines an error message's inventory annotation.