### PR TITLE
fix(llm): don't crash token counting on tiktoken special-token literals

### DIFF
--- a/kolega_code/llm/providers/_token_encoding.py
+++ b/kolega_code/llm/providers/_token_encoding.py
@@ -1,0 +1,44 @@
+"""Shared tiktoken helpers for local token *counting*.
+
+Local token counting must never crash on content that merely contains a tiktoken
+special-token literal — e.g. ``<|endoftext|>`` in a GPT-2 / tokenizer file, or
+``<|im_start|>`` in a chat-format prompt. By default ``Encoding.encode`` uses
+``disallowed_special="all"`` and raises a ``ValueError`` the moment it sees such
+a string in ordinary text. That is the right default for *building a request*
+(you don't want to smuggle real control tokens into a prompt), but here we only
+want an approximate size for context management, so those strings should be
+counted as normal text. Passing ``disallowed_special=()`` disables the check —
+exactly what tiktoken's own error message recommends.
+"""
+
+from typing import List
+
+import tiktoken
+
+
+class CountingEncoding:
+    """A tiktoken ``Encoding`` wrapper whose ``encode`` never raises on special
+    tokens.
+
+    It forwards to the wrapped encoding with ``disallowed_special=()`` so
+    special-token literals in the text are counted as ordinary text instead of
+    raising. Only ``encode`` is exposed because counting is the only thing this
+    is used for.
+    """
+
+    __slots__ = ("_encoding",)
+
+    def __init__(self, encoding: "tiktoken.Encoding") -> None:
+        self._encoding = encoding
+
+    def encode(self, text: str) -> List[int]:
+        return self._encoding.encode(text, disallowed_special=())
+
+
+def get_counting_encoding(name: str) -> CountingEncoding:
+    """Return a :class:`CountingEncoding` for the named tiktoken encoding.
+
+    ``tiktoken.get_encoding`` caches the underlying BPE table in its own registry,
+    so repeated calls are cheap; the wrapper is a trivial object around it.
+    """
+    return CountingEncoding(tiktoken.get_encoding(name))

--- a/kolega_code/llm/providers/anthropic.py
+++ b/kolega_code/llm/providers/anthropic.py
@@ -5,13 +5,13 @@ import threading
 from typing import Any, AsyncContextManager, Dict, List, Optional, cast
 from weakref import WeakKeyDictionary
 
-import tiktoken
 from anthropic import AsyncAnthropic
 
 from ..models import ContentBlock, Message, MessageChunk, MessageHistory, ToolDefinition
 from ..specs import build_thinking_request_params, get_model_specs
 from ..timeouts import streaming_timeout
 from ..tool_execution_ids import ToolExecutionIdRegistry
+from ._token_encoding import get_counting_encoding
 from .base import BaseLLMProvider
 from .models import GenerationParams, TokenCount
 
@@ -241,7 +241,9 @@ class AnthropicProvider(BaseLLMProvider):
         Returns:
             TokenCount object with estimated input token count
         """
-        encoding = tiktoken.get_encoding("p50k_base")
+        # CountingEncoding so special-token literals (e.g. <|endoftext|>) in the
+        # content are counted as text instead of raising — see _token_encoding.
+        encoding = get_counting_encoding("p50k_base")
         self._ensure_local_token_memos()
         tools = tools or []
 

--- a/kolega_code/llm/providers/openai.py
+++ b/kolega_code/llm/providers/openai.py
@@ -8,7 +8,6 @@ import os
 import threading
 import uuid
 
-import tiktoken
 from openai import AsyncOpenAI
 
 from ..models import (
@@ -26,6 +25,7 @@ from ..models import (
 from ..specs import MODEL_SPECS, build_thinking_request_params
 from ..timeouts import streaming_timeout
 from ..tool_execution_ids import ToolExecutionIdRegistry
+from ._token_encoding import get_counting_encoding
 from .base import BaseLLMProvider
 from .models import GenerationParams, TokenCount
 
@@ -35,6 +35,10 @@ from .models import GenerationParams, TokenCount
 # de-facto encoding for every OpenAI-compatible provider (DeepSeek, xAI, Fireworks,
 # ... have no native tiktoken table); the count is an estimate for context
 # management, not billing.
+#
+# CountingEncoding treats special-token literals (e.g. ``<|endoftext|>`` in a
+# tokenizer file) as ordinary text instead of raising, so counting never crashes
+# on such content — see _token_encoding for the rationale.
 _ENCODING_NAME = "cl100k_base"
 _encoding = None
 
@@ -46,7 +50,7 @@ OPENROUTER_PROVIDER = "openrouter"
 def _get_encoding():
     global _encoding
     if _encoding is None:
-        _encoding = tiktoken.get_encoding(_ENCODING_NAME)
+        _encoding = get_counting_encoding(_ENCODING_NAME)
     return _encoding
 
 

--- a/tests/agent/llm/test_token_counting_special_tokens.py
+++ b/tests/agent/llm/test_token_counting_special_tokens.py
@@ -1,0 +1,56 @@
+"""Local token counting must not crash on tiktoken special-token literals.
+
+A message that merely contains a string like ``<|endoftext|>`` (a GPT-2 marker,
+common in tokenizer / ML repos and chat-format prompts) used to abort the whole
+session: tiktoken's default ``disallowed_special="all"`` raised a ``ValueError``,
+``count_tokens`` wrapped it as ``LLMInvalidRequestError``, and ``kolega-code ask``
+exited non-zero. Counting now treats special-token literals as ordinary text
+(``disallowed_special=()``), which is correct for a context-size estimate.
+"""
+
+import pytest
+
+from kolega_code.llm.models import Message, MessageHistory, TextBlock
+from kolega_code.llm.providers._token_encoding import get_counting_encoding
+from kolega_code.llm.providers.anthropic import AnthropicProvider
+from kolega_code.llm.providers.deepseek_responses import DeepSeekResponsesProvider
+from kolega_code.llm.providers.openai import OpenAIProvider
+
+# Real tiktoken special tokens that appear verbatim in ML/tokenizer content. Each
+# of these makes a default ``Encoding.encode`` raise.
+_SPECIAL_TOKEN_TEXT = "GPT-2 uses <|endoftext|>; chat formats use <|im_start|> and <|im_end|>."
+
+
+def _history() -> MessageHistory:
+    return MessageHistory([Message(role="user", content=[TextBlock(text=_SPECIAL_TOKEN_TEXT)])])
+
+
+@pytest.mark.parametrize("encoding_name", ["cl100k_base", "p50k_base"])
+def test_counting_encoding_treats_special_tokens_as_text(encoding_name):
+    enc = get_counting_encoding(encoding_name)
+    # Would raise ValueError under tiktoken's default disallowed_special="all".
+    assert len(enc.encode(_SPECIAL_TOKEN_TEXT)) > 0
+
+
+@pytest.mark.asyncio
+async def test_openai_count_tokens_survives_special_token_literals():
+    provider = OpenAIProvider.__new__(OpenAIProvider)  # __new__ skips __init__ (no API key)
+    result = await provider.count_tokens(messages=_history(), model="gpt-4")
+    assert result.input_tokens > 0
+
+
+@pytest.mark.asyncio
+async def test_deepseek_responses_count_tokens_survives_special_token_literals():
+    # deepseek-v4-flash runs on the Responses API; DeepSeekResponsesProvider inherits
+    # count_tokens from OpenAIProvider, which is exactly where the original crash was.
+    provider = DeepSeekResponsesProvider.__new__(DeepSeekResponsesProvider)
+    result = await provider.count_tokens(messages=_history(), model="deepseek-v4-flash")
+    assert result.input_tokens > 0
+
+
+@pytest.mark.asyncio
+async def test_anthropic_count_tokens_survives_special_token_literals():
+    provider = AnthropicProvider.__new__(AnthropicProvider)
+    provider.use_local_token_counting = True  # force the local tiktoken branch
+    result = await provider.count_tokens(messages=_history(), model="claude-3-5-sonnet")
+    assert result.input_tokens > 0


### PR DESCRIPTION
## Problem

kolega's local token counting (used for context-window management) encoded message text with tiktoken's default `disallowed_special="all"`. Any content that merely *contains* a tiktoken special-token literal — `<|endoftext|>` (GPT-2 / tokenizer files, datasets), `<|im_start|>` / `<|im_end|>` (chat-format prompts) — makes `Encoding.encode` raise `ValueError`. `count_tokens` wrapped that as `LLMInvalidRequestError`, which propagated unhandled and made a non-interactive `kolega-code ask` run exit non-zero — the whole session lost on otherwise-valid input.

Only the *local size estimate* is affected; the actual model request handles the text fine.

## Fix

Add a small `CountingEncoding` wrapper (`providers/_token_encoding.py`) that encodes with `disallowed_special=()`, so special-token literals are counted as ordinary text — correct for a size estimate, and exactly what tiktoken's own error message recommends.

- `OpenAIProvider._get_encoding()` now returns the wrapper. All ~15 existing `encoding.encode(...)` call sites are unchanged, and the DeepSeek **Responses** provider inherits this path (`DeepSeekResponsesProvider` → `ResponsesProviderBase` → `OpenAIProvider`), so it's covered too.
- `AnthropicProvider` local counting routes its `p50k_base` encoding through the same wrapper.
- `google.py` counts via the Google API (no tiktoken), so it's unaffected.

## Tests

New `test_token_counting_special_tokens.py`: the wrapper (`cl100k_base` + `p50k_base`) and `count_tokens` on `<|endoftext|>` / `<|im_start|>` content for OpenAI, DeepSeek-Responses, and Anthropic — each returns a positive count instead of raising. Existing token-counting suites still pass (19 total green locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
