### PR TITLE
chore: release v0.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.26.1 - 2026-07-31
+
 ### Fixed
 
 - Gigacode resume now matches cached `agent()` results by call content instead

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.26.0"
+__version__ = "0.26.1"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.26.0"
+__version__ = "0.26.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.26.0"
+version = "0.26.1"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-24T09:49:44.723497Z"
+exclude-newer = "2026-07-24T15:20:35.299594Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1531,7 +1531,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.26.0"
+version = "0.26.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- bump package versions to `0.26.1`
- lock the release version and refresh the relative dependency cutoff
- publish the workflow reliability fixes in the changelog

## Validation

- `UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" PYTHONDONTWRITEBYTECODE=1 ./run_tests.sh` (3817 passed, 1 skipped)
- `UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" PYTHONDONTWRITEBYTECODE=1 uv run pre-commit run --all-files --show-diff-on-failure`