### PR TITLE
chore: release v0.26.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.26.5 - 2026-08-02
+
 ### Fixed
 
 - DeepSeek `deepseek-v4-flash` on the Responses API no longer crashes mid-task

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.26.4"
+__version__ = "0.26.5"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.26.4"
+__version__ = "0.26.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.26.4"
+version = "0.26.5"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-26T08:13:30.801355Z"
+exclude-newer = "2026-07-26T10:11:09.250905Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1531,7 +1531,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.26.4"
+version = "0.26.5"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Release v0.26.5.

### Fixed
- `deepseek-v4-flash` on the Responses API no longer 400s ("No tool output found for tool call ...") when the model returns tool calls together with assistant text — the text is now emitted before the calls so each call's output stays adjacent. Tool calls are also defensively guaranteed a matching output on replay. (#403)

### Release checklist
- [x] Version bumped in `pyproject.toml`, both `__init__.py`, `uv.lock`
- [x] CHANGELOG updated (new `0.26.5` section, empty `Unreleased` retained)
- [x] Full suite + pre-commit green in `.venv-release` (3851 passed)
- [x] Live DeepSeek Responses provider tests pass
- [ ] Merge, then tag `v0.26.5` from the merge commit to trigger the Release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)