### PR TITLE
chore: release v0.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.26.2 - 2026-07-31
+
 ### Added
 
 - `kolega-code ask --gigacode` enables gigacode workflow orchestration in

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.26.1"
+__version__ = "0.26.2"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.26.1"
+__version__ = "0.26.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.26.1"
+version = "0.26.2"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-24T15:20:35.299594Z"
+exclude-newer = "2026-07-24T16:36:28.429489Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1531,7 +1531,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.26.1"
+version = "0.26.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- bump package versions to `0.26.2`
- refresh `uv.lock`
- move the gigacode CLI and fixed-concurrency notes into the `0.26.2` changelog section

## Testing
- `UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" PYTHONDONTWRITEBYTECODE=1 ./run_tests.sh` (3825 passed, 1 skipped)
- `UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" uv run pre-commit run --all-files --show-diff-on-failure` (all hooks passed except Pyright, which sees unrelated untracked local Harbor benchmark files)
- `UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" uv run pyright kolega_code tests scripts`