### PR TITLE
feat: attach normalized token usage to every completed provider Message

### DIFF
--- a/kolega_code/agent/conversation.py
+++ b/kolega_code/agent/conversation.py
@@ -163,6 +163,7 @@ def _message_with_content(message: Message, content: List[Any]) -> Message:
         stop_reason=message.stop_reason,
         tool_calls=tool_calls,
         usage_metadata=message.usage_metadata,
+        usage=message.usage,
     )
 
 
@@ -699,6 +700,7 @@ class Conversation:
                 stop_reason=message.stop_reason,
                 tool_calls=message.tool_calls,
                 usage_metadata=message.usage_metadata,
+                usage=message.usage,
             )
 
         self.history.append(message)

--- a/kolega_code/llm/instrumented_client.py
+++ b/kolega_code/llm/instrumented_client.py
@@ -17,37 +17,11 @@ from .client import LLMClient
 from .models import Message, MessageHistory, ToolDefinition
 from .providers.models import GenerationParams
 
+# The provider-family vocabulary lives in kolega_code/llm/usage.py, shared with
+# normalized usage attachment so both consumers stay covered by one guard test.
+from .usage import usage_token_fields as _usage_token_fields
+
 logger = logging.getLogger(__name__)
-
-_ANTHROPIC_USAGE_PROVIDERS = frozenset({"anthropic", "moonshot", "zai", "kimi_coding"})
-_OPENAI_USAGE_PROVIDERS = frozenset(
-    {
-        "openai",
-        "openai_chatgpt",
-        "together",
-        "groq",
-        "fireworks",
-        "llama",
-        "xai",
-        "dashscope",
-        "deepseek",
-        "ollama_cloud",
-        "openrouter",
-    }
-)
-
-
-def _usage_token_fields(provider: object) -> Optional[tuple[str, str]]:
-    """Return the normalized input/output field names for a known provider."""
-    if not isinstance(provider, str):
-        return None
-    if provider in _ANTHROPIC_USAGE_PROVIDERS:
-        return "input_tokens", "output_tokens"
-    if provider in _OPENAI_USAGE_PROVIDERS:
-        return "prompt_tokens", "completion_tokens"
-    if provider == "google":
-        return "prompt_token_count", "candidates_token_count"
-    return None
 
 
 def get_output_tokens(usage_metadata: Optional[Mapping[str, Any]], provider: Optional[str] = None) -> int:

--- a/kolega_code/llm/models.py
+++ b/kolega_code/llm/models.py
@@ -15,6 +15,7 @@ from kolega_code.utils.images import ascii_thumbnail_from_base64
 from .specs.accessors import _provider_value
 from .specs.thinking import reasoning_replay_field
 from .tool_execution_ids import ToolExecutionIdRegistry, new_tool_execution_id
+from .usage import NormalizedUsage, read_detail_int
 
 
 class _LazyModule:
@@ -1156,12 +1157,17 @@ class Message:
         stop_reason: Optional[str] = None,
         tool_calls: Optional[List[ToolCall]] = None,
         usage_metadata: Optional[Dict[str, Any]] = None,
+        usage: Optional[NormalizedUsage] = None,
     ):
         self.role = role
         self.content = content
         self.stop_reason = stop_reason
         self.tool_calls = tool_calls or []
         self.usage_metadata = usage_metadata or {}
+        # Provider-independent view of usage_metadata, attached by the provider
+        # layer on every completed response (kolega_code/llm/usage.py). None on
+        # user/system messages and on messages restored from pre-usage sessions.
+        self.usage = usage
 
     def get_text_content(self) -> str:
         """
@@ -1332,6 +1338,11 @@ class Message:
                 "cache_write_input_tokens": getattr(usage, "cache_creation_input_tokens", 0),
                 "provider": "anthropic",
             }
+            # Moonshot extends the Anthropic usage shape with a thinking-token
+            # subset of output_tokens (non-streaming responses only).
+            thinking = read_detail_int(getattr(usage, "output_tokens_details", None), "thinking_tokens")
+            if thinking is not None:
+                usage_metadata["reasoning_output_tokens"] = thinking
 
         # print(f"Stop reason: {message.stop_reason if hasattr(message, 'stop_reason') else ''}")
 
@@ -1444,16 +1455,25 @@ class Message:
         if tool_use_blocks:
             mapped_stop_reason = "tool_use"
 
-        # Extract usage metadata
+        # Extract usage metadata. A response without a usage object must yield an
+        # empty dict, not fabricated zero counts (zeros read as authoritative).
         usage_metadata = {}
-        if hasattr(message, "usage_metadata"):
-            usage = message.usage_metadata
+        usage = getattr(message, "usage_metadata", None)
+        if usage is not None:
             usage_metadata = {
                 "prompt_token_count": getattr(usage, "prompt_token_count", 0),
                 "candidates_token_count": getattr(usage, "candidates_token_count", 0),
                 "total_token_count": getattr(usage, "total_token_count", 0),
                 "provider": "google",
             }
+            for optional_key in (
+                "cached_content_token_count",
+                "thoughts_token_count",
+                "tool_use_prompt_token_count",
+            ):
+                value = getattr(usage, optional_key, None)
+                if value is not None:
+                    usage_metadata[optional_key] = value
 
         return cls(
             role="assistant",
@@ -1587,13 +1607,16 @@ class Message:
             serialized_content = []
 
         # Note: Tool calls are part of content list now, no separate field needed for dump
-        return {
+        result = {
             "role": self.role,
             "content": serialized_content,
             "stop_reason": self.stop_reason,
             "usage_metadata": self.usage_metadata,
             # 'tool_calls' is implicitly handled within the 'content' list
         }
+        if self.usage is not None:
+            result["usage"] = self.usage.to_dict()
+        return result
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Message":
@@ -1619,6 +1642,7 @@ class Message:
             stop_reason=data.get("stop_reason"),
             tool_calls=tool_calls,  # Populate from deserialized content
             usage_metadata=data.get("usage_metadata", {}),
+            usage=NormalizedUsage.from_dict(data.get("usage")),
         )
 
     def to_markdown(self) -> str:

--- a/kolega_code/llm/providers/anthropic.py
+++ b/kolega_code/llm/providers/anthropic.py
@@ -11,15 +11,17 @@ from ..models import ContentBlock, Message, MessageChunk, MessageHistory, ToolDe
 from ..specs import build_thinking_request_params, get_model_specs
 from ..timeouts import streaming_timeout
 from ..tool_execution_ids import ToolExecutionIdRegistry
+from ..usage import attach_normalized_usage
 from ._token_encoding import get_counting_encoding
 from .base import BaseLLMProvider
 from .models import GenerationParams, TokenCount
 
 
 class AnthropicStreamWrapper:
-    def __init__(self, anthropic_stream, provider_name: str = "anthropic"):
+    def __init__(self, anthropic_stream, provider_name: str = "anthropic", model: Optional[str] = None):
         self.anthropic_stream = anthropic_stream
         self.provider_name = provider_name
+        self.model = model
         self.generator: Any = None
         self._closed = False
 
@@ -92,7 +94,7 @@ class AnthropicStreamWrapper:
         )
         if message.usage_metadata:
             message.usage_metadata["provider"] = self.provider_name
-        return message
+        return attach_normalized_usage(message, self.provider_name, self.model)
 
 
 class AnthropicProvider(BaseLLMProvider):
@@ -486,7 +488,7 @@ class AnthropicProvider(BaseLLMProvider):
         # request has been sent, and the SDK's unawaited request coroutine only logs a
         # RuntimeWarning.
         manager = await asyncio.to_thread(open_stream)
-        return AnthropicStreamWrapper(manager, provider_name=self.provider_name)
+        return AnthropicStreamWrapper(manager, provider_name=self.provider_name, model=str(generation_params["model"]))
 
     async def generate(
         self,
@@ -518,4 +520,4 @@ class AnthropicProvider(BaseLLMProvider):
         message = Message.from_anthropic(response)
         if message.usage_metadata:
             message.usage_metadata["provider"] = self.provider_name
-        return message
+        return attach_normalized_usage(message, self.provider_name, str(generation_params["model"]))

--- a/kolega_code/llm/providers/google.py
+++ b/kolega_code/llm/providers/google.py
@@ -6,13 +6,15 @@ from google.genai import types as genai_types
 from ..models import Message, MessageChunk, MessageHistory, ToolDefinition
 from ..specs import build_thinking_request_params, get_model_specs
 from ..tool_execution_ids import ToolExecutionIdRegistry
+from ..usage import attach_normalized_usage
 from .base import BaseLLMProvider
 from .models import GenerationParams, TokenCount
 
 
 class GoogleStreamWrapper:
-    def __init__(self, gemini_stream):
+    def __init__(self, gemini_stream, model: Optional[str] = None):
         self.gemini_stream = gemini_stream
+        self.model = model
         self.final_content = ""
         # Maps a running index -> (FunctionCall, thought_signature). The signature is a
         # part-level field (Gemini 3.x), so we read it off the parts, not chunk.function_calls.
@@ -53,6 +55,14 @@ class GoogleStreamWrapper:
                     "candidates_token_count": getattr(usage, "candidates_token_count", 0),
                     "total_token_count": getattr(usage, "total_token_count", 0),
                 }
+                for optional_key in (
+                    "cached_content_token_count",
+                    "thoughts_token_count",
+                    "tool_use_prompt_token_count",
+                ):
+                    value = getattr(usage, optional_key, None)
+                    if value is not None:
+                        self.usage_metadata[optional_key] = value
 
             # Read function calls off the parts so we also capture each part's thought_signature
             # (Gemini 3.x requires it echoed back). Accumulate across chunks with a running index.
@@ -80,7 +90,7 @@ class GoogleStreamWrapper:
         )
         message.usage_metadata.update(self.usage_metadata)
         message.usage_metadata["provider"] = "google"
-        return message
+        return attach_normalized_usage(message, "google", self.model)
 
 
 class GoogleProvider(BaseLLMProvider):
@@ -186,7 +196,8 @@ class GoogleProvider(BaseLLMProvider):
         return GoogleStreamWrapper(
             await self.async_client.aio.models.generate_content_stream(
                 model=model, contents=messages.to_google(), config=config
-            )
+            ),
+            model=str(model),
         )
 
     async def generate(
@@ -206,4 +217,4 @@ class GoogleProvider(BaseLLMProvider):
             model=model, contents=messages.to_google(), config=config
         )
 
-        return Message.from_google(response)
+        return attach_normalized_usage(Message.from_google(response), "google", str(model))

--- a/kolega_code/llm/providers/openai.py
+++ b/kolega_code/llm/providers/openai.py
@@ -25,6 +25,7 @@ from ..models import (
 from ..specs import MODEL_SPECS, build_thinking_request_params
 from ..timeouts import streaming_timeout
 from ..tool_execution_ids import ToolExecutionIdRegistry
+from ..usage import attach_normalized_usage, read_detail_int
 from ._token_encoding import get_counting_encoding
 from .base import BaseLLMProvider
 from .models import GenerationParams, TokenCount
@@ -103,21 +104,20 @@ def _capture_usage_details(usage: Any, target: Dict[str, Any]) -> None:
     ``input_tokens`` exclusive of cache creation, so the write count is subtracted
     here to keep one meaning of "input tokens" across providers.
     """
+    completion_details = getattr(usage, "completion_tokens_details", None)
+    reasoning = read_detail_int(completion_details, "reasoning_tokens")
+    if reasoning is not None:
+        target["reasoning_output_tokens"] = reasoning
+
     details = getattr(usage, "prompt_tokens_details", None)
     if details is None:
         return
 
-    def _detail(name: str) -> Optional[int]:
-        value = getattr(details, name, None)
-        if value is None and isinstance(details, dict):
-            value = details.get(name)
-        return value if isinstance(value, int) and not isinstance(value, bool) else None
-
-    cached = _detail("cached_tokens")
+    cached = read_detail_int(details, "cached_tokens")
     if cached is not None:
         target["cache_read_input_tokens"] = cached
 
-    cache_write = _detail("cache_write_tokens")
+    cache_write = read_detail_int(details, "cache_write_tokens")
     if cache_write:
         target["cache_write_input_tokens"] = cache_write
         prompt_tokens = target.get("prompt_tokens")
@@ -126,8 +126,15 @@ def _capture_usage_details(usage: Any, target: Dict[str, Any]) -> None:
 
 
 class OpenAIStreamWrapper:
-    def __init__(self, openai_stream, requested_include_usage: bool = False, provider_name: str = "openai"):
+    def __init__(
+        self,
+        openai_stream,
+        requested_include_usage: bool = False,
+        provider_name: str = "openai",
+        model: Optional[str] = None,
+    ):
         self.openai_stream = openai_stream
+        self.model = model
         # Accumulate streamed deltas into lists and ''.join once at finalize. A
         # running ``str += delta`` is O(n^2) here because the buffer is an instance
         # attribute (CPython's in-place concat optimization only fires for locals
@@ -260,7 +267,7 @@ class OpenAIStreamWrapper:
                     "OpenAIStreamWrapper: no usage metadata captured from streaming response; billing may be skipped"
                 )
 
-        return message
+        return attach_normalized_usage(message, self.provider_name, self.model)
 
 
 class OpenAIProvider(BaseLLMProvider):
@@ -705,6 +712,7 @@ class OpenAIProvider(BaseLLMProvider):
             ),
             requested_include_usage=True,
             provider_name=self.provider_name,
+            model=str(generation_params["model"]),
         )
 
     async def generate(
@@ -752,4 +760,4 @@ class OpenAIProvider(BaseLLMProvider):
                 "OpenAIProvider.generate: response contains no usage metadata; billing may be skipped"
             )
 
-        return message
+        return attach_normalized_usage(message, self.provider_name, str(generation_params["model"]))

--- a/kolega_code/llm/providers/responses_common.py
+++ b/kolega_code/llm/providers/responses_common.py
@@ -37,6 +37,7 @@ from ..models import (
 )
 from ..specs import build_thinking_request_params
 from ..tool_execution_ids import ToolExecutionIdRegistry
+from ..usage import attach_normalized_usage, read_detail_int
 from .models import GenerationParams
 from .openai import OpenAIProvider
 
@@ -278,11 +279,18 @@ def _usage_from_response(response: Any) -> Dict[str, Any]:
         "provider": "openai",
     }
     details = getattr(usage, "input_tokens_details", None)
-    cached = getattr(details, "cached_tokens", None) if details is not None else None
-    if cached is None and isinstance(details, dict):
-        cached = details.get("cached_tokens")
+    cached = read_detail_int(details, "cached_tokens")
     if cached:
         metadata["cache_read_input_tokens"] = cached
+    # Deliberately NOT captured: input_tokens_details.cache_write_tokens. The
+    # chat-completions capture path subtracts cache writes from prompt_tokens
+    # (OpenRouter convention) and the normalizer adds them back; deepseek and
+    # openai appear in BOTH shapes under one provider key, so a Responses-side
+    # cache_write key would be indistinguishable from the subtracted kind and
+    # double-count input on add-back. OpenAI reports the field as 0 anyway.
+    reasoning = read_detail_int(getattr(usage, "output_tokens_details", None), "reasoning_tokens")
+    if reasoning is not None:
+        metadata["reasoning_output_tokens"] = reasoning
     return metadata
 
 
@@ -338,9 +346,15 @@ class ResponsesStreamWrapper:
     builds the authoritative final Message from the ``response.completed`` event.
     """
 
-    def __init__(self, responses_stream: Any, provider_name: str = chatgpt_constants.PROVIDER_KEY) -> None:
+    def __init__(
+        self,
+        responses_stream: Any,
+        provider_name: str = chatgpt_constants.PROVIDER_KEY,
+        model: Optional[str] = None,
+    ) -> None:
         self._stream = responses_stream
         self._provider_name = provider_name
+        self._model = model
         self._iterator: Optional[AsyncIterator[Any]] = None
         self._closed = False
         self._text = ""
@@ -682,13 +696,14 @@ class ResponsesStreamWrapper:
         # message/function_call output) so the backend continues the prior
         # chain-of-thought when this message is resent next turn.
         reasoning_blocks = self._collect_reasoning_blocks()
-        return Message(
+        message = Message(
             role="assistant",
             content=reasoning_blocks + content_blocks,
             tool_calls=tool_use_blocks or None,
             stop_reason=stop_reason,
             usage_metadata=usage_metadata,
         )
+        return attach_normalized_usage(message, self._provider_name, self._model)
 
     def _collect_reasoning_blocks(self) -> list:
         """Build the reasoning blocks to carry forward for continuity.
@@ -831,7 +846,7 @@ class ResponsesProviderBase(OpenAIProvider):
         # Per-request streaming timeout bounds the inter-chunk read wait (see
         # kolega_code/llm/timeouts.py) instead of the SDK's 600s default.
         responses_stream = await self.async_client.responses.create(timeout=streaming_timeout(), **request)
-        return ResponsesStreamWrapper(responses_stream, provider_name=self.provider_name)
+        return ResponsesStreamWrapper(responses_stream, provider_name=self.provider_name, model=str(request["model"]))
 
     async def generate(
         self,
@@ -844,7 +859,9 @@ class ResponsesProviderBase(OpenAIProvider):
         request = self._build_request(messages, system, params, kwargs)
         await self.rate_limiter.acquire()
         responses_stream = await self.async_client.responses.create(**request)
-        wrapper = ResponsesStreamWrapper(responses_stream, provider_name=self.provider_name)
+        wrapper = ResponsesStreamWrapper(
+            responses_stream, provider_name=self.provider_name, model=str(request["model"])
+        )
         async with wrapper:
             async for _chunk in wrapper:
                 pass

--- a/kolega_code/llm/usage.py
+++ b/kolega_code/llm/usage.py
@@ -1,0 +1,357 @@
+"""Provider-independent usage normalization for completed LLM messages.
+
+Every completed provider ``Message`` carries two usage views:
+
+- ``Message.usage_metadata`` — the raw provider-shaped dict (Anthropic
+  ``input_tokens``/…, OpenAI ``prompt_tokens``/…, Google ``prompt_token_count``/…),
+  preserved verbatim for callers that know the provider vocabulary.
+- ``Message.usage`` — the :class:`NormalizedUsage` produced here: one schema
+  across all providers with fixed semantics:
+
+  * ``input_tokens`` is inclusive of cached input.
+  * ``output_tokens`` includes reasoning the provider bills as output.
+  * ``total_tokens == input_tokens + output_tokens`` whenever reported.
+  * Cache/reasoning fields are informational subsets, never re-added to totals.
+  * Details a provider does not expose are ``None``, never fabricated zeros.
+
+Field semantics were live-verified against every keyed provider
+(findings/provider-usage-field-semantics.md): Anthropic-shaped providers report
+``input_tokens`` exclusive of cache reads/writes; OpenAI-shaped providers report
+``prompt_tokens`` inclusive of cached tokens; xAI alone bills reasoning outside
+``completion_tokens``; Google reports ``candidates_token_count`` exclusive of
+thoughts.
+
+This module is internal and has no runtime dependency on the rest of the
+package, so providers and ``models.py`` may import it freely.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING, Any, Mapping, Optional
+
+if TYPE_CHECKING:
+    from .models import Message
+
+logger = logging.getLogger(__name__)
+
+REASON_NOT_REPORTED = "provider_did_not_report_usage"
+REASON_MALFORMED = "provider_reported_malformed_usage"
+
+ANTHROPIC_USAGE_PROVIDERS = frozenset({"anthropic", "moonshot", "zai", "kimi_coding"})
+OPENAI_USAGE_PROVIDERS = frozenset(
+    {
+        "openai",
+        "openai_chatgpt",
+        "together",
+        "groq",
+        "fireworks",
+        "llama",
+        "xai",
+        "dashscope",
+        "deepseek",
+        "ollama_cloud",
+        "openrouter",
+    }
+)
+GOOGLE_USAGE_PROVIDERS = frozenset({"google"})
+
+# Live-verified exception: xAI's completion_tokens EXCLUDES reasoning_tokens and
+# its own total is prompt + completion + reasoning. Every other OpenAI-shaped
+# provider (including OpenRouter fronting Grok models) bills reasoning inside
+# completion_tokens.
+_OUTPUT_EXCLUDES_REASONING_PROVIDERS = frozenset({"xai"})
+
+_TOKEN_FIELDS = (
+    "input_tokens",
+    "output_tokens",
+    "total_tokens",
+    "cache_read_input_tokens",
+    "cache_write_input_tokens",
+    "reasoning_output_tokens",
+)
+
+
+def usage_token_fields(provider: object) -> Optional[tuple[str, str]]:
+    """Return the provider-shaped input/output field names for a known provider."""
+    if not isinstance(provider, str):
+        return None
+    if provider in ANTHROPIC_USAGE_PROVIDERS:
+        return "input_tokens", "output_tokens"
+    if provider in OPENAI_USAGE_PROVIDERS:
+        return "prompt_tokens", "completion_tokens"
+    if provider in GOOGLE_USAGE_PROVIDERS:
+        return "prompt_token_count", "candidates_token_count"
+    return None
+
+
+def _strict_nonneg_int(value: Any) -> Optional[int]:
+    # type(value) is int rejects bools, floats, and numeric strings — a malformed
+    # count must never be coerced into a billed number.
+    return value if type(value) is int and value >= 0 else None
+
+
+def read_detail_int(details: Any, name: str) -> Optional[int]:
+    """Read an int field from an SDK usage-details object or its dict form."""
+    value = getattr(details, name, None)
+    if value is None and isinstance(details, dict):
+        value = details.get(name)
+    return _strict_nonneg_int(value)
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizedUsage:
+    """One provider-independent usage record for a completed message."""
+
+    provider: str
+    model: Optional[str]
+    reported: bool
+    input_tokens: Optional[int]
+    output_tokens: Optional[int]
+    total_tokens: Optional[int]
+    cache_read_input_tokens: Optional[int]
+    cache_write_input_tokens: Optional[int]
+    reasoning_output_tokens: Optional[int]
+    unavailable_reason: Optional[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Any) -> Optional["NormalizedUsage"]:
+        """Rebuild from a serialized dict; anything malformed deserializes to None."""
+        if not isinstance(data, dict):
+            return None
+        provider = data.get("provider")
+        model = data.get("model")
+        reported = data.get("reported")
+        reason = data.get("unavailable_reason")
+        if not isinstance(provider, str) or not provider:
+            return None
+        if type(reported) is not bool:
+            return None
+        if model is not None and not isinstance(model, str):
+            return None
+        if reason is not None and not isinstance(reason, str):
+            return None
+        tokens: dict[str, Optional[int]] = {}
+        for field in _TOKEN_FIELDS:
+            value = data.get(field)
+            if value is not None and _strict_nonneg_int(value) is None:
+                return None
+            tokens[field] = value
+        return cls(provider=provider, model=model, reported=reported, unavailable_reason=reason, **tokens)
+
+
+def _unreported(provider: str, model: Optional[str], reason: str) -> NormalizedUsage:
+    return NormalizedUsage(
+        provider=provider,
+        model=model,
+        reported=False,
+        input_tokens=None,
+        output_tokens=None,
+        total_tokens=None,
+        cache_read_input_tokens=None,
+        cache_write_input_tokens=None,
+        reasoning_output_tokens=None,
+        unavailable_reason=reason,
+    )
+
+
+_ABSENT = object()
+
+
+def _classify(metadata: Mapping[str, Any], key: str) -> tuple[Optional[int], bool]:
+    """Return (value, malformed) for a raw count: absent/None -> (None, False)."""
+    raw = metadata.get(key, _ABSENT)
+    if raw is _ABSENT or raw is None:
+        return None, False
+    value = _strict_nonneg_int(raw)
+    return value, value is None
+
+
+def _read_counts(
+    metadata: Mapping[str, Any],
+    core_keys: tuple[str, str],
+    arithmetic_keys: tuple[str, ...],
+    informational_keys: tuple[str, ...],
+    provider: str,
+) -> tuple[Optional[dict[str, Optional[int]]], Optional[str]]:
+    """Validate raw counts into a dict, or classify why usage is unavailable.
+
+    Returns (values, None) when core usage is reported, (_, reason) otherwise.
+    A malformed core or arithmetic participant poisons the whole record: nulling
+    a component would silently shift tokens out of the inclusive totals. A
+    malformed informational subset only nulls itself — it never enters a total.
+    """
+    values: dict[str, Optional[int]] = {}
+    malformed = False
+    for key in core_keys + arithmetic_keys:
+        value, bad = _classify(metadata, key)
+        values[key] = value
+        malformed = malformed or bad
+    if malformed:
+        return None, REASON_MALFORMED
+    if any(values[key] is None for key in core_keys):
+        return None, REASON_NOT_REPORTED
+    for key in informational_keys:
+        value, bad = _classify(metadata, key)
+        if bad:
+            logger.debug("%s usage: discarding malformed %s=%r", provider, key, metadata.get(key))
+        values[key] = value
+    return values, None
+
+
+def _check_subset(values: dict[str, Optional[int]], subset_key: str, bound: int, provider: str) -> Optional[int]:
+    subset = values.get(subset_key)
+    if subset is not None and subset > bound:
+        logger.warning("%s usage: %s=%d exceeds its superset (%d); discarding", provider, subset_key, subset, bound)
+        return None
+    return subset
+
+
+def _log_total_mismatch(metadata: Mapping[str, Any], total_key: str, computed: int, provider: str) -> None:
+    raw_total = _strict_nonneg_int(metadata.get(total_key))
+    if raw_total is not None and raw_total != computed:
+        logger.debug("%s usage: provider total %d != computed %d", provider, raw_total, computed)
+
+
+def normalize_usage(
+    usage_metadata: Optional[Mapping[str, Any]], provider_name: str, model: Optional[str]
+) -> NormalizedUsage:
+    """Compute the NormalizedUsage for one completed message. Pure function.
+
+    ``provider_name`` is the client-resolved provider key and is authoritative
+    for family selection; ``usage_metadata["provider"]`` is not consulted (it is
+    absent on some no-usage paths). Unknown providers are a programming error —
+    the guard test enumerates every ModelProvider value against the family map.
+    """
+    metadata = usage_metadata or {}
+    if provider_name in ANTHROPIC_USAGE_PROVIDERS:
+        return _normalize_anthropic(metadata, provider_name, model)
+    if provider_name in OPENAI_USAGE_PROVIDERS:
+        return _normalize_openai(metadata, provider_name, model)
+    if provider_name in GOOGLE_USAGE_PROVIDERS:
+        return _normalize_google(metadata, provider_name, model)
+    raise ValueError(f"No usage-normalization family for provider {provider_name!r}")
+
+
+def _normalize_anthropic(metadata: Mapping[str, Any], provider: str, model: Optional[str]) -> NormalizedUsage:
+    # Raw input_tokens excludes cache reads and writes (live-verified for all
+    # four providers); reconstruct the inclusive value. Thinking is billed
+    # inside output_tokens; moonshot additionally reports it as a subset.
+    values, reason = _read_counts(
+        metadata,
+        core_keys=("input_tokens", "output_tokens"),
+        arithmetic_keys=("cache_read_input_tokens", "cache_write_input_tokens"),
+        informational_keys=("reasoning_output_tokens",),
+        provider=provider,
+    )
+    if reason is not None:
+        return _unreported(provider, model, reason)
+    assert values is not None
+    cache_read = values["cache_read_input_tokens"]
+    cache_write = values["cache_write_input_tokens"]
+    input_tokens = values["input_tokens"] + (cache_read or 0) + (cache_write or 0)  # type: ignore[operator]
+    output_tokens: int = values["output_tokens"]  # type: ignore[assignment]
+    return NormalizedUsage(
+        provider=provider,
+        model=model,
+        reported=True,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=input_tokens + output_tokens,
+        cache_read_input_tokens=cache_read,
+        cache_write_input_tokens=cache_write,
+        reasoning_output_tokens=_check_subset(values, "reasoning_output_tokens", output_tokens, provider),
+        unavailable_reason=None,
+    )
+
+
+def _normalize_openai(metadata: Mapping[str, Any], provider: str, model: Optional[str]) -> NormalizedUsage:
+    # Capture invariant: when cache_write_input_tokens is present it has already
+    # been subtracted from the stored prompt_tokens (the OpenRouter adjustment in
+    # providers/openai.py); adding it back restores the provider-inclusive input.
+    # For xAI, reasoning is billed outside completion_tokens, so it participates
+    # in output arithmetic instead of being a plain subset.
+    reasoning_is_arithmetic = provider in _OUTPUT_EXCLUDES_REASONING_PROVIDERS
+    arithmetic: tuple[str, ...] = ("cache_write_input_tokens",)
+    informational: tuple[str, ...] = ("cache_read_input_tokens",)
+    if reasoning_is_arithmetic:
+        arithmetic += ("reasoning_output_tokens",)
+    else:
+        informational += ("reasoning_output_tokens",)
+    values, reason = _read_counts(
+        metadata,
+        core_keys=("prompt_tokens", "completion_tokens"),
+        arithmetic_keys=arithmetic,
+        informational_keys=informational,
+        provider=provider,
+    )
+    if reason is not None:
+        return _unreported(provider, model, reason)
+    assert values is not None
+    cache_write = values["cache_write_input_tokens"]
+    reasoning = values["reasoning_output_tokens"]
+    input_tokens = values["prompt_tokens"] + (cache_write or 0)  # type: ignore[operator]
+    output_tokens: int = values["completion_tokens"]  # type: ignore[assignment]
+    if reasoning_is_arithmetic:
+        output_tokens += reasoning or 0
+    else:
+        reasoning = _check_subset(values, "reasoning_output_tokens", output_tokens, provider)
+    total = input_tokens + output_tokens
+    _log_total_mismatch(metadata, "total_tokens", total, provider)
+    return NormalizedUsage(
+        provider=provider,
+        model=model,
+        reported=True,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total,
+        cache_read_input_tokens=_check_subset(values, "cache_read_input_tokens", input_tokens, provider),
+        cache_write_input_tokens=cache_write,
+        reasoning_output_tokens=reasoning,
+        unavailable_reason=None,
+    )
+
+
+def _normalize_google(metadata: Mapping[str, Any], provider: str, model: Optional[str]) -> NormalizedUsage:
+    # prompt_token_count includes cached content; candidates_token_count excludes
+    # thoughts; the SDK's own total is prompt + candidates + thoughts +
+    # tool_use_prompt (live-verified), which matches the computed total here.
+    values, reason = _read_counts(
+        metadata,
+        core_keys=("prompt_token_count", "candidates_token_count"),
+        arithmetic_keys=("thoughts_token_count", "tool_use_prompt_token_count"),
+        informational_keys=("cached_content_token_count",),
+        provider=provider,
+    )
+    if reason is not None:
+        return _unreported(provider, model, reason)
+    assert values is not None
+    thoughts = values["thoughts_token_count"]
+    input_tokens = values["prompt_token_count"] + (values["tool_use_prompt_token_count"] or 0)  # type: ignore[operator]
+    output_tokens = values["candidates_token_count"] + (thoughts or 0)  # type: ignore[operator]
+    total = input_tokens + output_tokens
+    _log_total_mismatch(metadata, "total_token_count", total, provider)
+    return NormalizedUsage(
+        provider=provider,
+        model=model,
+        reported=True,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total,
+        cache_read_input_tokens=_check_subset(values, "cached_content_token_count", input_tokens, provider),
+        cache_write_input_tokens=None,
+        reasoning_output_tokens=thoughts,
+        unavailable_reason=None,
+    )
+
+
+def attach_normalized_usage(message: "Message", provider_name: str, model: Optional[str]) -> "Message":
+    """Attach the normalized usage to a completed message. Overwrite-safe:
+    recomputing from the same raw metadata yields an equal value, so repeated
+    stream finalization and double-attach paths stay idempotent."""
+    message.usage = normalize_usage(message.usage_metadata, provider_name, model)
+    return message

--- a/tests/agent/llm/test_google_provider.py
+++ b/tests/agent/llm/test_google_provider.py
@@ -23,7 +23,9 @@ from kolega_code.llm.providers.models import GenerationParams
 class _FakeGoogleModels:
     def __init__(self) -> None:
         self.calls: list[tuple[str, str, object]] = []
-        self.response = object()
+        # A real Message: the provider attaches normalized usage to the message
+        # produced by (the monkeypatched, identity) Message.from_google.
+        self.response = Message(role="assistant", content="")
         self.stream = SimpleNamespace()
 
     async def generate_content(self, *, model: str, contents: object, config: object) -> object:

--- a/tests/agent/llm/test_normalized_usage.py
+++ b/tests/agent/llm/test_normalized_usage.py
@@ -1,0 +1,383 @@
+"""Unit tests for kolega_code/llm/usage.py — the NormalizedUsage schema and
+per-family normalization formulas (live-verified against provider APIs; see
+findings/provider-usage-field-semantics.md)."""
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from kolega_code.config import ModelProvider
+from kolega_code.llm.models import Message
+from kolega_code.llm.usage import (
+    REASON_MALFORMED,
+    REASON_NOT_REPORTED,
+    NormalizedUsage,
+    normalize_usage,
+    usage_token_fields,
+)
+
+
+@pytest.mark.parametrize("provider_name", [provider.value for provider in ModelProvider])
+def test_every_model_provider_has_usage_family(provider_name: str) -> None:
+    """Guard: adding a ModelProvider without a normalization family must fail."""
+    assert usage_token_fields(provider_name) is not None
+    usage = normalize_usage({}, provider_name, model=None)
+    assert usage.reported is False
+    assert usage.unavailable_reason == REASON_NOT_REPORTED
+
+
+def test_unknown_provider_raises() -> None:
+    with pytest.raises(ValueError, match="no-such-provider"):
+        normalize_usage({}, "no-such-provider", model=None)
+
+
+# --- anthropic family -----------------------------------------------------------
+
+
+def test_anthropic_input_is_reconstructed_inclusive_of_cache() -> None:
+    usage = normalize_usage(
+        {"input_tokens": 13, "output_tokens": 4, "cache_read_input_tokens": 0, "cache_write_input_tokens": 19013},
+        "anthropic",
+        "claude-haiku-4-5-20251001",
+    )
+    assert usage.reported is True
+    assert usage.input_tokens == 19026
+    assert usage.output_tokens == 4
+    assert usage.total_tokens == 19030
+    assert usage.cache_read_input_tokens == 0
+    assert usage.cache_write_input_tokens == 19013
+    assert usage.reasoning_output_tokens is None
+    assert usage.unavailable_reason is None
+
+
+def test_anthropic_absent_cache_fields_stay_none_but_core_reported() -> None:
+    usage = normalize_usage({"input_tokens": 14, "output_tokens": 4}, "anthropic", None)
+    assert usage.reported is True
+    assert usage.input_tokens == 14
+    assert usage.total_tokens == 18
+    assert usage.cache_read_input_tokens is None
+    assert usage.cache_write_input_tokens is None
+
+
+def test_zai_null_cache_write_with_int_cache_read() -> None:
+    # Live-verified zai shape: cache_creation is always null, reads are ints.
+    usage = normalize_usage(
+        {"input_tokens": 28, "output_tokens": 2, "cache_read_input_tokens": 18432, "cache_write_input_tokens": None},
+        "zai",
+        "glm-5.2",
+    )
+    assert usage.input_tokens == 18460
+    assert usage.cache_write_input_tokens is None
+
+
+def test_moonshot_thinking_subset_passthrough() -> None:
+    usage = normalize_usage(
+        {"input_tokens": 92, "output_tokens": 32, "reasoning_output_tokens": 29},
+        "moonshot",
+        "kimi-k3",
+    )
+    assert usage.output_tokens == 32  # thinking already billed inside output
+    assert usage.reasoning_output_tokens == 29
+    assert usage.total_tokens == 124
+
+
+# --- openai family --------------------------------------------------------------
+
+
+def test_openai_plain_provider() -> None:
+    usage = normalize_usage(
+        {"prompt_tokens": 15, "completion_tokens": 28, "total_tokens": 43, "reasoning_output_tokens": 25},
+        "together",
+        "moonshotai/Kimi-K2.7-Code",
+    )
+    assert usage.input_tokens == 15
+    assert usage.output_tokens == 28  # reasoning billed inside completion
+    assert usage.total_tokens == 43
+    assert usage.reasoning_output_tokens == 25
+    assert usage.cache_write_input_tokens is None
+
+
+def test_openrouter_cache_write_add_back_restores_provider_total() -> None:
+    # Capture stores prompt_tokens with cache writes subtracted (openai.py); the
+    # normalizer's add-back must reproduce the provider's own inclusive counts.
+    # Live probe: raw prompt=19026 incl. 19023 written -> stored prompt=3.
+    usage = normalize_usage(
+        {
+            "prompt_tokens": 3,
+            "completion_tokens": 4,
+            "total_tokens": 19030,
+            "cache_write_input_tokens": 19023,
+            "cache_read_input_tokens": 0,
+        },
+        "openrouter",
+        "anthropic/claude-haiku-4.5",
+    )
+    assert usage.input_tokens == 19026
+    assert usage.output_tokens == 4
+    assert usage.total_tokens == 19030  # == the raw provider total
+    assert usage.cache_write_input_tokens == 19023
+
+
+def test_xai_reasoning_excluded_from_completion_is_added_to_output() -> None:
+    # Live-verified: xAI's completion_tokens excludes reasoning and its raw
+    # total is prompt + completion + reasoning.
+    usage = normalize_usage(
+        {
+            "prompt_tokens": 213,
+            "completion_tokens": 1,
+            "total_tokens": 238,
+            "cache_read_input_tokens": 128,
+            "reasoning_output_tokens": 24,
+        },
+        "xai",
+        "grok-4.5",
+    )
+    assert usage.input_tokens == 213
+    assert usage.output_tokens == 25
+    assert usage.total_tokens == 238  # matches xAI's own total
+    assert usage.reasoning_output_tokens == 24
+
+
+def test_xai_without_reasoning_field_keeps_completion_as_output() -> None:
+    usage = normalize_usage({"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}, "xai", "grok-4.5")
+    assert usage.output_tokens == 5
+    assert usage.total_tokens == 15
+
+
+def test_responses_shape_normalizes_like_chat() -> None:
+    # The Responses path stores chat-shaped keys; cache writes are never stored.
+    usage = normalize_usage(
+        {
+            "prompt_tokens": 93,
+            "completion_tokens": 57,
+            "total_tokens": 150,
+            "reasoning_output_tokens": 48,
+        },
+        "deepseek",
+        "deepseek-v4-flash",
+    )
+    assert usage.input_tokens == 93
+    assert usage.output_tokens == 57
+    assert usage.total_tokens == 150
+    assert usage.reasoning_output_tokens == 48
+    assert usage.cache_write_input_tokens is None
+
+
+# --- google ---------------------------------------------------------------------
+
+
+def test_google_thoughts_and_tool_use_enter_arithmetic() -> None:
+    usage = normalize_usage(
+        {
+            "prompt_token_count": 58,
+            "candidates_token_count": 16,
+            "total_token_count": 137,
+            "thoughts_token_count": 63,
+        },
+        "google",
+        "gemini-3.5-flash",
+    )
+    assert usage.input_tokens == 58
+    assert usage.output_tokens == 79  # candidates excludes thoughts
+    assert usage.total_tokens == 137  # matches Google's own total
+    assert usage.reasoning_output_tokens == 63
+    assert usage.cache_write_input_tokens is None
+
+    with_tool_use = normalize_usage(
+        {
+            "prompt_token_count": 100,
+            "candidates_token_count": 10,
+            "tool_use_prompt_token_count": 40,
+            "cached_content_token_count": 30,
+        },
+        "google",
+        None,
+    )
+    assert with_tool_use.input_tokens == 140
+    assert with_tool_use.output_tokens == 10
+    assert with_tool_use.cache_read_input_tokens == 30
+
+
+def test_google_none_valued_cores_are_not_reported() -> None:
+    usage = normalize_usage(
+        {"prompt_token_count": None, "candidates_token_count": None, "total_token_count": None, "provider": "google"},
+        "google",
+        None,
+    )
+    assert usage.reported is False
+    assert usage.unavailable_reason == REASON_NOT_REPORTED
+    assert usage.input_tokens is None
+
+
+# --- missing / malformed --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        None,
+        {},
+        {"provider": "openai"},
+        {"provider": "openai", "edit_protocol": "diff"},
+        {"prompt_tokens": 5},  # one core missing
+    ],
+)
+def test_missing_usage_is_unreported_never_zero(metadata) -> None:
+    usage = normalize_usage(metadata, "openai", "gpt-5.4-mini")
+    assert usage.reported is False
+    assert usage.unavailable_reason == REASON_NOT_REPORTED
+    assert usage.input_tokens is None
+    assert usage.output_tokens is None
+    assert usage.total_tokens is None
+
+
+@pytest.mark.parametrize("bad_value", [True, False, -1, "12", 1.0])
+def test_malformed_core_rejected(bad_value) -> None:
+    usage = normalize_usage({"prompt_tokens": bad_value, "completion_tokens": 5}, "openai", None)
+    assert usage.reported is False
+    assert usage.unavailable_reason == REASON_MALFORMED
+    assert usage.input_tokens is None
+
+
+def test_malformed_arithmetic_subset_poisons_whole_record() -> None:
+    # Anthropic cache fields participate in the inclusive-input arithmetic;
+    # nulling one would silently shift tokens, so the whole record is rejected.
+    usage = normalize_usage(
+        {"input_tokens": 10, "output_tokens": 5, "cache_read_input_tokens": "junk"},
+        "anthropic",
+        None,
+    )
+    assert usage.reported is False
+    assert usage.unavailable_reason == REASON_MALFORMED
+
+
+def test_malformed_informational_subset_is_nulled_core_kept() -> None:
+    usage = normalize_usage(
+        {"prompt_tokens": 10, "completion_tokens": 5, "cache_read_input_tokens": True},
+        "openai",
+        None,
+    )
+    assert usage.reported is True
+    assert usage.input_tokens == 10
+    assert usage.cache_read_input_tokens is None
+
+
+def test_subset_exceeding_superset_is_discarded() -> None:
+    usage = normalize_usage(
+        {"prompt_tokens": 10, "completion_tokens": 5, "cache_read_input_tokens": 11},
+        "openai",
+        None,
+    )
+    assert usage.reported is True
+    assert usage.cache_read_input_tokens is None
+
+
+# --- serialization --------------------------------------------------------------
+
+
+def test_normalized_usage_round_trip() -> None:
+    usage = normalize_usage(
+        {"prompt_tokens": 213, "completion_tokens": 1, "reasoning_output_tokens": 24},
+        "xai",
+        "grok-4.5",
+    )
+    data = usage.to_dict()
+    assert set(data) == {
+        "provider",
+        "model",
+        "reported",
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "cache_read_input_tokens",
+        "cache_write_input_tokens",
+        "reasoning_output_tokens",
+        "unavailable_reason",
+    }
+    assert NormalizedUsage.from_dict(data) == usage
+
+
+@pytest.mark.parametrize(
+    "junk",
+    [
+        None,
+        "junk",
+        42,
+        [],
+        {"reported": 1},
+        {"provider": "", "reported": True},
+        {"provider": "x", "reported": True, "input_tokens": -1},
+    ],
+)
+def test_from_dict_rejects_malformed(junk) -> None:
+    assert NormalizedUsage.from_dict(junk) is None
+
+
+def test_message_serialization_round_trip_with_usage() -> None:
+    message = Message(
+        role="assistant",
+        content="hi",
+        usage_metadata={"input_tokens": 1, "output_tokens": 2, "provider": "anthropic"},
+        usage=normalize_usage({"input_tokens": 1, "output_tokens": 2}, "anthropic", "claude-opus-5"),
+    )
+    data = message.to_dict()
+    restored = Message.from_dict(data)
+    assert restored.usage == message.usage
+    assert restored.to_dict() == data
+
+
+def test_message_without_usage_serializes_without_usage_key() -> None:
+    message = Message(role="user", content="hi")
+    assert "usage" not in message.to_dict()
+
+
+def test_legacy_message_dict_deserializes_with_usage_none() -> None:
+    restored = Message.from_dict({"role": "assistant", "content": "x", "usage_metadata": {"prompt_tokens": 5}})
+    assert restored.usage is None
+    assert restored.usage_metadata == {"prompt_tokens": 5}
+
+
+# --- raw-capture behaviors in Message converters --------------------------------
+
+
+def test_from_google_without_usage_does_not_fabricate_zeros() -> None:
+    response = SimpleNamespace(candidates=[], usage_metadata=None, finish_reason=None)
+    message = Message.from_google(cast(Any, response))
+    assert message.usage_metadata == {}
+
+
+def test_from_google_captures_optional_token_fields() -> None:
+    response = SimpleNamespace(
+        candidates=[],
+        finish_reason=None,
+        usage_metadata=SimpleNamespace(
+            prompt_token_count=58,
+            candidates_token_count=16,
+            total_token_count=137,
+            cached_content_token_count=None,
+            thoughts_token_count=63,
+            tool_use_prompt_token_count=None,
+        ),
+    )
+    message = Message.from_google(cast(Any, response))
+    assert message.usage_metadata["thoughts_token_count"] == 63
+    assert "cached_content_token_count" not in message.usage_metadata
+    assert "tool_use_prompt_token_count" not in message.usage_metadata
+
+
+def test_from_anthropic_captures_moonshot_thinking_tokens() -> None:
+    sdk_message = SimpleNamespace(
+        role="assistant",
+        content=[],
+        stop_reason="end_turn",
+        usage=SimpleNamespace(
+            input_tokens=92,
+            output_tokens=32,
+            cache_read_input_tokens=0,
+            cache_creation_input_tokens=0,
+            output_tokens_details={"thinking_tokens": 29},
+        ),
+    )
+    message = Message.from_anthropic(sdk_message)
+    assert message.usage_metadata["reasoning_output_tokens"] == 29

--- a/tests/agent/llm/test_normalized_usage_attach.py
+++ b/tests/agent/llm/test_normalized_usage_attach.py
@@ -1,0 +1,267 @@
+"""Attach-path tests: every provider wrapper and generate() must return messages
+carrying NormalizedUsage, idempotently across repeated finalization."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from kolega_code.llm.client import LLMClient
+from kolega_code.llm.models import Message, MessageHistory
+from kolega_code.llm.providers.google import GoogleStreamWrapper
+from kolega_code.llm.providers.anthropic import AnthropicStreamWrapper
+from kolega_code.llm.providers.openai import OpenAIProvider, OpenAIStreamWrapper
+from kolega_code.llm.providers.responses_common import ResponsesStreamWrapper, _usage_from_response
+from kolega_code.llm.usage import REASON_NOT_REPORTED
+
+
+class _Chunk:
+    def __init__(self, text=None, usage=None):
+        delta = SimpleNamespace(content=text, tool_calls=[])
+        self.choices = [SimpleNamespace(delta=delta, finish_reason="stop" if usage else None)]
+        self.usage = usage
+
+
+class _AsyncStream:
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._chunks:
+            raise StopAsyncIteration
+        return self._chunks.pop(0)
+
+    async def aclose(self):
+        pass
+
+
+def _openai_usage(**overrides):
+    base = dict(
+        prompt_tokens=15,
+        completion_tokens=28,
+        total_tokens=43,
+        prompt_tokens_details=None,
+        completion_tokens_details=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+async def _drain(wrapper):
+    async with wrapper as s:
+        async for _ in s:
+            pass
+        return await s.get_final_message()
+
+
+@pytest.mark.asyncio
+async def test_openai_stream_wrapper_attaches_usage_and_is_idempotent():
+    usage = _openai_usage(completion_tokens_details={"reasoning_tokens": 25})
+    wrapper = OpenAIStreamWrapper(
+        _AsyncStream([_Chunk("hi"), _Chunk(usage=usage)]),
+        requested_include_usage=True,
+        provider_name="together",
+        model="moonshotai/Kimi-K2.7-Code",
+    )
+    message = await _drain(wrapper)
+    assert message.usage is not None
+    assert message.usage.reported is True
+    assert message.usage.provider == "together"
+    assert message.usage.model == "moonshotai/Kimi-K2.7-Code"
+    assert message.usage.input_tokens == 15
+    assert message.usage.output_tokens == 28
+    assert message.usage.total_tokens == 43
+    assert message.usage.reasoning_output_tokens == 25
+
+    # Repeated finalization (baseagent calls after __aexit__): equal values.
+    again = await wrapper.get_final_message()
+    assert again.usage == message.usage
+    assert again.usage_metadata == message.usage_metadata
+
+
+@pytest.mark.asyncio
+async def test_openai_stream_wrapper_without_usage_reports_unavailable():
+    wrapper = OpenAIStreamWrapper(
+        _AsyncStream([_Chunk("hi")]), requested_include_usage=True, provider_name="groq", model="m"
+    )
+    message = await _drain(wrapper)
+    assert message.usage is not None
+    assert message.usage.reported is False
+    assert message.usage.unavailable_reason == REASON_NOT_REPORTED
+    assert message.usage.input_tokens is None
+
+
+@pytest.mark.asyncio
+async def test_xai_stream_wrapper_adds_reasoning_to_output():
+    usage = _openai_usage(
+        prompt_tokens=213,
+        completion_tokens=1,
+        total_tokens=238,
+        completion_tokens_details={"reasoning_tokens": 24},
+        prompt_tokens_details={"cached_tokens": 128},
+    )
+    wrapper = OpenAIStreamWrapper(
+        _AsyncStream([_Chunk(usage=usage)]), requested_include_usage=True, provider_name="xai", model="grok-4.5"
+    )
+    message = await _drain(wrapper)
+    assert message.usage is not None
+    assert message.usage.output_tokens == 25
+    assert message.usage.total_tokens == 238  # matches xAI's own reported total
+    assert message.usage.cache_read_input_tokens == 128
+
+
+@pytest.mark.asyncio
+async def test_openrouter_stream_wrapper_subtracts_then_adds_back_cache_writes():
+    usage = _openai_usage(
+        prompt_tokens=19026,
+        completion_tokens=4,
+        total_tokens=19030,
+        prompt_tokens_details={"cached_tokens": 0, "cache_write_tokens": 19023},
+    )
+    wrapper = OpenAIStreamWrapper(
+        _AsyncStream([_Chunk(usage=usage)]),
+        requested_include_usage=True,
+        provider_name="openrouter",
+        model="anthropic/claude-haiku-4.5",
+    )
+    message = await _drain(wrapper)
+    # Raw metadata keeps the anthropic-style exclusive prompt count...
+    assert message.usage_metadata["prompt_tokens"] == 3
+    assert message.usage_metadata["cache_write_input_tokens"] == 19023
+    # ...and the normalized view restores the provider-inclusive input.
+    assert message.usage is not None
+    assert message.usage.input_tokens == 19026
+    assert message.usage.total_tokens == 19030
+
+
+@pytest.mark.asyncio
+async def test_anthropic_stream_wrapper_attaches_inclusive_input():
+    wrapper = AnthropicStreamWrapper(SimpleNamespace(), provider_name="anthropic", model="claude-haiku-4-5-20251001")
+
+    async def fake_final_message():
+        return SimpleNamespace(
+            role="assistant",
+            content=[],
+            stop_reason="end_turn",
+            usage=SimpleNamespace(
+                input_tokens=13,
+                output_tokens=4,
+                cache_read_input_tokens=0,
+                cache_creation_input_tokens=19013,
+            ),
+        )
+
+    wrapper.generator = SimpleNamespace(get_final_message=fake_final_message)
+    message = await wrapper.get_final_message()
+    assert message.usage is not None
+    assert message.usage.input_tokens == 19026
+    assert message.usage.cache_write_input_tokens == 19013
+    assert message.usage.model == "claude-haiku-4-5-20251001"
+
+    again = await wrapper.get_final_message()
+    assert again.usage == message.usage
+
+
+@pytest.mark.asyncio
+async def test_google_stream_wrapper_attaches_usage_with_thoughts():
+    chunk = SimpleNamespace(
+        text="ok",
+        usage_metadata=SimpleNamespace(
+            prompt_token_count=8,
+            candidates_token_count=1,
+            total_token_count=111,
+            cached_content_token_count=None,
+            thoughts_token_count=102,
+            tool_use_prompt_token_count=None,
+        ),
+        candidates=[SimpleNamespace(content=SimpleNamespace(parts=[]), finish_reason=SimpleNamespace(value="STOP"))],
+    )
+    wrapper = GoogleStreamWrapper(_AsyncStream([chunk]), model="gemini-3.5-flash")
+    message = await _drain(wrapper)
+    assert message.usage_metadata["thoughts_token_count"] == 102
+    assert message.usage is not None
+    assert message.usage.input_tokens == 8
+    assert message.usage.output_tokens == 103
+    assert message.usage.total_tokens == 111  # matches Google's own total
+    assert message.usage.reasoning_output_tokens == 102
+
+    again = await wrapper.get_final_message()
+    assert again.usage == message.usage
+
+
+@pytest.mark.asyncio
+async def test_responses_stream_wrapper_attaches_usage_with_reasoning():
+    wrapper = ResponsesStreamWrapper(SimpleNamespace(), provider_name="openai", model="gpt-5.4-mini")
+    wrapper._final_response = SimpleNamespace(
+        usage=SimpleNamespace(
+            input_tokens=93,
+            output_tokens=57,
+            total_tokens=150,
+            input_tokens_details=SimpleNamespace(cached_tokens=0),
+            output_tokens_details=SimpleNamespace(reasoning_tokens=48),
+        ),
+        output=[],
+        status="completed",
+    )
+    message = await wrapper.get_final_message()
+    assert message.usage_metadata["reasoning_output_tokens"] == 48
+    assert message.usage is not None
+    assert message.usage.reported is True
+    assert message.usage.provider == "openai"
+    assert message.usage.model == "gpt-5.4-mini"
+    assert message.usage.input_tokens == 93
+    assert message.usage.output_tokens == 57
+    assert message.usage.total_tokens == 150
+
+    again = await wrapper.get_final_message()
+    assert again.usage == message.usage
+
+
+@pytest.mark.asyncio
+async def test_responses_stream_wrapper_without_completed_event_reports_unavailable():
+    wrapper = ResponsesStreamWrapper(SimpleNamespace(), provider_name="openai_chatgpt", model="gpt-5.6-sol")
+    message = await wrapper.get_final_message()
+    assert message.usage is not None
+    assert message.usage.reported is False
+    assert message.usage.provider == "openai_chatgpt"
+    assert message.usage.unavailable_reason == REASON_NOT_REPORTED
+
+
+def test_usage_from_response_does_not_capture_cache_writes():
+    # Guard for the double-count trap documented in _usage_from_response: the
+    # Responses shape must never store cache_write_input_tokens.
+    usage = SimpleNamespace(
+        input_tokens=100,
+        output_tokens=10,
+        total_tokens=110,
+        input_tokens_details=SimpleNamespace(cached_tokens=50, cache_write_tokens=25),
+        output_tokens_details=None,
+    )
+    metadata = _usage_from_response(SimpleNamespace(usage=usage))
+    assert metadata["prompt_tokens"] == 100
+    assert metadata["cache_read_input_tokens"] == 50
+    assert "cache_write_input_tokens" not in metadata
+
+
+@pytest.mark.asyncio
+async def test_plain_llm_client_generate_attaches_usage_without_langfuse(monkeypatch):
+    client = LLMClient(provider="together", api_key="sk-test")
+
+    async def fake_create(*args, **kwargs):
+        return SimpleNamespace(
+            usage=_openai_usage(),
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok", tool_calls=None, finish_reason="stop"))],
+        )
+
+    provider = client.provider
+    assert isinstance(provider, OpenAIProvider)
+    monkeypatch.setattr(provider.async_client.chat.completions, "create", fake_create)
+
+    message = await client.generate(MessageHistory([Message(role="user", content="hi")]))
+    assert message.usage is not None
+    assert message.usage.reported is True
+    assert message.usage.provider == "together"
+    assert message.usage.input_tokens == 15
+    assert message.usage.output_tokens == 28

--- a/tests/agent/llm/test_normalized_usage_live.py
+++ b/tests/agent/llm/test_normalized_usage_live.py
@@ -1,0 +1,140 @@
+"""Live checks that every keyed provider's completed Message carries a reported
+NormalizedUsage on both the generate and streaming paths.
+
+Same conventions as test_live_providers.py: marked ``integration``, skipped in
+CI and for providers whose API key is absent (keys load from repo ``.env``).
+The streaming test also finalizes twice, mirroring BaseAgent's
+call-after-__aexit__ pattern, to lock idempotency against live payloads.
+"""
+
+import os
+from typing import Any, cast
+
+import anthropic
+import openai
+import pytest
+
+from kolega_code.cli.config import API_KEY_ENV, OAUTH_PROVIDERS
+from kolega_code.cli.provider_registry import default_model_for_provider
+from kolega_code.config import ModelProvider
+from kolega_code.llm.client import LLMClient
+from kolega_code.llm.exceptions import LLMBillingError, LLMRateLimitError
+from kolega_code.llm.models import Message, MessageHistory, TextBlock
+from kolega_code.llm.specs import MODEL_SPECS, default_thinking_effort, get_model_specs
+from kolega_code.llm.usage import NormalizedUsage
+
+pytestmark = pytest.mark.integration
+
+SKIP_IN_CI = bool(os.getenv("CI")) or bool(os.getenv("GITLAB_CI"))
+
+# generate() maps SDK errors to the repo's LLM exceptions, but the streaming
+# path surfaces raw SDK errors — skip on both shapes of quota/capacity failure.
+_QUOTA_ERRORS = (LLMRateLimitError, LLMBillingError, anthropic.RateLimitError, openai.RateLimitError)
+
+SYSTEM = Message(
+    role="system",
+    content=[TextBlock(text="You are a concise math assistant. Answer with as few tokens as possible.")],
+)
+
+OLLAMA_CLOUD_SMOKE_MODEL = "gpt-oss:20b"
+OPENROUTER_SMOKE_MODEL = "openai/gpt-5.4-mini"
+
+
+def _messages() -> MessageHistory:
+    return MessageHistory(
+        [Message(role="user", content=[TextBlock(text="What is 2 + 2? Reply with just the number.")])]
+    )
+
+
+def _provider_models() -> list[tuple[str, str]]:
+    pairs: list[tuple[str, str]] = []
+    added: set[str] = set()
+    for provider_value, _model in MODEL_SPECS:
+        if provider_value in added or ModelProvider(provider_value) in OAUTH_PROVIDERS:
+            continue
+        added.add(provider_value)
+        if provider_value == ModelProvider.OLLAMA_CLOUD.value:
+            model = OLLAMA_CLOUD_SMOKE_MODEL
+        elif provider_value == ModelProvider.OPENROUTER.value:
+            model = OPENROUTER_SMOKE_MODEL
+        else:
+            model = default_model_for_provider(ModelProvider(provider_value))
+        pairs.append((provider_value, model))
+    # The one model-level dispatch split: deepseek-v4-flash speaks the Responses
+    # API while the rest of the deepseek catalog stays on Chat Completions.
+    pairs.append((ModelProvider.DEEPSEEK.value, "deepseek-v4-flash"))
+    return pairs
+
+
+PROVIDER_MODELS = _provider_models()
+_IDS = [f"{p}-{m.rsplit('/', 1)[-1]}" for p, m in PROVIDER_MODELS]
+
+
+def _require_key(provider_value: str) -> str:
+    if SKIP_IN_CI:
+        pytest.skip("Skipping live provider call in CI")
+    env_name = API_KEY_ENV[ModelProvider(provider_value)]
+    api_key = os.getenv(env_name)
+    if not api_key:
+        pytest.skip(f"{env_name} not set")
+    return api_key
+
+
+def _generation_kwargs(provider_value: str, model: str) -> dict:
+    return dict(
+        system=SYSTEM,
+        model=model,
+        max_completion_tokens=4096,
+        temperature=get_model_specs(provider_value, model)["default_temperature"],
+        thinking=default_thinking_effort(provider_value, model),
+    )
+
+
+def _assert_reported_usage(message: Message, provider_value: str, model: str) -> NormalizedUsage:
+    usage = message.usage
+    assert usage is not None, f"{provider_value}/{model}: message has no normalized usage"
+    assert usage.reported is True, f"{provider_value}/{model}: usage not reported ({usage.unavailable_reason})"
+    assert usage.provider == provider_value
+    assert usage.model == model
+    assert usage.input_tokens is not None and usage.input_tokens > 0
+    assert usage.output_tokens is not None and usage.output_tokens > 0
+    assert usage.total_tokens == usage.input_tokens + usage.output_tokens
+    if usage.cache_read_input_tokens is not None:
+        assert usage.cache_read_input_tokens <= usage.input_tokens
+    if usage.cache_write_input_tokens is not None:
+        assert usage.cache_write_input_tokens <= usage.input_tokens
+    if usage.reasoning_output_tokens is not None:
+        assert usage.reasoning_output_tokens <= usage.output_tokens
+    assert message.usage_metadata, f"{provider_value}/{model}: raw usage_metadata went missing"
+    return usage
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider_value,model", PROVIDER_MODELS, ids=_IDS)
+async def test_live_generate_attaches_reported_usage(provider_value: str, model: str) -> None:
+    api_key = _require_key(provider_value)
+    client = LLMClient(provider=provider_value, api_key=api_key, model=model)
+    try:
+        message = await client.generate(messages=_messages(), **_generation_kwargs(provider_value, model))
+    except _QUOTA_ERRORS as exc:
+        pytest.skip(f"provider quota exhausted for this key: {exc}")
+    _assert_reported_usage(message, provider_value, model)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider_value,model", PROVIDER_MODELS, ids=_IDS)
+async def test_live_stream_attaches_reported_usage_idempotently(provider_value: str, model: str) -> None:
+    api_key = _require_key(provider_value)
+    client = LLMClient(provider=provider_value, api_key=api_key, model=model)
+    try:
+        stream_cm = await cast(Any, client.stream(messages=_messages(), **_generation_kwargs(provider_value, model)))
+        async with stream_cm as stream:
+            async for _ in stream:
+                pass
+        # Finalize AFTER __aexit__, exactly like BaseAgent.process_message_stream.
+        message = await stream.get_final_message()
+    except _QUOTA_ERRORS as exc:
+        pytest.skip(f"provider quota exhausted for this key: {exc}")
+    usage = _assert_reported_usage(message, provider_value, model)
+    again = await stream.get_final_message()
+    assert again.usage == usage


### PR DESCRIPTION
## Summary

First PR in the token-accounting initiative: every completed provider `Message` now carries `Message.usage`, a provider-independent `NormalizedUsage` record, across all 16 `ModelProvider` values and both streaming and non-streaming paths — with or without Langfuse. The provider-shaped `usage_metadata` is preserved verbatim.

**Normalized semantics** (`kolega_code/llm/usage.py`):
- `input_tokens` is inclusive of cached input; `output_tokens` includes reasoning the provider bills as output; `total_tokens == input_tokens + output_tokens` whenever reported.
- Cache/reasoning fields are subsets, never re-added to totals; details a provider doesn't expose are `null`, never fabricated zeros.
- A completed response with no authoritative usage still gets a usage value with `reported: false` and `unavailable_reason: "provider_did_not_report_usage"`; malformed counts (bools, negatives, string/float coercions) are rejected as `"provider_reported_malformed_usage"` instead of becoming billed zeros.

**Live-verified formulas.** Field semantics were probed against all 13 keyed providers (cache, reasoning, and total-arithmetic probes on both paths; notes in the local `findings/` library). Two findings that source/SDK reading alone would have missed:
- **xAI** bills reasoning outside `completion_tokens` (probe: 17125 prompt + 1 completion + 13 reasoning = 17139 total), so the xai family formula adds reasoning into output — reproducing xAI's own totals.
- **Moonshot** reports `output_tokens_details.thinking_tokens` (a subset of output), now captured as the anthropic-family reasoning subset.

Also confirmed live: all four Anthropic-shaped providers report exclusive input (reconstructed as `input + cache_read + cache_write`); OpenRouter counts cache writes inside `prompt_tokens`, so the existing capture-time subtraction is inverted exactly by the normalizer's add-back; Google's `candidates_token_count` excludes thoughts and its total = prompt + candidates + thoughts + tool_use_prompt.

**Wiring:**
- Attach happens at the provider final-message construction points: all four stream wrappers' `get_final_message()` (with the resolved request model threaded into each wrapper) plus the non-Responses `generate()` paths. Repeated `get_final_message()` calls return equal usage.
- Additive raw-capture tightening: reasoning tokens on Chat Completions and Responses paths, Google cached/thoughts/tool-use fields, Moonshot thinking tokens. `from_google` no longer fabricates zero counts when Google reports no usage. Responses-side `cache_write_tokens` is deliberately not captured (double-count trap, documented in a code comment).
- `Message.to_dict()`/`from_dict()` round-trip usage; legacy serialized messages deserialize with `usage=None`; messages without usage serialize without the key.
- `instrumented_client.py` imports the provider-family vocabulary from `usage.py` (dedupe; zero behavior change to `get_output_tokens` or the external `usage_recorder` contract). `BaseAgent.total_tokens_used` is untouched.

## Test plan

- [x] `tests/agent/llm/test_normalized_usage.py` — 46 unit tests: per-family formulas (incl. OpenRouter add-back and xAI arithmetic locked to live-probe numbers), malformed/missing rejection, serialization round-trips, and a guard test that fails when a `ModelProvider` value has no normalization family.
- [x] `tests/agent/llm/test_normalized_usage_attach.py` — wrapper attach + idempotency (double finalization) + plain-`LLMClient`-without-Langfuse coverage.
- [x] `tests/agent/llm/test_normalized_usage_live.py` — live integration: generate + stream per keyed provider (13 providers incl. the `deepseek-v4-flash` Responses split), asserting `reported=true`, the total invariant, subset bounds, and double-finalization equality. 28/28 passed live.
- [x] Full suite: 3955 passed, 0 failed (skips were transient Moonshot engine-overload 429s).
- [x] `ruff check`, `ruff format`, `pyright` clean on all touched files (pre-commit hooks pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014i5XzWgcpSWu5v85iXXiE5