### PR TITLE
feat(cli): add gigacode flag to ask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+### Added
+
+- `kolega-code ask --gigacode` enables gigacode workflow orchestration in
+  headless runs, matching the TUI's `/gigacode` toggle: the `run_workflow` and
+  `list_workflow_runs` tools are exposed and the authoring guide is injected.
+  The setting persists with the session, so `ask --session <id>` resumes with
+  gigacode still on.
+
 ## 0.26.1 - 2026-07-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   The setting persists with the session, so `ask --session <id>` resumes with
   gigacode still on.
 
+### Changed
+
+- Gigacode's concurrent-worker cap is now a flat 8 instead of being derived from
+  the host's core count. Workers wait on provider responses rather than CPU, so
+  the old formula only made fan-out width vary with the machine — and collapse to
+  a single serial worker on a one-CPU host or container.
+
 ## 0.26.1 - 2026-07-31
 
 ### Fixed

--- a/docs/src/content/docs/gigacode.mdx
+++ b/docs/src/content/docs/gigacode.mdx
@@ -55,8 +55,15 @@ Gigacode is **off by default**. Toggle it with the `/gigacode`
 | `/gigacode on` | Enable workflow orchestration for the session |
 | `/gigacode off` | Disable it |
 
+Headless runs use the `--gigacode` flag instead:
+
+```bash
+kolega-code ask "audit every API route for auth gaps" --gigacode
+```
+
 Once on, it stays on for that resumable session — if you quit and resume the same
-session, the setting is restored. New sessions still start with Gigacode off. The
+session, the setting is restored, whether you resume in the TUI or with
+`kolega-code ask --session <id>`. New sessions still start with Gigacode off. The
 agent decides when a task is worth orchestrating. It works in both
 [Build and Plan modes](../tui/modes/) — see [Behavior and safety](#behavior-and-safety)
 for how each differs.

--- a/kolega_code/agent/orchestration/__init__.py
+++ b/kolega_code/agent/orchestration/__init__.py
@@ -20,7 +20,7 @@ from .errors import (
 )
 from .executor import DEFAULT_MAX_AGENT_DEPTH, MAX_AGENT_DEPTH, extract_meta, run_script, safe_builtins
 from .journal import ResumeCache, RunJournal, saved_workflows_dir, workflows_root
-from .runtime import DEFAULT_AGENT_CAP, MAX_FANOUT, WorkflowRuntime, default_concurrency
+from .runtime import DEFAULT_AGENT_CAP, DEFAULT_WORKFLOW_CONCURRENCY, MAX_FANOUT, WorkflowRuntime
 from .types import AgentRunResult, AgentRunSpec, DispatchFn, EmitFn
 
 __all__ = [
@@ -39,7 +39,7 @@ __all__ = [
     "workflows_root",
     "saved_workflows_dir",
     "WorkflowRuntime",
-    "default_concurrency",
+    "DEFAULT_WORKFLOW_CONCURRENCY",
     "MAX_FANOUT",
     "DEFAULT_AGENT_CAP",
     "AgentRunSpec",

--- a/kolega_code/agent/orchestration/guide.py
+++ b/kolega_code/agent/orchestration/guide.py
@@ -5,6 +5,8 @@ it in sync with the primitives in :mod:`runtime` and the tool in
 ``tool_backend/workflow_tool.py``.
 """
 
+from ..prompt_provider import PromptExtension
+
 GIGACODE_AUTHORING_GUIDE = """\
 ## gigacode — dynamic workflow orchestration
 
@@ -299,3 +301,21 @@ id as `resume_from_run_id` — every agent call it completed replays from the jo
 no cost. `list_workflow_runs` shows only this session's runs; a run still listed as
 "running" when no workflow is in flight died mid-run and is resumable the same way.
 """
+
+
+def gigacode_prompt_extension() -> PromptExtension:
+    """The authoring guide as a prompt extension, for every frontend that enables gigacode.
+
+    The TUI's ``/gigacode`` toggle and ``kolega-code ask --gigacode`` share this
+    so a headless run sees exactly the guidance an interactive session does.
+    """
+    return PromptExtension(
+        id="gigacode",
+        title="gigacode — workflow orchestration",
+        markdown=GIGACODE_AUTHORING_GUIDE,
+        agent_types=None,
+        modes=None,
+        # Sub-agents can't run workflows (run_workflow is gated off for them),
+        # so the authoring guide is just prompt bloat for a sub-agent.
+        propagate_to_sub_agents=False,
+    )

--- a/kolega_code/agent/orchestration/runtime.py
+++ b/kolega_code/agent/orchestration/runtime.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-import os
 import random
 from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional
 
@@ -43,14 +42,12 @@ DROPPED_ITEM_LOG_LIMIT = 10
 START_STAGGER_SECONDS = 0.75
 
 
-def default_concurrency() -> int:
-    """Concurrent-agent cap: a few below the core count, clamped to [1, 8].
-
-    Kept modest so a fan-out doesn't burst enough simultaneous LLM requests to trip
-    account-level rate limits; the jittered start-stagger further de-correlates them.
-    """
-    cpus = os.cpu_count() or 4
-    return max(1, min(8, cpus - 2))
+# Concurrent-agent cap for one workflow. A worker spends nearly all its wall-clock
+# waiting on a provider response, so the binding constraint is the account's rate
+# limit, not the host's core count — deriving this from cores only made the fan-out
+# width vary arbitrarily with the machine (and collapse to 1 in a single-CPU
+# container). The jittered start-stagger de-correlates the burst on top of this cap.
+DEFAULT_WORKFLOW_CONCURRENCY = 8
 
 
 def _call_with_arity(fn: Callable[..., Any], *args: Any) -> Any:
@@ -97,7 +94,7 @@ class WorkflowRuntime:
         if self._accounting.budget is not budget:
             raise ValueError("workflow accounting must own the runtime budget")
         self.budget = self._accounting.budget
-        self._sem = asyncio.Semaphore(concurrency or default_concurrency())
+        self._sem = asyncio.Semaphore(concurrency or DEFAULT_WORKFLOW_CONCURRENCY)
         self._max_agent_depth = max_agent_depth
         self._resolver = workflow_resolver
         self._routing_fingerprint = routing_fingerprint

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -16,6 +16,7 @@ from typing import Any, Iterable, Optional
 from kolega_code.agent import CoderAgent
 from kolega_code.config import EditProtocol
 from kolega_code.agent.custom_agents import discover_custom_agents, validate_custom_agent_models
+from kolega_code.agent.orchestration.guide import gigacode_prompt_extension
 from kolega_code.agent.prompt_provider import PromptExtension
 from kolega_code.agent.prompt_dump import (
     dump_prompt_overrides,
@@ -391,6 +392,11 @@ def _build_subcommand_parser() -> argparse.ArgumentParser:
     )
     ask.add_argument(
         "--mode", choices=[mode.value for mode in AgentMode], default=CLI_AGENT_MODE, help=argparse.SUPPRESS
+    )
+    ask.add_argument(
+        "--gigacode",
+        action="store_true",
+        help="Enable gigacode workflow orchestration (the TUI's /gigacode, for headless runs).",
     )
     ask.add_argument("--save", action="store_true", help="Persist the session after the prompt completes.")
     ask.add_argument("--json", action="store_true", help="Emit response chunks and events as JSON.")
@@ -1339,6 +1345,12 @@ async def _run_ask(args: argparse.Namespace) -> int:
         memory_project_path=launch_project_path,
     )
     agent_ref["agent"] = agent
+    # --gigacode turns orchestration on for this run; a resumed session that had
+    # it on keeps it on, exactly as the TUI's /gigacode toggle persists.
+    gigacode_enabled = bool(getattr(args, "gigacode", False)) or bool(session.gigacode_enabled)
+    if gigacode_enabled:
+        agent.apply_gigacode(True, gigacode_prompt_extension())
+    session.gigacode_enabled = gigacode_enabled
     lsp_messages = await agent.tool_collection.initialize()
     if not args.json:
         for msg in lsp_messages:

--- a/kolega_code/cli/tui/command_handlers.py
+++ b/kolega_code/cli/tui/command_handlers.py
@@ -257,18 +257,9 @@ class CommandHandlersMixin(tui_app_base.KolegaAppBase):
         self._update_mode_chrome()
 
     def _gigacode_prompt_extension(self) -> PromptExtension:
-        from kolega_code.agent.orchestration.guide import GIGACODE_AUTHORING_GUIDE
+        from kolega_code.agent.orchestration.guide import gigacode_prompt_extension
 
-        return PromptExtension(
-            id="gigacode",
-            title="gigacode — workflow orchestration",
-            markdown=GIGACODE_AUTHORING_GUIDE,
-            agent_types=None,
-            modes=None,
-            # Sub-agents can't run workflows (run_workflow is gated off for them),
-            # so the authoring guide is just prompt bloat for a sub-agent.
-            propagate_to_sub_agents=False,
-        )
+        return gigacode_prompt_extension()
 
     async def _command_goal(self, args: str) -> None:
         clean = args.strip()

--- a/tests/agent/orchestration/test_orchestration.py
+++ b/tests/agent/orchestration/test_orchestration.py
@@ -6,6 +6,7 @@ so they need none of the agent/LLM stack.
 
 import asyncio
 import json
+import os
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Optional
@@ -13,6 +14,7 @@ from typing import Any, Optional
 import pytest
 
 from kolega_code.agent.orchestration import (
+    DEFAULT_WORKFLOW_CONCURRENCY,
     AgentRunResult,
     AgentRunSpec,
     Budget,
@@ -38,7 +40,7 @@ def make_runtime(
     budget: Optional[Budget] = None,
     accounting: Optional[WorkflowRunAccounting] = None,
     resume_cache: Optional[ResumeCache] = None,
-    concurrency: int = 4,
+    concurrency: Optional[int] = 4,
     agent_cap: int = 1000,
     max_agent_depth: int = 1,
     run_id: str = "run",
@@ -422,6 +424,19 @@ async def test_unbounded_budget_remaining_is_inf(tmp_path):
 
 
 # ----------------------------------------------------------------------- caps
+@pytest.mark.parametrize("reported_cpus", [1, 2, 64, None])
+def test_default_concurrency_ignores_host_cpu_count(tmp_path: Path, monkeypatch, reported_cpus) -> None:
+    """Workers wait on the provider, not the CPU, so the cap is machine-independent.
+
+    A core-derived cap collapsed to 1 in a single-CPU container and varied with
+    whatever laptop the fan-out happened to run on.
+    """
+    monkeypatch.setattr(os, "cpu_count", lambda: reported_cpus)
+    runtime, _, _, _ = make_runtime(tmp_path, concurrency=None)
+
+    assert runtime._sem._value == DEFAULT_WORKFLOW_CONCURRENCY
+
+
 @pytest.mark.asyncio
 async def test_agent_cap_raises(tmp_path):
     runtime, _, _, _ = make_runtime(tmp_path, agent_cap=2)

--- a/tests/cli/_app_test_utils.py
+++ b/tests/cli/_app_test_utils.py
@@ -44,6 +44,8 @@ class FakeCoderAgent:
         self.active_goal_condition = None
         self.loop_active = False
         self.loop_prompt_extension = None
+        self.gigacode_enabled = False
+        self.gigacode_prompt_extension = None
         self.clear_history_calls = 0
         self.session_recorder = kwargs.get("session_recorder")
         self.queued_input_provider = None
@@ -56,6 +58,10 @@ class FakeCoderAgent:
     def apply_loop(self, active, prompt_extension=None):
         self.loop_active = active
         self.loop_prompt_extension = prompt_extension if active else None
+
+    def apply_gigacode(self, enabled, prompt_extension=None):
+        self.gigacode_enabled = enabled
+        self.gigacode_prompt_extension = prompt_extension if enabled else None
 
     def clear_history(self):
         self.clear_history_calls += 1

--- a/tests/cli/test_ask_gigacode.py
+++ b/tests/cli/test_ask_gigacode.py
@@ -1,0 +1,120 @@
+"""Tests for the ``kolega-code ask --gigacode`` headless orchestration flag.
+
+The flag has to do everything the TUI's ``/gigacode`` does: expose the
+``run_workflow`` / ``list_workflow_runs`` tools *and* inject the authoring
+guide. The end-to-end tests below drive a real ``CoderAgent`` through
+``main(["ask", ...])`` with only the LLM turn stubbed out, so a regression that
+sets the flag without opening the tool gate fails here.
+"""
+
+from kolega_code.agent.coder import CoderAgent
+from kolega_code.agent.orchestration.guide import GIGACODE_AUTHORING_GUIDE
+
+from ._app_test_utils import FakeCoderAgent
+
+ORCHESTRATION_TOOLS = {"run_workflow", "list_workflow_runs"}
+
+
+class RecordingCoderAgent(CoderAgent):
+    """The real agent, minus the network turn, recording every instance built."""
+
+    instances: list["RecordingCoderAgent"] = []
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        RecordingCoderAgent.instances.append(self)
+
+    async def process_message_stream(self, message, attachments=None):
+        yield {"type": "response", "content": "done", "complete": True, "uuid": "response-1"}
+
+    def tool_names(self) -> set[str]:
+        assert self.tool_collection is not None
+        return {tool.name for tool in self.tool_collection.get_tool_list()}
+
+    def system_prompt_text(self) -> str:
+        return "".join(getattr(block, "text", "") for block in self.system_prompt.content)
+
+
+class GigacodeAskFakeAgent(FakeCoderAgent):
+    agent_name = "coder"
+    instances: list["GigacodeAskFakeAgent"] = []
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        GigacodeAskFakeAgent.instances.append(self)
+
+    async def fire_hook(self, event, payload):
+        class Result:
+            additional_context = None
+            blocked = False
+            end_turn = False
+
+        return Result()
+
+
+def _setup(tmp_path, monkeypatch, agent_cls):
+    from kolega_code.cli import main as main_module
+
+    agent_cls.instances = []
+    monkeypatch.setattr(main_module, "CoderAgent", agent_cls)
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("KOLEGA_CODE_PROVIDER", "anthropic")
+    return main_module, project
+
+
+def test_ask_gigacode_exposes_orchestration_tools(tmp_path, monkeypatch, isolated_cli_env):
+    """The flag opens the run_workflow tool gate, not just a boolean."""
+    main_module, project = _setup(tmp_path, monkeypatch, RecordingCoderAgent)
+
+    exit_code = main_module.main(["ask", "do the thing", "--project", str(project), "--gigacode"])
+
+    assert exit_code == 0
+    agent = RecordingCoderAgent.instances[0]
+    assert agent.gigacode_enabled is True
+    assert ORCHESTRATION_TOOLS <= agent.tool_names()
+    # The authoring guide has to reach the model, or the tools are unusable.
+    assert GIGACODE_AUTHORING_GUIDE in agent.system_prompt_text()
+
+
+def test_ask_without_gigacode_hides_orchestration_tools(tmp_path, monkeypatch, isolated_cli_env):
+    main_module, project = _setup(tmp_path, monkeypatch, RecordingCoderAgent)
+
+    exit_code = main_module.main(["ask", "do the thing", "--project", str(project)])
+
+    assert exit_code == 0
+    agent = RecordingCoderAgent.instances[0]
+    assert agent.gigacode_enabled is False
+    assert not (ORCHESTRATION_TOOLS & agent.tool_names())
+    assert GIGACODE_AUTHORING_GUIDE not in agent.system_prompt_text()
+
+
+def test_ask_gigacode_persists_and_resumes_with_the_session(tmp_path, monkeypatch, isolated_cli_env):
+    """/gigacode sticks to a session; a resumed headless session inherits it."""
+    main_module, project = _setup(tmp_path, monkeypatch, RecordingCoderAgent)
+
+    assert main_module.main(["ask", "first", "--project", str(project), "--session", "s1", "--gigacode"]) == 0
+    # No --gigacode on the resume: the stored session state carries it.
+    assert main_module.main(["ask", "second", "--project", str(project), "--session", "s1"]) == 0
+
+    resumed = RecordingCoderAgent.instances[1]
+    assert resumed.gigacode_enabled is True
+    assert ORCHESTRATION_TOOLS <= resumed.tool_names()
+
+
+def test_ask_gigacode_applies_the_shared_prompt_extension(tmp_path, monkeypatch, isolated_cli_env):
+    """ask and the TUI's /gigacode must hand the agent the same extension."""
+    main_module, project = _setup(tmp_path, monkeypatch, GigacodeAskFakeAgent)
+
+    exit_code = main_module.main(["ask", "do the thing", "--project", str(project), "--gigacode"])
+
+    assert exit_code == 0
+    agent = GigacodeAskFakeAgent.instances[0]
+    assert agent.gigacode_enabled is True
+    extension = agent.gigacode_prompt_extension
+    assert extension is not None
+    assert extension.id == "gigacode"
+    assert extension.markdown == GIGACODE_AUTHORING_GUIDE
+    # Sub-agents can't run workflows, so the guide must not propagate to them.
+    assert extension.propagate_to_sub_agents is False


### PR DESCRIPTION
## Summary
- add `--gigacode` to headless `kolega-code ask` runs
- inherit and persist gigacode state when resuming sessions
- share the gigacode prompt extension between the CLI and TUI
- document the flag and add focused coverage

## Testing
- `PYTHONDONTWRITEBYTECODE=1 uv run pytest tests/cli/test_ask_gigacode.py -ra`
- `uv run ruff check kolega_code/agent/orchestration/guide.py kolega_code/cli/main.py kolega_code/cli/tui/command_handlers.py tests/cli/_app_test_utils.py tests/cli/test_ask_gigacode.py`
- `uv run ruff format --check kolega_code/agent/orchestration/guide.py kolega_code/cli/main.py kolega_code/cli/tui/command_handlers.py tests/cli/_app_test_utils.py tests/cli/test_ask_gigacode.py`
- `uv run pyright kolega_code/agent/orchestration/guide.py kolega_code/cli/main.py kolega_code/cli/tui/command_handlers.py tests/cli/_app_test_utils.py tests/cli/test_ask_gigacode.py`