### PR TITLE
chore: release v0.26.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.26.3 - 2026-08-02
+
+### Added
+
+- `kolega-code ask --no-memory-tools` disables the persistent project-memory
+  tools (read/list/write/edit/delete memory) and their prompt guidance for a
+  run — useful for headless or benchmark use where there is no durable memory
+  store.
+- `search_codebase` accepts `path` to restrict the search to a subdirectory and
+  `max_results` to cap how many files are returned.
+
+### Changed
+
+- `eval` now defaults `language` to `py`, so a call that omits the language runs
+  Python instead of failing.
+- A tool call made with the wrong arguments now returns a clear message naming
+  the expected signature (for example `Usage: eval(code, language='py', …)`) and
+  no longer exposes internal class or method names.
+- "Memory off" now has a single, consistent representation: a non-local host,
+  the new `--no-memory-tools` flag, and the memory toggle all behave the same
+  way, hiding both the memory tools and the memory prompt section.
+- The browser agent's dispatch tool is now hidden when the model configured for
+  the browser agent cannot accept images, instead of failing only when invoked.
+
 ## 0.26.2 - 2026-07-31
 
 ### Added

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.26.2"
+__version__ = "0.26.3"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.26.2"
+__version__ = "0.26.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.26.2"
+version = "0.26.3"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-24T16:36:28.429489Z"
+exclude-newer = "2026-07-26T06:50:28.619016Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1531,7 +1531,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.26.2"
+version = "0.26.3"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Release **v0.26.3**. Bumps the version in `pyproject.toml`, `uv.lock`, and both `__version__`s, and moves the changelog entry out of `Unreleased`.

Ships the tool-layer and memory work merged in #397 since v0.26.2:

- **Added** — `ask --no-memory-tools`; `search_codebase` `path` + `max_results`.
- **Changed** — `eval` defaults `language=py`; wrong-argument tool calls return a clear, signature-teaching error with no internal-name leaks; "memory off" has one consistent representation; the browser dispatch tool is hidden when the browser-agent model lacks vision.

Tag `v0.26.3` **after merge** to trigger the Release workflow (build → smoke → PyPI publish → GitHub Release), per RELEASING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9yP5w5toLeth9mQU3KJeq
