### PR TITLE
chore(skills): sync bundled skills v0.3.0

### DIFF
--- a/kolega_code/_bundled_skills/manifest.json
+++ b/kolega_code/_bundled_skills/manifest.json
@@ -5,6 +5,26 @@
       "sha256": "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4"
     },
     {
+      "path": "skills/deep-research/SKILL.md",
+      "sha256": "1fbbef0e49a27ff23917a28c8c4baf7aa9005458ce10e55f895f2649103f12af"
+    },
+    {
+      "path": "skills/deep-research/references/evidence-and-reporting.md",
+      "sha256": "933965dde6b5f95c00d68185251469553fde727779d2bb4113e7749527955418"
+    },
+    {
+      "path": "skills/deep-research/references/gigacode-workflow.md",
+      "sha256": "097807156d55a29d12b16a3a5d496a41fb07f152476e95e390699dec1842bc6a"
+    },
+    {
+      "path": "skills/deep-research/scripts/deep-research.workflow",
+      "sha256": "5207a175f1f1b4144d1c1e53c66e351c20006444e9d31abc7ce3f9be9204df3c"
+    },
+    {
+      "path": "skills/deep-research/scripts/materialize_report.py",
+      "sha256": "2e9d652b05b62c9f08ebbbf47b72b0156e1cf8bd39ddf33ee1416315932c600f"
+    },
+    {
       "path": "skills/docx/LICENSE",
       "sha256": "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4"
     },
@@ -39,6 +59,14 @@
     {
       "path": "skills/docx/scripts/smoke_test.py",
       "sha256": "1cb265f9b129032a09586132a4bfb4924bbd0aefa6dfa6c641576e1e159b3ece"
+    },
+    {
+      "path": "skills/humanizer/LICENSE",
+      "sha256": "4ac4810254ab36d45419141aeb8e69bf50652cfafe5b2dab947d06d44e5cbf96"
+    },
+    {
+      "path": "skills/humanizer/SKILL.md",
+      "sha256": "2fc8fa3cefe67013f2fecfa9ec63564a4a821ddcc03da483d7b1ade00762ca3c"
     },
     {
       "path": "skills/pdf/LICENSE",
@@ -179,7 +207,9 @@
   ],
   "schema_version": 1,
   "skills": [
+    "deep-research",
     "docx",
+    "humanizer",
     "pdf",
     "pptx",
     "review",
@@ -187,8 +217,8 @@
     "xlsx"
   ],
   "source": {
-    "commit": "22eeee98363a92c199d234a10a798cbdaf3998e2",
+    "commit": "c0ba68e7aee0994318913aa9fcaad4f57cbc11d7",
     "repository": "https://github.com/kolega-ai/kolega-skills",
-    "tag": "v0.2.1"
+    "tag": "v0.3.0"
   }
 }

--- a/kolega_code/_bundled_skills/skills/deep-research/SKILL.md
+++ b/kolega_code/_bundled_skills/skills/deep-research/SKILL.md
@@ -1,0 +1,403 @@
+---
+name: deep-research
+description: >
+  Conduct rigorous multi-source investigation and create citation-backed Markdown
+  reports with reader-appropriate structure and voice. Use for explicit deep-research
+  requests, historical or cultural reports, decision comparisons, disputed claims,
+  literature landscapes, and questions requiring source discovery, selective
+  verification, synthesis, and uncertainty analysis. Do not use for a single-fact
+  lookup, a one-URL summary, routine coding research, or a simple search-result list.
+license: Apache-2.0
+compatibility: >
+  Requires web search and page-reading tools for live research. Best with Kolega
+  Code Gigacode workflows and runtime model discovery; prompts to enable Gigacode
+  before offering a bounded sequential fallback when orchestration is unavailable.
+  Uses a session scratchpad directory for evidence dossiers when one is available,
+  and falls back to compact in-result records when it is not.
+metadata:
+  owner: Kolega
+  version: "3.0"
+---
+
+# Deep Research
+
+Produce a useful report, not a transcript of research operations. Research only as
+widely as the question, stakes, and remaining uncertainty require. Preserve source
+quality and uncertainty while adapting the report's shape and voice to its readers.
+
+## Activation examples
+
+Use this skill for requests such as:
+
+- "Run deep research and create a report on Saturnian magic throughout history."
+- "Compare these three observability platforms and recommend one for a small
+  regulated team."
+- "Investigate the disputed claim that this policy reduced housing costs, and show
+  what the best evidence supports."
+
+Do not activate it for near misses such as:
+
+- "What year did the policy take effect?" — answer the fact directly.
+- "Summarize this one article." — read and summarize that source without a research
+  workflow.
+
+## Brief the report with the user
+
+Before checking Gigacode availability or acquiring sources, ask one compact batch
+covering all unresolved core fields and 1–3 genuinely topic-specific questions. A
+silent capability check may occur at any time, but do not offer the Gigacode
+enablement choice until the brief is confirmed.
+
+### Core fields
+
+Extract everything the initial request already answers and carry those values into
+the confirmation summary. Ask only what remains unresolved:
+
+- **Length** — offer exactly these presets:
+  - `concise` — about 1,500 words;
+  - `standard` — about 3,000 words;
+  - `detailed` — about 6,000 words;
+  - `long` — 10,000 words or more;
+  - or a custom word target.
+
+  Map `long` to a 10,000-word minimum. If the user wants materially more than
+  10,000 words, obtain a concrete custom target before confirmation. Never infer
+  length from tier when the user has not supplied it.
+
+- **Audience and use** — who will read the report and what decision,
+  understanding, or action it should support.
+
+- **Scope** — relevant timeframe, geography, comparison set, definitions,
+  inclusions, and exclusions. Ask only the applicable dimensions.
+
+- **Delivery** — Markdown artifact and path versus conversation-only; preserve
+  the collision-safe default when the user accepts it.
+
+### Topic-specific questions
+
+In the same batch, ask 1–3 concise questions whose answers will shape lanes,
+evidence standards, or synthesis. Choose questions specific to this topic, for
+example:
+
+- **Historical/cultural:** endpoint, tradition or interpretive lens, primary
+  practice versus later reception.
+- **Product/market:** options, operating constraints, decision criteria, current
+  environment.
+- **Disputed/high-stakes:** jurisdiction, decision at stake, acceptable evidence
+  threshold.
+- **Experiential/community:** communities or platforms, period, whose experiences
+  matter, desired treatment of representativeness.
+
+Do not ask generic questions that merely restate the title, expose workflow
+mechanics, or ask the user to choose tier, lanes, models, verification, audit, or
+drafting mode.
+
+### Proposed research brief
+
+After the user answers, return a compact **Proposed research brief** containing
+the research question, audience and use, scope, selected length preset and numeric
+target, report style and structure requirements, delivery path or mode, and the
+settled topic-specific decisions. Explicitly ask the user to confirm or correct
+the brief, and wait. Begin Gigacode enablement, routing, and research only after
+confirmation.
+
+### Narrow exceptions
+
+- **Already-answered field:** skip that question; show the extracted value in the
+  confirmation summary.
+- **User-directed no-questions:** if the user explicitly asks not to be asked
+  follow-ups or to start immediately, state the proposed defaults—including a
+  concrete word target—and proceed without the second confirmation turn. Record
+  this as a user-directed exception.
+- **Correction:** reopens only the affected part of the brief; do not repeat the
+  complete questionnaire.
+
+### Examples
+
+**Underspecified request — "Research the history of Saturnian magic."**
+
+No core fields are supplied. Ask all four plus a topic question in one batch:
+
+> To research this well I need a few details.
+>
+> **Length:** concise (~1,500 words), standard (~3,000), detailed (~6,000), long
+> (10,000+), or a custom target?
+> **Audience and use:** who will read this and what should it help them understand
+> or decide?
+> **Scope:** any particular traditions, periods, or geographies to focus on or
+> exclude?
+> **Delivery:** Markdown file (I will propose a collision-safe path) or
+> in-conversation?
+> **Topic question:** Are you more interested in the ancient and Renaissance
+> textual tradition, the later occult revival, or both?
+
+After the user answers, summarize the **Proposed research brief** and wait for
+confirmation before proceeding.
+
+**Detailed initial request — "Write a detailed 6,000-word report on Saturnian magic
+in Renaissance Europe for a general educated audience, focusing on Ficino and
+Agrippa, as a Markdown file."**
+
+Length (`detailed` / 6,000 words), audience, scope, and delivery are all resolved.
+Skip those questions and ask only what remains:
+
+> You have given me most of what I need. One question before I start:
+>
+> Should the report emphasize the philosophical underpinnings of Saturn's role, the
+> practical magical techniques described, or both in roughly equal measure?
+
+After the user answers, return the **Proposed research brief** and wait for
+confirmation.
+
+## Check Gigacode before research
+
+After the brief is confirmed, check whether `run_workflow` is available before
+acquiring sources. If it is unavailable and the user has not
+already requested sequential execution or told you to continue without Gigacode,
+pause and offer this choice:
+
+> Gigacode is off. Parallel research is faster and keeps the bounded research lanes
+> isolated. Run `/gigacode on` and then resend this research request, or tell me to
+> continue without Gigacode.
+
+Do not claim that the skill can execute a TUI slash command itself. Do not start the
+sequential fallback until the user chooses it. If the user continues without
+Gigacode, do not ask again during that research request. If `run_workflow` is
+available, proceed without this prompt; absence of `list_subagent_models` alone does
+not mean Gigacode is off.
+
+After this preflight, read
+[Evidence and reporting](references/evidence-and-reporting.md) before research.
+When Gigacode is available, also read the concise
+[Gigacode workflow guide](references/gigacode-workflow.md) and invoke the bundled
+[`scripts/deep-research.workflow`](scripts/deep-research.workflow) instead of
+generating a new orchestration script.
+
+## 1. Apply the confirmed brief and settle delivery
+
+Use the question, audience, scope, length target, and delivery mode confirmed during
+intake. Do not re-ask resolved fields. If a detail needed for the artifact path or
+report profile was not covered during intake, resolve it now before announcing the
+output path.
+
+### Artifact-first delivery
+
+In an edit-enabled session, an explicit report request produces a Markdown file by
+default:
+
+1. Honor a user-supplied path.
+2. Otherwise derive a short topic slug and announce
+   `reports/<topic-slug>.md` before research starts.
+3. Never silently overwrite. If the path exists and overwrite was not requested,
+   choose `<topic-slug>-2.md`, then `-3`, and so on.
+4. Treat conversation-only delivery as an explicit format choice.
+5. In read-only mode, return the report in conversation and say that no file could be
+   written.
+
+After a workflow run, immediately use
+[`scripts/materialize_report.py`](scripts/materialize_report.py) with its
+`resultPath`. The materializer is the authoritative gate: it builds `## Sources`
+from the body, validates structure, appends a sanitized `## Scope and gaps` section
+for a partial result, and warns when the delivered length departs from the confirmed
+target or a stage was degraded. Report any warning it prints, and check
+`run_summary.degraded_stages`: a degraded stage means a decision the run was supposed
+to make was discarded, which is worth telling the user about. Finish with the report
+path and a short status; do not paste the full report again.
+
+### Keep intermediate work out of the project
+
+Research intermediates belong in the session scratchpad, not in the user's
+repository. When the session advertises a scratchpad directory, pass it to the
+workflow as `workspace.scratchpad_dir` with a short `run_slug`, so scouts can write
+full-fidelity evidence dossiers that later stages read on demand instead of
+squeezing everything through compact return values.
+
+The scratchpad holds dossiers, section drafts, and the assembled report body. The
+finished report is the only deliverable and it goes into the project. If no
+scratchpad is available, the workflow runs on its inline records instead — say so
+if evidence depth suffered.
+
+## 2. Choose proportional effort
+
+Choose by uncertainty and consequence, not by topic breadth alone.
+
+| Tier | Use when | Base lanes | Per-lane acquisition ceiling |
+| --- | --- | ---: | --- |
+| Focused | Narrow, low-stakes synthesis with modest uncertainty | 2 | 4 searches, 6 fetches |
+| Standard | Default multi-source report or comparison | 3–4 | 6 searches, 8 fetches |
+| Extended | Explicitly exhaustive, high-stakes, or unusually disputed | 5–6 | 8 searches, 12 fetches |
+
+These are ceilings, never quotas. Stop a lane as soon as its material claims have
+adequate support. Lane ownership must be disjoint; do not add a cross-cutting lane
+that re-fetches every period or option.
+
+Focused runs skip follow-up research by default. Standard runs may add at most one
+follow-up, and only when the gap could change the thesis or recommendation. Extended
+runs may use one acquisition escalation under the rules below, not an open-ended
+retry chain.
+
+## 3. Plan source classes, not source counts
+
+Before searching, identify the source classes the question needs: primary records,
+official data, peer-reviewed analysis, technical documentation, contemporary
+reporting, or lived-experience sources. Assign each class to one lane.
+
+Use discovery sources to find authoritative evidence, then cite the authoritative
+evidence. Prefer a smaller set of strong, representative citations over collecting
+sources to meet a quota.
+
+## 4. Route stages at runtime
+
+When Gigacode and model discovery are available:
+
+1. Call `list_subagent_models` once.
+2. Use the user's requested model family when specified; otherwise anchor routing
+   to the effective Investigation default's provider and model family.
+3. Keep stage roles in that family. Prefer the same exact model with lower effort
+   for bounded discovery, extraction, coverage classification, and
+   mechanical/editorial checks; next prefer a clearly related faster sibling from
+   the same provider and family.
+4. Use higher effort or the stronger sibling in that same family for difficult
+   conclusion-driving verification, conflict resolution, and synthesis.
+5. If family membership is unclear, stay on the same exact model or omit the
+   override. Do not assemble a sampler of unrelated providers or model families
+   merely to specialize each stage.
+6. Cross the family boundary only when the user directs it or the chosen family
+   lacks a required capability, such as vision for the one permitted Browser
+   escalation. Limit the exception to the affected role and disclose it.
+7. Pass only exact configured routes in workflow `args.routes`. If no safe
+   same-family alternate is clear, omit that role's override and inherit the
+   configured agent-type default. An omitted role inherits silently; a route that
+   is present but malformed fails the run before dispatch rather than quietly
+   falling back.
+
+Never guess a route. Do not copy a provider, model ID, or effort value into this
+skill or its resources. Routes are complete runtime values returned by the current
+session's discovery tool. A shared provider name alone does not establish a shared
+model family; use only an obvious lineage shown by runtime model names, and treat
+ambiguous cases as unrelated.
+
+Use read-only Investigation workers for ordinary research. A Browser worker is an
+exception for one approved acquisition escalation and requires a runtime-discovered
+vision-capable route when an override is used.
+
+## 5. Use the bounded workflow
+
+With Gigacode:
+
+1. Call `run_workflow` with `script_path` pointing at this skill's
+   [`scripts/deep-research.workflow`](scripts/deep-research.workflow). Do not read
+   the file into context to pass it as `script`; `script_path` takes precedence and
+   avoids a large pointless round trip.
+2. Pass the settled brief — including `current_as_of`, since workers have no clock —
+   plus disjoint lanes, tier, ceilings, report profile, stage plan, workspace, and
+   optional runtime routes.
+3. Use a tier-appropriate budget. Do not increase an exhausted budget by a large
+   multiplier without changing scope or workflow shape.
+4. On interruption, inspect `resultPath` and `transcriptPath`. Resume only to reuse
+   valid persisted calls while narrowing optional work; do not rerun merely to
+   recover omitted inline output.
+5. Materialize the final or explicitly supported partial report from `resultPath`.
+
+The workflow researches and verifies lanes as one pipeline with no barrier between
+the stages, verifies every lane that holds important or disputed claims, constructs
+its registry deterministically, and uses one ordinary drafting agent. The
+skill—not the user—decides whether section fan-out is warranted after coverage
+analysis. It uses sections for an explicitly long report, usually around 5,000 words
+or more, or when the supported evidence separates into genuinely independent
+sections that benefit from bounded parallel drafting. An assembly pass then unifies
+argument, transitions, voice, and citations.
+
+A `failed` result means no report exists. A drafted report with residual issues
+comes back as `partial` with those issues in `gaps` — never discarded.
+
+### Sequential fallback
+
+The confirmed brief from intake applies to sequential research unchanged. Bypassing
+Gigacode does not bypass intake; if the brief has not been confirmed, complete it
+before proceeding.
+
+If Gigacode is unavailable and the user chooses to continue without it:
+
+1. Research the same 2–6 disjoint lanes sequentially with the same ceilings.
+2. Keep the source/evidence registry and failed-acquisition ledger **in scratchpad
+   files**, not in conversation context, using the same layout the workflow uses:
+   `lanes/<lane>.md` per lane plus a `registry.json`. A long sequential run will
+   outlive its own context; citations must survive compaction.
+3. Verify conclusion-driving or disputed claims with genuinely independent support.
+4. Run one combined evidence/editorial audit for Focused or Standard work.
+5. Revise only if the audit finds a material problem.
+6. Rebuild `## Sources` from the files, restricted to URLs actually cited in the
+   final body. Preserve query strings when comparing URLs: two pages that differ
+   only in a query parameter are different documents.
+7. Write the report directly using the artifact-first path rules.
+
+Orchestration improves speed and cost control; its absence must not weaken the
+evidence standard or prevent delivery.
+
+## 6. Stop failed acquisition quickly
+
+Every worker prompt must carry these rules:
+
+- Never repeat an identical query.
+- Never retry a terminally failed URL by changing only protocol, anchor, query
+  string, or endpoint shape.
+- Treat 403/404, login/paywall, robots denial, certificate failure, unsupported
+  type, oversized document, and scanned/no-text results as terminal for that source.
+- For a conclusion-driving source, try at most one obvious accessible equivalent.
+- Retry a transient timeout once, then move on.
+- Pass failures to verification; verifiers must not retry known failures or broadly
+  re-fetch every scout source.
+- Prefer a substitute source or narrower claim over downloading, conversion,
+  browser automation, or OCR.
+- Focused and Standard runs do not initiate OCR.
+- Extended/high-stakes or explicitly exhaustive work may use at most one Browser
+  **or** local conversion/OCR escalation—not both—for an irreplaceable source that
+  could change the answer. If it fails, disclose the gap and continue.
+
+## 7. Draft for the reader
+
+All reports must answer the question early, cite material factual claims, separate
+evidence from inference, preserve important disagreement, and include exactly one
+deduplicated Sources section containing only cited sources.
+
+Presentation is adaptive:
+
+- **Historical/cultural/humanities:** use a narrative or chronological arc, a
+  specific title, concrete period-appropriate headings, and an opening thesis. Do
+  not default to `Executive answer`, `Methods`, or `Limitations`.
+- **Product/market/policy:** lead with the answer, comparisons, trade-offs,
+  recommendation, and risks. An executive summary may fit.
+- **Scientific/technical/high-stakes:** foreground method, evidence quality,
+  uncertainty, and limitations when they aid interpretation.
+- **Community/trend/experiential:** organize around patterns and voices while making
+  representativeness limits clear without repetitive disclaimers.
+
+Match the user's register and the subject's texture without sensationalizing,
+imitating an author, or sacrificing precision. Keep material uncertainty near the
+affected claim, but do not expose worker mechanics, evidence IDs, audit language, or
+repeated boilerplate caveats in the report.
+
+Use the confirmed numeric target from intake for orchestration purposes. Do not
+ask the user to choose single-agent versus section-based drafting.
+
+## 8. Audit only what needs judgment
+
+- Focused and ordinary Standard: one combined evidence/editorial audit — pass
+  `stage_plan.audit: "combined"`.
+- Extended or high-stakes: two independent audits — pass
+  `stage_plan.audit: "dual"`. This does not happen by default; set it explicitly.
+- Use `stage_plan.audit: "deterministic"` only when no judgment-based audit is
+  warranted.
+- Set `stage_plan.verification` and `stage_plan.followup` in the same object:
+  `risk_only` verification for experiential or testimony-led work, `selective` for
+  ordinary reports, `required` when nearly every lane carries checkable
+  conclusions; `followup: "off"` for Focused runs.
+- Revise only for material issues.
+- Use an independent closure review only for unresolved critical or major evidence
+  issues in high-stakes work.
+- Never dispatch an agent for deterministic citation, bibliography, duplicate
+  heading, empty-section, or output-file checks.
+
+If a critical claim remains unsupported, remove or narrow it. A disclosed gap is
+better than another expensive loop that is unlikely to change the answer.

--- a/kolega_code/_bundled_skills/skills/deep-research/references/evidence-and-reporting.md
+++ b/kolega_code/_bundled_skills/skills/deep-research/references/evidence-and-reporting.md
@@ -1,0 +1,499 @@
+# Evidence and reporting
+
+Use this reference to keep deep research rigorous without turning every report into
+an institutional audit. The evidence rules are fixed; the report's structure and
+voice are reader-dependent.
+
+## Briefing and source planning
+
+Topic-specific intake questions should change what is researched, not serve as
+procedural form-filling. Before assigning source classes to lanes, use the answers
+from intake to narrow scope and select evidence:
+
+- **Scope answer** sets the timeframe, jurisdiction, geography, or comparison set
+  for every lane, eliminating irrelevant source classes before acquisition begins.
+- **Interpretive-lens question** (historical/cultural) targets primary texts,
+  scholarly commentary, and reception records rather than news sources.
+- **Options/constraints question** (product/market) determines whether technical
+  documentation, independent benchmarks, or regulatory filings belong in scope.
+- **Jurisdiction/decision question** (disputed/high-stakes) specifies which legal,
+  clinical, or policy evidence applies and at what threshold.
+- **Communities/period question** (experiential/community) identifies the platforms,
+  forums, or archival sources appropriate for lived-experience evidence.
+- **Audience and use answer** calibrates evidence depth: a practitioner audience
+  may need primary or technical sources where a general audience benefits from
+  authoritative synthesis.
+
+Treat intake as a research-design step. If the topic-specific answers do not change
+any lane boundary, source class, or evidence standard, the questions were not
+specific enough.
+
+## 1. Build claims from evidence
+
+Separate four layers:
+
+1. **Source** — who published the material, when, and under what incentives.
+2. **Evidence** — the specific passage, datum, observation, or record.
+3. **Claim** — the proposition that the evidence supports.
+4. **Inference** — the analyst's interpretation that joins multiple claims.
+
+Record evidence atomically. One evidence record should support one proposition and
+name the source URL that can be cited. Do not use an entire document as if every
+claim in it had been verified.
+
+For each candidate claim, record:
+
+- stable lane-local claim and evidence IDs;
+- claim text;
+- evidence IDs;
+- importance: `background`, `supporting`, or `conclusion-driving`;
+- whether the claim is disputed, surprising, or high-stakes; and
+- a short qualification when support is partial.
+
+The reader-facing report must never expose internal IDs.
+
+### Classify claims with the exact enum values
+
+`claim_type` and `verification_triggers` are schema enums. They decide what gets
+verified, so an invented value is rejected outright rather than silently changing
+behavior:
+
+| `claim_type` | Use for |
+| --- | --- |
+| `external_fact` | a checkable fact about the world |
+| `quantitative` | a number, rate, magnitude, or trend |
+| `causal` | an assertion that one thing produced another |
+| `comparative` | a ranking or "more/less than" judgment |
+| `attributed_report` | what a named source said, did, or experienced |
+| `interpretation` | an analytic or scholarly reading of material |
+
+| `verification_triggers` | Use when |
+| --- | --- |
+| `known_dispute` | credible sources are known to disagree |
+| `cross_source_conflict` | this lane's own sources conflict |
+| `scope_risk` | the sample, jurisdiction, or period may not match the claim |
+| `source_access_uncertain` | the supporting source may not stay reachable |
+| `high_stakes` | a wrong answer here carries real cost |
+
+`attributed_report` and `interpretation` are the only types that opt out of
+verification, and only when the claim is neither disputed nor conclusion-driving.
+Testimony that carries the argument still gets checked. A claim whose type is
+absent falls back to the conservative rule — verify it if it is
+conclusion-driving or disputed — so a mislabeled claim is never skipped.
+
+### Claim statuses
+
+Verification assigns each claim exactly one status, and the drafter is bound by it:
+
+| Status | Meaning | Drafting |
+| --- | --- | --- |
+| `verified` | independently checked and supported | may carry a factual conclusion |
+| `qualified` | supported within a stated limit | keep the qualification next to the claim |
+| `contested` | credible support is unresolved or conflicting | present the disagreement; conclude nothing decisive |
+| `refuted` | the evidence does not support it | excluded from the report |
+| `attributed` | testimony or interpretation, not externally checkable | attribute explicitly; never evidence of prevalence |
+| `single-source` | background resting on one source | cite and attribute; not independently corroborated |
+| `unverified` | eligible but not checked | usable with explicit attribution and hedged language |
+
+Not being selected for verification is never a mark of quality. `single-source`
+does not outrank `unverified`, and neither may be presented as corroborated.
+
+## 2. Judge source fitness
+
+Use the strongest available source for the claim:
+
+1. primary record, official data, standard, or original research;
+2. high-quality scholarly synthesis or authoritative technical documentation;
+3. reputable specialist reporting or analysis;
+4. contemporaneous reporting, trade material, or institutional commentary;
+5. community or anecdotal material for experience and discovery, not universal
+   factual claims.
+
+Source class is not a universal ranking. A community post can be the primary source
+for what a participant said; it is not primary evidence for broad prevalence.
+
+Assess:
+
+- directness: does the source actually support the proposition?
+- authority: does the author or institution have relevant competence?
+- independence: are apparently separate sources copying one origin?
+- date fitness: is the evidence current enough for the claim?
+- scope fitness: does the sample, jurisdiction, population, or period match?
+- incentives and missing context;
+- access stability and whether the citation is reader-verifiable.
+
+Use discovery pages to locate authoritative evidence. Do not cite a search snippet
+when the underlying source is available.
+
+## 3. Acquire proportionally
+
+### Lane ceilings
+
+| Tier | Materially different searches | Fetches |
+| --- | ---: | ---: |
+| Focused | 4 | 6 |
+| Standard | 6 | 8 |
+| Extended | 8 | 12 |
+
+Ceilings are upper bounds, not quotas. Stop when:
+
+- every conclusion-driving claim in the lane has adequate direct support;
+- another source would merely repeat established background;
+- remaining uncertainty is unlikely to change the answer; or
+- the writing/audit reserve would be threatened.
+
+No source-count minimum applies. Prefer two independent strong sources for a
+disputed conclusion-driving claim when they are realistically available; do not
+manufacture independence by citing syndicated copies.
+
+### Failed-acquisition ledger
+
+Keep a compact shared ledger:
+
+```text
+canonical URL | failure class | attempts | alternate tried | claim affected
+```
+
+Canonicalize away the fragment and known tracking parameters, but **keep the rest
+of the query string**: `?report=2019` and `?report=2024` are different documents,
+and collapsing them mis-attributes citations.
+
+Under orchestration, a verifier receives its own lane's ledger, which is what
+prevents same-source retries. The cross-lane ledger is assembled after the research
+pipeline for the follow-up and escalation stages. Working sequentially, keep one
+ledger for the whole run.
+
+Terminal failures require zero same-source retries:
+
+- 403/404 or other access denial;
+- login, paywall, or robots restriction;
+- certificate or protocol failure;
+- unsupported or oversized content;
+- scanned/no-text content;
+- a source that requires prohibited or unavailable tooling.
+
+If the source could change a conclusion, try at most one obvious lawful accessible
+equivalent: an author manuscript, official mirror, archived official copy, or another
+source reporting the same primary evidence. If that attempt fails, record the gap.
+
+A transient timeout may be retried once. A second timeout is terminal.
+
+Do not:
+
+- repeat an identical query;
+- vary only protocol, fragment, query string, mirror endpoint, or download parameter
+  to create the appearance of a new attempt;
+- let a verifier revisit a URL or access strategy already marked terminal;
+- download and shell-convert a document merely because ordinary fetching failed; or
+- treat OCR output as strong evidence without checking the relevant passage.
+
+Focused and Standard runs never initiate OCR by default. Extended/high-stakes or
+explicitly exhaustive work may use one Browser **or** local conversion/OCR
+escalation—not both—only for an irreplaceable source that could change the answer.
+Bound the target and question before the attempt. Stop after failure and disclose
+the gap.
+
+## 4. Verify selectively
+
+Verification is for:
+
+- conclusion-driving claims;
+- disputed or surprising claims;
+- claims whose scope, date, or causal language may exceed the evidence;
+- conflicts between credible sources; and
+- pivotal translations or interpretations.
+
+Background claims with direct authoritative support do not need a wholesale second
+research pass.
+
+Every lane holding eligible claims is verified. Verification capacity is not
+rationed across lanes and none is held back for a possible follow-up: a report
+whose conclusion-driving claims went unchecked is worse than one that costs a few
+more bounded calls.
+
+A verifier receives:
+
+- the lane's summary, its selected claims, and only the evidence and source cards
+  those claims depend on;
+- the path to the lane's evidence dossier, when one exists;
+- the lane's failed-acquisition ledger; and
+- a small verification acquisition ceiling.
+
+It reads the dossier for depth rather than being handed the whole scout record.
+
+It returns a delta only:
+
+- verdict per claim: `supported`, `qualified`, `unsupported`, or `disputed`;
+- approved existing evidence IDs;
+- concise qualifications;
+- rejected evidence IDs and reason;
+- genuinely new sources/evidence; and
+- new failed acquisitions or gaps.
+
+It must not echo the scout record or broadly re-fetch every source. Independence
+means finding separate support for a material proposition, not mechanically
+repeating the same acquisition work.
+
+## 5. Handle disagreement honestly
+
+When credible sources disagree:
+
+1. identify the exact proposition in dispute;
+2. compare definitions, dates, jurisdiction, samples, and incentives;
+3. distinguish factual conflict from interpretive difference;
+4. prefer the source closest to the underlying event or data when appropriate;
+5. state what is established, what is probable, and what remains open.
+
+Do not collapse a live disagreement into false certainty. Do not give fringe claims
+equal weight merely because they exist.
+
+Calibrate language:
+
+- **Strong:** demonstrates, establishes, directly records.
+- **Moderate:** supports, indicates, is consistent with.
+- **Tentative:** suggests, may reflect, is plausibly explained by.
+- **Unresolved:** evidence is insufficient or credible sources disagree.
+
+## 6. Keep handoffs compact by writing evidence down
+
+Research cost grows when every stage reproduces full source cards, but compressing
+evidence into one-line paraphrases starves the drafter. Resolve the tension by
+separating depth from transport: write full-fidelity evidence to a file and pass
+paths.
+
+### Evidence dossiers
+
+When a session scratchpad is available, each scout writes a dossier alongside its
+compact record:
+
+```text
+<scratchpad>/deep-research/<run-slug>/lanes/<lane-key>.md
+```
+
+The dossier is where depth belongs — full bibliographic metadata, access status,
+and generous verbatim quotation with enough surrounding context for a later stage
+to judge directness, scope, and date fitness without refetching. Record rejected
+leads and the detail behind each failed acquisition too.
+
+Downstream stages receive the path and read what they need. Verifiers add their own
+working notes next to the dossier. Nothing large travels through a stage's return
+value.
+
+This is additive. When no scratchpad is available or a worker cannot write one,
+every stage falls back to the inline compact records below and the run still
+completes; say so in the gaps rather than failing.
+
+Never write a deliverable to the scratchpad — it is throwaway by design. The report
+is written into the project at the end.
+
+### Scout record
+
+- lane ID and a short synthesis;
+- compact source cards: local ID, title, URL, publisher, date, type;
+- atomic evidence: local ID, claim, source ID, short quote/paraphrase;
+- candidate claims with importance and dispute flags;
+- failed acquisitions; and
+- unresolved gaps.
+
+### Verification delta
+
+- claim verdicts and approved evidence IDs;
+- qualifications and rejections;
+- only new sources/evidence;
+- new failures and remaining gaps; and
+- a short verifier synthesis.
+
+### Coverage input
+
+- one short supported synthesis per lane;
+- a claim index with status and source IDs but **no evidence excerpts**;
+- source-class coverage;
+- dossier paths for anything that needs a closer look;
+- unresolved gaps and failed-source effects; and
+- the inferred target length and report profile needed to decide drafting shape.
+
+Do not pass complete fetched text, search transcripts, duplicated source cards, or
+full evidence ledgers into coverage and audit prompts. Pass the path instead.
+
+### Drafting-shape decision
+
+The skill decides the drafting shape; do not ask the user to choose an
+implementation detail. A long report must never collapse back to a single drafting
+call merely because the stage that was supposed to propose an outline failed to
+return one; fall back to a deterministic outline and let the assembly pass turn it
+into reader-facing sections.
+
+Use one drafting agent by default. Use bounded section drafting when:
+
+- the inferred target is roughly 5,000 words or more; or
+- coverage analysis identifies at least two genuinely independent sections with
+  distinct claim sets whose parallel drafting improves clarity or context fit.
+
+Do not use section fan-out merely because research had multiple lanes. Lanes are
+evidence boundaries; report sections are reader-facing argument boundaries.
+
+When section drafting is warranted:
+
+1. coverage returns a short outline, purpose, and supported claim IDs per section;
+2. draft the bounded sections in parallel using only their assigned claims;
+3. assemble the sections into one body, then
+4. build the bibliography from the assembled body, not from section-reported
+   source lists.
+
+With a scratchpad, each section is written to its own file and the assembly stage
+writes `report/body.md`: a title, an opening that answers the question early, the
+sections in order with reconciled transitions and normalized voice, and an
+evidence-calibrated conclusion. A long report must not be re-emitted as one giant
+JSON string; that is the most truncation-prone shape available.
+
+Verify the delivered length against the target with `wc -w` rather than trusting an
+impression, and check both directions. A report materially shorter than the confirmed
+target gets one bounded expansion pass over its thinnest sections — adding evidence,
+mechanism, and concrete detail from the dossiers, never padding — and is then
+reassembled. One pass only: a short report that is honest still ships, with the
+shortfall disclosed. A report far longer than the target is a defect of a different
+kind: it disregarded the brief, so tighten it rather than disclosing it.
+
+## 7. Reader-fit report contract
+
+### Core invariants
+
+Every report must:
+
+- answer the research question early;
+- cite material factual claims with descriptive Markdown links;
+- distinguish sourced fact from synthesis or inference;
+- preserve material disagreement and uncertainty;
+- conclude only as strongly as the evidence allows; and
+- contain exactly one `## Sources` section with deduplicated sources actually cited
+  in the body.
+
+Keep uncertainty next to the affected claim. Consolidate secondary caveats instead
+of repeating "the accessible evidence is limited" in every section. Do not expose
+research lanes, worker names, evidence IDs, audit verdicts, or retry history unless
+the user explicitly asks for methods.
+
+That applies to recorded gaps too. A gap is read by a person, so name the missing
+evidence and why it matters — never a lane identifier, a claim or evidence ID, or the
+shape of an internal record. "Klibansky and Panofsky's study was reached only at
+second hand" is a disclosure; "lane-1/C11's second half needs the reception lanes" is
+leaked machinery. A reader-facing note is a short disclosure of what stayed
+unresolved, not a transcript of the research ledger.
+
+The user's requested format wins. Otherwise choose the closest profile below.
+
+### Historical, cultural, and humanities
+
+- Open with a clear thesis in natural prose.
+- Use a narrative, chronological, or thematic arc suited to the material.
+- Write a specific, engaging title and concrete period-appropriate headings.
+- Integrate interpretive disputes where they arise.
+- Use a brief, naturally titled note on gaps only if it changes how the history
+  should be read.
+- Do not default to headings named `Executive answer`, `Methods`, or `Limitations`.
+
+For a history of Saturnian magic, for example, prefer headings tied to periods,
+texts, and transformations over corporate or methodological labels. Evocative does
+not mean sensational: preserve ambiguity between documentary fact, later tradition,
+and modern reconstruction.
+
+### Product, market, and policy decision
+
+- Lead with the answer or decision frame.
+- Compare options on criteria that matter to the stated audience.
+- Explain trade-offs, recommendation, risks, and what would change the choice.
+- Use an executive summary when the decision-maker benefits from one.
+
+### Scientific, technical, and high-stakes
+
+- State scope and definitions precisely.
+- Explain method, evidence quality, and uncertainty where they affect
+  interpretation.
+- Distinguish association, mechanism, and causation.
+- Give limitations their own section when needed for safe use of the findings.
+
+### Community, trend, and experiential
+
+- Organize around observed patterns and participant voices.
+- Identify the sampled community and missing groups.
+- Treat anecdotes as experience evidence, not prevalence estimates.
+- State representativeness limits once clearly rather than as a disclaimer in every
+  paragraph.
+
+### Voice
+
+Match the user's register and the subject's texture. Prefer concrete nouns and
+active sentences. Avoid generic institutional phrases, audit-shaped headings, and
+inflated abstractions when plain language is more accurate.
+
+Do not:
+
+- imitate a living author;
+- manufacture scenes, quotations, or emotional certainty;
+- sensationalize cultural or religious material;
+- trade factual precision for color; or
+- force all discovered sources into the prose.
+
+## 8. Cite economically and immediately
+
+Use descriptive Markdown links near the supported claim:
+
+```markdown
+The [official release notes](https://example.com/release) date the change to May.
+```
+
+Avoid:
+
+- bare URLs in body prose;
+- one citation at the end of a paragraph containing several unrelated claims;
+- bibliography entries never cited in the body;
+- multiple citations that all derive from one origin; and
+- citation density that obscures the argument when one stronger source suffices.
+
+The deterministic bibliography builder extracts URLs from the final body, resolves
+them against the canonical registry, and creates `## Sources`. Writer-reported
+source lists are advisory only.
+
+Link extraction has to be exact, because a mis-parsed URL looks like an unsupported
+citation. It must honor balanced parentheses in a destination — Wikipedia's
+`Saturn_(mythology)` style is everywhere in historical research — skip images,
+inline code, and fenced blocks, tolerate an optional link title, and ignore
+anchors and mail links rather than reporting them as unknown sources.
+
+## 9. Audit proportionally
+
+Choose the audit mode deliberately rather than leaving it implicit: `combined` for
+Focused and ordinary Standard work, `dual` for Extended or high-stakes work, and
+`deterministic` only when no judgment-based audit is warranted.
+
+One combined evidence/editorial audit is enough for Focused and ordinary Standard
+reports. It checks:
+
+- whether material claims are supported by cited registry sources;
+- whether claim strength matches the evidence;
+- whether disagreement and scope limits are represented fairly;
+- whether the answer addresses the settled brief; and
+- whether structure, headings, and voice fit the report profile.
+
+Use two independent audits for Extended or high-stakes work: one evidence-focused
+and one reader/editorial-focused. Revise only when an audit identifies a material
+issue.
+
+An independent closure review is justified only when high-stakes revision leaves an
+unresolved critical or major evidence issue. Deterministic checks—not agents—own:
+
+- unknown citation URLs;
+- duplicate citation URLs or headings;
+- missing cited sources;
+- uncited bibliography entries;
+- empty sections;
+- malformed Markdown output; and
+- missing/empty output files.
+
+If evidence cannot support a material claim, remove or narrow the claim and name
+the gap. More process is not a substitute for better evidence.
+
+A residual defect never justifies throwing the report away. Deliver it as a
+supported partial result with the unresolved issues named, and let the reader see
+what is unsettled. Discarding a finished report because a citation would not
+resolve serves nobody.

--- a/kolega_code/_bundled_skills/skills/deep-research/references/gigacode-workflow.md
+++ b/kolega_code/_bundled_skills/skills/deep-research/references/gigacode-workflow.md
@@ -1,0 +1,392 @@
+# Bounded Gigacode workflow
+
+Use the bundled [`scripts/deep-research.workflow`](scripts/deep-research.workflow)
+verbatim. Do not ask a coordinator agent to generate another workflow.
+
+This guide defines the runtime arguments, routing procedure, budget behavior, and
+recovery path. Kolega Code's injected Gigacode authoring guide remains authoritative
+for primitive signatures.
+
+Use this guide only after the skill's Gigacode preflight. If `run_workflow` is
+unavailable, prompt the user to run `/gigacode on` or explicitly choose the
+sequential fallback; do not silently fall back.
+
+## Before invocation
+
+1. Confirm that the research brief is complete and confirmed with the user.
+   The `intake` object passed to `run_workflow` must carry `confirmed: true`
+   (or `mode: "user_directed_defaults"` for the no-questions exception) with all
+   four resolved fields present. The workflow validates intake before any worker
+   dispatch and returns the standard failed result when intake is missing or
+   invalid.
+2. Settle the tier, output path, and disjoint lanes from the confirmed brief.
+3. If `list_subagent_models` is available, call it exactly once.
+4. Select complete exact route objects only from that response, applying the
+   same-family-first policy below. Omit a role entirely when no safe alternate is
+   clear; a malformed route is rejected, never silently ignored.
+5. Pass `script_path` pointing at this skill's own
+   `scripts/deep-research.workflow`. Do not read the file into context and pass
+   `script`; `script_path` takes precedence and saves the whole round trip. Read
+   the file into `script` only if `script_path` fails.
+6. Announce the output path before starting.
+
+No provider, model ID, or fixed effort selection belongs in this skill. Route
+objects exist only in the current invocation's arguments.
+
+## Arguments
+
+Pass an object with this shape:
+
+```json
+{
+  "intake": {
+    "mode": "interactive",
+    "confirmed": true,
+    "resolved_fields": ["length", "audience_use", "scope", "delivery"],
+    "topic_questions_asked": 2
+  },
+  "brief": {
+    "question": "The settled research question",
+    "audience": "Who will read and use the report",
+    "scope": "Timeframe, geography, comparison set, and exclusions",
+    "current_as_of": "2026-07-28",
+    "high_stakes": false
+  },
+  "tier": "standard",
+  "lanes": [
+    {
+      "id": "lane-1",
+      "title": "A disjoint source/subject boundary",
+      "question": "What this lane alone must establish",
+      "source_classes": ["primary records", "scholarly synthesis"]
+    }
+  ],
+  "acquisition": {
+    "searches_per_lane": 6,
+    "fetches_per_lane": 8,
+    "verification_searches": 2,
+    "verification_fetches": 4
+  },
+  "report_profile": {
+    "kind": "historical-cultural",
+    "length": "standard",
+    "voice": "Engaging, precise, and accessible",
+    "target_words": 3000,
+    "required_structure": [],
+    "avoid_structure": ["Executive answer", "Methods", "Limitations"]
+  },
+  "stage_plan": {
+    "verification": "selective",
+    "followup": "thesis_changing",
+    "audit": "combined",
+    "reason": "ordinary multi-source report"
+  },
+  "workspace": {
+    "scratchpad_dir": "<this session's absolute scratchpad path>",
+    "run_slug": "topic-slug"
+  },
+  "writing_reserve_tokens": 18000,
+  "allow_acquisition_escalation": false,
+  "escalation": null,
+  "routes": {
+    "discovery": "<optional complete runtime route object>",
+    "verification": "<optional complete runtime route object>",
+    "synthesis": "<optional complete runtime route object>",
+    "audit": "<optional complete runtime route object>",
+    "acquisition": "<optional complete runtime route object>"
+  }
+}
+```
+
+The example values describe a Standard run; adjust ceilings to the tier table in
+`SKILL.md`. Do not pass string placeholders as routes in a real invocation. Include
+a route key only when its value is a complete object returned for the current
+session.
+
+`brief.current_as_of` is **required**. Workflow scripts have no clock, so workers
+cannot judge date fitness without it. Pass today's date.
+
+There is no `research_batch_size`. Lanes run as one pipeline and the runtime caps
+concurrency automatically; passing the key is a validation error.
+
+### Length
+
+Map the user's confirmed length preset to `target_words` exactly:
+
+| `report_profile.length` | `target_words` |
+| --- | ---: |
+| `concise` | 1,500 |
+| `standard` | 3,000 |
+| `detailed` | 6,000 |
+| `long` | ≥ 10,000 (use the confirmed custom numeric target) |
+| `custom` | any explicit user-confirmed target ≥ 500 |
+
+`long` requires a confirmed numeric target of at least 10,000. `custom` accepts any
+target confirmed by the user of at least 500. There is no silent default for
+`target_words`; an invocation without a valid `length` preset and corresponding
+numeric target is rejected before dispatch.
+
+The user does not select a drafting mode. After verification, coverage analysis
+decides whether the report needs bounded section drafting. A target of roughly
+5,000 words or more qualifies; a shorter report qualifies only when it has at least
+two genuinely independent reader-facing sections with distinct supported claim sets.
+
+### Stage plan
+
+`stage_plan` is optional and defaults to `selective` + `thesis_changing` +
+`combined`. Set it deliberately rather than leaving the audit mode implicit:
+
+| Key | Values | Choose |
+| --- | --- | --- |
+| `verification` | `risk_only`, `selective`, `required` | `risk_only` for experiential/testimony work where external checking does not apply; `selective` for ordinary reports; `required` when nearly every lane carries checkable conclusions |
+| `followup` | `off`, `thesis_changing` | `off` for Focused runs and for anything that must not grow; `thesis_changing` otherwise |
+| `audit` | `deterministic`, `combined`, `dual` | `combined` for Focused and ordinary Standard; `dual` for Extended or `high_stakes: true`; `deterministic` only when no judgment-based audit is warranted |
+
+`reason` is a short free-text note recorded in telemetry.
+
+Every lane holding eligible claims gets one verifier call carrying up to eight
+claims, ordered by risk and importance. No verifier capacity is held back for the
+conditional follow-up; the follow-up is gated on the writing reserve when coverage
+actually requests it.
+
+### Lane and claim classification
+
+Lane-count validation:
+
+- Focused: exactly 2;
+- Standard: 3 or 4;
+- Extended: 5 or 6.
+
+Lanes must not overlap. A historical run might divide by periods; a product run
+might divide by options or evidence domains. Cross-lane comparison happens after
+verification, not in another broad research lane.
+
+Lane identity for evidence keying is assigned by the workflow (`lane-1…N`,
+`followup-1`, `escalation-1`), so a worker cannot cross-wire evidence by reusing
+another lane's id.
+
+Scouts classify each candidate claim with `claim_type` and optional
+`verification_triggers`. Both are schema enums; see
+[Evidence and reporting](references/evidence-and-reporting.md) for the values and
+what each one means for verification.
+
+### Workspace and scratchpad dossiers
+
+`workspace` is optional but should be passed whenever the session advertises a
+scratchpad directory. It turns on full-fidelity evidence dossiers:
+
+- `scratchpad_dir` must be an absolute path — the session scratchpad path from
+  your own context, not a project path.
+- `run_slug` must be 1–64 characters of lowercase letters, digits, and hyphens,
+  starting with a letter or digit.
+
+The workflow derives every path deterministically:
+
+```text
+<scratchpad_dir>/deep-research/<run_slug>/
+├── lanes/<lane-key>.md          # scout dossier: full quotes with context
+├── lanes/<lane-key>.verify.md   # verifier working notes
+├── sections/<NN>-<slug>.md      # section bodies for a long report
+└── report/body.md               # assembled body, no Sources section
+```
+
+Scouts write their dossier with `exec_command` and return only a compact record
+plus `dossier_path`. Verification, coverage, drafting, and audit receive paths and
+read the depth they need with `read_file_section`. This is what keeps the
+handoffs compact without starving later stages of evidence.
+
+The scratchpad is additive and best-effort. When `workspace` is omitted, a worker
+cannot write, or a file has been reclaimed from temp, every stage falls back to the
+inline compact records and the run still completes. `run_summary.dossiers` reports
+how many dossiers were actually persisted.
+
+Never write a deliverable to the scratchpad. The finished report is written into
+the project by the materializer.
+
+## Stage routing
+
+Map work to runtime routes by capability:
+
+- `discovery`: bounded search, source metadata, direct extraction;
+- `verification`: disputed, ambiguous, or conclusion-driving claims;
+- `synthesis`: coverage judgment, final argument, and material revision;
+- `audit`: bounded evidence/editorial checks;
+- `acquisition`: the one permitted Browser or local escalation.
+
+Choose one routing family rather than a different provider for every role:
+
+1. If the user names a model family, use it. Otherwise use the effective
+   Investigation default's provider and model family as the anchor.
+2. First vary effort on the same exact model: lower it for bounded discovery and
+   mechanical checks, and raise it for verification and synthesis.
+3. If useful, choose a runtime-listed faster or stronger sibling only when it is
+   clearly in the same provider and model lineage.
+4. If lineage is ambiguous, keep the exact anchor model or inherit the configured
+   default. Sharing a provider is not enough to infer family membership.
+5. Do not distribute ordinary stages across unrelated providers or families merely
+   to optimize each role independently.
+6. Use another family only at the user's direction or when the anchor family lacks
+   a required capability. Keep a capability-driven exception to the affected role
+   and disclose it.
+
+The workflow omits `model_override` when a role key is absent. A route that is
+present but malformed — a missing `effort`, an extra key, an empty `provider` or
+`model`, or an unrecognized role name — is a validation error that fails the run
+before dispatch. The workflow never invents a partial override and never quietly
+falls back from an invalid one.
+
+## Budget and concurrency
+
+Set a tier-appropriate workflow budget and reserve enough completed-output capacity
+for coverage, drafting, audit, and possible material revision. The workflow:
+
+- researches and verifies lanes as one pipeline, with no barrier between the
+  stages, so a fast lane's verification starts while a slow lane is still scouting;
+- checks the writing reserve before research and before each optional stage;
+- filters failed workers at every join;
+- skips optional follow-up when it would threaten the reserve; and
+- returns a supported partial status when some lanes fail but the remaining evidence
+  can answer the question honestly.
+
+`writing_reserve_tokens` defaults to `max(18000, target_words × 1.4 × 2)` — one
+full draft plus one full revision. An explicit value below that floor is rejected
+with the computed minimum in the message, because a 10,000-word report cannot be
+drafted and revised inside an 18,000-token reserve.
+
+Budget admission cannot stop workers already in flight, but the runtime's automatic
+active-chain cap bounds the overshoot. Do not respond to exhaustion with a blanket
+budget multiplier: inspect persisted artifacts, remove low-value optional work, and
+resume from the run ID so unchanged successful calls are reused.
+
+## Optional acquisition escalation
+
+Default `allow_acquisition_escalation` to `false`.
+
+Set it to `true` only for Extended/high-stakes or explicitly exhaustive work and
+provide one bounded `escalation` object:
+
+```json
+{
+  "kind": "browser",
+  "target": "Exact source URL",
+  "question": "The one conclusion-changing fact to recover"
+}
+```
+
+`kind` is `browser` or `local`. The workflow performs one attempt total. Browser
+requires an available Browser worker and, when overridden, a runtime-discovered
+vision-capable route. Local means one bounded read-only conversion/OCR investigation.
+Do not combine kinds or retry a failed escalation.
+
+## Results and materialization
+
+The workflow returns a compact object:
+
+```json
+{
+  "status": "complete | partial | failed",
+  "report_markdown": "Present for a single-draft report",
+  "report_plan": {
+    "title": "Report title",
+    "body_path": "<scratchpad>/deep-research/<run_slug>/report/body.md",
+    "section_paths": ["..."],
+    "assembled_word_count": 11500
+  },
+  "cited_sources": [{"id": "S001", "title": "...", "url": "..."}],
+  "source_registry": [{"id": "S001", "title": "...", "url": "..."}],
+  "gaps": ["Concise unresolved gap"],
+  "run_summary": {
+    "stage_plan": {"verification": "selective", "followup": "thesis_changing", "audit": "combined"},
+    "tier": "standard",
+    "base_lanes_requested": 4,
+    "base_lanes_completed": 4,
+    "verifier_calls": 4,
+    "eligible_claims": 12,
+    "selected_claims": 12,
+    "deferred_claims": 0,
+    "followups_run": 0,
+    "escalations_run": 0,
+    "draft_mode": "single | sections",
+    "section_outline_source": "coverage | derived | none",
+    "degraded_stages": [],
+    "target_words": 3000,
+    "assembled_word_count": 3120,
+    "expansion_passes": 0,
+    "dossiers": 4,
+    "workspace_enabled": true
+  }
+}
+```
+
+`degraded_stages` names any stage whose structured output was unusable. Structured
+output occasionally degenerates — for example collapsing every later field into the
+first string field — leaving a dict that passes an isinstance check while carrying
+none of the decisions the stage was asked for. The workflow checks the keys it
+actually acts on, discards such a record, records the stage here, and names it in
+`gaps`. It never proceeds as though the stage had simply chosen the default, because
+that silently loses a requested follow-up or a section outline.
+
+`section_outline_source` records where the drafting outline came from. When the
+target is 5,000 words or more and coverage supplied no usable outline, the workflow
+derives one from the lanes rather than forcing a long report through a single
+drafting call, and tells the assembly stage to rename and reorder those headings —
+lanes are evidence boundaries, not reader-facing argument boundaries.
+
+Either `report_markdown` or `report_plan` carries the report. A long, section-drafted
+report is assembled in a scratchpad file rather than squeezed through one
+schema-constrained JSON string, so `report_plan.body_path` is the authoritative
+text and `report_markdown` is empty. `source_registry` is always present so the
+bibliography can be rebuilt deterministically.
+
+`status` is `failed` only when no report exists at all — a failed drafting worker,
+or no claim set that can sustain a cited report. A drafted report with residual
+structural or material issues is returned as `partial` with those issues in `gaps`.
+
+Length is treated asymmetrically, because the two failures mean different things. A
+shortfall is owned by the expansion pass and reported in `gaps` without blocking
+delivery: an honest short report is still worth having. A report more than about
+1.35× the target is a material issue handed to the revision pass to tighten, and if
+it survives that pass the run is marked `partial` — it disregarded an explicit
+instruction it was asked to fix.
+
+Gaps in the result are written for the operator and may be numerous. Workers are
+instructed to phrase them for a reader, and the materializer sanitises and caps them
+before any of them reach the report.
+
+Raw scout, verifier, coverage, and audit outputs remain visible in normal workflow
+artifacts and are not copied into the final result.
+
+Run the materializer with the manifest's `resultPath`:
+
+```bash
+python skills/deep-research/scripts/materialize_report.py \
+  /path/to/workflow/result.md \
+  reports/topic.md \
+  --collision-safe
+```
+
+Use the available Python 3.11+ interpreter; do not assume the executable is literally
+`python`. Use `--overwrite` only when the user explicitly approved replacing the
+target.
+
+The materializer is the authoritative gate. It owns Markdown link extraction, URL
+identity, `## Sources` construction, and structural validation, and it reads
+`report_plan.body_path` when present. For a partial result it appends a
+`## Scope and gaps` section, first stripping internal lane and claim identifiers,
+dropping entries that are about research machinery rather than evidence, and capping
+the list so the report ends with a short disclosure instead of a research ledger. It
+warns when the delivered length departs materially from the target in either
+direction, and when any stage was degraded. It refuses to write anything for a
+`failed` result or an unreadable body file.
+
+## Resume and failure handling
+
+- Read `resultPath` first when inline workflow output is omitted.
+- Read `transcriptPath` only to diagnose stage failure or budget use.
+- Resume to reuse an unchanged successful prefix while narrowing later work.
+- The scratchpad path is stable for a session, so dossiers usually survive a
+  resume. If temp has been reclaimed, stages fall back to the inline records.
+- If some lanes failed, proceed only when the surviving supported evidence can
+  sustain an honest answer. The result is marked `partial` with the consequential
+  gaps named.
+- Never rerun a completed workflow solely to recover a long result from chat output.

--- a/kolega_code/_bundled_skills/skills/deep-research/scripts/deep-research.workflow
+++ b/kolega_code/_bundled_skills/skills/deep-research/scripts/deep-research.workflow
@@ -1,0 +1,2357 @@
+meta = {
+    "name": "deep-research",
+    "description": "Research disjoint lanes, adaptively verify claims, and produce a compact cited report",
+    "max_agent_depth": 1,
+    "phases": [
+        {"title": "Research"},
+        {"title": "Verify"},
+        {"title": "Coverage"},
+        {"title": "Draft"},
+        {"title": "Audit"},
+        {"title": "Revise"},
+    ],
+}
+
+# Claim-type classification. The enum is enforced by the schema so scouts cannot
+# invent a value that silently changes verification eligibility.
+CLAIM_TYPES = [
+    "attributed_report",
+    "external_fact",
+    "quantitative",
+    "causal",
+    "comparative",
+    "interpretation",
+]
+VERIFICATION_TRIGGERS = [
+    "known_dispute",
+    "source_access_uncertain",
+    "cross_source_conflict",
+    "scope_risk",
+    "high_stakes",
+]
+
+SCOUT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "lane_id": {"type": "string"},
+        "summary": {"type": "string"},
+        "dossier_path": {"type": "string"},
+        "sources": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "title": {"type": "string"},
+                    "url": {"type": "string"},
+                    "publisher": {"type": "string"},
+                    "date": {"type": "string"},
+                    "source_type": {"type": "string"},
+                },
+                "required": ["id", "title", "url"],
+            },
+        },
+        "evidence": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "claim": {"type": "string"},
+                    "source_id": {"type": "string"},
+                    "quote_or_paraphrase": {"type": "string"},
+                },
+                "required": ["id", "claim", "source_id", "quote_or_paraphrase"],
+            },
+        },
+        "candidate_claims": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "text": {"type": "string"},
+                    "evidence_ids": {"type": "array", "items": {"type": "string"}},
+                    "importance": {"type": "string"},
+                    "disputed": {"type": "boolean"},
+                    "claim_type": {"type": "string", "enum": CLAIM_TYPES},
+                    "verification_triggers": {
+                        "type": "array",
+                        "items": {"type": "string", "enum": VERIFICATION_TRIGGERS},
+                    },
+                },
+                "required": ["id", "text", "evidence_ids", "importance", "disputed"],
+            },
+        },
+        "failures": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "url": {"type": "string"},
+                    "reason": {"type": "string"},
+                    "terminal": {"type": "boolean"},
+                },
+                "required": ["url", "reason", "terminal"],
+            },
+        },
+        "gaps": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": [
+        "lane_id",
+        "summary",
+        "sources",
+        "evidence",
+        "candidate_claims",
+        "failures",
+        "gaps",
+    ],
+}
+
+VERIFIER_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "lane_id": {"type": "string"},
+        "summary": {"type": "string"},
+        "notes_path": {"type": "string"},
+        "verdicts": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "claim_id": {"type": "string"},
+                    "status": {
+                        "type": "string",
+                        "enum": ["supported", "qualified", "unsupported", "unresolved"],
+                    },
+                    "approved_evidence_ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "qualification": {"type": "string"},
+                },
+                "required": [
+                    "claim_id",
+                    "status",
+                    "approved_evidence_ids",
+                    "qualification",
+                ],
+            },
+        },
+        "rejected_evidence_ids": {"type": "array", "items": {"type": "string"}},
+        "new_sources": SCOUT_SCHEMA["properties"]["sources"],
+        "new_evidence": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "claim_id": {"type": "string"},
+                    "claim": {"type": "string"},
+                    "source_id": {"type": "string"},
+                    "quote_or_paraphrase": {"type": "string"},
+                },
+                "required": [
+                    "id",
+                    "claim_id",
+                    "claim",
+                    "source_id",
+                    "quote_or_paraphrase",
+                ],
+            },
+        },
+        "new_failures": SCOUT_SCHEMA["properties"]["failures"],
+        "gaps": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": [
+        "lane_id",
+        "summary",
+        "verdicts",
+        "rejected_evidence_ids",
+        "new_sources",
+        "new_evidence",
+        "new_failures",
+        "gaps",
+    ],
+}
+
+COVERAGE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "summary": {"type": "string"},
+        "followup_needed": {"type": "boolean"},
+        "decision_affected": {"type": "string"},
+        "followup_lane": {
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"},
+                "title": {"type": "string"},
+                "question": {"type": "string"},
+                "source_classes": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": ["id", "title", "question", "source_classes"],
+        },
+        "gaps": {"type": "array", "items": {"type": "string"}},
+        "section_drafting_needed": {"type": "boolean"},
+        "section_drafting_reason": {"type": "string"},
+        "section_outline": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "heading": {"type": "string"},
+                    "purpose": {"type": "string"},
+                    "claim_ids": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": ["heading", "purpose", "claim_ids"],
+            },
+        },
+    },
+    "required": [
+        "summary",
+        "followup_needed",
+        "decision_affected",
+        "gaps",
+        "section_drafting_needed",
+        "section_drafting_reason",
+        "section_outline",
+    ],
+}
+
+DRAFT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "title": {"type": "string"},
+        "body_markdown": {"type": "string"},
+        "gaps": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["title", "body_markdown", "gaps"],
+}
+
+SECTION_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "heading": {"type": "string"},
+        "body_markdown": {"type": "string"},
+        "used_claim_ids": {"type": "array", "items": {"type": "string"}},
+        "gaps": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["heading", "body_markdown", "used_claim_ids", "gaps"],
+}
+
+# File-mode section drafting: the body lives in the scratchpad, never in the
+# workflow return value.
+SECTION_FILE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "heading": {"type": "string"},
+        "section_path": {"type": "string"},
+        "word_count": {"type": "integer"},
+        "cited_urls": {"type": "array", "items": {"type": "string"}},
+        "used_claim_ids": {"type": "array", "items": {"type": "string"}},
+        "gaps": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["heading", "section_path", "word_count", "cited_urls", "used_claim_ids", "gaps"],
+}
+
+SEAMS_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "title": {"type": "string"},
+        "body_path": {"type": "string"},
+        "assembled_word_count": {"type": "integer"},
+        "cited_urls": {"type": "array", "items": {"type": "string"}},
+        "gaps": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["title", "body_path", "assembled_word_count", "cited_urls", "gaps"],
+}
+
+AUDIT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "revision_needed": {"type": "boolean"},
+        "material_issues": {"type": "array", "items": {"type": "string"}},
+        "minor_issues": {"type": "array", "items": {"type": "string"}},
+        "summary": {"type": "string"},
+    },
+    "required": ["revision_needed", "material_issues", "minor_issues", "summary"],
+}
+
+REVISION_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "title": {"type": "string"},
+        "body_markdown": {"type": "string"},
+        "remaining_material_issues": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["title", "body_markdown", "remaining_material_issues"],
+}
+
+REVISION_FILE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "title": {"type": "string"},
+        "body_path": {"type": "string"},
+        "assembled_word_count": {"type": "integer"},
+        "remaining_material_issues": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["title", "body_path", "assembled_word_count", "remaining_material_issues"],
+}
+
+CLOSURE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "supported": {"type": "boolean"},
+        "unresolved_material_issues": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["supported", "unresolved_material_issues"],
+}
+
+KNOWN_CLAIM_TYPES = set(CLAIM_TYPES)
+# Claim types whose form alone warrants a check, whatever their stated importance.
+ALWAYS_CHECK_TYPES = {"quantitative", "causal", "comparative"}
+TESTIMONY_TYPES = {"attributed_report", "interpretation"}
+RISK_TRIGGERS = {"high_stakes", "known_dispute"}
+SCOPE_TRIGGERS = {"cross_source_conflict", "scope_risk", "source_access_uncertain"}
+
+# Stage-plan mode constants
+VALID_VERIFICATION_MODES = {"risk_only", "selective", "required"}
+VALID_FOLLOWUP_MODES = {"off", "thesis_changing"}
+VALID_AUDIT_MODES = {"deterministic", "combined", "dual"}
+
+# Claim statuses. `refuted` is the only status excluded from drafting.
+VERDICT_STATUS = {
+    "supported": "verified",
+    "qualified": "qualified",
+    "unsupported": "refuted",
+    "unresolved": "contested",
+}
+
+# Query parameters that never identify a distinct document.
+TRACKING_PARAMS = {"gclid", "fbclid", "ref", "ref_src", "s", "share"}
+
+ROUTE_ROLES = ("discovery", "verification", "synthesis", "audit", "acquisition")
+
+MAX_CLAIMS_PER_VERIFIER_CALL = 8
+SHORTFALL_RATIO_NUMERATOR = 4
+SHORTFALL_RATIO_DENOMINATOR = 5
+# 1.35x the target: past this the report has stopped honoring the confirmed brief.
+OVERLENGTH_RATIO_NUMERATOR = 27
+OVERLENGTH_RATIO_DENOMINATOR = 20
+MAX_EXPANDED_SECTIONS = 3
+
+# Keys the workflow actually acts on. A worker whose structured output degenerates
+# can return a dict that satisfies "is a dict" while omitting the decisions the
+# stage exists to make; treat that as a stage failure instead of degrading quietly.
+COVERAGE_ACTED_ON_KEYS = (
+    "followup_needed",
+    "section_drafting_needed",
+    "section_outline",
+    "gaps",
+)
+
+READER_FACING_GAPS = (
+    "State every gap in reader-facing language: name the missing evidence and why it "
+    "matters. Never mention lane identifiers, claim or evidence IDs, worker roles, "
+    "or the structure of these records."
+)
+
+
+# ---------------------------------------------------------------------------
+# Deterministic text helpers
+#
+# canonical_url and markdown_urls mirror the authoritative implementations in
+# scripts/materialize_report.py. The copies here are advisory only: they feed
+# audit hints and telemetry, never a hard failure. tests/test_deep_research.py
+# asserts both implementations agree on a shared fixture corpus.
+# ---------------------------------------------------------------------------
+def canonical_url(value):
+    """Return a comparison key that preserves meaningful query parameters."""
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    text = text.split("#", 1)[0]
+    scheme = ""
+    rest = text
+    marker = text.find("://")
+    if marker >= 0:
+        scheme = text[:marker].lower()
+        rest = text[marker + 3 :]
+    query = ""
+    question = rest.find("?")
+    if question >= 0:
+        query = rest[question + 1 :]
+        rest = rest[:question]
+    slash = rest.find("/")
+    if slash >= 0:
+        host = rest[:slash].lower()
+        path = rest[slash:]
+    else:
+        host = rest.lower()
+        path = ""
+    if len(path) > 1 and path.endswith("/"):
+        path = path[:-1]
+    kept = []
+    for part in query.split("&"):
+        if not part:
+            continue
+        key = part.split("=", 1)[0].lower()
+        if key in TRACKING_PARAMS or key.startswith("utm_"):
+            continue
+        kept.append(part)
+    base = (scheme + "://" if scheme else "") + host + path
+    if kept:
+        return base + "?" + "&".join(sorted(kept))
+    return base
+
+
+def strip_fenced_code(text):
+    """Blank out fenced code blocks so their contents cannot look like citations."""
+    kept = []
+    in_fence = False
+    fence = ""
+    for line in str(text or "").split("\n"):
+        stripped = line.strip()
+        marker = ""
+        if stripped.startswith("```"):
+            marker = "```"
+        elif stripped.startswith("~~~"):
+            marker = "~~~"
+        if marker:
+            if in_fence:
+                if marker == fence:
+                    in_fence = False
+                    fence = ""
+            else:
+                in_fence = True
+                fence = marker
+            kept.append("")
+            continue
+        kept.append("" if in_fence else line)
+    return "\n".join(kept)
+
+
+def strip_inline_code(text):
+    """Drop inline code spans so `[a](b)` is not read as a citation."""
+    source = str(text or "")
+    length = len(source)
+    kept = []
+    index = 0
+    while index < length:
+        if source[index] == "`":
+            run = 0
+            while index + run < length and source[index + run] == "`":
+                run += 1
+            closing = source.find("`" * run, index + run)
+            if closing < 0:
+                index += run
+                continue
+            index = closing + run
+            continue
+        kept.append(source[index])
+        index += 1
+    return "".join(kept)
+
+
+def matching_bracket(text, start):
+    """Index of the `]` closing the `[` at `start`, or -1."""
+    depth = 0
+    index = start
+    length = len(text)
+    while index < length:
+        char = text[index]
+        if char == "[":
+            depth += 1
+        elif char == "]":
+            depth -= 1
+            if depth == 0:
+                return index
+        index += 1
+    return -1
+
+
+def link_destination(text, start):
+    """Parse a Markdown link destination, returning (destination, closing index)."""
+    length = len(text)
+    index = start
+    while index < length and text[index] in " \t\n":
+        index += 1
+    destination = ""
+    if index < length and text[index] == "<":
+        end = text.find(">", index + 1)
+        if end < 0:
+            return "", -1
+        destination = text[index + 1 : end]
+        index = end + 1
+    else:
+        depth = 0
+        chars = []
+        while index < length:
+            char = text[index]
+            if char in " \t\n":
+                break
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                if depth == 0:
+                    break
+                depth -= 1
+            chars.append(char)
+            index += 1
+        destination = "".join(chars)
+    while index < length and text[index] in " \t\n":
+        index += 1
+    if index < length and text[index] in ('"', "'", "("):
+        closer = ")" if text[index] == "(" else text[index]
+        end = text.find(closer, index + 1)
+        if end < 0:
+            return "", -1
+        index = end + 1
+        while index < length and text[index] in " \t\n":
+            index += 1
+    if index < length and text[index] == ")":
+        return destination.strip(), index
+    return "", -1
+
+
+def markdown_urls(markdown):
+    """Extract http(s) destinations from Markdown inline links, in order.
+
+    Skips fenced blocks, inline code, and images; honors balanced parentheses in
+    the destination and an optional link title; ignores non-http destinations.
+    """
+    text = strip_inline_code(strip_fenced_code(markdown))
+    length = len(text)
+    urls = []
+    index = 0
+    while index < length:
+        if text[index] != "[":
+            index += 1
+            continue
+        is_image = index > 0 and text[index - 1] == "!"
+        label_end = matching_bracket(text, index)
+        if label_end < 0 or label_end + 1 >= length or text[label_end + 1] != "(":
+            index += 1
+            continue
+        destination, close = link_destination(text, label_end + 2)
+        if close < 0:
+            index += 1
+            continue
+        if not is_image and destination:
+            lowered = destination.lower()
+            if lowered.startswith("http://") or lowered.startswith("https://"):
+                if destination not in urls:
+                    urls.append(destination)
+        index = close + 1
+    return urls
+
+
+def slugify(value, fallback):
+    """Deterministic filesystem-safe slug (no regex, no randomness)."""
+    allowed = "abcdefghijklmnopqrstuvwxyz0123456789"
+    chars = []
+    for char in str(value or "").strip().lower():
+        if char in allowed:
+            chars.append(char)
+        elif chars and chars[-1] != "-":
+            chars.append("-")
+    slug = "".join(chars).strip("-")
+    slug = slug[:48].strip("-")
+    return slug or fallback
+
+
+# ---------------------------------------------------------------------------
+# Routing and dispatch
+# ---------------------------------------------------------------------------
+def route_issues(candidate_routes):
+    """Validation errors for `args.routes`; malformed routes are never ignored."""
+    issues = []
+    if not isinstance(candidate_routes, dict):
+        return ["routes must be an object"]
+    for role in sorted(candidate_routes.keys()):
+        if role not in ROUTE_ROLES:
+            issues.append("routes." + str(role) + " is not a recognized stage role")
+            continue
+        value = candidate_routes[role]
+        if not isinstance(value, dict):
+            issues.append("routes." + role + " must be a complete route object")
+            continue
+        if set(value.keys()) != {"provider", "model", "effort"}:
+            issues.append(
+                "routes." + role + " must contain exactly provider, model, and effort"
+            )
+            continue
+        if not str(value.get("provider") or "").strip() or not str(value.get("model") or "").strip():
+            issues.append("routes." + role + " requires a non-empty provider and model")
+    return issues
+
+
+def route_for(role):
+    value = routes.get(role)
+    if not isinstance(value, dict):
+        return None
+    return value
+
+
+async def dispatch(prompt, label, phase_name, schema, role, agent_type="investigation"):
+    override = route_for(role)
+    if override is None:
+        return await agent(
+            prompt,
+            label=label,
+            phase=phase_name,
+            schema=schema,
+            agent_type=agent_type,
+        )
+    return await agent(
+        prompt,
+        label=label,
+        phase=phase_name,
+        schema=schema,
+        model_override=override,
+        agent_type=agent_type,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Evidence bookkeeping
+# ---------------------------------------------------------------------------
+def failure_entries(source):
+    entries = []
+    for failure in (source or {}).get("failures", []) or []:
+        entries.append(
+            {
+                "url": failure.get("url", ""),
+                "reason": failure.get("reason", ""),
+                "terminal": bool(failure.get("terminal", False)),
+            }
+        )
+    return entries
+
+
+def lane_failed_ledger(record):
+    """Deterministic per-lane ledger: only this lane's own failures.
+
+    Research and verification run as one pipeline with no barrier, so a
+    cross-lane ledger would make prompts depend on completion order and break
+    resume caching. The global ledger is assembled after the pipeline for the
+    follow-up and escalation stages.
+    """
+    ledger = {}
+    scout = (record or {}).get("scout") or {}
+    for failure in failure_entries(scout):
+        key = canonical_url(failure["url"])
+        if key and key not in ledger:
+            ledger[key] = failure
+    return [ledger[key] for key in sorted(ledger.keys())]
+
+
+def compact_failed_ledger(records):
+    ledger = {}
+    for record in records:
+        scout = (record or {}).get("scout") or {}
+        for failure in failure_entries(scout):
+            key = canonical_url(failure["url"])
+            if key and key not in ledger:
+                ledger[key] = failure
+        verifier = (record or {}).get("verification") or {}
+        for failure in verifier.get("new_failures", []) or []:
+            entry = {
+                "url": failure.get("url", ""),
+                "reason": failure.get("reason", ""),
+                "terminal": bool(failure.get("terminal", False)),
+            }
+            key = canonical_url(entry["url"])
+            if key and key not in ledger:
+                ledger[key] = entry
+    return [ledger[key] for key in sorted(ledger.keys())]
+
+
+def normalized_claim_type(claim):
+    """Lowercased known claim type, or "" when absent or unrecognized."""
+    raw = str((claim or {}).get("claim_type", "")).strip().lower()
+    return raw if raw in KNOWN_CLAIM_TYPES else ""
+
+
+def is_eligible_for_verification(claim, mode):
+    """Whether a claim should be sent to the verifier under the given mode.
+
+    Unrecognized claim types fail *open* to the conservative importance/dispute
+    heuristic, so a mislabeled claim can never silently skip verification. Only
+    the two testimony types opt out, and only when nothing else raises them.
+    """
+    claim_type = normalized_claim_type(claim)
+    triggers = set(
+        str(trigger).strip().lower() for trigger in (claim.get("verification_triggers") or [])
+    )
+    importance = str(claim.get("importance", "")).strip().lower()
+    disputed = bool(claim.get("disputed", False))
+    conclusion_driving = importance == "conclusion-driving"
+
+    if claim_type in TESTIMONY_TYPES and not disputed and not conclusion_driving:
+        return False
+
+    if mode == "risk_only":
+        return disputed or bool(triggers & RISK_TRIGGERS)
+
+    if not claim_type:
+        return conclusion_driving or disputed
+
+    return (
+        conclusion_driving
+        or disputed
+        or claim_type in ALWAYS_CHECK_TYPES
+        or bool(triggers & (RISK_TRIGGERS | SCOPE_TRIGGERS))
+    )
+
+
+def claim_priority_key(claim):
+    """Lower value = higher verification priority."""
+    triggers = set(
+        str(trigger).strip().lower() for trigger in (claim.get("verification_triggers") or [])
+    )
+    importance = str(claim.get("importance", "")).strip().lower()
+    claim_type = normalized_claim_type(claim)
+    if triggers & RISK_TRIGGERS:
+        return 0
+    if importance == "conclusion-driving" or claim_type in ALWAYS_CHECK_TYPES:
+        return 1
+    return 2
+
+
+def claim_index(claims):
+    """Claim list without evidence excerpts, for coverage and audit prompts."""
+    return [
+        {
+            "id": claim.get("id", ""),
+            "text": claim.get("text", ""),
+            "status": claim.get("status", ""),
+            "qualification": claim.get("qualification", ""),
+            "source_ids": claim.get("source_ids", []),
+        }
+        for claim in claims
+    ]
+
+
+def missing_stage_keys(value, required_keys):
+    """Required keys a stage result omitted or left null.
+
+    Structured output occasionally degenerates — for example collapsing every
+    later field into the first string field — leaving a dict that passes an
+    isinstance check but carries none of the decisions the stage was asked for.
+    """
+    if not isinstance(value, dict):
+        return sorted(required_keys)
+    return sorted(key for key in required_keys if value.get(key) is None)
+
+
+def derive_section_outline(records, claims):
+    """One reader-facing section per lane that produced citable claims.
+
+    Fallback only. Lanes are evidence boundaries rather than argument boundaries,
+    so the assembly stage is told to rename and reorder these headings. It exists
+    so that a long report is never forced through a single drafting call merely
+    because the coverage stage failed to return a usable outline.
+    """
+    by_lane = {}
+    for claim in claims:
+        lane_key = str(claim.get("id", "")).split("/", 1)[0]
+        by_lane.setdefault(lane_key, []).append(claim.get("id"))
+    outline = []
+    for record in records:
+        lane_key = record.get("lane_key", "")
+        claim_ids = by_lane.get(lane_key) or []
+        if not claim_ids:
+            continue
+        heading = (
+            str(record.get("lane_title", "")).strip()
+            or str(record.get("lane_id", "")).strip()
+            or lane_key
+        )
+        purpose = str(record.get("lane_question", "")).strip() or (
+            "Present the supported evidence gathered for " + heading + "."
+        )
+        outline.append({"heading": heading, "purpose": purpose, "claim_ids": claim_ids})
+    return outline
+
+
+def new_record(scout, lane_key, lane_id, dossier_path, lane_title="", lane_question=""):
+    return {
+        "lane_key": lane_key,
+        "lane_id": lane_id,
+        "lane_title": lane_title,
+        "lane_question": lane_question,
+        "scout": scout,
+        "verification": None,
+        "eligible_claim_ids": [],
+        "selected_claim_ids": [],
+        "deferred_claim_ids": [],
+        "verifier_failed": False,
+        "verifier_attempted": False,
+        "dossier_path": dossier_path,
+    }
+
+
+def budget_allows_optional(extra=0):
+    if budget.total is None:
+        return True
+    return budget.remaining() > writing_reserve + extra
+
+
+def build_registry(records):
+    """Build the source registry and claim list from all research records.
+
+    Sources are keyed by workflow-assigned lane identity, so a follow-up or
+    escalation worker cannot cross-wire evidence by reusing a base lane's id.
+    Verifier-added sources are admitted only when referenced by evidence approved
+    by a valid verdict for a claim selected in that same verifier call.
+    """
+    raw_sources = []
+    source_keys = {}
+    for record in records:
+        scout = record.get("scout") or {}
+        lane_key = record.get("lane_key", "lane")
+        for source in scout.get("sources", []):
+            key = canonical_url(source.get("url"))
+            if key:
+                raw_sources.append((key, lane_key, source))
+                source_keys[(lane_key, str(source.get("id", "")))] = key
+        verifier = record.get("verification") or {}
+        selected_claim_ids = set(str(claim_id) for claim_id in record.get("selected_claim_ids", []))
+        approved_new_evidence_ids = set()
+        verdicts = verifier.get("verdicts", [])
+        new_evidence = verifier.get("new_evidence", [])
+        for verdict in verdicts:
+            if str(verdict.get("status", "")) not in VERDICT_STATUS:
+                continue
+            verdict_claim_id = str(verdict.get("claim_id", ""))
+            if verdict_claim_id not in selected_claim_ids:
+                continue
+            approved_ids = set(str(eid) for eid in verdict.get("approved_evidence_ids", []))
+            for evidence_item in new_evidence:
+                evidence_id = str(evidence_item.get("id", ""))
+                if (
+                    evidence_id in approved_ids
+                    and str(evidence_item.get("claim_id", "")) == verdict_claim_id
+                ):
+                    approved_new_evidence_ids.add(evidence_id)
+        new_ev_by_source = {}
+        for ev in new_evidence:
+            sid = str(ev.get("source_id", ""))
+            if sid:
+                new_ev_by_source.setdefault(sid, set()).add(str(ev.get("id", "")))
+        for source in verifier.get("new_sources", []):
+            src_id = str(source.get("id", ""))
+            ev_ids_for_source = new_ev_by_source.get(src_id, set())
+            if ev_ids_for_source & approved_new_evidence_ids:
+                key = canonical_url(source.get("url"))
+                if key:
+                    raw_sources.append((key, lane_key, source))
+                    source_keys[(lane_key, src_id)] = key
+
+    by_url = {}
+    for key, lane_key, source in sorted(raw_sources, key=lambda item: (item[0], item[1])):
+        if key not in by_url:
+            by_url[key] = {
+                "title": str(source.get("title", "")).strip() or key,
+                "url": str(source.get("url", "")).strip(),
+                "publisher": str(source.get("publisher", "")).strip(),
+                "date": str(source.get("date", "")).strip(),
+                "source_type": str(source.get("source_type", "")).strip(),
+            }
+
+    registry = []
+    registry_ids = {}
+    for index, key in enumerate(sorted(by_url.keys()), 1):
+        card = dict(by_url[key])
+        card["id"] = "S" + str(index).zfill(3)
+        registry.append(card)
+        registry_ids[key] = card["id"]
+
+    claims = []
+    lane_summaries = []
+    all_gaps = []
+
+    for record in records:
+        scout = record.get("scout") or {}
+        verifier = record.get("verification") or {}
+        lane_key = record.get("lane_key", "lane")
+        selected_ids = set(str(cid) for cid in (record.get("selected_claim_ids") or []))
+        deferred_ids = set(str(cid) for cid in (record.get("deferred_claim_ids") or []))
+        verifier_failed = bool(record.get("verifier_failed", False))
+
+        lane_summaries.append(
+            {
+                "lane_id": lane_key,
+                "summary": verifier.get("summary") or scout.get("summary", ""),
+                "dossier_path": record.get("dossier_path", ""),
+            }
+        )
+        all_gaps.extend(scout.get("gaps", []))
+        all_gaps.extend(verifier.get("gaps", []))
+
+        verdicts = {str(item.get("claim_id", "")): item for item in verifier.get("verdicts", [])}
+        evidence = {item.get("id"): item for item in scout.get("evidence", [])}
+        for item in verifier.get("new_evidence", []):
+            evidence[item.get("id")] = item
+
+        for claim in scout.get("candidate_claims", []):
+            claim_id = str(claim.get("id", ""))
+            verdict = verdicts.get(claim_id)
+            qualification = ""
+
+            if claim_id in selected_ids:
+                if verifier_failed or not verdict:
+                    status = "unverified"
+                else:
+                    status = VERDICT_STATUS.get(str(verdict.get("status", "")), "unverified")
+                    qualification = str(verdict.get("qualification", ""))
+            elif claim_id in deferred_ids:
+                status = "unverified"
+            elif normalized_claim_type(claim) in TESTIMONY_TYPES:
+                status = "attributed"
+            else:
+                status = "single-source"
+
+            if verdict and verdict.get("approved_evidence_ids"):
+                approved_eids = verdict.get("approved_evidence_ids")
+            else:
+                approved_eids = claim.get("evidence_ids", [])
+
+            source_ids = []
+            excerpts = []
+            for eid in approved_eids:
+                ev_item = evidence.get(eid) or {}
+                source_key = source_keys.get((lane_key, str(ev_item.get("source_id", ""))))
+                if source_key and source_key in registry_ids:
+                    source_ids.append(registry_ids[source_key])
+                excerpt = ev_item.get("quote_or_paraphrase")
+                if excerpt:
+                    excerpts.append(str(excerpt))
+
+            if source_ids:
+                claims.append(
+                    {
+                        "id": lane_key + "/" + claim_id,
+                        "text": claim.get("text", ""),
+                        "status": status,
+                        "qualification": qualification,
+                        "source_ids": sorted(set(source_ids)),
+                        "evidence": excerpts,
+                        "dossier_path": record.get("dossier_path", ""),
+                    }
+                )
+
+    return (
+        registry,
+        claims,
+        lane_summaries,
+        sorted(set(str(gap) for gap in all_gaps if gap)),
+    )
+
+
+def strip_sources(markdown):
+    lines = str(markdown or "").strip().splitlines()
+    kept = []
+    for line in lines:
+        if line.strip().lower() == "## sources":
+            break
+        kept.append(line)
+    if kept and kept[0].startswith("# "):
+        kept = kept[1:]
+    return "\n".join(kept).strip()
+
+
+def structural_issues(markdown):
+    issues = []
+    text = str(markdown or "").strip()
+    if not text.startswith("# "):
+        issues.append("missing level-one title")
+    if text.count("\n## Sources\n") != 1:
+        issues.append("report must contain exactly one Sources section")
+    lines = text.splitlines()
+    headings = []
+    for index, line in enumerate(lines):
+        if line.startswith("## "):
+            key = line.strip().lower()
+            if key in headings:
+                issues.append("duplicate heading: " + line.strip())
+            headings.append(key)
+            next_index = index + 1
+            has_content = False
+            while next_index < len(lines) and not lines[next_index].startswith("## "):
+                if lines[next_index].strip():
+                    has_content = True
+                    break
+                next_index += 1
+            if not has_content:
+                issues.append("empty section: " + line.strip())
+    return issues
+
+
+def assemble_report(draft, registry):
+    """Assemble an inline draft into a cited report. Issues are advisory."""
+    title = str((draft or {}).get("title", "")).strip().lstrip("#").strip()
+    body = strip_sources((draft or {}).get("body_markdown", ""))
+    by_url = {canonical_url(source.get("url")): source for source in registry}
+    cited = []
+    unknown = []
+    for url in markdown_urls(body):
+        key = canonical_url(url)
+        if key in by_url:
+            if key not in cited:
+                cited.append(key)
+        else:
+            unknown.append(url)
+    source_lines = []
+    cited_sources = []
+    for key in cited:
+        source = by_url[key]
+        detail = source.get("publisher") or source.get("source_type") or ""
+        if source.get("date"):
+            detail = (detail + ", " + source.get("date")).strip(", ")
+        suffix = " — " + detail if detail else ""
+        source_lines.append(
+            "- [" + source.get("title", key) + "](" + source.get("url", key) + ")" + suffix
+        )
+        cited_sources.append(source)
+    report = "# " + title + "\n\n" + body + "\n\n## Sources\n\n" + "\n".join(source_lines)
+    issues = []
+    if not title:
+        issues.append("missing report title")
+    if not body:
+        issues.append("missing report body")
+    if not cited_sources:
+        issues.append("report body cites no registry source")
+    if unknown:
+        issues.append("unknown citation URLs: " + repr(unknown))
+    issues.extend(structural_issues(report))
+    return report.strip() + "\n", cited_sources, issues
+
+
+def word_count(text):
+    return len(str(text or "").split())
+
+
+# ---------------------------------------------------------------------------
+# Telemetry accumulators (initialized before validation so every return path
+# can use one summary helper)
+# ---------------------------------------------------------------------------
+stages_run = []
+stages_skipped = []
+degraded_stages = []
+research_records = []
+partial_reasons = []
+draft_mode = "single"
+section_outline_source = "none"
+followups_run = 0
+escalations_run = 0
+expansion_passes = 0
+base_lanes_completed = 0
+assembled_words = 0
+dossier_count = 0
+
+# ---------------------------------------------------------------------------
+# Argument validation
+# ---------------------------------------------------------------------------
+validation_errors = []
+if not isinstance(args, dict):
+    validation_errors.append("args must be an object")
+brief = args.get("brief", {}) if isinstance(args, dict) else {}
+tier = args.get("tier", "") if isinstance(args, dict) else ""
+lanes = args.get("lanes", []) if isinstance(args, dict) else []
+acquisition = args.get("acquisition", {}) if isinstance(args, dict) else {}
+report_profile = args.get("report_profile", {}) if isinstance(args, dict) else {}
+routes = args.get("routes", {}) if isinstance(args, dict) else {}
+intake = args.get("intake", {}) if isinstance(args, dict) else {}
+workspace = args.get("workspace") if isinstance(args, dict) else None
+
+lane_ranges = {"focused": (2, 2), "standard": (3, 4), "extended": (5, 6)}
+tier_caps = {"focused": (4, 6), "standard": (6, 8), "extended": (8, 12)}
+if not isinstance(brief, dict) or not str(brief.get("question", "")).strip():
+    validation_errors.append("brief.question is required")
+if not isinstance(brief, dict) or not str(brief.get("audience", "")).strip():
+    validation_errors.append("brief.audience is required")
+if not isinstance(brief, dict) or not str(brief.get("scope", "")).strip():
+    validation_errors.append("brief.scope is required")
+if not isinstance(brief, dict) or not str(brief.get("current_as_of", "")).strip():
+    validation_errors.append("brief.current_as_of is required; workers have no clock")
+if tier not in lane_ranges:
+    validation_errors.append("tier must be focused, standard, or extended")
+if not isinstance(lanes, list):
+    validation_errors.append("lanes must be an array")
+elif tier in lane_ranges:
+    minimum, maximum = lane_ranges[tier]
+    if len(lanes) < minimum or len(lanes) > maximum:
+        validation_errors.append(
+            tier
+            + " requires "
+            + str(minimum)
+            + ("-" + str(maximum) if minimum != maximum else "")
+            + " lanes"
+        )
+lane_ids = []
+for lane in lanes if isinstance(lanes, list) else []:
+    if not isinstance(lane, dict):
+        validation_errors.append("every lane must be an object")
+        continue
+    lane_id = str(lane.get("id", "")).strip()
+    if not lane_id or not str(lane.get("question", "")).strip():
+        validation_errors.append("every lane requires id and question")
+    if lane_id in lane_ids:
+        validation_errors.append("lane ids must be unique")
+    lane_ids.append(lane_id)
+
+default_searches, default_fetches = tier_caps.get(tier, (0, 0))
+searches_per_lane = acquisition.get("searches_per_lane", default_searches)
+fetches_per_lane = acquisition.get("fetches_per_lane", default_fetches)
+verification_searches = acquisition.get("verification_searches", 2)
+verification_fetches = acquisition.get("verification_fetches", 4)
+if (
+    not isinstance(searches_per_lane, int)
+    or searches_per_lane < 0
+    or searches_per_lane > default_searches
+):
+    validation_errors.append("searches_per_lane exceeds the tier ceiling")
+if (
+    not isinstance(fetches_per_lane, int)
+    or fetches_per_lane < 0
+    or fetches_per_lane > default_fetches
+):
+    validation_errors.append("fetches_per_lane exceeds the tier ceiling")
+if not isinstance(verification_searches, int) or verification_searches < 0:
+    validation_errors.append("verification_searches must be a nonnegative integer")
+if not isinstance(verification_fetches, int) or verification_fetches < 0:
+    validation_errors.append("verification_fetches must be a nonnegative integer")
+length_preset = report_profile.get("length", "") if isinstance(report_profile, dict) else ""
+target_words = report_profile.get("target_words") if isinstance(report_profile, dict) else None
+length_targets = {"concise": 1500, "standard": 3000, "detailed": 6000}
+if length_preset not in ("concise", "standard", "detailed", "long", "custom"):
+    validation_errors.append(
+        "report_profile.length must be concise, standard, detailed, long, or custom"
+    )
+if not isinstance(target_words, int) or isinstance(target_words, bool) or target_words < 500:
+    validation_errors.append("report_profile.target_words must be an integer of at least 500")
+elif length_preset in length_targets and target_words != length_targets[length_preset]:
+    validation_errors.append(
+        "report_profile.target_words does not match the selected length preset"
+    )
+elif length_preset == "long" and target_words < 10000:
+    validation_errors.append("report_profile.long requires at least 10000 target words")
+
+validation_errors.extend(route_issues(routes))
+
+required_intake_fields = {"length", "audience_use", "scope", "delivery"}
+topic_questions_asked = 0
+if not isinstance(intake, dict):
+    validation_errors.append("intake must be an object")
+else:
+    intake_mode = intake.get("mode")
+    intake_confirmed = intake.get("confirmed")
+    resolved_fields = intake.get("resolved_fields")
+    asked = intake.get("topic_questions_asked", 0)
+    if intake_mode not in ("interactive", "user_directed_defaults"):
+        validation_errors.append("intake.mode must be interactive or user_directed_defaults")
+    if intake_mode == "interactive" and intake_confirmed is not True:
+        validation_errors.append("interactive intake must be confirmed")
+    if not isinstance(resolved_fields, list) or not required_intake_fields.issubset(
+        set(str(field) for field in resolved_fields)
+    ):
+        validation_errors.append(
+            "intake.resolved_fields must include length, audience_use, scope, and delivery"
+        )
+    # Caller-asserted and unverifiable: recorded for telemetry, never a hard gate.
+    if isinstance(asked, int) and not isinstance(asked, bool) and asked >= 0:
+        topic_questions_asked = asked
+    else:
+        validation_errors.append("intake.topic_questions_asked must be a nonnegative integer")
+
+# Scratchpad workspace (optional). Absent means inline-only operation.
+scratchpad_root = ""
+run_slug = ""
+if workspace is not None:
+    if not isinstance(workspace, dict):
+        validation_errors.append("workspace must be an object")
+    else:
+        scratchpad_dir = str(workspace.get("scratchpad_dir", "")).strip()
+        run_slug = str(workspace.get("run_slug", "")).strip()
+        absolute = scratchpad_dir.startswith("/") or (
+            len(scratchpad_dir) > 2
+            and scratchpad_dir[1] == ":"
+            and scratchpad_dir[2] in ("/", "\\")
+        )
+        if not scratchpad_dir or not absolute:
+            validation_errors.append("workspace.scratchpad_dir must be an absolute path")
+        slug_allowed = "abcdefghijklmnopqrstuvwxyz0123456789-"
+        slug_valid = (
+            1 <= len(run_slug) <= 64
+            and run_slug[0] in "abcdefghijklmnopqrstuvwxyz0123456789"
+            and all(char in slug_allowed for char in run_slug)
+        )
+        if not slug_valid:
+            validation_errors.append(
+                "workspace.run_slug must be 1-64 lowercase alphanumeric or hyphen characters "
+                "starting with a letter or digit"
+            )
+        if absolute and slug_valid:
+            scratchpad_root = scratchpad_dir.rstrip("/") + "/deep-research/" + run_slug
+
+use_workspace = bool(scratchpad_root)
+
+# The writing reserve must cover one full draft plus one full revision.
+required_reserve = 18000
+if isinstance(target_words, int) and not isinstance(target_words, bool) and target_words > 0:
+    required_reserve = max(18000, ((target_words * 14) // 10) * 2)
+writing_reserve = args.get("writing_reserve_tokens", required_reserve) if isinstance(args, dict) else required_reserve
+if not isinstance(writing_reserve, int) or isinstance(writing_reserve, bool) or writing_reserve < 0:
+    validation_errors.append("writing_reserve_tokens must be a nonnegative integer")
+    writing_reserve = required_reserve
+elif writing_reserve < required_reserve:
+    validation_errors.append(
+        "writing_reserve_tokens must be at least " + str(required_reserve) + " for this target length"
+    )
+if isinstance(args, dict) and "research_batch_size" in args:
+    validation_errors.append(
+        "research_batch_size is no longer supported; lanes run as one pipeline and "
+        "concurrency is capped by the runtime"
+    )
+
+# ---------------------------------------------------------------------------
+# Stage-plan parsing (optional; defaults: selective + thesis_changing + combined)
+# ---------------------------------------------------------------------------
+stage_plan_arg = args.get("stage_plan", {}) if isinstance(args, dict) else {}
+if not isinstance(stage_plan_arg, dict):
+    stage_plan_arg = {}
+
+verification_mode = str(stage_plan_arg.get("verification", "selective")).strip() or "selective"
+followup_mode = str(stage_plan_arg.get("followup", "thesis_changing")).strip() or "thesis_changing"
+audit_mode = str(stage_plan_arg.get("audit", "combined")).strip() or "combined"
+plan_reason = str(stage_plan_arg.get("reason", "")).strip()
+
+if verification_mode not in VALID_VERIFICATION_MODES:
+    validation_errors.append("stage_plan.verification must be risk_only, selective, or required")
+    verification_mode = "selective"
+if followup_mode not in VALID_FOLLOWUP_MODES:
+    validation_errors.append("stage_plan.followup must be off or thesis_changing")
+    followup_mode = "thesis_changing"
+if audit_mode not in VALID_AUDIT_MODES:
+    validation_errors.append("stage_plan.audit must be deterministic, combined, or dual")
+    audit_mode = "combined"
+
+resolved_plan = {
+    "verification": verification_mode,
+    "followup": followup_mode,
+    "audit": audit_mode,
+    "reason": plan_reason,
+}
+
+high_stakes = bool(brief.get("high_stakes", False)) if isinstance(brief, dict) else False
+
+
+def make_summary():
+    """One authoritative telemetry snapshot, used by every return path."""
+    eligible = sum(len(r.get("eligible_claim_ids", [])) for r in research_records)
+    selected = sum(len(r.get("selected_claim_ids", [])) for r in research_records)
+    deferred = sum(len(r.get("deferred_claim_ids", [])) for r in research_records)
+    verifier_calls = sum(1 for r in research_records if r.get("verifier_attempted"))
+    skipped_no_eligible = sum(1 for r in research_records if not r.get("eligible_claim_ids"))
+    verdict_counts = {}
+    for record in research_records:
+        for verdict in (record.get("verification") or {}).get("verdicts", []):
+            status = str(verdict.get("status", "unknown"))
+            verdict_counts[status] = verdict_counts.get(status, 0) + 1
+    return {
+        "stage_plan": resolved_plan,
+        "stages_run": stages_run,
+        "stages_skipped": stages_skipped,
+        "degraded_stages": degraded_stages,
+        "section_outline_source": section_outline_source,
+        "eligible_claims": eligible,
+        "selected_claims": selected,
+        "deferred_claims": deferred,
+        "verifier_calls": verifier_calls,
+        "lanes_skipped_no_eligible": skipped_no_eligible,
+        "verifier_verdict_counts": verdict_counts,
+        "tier": tier or "unknown",
+        "base_lanes_requested": len(lanes) if isinstance(lanes, list) else 0,
+        "base_lanes_completed": base_lanes_completed,
+        "followups_run": followups_run,
+        "escalations_run": escalations_run,
+        "draft_mode": draft_mode,
+        "topic_questions_asked": topic_questions_asked,
+        "target_words": target_words if isinstance(target_words, int) else 0,
+        "assembled_word_count": assembled_words,
+        "expansion_passes": expansion_passes,
+        "dossiers": dossier_count,
+        "workspace_enabled": use_workspace,
+    }
+
+
+if validation_errors:
+    return {
+        "status": "failed",
+        "report_markdown": "",
+        "report_plan": None,
+        "cited_sources": [],
+        "source_registry": [],
+        "gaps": validation_errors,
+        "run_summary": make_summary(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Scratchpad paths (deterministic; derived only from run_slug and lane identity)
+# ---------------------------------------------------------------------------
+def lane_dossier_path(lane_key):
+    if not use_workspace:
+        return ""
+    return scratchpad_root + "/lanes/" + lane_key + ".md"
+
+
+def lane_notes_path(lane_key):
+    if not use_workspace:
+        return ""
+    return scratchpad_root + "/lanes/" + lane_key + ".verify.md"
+
+
+def section_file_path(index, heading):
+    return (
+        scratchpad_root
+        + "/sections/"
+        + str(index + 1).zfill(2)
+        + "-"
+        + slugify(heading, "section")
+        + ".md"
+    )
+
+
+REPORT_BODY_PATH = scratchpad_root + "/report/body.md" if use_workspace else ""
+
+WRITE_INSTRUCTIONS = (
+    "Write the file with a shell heredoc so nothing is interpolated, for example: "
+    "mkdir -p <parent directory> && cat > <path> <<'DOSSIER'\\n...content...\\nDOSSIER\\n"
+    "Use exec_command for this; do not assume any other write tool is available. "
+    "If the write fails, continue and return your compact record without the path."
+)
+
+READ_INSTRUCTIONS = (
+    "Read the referenced files with read_file_section (preferred) or read_entire_file "
+    "using the absolute paths given. If a file is missing or unreadable, continue from "
+    "the inline records below and note the degradation in your gaps."
+)
+
+
+def dossier_instruction(lane_key):
+    if not use_workspace:
+        return ""
+    return (
+        "\n\nEVIDENCE DOSSIER (required): before returning, write your full-fidelity "
+        "working notes to "
+        + lane_dossier_path(lane_key)
+        + " and set dossier_path to that path. The dossier is where depth belongs: for "
+        "every source record full bibliographic metadata, access status, and generous "
+        "verbatim quotations with enough surrounding context that a later stage can judge "
+        "directness and scope without refetching. Also record leads you rejected and why, "
+        "and the detail behind every failed acquisition. "
+        + WRITE_INSTRUCTIONS
+    )
+
+
+def research_prompt(lane, lane_key, searches, fetches, special_instruction=""):
+    return (
+        "Research only this disjoint lane for the settled brief.\n\n"
+        "BRIEF: "
+        + repr(brief)
+        + "\nLANE: "
+        + repr(lane)
+        + "\nREPORT PROFILE: "
+        + repr(report_profile)
+        + "\n\nACQUISITION CEILING: at most "
+        + str(searches)
+        + " materially different searches and "
+        + str(fetches)
+        + " fetches. These are ceilings, not quotas; stop as soon as material "
+        "claims are adequately supported. Never repeat a query. Retry a transient "
+        "timeout once only. Treat access denial, 403/404, login/paywall, robots, "
+        "certificate failure, unsupported/oversized content, and scanned/no-text "
+        "content as terminal for that URL. Do not vary URL syntax to retry. Try at "
+        "most one obvious accessible equivalent for a conclusion-driving source. "
+        "Do not use browser automation, downloading, conversion, or OCR. "
+        + special_instruction
+        + "\n\nReturn a compact record only. Use atomic evidence and lane-local IDs. "
+        "Do not include fetched full text, search transcripts, prose bibliography, "
+        "or process narration."
+        "\n\nClassify each candidate claim with claim_type (one of "
+        + ", ".join(CLAIM_TYPES)
+        + ") and verification_triggers (any of "
+        + ", ".join(VERIFICATION_TRIGGERS)
+        + ") where applicable. Use only these exact values; an unrecognized value is "
+        "rejected by the schema.\n\n"
+        + READER_FACING_GAPS
+        + dossier_instruction(lane_key)
+    )
+
+
+def verification_prompt(record, selected_claims, failed_ledger, extra=""):
+    """Verifier prompt carrying only what the verifier needs, plus the dossier path."""
+    scout = record.get("scout") or {}
+    lane_key = record.get("lane_key", "lane")
+    selected_ids = set(str(claim.get("id", "")) for claim in selected_claims)
+    wanted_evidence_ids = set()
+    for claim in selected_claims:
+        for eid in claim.get("evidence_ids", []) or []:
+            wanted_evidence_ids.add(str(eid))
+    evidence_for_claims = [
+        item
+        for item in scout.get("evidence", [])
+        if str(item.get("id", "")) in wanted_evidence_ids
+    ]
+    wanted_source_ids = set(str(item.get("source_id", "")) for item in evidence_for_claims)
+    sources_for_claims = [
+        source
+        for source in scout.get("sources", [])
+        if str(source.get("id", "")) in wanted_source_ids
+    ]
+    dossier = record.get("dossier_path", "")
+    dossier_block = ""
+    if dossier:
+        dossier_block = (
+            "\nLANE DOSSIER: "
+            + dossier
+            + "\n"
+            + READ_INSTRUCTIONS
+            + " Read the dossier sections covering the selected claims before judging "
+            "directness, scope, and date fitness."
+        )
+        if use_workspace:
+            dossier_block += (
+                " Write your own working notes to "
+                + lane_notes_path(lane_key)
+                + " and set notes_path. "
+                + WRITE_INSTRUCTIONS
+            )
+    return (
+        "Verify only the selected candidate claims listed below. "
+        "Do not re-research background claims or broadly re-fetch the lane's "
+        "sources. Return a delta; never echo the scout record.\n\nBRIEF: "
+        + repr(brief)
+        + "\nLANE: "
+        + lane_key
+        + "\nLANE SUMMARY: "
+        + repr(str(scout.get("summary", "")))
+        + "\nSELECTED CLAIMS: "
+        + repr(selected_claims)
+        + "\nEVIDENCE FOR SELECTED CLAIMS: "
+        + repr(evidence_for_claims)
+        + "\nSOURCES FOR SELECTED CLAIMS: "
+        + repr(sources_for_claims)
+        + "\nKNOWN FAILED ACQUISITIONS: "
+        + repr(failed_ledger)
+        + dossier_block
+        + "\n\nDo not retry any terminal URL or equivalent access strategy in the "
+        "failed ledger. Use at most "
+        + str(verification_searches)
+        + " materially different searches and "
+        + str(verification_fetches)
+        + " fetches. Never use OCR or conversion. Seek independent support only "
+        "where it can affect the answer. Verdict status must be supported, "
+        "qualified, unsupported, or unresolved. New records contain only genuinely "
+        "new evidence tied to a verdict. Report only claim IDs from SELECTED CLAIMS; "
+        "ignore anything else. Selected IDs: "
+        + repr(sorted(selected_ids))
+        + "\n\n"
+        + READER_FACING_GAPS
+        + extra
+    )
+
+
+def select_claims(record, mode):
+    """Assign eligible / selected / deferred claim IDs for one record."""
+    candidate_claims = (record.get("scout") or {}).get("candidate_claims", []) or []
+    eligible = [claim for claim in candidate_claims if is_eligible_for_verification(claim, mode)]
+    record["eligible_claim_ids"] = [str(claim.get("id", "")) for claim in eligible]
+    ordered = sorted(eligible, key=claim_priority_key)
+    record["selected_claim_ids"] = [
+        str(claim.get("id", "")) for claim in ordered[:MAX_CLAIMS_PER_VERIFIER_CALL]
+    ]
+    record["deferred_claim_ids"] = [
+        str(claim.get("id", "")) for claim in ordered[MAX_CLAIMS_PER_VERIFIER_CALL:]
+    ]
+    return ordered
+
+
+def selected_claim_objects(record):
+    selected = set(record.get("selected_claim_ids", []))
+    return [
+        claim
+        for claim in (record.get("scout") or {}).get("candidate_claims", []) or []
+        if str(claim.get("id", "")) in selected
+    ]
+
+
+async def verify_record(record, label, failed_ledger, extra=""):
+    """Run one verifier call for a record that has selected claims."""
+    record["verifier_attempted"] = True
+    verification = await dispatch(
+        verification_prompt(record, selected_claim_objects(record), failed_ledger, extra),
+        label,
+        "Verify",
+        VERIFIER_SCHEMA,
+        "verification",
+    )
+    if verification is None:
+        record["verifier_failed"] = True
+        return False
+    record["verification"] = verification
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Research and verification: one pipeline, no barrier between the stages
+# ---------------------------------------------------------------------------
+phase("Research")
+stages_run.append("Research")
+
+indexed_lanes = [
+    {"index": index, "lane": lane, "lane_key": "lane-" + str(index + 1)}
+    for index, lane in enumerate(lanes)
+]
+
+
+# Both stages take the full (previous result, original item, index) signature the
+# runtime supplies to a pipeline stage.
+async def scout_stage(item, original, index):
+    lane = item["lane"]
+    return await dispatch(
+        research_prompt(lane, item["lane_key"], searches_per_lane, fetches_per_lane),
+        "scout:" + str(lane.get("id")),
+        "Research",
+        SCOUT_SCHEMA,
+        "discovery",
+    )
+
+
+async def verify_stage(scout, item, index):
+    if scout is None:
+        return None
+    lane_key = item["lane_key"]
+    reported_path = str(scout.get("dossier_path", "")).strip()
+    record = new_record(
+        scout,
+        lane_key,
+        str(item["lane"].get("id", "")),
+        reported_path,
+        str(item["lane"].get("title", "")),
+        str(item["lane"].get("question", "")),
+    )
+    select_claims(record, verification_mode)
+    if record["selected_claim_ids"] and budget_allows_optional():
+        await verify_record(record, "verify:" + str(item["lane"].get("id")), lane_failed_ledger(record))
+    elif record["eligible_claim_ids"]:
+        record["deferred_claim_ids"] = list(record["eligible_claim_ids"])
+        record["selected_claim_ids"] = []
+    return record
+
+
+research_ran = budget_allows_optional()
+if research_ran:
+    pipeline_records = await pipeline(indexed_lanes, scout_stage, verify_stage)
+else:
+    partial_reasons.append("research did not start; the writing and audit reserve was exhausted")
+    pipeline_records = [None for _ in indexed_lanes]
+
+for item, record in zip(indexed_lanes, pipeline_records):
+    if record is None:
+        if research_ran:
+            partial_reasons.append("research worker failed for " + str(item["lane"].get("id")))
+    else:
+        research_records.append(record)
+
+if any(record.get("verifier_attempted") for record in research_records):
+    stages_run.append("Verify")
+else:
+    stages_skipped.append("Verify")
+
+base_lanes_completed = len(research_records)
+
+# ---------------------------------------------------------------------------
+# Acquisition escalation (optional, one attempt total)
+# ---------------------------------------------------------------------------
+escalation = args.get("escalation")
+allow_escalation = bool(args.get("allow_acquisition_escalation", False))
+if (
+    allow_escalation
+    and (tier == "extended" or high_stakes)
+    and isinstance(escalation, dict)
+    and escalation.get("kind") in ("browser", "local")
+    and escalation.get("target")
+    and escalation.get("question")
+    and budget_allows_optional()
+):
+    kind = escalation.get("kind")
+    escalation_prompt = (
+        "Perform one bounded acquisition escalation for an irreplaceable source. "
+        "Make exactly one "
+        + str(kind)
+        + " attempt against "
+        + str(escalation.get("target"))
+        + ". Answer only this question: "
+        + str(escalation.get("question"))
+        + ". Do not try another URL, mirror, method, conversion, browser path, or OCR "
+        "engine. Stop after success or failure. Return the same compact source, atomic "
+        "evidence, candidate-claim, failure, and gap record used by a research lane. "
+        "Do not include full fetched text, a search transcript, or process narration."
+        + dossier_instruction("escalation-1")
+    )
+    esc_scout = await dispatch(
+        escalation_prompt,
+        "escalation:" + str(kind),
+        "Research",
+        SCOUT_SCHEMA,
+        "acquisition",
+        "browser" if kind == "browser" else "investigation",
+    )
+    escalations_run = 1
+    if esc_scout is None:
+        partial_reasons.append("the single acquisition escalation failed")
+    else:
+        esc_record = new_record(
+            esc_scout,
+            "escalation-1",
+            "acquisition-escalation",
+            str(esc_scout.get("dossier_path", "")).strip(),
+            "The escalated source",
+            str(escalation.get("question", "")),
+        )
+        select_claims(esc_record, verification_mode)
+        if esc_record["selected_claim_ids"] and budget_allows_optional():
+            esc_ok = await verify_record(
+                esc_record,
+                "verify:acquisition-escalation",
+                compact_failed_ledger(research_records + [esc_record]),
+                "\nDo not reacquire the escalation target; assess the returned "
+                "evidence and seek ordinary independent support only if essential.",
+            )
+            if not esc_ok:
+                partial_reasons.append("the acquisition escalation could not be verified")
+        elif esc_record["eligible_claim_ids"]:
+            esc_record["deferred_claim_ids"] = list(esc_record["eligible_claim_ids"])
+            esc_record["selected_claim_ids"] = []
+        research_records.append(esc_record)
+
+# First registry build (for coverage's lane summaries and claim index)
+registry, all_claims, lane_summaries, evidence_gaps = build_registry(research_records)
+
+# ---------------------------------------------------------------------------
+# Coverage phase (only when it can change something)
+# ---------------------------------------------------------------------------
+required_structure = (
+    report_profile.get("required_structure", []) if isinstance(report_profile, dict) else []
+)
+followup_possible = followup_mode == "thesis_changing" and tier != "focused"
+run_coverage = (
+    followup_possible
+    or target_words >= 5000
+    or (isinstance(required_structure, list) and len(required_structure) >= 2)
+)
+
+coverage = None
+if run_coverage and research_records:
+    phase("Coverage")
+    stages_run.append("Coverage")
+    coverage = await dispatch(
+        "Assess whether one bounded follow-up could change the thesis or recommendation. "
+        "Do not research. Focused work must not request a follow-up. A Standard or "
+        "Extended follow-up must identify the exact decision affected and one narrow, "
+        "non-overlapping lane. Return followup_needed=false for merely useful context. "
+        "Also decide the reader-facing drafting shape. Section drafting is warranted "
+        "for a target of roughly 5000 words or more, or for a shorter report only when "
+        "at least two genuinely independent sections have distinct supported claim sets. "
+        "Research lanes alone are not a reason. Return a compact section outline with "
+        "purpose and claim IDs when sections are warranted; otherwise return an empty "
+        "outline.\n\n"
+        "BRIEF: "
+        + repr(brief)
+        + "\nTIER: "
+        + tier
+        + "\nTARGET WORDS: "
+        + str(target_words)
+        + "\nREPORT PROFILE: "
+        + repr(report_profile)
+        + "\nSUPPORTED LANE SUMMARIES: "
+        + repr(lane_summaries)
+        + "\nCLAIM INDEX: "
+        + repr(claim_index(all_claims))
+        + "\nGAPS: "
+        + repr(evidence_gaps)
+        + "\nFAILED ACQUISITIONS: "
+        + repr(compact_failed_ledger(research_records))
+        + ("\n" + READ_INSTRUCTIONS if use_workspace else "")
+        + "\n\n"
+        + READER_FACING_GAPS
+        + "\n\nReturn every field of the schema as its own value. Do not pack later "
+        "fields into the summary text; a record missing followup_needed, "
+        "section_drafting_needed, section_outline, or gaps is discarded.",
+        "coverage",
+        "Coverage",
+        COVERAGE_SCHEMA,
+        "audit",
+    )
+    coverage_missing = missing_stage_keys(coverage, COVERAGE_ACTED_ON_KEYS) if coverage else []
+    if coverage_missing:
+        # Loud, not silent: the follow-up and drafting-shape decisions are lost.
+        degraded_stages.append("Coverage")
+        partial_reasons.append(
+            "the coverage stage returned an unusable record (missing "
+            + ", ".join(coverage_missing)
+            + "), so its follow-up and section decisions were discarded"
+        )
+        coverage = None
+else:
+    stages_skipped.append("Coverage")
+
+# ---------------------------------------------------------------------------
+# Follow-up lane (conditional on coverage's recommendation)
+# ---------------------------------------------------------------------------
+if (
+    followup_possible
+    and coverage
+    and coverage.get("followup_needed")
+    and str(coverage.get("decision_affected", "")).strip()
+    and isinstance(coverage.get("followup_lane"), dict)
+    and budget_allows_optional(verification_fetches * 250)
+):
+    followup_lane = coverage["followup_lane"]
+    followup_scout_result = await dispatch(
+        research_prompt(
+            followup_lane,
+            "followup-1",
+            searches_per_lane,
+            fetches_per_lane,
+            "This is the only follow-up. Research only the decision-changing gap: "
+            + str(coverage.get("decision_affected")),
+        ),
+        "followup:scout",
+        "Research",
+        SCOUT_SCHEMA,
+        "discovery",
+    )
+
+    if followup_scout_result is not None:
+        followup_record = new_record(
+            followup_scout_result,
+            "followup-1",
+            "followup",
+            str(followup_scout_result.get("dossier_path", "")).strip(),
+            str(followup_lane.get("title", "")),
+            str(followup_lane.get("question", "")),
+        )
+        select_claims(followup_record, verification_mode)
+        if followup_record["selected_claim_ids"] and budget_allows_optional():
+            await verify_record(
+                followup_record,
+                "followup:verify",
+                compact_failed_ledger(research_records),
+                "\nDo not reacquire the follow-up target; assess the returned "
+                "evidence and seek ordinary independent support only if essential.",
+            )
+        elif followup_record["eligible_claim_ids"]:
+            followup_record["deferred_claim_ids"] = list(followup_record["eligible_claim_ids"])
+            followup_record["selected_claim_ids"] = []
+        research_records.append(followup_record)
+        followups_run = 1
+    else:
+        partial_reasons.append("the single decision-changing follow-up failed")
+
+# Final registry build (includes follow-up lane if present)
+registry, all_claims, lane_summaries, evidence_gaps = build_registry(research_records)
+all_gaps = sorted(set(partial_reasons + evidence_gaps + ((coverage or {}).get("gaps", []))))
+dossier_count = sum(1 for record in research_records if record.get("dossier_path"))
+
+# Claims usable for drafting: everything the evidence did not refute.
+citable_claims = [claim for claim in all_claims if claim.get("status") != "refuted"]
+
+if not citable_claims or not registry:
+    return {
+        "status": "failed",
+        "report_markdown": "",
+        "report_plan": None,
+        "cited_sources": [],
+        "source_registry": registry,
+        "gaps": all_gaps + ["no supported claim set was sufficient to draft a cited report"],
+        "run_summary": make_summary(),
+    }
+
+# ---------------------------------------------------------------------------
+# Draft phase
+# ---------------------------------------------------------------------------
+STATUS_USE_MATRIX = (
+    "Status-use matrix:\n"
+    "verified – independently checked; may carry a factual conclusion.\n"
+    "qualified – usable with its qualification kept next to the claim.\n"
+    "contested – present the disagreement; draw no decisive conclusion.\n"
+    "attributed – testimony or interpretation; attribute it explicitly and never "
+    "treat it as evidence of prevalence.\n"
+    "single-source – background resting on one source; cite and attribute it, and do "
+    "not describe it as independently corroborated.\n"
+    "unverified – not independently checked; usable with explicit attribution and "
+    "hedged language, never as a bare assertion."
+)
+
+phase("Draft")
+stages_run.append("Draft")
+single_draft_prompt = (
+    "Write the complete reader-facing report from the supported-claim registry below. "
+    "Answer the question early. Match the report profile rather than using a fixed "
+    "institutional template. Cite material factual claims with descriptive Markdown "
+    "links using only exact URLs from the registry. Use a smaller set of strong "
+    "representative citations; do not force every source into the prose. Keep material "
+    "uncertainty near the affected claim without repeating boilerplate caveats. Do not "
+    "mention workers, lanes, evidence IDs, audits, or retry history. Aim for about "
+    + str(target_words)
+    + " words. Return title and body only: do not write a Sources section because it "
+    "is built deterministically.\n\n"
+    "BRIEF: "
+    + repr(brief)
+    + "\nREPORT PROFILE: "
+    + repr(report_profile)
+    + "\nSUPPORTED CLAIMS: "
+    + repr(citable_claims)
+    + "\nSOURCE REGISTRY: "
+    + repr(registry)
+    + "\nCONSEQUENTIAL GAPS: "
+    + repr(all_gaps)
+    + ("\n" + READ_INSTRUCTIONS if use_workspace else "")
+    + "\n\n"
+    + STATUS_USE_MATRIX
+)
+coverage_outline = (coverage or {}).get("section_outline") or []
+section_outline = [
+    section
+    for section in coverage_outline
+    if isinstance(section, dict)
+    and str(section.get("heading", "")).strip()
+    and str(section.get("purpose", "")).strip()
+]
+section_decision = bool((coverage or {}).get("section_drafting_needed", False))
+section_outline_source = "coverage" if len(section_outline) >= 2 else "none"
+
+# Honor the documented rule: a long report never falls back to one drafting call
+# just because coverage failed to supply a usable outline.
+if len(section_outline) < 2 and target_words >= 5000:
+    derived = derive_section_outline(research_records, citable_claims)
+    if len(derived) >= 2:
+        section_outline = derived
+        section_outline_source = "derived"
+        log("coverage supplied no usable section outline; derived one from the lanes")
+
+use_section_drafting = len(section_outline) >= 2 and (target_words >= 5000 or section_decision)
+draft_mode = "sections" if use_section_drafting else "single"
+
+draft = None
+report_plan = None
+report = ""
+cited_sources = []
+deterministic_issues = []
+claims_by_id = {claim.get("id"): claim for claim in citable_claims}
+
+
+def section_claims(section):
+    return [
+        claims_by_id[claim_id]
+        for claim_id in section.get("claim_ids", [])
+        if claim_id in claims_by_id
+    ]
+
+
+def section_prompt(section, section_index, section_target, file_mode):
+    if file_mode:
+        destination = section_file_path(section_index, section.get("heading", ""))
+        tail = (
+            "Write the section heading and body to "
+            + destination
+            + ", set section_path to that path, count the words with `wc -w`, and return "
+            "the count plus the exact registry URLs you cited. Do not return the body text. "
+            + WRITE_INSTRUCTIONS
+        )
+    else:
+        tail = "Write the section heading and body in body_markdown."
+    return (
+        "Draft one bounded report section. Use only the assigned supported claims and "
+        "exact registry URLs. Write the section heading and body, not a title, "
+        "introduction, conclusion, or Sources section. Avoid repeating general context "
+        "that belongs elsewhere. Target about "
+        + str(section_target)
+        + " words.\n\nBRIEF: "
+        + repr(brief)
+        + "\nREPORT PROFILE: "
+        + repr(report_profile)
+        + "\nSECTION: "
+        + repr(section)
+        + "\nASSIGNED SUPPORTED CLAIMS: "
+        + repr(section_claims(section))
+        + "\nSOURCE REGISTRY: "
+        + repr(registry)
+        + ("\n" + READ_INSTRUCTIONS if use_workspace else "")
+        + "\n\n"
+        + STATUS_USE_MATRIX
+        + "\n\n"
+        + tail
+    )
+
+
+if use_section_drafting:
+    section_target = max(500, target_words // len(section_outline))
+    file_mode = use_workspace
+    section_results = await parallel(
+        [
+            (
+                lambda section=section, section_index=section_index: dispatch(
+                    section_prompt(section, section_index, section_target, file_mode),
+                    "section-draft:" + str(section_index + 1),
+                    "Draft",
+                    SECTION_FILE_SCHEMA if file_mode else SECTION_SCHEMA,
+                    "synthesis",
+                )
+            )
+            for section_index, section in enumerate(section_outline)
+        ]
+    )
+    section_results = [section for section in section_results if section is not None]
+
+    if len(section_results) < 2:
+        partial_reasons.append(
+            "section drafting did not produce enough usable sections; used one bounded draft"
+        )
+        draft_mode = "single"
+    elif file_mode:
+        usable_sections = [
+            section
+            for section in section_results
+            if str(section.get("section_path", "")).strip()
+        ]
+        if len(usable_sections) < 2:
+            partial_reasons.append(
+                "section drafters did not persist enough section files; used one bounded draft"
+            )
+            draft_mode = "single"
+        else:
+            seams_prompt = (
+                "Assemble the drafted sections into one coherent report file. Read each "
+                "section file, then write the complete report body to "
+                + REPORT_BODY_PATH
+                + " in the order given: a specific level-one title, an opening that "
+                "answers the question early, the sections with smooth transitions, and "
+                "an evidence-calibrated conclusion. Remove repetition and normalize "
+                "voice without flattening subject-specific texture. Preserve only "
+                "supported citations and use exact registry URLs. Do not write a Sources "
+                "section; it is built deterministically. Then count the words with "
+                "`wc -w` and return the count, the title, the body path, and the exact "
+                "registry URLs cited.\n\n"
+                + READ_INSTRUCTIONS
+                + "\n"
+                + WRITE_INSTRUCTIONS
+                + "\n\nBRIEF: "
+                + repr(brief)
+                + "\nREPORT PROFILE: "
+                + repr(report_profile)
+                + "\nTARGET WORDS: "
+                + str(target_words)
+                + "\nSECTION FILES IN ORDER: "
+                + repr(usable_sections)
+                + "\nSOURCE REGISTRY: "
+                + repr(registry)
+                + "\nCONSEQUENTIAL GAPS: "
+                + repr(all_gaps)
+                + (
+                    "\n\nThese section boundaries were derived from research lanes, "
+                    "which are evidence boundaries rather than reader-facing argument "
+                    "boundaries. Rename, reorder, split, or merge the headings so the "
+                    "report reads as one argument, keeping every supported citation."
+                    if section_outline_source == "derived"
+                    else ""
+                )
+            )
+            seams = await dispatch(
+                seams_prompt, "draft-assembly", "Draft", SEAMS_SCHEMA, "synthesis"
+            )
+            if seams is None or not str(seams.get("body_path", "")).strip():
+                partial_reasons.append(
+                    "report assembly did not persist a body file; used one bounded draft"
+                )
+                draft_mode = "single"
+            else:
+                assembled_words = int(seams.get("assembled_word_count", 0) or 0)
+                shortfall = (
+                    target_words * SHORTFALL_RATIO_NUMERATOR
+                ) // SHORTFALL_RATIO_DENOMINATOR
+                if assembled_words < shortfall and budget_allows_optional():
+                    shortest = sorted(
+                        usable_sections,
+                        key=lambda section: int(section.get("word_count", 0) or 0),
+                    )[:MAX_EXPANDED_SECTIONS]
+                    await parallel(
+                        [
+                            (
+                                lambda section=section, order=order: dispatch(
+                                    "The assembled report is materially shorter than the "
+                                    "requested length. Expand this one section in place at "
+                                    + str(section.get("section_path"))
+                                    + " using only its assigned supported claims and the "
+                                    "lane dossiers behind them. Add substance, not padding: "
+                                    "more evidence, mechanism, and concrete detail. Keep the "
+                                    "existing heading, cite only exact registry URLs, and "
+                                    "rewrite the same file. Then count the words with "
+                                    "`wc -w`.\n\n"
+                                    + READ_INSTRUCTIONS
+                                    + "\n"
+                                    + WRITE_INSTRUCTIONS
+                                    + "\n\nBRIEF: "
+                                    + repr(brief)
+                                    + "\nSECTION: "
+                                    + repr(section)
+                                    + "\nASSEMBLED WORDS: "
+                                    + str(assembled_words)
+                                    + "\nTARGET WORDS: "
+                                    + str(target_words)
+                                    + "\nSOURCE REGISTRY: "
+                                    + repr(registry)
+                                    + "\n\n"
+                                    + STATUS_USE_MATRIX,
+                                    "section-expand:" + str(order + 1),
+                                    "Draft",
+                                    SECTION_FILE_SCHEMA,
+                                    "synthesis",
+                                )
+                            )
+                            for order, section in enumerate(shortest)
+                        ]
+                    )
+                    expansion_passes = 1
+                    reassembled = await dispatch(
+                        seams_prompt
+                        + "\n\nThe sections have been expanded since the last assembly. "
+                        "Rebuild the body file from the current section files.",
+                        "draft-assembly:2",
+                        "Draft",
+                        SEAMS_SCHEMA,
+                        "synthesis",
+                    )
+                    if reassembled is not None and str(reassembled.get("body_path", "")).strip():
+                        seams = reassembled
+                        assembled_words = int(seams.get("assembled_word_count", 0) or 0)
+                report_plan = {
+                    "title": str(seams.get("title", "")).strip(),
+                    "body_path": str(seams.get("body_path", "")).strip(),
+                    "section_paths": [
+                        str(section.get("section_path", "")) for section in usable_sections
+                    ],
+                    "assembled_word_count": assembled_words,
+                }
+                all_gaps = sorted(set(all_gaps + [str(g) for g in seams.get("gaps", []) if g]))
+    else:
+        draft = await dispatch(
+            "Synthesize the independently drafted sections into one coherent report. "
+            "Write a specific title, an opening that answers the question early, smooth "
+            "transitions, and an evidence-calibrated conclusion. Remove repetition and "
+            "normalize voice without flattening subject-specific texture. Preserve only "
+            "supported citations and use exact registry URLs. Return title and body "
+            "without a Sources section.\n\nBRIEF: "
+            + repr(brief)
+            + "\nREPORT PROFILE: "
+            + repr(report_profile)
+            + "\nSECTION DRAFTS: "
+            + repr(section_results)
+            + "\nSUPPORTED CLAIMS: "
+            + repr(citable_claims)
+            + "\nSOURCE REGISTRY: "
+            + repr(registry)
+            + "\nCONSEQUENTIAL GAPS: "
+            + repr(all_gaps),
+            "draft-assembly",
+            "Draft",
+            DRAFT_SCHEMA,
+            "synthesis",
+        )
+        if draft is None:
+            partial_reasons.append("section synthesis failed; used one bounded draft")
+            draft_mode = "single"
+
+if report_plan is None and draft is None:
+    draft_mode = "single"
+    draft = await dispatch(
+        single_draft_prompt,
+        "draft",
+        "Draft",
+        DRAFT_SCHEMA,
+        "synthesis",
+    )
+
+if report_plan is None and draft is None:
+    return {
+        "status": "failed",
+        "report_markdown": "",
+        "report_plan": None,
+        "cited_sources": [],
+        "source_registry": registry,
+        "gaps": all_gaps + ["drafting worker failed"],
+        "run_summary": make_summary(),
+    }
+
+if report_plan is None:
+    report, cited_sources, deterministic_issues = assemble_report(draft, registry)
+    assembled_words = word_count(strip_sources(report))
+
+# ---------------------------------------------------------------------------
+# Audit phase (conditional on audit_mode)
+# ---------------------------------------------------------------------------
+if audit_mode == "dual":
+    audit_roles = ["evidence", "editorial"]
+elif audit_mode == "combined":
+    audit_roles = ["combined"]
+else:
+    audit_roles = []
+
+material_issues = list(deterministic_issues)
+
+# Length is part of the confirmed brief, so a large overshoot is a material issue
+# the single revision pass can act on. A shortfall is handled by the expansion
+# pass and reported as a gap rather than a defect.
+overlength_target = (
+    target_words * OVERLENGTH_RATIO_NUMERATOR
+) // OVERLENGTH_RATIO_DENOMINATOR
+if assembled_words and assembled_words > overlength_target:
+    material_issues.append(
+        "report is far longer than the requested length: "
+        + str(assembled_words)
+        + " words against a target of about "
+        + str(target_words)
+        + "; tighten it toward the target without dropping supported substance"
+    )
+
+if audit_roles:
+    phase("Audit")
+    stages_run.append("Audit")
+    if report_plan is None:
+        report_block = "\nREPORT: " + report
+    else:
+        report_block = (
+            "\nREPORT FILE: "
+            + report_plan["body_path"]
+            + "\n"
+            + READ_INSTRUCTIONS
+            + " The Sources section is built deterministically after the audit, so check "
+            "that every cited URL appears in the source registry rather than expecting a "
+            "bibliography in the file."
+        )
+    audit_prompt = (
+        "Audit this report against the brief, report profile, supported claims, and "
+        "source registry. Check support for material claims, calibrated certainty, "
+        "fair scope, reader fit, structure, and voice. Be compact. A revision is "
+        "needed only for a material issue, not optional polish. "
+        "Treat deterministic issues as material. "
+        "For experiential and testimony-based reports focus on attribution, "
+        "overgeneralization, sample limits, and separation of testimony from "
+        "inference — not relitigating whether the reported experience occurred.\n\n"
+        "BRIEF: "
+        + repr(brief)
+        + "\nREPORT PROFILE: "
+        + repr(report_profile)
+        + report_block
+        + "\nCLAIM INDEX: "
+        + repr(claim_index(citable_claims))
+        + "\nSOURCE REGISTRY: "
+        + repr(registry)
+        + "\nDETERMINISTIC ISSUES: "
+        + repr(deterministic_issues)
+    )
+    audits = await parallel(
+        [
+            (
+                lambda audit_role=audit_role: dispatch(
+                    audit_prompt + "\nAUDIT ROLE: " + audit_role,
+                    "audit:" + audit_role,
+                    "Audit",
+                    AUDIT_SCHEMA,
+                    "audit",
+                )
+            )
+            for audit_role in audit_roles
+        ]
+    )
+    audits = [audit for audit in audits if audit is not None]
+    for audit in audits:
+        material_issues.extend(audit.get("material_issues", []))
+    if not audits:
+        partial_reasons.append("the report audit failed")
+else:
+    stages_skipped.append("Audit")
+    audits = []
+
+# ---------------------------------------------------------------------------
+# Revision (at most one, only when material issues exist)
+# ---------------------------------------------------------------------------
+remaining_material_issues = []
+if material_issues or any(audit.get("revision_needed") for audit in audits):
+    phase("Revise")
+    stages_run.append("Revise")
+    issue_list = repr(sorted(set(str(issue) for issue in material_issues if issue)))
+    if report_plan is None:
+        revision = await dispatch(
+            "Revise the report only to fix the material issues below. Preserve the "
+            "reader-fit voice and supported useful detail. Use only exact registry URLs "
+            "for citations. Return title and body without a Sources section. If an issue "
+            "cannot be fixed from supported evidence, remove or narrow the claim and list "
+            "the remaining issue.\n\nBRIEF: "
+            + repr(brief)
+            + "\nREPORT PROFILE: "
+            + repr(report_profile)
+            + "\nCURRENT REPORT: "
+            + report
+            + "\nMATERIAL ISSUES: "
+            + issue_list
+            + "\nSUPPORTED CLAIMS: "
+            + repr(citable_claims)
+            + "\nSOURCE REGISTRY: "
+            + repr(registry),
+            "revision",
+            "Revise",
+            REVISION_SCHEMA,
+            "synthesis",
+        )
+        if revision is None:
+            partial_reasons.append("material revision failed")
+            remaining_material_issues = list(material_issues)
+        else:
+            report, cited_sources, deterministic_issues = assemble_report(revision, registry)
+            assembled_words = word_count(strip_sources(report))
+            remaining_material_issues = list(revision.get("remaining_material_issues", []))
+            remaining_material_issues.extend(deterministic_issues)
+    else:
+        revision = await dispatch(
+            "Revise the report file in place, only to fix the material issues below. "
+            "Preserve the reader-fit voice and supported useful detail. Use only exact "
+            "registry URLs for citations. Do not add a Sources section. If an issue "
+            "cannot be fixed from supported evidence, remove or narrow the claim and "
+            "list the remaining issue. Rewrite "
+            + report_plan["body_path"]
+            + ", then count the words with `wc -w` and return the count.\n\n"
+            + READ_INSTRUCTIONS
+            + "\n"
+            + WRITE_INSTRUCTIONS
+            + "\n\nBRIEF: "
+            + repr(brief)
+            + "\nREPORT PROFILE: "
+            + repr(report_profile)
+            + "\nREPORT FILE: "
+            + report_plan["body_path"]
+            + "\nMATERIAL ISSUES: "
+            + issue_list
+            + "\nCLAIM INDEX: "
+            + repr(claim_index(citable_claims))
+            + "\nSOURCE REGISTRY: "
+            + repr(registry),
+            "revision",
+            "Revise",
+            REVISION_FILE_SCHEMA,
+            "synthesis",
+        )
+        if revision is None:
+            partial_reasons.append("material revision failed")
+            remaining_material_issues = list(material_issues)
+        else:
+            revised_path = str(revision.get("body_path", "")).strip()
+            if revised_path:
+                report_plan["body_path"] = revised_path
+            revised_title = str(revision.get("title", "")).strip()
+            if revised_title:
+                report_plan["title"] = revised_title
+            revised_words = int(revision.get("assembled_word_count", 0) or 0)
+            if revised_words:
+                assembled_words = revised_words
+                report_plan["assembled_word_count"] = revised_words
+            remaining_material_issues = list(revision.get("remaining_material_issues", []))
+
+# ---------------------------------------------------------------------------
+# High-stakes closure check
+# ---------------------------------------------------------------------------
+if high_stakes and remaining_material_issues:
+    closure = await dispatch(
+        "Perform a final evidence closure check only on the unresolved material "
+        "issues. Do not edit prose and do not report formatting defects.\n\n"
+        + (
+            "REPORT: " + report
+            if report_plan is None
+            else "REPORT FILE: " + report_plan["body_path"] + "\n" + READ_INSTRUCTIONS
+        )
+        + "\nUNRESOLVED MATERIAL ISSUES: "
+        + repr(remaining_material_issues)
+        + "\nCLAIM INDEX: "
+        + repr(claim_index(citable_claims)),
+        "closure",
+        "Audit",
+        CLOSURE_SCHEMA,
+        "verification",
+    )
+    if closure is None or not closure.get("supported"):
+        remaining_material_issues = (
+            closure.get("unresolved_material_issues", remaining_material_issues)
+            if closure
+            else remaining_material_issues
+        )
+    else:
+        remaining_material_issues = []
+
+# ---------------------------------------------------------------------------
+# Advisory deterministic check. A drafted report is never discarded here;
+# scripts/materialize_report.py is the authoritative structural gate.
+# ---------------------------------------------------------------------------
+advisory_issues = structural_issues(report) if report_plan is None else []
+
+# A shortfall is a delivery warning, not an evidence defect: the expansion pass
+# owns it, an honest short report still ships, and it never demotes the run. A
+# report still far over the target after revision is different — it disregards an
+# explicit instruction it was asked to fix, so it counts as unresolved.
+length_notes = []
+overlength_notes = []
+shortfall_target = (target_words * SHORTFALL_RATIO_NUMERATOR) // SHORTFALL_RATIO_DENOMINATOR
+if assembled_words and assembled_words < shortfall_target:
+    length_notes.append(
+        "report is materially shorter than the requested length: "
+        + str(assembled_words)
+        + " of about "
+        + str(target_words)
+        + " words"
+    )
+elif assembled_words and assembled_words > overlength_target:
+    overlength_notes.append(
+        "report is materially longer than the requested length: "
+        + str(assembled_words)
+        + " of about "
+        + str(target_words)
+        + " words"
+    )
+
+unresolved = sorted(
+    set(
+        [str(issue) for issue in advisory_issues if issue]
+        + [str(issue) for issue in remaining_material_issues if issue]
+        + overlength_notes
+    )
+)
+gaps = sorted(set(all_gaps + partial_reasons + unresolved + length_notes))
+status = (
+    "partial"
+    if partial_reasons or unresolved or base_lanes_completed < len(lanes)
+    else "complete"
+)
+
+return {
+    "status": status,
+    "report_markdown": report,
+    "report_plan": report_plan,
+    "cited_sources": cited_sources,
+    "source_registry": registry,
+    "gaps": gaps,
+    "run_summary": make_summary(),
+}

--- a/kolega_code/_bundled_skills/skills/deep-research/scripts/materialize_report.py
+++ b/kolega_code/_bundled_skills/skills/deep-research/scripts/materialize_report.py
@@ -1,0 +1,710 @@
+#!/usr/bin/env python3
+"""Materialize a deep-research workflow result as a validated Markdown report.
+
+This module owns the authoritative deterministic report logic: Markdown link
+extraction, URL identity, ``## Sources`` construction, and structural
+validation. The bundled workflow keeps a mirrored in-sandbox copy for audit
+hints only, because a Gigacode script has no filesystem access. The regression
+suite asserts both implementations agree on a shared fixture corpus.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+# Query parameters that never identify a distinct document.
+TRACKING_PARAMS = frozenset({"gclid", "fbclid", "ref", "ref_src", "s", "share"})
+
+# Bounds on delivered length relative to the requested word target.
+SHORTFALL_RATIO = 0.8
+OVERLENGTH_RATIO = 1.35
+
+# Internal identifiers that must never reach a reader-facing gaps section.
+_INTERNAL_ID = re.compile(r"\b(?:lane-\d+|followup-\d+|escalation-\d+)(?:/[A-Za-z]+\d+)?\b")
+_BARE_RECORD_ID = re.compile(r"\b[CES]\d{1,3}\b")
+_INTERNAL_MARKERS = ("lane", "scout", "verifier", "claim_id", "evidence_id", "downstream")
+
+# A reader-facing note is a short disclosure, not a research ledger.
+MAX_READER_FACING_GAPS = 10
+
+# Content-word overlap above which two gaps are treated as the same disclosure.
+# Scouts and verifiers routinely report one gap in different words.
+NEAR_DUPLICATE_OVERLAP = 0.6
+# ...but boilerplate alone must never merge two distinct gaps, so also require a
+# floor of shared distinctive words.
+NEAR_DUPLICATE_MIN_SHARED = 4
+# Duplicated gaps almost always open on the same subject ("Agrippa's table of
+# Saturn...", "Ficino's chapters on engraved images..."), which distinguishes them
+# from two unrelated gaps that merely share stock phrasing.
+GAP_SUBJECT_WORDS = 6
+GAP_SUBJECT_MIN_SHARED = 4
+
+# Vocabulary common to almost every sourcing gap; useless for telling two apart.
+_GAP_BOILERPLATE = frozenset(
+    {
+        "about",
+        "accessible",
+        "also",
+        "available",
+        "because",
+        "been",
+        "checked",
+        "claim",
+        "claims",
+        "consulted",
+        "could",
+        "directly",
+        "established",
+        "evidence",
+        "failed",
+        "from",
+        "have",
+        "here",
+        "inaccessible",
+        "into",
+        "known",
+        "located",
+        "never",
+        "obtained",
+        "only",
+        "read",
+        "reached",
+        "recovered",
+        "remain",
+        "remains",
+        "report",
+        "rests",
+        "scholarship",
+        "secured",
+        "settled",
+        "source",
+        "sources",
+        "still",
+        "than",
+        "that",
+        "their",
+        "them",
+        "there",
+        "then",
+        "this",
+        "unverified",
+        "verified",
+        "were",
+        "which",
+        "with",
+        "would",
+    }
+)
+
+
+class MaterializationError(ValueError):
+    """Raised when a workflow result cannot be materialized safely."""
+
+
+# ---------------------------------------------------------------------------
+# Deterministic text helpers (mirrored by scripts/deep-research.workflow)
+# ---------------------------------------------------------------------------
+def canonical_url(value: Any) -> str:
+    """Return a comparison key that preserves meaningful query parameters.
+
+    Drops the fragment and known tracking parameters, lowercases the scheme and
+    host, sorts the surviving query parameters, and strips one trailing slash.
+    Two URLs differing only in a meaningful query parameter stay distinct.
+    """
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    text = text.split("#", 1)[0]
+    scheme = ""
+    rest = text
+    marker = text.find("://")
+    if marker >= 0:
+        scheme = text[:marker].lower()
+        rest = text[marker + 3 :]
+    query = ""
+    question = rest.find("?")
+    if question >= 0:
+        query = rest[question + 1 :]
+        rest = rest[:question]
+    slash = rest.find("/")
+    if slash >= 0:
+        host = rest[:slash].lower()
+        path = rest[slash:]
+    else:
+        host = rest.lower()
+        path = ""
+    if len(path) > 1 and path.endswith("/"):
+        path = path[:-1]
+    kept = []
+    for part in query.split("&"):
+        if not part:
+            continue
+        key = part.split("=", 1)[0].lower()
+        if key in TRACKING_PARAMS or key.startswith("utm_"):
+            continue
+        kept.append(part)
+    base = f"{scheme}://" if scheme else ""
+    base += host + path
+    if kept:
+        return base + "?" + "&".join(sorted(kept))
+    return base
+
+
+def strip_fenced_code(text: Any) -> str:
+    """Blank out fenced code blocks so their contents cannot look like citations."""
+    kept: list[str] = []
+    in_fence = False
+    fence = ""
+    for line in str(text or "").split("\n"):
+        stripped = line.strip()
+        marker = ""
+        if stripped.startswith("```"):
+            marker = "```"
+        elif stripped.startswith("~~~"):
+            marker = "~~~"
+        if marker:
+            if in_fence:
+                if marker == fence:
+                    in_fence = False
+                    fence = ""
+            else:
+                in_fence = True
+                fence = marker
+            kept.append("")
+            continue
+        kept.append("" if in_fence else line)
+    return "\n".join(kept)
+
+
+def strip_inline_code(text: Any) -> str:
+    """Drop inline code spans so `[a](b)` is not read as a citation."""
+    source = str(text or "")
+    length = len(source)
+    kept: list[str] = []
+    index = 0
+    while index < length:
+        if source[index] == "`":
+            run = 0
+            while index + run < length and source[index + run] == "`":
+                run += 1
+            closing = source.find("`" * run, index + run)
+            if closing < 0:
+                index += run
+                continue
+            index = closing + run
+            continue
+        kept.append(source[index])
+        index += 1
+    return "".join(kept)
+
+
+def matching_bracket(text: str, start: int) -> int:
+    """Index of the ``]`` closing the ``[`` at ``start``, or -1."""
+    depth = 0
+    index = start
+    length = len(text)
+    while index < length:
+        char = text[index]
+        if char == "[":
+            depth += 1
+        elif char == "]":
+            depth -= 1
+            if depth == 0:
+                return index
+        index += 1
+    return -1
+
+
+def link_destination(text: str, start: int) -> tuple[str, int]:
+    """Parse a Markdown link destination, returning (destination, closing index)."""
+    length = len(text)
+    index = start
+    while index < length and text[index] in " \t\n":
+        index += 1
+    destination = ""
+    if index < length and text[index] == "<":
+        end = text.find(">", index + 1)
+        if end < 0:
+            return "", -1
+        destination = text[index + 1 : end]
+        index = end + 1
+    else:
+        depth = 0
+        chars: list[str] = []
+        while index < length:
+            char = text[index]
+            if char in " \t\n":
+                break
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                if depth == 0:
+                    break
+                depth -= 1
+            chars.append(char)
+            index += 1
+        destination = "".join(chars)
+    while index < length and text[index] in " \t\n":
+        index += 1
+    if index < length and text[index] in ('"', "'", "("):
+        closer = ")" if text[index] == "(" else text[index]
+        end = text.find(closer, index + 1)
+        if end < 0:
+            return "", -1
+        index = end + 1
+        while index < length and text[index] in " \t\n":
+            index += 1
+    if index < length and text[index] == ")":
+        return destination.strip(), index
+    return "", -1
+
+
+def markdown_urls(markdown: Any) -> list[str]:
+    """Extract http(s) destinations from Markdown inline links, in order.
+
+    Skips fenced blocks, inline code, and images; honors balanced parentheses in
+    the destination and an optional link title; ignores non-http destinations so
+    anchors and mail links are not reported as unknown citations.
+    """
+    text = strip_inline_code(strip_fenced_code(markdown))
+    length = len(text)
+    urls: list[str] = []
+    index = 0
+    while index < length:
+        if text[index] != "[":
+            index += 1
+            continue
+        is_image = index > 0 and text[index - 1] == "!"
+        label_end = matching_bracket(text, index)
+        if label_end < 0 or label_end + 1 >= length or text[label_end + 1] != "(":
+            index += 1
+            continue
+        destination, close = link_destination(text, label_end + 2)
+        if close < 0:
+            index += 1
+            continue
+        if not is_image and destination:
+            lowered = destination.lower()
+            if lowered.startswith(("http://", "https://")) and destination not in urls:
+                urls.append(destination)
+        index = close + 1
+    return urls
+
+
+def strip_sources_section(markdown: Any) -> str:
+    """Return the body with any trailing ``## Sources`` section and title removed."""
+    lines = str(markdown or "").strip().splitlines()
+    kept: list[str] = []
+    for line in lines:
+        if line.strip().lower() == "## sources":
+            break
+        kept.append(line)
+    if kept and kept[0].startswith("# "):
+        kept = kept[1:]
+    return "\n".join(kept).strip()
+
+
+def structural_issues(report: str) -> list[str]:
+    """Structural defects that make a report unfit to deliver."""
+    issues: list[str] = []
+    text = str(report or "").strip()
+    if not text.startswith("# "):
+        issues.append("missing level-one title")
+    if text.count("\n## Sources\n") != 1:
+        issues.append("report must contain exactly one `## Sources` section")
+    lines = text.splitlines()
+    seen: list[str] = []
+    for index, line in enumerate(lines):
+        if not line.startswith("## "):
+            continue
+        key = line.strip().lower()
+        if key in seen:
+            issues.append(f"duplicate heading: {line.strip()}")
+        seen.append(key)
+        cursor = index + 1
+        has_content = False
+        while cursor < len(lines) and not lines[cursor].startswith("## "):
+            if lines[cursor].strip():
+                has_content = True
+                break
+            cursor += 1
+        if not has_content:
+            issues.append(f"empty section: {line.strip()}")
+    return issues
+
+
+def source_entry(source: dict[str, Any], fallback_url: str) -> str:
+    """One deduplicated bibliography line."""
+    title = str(source.get("title") or "").strip() or fallback_url
+    url = str(source.get("url") or "").strip() or fallback_url
+    detail = str(source.get("publisher") or source.get("source_type") or "").strip()
+    date = str(source.get("date") or "").strip()
+    if date:
+        detail = f"{detail}, {date}".strip(", ")
+    suffix = f" — {detail}" if detail else ""
+    return f"- [{title}]({url}){suffix}"
+
+
+def assemble_report(
+    title: str, body: str, registry: list[dict[str, Any]]
+) -> tuple[str, list[dict[str, Any]], list[str]]:
+    """Build the final report and its ``## Sources`` section from the body's links."""
+    clean_title = str(title or "").strip().lstrip("#").strip()
+    clean_body = strip_sources_section(body)
+    by_url = {canonical_url(source.get("url")): source for source in registry}
+    by_url.pop("", None)
+
+    cited_keys: list[str] = []
+    unknown: list[str] = []
+    for url in markdown_urls(clean_body):
+        key = canonical_url(url)
+        if key in by_url:
+            if key not in cited_keys:
+                cited_keys.append(key)
+        elif url not in unknown:
+            unknown.append(url)
+
+    cited_sources = [by_url[key] for key in cited_keys]
+    lines = [source_entry(by_url[key], key) for key in cited_keys]
+    report = f"# {clean_title}\n\n{clean_body}\n\n## Sources\n\n" + "\n".join(lines)
+    report = report.strip() + "\n"
+
+    issues: list[str] = []
+    if not clean_title:
+        issues.append("report has no title")
+    if not clean_body:
+        issues.append("report body is empty")
+    if not cited_sources:
+        issues.append("report body cites no source from the workflow registry")
+    if unknown:
+        issues.append(f"citations absent from the source registry: {', '.join(unknown)}")
+    return report, cited_sources, issues
+
+
+def _distinctive_words(text: str) -> list[str]:
+    return [
+        word
+        for word in re.findall(r"[a-z']+", text.lower())
+        if len(word) > 3 and word not in _GAP_BOILERPLATE
+    ]
+
+
+def _gap_signature(text: str) -> set[str]:
+    """Distinctive words used to recognize the same gap phrased two ways."""
+    return set(_distinctive_words(text))
+
+
+def _gap_subject(text: str) -> set[str]:
+    """The distinctive words that open a gap, i.e. what it is about."""
+    return set(_distinctive_words(text)[:GAP_SUBJECT_WORDS])
+
+
+def _near_duplicate_index(
+    signature: set[str],
+    subject: set[str],
+    existing: list[tuple[set[str], set[str]]],
+) -> int | None:
+    """Index of an already-kept gap that says substantially the same thing.
+
+    Two gaps merge when they open on the same subject, or when their distinctive
+    vocabulary overlaps heavily. The bar is deliberately conservative: showing one
+    disclosure twice is a cosmetic wart, whereas merging two distinct gaps hides a
+    limitation from the reader.
+    """
+    if len(signature) < NEAR_DUPLICATE_MIN_SHARED:
+        return None
+    for index, (other_signature, other_subject) in enumerate(existing):
+        if len(subject & other_subject) >= GAP_SUBJECT_MIN_SHARED:
+            return index
+        if len(other_signature) < NEAR_DUPLICATE_MIN_SHARED:
+            continue
+        shared = signature & other_signature
+        if len(shared) < NEAR_DUPLICATE_MIN_SHARED:
+            continue
+        if len(shared) / min(len(signature), len(other_signature)) >= NEAR_DUPLICATE_OVERLAP:
+            return index
+    return None
+
+
+def reader_facing_gaps(gaps: list[str], limit: int = MAX_READER_FACING_GAPS) -> list[str]:
+    """Filter workflow gaps down to disclosures a reader can actually use.
+
+    Workflow gaps are written for the operator and routinely carry internal claim
+    and lane identifiers, and the same gap often arrives several times in slightly
+    different words. Strip the identifiers, drop entries that are about research
+    machinery rather than evidence, collapse near-duplicates to their fullest
+    wording, and cap the list so a report ends with a short disclosure instead of a
+    research ledger.
+    """
+    cleaned: list[str] = []
+    fingerprints: list[tuple[set[str], set[str]]] = []
+    for gap in gaps:
+        text = str(gap).strip()
+        if not text:
+            continue
+        text = _INTERNAL_ID.sub("", text)
+        text = _BARE_RECORD_ID.sub("", text)
+        text = re.sub(r"\(\s*[,;'\"]*\s*\)", "", text)
+        text = re.sub(r"\s{2,}", " ", text).strip(" ,;:.—-")
+        if len(text) < 20:
+            continue
+        lowered = text.lower()
+        if any(marker in lowered for marker in _INTERNAL_MARKERS):
+            continue
+        if text[0].islower():
+            text = text[0].upper() + text[1:]
+        if not text.endswith("."):
+            text += "."
+        signature = _gap_signature(text)
+        subject = _gap_subject(text)
+        duplicate = _near_duplicate_index(signature, subject, fingerprints)
+        if duplicate is not None:
+            # Keep whichever phrasing tells the reader more.
+            if len(text) > len(cleaned[duplicate]):
+                cleaned[duplicate] = text
+                fingerprints[duplicate] = (signature, subject)
+            continue
+        fingerprints.append((signature, subject))
+        cleaned.append(text)
+
+    kept = cleaned[:limit]
+    overflow = len(cleaned) - len(kept)
+    if overflow > 0:
+        kept.append(
+            f"{overflow} further sourcing gaps are recorded in the research notes for this report."
+        )
+    return kept
+
+
+def insert_gaps_section(report: str, gaps: list[str]) -> str:
+    """Insert a ``## Scope and gaps`` section ahead of ``## Sources``."""
+    entries = reader_facing_gaps(gaps)
+    if not entries:
+        return report
+    block = "## Scope and gaps\n\nThis report is a supported partial result. The "
+    block += "following points remain unresolved:\n\n"
+    block += "\n".join(f"- {entry}" for entry in entries)
+    marker = "\n## Sources\n"
+    if marker in report:
+        head, tail = report.split(marker, 1)
+        return f"{head}\n\n{block}\n{marker}{tail}"
+    return f"{report.rstrip()}\n\n{block}\n"
+
+
+# ---------------------------------------------------------------------------
+# Workflow result loading
+# ---------------------------------------------------------------------------
+def _decode_json(text: str, source: Path) -> Any:
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise MaterializationError(f"{source}: invalid JSON: {exc}") from exc
+
+
+def _extract_json_from_markdown(text: str, source: Path) -> Any:
+    heading_index = text.find("## Full return value")
+    search_from = heading_index if heading_index >= 0 else 0
+    match = re.search(r"```(?:json)?\s*\n(.*?)\n```", text[search_from:], re.DOTALL)
+    if not match:
+        raise MaterializationError(f"{source}: could not find a fenced JSON workflow return value")
+    return _decode_json(match.group(1), source)
+
+
+def load_workflow_result(path: Path) -> dict[str, Any]:
+    """Load a persisted workflow result from JSON or the readable Markdown artifact."""
+    path = Path(path)
+    if not path.is_file():
+        raise MaterializationError(f"{path}: workflow result does not exist")
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() == ".json":
+        payload = _decode_json(text, path)
+    else:
+        payload = _extract_json_from_markdown(text, path)
+
+    if isinstance(payload, dict) and isinstance(payload.get("result"), dict):
+        payload = payload["result"]
+    if not isinstance(payload, dict):
+        raise MaterializationError(f"{path}: workflow return value must be an object")
+    return payload
+
+
+def _registry(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    registry = payload.get("source_registry")
+    if isinstance(registry, list):
+        return [source for source in registry if isinstance(source, dict)]
+    cited = payload.get("cited_sources")
+    if isinstance(cited, list):
+        return [source for source in cited if isinstance(source, dict)]
+    return []
+
+
+def _word_budget_warning(payload: dict[str, Any], report: str) -> str | None:
+    """Warn when the delivered length departs materially from the confirmed target."""
+    summary = payload.get("run_summary")
+    if not isinstance(summary, dict):
+        return None
+    target = summary.get("target_words")
+    if not isinstance(target, int) or isinstance(target, bool) or target <= 0:
+        return None
+    words = len(strip_sources_section(report).split())
+    if words < int(target * SHORTFALL_RATIO):
+        return f"report is short: {words} words against a requested target of about {target}"
+    if words > int(target * OVERLENGTH_RATIO):
+        return f"report is long: {words} words against a requested target of about {target}"
+    return None
+
+
+def _degraded_stage_warning(payload: dict[str, Any]) -> str | None:
+    """Surface stages whose structured output was unusable."""
+    summary = payload.get("run_summary")
+    if not isinstance(summary, dict):
+        return None
+    degraded = summary.get("degraded_stages")
+    if not isinstance(degraded, list) or not degraded:
+        return None
+    names = ", ".join(str(stage) for stage in degraded)
+    return f"one or more stages returned an unusable record and were skipped: {names}"
+
+
+def resolve_report(payload: dict[str, Any]) -> tuple[str, str, list[dict[str, Any]]]:
+    """Return (report Markdown, status, cited sources) after structural validation.
+
+    A ``report_plan`` is preferred: its body file is the authoritative text for a
+    long report, and the bibliography is built here from the workflow registry.
+    """
+    status = payload.get("status")
+    if status not in {"complete", "partial"}:
+        raise MaterializationError(
+            f"workflow status is {status!r}; only complete or supported partial "
+            "reports can be written"
+        )
+
+    plan = payload.get("report_plan")
+    if isinstance(plan, dict) and str(plan.get("body_path") or "").strip():
+        body_path = Path(str(plan["body_path"]).strip())
+        if not body_path.is_file():
+            raise MaterializationError(f"{body_path}: report body file does not exist")
+        body_text = body_path.read_text(encoding="utf-8")
+        if not body_text.strip():
+            raise MaterializationError(f"{body_path}: report body file is empty")
+        title = str(plan.get("title") or "").strip()
+        first_line = body_text.strip().splitlines()[0]
+        if not title and first_line.startswith("# "):
+            title = first_line[2:].strip()
+        report, cited, issues = assemble_report(title, body_text, _registry(payload))
+    else:
+        raw = payload.get("report_markdown")
+        if not isinstance(raw, str) or not raw.strip():
+            raise MaterializationError(
+                "workflow result has neither a report_plan body file nor a nonempty report_markdown"
+            )
+        report = raw.strip() + "\n"
+        cited = [source for source in payload.get("cited_sources", []) if isinstance(source, dict)]
+        issues = []
+
+    if not strip_sources_section(report).strip():
+        issues.append("report body is empty")
+    issues.extend(structural_issues(report))
+    if issues:
+        raise MaterializationError("report is not deliverable: " + "; ".join(issues))
+    return report, status, cited
+
+
+def collision_safe_path(path: Path) -> Path:
+    """Return path or the first available numbered sibling."""
+    path = Path(path)
+    if not path.exists():
+        return path
+    counter = 2
+    while True:
+        candidate = path.with_name(f"{path.stem}-{counter}{path.suffix}")
+        if not candidate.exists():
+            return candidate
+        counter += 1
+
+
+def materialize_report(
+    result_path: Path,
+    output_path: Path,
+    *,
+    overwrite: bool = False,
+    collision_safe: bool = False,
+) -> tuple[Path, str, list[str]]:
+    """Validate a workflow result and write its report.
+
+    Returns the destination path, the workflow status, and any advisory warnings.
+    """
+    if overwrite and collision_safe:
+        raise MaterializationError("choose either overwrite or collision-safe output, not both")
+
+    payload = load_workflow_result(result_path)
+    report, status, _cited = resolve_report(payload)
+
+    warnings: list[str] = []
+    for warning in (_word_budget_warning(payload, report), _degraded_stage_warning(payload)):
+        if warning:
+            warnings.append(warning)
+
+    if status == "partial":
+        gaps = [str(gap) for gap in payload.get("gaps", []) if str(gap).strip()]
+        report = insert_gaps_section(report, gaps)
+
+    destination = Path(output_path)
+    if destination.exists():
+        if overwrite:
+            pass
+        elif collision_safe:
+            destination = collision_safe_path(destination)
+        else:
+            raise MaterializationError(
+                f"{destination}: output exists; use --overwrite or --collision-safe"
+            )
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(report, encoding="utf-8")
+    if destination.stat().st_size == 0:
+        raise MaterializationError(f"{destination}: report write produced an empty file")
+    return destination, status, warnings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("result_path", type=Path, help="workflow result.md or result.json")
+    parser.add_argument("output_path", type=Path, help="destination Markdown report")
+    destination = parser.add_mutually_exclusive_group()
+    destination.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="replace an existing output file (only with explicit user approval)",
+    )
+    destination.add_argument(
+        "--collision-safe",
+        action="store_true",
+        help="choose a numbered filename when the destination exists",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        path, status, warnings = materialize_report(
+            args.result_path,
+            args.output_path,
+            overwrite=args.overwrite,
+            collision_safe=args.collision_safe,
+        )
+    except (OSError, MaterializationError) as exc:
+        print(f"Materialization failed: {exc}", file=sys.stderr)
+        return 1
+
+    for warning in warnings:
+        print(f"Warning: {warning}", file=sys.stderr)
+    print(f"Materialized {status} report: {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kolega_code/_bundled_skills/skills/humanizer/LICENSE
+++ b/kolega_code/_bundled_skills/skills/humanizer/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Siqi Chen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/kolega_code/_bundled_skills/skills/humanizer/SKILL.md
+++ b/kolega_code/_bundled_skills/skills/humanizer/SKILL.md
@@ -1,0 +1,410 @@
+---
+name: humanizer
+description: Rewrite supplied prose to remove formulaic signs of AI-generated writing while preserving its facts, intended tone, and any supplied voice sample. Use when a user asks to humanize, de-AI, naturalize, or make existing text sound less robotic, including prose in a file. Do not use for code review, factual research, AI-authorship detection, plagiarism detection, or writing new content without source text.
+license: MIT
+compatibility: Pasted and embedded text require no external runtime. In-place file editing requires filesystem read/write access, and writes remain subject to the current host mode and permissions.
+metadata:
+  author: Siqi Chen
+  version: "2.9.1"
+  source: "https://github.com/blader/humanizer/tree/v2.9.1"
+  upstream_commit: "523374dee72d67c7b2b5f858ea0094ffda49c3ac"
+---
+
+# Humanizer: Remove AI Writing Patterns
+
+You are a writing editor that identifies and removes signs of AI-generated text to make writing sound more natural and human. This guide is based on Wikipedia's "Signs of AI writing" page, maintained by WikiProject AI Cleanup.
+
+## Your Task
+
+When given text to humanize:
+
+1. **Identify AI patterns** - Scan for the patterns listed below.
+2. **Preserve the information, not the shape** - Every claim in the original survives into the rewrite, but depth doesn't have to be uniform: compress the dull parts, dwell where a human would, and merge or split paragraphs freely. When keeping the information and mirroring the original's structure pull in different directions, the information wins.
+3. **Never invent facts** - The rewrite must not contain any fact, name, number, date, quote, or citation that isn't in the source text. Swapping a vague claim for a specific one is allowed only when the specific comes from the source or from the user; if a sentence needs real-world detail to work, ask for it or write the plain version without it. Opinions and reactions are voice, not facts: where PERSONALITY AND SOUL applies you may add stance, but never new factual claims. (In fiction, invented detail is the job. This rule governs everything else.)
+4. **Match the voice** - Fit the intended tone (formal, casual, technical). Add personality only when the content and the author's voice call for it (see PERSONALITY AND SOUL).
+
+How you're invoked changes what you deliver (see Invocation Modes). The draft → audit → final loop itself is defined under Process and Output, below.
+
+## Voice Calibration
+
+If the user provides a writing sample (their own previous writing), analyze it before rewriting:
+
+1. Read the sample first. Note its sentence lengths, vocabulary, paragraph openings, punctuation, recurring phrases, and transitions.
+2. Match those habits instead of merely deleting AI patterns. Do not upgrade casual words or regularize deliberate quirks.
+3. Without a sample, use the default behavior below.
+
+A sample outranks this skill's style rules, including the em dash rule in §14: if the sample uses em dashes, keep them at roughly the sample's frequency. Matching the author beats scrubbing the tell.
+
+## PERSONALITY AND SOUL
+
+Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as obvious as slop. Good writing has a human behind it.
+
+**Apply this section only when the content and the author's voice call for it** - blog posts, essays, opinion, personal writing. For encyclopedic, technical, legal, or reference text, neutral and plain *is* the correct human voice; don't inject opinions or first person there.
+
+When voice is appropriate, avoid uniform sentence structures, bloodless neutrality, and perfect organization. Let the writer have opinions, uncertainty, mixed feelings, humor, asides, and uneven rhythm. Never add factual claims to create that personality.
+
+## CONTENT PATTERNS
+
+### 1. Undue Emphasis on Significance, Legacy, and Broader Trends
+
+**Words to watch:** stands/serves as, is a testament/reminder, a vital/significant/crucial/pivotal/key role/moment, underscores/highlights its importance/significance, reflects broader, symbolizing its ongoing/enduring/lasting, contributing to the, setting the stage for, marking/shaping the, represents/marks a shift, key turning point, evolving landscape, focal point, indelible mark, deeply rooted
+**Problem:** LLM writing puffs up importance by adding statements about how arbitrary aspects represent or contribute to a broader topic.
+**Before:**
+> The Statistical Institute of Catalonia was officially established in 1989, marking a pivotal moment in the evolution of regional statistics in Spain. This initiative was part of a broader movement across Spain to decentralize administrative functions and enhance regional governance.
+**After:**
+> The Statistical Institute of Catalonia was established in 1989, part of a wider decentralization of administrative functions in Spain.
+
+### 2. Undue Emphasis on Notability and Media Coverage
+
+**Words to watch:** independent coverage, local/regional/national media outlets, written by a leading expert, active social media presence
+**Problem:** LLMs hit readers over the head with claims of notability, often listing sources without context.
+**Before:**
+> Her views have been cited in The New York Times, BBC, Financial Times, and The Hindu. She maintains an active social media presence with over 500,000 followers.
+**After:**
+> Her views have been cited in The New York Times and the BBC.
+
+(If the source gives real context for one citation, what she said and where, keep that one and drop the rest of the list. Don't invent the context to make the trimmed version sound better.)
+
+### 3. Superficial Analyses with -ing Endings
+
+**Words to watch:** highlighting/underscoring/emphasizing..., ensuring..., reflecting/symbolizing..., contributing to..., cultivating/fostering..., encompassing..., showcasing...
+**Problem:** AI chatbots tack present participle ("-ing") phrases onto sentences to add fake depth.
+**Before:**
+> The temple's color palette of blue, green, and gold resonates with the region's natural beauty, symbolizing Texas bluebonnets, the Gulf of Mexico, and the diverse Texan landscapes, reflecting the community's deep connection to the land.
+**After:**
+> The temple is painted blue, green, and gold, colors meant to evoke Texas bluebonnets and the Gulf of Mexico.
+
+### 4. Promotional and Advertisement-like Language
+
+**Words to watch:** boasts a, vibrant, rich (figurative), profound, enhancing its, showcasing, exemplifies, commitment to, natural beauty, nestled, in the heart of, groundbreaking (figurative), renowned, breathtaking, must-visit, stunning
+**Problem:** LLMs have serious problems keeping a neutral tone, especially for "cultural heritage" topics.
+**Before:**
+> Nestled within the breathtaking region of Gonder in Ethiopia, Alamata Raya Kobo stands as a vibrant town with a rich cultural heritage and stunning natural beauty.
+**After:**
+> Alamata Raya Kobo is a town in the Gonder region of Ethiopia.
+
+### 5. Vague Attributions and Weasel Words
+
+**Words to watch:** Industry reports, Observers have cited, Experts argue, Some critics argue, several sources/publications (when few cited)
+**Problem:** AI chatbots attribute opinions to vague authorities without specific sources.
+**Before:**
+> Due to its unique characteristics, the Haolai River is of interest to researchers and conservationists. Experts believe it plays a crucial role in the regional ecosystem.
+**After:**
+> Researchers and conservationists study the Haolai River for its unusual characteristics.
+
+(If a real source exists, name it. Never invent one to make a sentence sound sourced; an unsupported claim gets cut, not decorated.)
+
+### 6. Outline-like "Challenges and Future Prospects" Sections
+
+**Words to watch:** Despite its... faces several challenges..., Despite these challenges, Challenges and Legacy, Future Outlook
+**Problem:** Many LLM-generated articles include formulaic "Challenges" sections.
+**Before:**
+> Despite its industrial prosperity, Korattur faces challenges typical of urban areas, including traffic congestion and water scarcity. Despite these challenges, with its strategic location and ongoing initiatives, Korattur continues to thrive as an integral part of Chennai's growth.
+**After:**
+> Korattur has recurring traffic congestion and water shortages.
+
+(The specifics you'd want here, like when the congestion worsened or what the city did about it, come from sources or the user, not from the rewrite.)
+
+## LANGUAGE AND GRAMMAR PATTERNS
+
+### 7. Overused "AI Vocabulary" Words
+
+**High-frequency AI words:** Actually, additionally, align with, crucial, delve, emphasizing, enduring, enhance, fostering, garner, highlight (verb), interplay, intricate/intricacies, key (adjective), landscape (abstract noun), pivotal, showcase, tapestry (abstract noun), testament, underscore (verb), valuable, vibrant
+**Problem:** These words appear far more frequently in post-2023 text. They often co-occur.
+**Before:**
+> Additionally, a distinctive feature of Somali cuisine is the incorporation of camel meat. An enduring testament to Italian colonial influence is the widespread adoption of pasta in the local culinary landscape, showcasing how these dishes have integrated into the traditional diet.
+**After:**
+> Somali cuisine also includes camel meat, which is considered a delicacy. Pasta dishes, introduced during Italian colonization, remain common, especially in the south.
+
+### 8. Avoidance of "is"/"are" (Copula Avoidance)
+
+**Words to watch:** serves as/stands as/marks/represents [a], boasts/features/offers [a]
+**Problem:** LLMs substitute elaborate constructions for simple copulas.
+**Before:**
+> Gallery 825 serves as LAAA's exhibition space for contemporary art. The gallery features four separate spaces and boasts over 3,000 square feet.
+**After:**
+> Gallery 825 is LAAA's exhibition space for contemporary art. The gallery has four rooms totaling 3,000 square feet.
+
+### 9. Negative Parallelisms and Tailing Negations
+**Problem:** Constructions like "Not only...but..." or "It's not just about..., it's..." are overused. So are clipped tailing-negation fragments such as "no guessing" or "no wasted motion" tacked onto the end of a sentence instead of written as a real clause.
+**Before:**
+> It's not just about the beat riding under the vocals; it's part of the aggression and atmosphere. It's not merely a song, it's a statement.
+**After:**
+> The heavy beat adds to the aggressive tone.
+**Before (tailing negation):**
+> The options come from the selected item, no guessing.
+**After:**
+> The options come from the selected item without forcing the user to guess.
+
+### 10. Rule of Three Overuse
+**Problem:** LLMs force ideas into groups of three to appear comprehensive.
+**Before:**
+> The event features keynote sessions, panel discussions, and networking opportunities. Attendees can expect innovation, inspiration, and industry insights.
+**After:**
+> The event includes talks and panels. There's also time for informal networking between sessions.
+
+### 11. Elegant Variation (Synonym Cycling)
+**Problem:** AI has repetition-penalty code causing excessive synonym substitution.
+**Before:**
+> The protagonist faces many challenges. The main character must overcome obstacles. The central figure eventually triumphs. The hero returns home.
+**After:**
+> The protagonist faces many challenges but eventually triumphs and returns home.
+
+### 12. False Ranges
+**Problem:** LLMs use "from X to Y" constructions where X and Y aren't on a meaningful scale.
+**Before:**
+> Our journey through the universe has taken us from the singularity of the Big Bang to the grand cosmic web, from the birth and death of stars to the enigmatic dance of dark matter.
+**After:**
+> The book covers the Big Bang, star formation, and current theories about dark matter.
+
+### 13. Passive Voice and Subjectless Fragments
+**Problem:** LLMs often hide the actor or drop the subject entirely with lines like "No configuration file needed" or "The results are preserved automatically." Rewrite these when active voice makes the sentence clearer and more direct.
+**Before:**
+> No configuration file needed. The results are preserved automatically.
+**After:**
+> You do not need a configuration file. The system preserves the results automatically.
+
+## STYLE PATTERNS
+
+### 14. Em Dashes (and En Dashes): Cut Them
+
+**Rule:** The final rewrite contains no em dashes (—) or en dashes (–). The em dash is one of the most reliable AI tells, so treat this as a hard constraint, not a "use sparingly" preference. Replace each one, in rough order of preference: a period (start a new sentence), a comma (a tight aside), a colon (introducing an explanation), parentheses (a true aside), or restructure the sentence. Also catch spaced em dashes (` — `) and double hyphens (` -- `) used the same way.
+**Before:**
+> The term is primarily promoted by Dutch institutions—not by the people themselves. You don't say "Netherlands, Europe" as an address—yet this mislabeling continues—even in official documents.
+**After:**
+> The term is primarily promoted by Dutch institutions, not by the people themselves. You don't say "Netherlands, Europe" as an address, yet this mislabeling continues in official documents.
+**Before:**
+> The new policy — announced without warning — affects thousands of workers. The changes -- long overdue according to critics -- will take effect immediately.
+**After:**
+> The new policy, announced without warning, affects thousands of workers. The changes, long overdue according to critics, will take effect immediately.
+
+Before returning the final rewrite, scan it for `—` and `–`. Any hit means the draft isn't done. One exception: a user-provided writing sample that uses em dashes overrides this rule (see Voice Calibration); match the sample's frequency instead of banning them.
+
+### 15. Overuse of Boldface
+**Problem:** AI chatbots emphasize phrases in boldface mechanically.
+**Before:**
+> It blends **OKRs (Objectives and Key Results)**, **KPIs (Key Performance Indicators)**, and visual strategy tools such as the **Business Model Canvas (BMC)** and **Balanced Scorecard (BSC)**.
+**After:**
+> It blends OKRs, KPIs, and visual strategy tools like the Business Model Canvas and Balanced Scorecard.
+
+### 16. Inline-Header Vertical Lists
+**Problem:** AI outputs lists where items start with bolded headers followed by colons.
+**Before:**
+> - **User Experience:** The user experience has been significantly improved with a new interface.
+> - **Performance:** Performance has been enhanced through optimized algorithms.
+> - **Security:** Security has been strengthened with end-to-end encryption.
+**After:**
+> The update improves the interface, speeds up load times through optimized algorithms, and adds end-to-end encryption.
+
+### 17. Title Case in Headings
+**Problem:** AI chatbots capitalize all main words in headings.
+**Before:**
+> ## Strategic Negotiations And Global Partnerships
+**After:**
+> ## Strategic negotiations and global partnerships
+
+### 18. Emojis
+**Problem:** AI chatbots often decorate headings or bullet points with emojis.
+**Before:**
+> 🚀 **Launch Phase:** The product launches in Q3
+> 💡 **Key Insight:** Users prefer simplicity
+> ✅ **Next Steps:** Schedule follow-up meeting
+**After:**
+> The product launches in Q3. User research showed a preference for simplicity. Next step: schedule a follow-up meeting.
+
+### 19. Curly Quotation Marks
+**Problem:** ChatGPT uses curly quotes (“...”) instead of straight quotes ("...").
+**Before:**
+> He said “the project is on track” but others disagreed.
+**After:**
+> He said "the project is on track" but others disagreed.
+
+## COMMUNICATION PATTERNS
+
+### 20. Collaborative Communication Artifacts
+
+**Words to watch:** I hope this helps, Of course!, Certainly!, You're absolutely right!, Would you like..., Want me to...?, Want me to give examples?, Should I continue?, let me know, here is a...
+**Problem:** Text meant as chatbot correspondence gets pasted as content.
+**Before:**
+> Here is an overview of the French Revolution. I hope this helps! Let me know if you'd like me to expand on any section.
+**After:**
+> The French Revolution began in 1789 when financial crisis and food shortages led to widespread unrest.
+
+### 21. Knowledge-Cutoff Disclaimers and Speculative Gap-Filling
+
+**Words to watch:** as of [date], Up to my last training update, While specific details are limited/scarce..., based on available information, not publicly available, maintains a low profile, keeps personal details private, prefers to stay out of the spotlight, likely [grew up/studied/began], it is believed that
+**Problem:** Two related tells. (a) Older models leave hard knowledge-cutoff disclaimers in the text. (b) When a model can't find a source, it writes a paragraph *about* not finding one and then invents plausible filler to cover the gap. For a private person the guess almost always lands on the same stock phrases ("maintains a low profile," "keeps personal details private"), none of it sourced. Say what isn't known, or cut the sentence; don't dress a guess up as fact.
+**Before (cutoff disclaimer):**
+> While specific details about the company's founding are not extensively documented in readily available sources, it appears to have been established sometime in the 1990s.
+**After:**
+> The company's founding date is not documented in the available sources. (Or cut the sentence. State a date only if a source provides one.)
+**Before (speculative gap-fill):**
+> Information about her early life is not publicly available, suggesting she maintains a low profile and keeps personal details private. She likely grew up in a middle-class household, which shaped her later interest in education reform.
+**After:**
+> Her early life is not documented in the available sources. (Or omit the section.)
+
+### 22. Sycophantic/Servile Tone
+**Problem:** Overly positive, people-pleasing language.
+**Before:**
+> Great question! You're absolutely right that this is a complex topic. That's an excellent point about the economic factors.
+**After:**
+> The economic factors you mentioned are relevant here.
+
+## FILLER AND HEDGING
+
+### 23. Filler Phrases
+
+**Before → After:**
+- "In order to achieve this goal" → "To achieve this"
+- "Due to the fact that it was raining" → "Because it was raining"
+- "At this point in time" → "Now"
+- "In the event that you need help" → "If you need help"
+- "The system has the ability to process" → "The system can process"
+- "It is important to note that the data shows" → "The data shows"
+
+### 24. Excessive Hedging
+**Problem:** Over-qualifying statements.
+**Before:**
+> It could potentially possibly be argued that the policy might have some effect on outcomes.
+**After:**
+> The policy may affect outcomes.
+
+### 25. Generic Positive Conclusions
+**Problem:** Vague upbeat endings.
+**Before:**
+> The future looks bright for the company. Exciting times lie ahead as they continue their journey toward excellence. This represents a major step in the right direction.
+**After:**
+> (Cut the paragraph. End on the last concrete fact instead of a send-off. If the source states real plans, use those.)
+
+### 26. Hyphenated Word Pair Overuse
+
+**Words to watch:** third-party, cross-functional, client-facing, data-driven, decision-making, well-known, high-quality, real-time, long-term, end-to-end
+**Problem:** AI hyphenates these uniformly, including in predicate position (`the report is high-quality`). Humans hyphenate inconsistently — typically only when the compound is attributive (`a high-quality report`) and often dropping the hyphen otherwise (`the report is high quality`). Keep attributive-position hyphens; drop them when the compound follows the noun.
+**Before:**
+> The cross-functional team delivered a high-quality, data-driven report. The team is cross-functional, the report is high-quality, and the methodology is data-driven.
+**After:**
+> The cross-functional team delivered a high-quality, data-driven report. The team is cross functional, the report is high quality, and the methodology is data driven.
+
+### 27. Persuasive Authority Tropes
+
+**Phrases to watch:** The real question is, at its core, in reality, what really matters, fundamentally, the deeper issue, the heart of the matter
+**Problem:** LLMs use these phrases to pretend they are cutting through noise to some deeper truth, when the sentence that follows usually just restates an ordinary point with extra ceremony.
+**Before:**
+> The real question is whether teams can adapt. At its core, what really matters is organizational readiness.
+**After:**
+> The question is whether teams can adapt. That mostly depends on whether the organization is ready to change its habits.
+
+### 28. Signposting and Announcements
+
+**Phrases to watch:** Let's dive in, let's explore, let's break this down, here's what you need to know, now let's look at, without further ado
+**Problem:** LLMs announce what they are about to do instead of doing it. This meta-commentary slows the writing down and gives it a tutorial-script feel.
+**Before:**
+> Let's dive into how caching works in Next.js. Here's what you need to know.
+**After:**
+> Next.js caches data at multiple layers, including request memoization, the data cache, and the router cache.
+
+### 29. Fragmented Headers
+
+**Signs to watch:** A heading followed by a one-line paragraph that simply restates the heading before the real content begins.
+**Problem:** LLMs often add a generic sentence after a heading as a rhetorical warm-up. It usually adds nothing and makes the prose feel padded.
+**Before:**
+> ## Performance
+>
+> Speed matters.
+>
+> When users hit a slow page, they leave.
+**After:**
+> ## Performance
+>
+> When users hit a slow page, they leave.
+
+### 30. Diff-Anchored Writing
+**Problem:** Documentation or comments written as if narrating a change rather than describing the thing as it is. Unless the document is inherently version-scoped (changelogs, release notes, migration guides), it should read coherently without knowing what changed in the last commit.
+**Before:**
+> This function was added to replace the previous approach of iterating through all items, which caused O(n²) performance.
+**After:**
+> This function uses a hash map for O(1) lookups, avoiding the O(n²) cost of naive iteration.
+
+### 31. Manufactured Punchlines and Staccato Drama
+**Problem:** LLMs often make every sentence land like a quotable closer, then stack short declarative fragments to manufacture drama. A single short sentence for emphasis is fine; a run of them starts to sound engineered.
+**Before:**
+> Then AlphaEvolve arrived. It had no preference for symmetry. No aesthetic prior. No nostalgia for human taste. The old rules were gone.
+**After:**
+> AlphaEvolve changed the search because it did not favor symmetry or human-looking designs. That made some of the older assumptions less useful.
+
+### 32. Aphorism Formulas
+
+**Words to watch:** X is the Y of Z, X becomes a trap, X is not a tool but a mirror, the language of, the currency of, the architecture of
+**Problem:** LLMs turn ordinary claims into reusable aphorisms that sound profound without adding precision. Replace the formula with the concrete claim it is gesturing at.
+**Before:**
+> Symmetry is the language of trust. Efficiency becomes a trap when teams forget the human layer.
+**After:**
+> Symmetric layouts often feel more predictable to users. Teams can over-optimize workflows and miss how people actually use them.
+
+### 33. Conversational Rhetorical Openers
+
+**Phrases to watch:** Honestly?, Look, Here's the thing, The thing is, Let's be honest, Real talk, when used as standalone hooks or fake-candid pauses before an ordinary point.
+**Problem:** LLMs open with a fake-candid hook to manufacture intimacy before delivering a routine claim. The tell is the theatrical pause-and-reveal: a one-word question or aside, then the "real" answer. A person being honest usually just says the thing.
+**Before:**
+> Is it worth the price? Honestly? It depends on how often you'll use it.
+**After:**
+> Whether it's worth the price depends on how often you'll use it.
+
+## DETECTION GUIDANCE
+
+### What NOT to flag (false positives)
+
+A clean human writer can hit several of the patterns above without any AI involvement. Before rewriting, sanity-check that you are not gutting legitimate prose. The following are *not* reliable indicators on their own:
+
+- **Perfect grammar and consistent style.** Many writers are professionals or have been edited. Polish does not equal AI.
+- **Mixed casual and formal registers.** This often signals a person in a technical field, a young writer, or someone with neurodivergent prose habits — not a chatbot.
+- **"Bland" or "robotic" prose.** AI prose has *specific* tells. Generic dryness without those tells is just dry writing.
+- **Formal or academic vocabulary.** AI overuses *specific* fancy words (see §7), not all fancy words. Don't flatten "ostensibly" or "constituent" just because they sound brainy.
+- **Letter-style opening or closing on a comment.** Salutations and sign-offs predate ChatGPT by centuries.
+- **Common transition words in isolation.** *Additionally*, *moreover*, *consequently* are AI-coded only when piled up. One *however* is not a tell.
+- **Curly quotes alone.** macOS, Word, Google Docs, and most CMSes auto-curl by default. Curly quotes only count when stacked with other tells.
+- **Em dashes alone.** Many editors and journalists use them often. Em dashes are evidence only when paired with formulaic sales-y rhythm.
+- **One short emphatic sentence.** Humans use clipped sentences to land a point. Flag staccato drama only when several short fragments appear in a row and inflate the tone.
+- **"Honestly" or "look" mid-sentence.** These are ordinary in casual writing. The tell is the standalone theatrical opener, not the word itself.
+- **Unsourced claims.** Most of the web is unsourced. Lack of citations doesn't prove anything.
+- **Correct, complex formatting.** Visual editors and templates produce clean output without any AI.
+- **Secondhand text.** Do not rewrite watched phrases inside quotations, titles, proper names, or examples where the phrase is being discussed rather than used.
+
+When in doubt, look for **clusters** of tells, not isolated ones. A single em dash means nothing; em dashes plus rule-of-three plus *vibrant tapestry* plus a "Conclusion" section is a confession.
+
+### Signs of human writing (preserve these)
+
+When you see these, lean toward leaving the prose alone — they are evidence of a real person writing, and over-editing will destroy what makes the piece sound human:
+
+- **Specific, unusual, hard-to-fabricate detail.** A real address. A weird quote. The phrase "the lawyer who used to work upstairs from my dentist." LLMs round off specifics; humans hoard them.
+- **Mixed feelings and unresolved tension.** "I think this is mostly good, but it bothers me, and I can't fully explain why." LLMs default to clean takes.
+- **Dated, era-bound references.** Slang, memes, or in-jokes that map to a specific year and subculture. Models lag by a year or more.
+- **First-person editorial choices the writer can defend.** If the writer can explain *why* they made a particular cut or used a particular word, that's a strong human signal.
+- **Variety in sentence length.** Real writing alternates short and long. AI writing tends toward an even, mid-length cadence.
+- **Genuine asides, parentheticals, or self-corrections.** "(I keep wanting to say 'almost' here, but it really was certain.)" Models rarely interrupt themselves like this.
+- **Edits made before November 30, 2022.** ChatGPT's public launch. Anything older than that is, with very rare exceptions, not AI-written.
+
+---
+
+## Invocation Modes
+
+**Pasted text (default).** The user gives text in the conversation. Run the full loop below and deliver the draft, the audit bullets, and the final rewrite.
+
+**File mode.** The user points at a file and asks for it to be changed. Read it and run the draft → audit → final loop internally. When the current host mode and filesystem permissions allow writes, rewrite the file in place so it ends up containing only the final rewrite. Humanize the prose only: leave code blocks, frontmatter, structured data, and link targets untouched. In a read-only or planning context, do not attempt a write. Return the proposed rewrite when useful, or a concise limitation notice, and explicitly state that the file was not changed. After a successful edit, report a short summary of what changed rather than pasting the whole rewrite back.
+
+**Embedded mode.** Another task or agent is using this skill as one step of a larger job (a PR description, a commit message, a doc). Run the loop internally and output only the final text. No draft, no audit bullets, no summary. The caller wants prose, not ceremony.
+
+## Process and Output
+
+1. Read the input carefully and identify every instance of the patterns above.
+2. Write a **draft rewrite**. Check that it reads naturally aloud, varies sentence length, prefers specific details and simple constructions (is/are/has), and keeps the appropriate register.
+3. Ask two questions: **"What makes the below so obviously AI generated?"** and **"Does the rewrite state any fact, name, number, date, or citation that isn't in the source?"** Answer briefly. A fabrication is a defect even when it sounds more human than the vague original.
+4. Revise into a **final rewrite** that addresses them and contains no em or en dashes (see §14).
+
+In pasted-text mode, deliver the draft, the brief "still-AI" bullets, the final rewrite, and (optionally) a short summary of changes. In file and embedded modes, run the same loop but deliver only what the mode calls for (see Invocation Modes).
+
+## Reference
+
+This skill is based on [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), maintained by WikiProject AI Cleanup. The patterns documented there come from observations of thousands of instances of AI-generated text on Wikipedia.
+
+Key insight from Wikipedia: "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."


### PR DESCRIPTION
## Summary

- sync bundled skills from [`kolega-skills` v0.3.0](https://github.com/kolega-ai/kolega-skills/releases/tag/v0.3.0) at `c0ba68e7aee0994318913aa9fcaad4f57cbc11d7`
- add the `deep-research` bundled skill and its workflow/resources
- add the `humanizer` bundled skill
- refresh the bundle manifest and file hashes

## Validation

- `kolega-skills`: validation script, 114 unit tests, Ruff check/format, and packaging for all skills
- sync idempotency and exact archive comparison against tag `v0.3.0`
- `PYTHONDONTWRITEBYTECODE=1 uv run pytest tests/cli/test_bundled_skills.py -ra`
- `PYTHONDONTWRITEBYTECODE=1 uv run pre-commit run --all-files --show-diff-on-failure`
- built wheel and sdist, then verified both with `scripts/verify_bundled_skill_artifacts.py`
