### PR TITLE
fix(agent): prevent duplicate prompt after cancelled tool call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,9 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ### Fixed
 
+- Continuing after cancelling an in-flight tool call no longer duplicates the
+  next prompt or makes Anthropic reject the request for exceeding its maximum
+  of four `cache_control` blocks.
 - Stopped image-heavy sessions from freezing the TUI. Building request history
   re-encoded every screenshot in history on every LLM request, on the event
   loop — dozens of multi-second stalls per session, multiplied by each running

--- a/kolega_code/agent/conversation.py
+++ b/kolega_code/agent/conversation.py
@@ -839,8 +839,10 @@ class Conversation:
                                 else:
                                     other_content_blocks.append(block)
 
-                            if all_tool_results:
-                                processed_indices.add(i + 1)
+                            # Every block from this message is rebuilt below beside the complete
+                            # tool-result set. Leaving the original message in the output would
+                            # duplicate its non-result content when no matching result existed.
+                            processed_indices.add(i + 1)
 
                     # Search the entire remaining conversation for any missing tool results
                     missing_ids = tool_call_ids - set(all_tool_results.keys())

--- a/tests/agent/test_base_agent_tool_call_repair.py
+++ b/tests/agent/test_base_agent_tool_call_repair.py
@@ -80,6 +80,43 @@ class TestBaseAgent:
         assert placeholder_msg.content[0].is_error is True
         assert "interrupted" in placeholder_msg.content[0].content.lower()
 
+    def testfix_incomplete_tool_call_does_not_duplicate_following_user_content(self, base_agent):
+        """The next prompt is merged beside the placeholder, not also emitted again."""
+        continuation = TextBlock(text="Continue after the cancelled tool")
+        following_user = Message(
+            role="user",
+            content=[continuation],
+            stop_reason="end_turn",
+            tool_calls=[],
+            usage_metadata={"source": "regression"},
+        )
+        incomplete_history = [
+            Message(role="assistant", content=[ToolCall(id="tool1", name="test_tool", input={})]),
+            following_user,
+        ]
+
+        fixed_history = base_agent.fix_incomplete_tool_calls(incomplete_history)
+
+        assert len(fixed_history) == 2
+        repaired_following = fixed_history[1]
+        assert repaired_following.role == "user"
+        assert repaired_following.stop_reason == following_user.stop_reason
+        assert repaired_following.tool_calls == following_user.tool_calls
+        assert repaired_following.usage_metadata == following_user.usage_metadata
+        assert isinstance(repaired_following.content, list)
+        assert isinstance(repaired_following.content[0], ToolResult)
+        assert repaired_following.content[0].tool_use_id == "tool1"
+        assert repaired_following.content[0].is_error is True
+
+        continuation_blocks = [
+            block
+            for message in fixed_history
+            if isinstance(message.content, list)
+            for block in message.content
+            if isinstance(block, TextBlock) and block.text == continuation.text
+        ]
+        assert continuation_blocks == [continuation]
+
     def testfix_incomplete_tool_calls_multiple_tools(self, base_agent):
         """Test fix method handles multiple incomplete tool calls."""
         incomplete_history = [
@@ -639,7 +676,12 @@ class TestBaseAgent:
 
         # But verify that fix_incomplete_tool_calls can fix it
         fixed_history = base_agent.fix_incomplete_tool_calls(list(base_agent.history))
-        assert len(fixed_history) == 3  # assistant, user (tool result), user (new message)
+        assert len(fixed_history) == 2  # assistant, user (tool result + original message)
+        repaired_user = fixed_history[1]
+        assert isinstance(repaired_user.content[0], ToolResult)
+        assert repaired_user.content[0].tool_use_id == "tool1"
+        assert isinstance(repaired_user.content[1], TextBlock)
+        assert repaired_user.content[1].text == "New user message"
         assert base_agent._is_history_valid_for_anthropic(fixed_history) is True
 
     def test_append_user_message_no_fix_needed(self, base_agent):

--- a/tests/agent/test_duplicate_tool_results.py
+++ b/tests/agent/test_duplicate_tool_results.py
@@ -413,23 +413,22 @@ class TestDuplicateToolResultPrevention:
         # Test fix_incomplete_tool_calls
         fixed_messages = base_agent.fix_incomplete_tool_calls(messages)
 
-        # Should have 3 messages: assistant with tool call, user with tool result, user with text
-        assert len(fixed_messages) == 3
+        # The intervening text is retained in the same repaired user message as the relocated
+        # result, rather than duplicated as a second user message.
+        assert len(fixed_messages) == 2
 
         # First message should be the assistant message
         assert fixed_messages[0].role == "assistant"
         assert any(isinstance(block, ToolCall) for block in fixed_messages[0].content)
 
-        # Second message should have the tool result (moved to correct position)
+        # Second message should have the tool result (moved to correct position) and user text.
         assert fixed_messages[1].role == "user"
         tool_results = [block for block in fixed_messages[1].content if isinstance(block, ToolResult)]
         assert len(tool_results) == 1
         assert tool_results[0].tool_use_id == "toolu_test123"
         assert tool_results[0].content == "File contents: print('hello')"
-
-        # Third message should be the user text message
-        assert fixed_messages[2].role == "user"
-        assert fixed_messages[2].content[0].text == "Please hurry up!"
+        text_blocks = [block for block in fixed_messages[1].content if isinstance(block, TextBlock)]
+        assert [block.text for block in text_blocks] == ["Please hurry up!"]
 
         # Verify no duplicate tool results
         all_tool_results = []

--- a/tests/agent/test_prompt_cache_stability.py
+++ b/tests/agent/test_prompt_cache_stability.py
@@ -33,10 +33,12 @@ class RecordingLLM(FakeLLM):
     async def _stream(self, *args: Any, **kwargs: Any):
         messages = kwargs.get("messages")
         system = kwargs.get("system")
+        tools = kwargs.get("tools")
         self.payloads.append(
             {
                 "messages": copy.deepcopy(messages.to_anthropic()) if messages is not None else None,
                 "system": copy.deepcopy([block.to_anthropic() for block in system.content]) if system else None,
+                "tools": copy.deepcopy([tool.to_anthropic() for tool in tools]) if tools else [],
             }
         )
         return await super()._stream(*args, **kwargs)
@@ -249,6 +251,74 @@ class TestInjectionDoesNotBreakToolPairing:
 
 
 class TestBreakpointBudgetInRealRequests:
+    @pytest.mark.asyncio
+    async def test_cancelled_tool_followup_stays_within_four_breakpoints(self, recording_agent):
+        """Repair must not serialize the marked follow-up twice and create a fifth breakpoint."""
+        from kolega_code.llm.models import Message, TextBlock, ToolCall, ToolDefinition
+        from kolega_code.tools import Tool, ToolRegistry
+
+        agent, llm, _manager = recording_agent
+
+        async def handler(**inputs):
+            return "ok"
+
+        registry = ToolRegistry().add(
+            Tool(
+                name="write_stdin",
+                definition=ToolDefinition(name="write_stdin", description="write", parameters=[]),
+                handler=handler,
+            )
+        )
+        agent.tool_collection.get_tool_list = lambda: registry.definitions()
+
+        # Seed both the prior rolling checkpoint and the volatile-context tracker. The next turn
+        # then recreates the production failure exactly: an older marker survives while the
+        # ordinary user message immediately following an orphaned tool call is the newest marker.
+        await run_turn(agent, "prime cache")
+        agent.conversation.history.append(Message(role="user", content=[TextBlock(text="earlier ask")]))
+        agent.conversation.history.append(
+            Message(
+                role="assistant",
+                content=[ToolCall(id="orphan-1", name="write_stdin", input={})],
+                stop_reason="tool_use",
+            )
+        )
+
+        await run_turn(agent, "continue after cancellation")
+
+        payload = llm.payloads[-1]
+        matching_text = [
+            block
+            for message in payload["messages"]
+            for block in message["content"]
+            if isinstance(block, dict)
+            and block.get("type") == "text"
+            and block.get("text") == "continue after cancellation"
+        ]
+        assert len(matching_text) == 1
+
+        orphan_index = next(
+            index
+            for index, message in enumerate(payload["messages"])
+            if any(isinstance(block, dict) and block.get("id") == "orphan-1" for block in message["content"])
+        )
+        repaired_following = payload["messages"][orphan_index + 1]
+        assert any(
+            isinstance(block, dict) and block.get("type") == "tool_result" and block.get("tool_use_id") == "orphan-1"
+            for block in repaired_following["content"]
+        )
+
+        tools = sum("cache_control" in tool for tool in payload["tools"])
+        system = sum("cache_control" in block for block in payload["system"])
+        history = sum(
+            "cache_control" in block
+            for message in payload["messages"]
+            for block in message["content"]
+            if isinstance(block, dict)
+        )
+        assert (tools, system, history) == (1, 1, 2)
+        assert tools + system + history == 4
+
     @pytest.mark.asyncio
     async def test_a_multi_turn_request_never_exceeds_four_breakpoints(self, recording_agent):
         """The API rejects a fifth. Assert on real payloads, not on the pieces in isolation."""


### PR DESCRIPTION
## Summary

- consume a list-based user follow-up after rebuilding it beside repaired tool results
- prevent the follow-up prompt from being serialized twice and creating a fifth Anthropic `cache_control` block
- add regressions for duplicate-content repair, relocated tool results, and the complete four-marker request budget
- document the cancellation fix in the changelog

## Testing

- `PYTHONDONTWRITEBYTECODE=1 ./run_tests.sh tests/agent/test_base_agent_tool_call_repair.py tests/agent/test_duplicate_tool_results.py tests/agent/test_cache_breakpoints.py tests/agent/test_prompt_cache_stability.py -ra` (`58 passed, 1 deselected`)
- `PYTHONDONTWRITEBYTECODE=1 ./run_tests.sh` (`3773 passed, 1 skipped, 108 deselected`)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pre-commit run --all-files --show-diff-on-failure`
