### PR TITLE
docs: add Parallel Search MCP configuration

### DIFF
--- a/docs/src/content/docs/configuration/mcp.md
+++ b/docs/src/content/docs/configuration/mcp.md
@@ -59,6 +59,20 @@ Project MCP config is intentionally gated because it can point at local executab
 }
 ```
 
+#### Parallel Search
+
+Parallel Search MCP provides live web search and URL fetching through `web_search` and `web_fetch`. The default endpoint requires no account, API key, or OAuth:
+
+```json
+{
+  "id": "parallel-search",
+  "name": "Parallel Search",
+  "transport": "streamable_http",
+  "url": "https://search.parallel.ai/mcp",
+  "enabled": true
+}
+```
+
 ### `sse`
 
 ```json


### PR DESCRIPTION
Kolega Code already supports Streamable HTTP MCP servers, so users can connect a search service without adding another backend or adapter. This adds a direct Parallel Search example to the existing MCP configuration guide and leaves the built-in search options unchanged.

## What changed

- Added a `parallel-search` server record using the native `streamable_http` transport.
- Documented the available web search and URL fetching tools and the credential-free default setup.

## Validation

- Parsed and asserted the exact JSON configuration and one-file scope.
- Ran `git diff --check`.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.