### PR TITLE
chore: release v0.26.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.26.4 - 2026-08-02
+
 ### Changed
 
 - `deepseek-v4-flash` now connects over DeepSeek's **Responses API**

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.26.3"
+__version__ = "0.26.4"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.26.3"
+__version__ = "0.26.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.26.3"
+version = "0.26.4"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-26T06:50:28.619016Z"
+exclude-newer = "2026-07-26T08:13:30.801355Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1531,7 +1531,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.26.3"
+version = "0.26.4"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Release v0.26.4.

### Changed
- `deepseek-v4-flash` now connects over DeepSeek's **Responses API** (`https://api.deepseek.com`) for its native tool-calling format and graded reasoning effort, while every other DeepSeek model (including `deepseek-v4-pro`) stays on the OpenAI-compatible Chat Completions endpoint. Per-model routing decision; no configuration change required. (#400)

### Release checklist
- [x] Version bumped in `pyproject.toml`, `kolega_code/__init__.py`, `kolega_code/agent/__init__.py`, `uv.lock`
- [x] CHANGELOG updated (new `0.26.4` section, empty `Unreleased` retained)
- [x] Full suite + pre-commit green in `.venv-release` (3847 passed, 1 skipped)
- [ ] Merge, then tag `v0.26.4` from the merge commit to trigger the Release workflow (build → PyPI publish → GitHub Release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)