### PR TITLE
perf(tests): run pytest suite in parallel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
           PY
 
       - name: Run tests
-        run: uv run pytest -ra --durations=50 --import-mode=importlib -m "not slow"
+        run: ./run_tests.sh
 
       - name: Build distributions
         run: uv build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,15 @@ Run the fast test suite before opening a pull request:
 ./run_tests.sh
 ```
 
+The wrapper runs tests in parallel using the available CPU cores. Set
+`PYTEST_WORKERS` to cap concurrency, or set it to `0` for a serial debugging
+run:
+
+```bash
+PYTEST_WORKERS=4 ./run_tests.sh
+PYTEST_WORKERS=0 ./run_tests.sh tests/test_git_env.py
+```
+
 Run slow and integration tests only when you have the required credentials:
 
 ```bash
@@ -108,7 +117,7 @@ Run slow and integration tests only when you have the required credentials:
 You can pass additional pytest arguments through the wrapper:
 
 ```bash
-./run_tests.sh tests/agent/llm/test_client.py -ra
+./run_tests.sh tests/test_git_env.py -ra
 ```
 
 ## Updating bundled skills

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ dev = [
     "pytest==9.0.3",
     "pytest-asyncio==1.3.0",
     "pytest-cov==7.0.0",
+    "pytest-xdist==3.8.0",
     "pyright==1.1.411",
     "ruff==0.15.12",
     "twine==6.2.0",

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -30,7 +30,19 @@ for arg in "$@"; do
   esac
 done
 
-PYTEST_BASE_ARGS=(-ra --durations=50 --import-mode=importlib)
+if [ -n "${PYTEST_WORKERS:-}" ]; then
+  NUM_CPUS="$PYTEST_WORKERS"
+elif command -v nproc &> /dev/null; then
+  NUM_CPUS=$(nproc)
+elif command -v sysctl &> /dev/null; then
+  NUM_CPUS=$(sysctl -n hw.ncpu 2>/dev/null || echo auto)
+else
+  NUM_CPUS=auto
+fi
+
+echo "Running tests with ${NUM_CPUS} parallel workers"
+
+PYTEST_BASE_ARGS=(-ra --durations=50 --import-mode=importlib -n "$NUM_CPUS")
 
 if [ "$RUN_COVERAGE" = true ]; then
   PYTEST_BASE_ARGS+=(--cov=kolega_code --cov-report=term-missing --cov-report=xml --cov-fail-under="$COVERAGE_FAIL_UNDER")

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-22T09:56:40.449154Z"
+exclude-newer = "2026-07-24T09:49:44.723497Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -856,6 +856,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fake-useragent"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1570,6 +1579,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "twine" },
 ]
@@ -1612,6 +1622,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.3.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.0.0" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = "==3.8.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "readability-lxml", specifier = "==0.8.4.1" },
@@ -3241,6 +3252,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add pinned `pytest-xdist` support and lock its `execnet` dependency
- run the pytest wrapper with all detected logical CPUs by default, with `PYTEST_WORKERS` available to cap workers or select serial execution with `0`
- route release validation through `run_tests.sh` and document parallel, serial, and focused test usage

## Validation
- `PYTEST_WORKERS=2 ./run_tests.sh --coverage` — 3793 passed, 1 skipped; 82.73% coverage; one `coverage.xml` generated
- serial worker override focused run — 4 passed
- `uv run pre-commit run --all-files --show-diff-on-failure`
- `uv lock --check`
- `bash -n run_tests.sh`
- `git diff --check`

`./run_tests.sh --all` was not run because it may require credentialed integration services.