### PR TITLE
chore: release v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.26.0 - 2026-07-31
+
 ### Added
 
+- **New bundled research and writing skills.** `deep-research` orchestrates
+  evidence-backed research and materializes cited reports, while `humanizer`
+  helps revise generated prose into more natural writing.
 - **OpenRouter provider.** `openrouter` (`OPENROUTER_API_KEY`) reaches the
   OpenRouter gateway, shipping a generated catalog of every tool-capable
   OpenRouter model with per-model context, output, vision, reasoning-effort and

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.25.2"
+__version__ = "0.26.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.25.2"
+__version__ = "0.26.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.25.2"
+version = "0.26.0"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -1531,7 +1531,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.25.2"
+version = "0.26.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- bump Kolega Code from `0.25.2` to `0.26.0`
- publish the accumulated `Unreleased` notes as the `2026-07-31` release entry
- include the newly bundled `deep-research` and `humanizer` skills in the changelog

## Validation
- `UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" uv sync --extra dev --frozen`
- `UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" ./run_tests.sh` (3794 passed, 1 skipped)
- `UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" uv run pre-commit run --all-files --show-diff-on-failure`
- `UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" uv build`
- verified bundled-skill package data in the wheel and sdist
- verified wheel metadata reports `0.26.0`
