### PR TITLE
fix(tui): guard MemoryScreen worker renders against teardown (flaky NoMatches)

### DIFF
--- a/kolega_code/cli/tui/memory_screen.py
+++ b/kolega_code/cli/tui/memory_screen.py
@@ -115,6 +115,22 @@ class MemoryScreen(ModalScreen[None]):
         if self._owner._memory_screen is self:
             self._owner._memory_screen = None
 
+    def _work_current(self, generation: int) -> bool:
+        """Whether a worker may still render — not superseded, and still attached.
+
+        A worker finishes its threaded load asynchronously, by which point the
+        screen may have been replaced by a newer refresh or torn down. Rendering
+        then calls ``query_one`` on detached widgets and raises ``NoMatches``
+        *inside the worker* (surfacing as ``WorkerFailed``). ``_work_generation``
+        covers supersede; ``is_attached`` additionally closes the teardown race
+        where child widgets detach before ``on_unmount`` bumps the generation.
+        (``is_mounted`` is the wrong signal here: it stays True after the screen
+        is popped, while ``is_attached`` flips exactly when ``query_one`` starts
+        raising.) The render after this check is synchronous, so ``is_attached``
+        cannot flip mid-render.
+        """
+        return generation == self._work_generation and self.is_attached
+
     # ---- loading -------------------------------------------------------------
 
     def _start_refresh(self, *, select_reference: str | None = None, from_disk: bool = False) -> None:
@@ -148,17 +164,17 @@ class MemoryScreen(ModalScreen[None]):
                     allow_disabled=True,
                 )
         except Exception as error:
-            if generation == self._work_generation:
+            if self._work_current(generation):
                 self._status = None
                 self._all_entries = []
                 self._entries = []
                 self._render_error(str(error))
             return
         finally:
-            if generation == self._work_generation:
+            if self._work_current(generation):
                 self._set_busy(False)
 
-        if generation != self._work_generation:
+        if not self._work_current(generation):
             return
         self._status = status
         self._all_entries = entries
@@ -189,13 +205,13 @@ class MemoryScreen(ModalScreen[None]):
                 allow_disabled=True,
             )
         except Exception as error:
-            if generation == self._work_generation:
+            if self._work_current(generation):
                 self._render_error(str(error))
             return
         finally:
-            if generation == self._work_generation:
+            if self._work_current(generation):
                 self._set_busy(False)
-        if generation != self._work_generation:
+        if not self._work_current(generation):
             return
         self._loaded_entry = entry
         self._render_entry(entry)
@@ -448,7 +464,7 @@ class MemoryScreen(ModalScreen[None]):
         try:
             context = await asyncio.to_thread(self._manager.prompt_context)
         except MemoryUnavailableError as error:
-            if generation != self._work_generation:
+            if not self._work_current(generation):
                 return
             self._set_busy(False)
             self._enter_agent_view(
@@ -458,11 +474,11 @@ class MemoryScreen(ModalScreen[None]):
             )
             return
         except Exception as error:
-            if generation == self._work_generation:
+            if self._work_current(generation):
                 self._set_busy(False)
                 self.query_one("#memory_notice", Static).update(str(error))
             return
-        if generation != self._work_generation:
+        if not self._work_current(generation):
             return
         self._set_busy(False)
         truncated = " · truncated" if context.truncated else ""

--- a/tests/cli/test_app_memory.py
+++ b/tests/cli/test_app_memory.py
@@ -320,6 +320,44 @@ async def test_memory_screen_create_and_path_delete_refresh_prompt(
 
 
 @pytest.mark.asyncio
+async def test_memory_screen_refresh_worker_after_teardown_does_not_raise(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A refresh worker that finishes after the screen is torn down must not
+    render into the detached DOM.
+
+    Regression for a flaky ``WorkerFailed: NoMatches("#memory_new")``: workers
+    load off-thread and then ``query_one`` to render. The ``_work_generation``
+    guard alone misses the teardown race where child widgets detach before
+    ``on_unmount`` bumps the generation, so rendering is now also gated on
+    ``is_mounted``.
+    """
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.memory_screen import MemoryScreen
+
+    app = _build_mention_test_app(tmp_path, monkeypatch)
+    async with app.run_test() as pilot:
+        app.action_open_memory()
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, MemoryScreen)
+
+        await app.pop_screen()
+        await pilot.pause()
+        # Popping detaches the screen's widgets, so query_one now raises NoMatches
+        # even though is_mounted is still True.
+        assert not screen.is_attached
+
+        # Pass the *current* generation so it still matches — only the is_attached
+        # guard can stop the render. Before the fix this reached
+        # query_one("#memory_new") on the detached DOM and raised NoMatches; now
+        # the worker bails cleanly.
+        await screen._refresh(screen._work_generation, None)
+
+
+@pytest.mark.asyncio
 async def test_memory_screen_edit_mode_blocks_roster_and_filter(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Problem

`MemoryScreen`'s background workers (`_refresh`, `_load_entry`, `_load_agent_view`) load off-thread (`await asyncio.to_thread(...)`) and then render by calling `query_one(...)`. They were gated only by `_work_generation`. That misses a teardown race: when the screen is popped/torn down, its child widgets detach **before** `on_unmount` bumps the generation, so a worker that completes in that window still passes the generation check and then queries a detached `#memory_new` — raising `NoMatches` *inside the worker*, which surfaces as an intermittent `WorkerFailed` CI failure:

```
WorkerFailed: NoMatches("No nodes match '#memory_new' on MemoryScreen()")
```

## Fix

Gate every worker render on `_work_current(generation)` = *generation still matches* **and** `self.is_attached`.

`is_attached` is the right signal — empirically it flips to `False` exactly when `query_one` starts raising, whereas `is_mounted` stays `True` after a screen is popped. The render after the check is synchronous, so `is_attached` can't flip mid-render.

## Verification

New regression test pops the screen (which detaches its widgets — confirmed `is_attached` is `False` and `query_one` raises there), then drives a worker render with the *current* generation so only the `is_attached` guard can stop it. It raises `NoMatches` **without** the guard and passes **with** it. Full `test_app_memory.py` suite green (17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
