### PR TITLE
fix(llm): order assistant text before tool calls in Responses input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+### Fixed
+
+- DeepSeek `deepseek-v4-flash` on the Responses API no longer crashes mid-task
+  with a 400 "No tool output found for tool call ..." when the model returns tool
+  calls together with assistant text. The text was serialized between the tool
+  calls and their outputs, which DeepSeek rejects; it is now emitted before the
+  calls so each call's output stays adjacent. Tool calls are also defensively
+  guaranteed a matching output on replay.
+
 ## 0.26.4 - 2026-08-02
 
 ### Changed

--- a/kolega_code/llm/providers/responses_common.py
+++ b/kolega_code/llm/providers/responses_common.py
@@ -129,6 +129,7 @@ def to_responses_input(messages: MessageHistory) -> List[Dict[str, Any]]:
             continue
 
         text_parts: List[tuple] = []
+        tool_call_items: List[Dict[str, Any]] = []
         tool_image_messages: List[Dict[str, Any]] = []
         for block in message.content or []:
             if isinstance(block, ResponsesReasoningBlock):
@@ -140,8 +141,14 @@ def to_responses_input(messages: MessageHistory) -> List[Dict[str, Any]]:
                 # reasoning block first in the assistant message.
                 items.append(block.to_responses_item())
             elif isinstance(block, ToolCall):
+                # Collected, not emitted inline: the function_call items must be the
+                # LAST items of the assistant turn so the next message's
+                # function_call_output items follow them immediately. An assistant
+                # text item interposed between the calls and their outputs makes
+                # DeepSeek's Responses API 400 ("No tool output found for tool call
+                # ..."). See the assistant-text ordering below.
                 if block.input_kind == "freeform":
-                    items.append(
+                    tool_call_items.append(
                         {
                             "type": "custom_tool_call",
                             "call_id": block.id,
@@ -150,7 +157,7 @@ def to_responses_input(messages: MessageHistory) -> List[Dict[str, Any]]:
                         }
                     )
                 else:
-                    items.append(
+                    tool_call_items.append(
                         {
                             "type": "function_call",
                             "call_id": block.id,
@@ -178,11 +185,42 @@ def to_responses_input(messages: MessageHistory) -> List[Dict[str, Any]]:
             # Foreign Anthropic thinking/redacted-thinking blocks (from a prior
             # provider) are skipped here; adapt_history_for_provider has already
             # dropped them before this conversion runs.
+        # Assistant text goes BEFORE the tool calls; the calls stay last so their
+        # outputs (next message) are adjacent — required by DeepSeek's Responses API.
         if text_parts:
             item = _role_message_item(message.role, text_parts)
             if item:
                 items.append(item)
+        items.extend(tool_call_items)
         items.extend(tool_image_messages)
+
+    # Every function_call must be answered by a function_call_output or the
+    # Responses API 400s ("No tool output found for tool call ..."). A tool call
+    # can be left unanswered when a turn made several parallel calls and one
+    # result went missing (e.g. a yielded/long-running command). Mirror the Chat
+    # path (Message.to_openai) and pad any orphan with a placeholder output so the
+    # request stays valid. Keyed by call_id, preserving the freeform vs json shape.
+    # Defense-in-depth: every function_call must still be answered by a
+    # function_call_output, or the Responses API 400s. Pad any orphan (mirrors the
+    # Chat path, Message.to_openai). With the ordering above this should not fire,
+    # but a genuinely dropped result must not become a hard request failure.
+    answered = {
+        it.get("call_id") for it in items if it.get("type") in ("function_call_output", "custom_tool_call_output")
+    }
+    for it in items:
+        if it.get("type") not in ("function_call", "custom_tool_call"):
+            continue
+        call_id = it.get("call_id")
+        if call_id in answered:
+            continue
+        answered.add(call_id)
+        items.append(
+            {
+                "type": "custom_tool_call_output" if it["type"] == "custom_tool_call" else "function_call_output",
+                "call_id": call_id,
+                "output": "[no tool output recorded]",
+            }
+        )
     return items
 
 

--- a/tests/agent/llm/test_openai_responses_provider.py
+++ b/tests/agent/llm/test_openai_responses_provider.py
@@ -16,16 +16,98 @@ from kolega_code.llm.models import (
     MessageHistory,
     ResponsesReasoningBlock,
     TextBlock,
+    ToolCall,
     ToolDefinition,
+    ToolInputKind,
     ToolParameter,
+    ToolResult,
 )
 from kolega_code.llm.providers.models import GenerationParams
 from kolega_code.llm.providers.openai import OpenAIProvider
 from kolega_code.llm.providers.openai_responses import OpenAIResponsesProvider
+from kolega_code.llm.providers.responses_common import to_responses_input
 
 
 def _ns(**kwargs):
     return types.SimpleNamespace(**kwargs)
+
+
+def _mk_call(cid, kind: ToolInputKind = "json"):
+    inp = "{}" if kind == "freeform" else {"cmd": "x"}
+    return ToolCall(id=cid, name="run", input=inp, execution_id=cid, input_kind=kind)
+
+
+def _mk_result(cid, kind: ToolInputKind = "json"):
+    return ToolResult(tool_use_id=cid, content="ok", name="run", is_error=False, input_kind=kind)
+
+
+class TestOrphanedToolCallPadding:
+    """Every function_call must be answered or the Responses API 400s with
+    'No tool output found for tool call ...'. Parallel tool calls can leave one
+    unanswered (e.g. a yielded command); to_responses_input pads the orphan."""
+
+    def test_orphaned_parallel_call_gets_placeholder_output(self):
+        ids = ["call_00_a", "call_01_b", "call_02_c", "call_03_d"]
+        history = MessageHistory(
+            [
+                Message(role="user", content=[TextBlock(text="inspect")]),
+                Message(role="assistant", content=[_mk_call(i) for i in ids]),
+                Message(role="user", content=[_mk_result(i) for i in ids[:3]]),  # call_03_d orphaned
+            ]
+        )
+        items = to_responses_input(history)
+        calls = {it["call_id"] for it in items if it.get("type") == "function_call"}
+        outputs = {it["call_id"] for it in items if it.get("type") == "function_call_output"}
+        assert calls == set(ids)
+        assert calls == outputs  # every call answered, orphan padded
+        placeholder = [it for it in items if it.get("type") == "function_call_output" and it["call_id"] == "call_03_d"]
+        assert len(placeholder) == 1 and placeholder[0]["output"]
+
+    def test_fully_answered_calls_are_not_double_padded(self):
+        ids = ["call_00_a", "call_01_b"]
+        history = MessageHistory(
+            [
+                Message(role="assistant", content=[_mk_call(i) for i in ids]),
+                Message(role="user", content=[_mk_result(i) for i in ids]),
+            ]
+        )
+        outputs = [it for it in to_responses_input(history) if it.get("type") == "function_call_output"]
+        assert [o["call_id"] for o in outputs] == ids  # exactly one each, no extras
+
+    def test_orphaned_freeform_call_gets_custom_placeholder(self):
+        history = MessageHistory([Message(role="assistant", content=[_mk_call("call_00_ff", kind="freeform")])])
+        items = to_responses_input(history)
+        pad = [it for it in items if it.get("type") == "custom_tool_call_output"]
+        assert len(pad) == 1 and pad[0]["call_id"] == "call_00_ff"
+
+
+class TestAssistantTextToolCallOrdering:
+    """When an assistant turn has both text and tool calls, the text must be
+    emitted BEFORE the function_calls so the next message's outputs stay adjacent
+    to the calls. An interposed assistant message makes DeepSeek's Responses API
+    400 ("No tool output found for tool call ...")."""
+
+    def test_assistant_text_precedes_tool_calls_and_outputs_are_adjacent(self):
+        ids = ["call_00_a", "call_01_b"]
+        history = MessageHistory(
+            [
+                Message(role="user", content=[TextBlock(text="inspect the repo")]),
+                # The model emitted a preamble sentence AND two tool calls.
+                Message(
+                    role="assistant",
+                    content=[TextBlock(text="I'll check a couple things."), *[_mk_call(i) for i in ids]],
+                ),
+                Message(role="user", content=[_mk_result(i) for i in ids]),
+            ]
+        )
+        types = [it.get("type") or it.get("role") for it in to_responses_input(history)]
+        # assistant text must come before the first function_call
+        assert types.index("assistant") < types.index("function_call")
+        # and NO assistant/user message may sit between the calls and their outputs
+        first_call = types.index("function_call")
+        first_output = types.index("function_call_output")
+        between = types[first_call:first_output]
+        assert set(between) == {"function_call"}, f"non-call item interposed: {between}"
 
 
 class _FakeStream:


### PR DESCRIPTION
## Summary

`deepseek-v4-flash` on the Responses API crashed mid-task with a 400 **"No tool output found for tool call ..."** whenever the model returned **tool calls together with assistant text**.

`to_responses_input` emitted the assistant text **after** the function_calls, so it landed **between** the calls and their outputs (which are in the next message). DeepSeek's Responses API requires each `function_call` to be immediately followed by its `function_call_output` and rejects an interposed assistant message — reporting it (misleadingly) as a missing output for the last call.

**Fix:** emit assistant text **before** the tool calls, so the calls stay last in the assistant turn and their outputs are adjacent. Applies to all Responses providers (OpenAI/ChatGPT/DeepSeek); it was only fatal on DeepSeek because OpenAI tolerated the old order.

## Root-caused with a reproduction harness

Built a harness that drives the real `kolega-code ask` against DeepSeek Responses (matching the Harbor adapter's exact invocation — `--json`, `KOLEGA_CODE_ENVIRONMENT=harbor`) and dumps the serialized request. The failing item order was:

```
function_call x5
assistant            <- the model's text, between the calls and outputs
function_call_output x5
```

After the fix: `function_call x5` immediately followed by `function_call_output x5`; the reproducing `ask` exits 0.

## Also

- **Defense-in-depth:** `to_responses_input` pads any genuinely-unanswered tool call with a placeholder output (mirrors `Message.to_openai`), so a dropped result can never become a hard request failure.

## Testing

- Unit: assistant-text-before-calls ordering (outputs adjacent) + orphan padding (`tests/agent/llm/test_openai_responses_provider.py`)
- Live: full Responses suite; a live parallel-tool-call `ask` that previously 400'd now exits 0
- Found by the TB2.1 Daytona smoke (both easy tasks failed on this 400)

🤖 Generated with [Claude Code](https://claude.com/claude-code)