### PR TITLE
Tool-call robustness + memory-off unification

### DIFF
--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -170,6 +170,7 @@ class BaseAgent(LogMixin):
         custom_agent_catalog: Optional[Any] = None,
         memory_manager: Optional[Any] = None,
         memory_project_path: Optional[Path] = None,
+        memory_enabled: bool = True,
     ) -> None:
         """
         Initialize a new BaseAgent instance.
@@ -308,15 +309,21 @@ class BaseAgent(LogMixin):
             from kolega_code.memory import MemoryAccessScope
 
             self.memory_manager = self.memory_manager.with_scope(MemoryAccessScope.SUBAGENT)
-        if self.memory_manager is None and not sub_agent and isinstance(self.filesystem, LocalFileSystem):
-            # Keep non-local/sandbox hosts unchanged unless they inject a manager.
+        elif self.memory_manager is None and not sub_agent:
             from kolega_code.cli.session_store import default_state_dir
             from kolega_code.memory import ProjectMemoryManager
 
-            self.memory_manager = ProjectMemoryManager(
-                memory_project_path if memory_project_path is not None else self.project_path,
-                default_state_dir(),
-            )
+            project = memory_project_path if memory_project_path is not None else self.project_path
+            # "Memory off" has one representation everywhere: a present-but-disabled
+            # manager, never a None. Memory is live only for a local project with the
+            # per-run opt-out unset; a non-local/sandbox host (whose storage would be a
+            # local state dir, disconnected from the remote project) or an explicit
+            # `--no-memory-tools` opt-out gets an inert, storage-inert manager that
+            # writes nothing. Dispatched sub-agents inherit whichever it is.
+            if memory_enabled and isinstance(self.filesystem, LocalFileSystem):
+                self.memory_manager = ProjectMemoryManager(project, default_state_dir())
+            else:
+                self.memory_manager = ProjectMemoryManager.disabled(project, default_state_dir())
             self.context.services.memory_manager = self.memory_manager
             self._owns_memory_manager = True
 

--- a/kolega_code/agent/browseragent.py
+++ b/kolega_code/agent/browseragent.py
@@ -20,12 +20,29 @@ class BrowserAgent(BaseAgent):
     agent_name = "browser-agent"
 
     @classmethod
-    def validate_model_capabilities(cls, config: AgentConfig) -> None:
-        """Require the resolved browser-agent model to accept image input."""
+    def resolved_model_supports_vision(cls, config: AgentConfig) -> bool:
+        """True if the model resolved for the browser-agent role accepts image input.
+
+        The browser agent may run on its own ``agent_models`` override, so this is
+        deliberately keyed on the browser-agent's resolved model — not the main
+        coding model, which can differ in either direction.
+        """
         model_config = config.model_config_for_agent(cls.agent_name)
         provider = getattr(model_config.provider, "value", model_config.provider)
-        if model_supports_vision(provider, model_config.model):
+        try:
+            return model_supports_vision(provider, model_config.model)
+        except ValueError:
+            # Unknown model → can't confirm image support → treat as no vision.
+            # This runs on every tool-list build, so it must never raise.
+            return False
+
+    @classmethod
+    def validate_model_capabilities(cls, config: AgentConfig) -> None:
+        """Require the resolved browser-agent model to accept image input."""
+        if cls.resolved_model_supports_vision(config):
             return
+        model_config = config.model_config_for_agent(cls.agent_name)
+        provider = getattr(model_config.provider, "value", model_config.provider)
         raise ValueError(
             "BrowserAgent requires a vision-capable model, but "
             f"{provider}/{model_config.model} does not support image input. "

--- a/kolega_code/agent/coder.py
+++ b/kolega_code/agent/coder.py
@@ -53,6 +53,7 @@ class CoderAgent(BaseAgent, LogMixin):
         custom_agent_catalog: Optional[Any] = None,
         memory_manager: Optional[Any] = None,
         memory_project_path: Optional[Path] = None,
+        memory_enabled: bool = True,
     ) -> None:
         """
         Initialize a new CoderAgent instance.
@@ -117,6 +118,7 @@ class CoderAgent(BaseAgent, LogMixin):
             custom_agent_catalog=custom_agent_catalog,
             memory_manager=memory_manager,
             memory_project_path=memory_project_path,
+            memory_enabled=memory_enabled,
         )
 
         # Configure tool collection with custom coder agent tools

--- a/kolega_code/agent/planningagent.py
+++ b/kolega_code/agent/planningagent.py
@@ -47,6 +47,7 @@ class PlanningAgent(BaseAgent):
         max_iterations: Optional[int] = None,
         custom_agent_catalog: Optional[Any] = None,
         memory_manager: Optional[Any] = None,
+        memory_enabled: bool = True,
     ) -> None:
         if custom_agent_catalog is not None:
             custom_agent_catalog = custom_agent_catalog.for_mode("plan")
@@ -81,6 +82,7 @@ class PlanningAgent(BaseAgent):
             max_iterations=max_iterations,
             custom_agent_catalog=custom_agent_catalog,
             memory_manager=memory_manager,
+            memory_enabled=memory_enabled,
         )
 
         self._completed_plan: Optional[str] = None

--- a/kolega_code/agent/tool_backend/search_codebase_tool.py
+++ b/kolega_code/agent/tool_backend/search_codebase_tool.py
@@ -22,6 +22,8 @@ _RC_MARKER = "__KOLEGA_RG_RC"
 
 # Display caps (shared by every engine via the single formatter).
 _MAX_FILES = 128
+# Ceiling for a caller-supplied ``max_results`` so a huge request can't flood context.
+_MAX_FILES_CEILING = 512
 _MAX_LINES_PER_FILE = 5
 _MAX_LINE_LENGTH = 200
 _MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
@@ -44,6 +46,10 @@ _BROAD_ROOT_EXCLUDE_DIRS = {
 class _EngineUnavailable(Exception):
     """Raised by an engine runner when it cannot run (binary missing, unknown
     flag, non-regex error) so the caller falls back to the next engine tier."""
+
+
+class _InvalidSearchPath(Exception):
+    """A caller-supplied ``path`` that escapes the project or isn't a directory."""
 
 
 class _SearchTimedOut(Exception):
@@ -147,6 +153,31 @@ class SearchCodebaseTool(BaseTool):
             excluded.update(_BROAD_ROOT_EXCLUDE_DIRS)
         return excluded
 
+    def _resolve_search_target(self, path: Optional[str]) -> str:
+        """Validate a caller-supplied ``path`` and return a project-relative search
+        root (``.`` for the whole project). Rejects absolute paths, parent escapes,
+        and non-directories so the search can never wander outside the project."""
+        if not path or path.strip() in ("", ".", "./"):
+            return "."
+        candidate = Path(path.strip())
+        if candidate.is_absolute() or ".." in candidate.parts:
+            raise _InvalidSearchPath(f"path must be a relative directory inside the project, got '{path}'")
+        rel = candidate.as_posix().strip("/")
+        if not rel:
+            return "."
+        try:
+            exists = self.filesystem.exists(rel)
+            is_dir = exists and self.filesystem.is_dir(rel)
+        except Exception:
+            # If the filesystem can't answer (e.g. an exotic sandbox), let the
+            # engine handle the path rather than blocking a legitimate search.
+            return rel
+        if not exists:
+            raise _InvalidSearchPath(f"path '{path}' was not found in the project")
+        if not is_dir:
+            raise _InvalidSearchPath(f"path '{path}' is not a directory; use file_pattern to filter files")
+        return rel
+
     async def search_codebase(
         self,
         pattern: str,
@@ -154,6 +185,8 @@ class SearchCodebaseTool(BaseTool):
         case_sensitive: bool = False,
         literal: bool = False,
         *,
+        path: Optional[str] = None,
+        max_results: int = _MAX_FILES,
         line_formatter: Optional[Callable[[int, str], str]] = None,
     ) -> str:
         """
@@ -170,9 +203,11 @@ class SearchCodebaseTool(BaseTool):
             file_pattern: Optional glob to filter which files to search (default: all files)
             case_sensitive: Whether the search is case-sensitive (default: False)
             literal: Treat the pattern as plain text instead of a regular expression (default: False)
+            path: Optional directory (relative to the project root) to restrict the search to; searches the whole project when omitted
+            max_results: Maximum number of matching files to return (default 128, capped at 512)
 
         Returns:
-            Markdown formatted list of files and matches, limited to 128 results
+            Markdown formatted list of files and matches, capped at ``max_results`` files
 
         Raises:
             Exception: If any error occurs during the search operation
@@ -198,10 +233,16 @@ class SearchCodebaseTool(BaseTool):
                 await self.log_error(error_msg, sender=self.caller.agent_name)
                 return f"Error: {error_msg}"
 
+            limit = max(1, min(int(max_results), _MAX_FILES_CEILING))
+            try:
+                search_target = self._resolve_search_target(path)
+            except _InvalidSearchPath as exc:
+                return f"Error: {exc}"
+
             # Run the first available engine; fall back down the tiers on failure.
             for runner in await self._engine_chain():
                 try:
-                    run = await runner(pattern, file_pattern, case_sensitive, literal, regex)
+                    run = await runner(pattern, file_pattern, case_sensitive, literal, regex, search_target, limit)
                 except _EngineUnavailable:
                     continue
                 except _SearchTimedOut:
@@ -213,7 +254,7 @@ class SearchCodebaseTool(BaseTool):
                         f"elapsed={run.elapsed_seconds:.2f}s)",
                         sender=self.caller.agent_name,
                     )
-                return self._format_results(run, pattern, line_formatter=line_formatter)
+                return self._format_results(run, pattern, limit=limit, line_formatter=line_formatter)
 
             # The Python tier never raises _EngineUnavailable, so this is unreachable.
             return f"No matches found for pattern '{pattern}'"
@@ -266,7 +307,9 @@ class SearchCodebaseTool(BaseTool):
     # ripgrep engine
     # ------------------------------------------------------------------
 
-    def _rg_args(self, pattern: str, file_pattern: str, case_sensitive: bool, literal: bool) -> List[str]:
+    def _rg_args(
+        self, pattern: str, file_pattern: str, case_sensitive: bool, literal: bool, search_target: str = "."
+    ) -> List[str]:
         args = [
             "--json",
             "--no-config",
@@ -297,17 +340,25 @@ class SearchCodebaseTool(BaseTool):
         if file_pattern != "*":
             glob = file_pattern if "/" not in file_pattern else f"**/{file_pattern}"
             args += ["-g", glob]
-        # Pattern as its own argv element (after -e) and an explicit search path so
-        # ripgrep never reads stdin in a headless context.
-        args += ["-e", pattern, "."]
+        # Pattern as its own argv element (after -e) and an explicit search path
+        # (the whole tree, or the caller's ``path`` subtree) so ripgrep never reads
+        # stdin in a headless context.
+        args += ["-e", pattern, search_target]
         return args
 
     async def _run_rg_local(
-        self, pattern: str, file_pattern: str, case_sensitive: bool, literal: bool, regex
+        self,
+        pattern: str,
+        file_pattern: str,
+        case_sensitive: bool,
+        literal: bool,
+        regex,
+        search_target: str = ".",
+        limit: int = _MAX_FILES,
     ) -> SearchRun:
         if shutil.which("rg") is None:
             raise _EngineUnavailable()
-        args = self._rg_args(pattern, file_pattern, case_sensitive, literal)
+        args = self._rg_args(pattern, file_pattern, case_sensitive, literal, search_target)
         env = {**os.environ, "RIPGREP_CONFIG_FILE": ""}
         try:
             proc = await asyncio.create_subprocess_exec(
@@ -329,9 +380,16 @@ class SearchCodebaseTool(BaseTool):
         return SearchRun(self._parse_rg_json(stdout.decode("utf-8", "replace")))
 
     async def _run_rg_sandbox(
-        self, pattern: str, file_pattern: str, case_sensitive: bool, literal: bool, regex
+        self,
+        pattern: str,
+        file_pattern: str,
+        case_sensitive: bool,
+        literal: bool,
+        regex,
+        search_target: str = ".",
+        limit: int = _MAX_FILES,
     ) -> SearchRun:
-        args = self._rg_args(pattern, file_pattern, case_sensitive, literal)
+        args = self._rg_args(pattern, file_pattern, case_sensitive, literal, search_target)
         cmd = "RIPGREP_CONFIG_FILE= rg " + " ".join(shlex.quote(a) for a in args)
         full_cmd = f"cd {shlex.quote(self._fs_root)} && {cmd} ; echo {_RC_MARKER}=$?"
         try:
@@ -390,7 +448,9 @@ class SearchCodebaseTool(BaseTool):
     # grep engine
     # ------------------------------------------------------------------
 
-    def _grep_argv(self, pattern: str, file_pattern: str, case_sensitive: bool, literal: bool) -> List[str]:
+    def _grep_argv(
+        self, pattern: str, file_pattern: str, case_sensitive: bool, literal: bool, search_target: str = "."
+    ) -> List[str]:
         argv = ["grep", "-r", "-n", "--binary-files=without-match"]
         if not case_sensitive:
             argv.append("-i")
@@ -403,16 +463,24 @@ class SearchCodebaseTool(BaseTool):
             argv.append("--exclude-dir=.*")
         for ext in sorted(self.BINARY_EXTENSIONS):
             argv.append(f"--exclude=*{ext}")
-        # -e guards a pattern that starts with '-'; '.' is the search root.
-        argv += ["-e", pattern, "."]
+        # -e guards a pattern that starts with '-'; search_target is the search
+        # root (the whole tree, or the caller's ``path`` subtree).
+        argv += ["-e", pattern, search_target]
         return argv
 
     async def _run_grep_local(
-        self, pattern: str, file_pattern: str, case_sensitive: bool, literal: bool, regex
+        self,
+        pattern: str,
+        file_pattern: str,
+        case_sensitive: bool,
+        literal: bool,
+        regex,
+        search_target: str = ".",
+        limit: int = _MAX_FILES,
     ) -> SearchRun:
         if shutil.which("grep") is None:
             raise _EngineUnavailable()
-        argv = self._grep_argv(pattern, file_pattern, case_sensitive, literal)
+        argv = self._grep_argv(pattern, file_pattern, case_sensitive, literal, search_target)
         try:
             proc = await asyncio.create_subprocess_exec(
                 *argv,
@@ -431,9 +499,16 @@ class SearchCodebaseTool(BaseTool):
         return SearchRun(self._drop_oversize_local(records))
 
     async def _run_grep_sandbox(
-        self, pattern: str, file_pattern: str, case_sensitive: bool, literal: bool, regex
+        self,
+        pattern: str,
+        file_pattern: str,
+        case_sensitive: bool,
+        literal: bool,
+        regex,
+        search_target: str = ".",
+        limit: int = _MAX_FILES,
     ) -> SearchRun:
-        argv = self._grep_argv(pattern, file_pattern, case_sensitive, literal)
+        argv = self._grep_argv(pattern, file_pattern, case_sensitive, literal, search_target)
         cmd = " ".join(shlex.quote(a) for a in argv)
         full_cmd = f"cd {shlex.quote(self._fs_root)} && {cmd} ; echo {_RC_MARKER}=$?"
         try:
@@ -524,15 +599,23 @@ class SearchCodebaseTool(BaseTool):
     # ------------------------------------------------------------------
 
     async def _run_python(
-        self, pattern: str, file_pattern: str, case_sensitive: bool, literal: bool, regex
+        self,
+        pattern: str,
+        file_pattern: str,
+        case_sensitive: bool,
+        literal: bool,
+        regex,
+        search_target: str = ".",
+        limit: int = _MAX_FILES,
     ) -> SearchRun:
         if hasattr(self.filesystem, "sandbox"):
-            return await self._run_python_sandbox_fallback(file_pattern, regex)
+            return await self._run_python_sandbox_fallback(file_pattern, regex, search_target, limit)
 
         normalized_pattern = "**/*" if file_pattern == "*" else f"**/{file_pattern}"
         self._load_gitignore_patterns()
+        scan_root = Path(self._fs_root) if search_target == "." else Path(self._fs_root) / search_target
         scan = await scan_workspace(
-            Path(self._fs_root),
+            scan_root,
             pattern=normalized_pattern,
             include_files=True,
             include_directories=False,
@@ -543,9 +626,9 @@ class SearchCodebaseTool(BaseTool):
             ignore_spec=getattr(self, "_gitignore_spec", None),
             limits=ScanLimits(timeout_seconds=_SCAN_TIMEOUT_SECONDS, max_entries=_SCAN_MAX_ENTRIES),
         )
-        return await self._search_scanned_files(scan, regex)
+        return await self._search_scanned_files(scan, regex, limit)
 
-    async def _search_scanned_files(self, scan: ScanOutcome, regex) -> SearchRun:
+    async def _search_scanned_files(self, scan: ScanOutcome, regex, limit: int = _MAX_FILES) -> SearchRun:
         cancel_event = threading.Event()
         started = time.monotonic()
         remaining = max(0.01, _SEARCH_TIMEOUT_SECONDS - scan.elapsed_seconds)
@@ -570,7 +653,7 @@ class SearchCodebaseTool(BaseTool):
                     if regex.search(line):
                         records.append((norm, line_num, line))
                         matched_files.add(norm)
-                if len(matched_files) > _MAX_FILES:
+                if len(matched_files) > limit:
                     return SearchRun(
                         records,
                         False,
@@ -598,17 +681,24 @@ class SearchCodebaseTool(BaseTool):
             task.cancel()
             return SearchRun([], False, "deadline", scan.visited_entries, _SEARCH_TIMEOUT_SECONDS)
 
-    async def _run_python_sandbox_fallback(self, file_pattern: str, regex) -> SearchRun:
+    async def _run_python_sandbox_fallback(
+        self, file_pattern: str, regex, search_target: str = ".", limit: int = _MAX_FILES
+    ) -> SearchRun:
         """Keep the legacy remote-files fallback off-loop and time bounded."""
         cancel_event = threading.Event()
         started = time.monotonic()
+        prefix = "" if search_target == "." else search_target.rstrip("/") + "/"
 
         def search() -> SearchRun:
             records: List[Record] = []
+            matched_files: set[str] = set()
             for file_path, file_size in self._get_files_batch_sync(file_pattern):
                 if cancel_event.is_set() or time.monotonic() - started >= _SEARCH_TIMEOUT_SECONDS:
                     return SearchRun(records, False, "deadline", elapsed_seconds=time.monotonic() - started)
                 if file_size > _MAX_FILE_SIZE or self._is_likely_binary_by_extension(file_path):
+                    continue
+                norm = self._normalize_path(file_path)
+                if prefix and not norm.startswith(prefix):
                     continue
                 try:
                     content = self.filesystem.read_text(file_path)
@@ -616,10 +706,12 @@ class SearchCodebaseTool(BaseTool):
                         continue
                 except Exception:
                     continue
-                norm = self._normalize_path(file_path)
                 for line_num, line in enumerate(content.splitlines(), start=1):
                     if regex.search(line):
                         records.append((norm, line_num, line))
+                        matched_files.add(norm)
+                if len(matched_files) > limit:
+                    return SearchRun(records, False, "result_limit", elapsed_seconds=time.monotonic() - started)
             return SearchRun(records, elapsed_seconds=time.monotonic() - started)
 
         task = asyncio.create_task(asyncio.to_thread(search))
@@ -643,6 +735,7 @@ class SearchCodebaseTool(BaseTool):
         run: SearchRun,
         original_pattern: str,
         *,
+        limit: int = _MAX_FILES,
         line_formatter: Optional[Callable[[int, str], str]] = None,
     ) -> str:
         """Group records by file (first-seen order), apply the display caps, and
@@ -652,7 +745,7 @@ class SearchCodebaseTool(BaseTool):
         for path, line_num, raw in run.records:
             if path in files:
                 files[path].append((line_num, raw))
-            elif len(files) < _MAX_FILES:
+            elif len(files) < limit:
                 files[path] = [(line_num, raw)]
             else:
                 limit_hit = True
@@ -690,9 +783,7 @@ class SearchCodebaseTool(BaseTool):
 
         output = f"# Search Results for '{original_pattern}'\n\n"
         if limit_hit or run.stop_reason == "result_limit":
-            output += (
-                f"⚠️ **Note:** Showing only the first {_MAX_FILES} results. There are more matches in the codebase.\n\n"
-            )
+            output += f"⚠️ **Note:** Showing only the first {limit} results. There are more matches in the codebase.\n\n"
         elif not run.complete:
             output += (
                 f"⚠️ **Incomplete search:** stopped because of {run.stop_reason or 'a search limit'}. "

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -2003,8 +2003,8 @@ class ToolCollection(LogMixin):
 
     async def eval(
         self,
-        language: str,
         code: str,
+        language: str = "py",
         title: Optional[str] = None,
         timeout: Optional[float] = None,
         reset: bool = False,
@@ -2034,8 +2034,8 @@ class ToolCollection(LogMixin):
         Top-level await works; declarations inside await-wrapped cells do NOT persist — use setGlobal(name, value) for cross-cell state there. Redeclaring an existing top-level name errors: assign without redeclaring, or pass reset=true.
 
         Args:
-            language: "py" for the persistent Python kernel, "js" for the persistent JavaScript kernel (js needs bun or node >= 18 on PATH).
             code: code to run in this eval call, verbatim. Top-level await is fine.
+            language: which kernel to run in; defaults to "py" (the persistent Python kernel). Pass "js" for the persistent JavaScript kernel (needs bun or node >= 18 on PATH).
             title: short label for this step shown in the transcript (e.g. "load csv", "chart by region").
             timeout: timeout for this cell in seconds; 0 disables it. Default 120, max 600.
             reset: wipe this language's kernel before running (fresh state). The other language is untouched.
@@ -2199,7 +2199,13 @@ class ToolCollection(LogMixin):
         return await self.memory_tool.delete_memory(path)
 
     async def search_codebase(
-        self, pattern: str, file_pattern: str = "*", case_sensitive: bool = False, literal: bool = False
+        self,
+        pattern: str,
+        file_pattern: str = "*",
+        case_sensitive: bool = False,
+        literal: bool = False,
+        path: Optional[str] = None,
+        max_results: int = 128,
     ) -> str:
         """
         Search the codebase for lines matching a regular expression (grep/ripgrep).
@@ -2210,14 +2216,19 @@ class ToolCollection(LogMixin):
         `^ $`, quantifiers `* + ? {n,m}`, groups `(...)`). Set `literal=True` to match
         the pattern as plain text instead (e.g. to find `arr[0]` or `a||b` verbatim).
 
+        Narrow a search with `path` (search only within a subdirectory) and
+        `max_results` (cap the number of files returned).
+
         Args:
             pattern: The regular expression to search for (use `literal=True` to match it as plain text)
-            file_pattern: Optional glob to filter which files to search (default: all files)
+            file_pattern: Glob to filter which files to search by name, e.g. `*.py` (default: all files)
             case_sensitive: Whether the search is case-sensitive (default: False)
             literal: Treat the pattern as plain text instead of a regular expression (default: False)
+            path: Directory (relative to the project root) to search within; searches the whole project when omitted
+            max_results: Maximum number of matching files to return (default 128, capped at 512)
 
         Returns:
-            Markdown formatted list of files and matches, limited to 128 results
+            Markdown formatted list of files and matches, capped at `max_results` files
 
         Raises:
             Exception: If any error occurs during the search operation
@@ -2236,6 +2247,8 @@ class ToolCollection(LogMixin):
             "file_pattern": file_pattern,
             "case_sensitive": case_sensitive,
             "literal": literal,
+            "path": path,
+            "max_results": max_results,
         }
         if formatter is not None:
             kwargs["line_formatter"] = formatter
@@ -2679,6 +2692,17 @@ class ToolCollection(LogMixin):
         # Vision gate: read_image is only surfaced to vision-capable models.
         if method_name == "read_image":
             return bool(getattr(self.caller, "supports_vision", False))
+
+        # Vision gate: dispatching the browser agent only works when the model
+        # resolved for the browser-agent role accepts images (it reads page
+        # screenshots). That model may differ from the main one, so gate on it —
+        # not caller.supports_vision — rather than offer a call that can only
+        # fail at dispatch.
+        if method_name == "dispatch_browser_agent":
+            from kolega_code.agent.browseragent import BrowserAgent
+
+            if not BrowserAgent.resolved_model_supports_vision(self.config):
+                return False
 
         # Settings gate: eval can be disabled host-wide (AgentConfig.eval_enabled).
         # Strict `is False` so Mock configs in tests keep the default (enabled).

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -398,6 +398,12 @@ def _build_subcommand_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Enable gigacode workflow orchestration (the TUI's /gigacode, for headless runs).",
     )
+    ask.add_argument(
+        "--no-memory-tools",
+        action="store_true",
+        help="Disable the persistent project-memory tools (read/list/write/edit/delete memory). "
+        "Use for headless or benchmark runs where there is no durable memory store to read or write.",
+    )
     ask.add_argument("--save", action="store_true", help="Persist the session after the prompt completes.")
     ask.add_argument("--json", action="store_true", help="Emit response chunks and events as JSON.")
     ask.add_argument("--browser-visible", action="store_true", help="Launch visible Playwright browser windows.")
@@ -1343,6 +1349,7 @@ async def _run_ask(args: argparse.Namespace) -> int:
         hook_dispatcher=hook_dispatcher,
         custom_agent_catalog=custom_agent_catalog,
         memory_project_path=launch_project_path,
+        memory_enabled=not getattr(args, "no_memory_tools", False),
     )
     agent_ref["agent"] = agent
     # --gigacode turns orchestration on for this run; a resumed session that had

--- a/kolega_code/memory/manager.py
+++ b/kolega_code/memory/manager.py
@@ -53,6 +53,7 @@ class ProjectMemoryManager:
         registry: MemoryBackendRegistry | None = None,
         access_scope: MemoryAccessScope = MemoryAccessScope.TOP_LEVEL,
         identity: ProjectIdentity | None = None,
+        inert: bool = False,
     ) -> None:
         self.identity = identity or resolve_project_identity(project_path)
         self.state_root = Path(state_root).expanduser()
@@ -64,15 +65,21 @@ class ProjectMemoryManager:
         self.registry = registry or default_registry()
         self.access_scope = access_scope
         self._source: ProjectMemoryManager | None = None
-        safety_error = self._storage_safety_error()
-        if safety_error is None:
+        # An inert manager is "present but off" and never touches storage: it
+        # skips the manifest read, refuses to create a backend, and rejects every
+        # mutation. It gives "memory disabled" one representation — used for
+        # non-local hosts and per-run opt-outs instead of a null manager.
+        self._inert = inert
+        if inert:
+            self._manifest = MemoryManifest.defaults(self.identity)
+            self._manifest.enabled = False
+            self._manifest_error = None
+        elif (safety_error := self._storage_safety_error()) is None:
             self._manifest, self._manifest_error = load_manifest(
                 self.manifest_path,
                 self.identity,
             )
         else:
-            from .manifest import MemoryManifest
-
             self._manifest = MemoryManifest.defaults(self.identity)
             self._manifest.enabled = False
             self._manifest_error = safety_error
@@ -82,6 +89,32 @@ class ProjectMemoryManager:
         self._lifecycle_lock = threading.RLock()
         self._closed = False
         self._owns_backend = True
+
+    @classmethod
+    def disabled(
+        cls,
+        project_path: Path | str,
+        state_root: Path | str,
+        *,
+        registry: MemoryBackendRegistry | None = None,
+        access_scope: MemoryAccessScope = MemoryAccessScope.TOP_LEVEL,
+        identity: ProjectIdentity | None = None,
+    ) -> "ProjectMemoryManager":
+        """A present-but-off manager that never touches storage.
+
+        Behaviorally identical to a ``None`` manager — empty tool bindings, empty
+        prompt context, no disk reads or writes — but gives "memory off" a single
+        representation for non-local hosts and per-run opt-outs. ``set_enabled(True)``
+        is refused: an inert manager has no storage to enable.
+        """
+        return cls(
+            project_path,
+            state_root,
+            registry=registry,
+            access_scope=access_scope,
+            identity=identity,
+            inert=True,
+        )
 
     @property
     def enabled(self) -> bool:
@@ -100,7 +133,7 @@ class ProjectMemoryManager:
         if self._source is not None:
             return self._source.backend
         with self._lifecycle_lock:
-            if self._closed or self._storage_safety_error() is not None:
+            if self._closed or self._inert or self._storage_safety_error() is not None:
                 return None
             if self._backend is None and self._backend_error is None and self.registry.available(self.backend_id):
                 try:
@@ -141,6 +174,7 @@ class ProjectMemoryManager:
             view._backend_warning = self._backend_warning
             view._lifecycle_lock = self._lifecycle_lock
             view._closed = self._closed
+            view._inert = self._inert
             view._owns_backend = False
             return view
 
@@ -174,6 +208,8 @@ class ProjectMemoryManager:
         )
 
     def set_enabled(self, enabled: bool) -> None:
+        if self._inert:
+            raise MemoryUnavailableError("project memory is disabled for this session and has no storage to enable")
         self._require_top_level()
         with self._manifest_lock():
             with self._lifecycle_lock:
@@ -186,6 +222,8 @@ class ProjectMemoryManager:
                 self._adopt_manifest(manifest, None)
 
     def select_backend(self, backend_id: str, settings: dict[str, Any] | None = None) -> None:
+        if self._inert:
+            raise MemoryUnavailableError("project memory is disabled for this session and has no storage to configure")
         self._require_top_level()
         validate_backend_id(backend_id)
         with self._manifest_lock():
@@ -298,6 +336,10 @@ class ProjectMemoryManager:
 
     def refresh(self) -> None:
         """Reload common config and notify the owned backend (top-level lifecycle only)."""
+        if self._inert:
+            # Reloading would read the manifest and, when absent, default to
+            # enabled=True — silently un-disabling. An inert manager stays off.
+            return
         self._require_top_level()
         safety_error = self._storage_safety_error()
         if safety_error is not None:
@@ -375,6 +417,8 @@ class ProjectMemoryManager:
     @contextmanager
     def _prepared_mutation(self) -> Generator[None, None, None]:
         """Serialize config observation and mutation against opt-out/backend changes."""
+        if self._inert:
+            raise MemoryUnavailableError("project memory is disabled for this session and has no storage to write")
         self._require_open()
         with self._manifest_lock():
             manifest, error = load_manifest(self.manifest_path, self.identity)

--- a/kolega_code/tools/core.py
+++ b/kolega_code/tools/core.py
@@ -1,7 +1,8 @@
 """Tool: a definition paired with its implementation and execution metadata."""
 
+import inspect
 from dataclasses import dataclass, field
-from typing import Any, Awaitable, Callable, FrozenSet
+from typing import Any, Awaitable, Callable, Dict, FrozenSet
 
 from ..llm.models import ToolDefinition
 
@@ -30,4 +31,41 @@ class Tool:
     parallel_safe: bool = False
 
     async def call(self, **inputs: Any) -> Any:
+        self._reject_malformed_call(inputs)
         return await self.handler(**inputs)
+
+    def _reject_malformed_call(self, inputs: Dict[str, Any]) -> None:
+        """Convert an argument-shape mismatch into a clean, public ``ToolError``.
+
+        Binding against the handler's signature *before* its body runs does two
+        things a post-hoc ``except`` cannot: it separates "the model called this
+        tool with the wrong arguments" from a genuine ``TypeError`` raised inside
+        the tool, and it never turns a valid call into an error (``bind`` binds
+        exactly when the real call would). ``Signature.bind``'s own message names
+        only arguments — never the handler's internal qualname — and the usage
+        string is built from the *public* tool name, so nothing internal leaks.
+        """
+        try:
+            signature = inspect.signature(self.handler)
+        except (TypeError, ValueError):
+            return  # Uninspectable callable: let the real call proceed unchanged.
+        try:
+            signature.bind(**inputs)
+        except TypeError as exc:
+            raise ToolError(f"Invalid arguments for `{self.name}`: {exc}. Usage: {self._usage(signature)}") from None
+
+    def _usage(self, signature: inspect.Signature) -> str:
+        """Render the tool's public call signature, e.g. ``eval(code, language='py')``."""
+        parts = []
+        for param in signature.parameters.values():
+            if param.name in ("self", "cls"):
+                continue
+            if param.kind is inspect.Parameter.VAR_POSITIONAL:
+                parts.append(f"*{param.name}")
+            elif param.kind is inspect.Parameter.VAR_KEYWORD:
+                parts.append(f"**{param.name}")
+            elif param.default is inspect.Parameter.empty:
+                parts.append(param.name)
+            else:
+                parts.append(f"{param.name}={param.default!r}")
+        return f"{self.name}({', '.join(parts)})"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,13 @@ exclude-newer = "1 week"
 
 [tool.pyright]
 include = ["kolega_code", "benchmarks", "tests"]
-exclude = ["benchmarks/edit_tools/fixtures/snapshots", "kolega_code/_bundled_skills"]
+exclude = [
+    "benchmarks/edit_tools/fixtures/snapshots",
+    # Terminal-Bench (Harbor) adapter: imports the optional `harbor` package,
+    # which isn't a project dependency, so pyright can't resolve it.
+    "benchmarks/terminal_bench",
+    "kolega_code/_bundled_skills",
+]
 typeCheckingMode = "basic"
 pythonVersion = "3.11"
 venvPath = "."

--- a/tests/agent/test_agent_tools_inventory.py
+++ b/tests/agent/test_agent_tools_inventory.py
@@ -261,6 +261,75 @@ def test_coder_agent_exposes_dispatch_general_agent(project_path, mock_connectio
     assert not tool_names.intersection(ToolCollection.browser_tools)
 
 
+MEMORY_TOOL_NAMES = {"read_memory", "list_memory", "write_memory", "edit_memory", "delete_memory"}
+
+
+@pytest.mark.parametrize("agent_cls", [CoderAgent, PlanningAgent])
+def test_memory_enabled_false_gates_tools_and_prompt_for_top_level_agents(
+    agent_cls, project_path, mock_connection_manager, agent_config
+):
+    """memory_enabled=False nulls the manager, removing memory tools AND the memory-policy
+    prompt section — for whichever top-level agent the mode selects, not just the coder."""
+
+    def build(*, memory_enabled):
+        return agent_cls(
+            project_path=project_path,
+            workspace_id="test_workspace",
+            thread_id=str(uuid.uuid4()),
+            connection_manager=mock_connection_manager,
+            config=agent_config,
+            agent_mode=AgentMode.CLI,
+            memory_enabled=memory_enabled,
+        )
+
+    enabled = build(memory_enabled=True)
+    disabled = build(memory_enabled=False)
+
+    # "Off" is one representation: a present-but-disabled manager, never None.
+    assert enabled.memory_manager is not None and enabled.memory_manager.enabled
+    assert disabled.memory_manager is not None and not disabled.memory_manager.enabled
+
+    # Both surfaces follow the manager: tools...
+    enabled_tools = {tool.name for tool in enabled.tool_collection.get_tool_list()}
+    disabled_tools = {tool.name for tool in disabled.tool_collection.get_tool_list()}
+    assert MEMORY_TOOL_NAMES & enabled_tools  # at least the read tools when enabled
+    assert not (MEMORY_TOOL_NAMES & disabled_tools)
+
+    # ...and the memory-policy section injected into the system prompt.
+    assert enabled.build_prompt_context().memory_policy != ""
+    assert disabled.build_prompt_context().memory_policy == ""
+
+
+def test_dispatch_browser_agent_gated_on_browser_agent_model_vision(
+    project_path, mock_connection_manager, agent_config
+):
+    """dispatch_browser_agent is offered iff the model *resolved for the browser-agent
+    role* is vision-capable — independent of the main coding model."""
+    main = agent_config.long_context_config  # claude-sonnet — vision-capable
+
+    vision_browser = Mock(provider="anthropic", model="claude-sonnet-4-5-20250929")
+    blind_browser = Mock(provider="deepseek", model="deepseek-v4-flash")
+
+    def tools_with_browser_model(browser_model):
+        agent_config.model_config_for_agent.side_effect = lambda name: (
+            browser_model if name == "browser-agent" else main
+        )
+        agent = CoderAgent(
+            project_path=project_path,
+            workspace_id="test_workspace",
+            thread_id=str(uuid.uuid4()),
+            connection_manager=mock_connection_manager,
+            config=agent_config,
+            agent_mode=AgentMode.CLI,
+        )
+        return {tool.name for tool in agent.tool_collection.get_tool_list()}
+
+    # Vision-capable browser-agent model -> offered even if we later flip the main model.
+    assert "dispatch_browser_agent" in tools_with_browser_model(vision_browser)
+    # Vision-less browser-agent model -> not offered, so the model can't waste a turn on it.
+    assert "dispatch_browser_agent" not in tools_with_browser_model(blind_browser)
+
+
 def test_sub_agent_coder_cannot_dispatch_general_agent(project_path, mock_connection_manager, agent_config):
     """A dispatched CoderAgent must not fan out into further sub-agents."""
     agent = CoderAgent(
@@ -475,8 +544,10 @@ def test_eval_tool_schema_carries_the_kernel_contract(project_path, mock_connect
     assert "model-facing format" in description
 
     params = {param.name: param for param in eval_tool.parameters}
-    assert params["language"].required is True
+    # `code` is the payload and stays required; `language` defaults to "py" (the
+    # dominant case), so omitting it is a valid call rather than a hard error.
     assert params["code"].required is True
+    assert params["language"].required is False
     assert params["title"].required is False
     assert params["timeout"].type == "number"
     assert params["reset"].type == "boolean"

--- a/tests/agent/test_browser_capabilities.py
+++ b/tests/agent/test_browser_capabilities.py
@@ -21,7 +21,11 @@ _EXTENSION_ORIGIN = "chrome-extension://edihigldhbmimflgjkohkgnjefmhngdn/"
 
 
 def _agent_config() -> AgentConfig:
-    model = ModelConfig(provider=ModelProvider.ANTHROPIC, model="test-model", rate_limits=RateLimitConfig())
+    # A real vision-capable model: the browser agent requires image support, and
+    # dispatch_browser_agent is now gated on the browser-agent model's vision.
+    model = ModelConfig(
+        provider=ModelProvider.ANTHROPIC, model="claude-sonnet-4-5-20250929", rate_limits=RateLimitConfig()
+    )
     return AgentConfig(
         anthropic_api_key="test-key",
         long_context_config=model,

--- a/tests/agent/test_tool_collection_builtin_dispatch.py
+++ b/tests/agent/test_tool_collection_builtin_dispatch.py
@@ -180,7 +180,7 @@ class TestToolCollection:
         result = await tool_collection.search_codebase(pattern, file_pattern, case_sensitive)
         assert result == expected_response
         tool_collection.search_codebase_tool.search_codebase.assert_called_once_with(
-            pattern, file_pattern=file_pattern, case_sensitive=case_sensitive, literal=False
+            pattern, file_pattern=file_pattern, case_sensitive=case_sensitive, literal=False, path=None, max_results=128
         )
 
     async def test_web_fetch(self, tool_collection: AsyncMock) -> None:

--- a/tests/agent/test_tool_collection_config.py
+++ b/tests/agent/test_tool_collection_config.py
@@ -41,12 +41,14 @@ def agent_config() -> AgentConfig:
         anthropic_api_key="test_key",
         openai_api_key="test-key",
         long_context_config=ModelConfig(
-            provider=ModelProvider.ANTHROPIC, model="test-model", rate_limits=RateLimitConfig()
+            provider=ModelProvider.ANTHROPIC, model="claude-sonnet-4-5-20250929", rate_limits=RateLimitConfig()
         ),
-        fast_config=ModelConfig(provider=ModelProvider.ANTHROPIC, model="test-model", rate_limits=RateLimitConfig()),
+        fast_config=ModelConfig(
+            provider=ModelProvider.ANTHROPIC, model="claude-sonnet-4-5-20250929", rate_limits=RateLimitConfig()
+        ),
         thinking_config=ModelConfig(
             provider=ModelProvider.ANTHROPIC,
-            model="test-model",
+            model="claude-sonnet-4-5-20250929",
             rate_limits=RateLimitConfig(),
             thinking_effort="medium",
         ),

--- a/tests/agent/test_tool_collection_memory.py
+++ b/tests/agent/test_tool_collection_memory.py
@@ -58,6 +58,7 @@ def _tools(
     manager: ProjectMemoryManager,
     *,
     sub_agent: bool = False,
+    include_memory_tools: bool = True,
     write_access: bool = True,
     allowed_tools: list[str] | None = None,
 ) -> ToolCollection:
@@ -69,7 +70,7 @@ def _tools(
         _config(),
         _caller(manager, sub_agent=sub_agent),
         tool_config=ToolCollectionConfig(
-            include_memory_tools=True,
+            include_memory_tools=include_memory_tools,
             memory_write_access=write_access,
             allowed_tools=allowed_tools,
         ),
@@ -302,6 +303,20 @@ def test_tool_schema_order_availability_and_revision_free_file_api(tmp_path: Pat
     assert "do nothing when the fact is already covered" in definitions["write_memory"].description
     assert "exact, unique" in definitions["edit_memory"].description
     assert "remove its link from MEMORY.md before deleting" in definitions["delete_memory"].description
+
+
+def test_include_memory_tools_false_removes_all_memory_tools(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    manager = ProjectMemoryManager(project, tmp_path / "state")
+
+    enabled = _tools(project, manager, include_memory_tools=True).registry()
+    disabled = _tools(project, manager, include_memory_tools=False).registry()
+
+    assert [name for name in enabled.names() if name in MEMORY_TOOL_NAMES] == MEMORY_TOOL_NAMES
+    assert not any(name in MEMORY_TOOL_NAMES for name in disabled.names())
+    # Non-memory tools are unaffected by the toggle.
+    assert "read_entire_file" in disabled.names()
 
 
 def test_subagent_exposes_only_read_and_list_even_when_write_is_requested(tmp_path: Path) -> None:

--- a/tests/agent/test_tool_registry.py
+++ b/tests/agent/test_tool_registry.py
@@ -3,7 +3,7 @@
 import pytest
 
 from kolega_code.llm.models import ToolDefinition
-from kolega_code.tools import Tool, ToolPolicy, ToolRegistry
+from kolega_code.tools import Tool, ToolError, ToolPolicy, ToolRegistry
 
 
 def make_tool(name: str, *, parallel_safe: bool = False, result: str = "ok") -> Tool:
@@ -91,6 +91,77 @@ class TestToolRegistry:
         subset_definitions = subset.definitions()
         assert [d.name for d in subset_definitions] == ["a", "b"]
         assert [d.cache_checkpoint for d in subset_definitions] == [False, True]
+
+
+class TestMalformedArgumentErrors:
+    """A wrong-arguments call becomes a clean, public ToolError — never a raw
+    TypeError that leaks the handler's internal class/method name."""
+
+    @staticmethod
+    def _tool(handler, name="eval"):
+        return Tool(
+            name=name,
+            definition=ToolDefinition(name=name, description=f"{name} tool", parameters=[]),
+            handler=handler,
+        )
+
+    @pytest.mark.asyncio
+    async def test_missing_required_argument_reports_usage(self):
+        async def handler(code: str, language: str = "py"):
+            return code
+
+        tool = self._tool(handler)
+        with pytest.raises(ToolError) as exc_info:
+            await tool.call(language="py")  # required `code` omitted
+        message = str(exc_info.value)
+        assert "Invalid arguments for `eval`" in message
+        assert "code" in message
+        assert "Usage: eval(code, language='py')" in message
+
+    @pytest.mark.asyncio
+    async def test_unexpected_keyword_reports_usage(self):
+        async def handler(code: str):
+            return code
+
+        tool = self._tool(handler)
+        with pytest.raises(ToolError) as exc_info:
+            await tool.call(code="x", bogus=1)
+        message = str(exc_info.value)
+        assert "unexpected keyword argument" in message
+        assert "Usage: eval(code)" in message
+
+    @pytest.mark.asyncio
+    async def test_message_never_leaks_handler_qualname(self):
+        # Public tool name `write` is backed by an internal method on a class the
+        # model must never see the name of.
+        class _SecretInternalCollection:
+            async def claude_write(self, path: str, content: str):
+                return content
+
+        tool = self._tool(_SecretInternalCollection().claude_write, name="write")
+        with pytest.raises(ToolError) as exc_info:
+            await tool.call(path="a.txt")  # required `content` omitted
+        message = str(exc_info.value)
+        assert "_SecretInternalCollection" not in message
+        assert "claude_write" not in message
+        assert "`write`" in message
+        assert "Usage: write(path, content)" in message
+
+    @pytest.mark.asyncio
+    async def test_varkw_handler_accepts_any_arguments(self):
+        async def handler(**kwargs):
+            return sorted(kwargs)
+
+        tool = self._tool(handler, name="flex")
+        assert await tool.call(a=1, b=2) == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_valid_call_passes_through_unchanged(self):
+        async def handler(code: str, language: str = "py"):
+            return f"{language}:{code}"
+
+        tool = self._tool(handler)
+        assert await tool.call(code="1+1") == "py:1+1"
 
 
 class TestToolCollectionRegistry:

--- a/tests/agent/tool_backend/test_search_codebase_tool.py
+++ b/tests/agent/tool_backend/test_search_codebase_tool.py
@@ -141,6 +141,42 @@ class TestSearchCodebaseTool:
         assert "src/utils.py" in result
         assert "tests/test_main.py" in result
 
+    async def test_search_codebase_path_scopes_to_subdirectory(self, search_codebase_tool, sample_files):
+        # "def" matches under both src/ and tests/; path="tests" restricts the search.
+        result = await search_codebase_tool.search_codebase("def", path="tests")
+
+        assert "tests/test_main.py" in result
+        assert "src/main.py" not in result
+        assert "src/utils.py" not in result
+
+    async def test_search_codebase_max_results_caps_files(self, search_codebase_tool, project_path):
+        for index in range(5):
+            (project_path / f"f{index}.py").write_text("needle\n")
+
+        result = await search_codebase_tool.search_codebase("needle", max_results=2)
+
+        shown = sum(1 for index in range(5) if f"f{index}.py" in result)
+        assert shown == 2
+        assert "Showing only the first 2 results" in result
+
+    async def test_search_codebase_rejects_path_escaping_project(self, search_codebase_tool, sample_files):
+        result = await search_codebase_tool.search_codebase("def", path="../outside")
+
+        assert result.startswith("Error:")
+        assert "inside the project" in result
+
+    async def test_search_codebase_rejects_nonexistent_path(self, search_codebase_tool, sample_files):
+        result = await search_codebase_tool.search_codebase("def", path="does-not-exist")
+
+        assert result.startswith("Error:")
+        assert "not found" in result
+
+    async def test_search_codebase_rejects_file_as_path(self, search_codebase_tool, sample_files):
+        result = await search_codebase_tool.search_codebase("def", path="src/main.py")
+
+        assert result.startswith("Error:")
+        assert "not a directory" in result
+
     async def test_search_codebase_no_matches(self, search_codebase_tool, sample_files):
         result = await search_codebase_tool.search_codebase("nonexistent_pattern")
 

--- a/tests/memory/test_project_memory_manager.py
+++ b/tests/memory/test_project_memory_manager.py
@@ -43,6 +43,39 @@ def test_lazy_private_persistence_and_project_isolation(tmp_path: Path) -> None:
     assert not ProjectMemoryManager(other, state).read_entry("MEMORY.md").present
 
 
+def test_disabled_manager_is_inert_and_never_touches_storage(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    project.mkdir()
+    state = tmp_path / "state"
+
+    manager = ProjectMemoryManager.disabled(project, state)
+
+    # Present but off — the single representation of "memory off".
+    assert not manager.enabled
+    assert not manager.status().enabled
+    assert manager.tool_bindings() == ()
+    with pytest.raises(MemoryUnavailableError):
+        manager.prompt_context()
+
+    # Every path that would touch disk on a live manager must stay inert here.
+    manager.refresh()  # must NOT reload the manifest and silently re-enable
+    assert not manager.enabled
+    scoped = manager.with_scope(MemoryAccessScope.SUBAGENT)
+    assert not scoped.enabled and scoped.tool_bindings() == ()
+    manager.status()
+    manager.close()
+
+    # Refuses to enable, reconfigure, or write.
+    fresh = ProjectMemoryManager.disabled(project, state)
+    with pytest.raises(MemoryUnavailableError):
+        fresh.set_enabled(True)
+    with pytest.raises(MemoryUnavailableError):
+        fresh.write_entry("MEMORY.md", "should not persist")
+
+    # After all of that, storage was never materialized on disk.
+    assert not state.exists()
+
+
 def test_complete_writes_and_path_only_deletes_are_revision_free(tmp_path: Path) -> None:
     project = tmp_path / "repo"
     project.mkdir()


### PR DESCRIPTION
Five tool-layer and memory improvements, most of them surfaced by mining a Terminal-Bench 2 run (deepseek-v4-flash) for where the model diverged from what kolega's tools accept. Three commits:

## 1. Memory off: one representation (inert-disabled manager)
"Memory off" had two in-memory representations — a `None` manager (non-local/sandbox hosts) and a present-but-disabled manager (the TUI toggle). Unified to one: **memory is off iff a manager is present with `enabled=False`**.
- `ProjectMemoryManager.disabled()` — in-memory `enabled=False`, skips `load_manifest`, guarded on every path (`backend`/`refresh`/`set_enabled`/`select_backend`/`_prepared_mutation`) so it never creates a backend or writes to disk (a test asserts **zero files written**).
- `BaseAgent` auto-create selects enabled-vs-inert instead of create-vs-`None`; sub-agents inherit via `with_scope`.
- New `ask --no-memory-tools` flag (threaded via `memory_enabled` through Coder/Planning). Gates **both** memory tools and the memory-policy prompt section from one lever.

## 2. Clean, signature-teaching tool-arg errors
Malformed tool calls leaked the raw Python `TypeError` (e.g. `ToolCollection.eval() missing 1 required positional argument`) to the model and transcript. `Tool.call` now binds inputs against the handler signature first and, on mismatch, raises a `ToolError` built from the **public** name + signature:
```
Invalid arguments for `eval`: got an unexpected keyword argument 'banana'.
Usage: eval(code, language='py', title=None, timeout=None, reset=False)
```
`Signature.bind` binds exactly when the real call would, so valid calls are untouched — only already-failing calls get a cleaner, leak-free, self-correcting message.

## 3. Tool schema: eval default · search scoping · browser vision gate
- **`eval`**: default `language="py"` and make `code` first/required — omitting `language` was the single most common malformed call, now just runs.
- **`search_codebase`**: add `path` (restrict to a validated subdirectory) and `max_results` (clamped to 512), threaded through all engines (ripgrep/grep/python, local + sandbox).
- **`dispatch_browser_agent`**: gated out of the registry when the model *resolved for the browser-agent role* lacks vision (keyed on that model, not the main one; robust to unknown models).

## Testing
- Full suite: **3891 passing** (the one red is a pre-existing live-API test, unrelated).
- Exercised end-to-end against a real model via `kolega-code ask`: `search_codebase(path, max_results)` scoping, the `eval` default, the clean `bind()` error, and `--no-memory-tools` all confirmed live.

## Not included
Benchmark tooling (the Terminal-Bench adapter) and the analysis/spec docs are intentionally left out of this PR — code + tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9yP5w5toLeth9mQU3KJeq
