### PR TITLE
chore: release v0.26.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.26.7 - 2026-08-03
+
+### Fixed
+
+- Local token counting no longer crashes on content that contains a tokenizer
+  special-token literal (for example `<|endoftext|>` or `<|im_start|>`, common in
+  ML/tokenizer files and chat-format prompts); those strings are now counted as
+  ordinary text instead of aborting the run.
+- The Private Project Memory screen no longer crashes with an internal
+  "NoMatches" error when it is closed while still loading.
+
 ## 0.26.6 - 2026-08-03
 
 ### Changed

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.26.6"
+__version__ = "0.26.7"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.26.6"
+__version__ = "0.26.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.26.6"
+version = "0.26.7"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-27T01:33:07.719822Z"
+exclude-newer = "2026-07-27T02:41:25.262267Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1531,7 +1531,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.26.6"
+version = "0.26.7"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Release v0.26.7.

### Fixed
- Local token counting no longer crashes on content containing a tokenizer special-token literal (e.g. `<|endoftext|>`, `<|im_start|>`).
- The Private Project Memory screen no longer crashes with an internal `NoMatches` error when closed while still loading.

Version bumped in `pyproject.toml`, `uv.lock`, and both package `__version__` files; `CHANGELOG.md` updated. Verified in `.venv-release`: fast test suite + `pre-commit run --all-files` (one live-provider test flaked under load and passes in isolation; it is skipped in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
