### PR TITLE
fix(tui): hide system reminders from restored transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,9 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ### Fixed
 
+- Standalone generated `<system-reminder>` context no longer appears in the TUI
+  transcript after resuming a session or rebuilding the agent for model and
+  settings changes; the context remains unchanged in model and session history.
 - Continuing after cancelling an in-flight tool call no longer duplicates the
   next prompt or makes Anthropic reject the request for exceeding its maximum
   of four `cache_control` blocks.

--- a/kolega_code/cli/tui/transcript.py
+++ b/kolega_code/cli/tui/transcript.py
@@ -38,6 +38,22 @@ from .sub_agent_screen import SubAgentEntryWidget
 from .widgets import ConversationEntryWidget, JumpToBottomBar, ToolEntryWidget
 
 
+def _is_standalone_system_reminder_history_item(item: dict) -> bool:
+    """Whether a raw history item is a generated volatile-context message."""
+    if item.get("role") != "user":
+        return False
+    content = item.get("content")
+    if not isinstance(content, list) or len(content) != 1:
+        return False
+    block = content[0]
+    if not isinstance(block, dict) or block.get("type") != "text":
+        return False
+    text = block.get("text")
+    return (
+        isinstance(text, str) and text.startswith('<system-reminder source="') and text.endswith("</system-reminder>")
+    )
+
+
 class _IndentedRenderState:
     """Incremental render cache for an indented streaming body (assistant/thinking).
 
@@ -135,6 +151,8 @@ class TranscriptRenderingMixin(tui_app_base.KolegaAppBase):
                     pending_tool_entries.pop(key, None)
 
         for item in history:
+            if _is_standalone_system_reminder_history_item(item):
+                continue
             try:
                 message = Message.from_dict(item)
             except Exception:

--- a/tests/cli/test_app_persistence_history.py
+++ b/tests/cli/test_app_persistence_history.py
@@ -28,6 +28,7 @@ from kolega_code.cli.provider_registry import (
 )
 from kolega_code.cli.session_store import SessionStore
 from kolega_code.cli.settings import CliSettings, SettingsStore
+from kolega_code.cli.tui.transcript import _is_standalone_system_reminder_history_item
 
 from ._app_test_utils import (
     FakeCoderAgent,
@@ -76,6 +77,35 @@ def _persist_history(
     loaded = store.load(session.session_id)
     session.history = loaded.history
     session.compaction = loaded.compaction
+
+
+def test_standalone_system_reminder_history_item_fast_path() -> None:
+    reminder = (
+        '<system-reminder source="memory">\nMemory context\n</system-reminder>\n'
+        '<system-reminder source="guidance" path="AGENTS.md">\nGuidance\n</system-reminder>\n'
+        '<system-reminder source="date">\nToday\n</system-reminder>'
+    )
+    assert _is_standalone_system_reminder_history_item(Message(role="user", content=[TextBlock(reminder)]).to_dict())
+
+    large_ordinary_text = "x" * 1_000_000 + reminder
+    large_tool_result = Message(
+        role="user",
+        content=[
+            ToolResult(
+                tool_use_id="large-tool",
+                content=reminder + ("y" * 1_000_000),
+                name="read_file",
+                is_error=False,
+            )
+        ],
+    ).to_dict()
+    ordinary_items = [
+        Message(role="assistant", content=[TextBlock(reminder)]).to_dict(),
+        Message(role="user", content=[TextBlock(large_ordinary_text)]).to_dict(),
+        large_tool_result,
+    ]
+
+    assert not any(_is_standalone_system_reminder_history_item(item) for item in ordinary_items)
 
 
 @pytest.mark.asyncio
@@ -474,8 +504,24 @@ async def test_textual_app_renders_resumed_history_in_chat(tmp_path: Path, monke
     config = build_test_config(project)
     store = SessionStore(tmp_path / "state")
     session = store.create(project, "code", config_summary(config))
+    reminder = (
+        '<system-reminder source="memory">\nMemory context\n</system-reminder>\n'
+        '<system-reminder source="guidance" path="AGENTS.md">\nGuidance\n</system-reminder>\n'
+        '<system-reminder source="date">\nToday\n</system-reminder>'
+    )
+    prose = "Please explain <system-reminder> tags in prose."
+    code_fence = f"```\n{reminder}\n```"
+    leading_text = f"Quoted reminder:\n{reminder}"
+    trailing_text = f"{reminder}\nAdditional notes."
+    tool_reminder = '<system-reminder source="tool">Tool output</system-reminder>'
     history = [
         Message(role="user", content=[TextBlock("Please read the README")]).to_dict(),
+        Message(role="user", content=[TextBlock(reminder)]).to_dict(),
+        Message(role="user", content=[TextBlock(prose)]).to_dict(),
+        Message(role="user", content=[TextBlock(code_fence)]).to_dict(),
+        Message(role="user", content=[TextBlock(leading_text)]).to_dict(),
+        Message(role="user", content=[TextBlock(trailing_text)]).to_dict(),
+        Message(role="assistant", content=[TextBlock(reminder)]).to_dict(),
         Message(
             role="assistant",
             content=[
@@ -485,7 +531,7 @@ async def test_textual_app_renders_resumed_history_in_chat(tmp_path: Path, monke
         ).to_dict(),
         Message(
             role="user",
-            content=[ToolResult(tool_use_id="tool-1", content="README contents", name="read_file", is_error=False)],
+            content=[ToolResult(tool_use_id="tool-1", content=tool_reminder, name="read_file", is_error=False)],
         ).to_dict(),
         Message(
             role="user",
@@ -507,8 +553,13 @@ async def test_textual_app_renders_resumed_history_in_chat(tmp_path: Path, monke
         assert f"Model: {expected_model}" in startup
         assert [(entry.kind, entry.content, entry.tool_name) for entry in app.conversation_entries[1:]] == [
             ("user", "Please read the README", None),
+            ("user", prose, None),
+            ("user", code_fence, None),
+            ("user", leading_text, None),
+            ("user", trailing_text, None),
+            ("assistant", reminder, None),
             ("assistant", "I'll inspect it.", None),
-            ("tool_result", "README contents", "read_file"),
+            ("tool_result", tool_reminder, "read_file"),
             ("tool_error", "Permission denied", "write_file"),
             ("assistant", "Done.", None),
         ]
@@ -647,6 +698,11 @@ async def test_textual_app_model_rebuild_rerenders_completed_tool_once(
     session = store.create(project, "code", config_summary(config))
     app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
     history = [
+        Message(role="user", content=[TextBlock("List the files")]).to_dict(),
+        Message(
+            role="user",
+            content=[TextBlock('<system-reminder source="memory">\nMemory context\n</system-reminder>')],
+        ).to_dict(),
         Message(
             role="assistant",
             content=[ToolCall(id="provider-1", name="list_directory", input={"path": "."})],
@@ -663,5 +719,9 @@ async def test_textual_app_model_rebuild_rerenders_completed_tool_once(
         app.agent.history = history
         await app._build_agent(config, rebuild=True)
 
+        assert app.agent.dump_message_history() == history
+        assert [(entry.kind, entry.content) for entry in app.conversation_entries if entry.kind == "user"] == [
+            ("user", "List the files")
+        ]
         tool_entries = [entry for entry in app.conversation_entries if entry.tool_name == "list_directory"]
         assert [(entry.kind, entry.content) for entry in tool_entries] == [("tool_result", "files")]


### PR DESCRIPTION
## Summary

- suppress standalone generated `<system-reminder>` messages only when projecting model history into the restored TUI transcript
- preserve the complete reminder-bearing session and model history unchanged
- cover resume, model rebuild, false-positive, assistant/tool payload, and large-payload paths

## Tests

- `PYTHONDONTWRITEBYTECODE=1 uv run pytest -q tests/cli/test_app_persistence_history.py` (14 passed)
- `uv run ruff check kolega_code/cli/tui/transcript.py tests/cli/test_app_persistence_history.py`
- `PYTHONDONTWRITEBYTECODE=1 ./run_tests.sh` (3776 passed, 1 skipped, 108 deselected)