### PR TITLE
feat(llm): route deepseek-v4-flash to the DeepSeek Responses API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+### Changed
+
+- `deepseek-v4-flash` now connects over DeepSeek's **Responses API**
+  (`https://api.deepseek.com`) for its native tool-calling format and graded
+  reasoning effort. Every other DeepSeek model (including `deepseek-v4-pro`)
+  continues to use the OpenAI-compatible Chat Completions endpoint. This is a
+  per-model routing decision; no configuration change is required.
+
 ## 0.26.3 - 2026-08-02
 
 ### Added

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -1399,6 +1399,7 @@ class BaseAgent(LogMixin):
         client = LLMClient(
             provider=model_config.provider.value,
             api_key=self.config.get_api_key(model_config.provider) or "",
+            model=model_config.model,
             max_retries=model_config.rate_limits.max_retries,
             requests_per_minute=model_config.rate_limits.requests_per_minute,
             tokens_per_minute=model_config.rate_limits.tokens_per_minute,

--- a/kolega_code/agent/context.py
+++ b/kolega_code/agent/context.py
@@ -109,6 +109,7 @@ class AgentContext:
             return InstrumentedLLMClient(
                 provider=model_config.provider,
                 api_key=self.config.get_api_key(model_config.provider) or "",
+                model=model_config.model,
                 max_retries=model_config.rate_limits.max_retries,
                 requests_per_minute=model_config.rate_limits.requests_per_minute,
                 tokens_per_minute=model_config.rate_limits.tokens_per_minute,
@@ -126,6 +127,7 @@ class AgentContext:
         return LLMClient(
             provider=model_config.provider,
             api_key=self.config.get_api_key(model_config.provider) or "",
+            model=model_config.model,
             max_retries=model_config.rate_limits.max_retries,
             requests_per_minute=model_config.rate_limits.requests_per_minute,
             tokens_per_minute=model_config.rate_limits.tokens_per_minute,

--- a/kolega_code/agent/tool_backend/terminal_tool.py
+++ b/kolega_code/agent/tool_backend/terminal_tool.py
@@ -76,6 +76,7 @@ class TerminalTool(BaseTool):
         client = LLMClient(
             provider=provider.value,
             api_key=api_key or "",
+            model=self.config.fast_config.model,
             max_retries=rate_limits.max_retries,
             requests_per_minute=rate_limits.requests_per_minute,
             tokens_per_minute=rate_limits.tokens_per_minute,

--- a/kolega_code/agent/tool_backend/think_hard_tool.py
+++ b/kolega_code/agent/tool_backend/think_hard_tool.py
@@ -37,6 +37,7 @@ class ThinkHardTool(StreamingTool):
             client = InstrumentedLLMClient(
                 provider=provider.value,
                 api_key=api_key or "",
+                model=self.config.thinking_config.model,
                 max_retries=rate_limits.max_retries,
                 requests_per_minute=rate_limits.requests_per_minute,
                 tokens_per_minute=rate_limits.tokens_per_minute,
@@ -54,6 +55,7 @@ class ThinkHardTool(StreamingTool):
             client = LLMClient(
                 provider=provider.value,
                 api_key=api_key or "",
+                model=self.config.thinking_config.model,
                 max_retries=rate_limits.max_retries,
                 requests_per_minute=rate_limits.requests_per_minute,
                 tokens_per_minute=rate_limits.tokens_per_minute,

--- a/kolega_code/agent/tool_backend/web_fetch_tool.py
+++ b/kolega_code/agent/tool_backend/web_fetch_tool.py
@@ -142,6 +142,7 @@ class WebFetchTool(StreamingTool):
         client_kwargs = {
             "provider": provider.value,
             "api_key": self.config.get_api_key(provider),
+            "model": self.config.fast_config.model,
             "max_retries": rate_limits.max_retries,
             "requests_per_minute": rate_limits.requests_per_minute,
             "tokens_per_minute": rate_limits.tokens_per_minute,

--- a/kolega_code/llm/client.py
+++ b/kolega_code/llm/client.py
@@ -73,11 +73,18 @@ class LLMClient:
         requests_per_minute: Optional[int] = None,
         tokens_per_minute: Optional[int] = None,
         token_manager: Optional[Any] = None,
+        model: Optional[str] = None,
     ):
         self.provider_name = provider.lower()
         self._api_key = api_key  # Store API key privately
         # Refreshing OAuth token manager, used only by the ChatGPT-subscription provider.
         self._token_manager = token_manager
+        # Routing hint only: nearly every model shares its provider's API surface, so
+        # the client is provider-scoped and the model id is passed per call. The one
+        # exception is deepseek-v4-flash (Responses API vs the deepseek Chat default),
+        # which must be known at construction to pick the right provider class. The
+        # per-call `model=` kwarg still governs the request body.
+        self._model = model
         self.provider = self._initialize_provider(
             provider,
             max_retries=max_retries,
@@ -161,6 +168,23 @@ class LLMClient:
                     tokens_per_minute=tokens_per_minute,
                     base_url=chatgpt_constants.INFERENCE_BASE_URL,
                     provider_name=chatgpt_constants.PROVIDER_KEY,
+                )
+
+            # TEMPORARY single exception: deepseek-v4-flash speaks the Responses API
+            # (bare host, no /v1) while the rest of the deepseek catalog stays on Chat
+            # Completions. Special-cased here — like the ChatGPT provider above —
+            # because it needs a distinct base URL. Delete this branch once DeepSeek
+            # moves its catalog to Responses (then route "deepseek" wholesale).
+            if provider.lower() == "deepseek" and self._model == "deepseek-v4-flash":
+                from .providers.deepseek_responses import DeepSeekResponsesProvider
+
+                return DeepSeekResponsesProvider(
+                    api_key=self._api_key,
+                    max_retries=max_retries,
+                    requests_per_minute=requests_per_minute,
+                    tokens_per_minute=tokens_per_minute,
+                    base_url="https://api.deepseek.com",
+                    provider_name="deepseek",
                 )
 
             base_urls: Dict[str, str] = {

--- a/kolega_code/llm/instrumented_client.py
+++ b/kolega_code/llm/instrumented_client.py
@@ -80,8 +80,11 @@ class InstrumentedLLMClient(LLMClient):
         user_email: Optional[str] = None,
         usage_recorder: Optional[Any] = None,
         token_manager: Optional[Any] = None,
+        model: Optional[str] = None,
     ):
-        super().__init__(provider, api_key, max_retries, requests_per_minute, tokens_per_minute, token_manager)
+        super().__init__(
+            provider, api_key, max_retries, requests_per_minute, tokens_per_minute, token_manager, model=model
+        )
         self.langfuse = langfuse_client
         self.workspace_id = workspace_id
         self.thread_id = thread_id

--- a/kolega_code/llm/providers/deepseek_responses.py
+++ b/kolega_code/llm/providers/deepseek_responses.py
@@ -1,0 +1,66 @@
+"""DeepSeek provider that speaks the **Responses API** (``/responses``).
+
+TEMPORARY: ``deepseek-v4-flash`` is the one DeepSeek model on the Responses API
+today; the rest of the deepseek catalog stays on Chat Completions
+(:class:`~kolega_code.llm.providers.openai.OpenAIProvider`). DeepSeek plans to move
+its catalog over (``deepseek-v4-pro`` in early Aug 2026), at which point this class
+and its routing branch in ``client.py`` can be deleted and the whole ``deepseek``
+provider routed to Responses wholesale.
+
+Request building, streaming, and token counting are shared with the OpenAI
+Responses providers via
+:class:`~kolega_code.llm.providers.responses_common.ResponsesProviderBase`; only the
+transport differs — a plain api key against ``api.deepseek.com``. DeepSeek's Responses
+API is stateless (no ``previous_response_id`` / ``reasoning.encrypted_content``), so
+there is no cross-turn reasoning continuity, but unsupported params (including the
+``include=["reasoning.encrypted_content"]`` the shared builder sends) are silently
+ignored, so the shared request builder works unmodified. The base URL is the bare
+host — DeepSeek's Responses guide uses ``https://api.deepseek.com`` (no ``/v1``).
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Optional
+
+from openai import AsyncOpenAI
+
+from .base import BaseLLMProvider
+from .responses_common import ResponsesProviderBase
+
+DEFAULT_BASE_URL = "https://api.deepseek.com"
+DEFAULT_MODEL = "deepseek-v4-flash"
+
+
+class DeepSeekResponsesProvider(ResponsesProviderBase):
+    """DeepSeek Responses-API provider authenticated with a standard api key."""
+
+    def __init__(
+        self,
+        api_key: str,
+        max_retries: int = 3,
+        requests_per_minute: Optional[int] = None,
+        tokens_per_minute: Optional[int] = None,
+        base_url: Optional[str] = None,
+        provider_name: str = "deepseek",
+    ) -> None:
+        # Skip OpenAIProvider.__init__ (it builds Chat Completions sync+async
+        # clients); wire a Responses-only async client instead.
+        BaseLLMProvider.__init__(
+            self,
+            api_key=api_key,
+            max_retries=max_retries,
+            requests_per_minute=requests_per_minute,
+            tokens_per_minute=tokens_per_minute,
+            base_url=base_url or DEFAULT_BASE_URL,
+        )
+        self.provider_name = provider_name
+        # A stable per-session prompt_cache_key lets the backend cache the prompt
+        # prefix across turns (DeepSeek ignores it if unsupported, which is harmless).
+        self._session_id = str(uuid.uuid4())
+        self.async_client = AsyncOpenAI(api_key=api_key, base_url=self.base_url, max_retries=max_retries)
+        # The Responses path is async-only; the sync client is unused.
+        self.sync_client = None
+
+    def _default_model(self) -> str:
+        return DEFAULT_MODEL

--- a/kolega_code/llm/specs/catalog/deepseek.py
+++ b/kolega_code/llm/specs/catalog/deepseek.py
@@ -14,6 +14,11 @@ DEEPSEEK_SPECS = {
             mode="deepseek_effort",
         ),
     },
+    # deepseek-v4-flash speaks the Responses API (see DeepSeekResponsesProvider), so its
+    # reasoning effort must be emitted as the Responses `reasoning` block rather than the
+    # Chat-Completions `reasoning_effort` field the shared Responses request builder ignores.
+    # DeepSeek's Responses API is stateless (no reasoning.encrypted_content), so this mode
+    # also correctly excludes flash from the flat reasoning_content replay path.
     ("deepseek", "deepseek-v4-flash"): {
         "context_length": 1000000,
         "max_completion_tokens": 384000,
@@ -23,7 +28,7 @@ DEEPSEEK_SPECS = {
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "high", "max"),
             default="high",
-            mode="deepseek_effort",
+            mode="openai_responses_reasoning",
         ),
     },
 }

--- a/tests/agent/llm/test_client_live.py
+++ b/tests/agent/llm/test_client_live.py
@@ -100,11 +100,12 @@ async def test_anthropic_count_tokens(anthropic_client):
 async def test_anthropic_generate(anthropic_client):
     """Test text generation with Anthropic"""
     response = await anthropic_client.generate(messages=TEST_MESSAGES, system=TEST_SYSTEM, temperature=0.7)
-    # Test that the response has the expected attributes
+    # The default model (claude-opus-5) is a reasoning model and may return a
+    # ThinkingBlock before the TextBlock, so assert on the text content rather than
+    # assuming content[0] is the text block.
     assert hasattr(response, "content")
     assert len(response.content) > 0
-    assert hasattr(response.content[0], "text")
-    assert len(response.content[0].text) > 0
+    assert response.get_text_content().strip()
 
 
 @pytest.mark.slow

--- a/tests/agent/llm/test_deepseek_responses_live.py
+++ b/tests/agent/llm/test_deepseek_responses_live.py
@@ -1,0 +1,98 @@
+"""Credential-gated live smoke for deepseek-v4-flash over the **Responses API**.
+
+`deepseek-v4-flash` is the one DeepSeek model routed to the Responses API (see
+DeepSeekResponsesProvider); every other DeepSeek model stays on Chat Completions.
+These tests hit the real ``https://api.deepseek.com`` Responses endpoint, so they are
+marked ``slow``/``integration`` and skip when ``DEEPSEEK_API_KEY`` is unset. Run with:
+
+    ./run_tests.sh --all tests/agent/llm/test_deepseek_responses_live.py
+"""
+
+import os
+
+import pytest
+
+from kolega_code.llm.client import LLMClient
+from kolega_code.llm.models import Message, MessageHistory, TextBlock, ToolCall, ToolDefinition, ToolParameter
+from kolega_code.llm.providers.deepseek_responses import DeepSeekResponsesProvider
+
+pytestmark = [pytest.mark.slow, pytest.mark.integration]
+
+_MODEL = "deepseek-v4-flash"
+
+
+@pytest.fixture
+def deepseek_flash_client() -> LLMClient:
+    api_key = os.getenv("DEEPSEEK_API_KEY")
+    if not api_key:
+        pytest.skip("DEEPSEEK_API_KEY not set")
+    return LLMClient(provider="deepseek", api_key=api_key, model=_MODEL)
+
+
+def test_flash_client_routes_to_responses_provider(deepseek_flash_client):
+    # The live client must actually be on the Responses transport (bare host, no /v1),
+    # otherwise the tests below would silently exercise Chat Completions instead.
+    provider = deepseek_flash_client.provider
+    assert isinstance(provider, DeepSeekResponsesProvider)
+    assert provider.base_url == "https://api.deepseek.com"
+    assert provider.provider_name == "deepseek"
+
+
+@pytest.mark.asyncio
+async def test_generate_text_over_responses_api(deepseek_flash_client):
+    messages = MessageHistory([Message("user", [TextBlock("Reply with exactly: deepseek-ok")])])
+    system = Message("system", [TextBlock("Follow the user's instruction exactly.")])
+
+    response = await deepseek_flash_client.generate(
+        messages=messages,
+        system=system,
+        model=_MODEL,
+        thinking="high",
+        temperature=1.0,
+    )
+
+    assert isinstance(response, Message)
+    assert response.role == "assistant"
+    # Reasoning is on by default; assert on extracted text rather than a fixed index.
+    assert response.get_text_content().strip()
+
+    usage = response.usage_metadata or {}
+    assert usage.get("provider") == "deepseek"
+    # The Responses path reports prompt/completion/total tokens; reasoning tokens are
+    # folded into completion_tokens (DeepSeek bills thinking at the output rate).
+    assert usage.get("completion_tokens", 0) > 0
+    assert usage.get("prompt_tokens", 0) > 0
+
+
+@pytest.mark.asyncio
+async def test_tool_call_over_responses_api(deepseek_flash_client):
+    # The main reason to move flash to Responses is the native tool-calling format —
+    # exercise a real function-call round trip.
+    weather_tool = ToolDefinition(
+        name="get_weather",
+        description="Get the current weather for a city.",
+        parameters=[ToolParameter(name="city", type="string", description="City name", required=True)],
+    )
+    messages = MessageHistory(
+        [Message("user", [TextBlock("What is the weather in Paris right now? Use the get_weather tool.")])]
+    )
+    system = Message("system", [TextBlock("You are a helpful assistant. Use the provided tools when relevant.")])
+
+    response = await deepseek_flash_client.generate(
+        messages=messages,
+        system=system,
+        model=_MODEL,
+        tools=[weather_tool],
+        thinking="high",
+        temperature=1.0,
+    )
+
+    assert isinstance(response, Message)
+    tool_calls = [block for block in response.content if isinstance(block, ToolCall)]
+    assert tool_calls, f"expected a get_weather tool call, got: {[type(b).__name__ for b in response.content]}"
+    call = tool_calls[0]
+    assert call.name == "get_weather"
+    # Native Responses function args parse to a dict with the declared parameter.
+    assert isinstance(call.input, dict)
+    assert "city" in call.input
+    assert response.stop_reason == "tool_use"

--- a/tests/agent/llm/test_deepseek_responses_routing.py
+++ b/tests/agent/llm/test_deepseek_responses_routing.py
@@ -1,0 +1,60 @@
+# ruff: noqa: E402
+"""Model-level API routing for DeepSeek.
+
+`deepseek-v4-flash` speaks the Responses API (its own base URL), while every other
+DeepSeek model stays on the OpenAI-compatible Chat Completions path. This is a
+*model*-level decision made at client construction — the rest of the client is
+provider-scoped. See DeepSeekResponsesProvider and LLMClient._initialize_provider.
+"""
+
+from kolega_code.llm.client import LLMClient
+from kolega_code.llm.providers.deepseek_responses import DeepSeekResponsesProvider
+from kolega_code.llm.providers.openai import OpenAIProvider
+from kolega_code.llm.specs.thinking import build_thinking_request_params, reasoning_replay_field
+
+
+class TestDeepSeekModelRouting:
+    def test_flash_routes_to_responses_provider(self):
+        provider = LLMClient(provider="deepseek", api_key="sk-test", model="deepseek-v4-flash").provider
+        assert isinstance(provider, DeepSeekResponsesProvider)
+        # Responses guide uses the bare host, not the /v1 Chat Completions base.
+        assert provider.base_url == "https://api.deepseek.com"
+        assert provider.provider_name == "deepseek"
+
+    def test_pro_stays_on_chat_completions(self):
+        provider = LLMClient(provider="deepseek", api_key="sk-test", model="deepseek-v4-pro").provider
+        assert isinstance(provider, OpenAIProvider)
+        assert not isinstance(provider, DeepSeekResponsesProvider)
+        assert provider.base_url == "https://api.deepseek.com/v1"
+
+    def test_missing_model_defaults_to_chat_completions(self):
+        # No model at construction => safe default (Chat Completions), never the
+        # Responses special-case.
+        provider = LLMClient(provider="deepseek", api_key="sk-test").provider
+        assert isinstance(provider, OpenAIProvider)
+        assert not isinstance(provider, DeepSeekResponsesProvider)
+
+    def test_other_provider_ignores_flash_model_name(self):
+        # The special-case is guarded on provider == "deepseek"; a same-named model on a
+        # different provider must not be hijacked into the DeepSeek Responses provider.
+        provider = LLMClient(provider="openrouter", api_key="sk-test", model="deepseek-v4-flash").provider
+        assert not isinstance(provider, DeepSeekResponsesProvider)
+
+
+class TestDeepSeekReasoningShape:
+    def test_flash_emits_responses_reasoning_block(self):
+        # The shared Responses request builder only acts on a `reasoning` key; the flat
+        # `reasoning_effort` the Chat path uses would be silently dropped.
+        for effort in ("high", "max"):
+            params = build_thinking_request_params("deepseek", "deepseek-v4-flash", effort)
+            assert params == {"reasoning": {"effort": effort, "summary": "auto"}}
+
+    def test_pro_keeps_flat_reasoning_effort(self):
+        params = build_thinking_request_params("deepseek", "deepseek-v4-pro", "high")
+        assert params == {"reasoning_effort": "high"}
+
+    def test_flash_excluded_from_flat_replay_but_pro_included(self):
+        # DeepSeek's Responses API is stateless (no reasoning.encrypted_content), so flash
+        # must not replay reasoning via the flat reasoning_content field; pro still does.
+        assert reasoning_replay_field("deepseek", "deepseek-v4-flash") is None
+        assert reasoning_replay_field("deepseek", "deepseek-v4-pro") == "reasoning_content"

--- a/tests/agent/tool_backend/test_think_hard_streaming_updates.py
+++ b/tests/agent/tool_backend/test_think_hard_streaming_updates.py
@@ -143,6 +143,7 @@ async def test_think_hard_streaming_with_thinking_and_text(think_hard_tool, mock
             mock_llm_class.assert_called_once_with(
                 provider="anthropic",
                 api_key="test-key",
+                model="claude-3-7-sonnet-20250131",
                 max_retries=3,
                 requests_per_minute=10,
                 tokens_per_minute=100000,


### PR DESCRIPTION
## Summary

`deepseek-v4-flash` now connects over DeepSeek's **Responses API** (`https://api.deepseek.com`) for its native tool-calling format and graded reasoning effort, while every other DeepSeek model — including `deepseek-v4-pro` — stays on the OpenAI-compatible **Chat Completions** endpoint.

Because two models under the same `deepseek` provider now take different API surfaces, provider selection becomes **model-aware** (previously it was purely provider-keyed). This is intentionally a small, temporary special-case: DeepSeek plans to move its whole catalog to Responses (pro ~early Aug 2026), at which point the branch and the dedicated provider can be deleted and `deepseek` routed to Responses wholesale.

## What changed

- **New `DeepSeekResponsesProvider`** — thin `ResponsesProviderBase` subclass (bare host `https://api.deepseek.com`, default model `deepseek-v4-flash`), sharing the request builder / streaming / usage parsing with the OpenAI Responses providers.
- **Model-aware routing** — `LLMClient`/`InstrumentedLLMClient` take a `model` routing hint; a narrow, clearly-marked temporary branch early in `LLMClient._initialize_provider` (same pattern as the ChatGPT provider) builds the DeepSeek Responses provider for `deepseek-v4-flash` only. The per-call `model=` kwarg still governs the request body.
- **`model` threaded** into all 5 client construction sites (`context.py` ×2, `baseagent.py`, and the web_fetch / think_hard / terminal tool backends).
- **flash reasoning mode** → `openai_responses_reasoning`, so effort is emitted as the Responses `reasoning` block. flash is correctly excluded from the flat `reasoning_content` replay path — DeepSeek's Responses API is stateless (no `previous_response_id` / `reasoning.encrypted_content`), so there is no reasoning to replay across turns.

### Contract notes (verified against [DeepSeek's docs](https://api-docs.deepseek.com/guides/responses_api/))
- Base URL is the bare host (no `/v1`).
- `reasoning.effort` supported; `summary` accepted but no summary returned (so no reasoning text renders in the TUI for flash — expected).
- Unsupported params are silently ignored (our `include`/`store`/`prompt_cache_key` are harmless).
- Thinking is on by default; whether `effort:"none"` disables it is not documented — flagged as the one thing to watch operationally.

## Testing

- **Unit** — `tests/agent/llm/test_deepseek_responses_routing.py` (7): flash → Responses @ bare host, pro/no-model → Chat @ `/v1`, other providers ignore the flash name; reasoning-shape + replay-field split.
- **Live** — `tests/agent/llm/test_deepseek_responses_live.py` (3, credential-gated `slow`/`integration`): real endpoint text generation with usage metadata, and a native `get_weather` tool-call round-trip. Passing against the live API.
- **`kolega-code ask`** — exercised end-to-end on `deepseek-v4-flash`: plain text (exact output) and a tool-driven directory enumeration that returned the correct file list.
- Full default suite green (**3847 passed, 1 skipped**).

Also fixes two pre-existing/adjacent test issues surfaced here: a fragile live Anthropic assertion (`content[0]` assumed to be text, but `claude-opus-5` returns a `ThinkingBlock` first) and a `think_hard` test that pinned exact `LLMClient` constructor args.

🤖 Generated with [Claude Code](https://claude.com/claude-code)