### PR TITLE
feat(cli): add "Other…" model option to OpenRouter settings pickers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   can be used without upgrading. Startup merges the cache without any network
   access; `KOLEGA_CODE_OPENROUTER_CATALOG` and
   `KOLEGA_CODE_DISABLE_OPENROUTER_CATALOG` control it.
+- **Settings "Other…" model picker.** The main Model dropdown and every Agent
+  Models role row lead with OpenRouter's most-used models and then offer an
+  "Other…" entry backed by a free-text field, so any catalogued model id
+  (bundled or added by `models refresh`) can be selected from Settings instead
+  of only by exact ID on the command line. Typed ids are validated against the
+  catalog before saving, and the Browser role keeps its vision-capability gate.
 - **Worktree-aware startup and workspace switching.** Interactive and headless
   launches can select a registered checkout with `--worktree`, or create one
   safely with `--create-worktree` plus optional `--from` and

--- a/docs/src/content/docs/configuration/providers-and-models.mdx
+++ b/docs/src/content/docs/configuration/providers-and-models.mdx
@@ -76,10 +76,12 @@ Model IDs are `vendor/model`, for example `anthropic/claude-opus-5` or
 are heavily rate limited and are best kept for experiments rather than long
 sessions.
 
-Because the catalog runs to hundreds of entries, the Settings picker, `/model`
-and the sub-agent model catalog list only OpenRouter's **20 most-used models**,
-in the order of [OpenRouter's own LLM Leaderboard](https://openrouter.ai/rankings).
-Every other catalogued model still works — pass the exact ID:
+Because the catalog runs to hundreds of entries, the Settings picker (the main
+Model dropdown and every Agent Models row) leads with OpenRouter's **20
+most-used models**, in the order of [OpenRouter's own LLM Leaderboard](https://openrouter.ai/rankings),
+and then offers an **Other…** option where you can type any catalogued model id
+directly. `/model` and the sub-agent model catalog stay most-used-only. Every
+catalogued model still works — pass the exact ID:
 
 ```bash
 kolega-code models list --provider openrouter        # the whole catalog, most-used first

--- a/kolega_code/cli/messages.py
+++ b/kolega_code/cli/messages.py
@@ -152,6 +152,11 @@ MENTIONS_NOT_FOUND = "Not found, sent as plain text: {mentions}"
 # Slash commands
 MODEL_SWITCHED = "Switched model to {provider}/{model} with thinking effort {effort}."
 MODEL_UNKNOWN = "Unknown model {model} for provider {provider}."
+MODEL_CUSTOM_EMPTY = "Type a model id (vendor/model) in the custom model field, or pick a listed model."
+MODEL_CUSTOM_UNKNOWN = (
+    '"{model}" is not a known {provider} model. See "kolega-code models list --provider {provider}" '
+    'for valid ids, or run "kolega-code models refresh" to pick up newer models.'
+)
 MODEL_SWITCH_HINT = "Choose below, or switch with /model <name>."
 MODEL_PARTIAL_LISTING_HINT = (
     "{provider} offers many more models. Any of them works with /model <id> — "

--- a/kolega_code/cli/model_catalog.py
+++ b/kolega_code/cli/model_catalog.py
@@ -7,8 +7,9 @@ cut, so a model published after that release is unknown to it. ``models refresh`
 fetches the documented ``/api/v1/models`` endpoint once, on request, and caches
 the result in the state directory; the cache is merged into ``MODEL_SPECS`` at
 CLI startup. Startup itself never touches the network, and cached entries are
-never marked ``featured`` — pickers and sub-agent prompts keep showing the
-curated-by-usage set from the bundled snapshot.
+never marked ``featured`` — Settings pickers lead with the release's curated-by-
+usage set (and admit any catalogued id through their "Other…" entry), while
+sub-agent prompts keep showing the featured set alone.
 """
 
 from __future__ import annotations

--- a/kolega_code/cli/tui/custom_model.py
+++ b/kolega_code/cli/tui/custom_model.py
@@ -1,0 +1,62 @@
+"""Settings-only "Other…" model picker affordance for gateway providers.
+
+The Settings screen (main dropdown and every per-agent role row) shows only a
+gateway provider's featured models so each picker stays short, but OpenRouter
+catalogs hundreds of tool-capable models beyond that curated head. This module
+owns the UI-side escape hatch: a trailing "Other…" select option backed by a
+free-text input for any catalogued model id.
+
+Everything here is deliberately a UI concern — ``kolega_code/cli/provider_registry.py``
+(the shared catalog/config layer) is untouched, and the sentinel value is never
+persisted: settings.json always stores the real model id.
+"""
+
+from __future__ import annotations
+
+from kolega_code.cli.provider_registry import (
+    UI_MODEL_OPTIONS,
+    get_ui_model,
+    provider_has_featured_models,
+    ui_model_options,
+)
+
+# Sentinel option value for the "Other…" picker entry. Every real catalogued
+# model id contains a '/', so this cannot collide with any of them.
+CUSTOM_MODEL_LABEL = "Other…"
+CUSTOM_MODEL_SENTINEL = "__custom_model__"
+
+# Placeholder shown in every custom-model input on the Settings screen.
+CUSTOM_MODEL_PLACEHOLDER = "Custom model id, e.g. anthropic/claude-sonnet-4.5"
+
+
+def settings_model_options(provider: str, *, vision_only: bool = False) -> list[tuple[str, str]]:
+    """Return model Select options for the Settings pickers, with "Other…".
+
+    Delegates to ``provider_registry.ui_model_options`` unchanged, then appends
+    the "Other…" entry when the provider is a gateway (it marks some models
+    featured) and catalogs at least one non-featured model matching the vision
+    filter. For every other provider the output is byte-identical to
+    ``ui_model_options``.
+    """
+    options = ui_model_options(provider, vision_only=vision_only)
+    has_non_featured = any(
+        option.provider == provider and not option.featured and (option.supports_vision or not vision_only)
+        for option in UI_MODEL_OPTIONS
+    )
+    if provider_has_featured_models(provider) and has_non_featured:
+        options.append((CUSTOM_MODEL_LABEL, CUSTOM_MODEL_SENTINEL))
+    return options
+
+
+def resolve_custom_model(provider: str, value: str) -> str | None:
+    """Return ``value`` (whitespace-trimmed) iff it names a catalogued model.
+
+    Exact-match semantics shared with the ``/model`` fallback and the
+    ``build_agent_config`` gate: anything not in the merged catalog (bundled
+    snapshot plus any ``kolega-code models refresh`` overlay) resolves to
+    ``None``.
+    """
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    return cleaned if get_ui_model(provider, cleaned) is not None else None

--- a/kolega_code/cli/tui/settings_panel.py
+++ b/kolega_code/cli/tui/settings_panel.py
@@ -49,6 +49,11 @@ from ..provider_registry import (
     ui_thinking_effort_options,
 )
 from . import app_base as tui_app_base
+from .custom_model import (
+    CUSTOM_MODEL_SENTINEL,
+    resolve_custom_model,
+    settings_model_options,
+)
 from ..settings import WEB_SEARCH_KEY_NAMES, CliSettings
 from ..theme import Color, Glyph
 
@@ -263,7 +268,7 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
                 provider = str(self._settings_query_one("#provider_select", Select).value)
             except NoMatches:
                 return
-            self._set_effort_select_default(provider, str(event.value))
+            self._sync_effort_for_model_value(provider, str(event.value), "model_select", "thinking_effort_select")
             self._update_browser_model_hint()
             return
 
@@ -308,7 +313,15 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
                 # A restored effort waits here for the model that hosts it; a manual
                 # model change has none pending and falls back to preserve/default.
                 preferred = self._pending_agent_efforts.pop(f"am_effort_{role}", None)
-                self._set_effort_select_default(provider, str(event.value), f"am_effort_{role}", preferred=preferred)
+                self._sync_effort_for_model_value(
+                    provider,
+                    str(event.value),
+                    f"am_model_{role}",
+                    f"am_effort_{role}",
+                    preferred=preferred,
+                )
+            else:
+                self._sync_custom_model_input(f"am_model_{role}", f"am_custom_model_{role}")
             if role == "browser":
                 self._update_browser_model_hint()
             return
@@ -320,6 +333,41 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             if name != theme.active_theme().name:
                 self._apply_theme(name)
 
+    def on_input_changed(self, event: Input.Changed) -> None:
+        """Keep effort selects and the browser hint in sync with "Other…" text.
+
+        The Settings screen has its own ``on_input_changed`` (API key staging and
+        dirty tracking); this app-level handler only reacts to the custom-model
+        inputs, so the two never conflict.
+        """
+        input_id = event.input.id or ""
+        if input_id == "model_custom_input":
+            model_select_id, effort_select_id, provider_id = (
+                "model_select",
+                "thinking_effort_select",
+                "provider_select",
+            )
+        elif input_id.startswith("am_custom_model_"):
+            role = input_id[len("am_custom_model_") :]
+            model_select_id, effort_select_id, provider_id = (
+                f"am_model_{role}",
+                f"am_effort_{role}",
+                f"am_provider_{role}",
+            )
+        else:
+            return
+        try:
+            model_select = self._settings_query_one(f"#{model_select_id}", Select)
+            provider = str(self._settings_query_one(f"#{provider_id}", Select).value)
+        except NoMatches:
+            return
+        if str(model_select.value) != CUSTOM_MODEL_SENTINEL:
+            return
+        typed = self._typed_custom_model(provider, input_id)
+        if typed is not None:
+            self._set_effort_select_default(provider, typed, effort_select_id)
+        self._update_browser_model_hint()
+
     def _populate_settings_controls(self) -> None:
         screen = getattr(self, "_settings_screen", None)
         if screen is None or not getattr(screen, "is_attached", False):
@@ -330,17 +378,26 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         provider = (
             self.settings.active_provider if self.settings.active_provider in provider_values else UI_DEFAULT_PROVIDER
         )
-        model_options = ui_model_options(provider)
+        model_options = settings_model_options(provider)
         valid_models = {value for _, value in model_options}
         model = self.settings.active_model if self.settings.active_model in valid_models else None
+        custom_value: Optional[str] = None
+        if model is None and self.settings.active_model:
+            # A saved catalogued id outside the listed (featured) models maps to
+            # the "Other…" entry backed by the custom input.
+            if CUSTOM_MODEL_SENTINEL in valid_models and get_ui_model(provider, self.settings.active_model) is not None:
+                model = CUSTOM_MODEL_SENTINEL
+                custom_value = self.settings.active_model
         if model is None:
             model = model_options[0][1] if model_options else UI_DEFAULT_MODEL
-        effort_options = {value for _, value in ui_thinking_effort_options(provider, model)}
+        # The sentinel itself has no spec: effort always comes from the real id.
+        effort_model = custom_value or model
+        effort_options = {value for _, value in ui_thinking_effort_options(provider, effort_model)}
         effort = (
             self.settings.active_thinking_effort if self.settings.active_thinking_effort in effort_options else None
         )
         if effort is None:
-            effort = default_ui_thinking_effort(provider, model)
+            effort = default_ui_thinking_effort(provider, effort_model)
         provider_select = self._settings_query_one("#provider_select", Select)
         model_select = self._settings_query_one("#model_select", Select)
         effort_select = self._settings_query_one("#thinking_effort_select", Select)
@@ -349,7 +406,12 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         provider_select.value = provider
         model_select.set_options(model_options)
         model_select.value = model
-        effort_select.set_options(ui_thinking_effort_options(provider, model))
+        try:
+            self._settings_query_one("#model_custom_input", Input).value = custom_value or ""
+        except NoMatches:
+            pass
+        self._sync_custom_model_input("model_select", "model_custom_input")
+        effort_select.set_options(ui_thinking_effort_options(provider, effort_model))
         if effort is not None:
             effort_select.value = effort
         theme_select = self._settings_query_one("#theme_select", Select)
@@ -451,9 +513,15 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         if inherited:
             try:
                 provider = str(self._settings_query_one("#provider_select", Select).value)
-                model = str(self._settings_query_one("#model_select", Select).value)
+                model_value = str(self._settings_query_one("#model_select", Select).value)
             except NoMatches:
                 return "", "info", False
+            if model_value == CUSTOM_MODEL_SENTINEL:
+                model = self._typed_custom_model(provider, "model_custom_input")
+                if model is None:
+                    return "", "info", False
+            else:
+                model = model_value
         else:
             provider = browser_provider
             try:
@@ -462,7 +530,12 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
                 return "", "info", False
             if model_value is Select.NULL:
                 return messages.BROWSER_MODEL_PROVIDER_NO_VISION.format(provider=provider), "error", True
-            model = str(model_value)
+            if model_value == CUSTOM_MODEL_SENTINEL:
+                model = self._typed_custom_model(provider, "am_custom_model_browser")
+                if model is None:
+                    return "", "info", False
+            else:
+                model = str(model_value)
 
         option = get_ui_model(provider, model)
         supports_vision = bool(option and option.supports_vision)
@@ -973,7 +1046,10 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         ``effort_value`` pre-select a model/effort (used while restoring saved
         settings). Otherwise the select's current model is kept when it is still valid
         for ``provider`` (so a restore is not clobbered), falling back to the
-        provider's first model."""
+        provider's first model. A catalogued model that is not among the listed
+        (featured) options maps to the "Other…" entry backed by the row's custom
+        input; on a non-gateway Browser row the stale model keeps its explicit
+        "(vision required)" option instead."""
         try:
             model_select = self._settings_query_one(f"#{model_id}", Select)
         except NoMatches:
@@ -982,12 +1058,32 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             current = model_select.value
             model_value = None if current is Select.NULL else str(current)
         browser_role = model_id == "am_model_browser"
-        model_options = ui_model_options(provider, vision_only=True) if browser_role else ui_model_options(provider)
-        valid_models = {value for _, value in model_options}
-        if browser_role and model_value and model_value not in valid_models:
+        model_options = settings_model_options(provider, vision_only=browser_role)
+        custom_input_id = self._custom_input_id(model_id)
+        custom_value: Optional[str] = None
+        option_values = {value for _, value in model_options}
+        if model_value and model_value not in option_values:
             stale_option = get_ui_model(provider, model_value)
             if stale_option is not None:
-                model_options.append((f"{stale_option.model_label} (vision required)", model_value))
+                if CUSTOM_MODEL_SENTINEL in option_values:
+                    # Gateway row: surface any catalogued-but-unlisted saved model
+                    # through "Other…" (non-featured ids, and on the Browser row
+                    # saved non-vision models).
+                    model_value = CUSTOM_MODEL_SENTINEL
+                    custom_value = stale_option.model
+                elif browser_role:
+                    # Non-gateway Browser row: keep the explicit stale option so a
+                    # saved non-vision model stays visible and selectable.
+                    model_options.append((f"{stale_option.model_label} (vision required)", stale_option.model))
+        if model_value == CUSTOM_MODEL_SENTINEL and custom_value is None:
+            # A cascade re-entered while "Other…" was already selected (e.g. the
+            # provider Changed posted during restore): keep what was typed.
+            try:
+                custom_input = self._settings_query_one(f"#{custom_input_id}", Input)
+            except NoMatches:
+                custom_input = None
+            if custom_input is not None:
+                custom_value = custom_input.value or None
         model_select.set_options(model_options)
         valid_models = {value for _, value in model_options}
         model = model_value if (model_value and model_value in valid_models) else None
@@ -995,7 +1091,19 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             model = model_options[0][1] if model_options else UI_DEFAULT_MODEL
         if model_options:
             model_select.value = model
-        self._set_effort_select_default(provider, model, effort_id, preferred=effort_value)
+        try:
+            custom_input = self._settings_query_one(f"#{custom_input_id}", Input)
+        except NoMatches:
+            custom_input = None
+        if custom_input is not None:
+            custom_input.value = custom_value or ""
+        # The sentinel itself has no spec; effort comes from the real id, and is
+        # left untouched when no valid id is typed yet (mid-typing text must not
+        # blank the effort select).
+        effort_model = custom_value or model
+        if effort_model != CUSTOM_MODEL_SENTINEL and resolve_custom_model(provider, effort_model) is not None:
+            self._set_effort_select_default(provider, effort_model, effort_id, preferred=effort_value)
+        self._sync_custom_model_input(model_id, custom_input_id)
 
     def _clear_model_effort_selects(self, model_id: str, effort_id: str) -> None:
         """Blank a per-agent row's model+effort selects (the role inherits)."""
@@ -1006,6 +1114,87 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
                 continue
             select.set_options([])
             select.value = Select.NULL
+        self._sync_custom_model_input(model_id, self._custom_input_id(model_id))
+
+    def _custom_input_id(self, model_select_id: str) -> str:
+        """Return the custom-model Input id paired with a model Select id."""
+        if model_select_id == "model_select":
+            return "model_custom_input"
+        return f"am_custom_model_{model_select_id.removeprefix('am_model_')}"
+
+    def _sync_custom_model_input(self, model_select_id: str, custom_input_id: str) -> None:
+        """Show the custom-model input iff its select holds the "Other…" sentinel.
+
+        A hidden input is cleared so it can never fake dirty state. Focus is a
+        user-action concern and is handled by the select-change handlers, not here.
+        """
+        try:
+            model_select = self._settings_query_one(f"#{model_select_id}", Select)
+            custom_input = self._settings_query_one(f"#{custom_input_id}", Input)
+        except NoMatches:
+            return
+        if str(model_select.value) == CUSTOM_MODEL_SENTINEL:
+            custom_input.display = True
+        else:
+            custom_input.display = False
+            custom_input.value = ""
+
+    def _typed_custom_model(self, provider: str, custom_input_id: str) -> Optional[str]:
+        """Resolve a custom input's current text to a catalogued model id."""
+        try:
+            custom_input = self._settings_query_one(f"#{custom_input_id}", Input)
+        except NoMatches:
+            return None
+        return resolve_custom_model(provider, custom_input.value)
+
+    def _custom_model_error(self, provider: str, model_select_id: str, custom_input_id: str) -> Optional[str]:
+        """Return a blocking status message for an invalid "Other…" entry, else None."""
+        try:
+            model_select = self._settings_query_one(f"#{model_select_id}", Select)
+            custom_input = self._settings_query_one(f"#{custom_input_id}", Input)
+        except NoMatches:
+            return None
+        if str(model_select.value) != CUSTOM_MODEL_SENTINEL:
+            return None
+        typed = custom_input.value.strip()
+        if not typed:
+            return messages.MODEL_CUSTOM_EMPTY
+        if resolve_custom_model(provider, typed) is None:
+            return messages.MODEL_CUSTOM_UNKNOWN.format(model=typed, provider=provider)
+        return None
+
+    def _sync_effort_for_model_value(
+        self,
+        provider: str,
+        value: str,
+        model_select_id: str,
+        effort_select_id: str,
+        *,
+        preferred: Optional[str] = None,
+    ) -> None:
+        """Apply an "Other…"-aware model selection to its effort select.
+
+        The sentinel has no model spec, so while it is selected the effort
+        select is only refreshed when the custom input already resolves to a
+        catalogued id; otherwise it is left untouched. The custom input is
+        focused only for genuine user selections, never while restoring.
+        """
+        custom_input_id = self._custom_input_id(model_select_id)
+        self._sync_custom_model_input(model_select_id, custom_input_id)
+        if value != CUSTOM_MODEL_SENTINEL:
+            self._set_effort_select_default(provider, value, effort_select_id, preferred=preferred)
+            return
+        screen = getattr(self, "_settings_screen", None)
+        initializing = bool(screen and getattr(screen, "_initializing", False))
+        if not initializing:
+            try:
+                custom_input = self._settings_query_one(f"#{custom_input_id}", Input)
+            except NoMatches:
+                return
+            self.call_after_refresh(custom_input.focus)
+        typed = self._typed_custom_model(provider, custom_input_id)
+        if typed is not None:
+            self._set_effort_select_default(provider, typed, effort_select_id, preferred=preferred)
 
     def _populate_lsp_controls(self) -> None:
         """Seed the LSP settings toggle from saved settings."""
@@ -1078,7 +1267,13 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
     def _settings_candidate_from_ui(self) -> tuple[CliSettings, Input, str, str, str]:
         """Collect the mounted form into a detached settings candidate."""
         provider = str(self._settings_query_one("#provider_select", Select).value)
-        model = str(self._settings_query_one("#model_select", Select).value)
+        model_value = str(self._settings_query_one("#model_select", Select).value)
+        if model_value == CUSTOM_MODEL_SENTINEL:
+            # Save is pre-validated in _save_settings_from_ui, so the typed id
+            # resolves to a catalogued model here; the sentinel never persists.
+            model = self._typed_custom_model(provider, "model_custom_input") or model_value
+        else:
+            model = model_value
         effort = str(self._settings_query_one("#thinking_effort_select", Select).value)
         valid_efforts = {value for _, value in ui_thinking_effort_options(provider, model)}
         if effort not in valid_efforts:
@@ -1117,6 +1312,27 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             self._update_browser_model_hint()
             self._set_settings_status(browser_message, "error")
             self._notify_user(browser_message, severity="error")
+            return
+        # "Other…" entries are UI-only: every typed id must resolve to a
+        # catalogued model before anything is written, so an unknown id can
+        # never produce a build-time "Configuration incomplete" lockout.
+        error = self._custom_model_error(
+            str(self._settings_query_one("#provider_select", Select).value), "model_select", "model_custom_input"
+        )
+        if error is None:
+            for _, role in agent_role_options():
+                try:
+                    row_provider = str(self._settings_query_one(f"#am_provider_{role}", Select).value)
+                except NoMatches:
+                    continue
+                if row_provider == INHERIT_SENTINEL:
+                    continue
+                error = self._custom_model_error(row_provider, f"am_model_{role}", f"am_custom_model_{role}")
+                if error is not None:
+                    break
+        if error is not None:
+            self._set_settings_status(error, "error")
+            self._notify_user(error, severity="error")
             return
         candidate, api_key_input, provider, _model, _effort = self._settings_candidate_from_ui()
 
@@ -1278,7 +1494,16 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             if provider == INHERIT_SENTINEL or model_select.value is Select.NULL:
                 self.settings.clear_agent_model(role)
                 continue
-            model = str(model_select.value)
+            model_value = str(model_select.value)
+            if model_value == CUSTOM_MODEL_SENTINEL:
+                # Save is pre-validated in _save_settings_from_ui; the defensive
+                # fallback clears the override rather than persisting the sentinel.
+                model = self._typed_custom_model(provider, f"am_custom_model_{role}")
+                if model is None:
+                    self.settings.clear_agent_model(role)
+                    continue
+            else:
+                model = model_value
             effort = "" if effort_select.value is Select.NULL else str(effort_select.value)
             valid_efforts = {value for _, value in ui_thinking_effort_options(provider, model)}
             if effort not in valid_efforts:

--- a/kolega_code/cli/tui/settings_screen.py
+++ b/kolega_code/cli/tui/settings_screen.py
@@ -30,7 +30,7 @@ from ..provider_registry import (
     ui_provider_options,
     ui_thinking_effort_options,
 )
-from . import settings_panel
+from . import custom_model, settings_panel
 
 if TYPE_CHECKING:
     from ..app import KolegaCodeApp
@@ -189,6 +189,9 @@ class SettingsScreen(ModalScreen[None]):
                     allow_blank=False,
                     value=UI_DEFAULT_MODEL,
                 )
+                custom_model_input = Input(id="model_custom_input", placeholder=custom_model.CUSTOM_MODEL_PLACEHOLDER)
+                custom_model_input.display = False
+                yield custom_model_input
                 yield Label("Thinking effort")
                 yield Select(
                     ui_thinking_effort_options(UI_DEFAULT_PROVIDER, UI_DEFAULT_MODEL),
@@ -259,6 +262,12 @@ class SettingsScreen(ModalScreen[None]):
                                 allow_blank=True,
                                 prompt="—",
                             )
+                        row_custom_model = Input(
+                            id=f"am_custom_model_{role_value}",
+                            placeholder=custom_model.CUSTOM_MODEL_PLACEHOLDER,
+                        )
+                        row_custom_model.display = False
+                        yield row_custom_model
                         with Horizontal(classes="agent-model-field"):
                             yield Label("Effort", classes="agent-model-field-label")
                             yield Select(

--- a/kolega_code/llm/specs/catalog/openrouter.py
+++ b/kolega_code/llm/specs/catalog/openrouter.py
@@ -4,7 +4,7 @@
 # Ranking: https://openrouter.ai/api/frontend/v1/rankings/models?view=week (snapshot 2026-07-31);
 #          catalog order is OpenRouter leaderboard rank, most-used first.
 #
-# 257 tool-capable models, 20 featured.
+# 258 tool-capable models, 20 featured.
 # Featured models are the ones every picker and the sub-agent model catalog
 # show; the rest stay selectable by id (--model, /model, settings.json).
 #
@@ -572,7 +572,7 @@ OPENROUTER_SPECS = {
     },
     ("openrouter", "qwen/qwen3.7-max"): {
         "context_length": 1000000,
-        "max_completion_tokens": 65536,
+        "max_completion_tokens": 131072,
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -586,7 +586,7 @@ OPENROUTER_SPECS = {
     },
     ("openrouter", "qwen/qwen3.7-plus"): {
         "context_length": 1000000,
-        "max_completion_tokens": 65536,
+        "max_completion_tokens": 131072,
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -2206,6 +2206,18 @@ OPENROUTER_SPECS = {
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
+    },
+    ("openrouter", "deepseek/deepseek-v4-flash-0731"): {
+        "context_length": 1048576,
+        "max_completion_tokens": 384000,
+        "default_temperature": 1.0,
+        "supports_vision": False,
+        "preferred_edit_protocol": "claude_code",
+        "thinking_effort": ThinkingEffortSpec(
+            options=("none", "low", "high", "max"),
+            default="high",
+            mode="openrouter_reasoning",
+        ),
     },
     ("openrouter", "google/gemini-2.5-pro-preview"): {
         "context_length": 1048576,

--- a/tests/cli/test_tui_custom_model.py
+++ b/tests/cli/test_tui_custom_model.py
@@ -1,0 +1,51 @@
+"""Settings "Other…" model picker affordance (TUI-only module)."""
+
+from kolega_code.cli.provider_registry import ui_model_options
+from kolega_code.cli.tui import custom_model
+from kolega_code.llm.specs import MODEL_SPECS, is_featured_model
+
+
+def test_gateway_picker_appends_other_last() -> None:
+    options = custom_model.settings_model_options("openrouter")
+
+    assert options[-1] == (custom_model.CUSTOM_MODEL_LABEL, custom_model.CUSTOM_MODEL_SENTINEL)
+    assert [model for _label, model in options[:-1]] == [model for _label, model in ui_model_options("openrouter")]
+
+
+def test_gateway_vision_only_picker_appends_other() -> None:
+    options = custom_model.settings_model_options("openrouter", vision_only=True)
+
+    assert options[-1] == (custom_model.CUSTOM_MODEL_LABEL, custom_model.CUSTOM_MODEL_SENTINEL)
+    assert [model for _label, model in options[:-1]] == [
+        model for _label, model in ui_model_options("openrouter", vision_only=True)
+    ]
+
+
+def test_non_gateway_pickers_are_unchanged() -> None:
+    for provider in ("anthropic", "moonshot", "deepseek"):
+        assert custom_model.settings_model_options(provider) == ui_model_options(provider)
+
+
+def test_sentinel_never_collides_with_a_catalogued_id() -> None:
+    catalogued = {model for provider, model in MODEL_SPECS}
+    assert custom_model.CUSTOM_MODEL_SENTINEL not in catalogued
+
+
+def test_resolve_custom_model_accepts_catalogued_ids() -> None:
+    featured = next(model for _label, model in ui_model_options("openrouter"))
+    non_featured = next(
+        model
+        for provider, model in MODEL_SPECS
+        if provider == "openrouter" and not is_featured_model("openrouter", model)
+    )
+
+    assert custom_model.resolve_custom_model("openrouter", featured) == featured
+    assert custom_model.resolve_custom_model("openrouter", non_featured) == non_featured
+    assert custom_model.resolve_custom_model("openrouter", f"  {non_featured}  ") == non_featured
+
+
+def test_resolve_custom_model_rejects_unknown_and_empty() -> None:
+    assert custom_model.resolve_custom_model("openrouter", "vendor/not-real") is None
+    assert custom_model.resolve_custom_model("openrouter", "  vendor/not-real  ") is None
+    assert custom_model.resolve_custom_model("openrouter", "") is None
+    assert custom_model.resolve_custom_model("openrouter", "   ") is None

--- a/tests/cli/test_tui_settings_screens.py
+++ b/tests/cli/test_tui_settings_screens.py
@@ -20,6 +20,7 @@ def _configured_app(
     provider: str = UI_DEFAULT_PROVIDER,
     model: str = UI_DEFAULT_MODEL,
     effort: str | None = None,
+    agent_models: dict | None = None,
 ):
     from kolega_code.cli.app import KolegaCodeApp
 
@@ -30,6 +31,8 @@ def _configured_app(
     settings_store = SettingsStore(state_dir)
     settings = CliSettings(active_provider=provider, active_model=model, active_thinking_effort=effort)
     settings.set_api_key(provider, "stored-key")
+    if agent_models:
+        settings.agent_models = agent_models
     settings_store.save(settings)
     config = build_agent_config(project, env={}, settings=settings, settings_store=settings_store)
     store = SessionStore(state_dir)
@@ -44,6 +47,30 @@ def _configured_app(
             session=session,
         ),
         settings_store,
+    )
+
+
+def _non_featured_openrouter_model() -> str:
+    """A catalogued OpenRouter id outside the featured picker set, with efforts."""
+    from kolega_code.llm.specs import MODEL_SPECS, is_featured_model, thinking_effort_options
+
+    return next(
+        model
+        for provider, model in MODEL_SPECS
+        if provider == "openrouter"
+        and not is_featured_model("openrouter", model)
+        and thinking_effort_options("openrouter", model)
+    )
+
+
+def _non_vision_openrouter_model() -> str:
+    """A catalogued OpenRouter id that cannot accept image input."""
+    from kolega_code.llm.specs import MODEL_SPECS, supports_vision
+
+    return next(
+        model
+        for provider, model in MODEL_SPECS
+        if provider == "openrouter" and not supports_vision("openrouter", model)
     )
 
 
@@ -143,6 +170,7 @@ async def test_settings_screen_retains_active_model_and_effort(
 
     async with app.run_test(size=(140, 40)) as pilot:
         app.action_open_settings()
+        await pilot.pause()
         screen = app.screen
         assert isinstance(screen, SettingsScreen)
         await _wait_for_select_values(
@@ -378,3 +406,386 @@ async def test_onboarding_actions_stay_on_screen_at_small_sizes(
             region = next_button.region
             assert region.height > 0, f"step {step}: Continue button not laid out"
             assert region.y + region.height <= 24, f"step {step}: Continue button clipped"
+
+
+# --- "Other…" custom model picker ----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_settings_other_model_restores_a_saved_non_featured_openrouter_model(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    """A saved catalogued-but-non-featured model opens as Other… + typed id."""
+    pytest.importorskip("textual")
+    from textual.widgets import Input, Select
+
+    from kolega_code.cli.tui.custom_model import CUSTOM_MODEL_SENTINEL
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+
+    custom_model_id = _non_featured_openrouter_model()
+    app, _ = _configured_app(tmp_path, monkeypatch, provider="openrouter", model=custom_model_id)
+
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.action_open_settings()
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+        await _wait_for_select_values(pilot, screen, {"model_select": CUSTOM_MODEL_SENTINEL})
+
+        custom_input = screen.query_one("#model_custom_input", Input)
+        assert custom_input.display is True
+        assert custom_input.value == custom_model_id
+        assert screen.dirty is False
+        # Effort options come from the typed id, never the sentinel.
+        from kolega_code.cli.provider_registry import ui_thinking_effort_options
+
+        effort = screen.query_one("#thinking_effort_select", Select)
+        valid_efforts = {value for _label, value in ui_thinking_effort_options("openrouter", custom_model_id)}
+        assert valid_efforts
+        assert str(effort.value) in valid_efforts
+
+
+@pytest.mark.asyncio
+async def test_settings_other_model_picks_and_applies_a_typed_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+    from textual.widgets import Input, Select
+
+    from kolega_code.cli.tui.custom_model import CUSTOM_MODEL_SENTINEL
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+
+    custom_model_id = _non_featured_openrouter_model()
+    app, settings_store = _configured_app(tmp_path, monkeypatch, provider="openrouter")
+
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.action_open_settings()
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+        model_select = screen.query_one("#model_select", Select)
+        model_select.value = CUSTOM_MODEL_SENTINEL
+        await _wait_for_select_values(pilot, screen, {"model_select": CUSTOM_MODEL_SENTINEL})
+
+        custom_input = screen.query_one("#model_custom_input", Input)
+        assert custom_input.display is True
+        await pilot.pause()
+        assert app.focused is custom_input
+
+        custom_input.value = custom_model_id
+        await pilot.pause()
+        await app._save_settings_from_ui()
+
+        assert settings_store.load().active_model == custom_model_id
+        # The picker keeps showing Other… with the typed id.
+        assert screen.query_one("#model_select", Select).value == CUSTOM_MODEL_SENTINEL
+        assert screen.query_one("#model_custom_input", Input).value == custom_model_id
+
+
+@pytest.mark.asyncio
+async def test_settings_other_model_rejects_an_unknown_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+    from textual.widgets import Input, Select, Static
+
+    from kolega_code.cli.tui.custom_model import CUSTOM_MODEL_SENTINEL
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+
+    app, settings_store = _configured_app(tmp_path, monkeypatch, provider="openrouter")
+
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.action_open_settings()
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+        screen.query_one("#model_select", Select).value = CUSTOM_MODEL_SENTINEL
+        await _wait_for_select_values(pilot, screen, {"model_select": CUSTOM_MODEL_SENTINEL})
+        screen.query_one("#model_custom_input", Input).value = "vendor/not-real"
+        await pilot.pause()
+        await app._save_settings_from_ui()
+
+        assert settings_store.load().active_model != "vendor/not-real"
+        status = str(screen.query_one("#settings_status", Static).render())
+        assert "vendor/not-real" in status
+
+
+@pytest.mark.asyncio
+async def test_settings_other_model_requires_a_typed_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+    from textual.widgets import Select, Static
+
+    from kolega_code.cli.tui.custom_model import CUSTOM_MODEL_SENTINEL
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+
+    app, settings_store = _configured_app(tmp_path, monkeypatch, provider="openrouter")
+    original_model = settings_store.load().active_model
+
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.action_open_settings()
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+        screen.query_one("#model_select", Select).value = CUSTOM_MODEL_SENTINEL
+        await _wait_for_select_values(pilot, screen, {"model_select": CUSTOM_MODEL_SENTINEL})
+        await app._save_settings_from_ui()
+
+        assert settings_store.load().active_model == original_model
+        status = str(screen.query_one("#settings_status", Static).render())
+        assert "Type a model id" in status
+
+
+@pytest.mark.asyncio
+async def test_settings_other_model_is_cleared_by_a_provider_switch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+    from textual.widgets import Input, Select
+
+    from kolega_code.cli.tui.custom_model import CUSTOM_MODEL_SENTINEL
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+
+    custom_model_id = _non_featured_openrouter_model()
+    app, _ = _configured_app(tmp_path, monkeypatch, provider="openrouter")
+
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.action_open_settings()
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+        screen.query_one("#model_select", Select).value = CUSTOM_MODEL_SENTINEL
+        await _wait_for_select_values(pilot, screen, {"model_select": CUSTOM_MODEL_SENTINEL})
+        custom_input = screen.query_one("#model_custom_input", Input)
+        custom_input.value = custom_model_id
+        await pilot.pause()
+
+        screen.query_one("#provider_select", Select).value = "anthropic"
+        await _wait_for_select_values(pilot, screen, {"model_select": "claude-fable-5"})
+        assert custom_input.display is False
+        assert custom_input.value == ""
+
+
+@pytest.mark.asyncio
+async def test_agent_row_other_model_restores_a_saved_non_featured_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+    from textual.widgets import Input
+
+    from kolega_code.cli.tui.custom_model import CUSTOM_MODEL_SENTINEL
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+
+    custom_model_id = _non_featured_openrouter_model()
+    agent_models = {"planning": {"provider": "openrouter", "model": custom_model_id}}
+    app, _ = _configured_app(tmp_path, monkeypatch, provider="openrouter", agent_models=agent_models)
+
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.action_open_settings("agents")
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+        await _wait_for_select_values(
+            pilot,
+            screen,
+            {"am_provider_planning": "openrouter", "am_model_planning": CUSTOM_MODEL_SENTINEL},
+        )
+
+        row_input = screen.query_one("#am_custom_model_planning", Input)
+        assert row_input.display is True
+        assert row_input.value == custom_model_id
+        assert screen.dirty is False
+
+
+@pytest.mark.asyncio
+async def test_agent_row_other_model_picks_and_applies_a_typed_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+    from textual.widgets import Input, Select
+
+    from kolega_code.cli.tui.custom_model import CUSTOM_MODEL_SENTINEL
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+
+    custom_model_id = _non_featured_openrouter_model()
+    app, settings_store = _configured_app(tmp_path, monkeypatch, provider="openrouter")
+
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.action_open_settings("agents")
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+        screen.query_one("#am_provider_planning", Select).value = "openrouter"
+        await _wait_for_select_values(pilot, screen, {"am_provider_planning": "openrouter"})
+        screen.query_one("#am_model_planning", Select).value = CUSTOM_MODEL_SENTINEL
+        await _wait_for_select_values(pilot, screen, {"am_model_planning": CUSTOM_MODEL_SENTINEL})
+
+        row_input = screen.query_one("#am_custom_model_planning", Input)
+        assert row_input.display is True
+        row_input.value = custom_model_id
+        await pilot.pause()
+        await app._save_settings_from_ui()
+
+        saved = settings_store.load().get_agent_model("planning")
+        assert saved is not None
+        assert saved["provider"] == "openrouter"
+        assert saved["model"] == custom_model_id
+
+
+@pytest.mark.asyncio
+async def test_agent_row_other_model_rejects_an_unknown_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+    from textual.widgets import Input, Select, Static
+
+    from kolega_code.cli.tui.custom_model import CUSTOM_MODEL_SENTINEL
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+
+    app, settings_store = _configured_app(tmp_path, monkeypatch, provider="openrouter")
+
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.action_open_settings("agents")
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+        screen.query_one("#am_provider_planning", Select).value = "openrouter"
+        await _wait_for_select_values(pilot, screen, {"am_provider_planning": "openrouter"})
+        screen.query_one("#am_model_planning", Select).value = CUSTOM_MODEL_SENTINEL
+        await _wait_for_select_values(pilot, screen, {"am_model_planning": CUSTOM_MODEL_SENTINEL})
+        screen.query_one("#am_custom_model_planning", Input).value = "vendor/not-real"
+        await pilot.pause()
+        await app._save_settings_from_ui()
+
+        assert settings_store.load().get_agent_model("planning") is None
+        status = str(screen.query_one("#settings_status", Static).render())
+        assert "vendor/not-real" in status
+
+
+@pytest.mark.asyncio
+async def test_agent_row_other_model_requires_a_typed_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+    from textual.widgets import Select, Static
+
+    from kolega_code.cli.tui.custom_model import CUSTOM_MODEL_SENTINEL
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+
+    app, settings_store = _configured_app(tmp_path, monkeypatch, provider="openrouter")
+
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.action_open_settings("agents")
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+        screen.query_one("#am_provider_planning", Select).value = "openrouter"
+        await _wait_for_select_values(pilot, screen, {"am_provider_planning": "openrouter"})
+        screen.query_one("#am_model_planning", Select).value = CUSTOM_MODEL_SENTINEL
+        await _wait_for_select_values(pilot, screen, {"am_model_planning": CUSTOM_MODEL_SENTINEL})
+        await app._save_settings_from_ui()
+
+        assert settings_store.load().get_agent_model("planning") is None
+        status = str(screen.query_one("#settings_status", Static).render())
+        assert "Type a model id" in status
+
+
+@pytest.mark.asyncio
+async def test_agent_row_other_model_is_cleared_when_row_returns_to_inherit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+    from textual.widgets import Input, Select
+
+    from kolega_code.cli.provider_registry import INHERIT_SENTINEL
+    from kolega_code.cli.tui.custom_model import CUSTOM_MODEL_SENTINEL
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+
+    custom_model_id = _non_featured_openrouter_model()
+    agent_models = {"planning": {"provider": "openrouter", "model": custom_model_id}}
+    app, settings_store = _configured_app(tmp_path, monkeypatch, provider="openrouter", agent_models=agent_models)
+
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.action_open_settings("agents")
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+        await _wait_for_select_values(pilot, screen, {"am_model_planning": CUSTOM_MODEL_SENTINEL})
+        assert screen.query_one("#am_custom_model_planning", Input).display is True
+
+        screen.query_one("#am_provider_planning", Select).value = INHERIT_SENTINEL
+        await pilot.pause()
+        await app._save_settings_from_ui()
+
+        assert settings_store.load().get_agent_model("planning") is None
+        assert screen.query_one("#am_custom_model_planning", Input).display is False
+        assert screen.query_one("#am_custom_model_planning", Input).value == ""
+
+
+@pytest.mark.asyncio
+async def test_agent_row_other_model_keeps_the_browser_vision_gate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    """A typed non-vision id in the Browser row blocks save, like the listed path."""
+    pytest.importorskip("textual")
+    from textual.widgets import Input, Select, Static
+
+    from kolega_code.cli.tui.custom_model import CUSTOM_MODEL_SENTINEL
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+
+    non_vision = _non_vision_openrouter_model()
+    app, settings_store = _configured_app(tmp_path, monkeypatch, provider="openrouter")
+
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.action_open_settings("agents")
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+        screen.query_one("#am_provider_browser", Select).value = "openrouter"
+        await _wait_for_select_values(pilot, screen, {"am_provider_browser": "openrouter"})
+        screen.query_one("#am_model_browser", Select).value = CUSTOM_MODEL_SENTINEL
+        await _wait_for_select_values(pilot, screen, {"am_model_browser": CUSTOM_MODEL_SENTINEL})
+        screen.query_one("#am_custom_model_browser", Input).value = non_vision
+        await pilot.pause()
+        await app._save_settings_from_ui()
+
+        assert settings_store.load().get_agent_model("browser") is None
+        status = str(screen.query_one("#settings_status", Static).render())
+        assert "does not support vision" in status
+
+
+@pytest.mark.asyncio
+async def test_agent_row_other_model_accepts_a_vision_capable_browser_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+    from textual.widgets import Input, Select
+
+    from kolega_code.llm.specs import MODEL_SPECS, supports_vision
+
+    from kolega_code.cli.tui.custom_model import CUSTOM_MODEL_SENTINEL
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+
+    vision_id = next(
+        model for provider, model in MODEL_SPECS if provider == "openrouter" and supports_vision("openrouter", model)
+    )
+    app, settings_store = _configured_app(tmp_path, monkeypatch, provider="openrouter")
+
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.action_open_settings("agents")
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+        screen.query_one("#am_provider_browser", Select).value = "openrouter"
+        await _wait_for_select_values(pilot, screen, {"am_provider_browser": "openrouter"})
+        screen.query_one("#am_model_browser", Select).value = CUSTOM_MODEL_SENTINEL
+        await _wait_for_select_values(pilot, screen, {"am_model_browser": CUSTOM_MODEL_SENTINEL})
+        screen.query_one("#am_custom_model_browser", Input).value = vision_id
+        await pilot.pause()
+        await app._save_settings_from_ui()
+
+        saved = settings_store.load().get_agent_model("browser")
+        assert saved is not None
+        assert saved["provider"] == "openrouter"
+        assert saved["model"] == vision_id


### PR DESCRIPTION
## Summary

The Settings screen (main Model dropdown and every **Agent Models** role row) leads with a gateway provider's curated most-used models and now also offers an **"Other…"** entry backed by a free-text field. Any catalogued OpenRouter model id — bundled with the release or added by `kolega-code models refresh` — can be selected from Settings instead of only by exact id on the command line.

## Design

- The "Other…" affordance is a **UI-only concern**: the sentinel option, the picker-list wrapper (`settings_model_options`), and the typed-id resolver (`resolve_custom_model`) live in the new `kolega_code/cli/tui/custom_model.py`. `provider_registry.py` and `ui_model_options()` are untouched, and the sentinel is never persisted — `settings.json` always stores the real model id.
- Typed ids are validated against the merged catalog before Apply: empty → "Type a model id…", unknown → "not a known {provider} model…" with pointers to `kolega-code models list` / `models refresh`. No build-time "Configuration incomplete" lockout.
- Restores re-open a saved non-featured id in the "Other…" field; typing refreshes the Thinking effort dropdown live; switching provider discards the draft; the Browser row keeps its vision-capability gate for typed ids (existing "(vision required)" stale-option path preserved for non-gateway providers).

## Tests

- New `tests/cli/test_tui_custom_model.py`: sentinel appending (gateway vs non-gateway, plain and `vision_only`), no sentinel collisions with real ids, resolver cases.
- New TUI tests in `tests/cli/test_tui_settings_screens.py`: restore/pick/apply/unknown/empty/provider-switch for the main dropdown and per-agent rows, plus the Browser vision gate.
- Full fast suite: 3791 passed, 1 skipped, 0 failures. ruff, ruff format, and pyright clean.
