### PR TITLE
chore: release v0.26.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.26.6 - 2026-08-03
+
+### Changed
+
+- `kolega-code ask` now runs with a system prompt built for autonomous,
+  non-interactive use: it carries a task through to a verified result on its own
+  instead of pausing to check in.
+- A background process started with `exec_command background=true` (for example a
+  dev server) now keeps running after kolega-code exits, instead of being stopped
+  when the session ends. Stop it explicitly with `kill_command`.
+
 ## 0.26.5 - 2026-08-02
 
 ### Fixed

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.26.5"
+__version__ = "0.26.6"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.26.5"
+__version__ = "0.26.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.26.5"
+version = "0.26.6"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-26T10:11:09.250905Z"
+exclude-newer = "2026-07-27T01:33:07.719822Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1531,7 +1531,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.26.5"
+version = "0.26.6"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Release v0.26.6.

### Changed
- `kolega-code ask` now runs with a system prompt built for autonomous, non-interactive use.
- Background processes started with `exec_command background=true` keep running after kolega-code exits (stop with `kill_command`).

Version bumped in `pyproject.toml`, `uv.lock`, and both package `__version__` files; `CHANGELOG.md` updated. Verified in `.venv-release`: fast test suite (3858 passed, 1 skipped) and `pre-commit run --all-files`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
