### PR TITLE
feat(agent): re-prompt instead of finalizing silent turns

### DIFF
--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -133,6 +133,14 @@ class BaseAgent(LogMixin):
     # Cap on how many times a Stop hook may force the agent to keep working in one
     # turn, so a misbehaving "don't stop until X" hook cannot loop forever.
     MAX_STOP_HOOK_OVERRIDES = 5
+    # Cap on consecutive re-prompts after a "silent turn": the model ended its
+    # turn with no tool call and no visible text (empty or reasoning-only).
+    # Finalizing such a turn reports nothing — in non-interactive modes that
+    # reads as success with empty output — so the loop nudges the model to act
+    # instead, and after the cap terminates the turn and surfaces the failure.
+    # Runtime half of the coder_base.md.j2 invariant ("Thinking is invisible
+    # and changes nothing on its own").
+    MAX_SILENT_TURN_NUDGES = 3
     long_content_tool_calls = ["write"]
     max_tool_result_chars_in_history = 100_000
     skill_content_pattern = re.compile(r'<skill_content name="[^"]+">')
@@ -491,6 +499,15 @@ class BaseAgent(LogMixin):
             message: The assistant message to append
         """
         self.conversation.append_assistant(message)
+
+    async def _record_context_user_message(self, text: str) -> None:
+        """Journal and append a runtime-injected user message (not typed by the user)."""
+        if self.session_recorder is not None:
+            await asyncio.to_thread(
+                self.session_recorder.record_context_message,
+                Message(role="user", content=[TextBlock(text=text)]),
+            )
+        self.append_user_message([TextBlock(text=text)])
 
     def extend_history(self, messages: List[Message]) -> None:
         """
@@ -1712,6 +1729,17 @@ class BaseAgent(LogMixin):
         """Return the agent's final report: the text of the last message in history."""
         return self.history[-1].get_text_content()
 
+    @staticmethod
+    def _is_silent_turn(message: Message) -> bool:
+        """True when an assistant message has no tool calls and no visible text.
+
+        ThinkingBlock carries ``.thinking`` rather than ``.text``, so a
+        reasoning-only message reads as empty here. Evaluate the streamed
+        message, not history: Conversation.append_assistant replaces empty
+        content with a placeholder TextBlock.
+        """
+        return not message.tool_calls and not message.get_text_content().strip()
+
     async def _deliver_queued_user_inputs(self) -> None:
         """Append user inputs drained from the host while the current turn is running."""
         if self.queued_input_provider is None:
@@ -1911,6 +1939,7 @@ class BaseAgent(LogMixin):
 
         stop_reason = None
         stop_overrides = 0
+        silent_turn_nudges = 0
         iterations = 0
         while stop_reason not in ["end_turn", "max_tokens", "stop_sequence"]:
             iterations += 1
@@ -2070,6 +2099,10 @@ class BaseAgent(LogMixin):
                 # A clean stream resets the transient-failure budget, so the cap measures
                 # only consecutive failures, not lifetime failures across the turn.
                 self._consecutive_llm_retries = 0
+                # Likewise, a response with a tool call or visible text resets the
+                # silent-turn budget: the cap measures only consecutive silence.
+                if not self._is_silent_turn(assistant_message):
+                    silent_turn_nudges = 0
 
                 if thinking_started or current_thinking:
                     yield {"type": "thinking", "content": current_thinking, "complete": True, "uuid": thinking_uuid}
@@ -2123,18 +2156,56 @@ class BaseAgent(LogMixin):
                     # host UI so the next model request sees them.
                     await self._deliver_queued_user_inputs()
 
+                # Silent-turn guard: the model ended this iteration with no tool
+                # call and no visible text (reasoning-only or empty). Finalizing
+                # would report nothing, so re-prompt with an escalating reminder;
+                # after the cap, terminate the turn and surface the failure. Runs
+                # before the Stop hook: a nudged iteration is not a turn end, and
+                # clearing stop_reason makes the stop-hook block skip itself.
+                if stop_reason in ["end_turn", "max_tokens", "stop_sequence"] and self._is_silent_turn(
+                    assistant_message
+                ):
+                    from .prompts import SILENT_TURN_EXHAUSTED_NOTICE, build_silent_turn_nudge
+
+                    if silent_turn_nudges < self.MAX_SILENT_TURN_NUDGES:
+                        silent_turn_nudges += 1
+                        await self.emitter.llm_status(
+                            "info",
+                            "Model returned no output — asking it to act "
+                            f"({silent_turn_nudges}/{self.MAX_SILENT_TURN_NUDGES})…",
+                        )
+                        await self._record_context_user_message(build_silent_turn_nudge(silent_turn_nudges))
+                        stop_reason = None
+                    else:
+                        await self.log_warning(
+                            f"Model ended {self.MAX_SILENT_TURN_NUDGES + 1} consecutive responses with "
+                            "no tool call and no visible output; terminating the turn.",
+                            sender=self.agent_name,
+                        )
+                        await self.emitter.llm_status(
+                            "warning",
+                            "Model returned no output after repeated reminders — ending the turn with no result.",
+                        )
+                        await self._record_context_user_message(SILENT_TURN_EXHAUSTED_NOTICE)
+                        yield {
+                            "type": "response",
+                            "content": (
+                                "[no output] The model ended its turn with no tool call and no visible "
+                                f"message {self.MAX_SILENT_TURN_NUDGES + 1} times in a row despite "
+                                "reminders. The turn was terminated without a result."
+                            ),
+                            "complete": True,
+                            "uuid": str(uuid.uuid4()),
+                        }
+                        break
+
                 # Stop hooks (main agent only). On a natural turn end, a hook may
                 # keep the agent working by blocking the stop and returning a reason.
                 if stop_reason in ["end_turn", "max_tokens", "stop_sequence"] and not self.sub_agent:
                     keep_working = await self._fire_stop_hook(stop_reason)
                     if keep_working is not None and stop_overrides < self.MAX_STOP_HOOK_OVERRIDES:
                         stop_overrides += 1
-                        if self.session_recorder is not None:
-                            await asyncio.to_thread(
-                                self.session_recorder.record_context_message,
-                                Message(role="user", content=[TextBlock(text=keep_working)]),
-                            )
-                        self.append_user_message([TextBlock(text=keep_working)])
+                        await self._record_context_user_message(keep_working)
                         stop_reason = None
 
             except Exception as ex:

--- a/kolega_code/agent/prompt_templates/auxiliary/agent_loop/silent_turn_exhausted.user.md
+++ b/kolega_code/agent/prompt_templates/auxiliary/agent_loop/silent_turn_exhausted.user.md
@@ -1,0 +1,3 @@
+<system-reminder>
+The turn was terminated by the runtime: the model ended four consecutive responses with no tool call and no visible message, despite three escalating reminders. No result was produced for the pending request.
+</system-reminder>

--- a/kolega_code/agent/prompt_templates/auxiliary/agent_loop/silent_turn_nudge.user.md.j2
+++ b/kolega_code/agent/prompt_templates/auxiliary/agent_loop/silent_turn_nudge.user.md.j2
@@ -1,0 +1,9 @@
+<system-reminder>
+{% if attempt == 1 %}
+Your last turn ended with only internal reasoning — no tool call and no visible message. Thinking is invisible and changes nothing on its own. Act now: emit the tool call you were planning, or reply with a visible message. Do not narrate what you will do — do it.
+{% elif attempt == 2 %}
+You have now ended two consecutive turns with no tool call and no visible message. Nothing you reasoned about has happened. Stop deliberating and act: this turn MUST end in a tool call or a visible, substantive reply.
+{% else %}
+FINAL WARNING: three consecutive turns have ended with no tool call and no visible message. If this turn is silent as well, it will be terminated and reported as producing no result — there will be no further reminders. Emit the tool call or the reply NOW.
+{% endif %}
+</system-reminder>

--- a/kolega_code/agent/prompts.py
+++ b/kolega_code/agent/prompts.py
@@ -43,6 +43,7 @@ SHARED_TASK_LIST_PROMPT = render_prompt_template("extensions/cli/shared_task_lis
 SHARED_TASK_LIST_READONLY_PROMPT = render_prompt_template("extensions/cli/shared_task_list_readonly.md")
 PLANNING_QUESTION_PROMPT = render_prompt_template("extensions/cli/planning_questions.md")
 BUILD_QUESTION_PROMPT = render_prompt_template("extensions/cli/build_questions.md")
+SILENT_TURN_EXHAUSTED_NOTICE = render_prompt_template("auxiliary/agent_loop/silent_turn_exhausted.user.md")
 
 # Compatibility templates for callers/tests that still use ``str.format`` or
 # ``replace`` style placeholders.
@@ -67,6 +68,11 @@ def build_compression_summary_user_prompt(history: str, previous_summary: Option
         history=history,
         previous_summary=previous_summary,
     )
+
+
+def build_silent_turn_nudge(attempt: int) -> str:
+    """Escalating reminder injected when the model ends a turn with no tool call and no visible text."""
+    return render_prompt_template("auxiliary/agent_loop/silent_turn_nudge.user.md.j2", attempt=attempt)
 
 
 def build_implement_plan_prompt(

--- a/tests/agent/test_hooks_integration.py
+++ b/tests/agent/test_hooks_integration.py
@@ -68,6 +68,14 @@ def stop_until_flag_hook(event):
     return HookOutcome.empty()
 
 
+_STOP_FIRE_COUNT = [0]
+
+
+def count_stop_hook(event):
+    _STOP_FIRE_COUNT[0] += 1
+    return HookOutcome.empty()
+
+
 def _dispatcher(event: HookEvent, func: str, matcher: str = "*") -> HookDispatcher:
     spec = HookSpec(type="python", timeout=5, scope="global", callable=f"{__name__}:{func}")
     return HookDispatcher(HookConfig(entries={event: [(HookMatcher(matcher), [spec])]}))
@@ -229,3 +237,33 @@ async def test_stop_hook_keeps_working_then_completes(tmp_path, agent_config):
     assert chunks[-1]["complete"] is True
     # The keep-working reason was appended to history as a user message.
     assert any("keep going" in m.get_text_content() for m in agent.history if m.role == "user")
+
+
+@pytest.mark.asyncio
+async def test_stop_hook_skipped_on_nudged_iteration_fires_on_real_end(tmp_path, agent_config):
+    """A silent-turn nudge is not a turn end: the Stop hook must not fire on the
+    nudged iteration, only once when the model actually finishes."""
+    from kolega_code.llm.models import ThinkingBlock
+
+    from .compaction_helpers import FakeStream
+
+    _STOP_FIRE_COUNT[0] = 0
+    agent = _make_agent(tmp_path, agent_config, _dispatcher(HookEvent.STOP, "count_stop_hook"))
+    agent.system_prompt = Message("system", [TextBlock("test agent")])
+    agent.tool_collection = Mock()
+    agent.tool_collection.get_tool_list = Mock(return_value=[])
+    agent.count_current_context = AsyncMock(return_value=TokenCount(input_tokens=10))
+    agent.llm = Mock()
+    agent.llm.stream = AsyncMock(
+        side_effect=[
+            FakeStream(Message(role="assistant", content=[ThinkingBlock(thinking="hmm")], stop_reason="end_turn")),
+            FakeStream(Message(role="assistant", content=[TextBlock(text="done")], stop_reason="end_turn")),
+        ]
+    )
+
+    chunks = [chunk async for chunk in agent.process_message_stream("hello")]
+
+    # Silent first iteration → nudged (no Stop hook), second iteration ends for real.
+    assert agent.llm.stream.await_count == 2
+    assert _STOP_FIRE_COUNT[0] == 1
+    assert chunks[-1]["complete"] is True

--- a/tests/agent/test_silent_turn_guard.py
+++ b/tests/agent/test_silent_turn_guard.py
@@ -1,0 +1,219 @@
+"""The silent-turn guard: re-prompt when the model ends a turn with no tool call
+and no visible text, instead of finalizing an empty result.
+
+Hermetic: every test scripts the LLM with ``FakeLLM(message_script=[...])``.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kolega_code.agent.baseagent import BaseAgent
+from kolega_code.cli.session_store import SessionStore
+from kolega_code.llm.models import Message, TextBlock, ThinkingBlock, ToolCall, ToolResult
+
+from .compaction_helpers import FakeLLM, build_agent
+
+STAGE_MARKERS = [
+    "only internal reasoning",
+    "two consecutive turns",
+    "FINAL WARNING",
+]
+EXHAUSTED_MARKER = "terminated by the runtime"
+
+
+def _silent_turn_message(stop_reason: str = "end_turn") -> Message:
+    return Message(role="assistant", content=[ThinkingBlock(thinking="pondering...")], stop_reason=stop_reason)
+
+
+def _end_turn_message(text: str = "done") -> Message:
+    return Message(role="assistant", content=[TextBlock(text=text)], stop_reason="end_turn")
+
+
+def _tool_call_message(tool_call: ToolCall) -> Message:
+    return Message(
+        role="assistant",
+        content=[tool_call],
+        stop_reason="tool_use",
+        tool_calls=[tool_call],
+    )
+
+
+def _tool_result(tool_call: ToolCall) -> ToolResult:
+    return ToolResult(
+        tool_use_id=tool_call.id,
+        name=tool_call.name,
+        content="ok",
+        is_error=False,
+    )
+
+
+def _configure_agent(agent, message_script: list[Message]) -> None:
+    agent.system_prompt = Message(role="system", content=[TextBlock(text="sys")])
+    agent.tool_collection = MagicMock()
+    agent.tool_collection.get_tool_list = MagicMock(return_value=[])
+    agent.llm = FakeLLM(token_script=[100], message_script=message_script)
+    agent.log_info = AsyncMock()
+    agent.log_error = AsyncMock()
+
+
+def _user_texts(agent) -> list[str]:
+    return [message.get_text_content() for message in agent.history if message.role == "user"]
+
+
+def _llm_status_events(connection_manager):
+    events = []
+    for call in connection_manager.broadcast_event.call_args_list:
+        event = call.args[0] if call.args else call.kwargs.get("event")
+        if event is not None and getattr(event, "event_type", None) == "llm_status_update":
+            events.append(event)
+    return events
+
+
+@pytest.mark.asyncio
+async def test_thinking_only_turn_is_nudged_then_recovers(base_agent) -> None:
+    _configure_agent(base_agent, [_silent_turn_message(), _end_turn_message()])
+
+    _ = [chunk async for chunk in base_agent.process_message_stream("do X")]
+
+    assert base_agent.llm.stream.await_count == 2
+    user_texts = _user_texts(base_agent)
+    assert any(STAGE_MARKERS[0] in text for text in user_texts)
+    assert not any(STAGE_MARKERS[1] in text for text in user_texts)
+    assert base_agent.history[-1].role == "assistant"
+    assert base_agent.history[-1].get_text_content() == "done"
+    assert base_agent.conversation.is_valid_for_anthropic() is True
+
+
+@pytest.mark.asyncio
+async def test_all_silent_turns_exhaust_cap_and_surface_failure(base_agent, mock_connection_manager) -> None:
+    _configure_agent(base_agent, [_silent_turn_message() for _ in range(4)])
+
+    chunks = [chunk async for chunk in base_agent.process_message_stream("do X")]
+
+    # Initial attempt + one per nudge; the fourth silent response exhausts the cap.
+    assert base_agent.llm.stream.await_count == 4
+    user_texts = _user_texts(base_agent)
+    stage_positions = []
+    for marker in STAGE_MARKERS:
+        matches = [index for index, text in enumerate(user_texts) if marker in text]
+        assert len(matches) == 1, f"expected exactly one nudge containing {marker!r}"
+        stage_positions.append(matches[0])
+    assert stage_positions == sorted(stage_positions)
+    assert any(EXHAUSTED_MARKER in text for text in user_texts)
+    assert any("[no output]" in chunk.get("content", "") for chunk in chunks)
+
+    statuses = _llm_status_events(mock_connection_manager)
+    assert sum(1 for event in statuses if event.content.get("status") == "info") == 3
+    assert sum(1 for event in statuses if event.content.get("status") == "warning") == 1
+
+
+@pytest.mark.asyncio
+async def test_text_only_turn_not_nudged(base_agent) -> None:
+    _configure_agent(base_agent, [_end_turn_message()])
+
+    _ = [chunk async for chunk in base_agent.process_message_stream("do X")]
+
+    assert base_agent.llm.stream.await_count == 1
+    assert not any(STAGE_MARKERS[0] in text for text in _user_texts(base_agent))
+
+
+@pytest.mark.asyncio
+async def test_tool_call_turn_not_nudged(base_agent) -> None:
+    tool_call = ToolCall(id="tool-1", name="read_file", input={})
+    _configure_agent(base_agent, [_tool_call_message(tool_call), _end_turn_message()])
+    base_agent.process_tool_calls = AsyncMock(return_value=[_tool_result(tool_call)])
+
+    _ = [chunk async for chunk in base_agent.process_message_stream("do X")]
+
+    assert base_agent.llm.stream.await_count == 2
+    assert not any(STAGE_MARKERS[0] in text for text in _user_texts(base_agent))
+
+
+@pytest.mark.asyncio
+async def test_silent_counter_resets_after_productive_turn(base_agent) -> None:
+    tool_call = ToolCall(id="tool-1", name="read_file", input={})
+    _configure_agent(
+        base_agent,
+        [
+            _silent_turn_message(),
+            _tool_call_message(tool_call),
+            _silent_turn_message(),
+            _silent_turn_message(),
+            _silent_turn_message(),
+            _end_turn_message(),
+        ],
+    )
+    base_agent.process_tool_calls = AsyncMock(return_value=[_tool_result(tool_call)])
+
+    chunks = [chunk async for chunk in base_agent.process_message_stream("do X")]
+
+    # Without the reset after the productive tool-call iteration, the fourth
+    # silent response overall would have exhausted the cap and terminated.
+    assert base_agent.llm.stream.await_count == 6
+    assert not any("[no output]" in chunk.get("content", "") for chunk in chunks)
+    assert base_agent.history[-1].get_text_content() == "done"
+
+
+@pytest.mark.asyncio
+async def test_max_tokens_silent_turn_is_nudged(base_agent) -> None:
+    _configure_agent(base_agent, [_silent_turn_message(stop_reason="max_tokens"), _end_turn_message()])
+
+    _ = [chunk async for chunk in base_agent.process_message_stream("do X")]
+
+    assert base_agent.llm.stream.await_count == 2
+    assert any(STAGE_MARKERS[0] in text for text in _user_texts(base_agent))
+
+
+@pytest.mark.asyncio
+async def test_empty_content_silent_turn_is_nudged(base_agent) -> None:
+    empty = Message(role="assistant", content=[], stop_reason="end_turn")
+    _configure_agent(base_agent, [empty, _end_turn_message()])
+
+    _ = [chunk async for chunk in base_agent.process_message_stream("do X")]
+
+    # Detection runs on the streamed message, before append_assistant papers the
+    # empty content over with a placeholder TextBlock.
+    assert base_agent.llm.stream.await_count == 2
+    assert any(STAGE_MARKERS[0] in text for text in _user_texts(base_agent))
+
+
+@pytest.mark.asyncio
+async def test_nudge_journal_ordering_and_replay(base_agent, tmp_path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", {})
+    base_agent.session_recorder = store.recorder(session.session_id)
+
+    _configure_agent(base_agent, [_silent_turn_message(), _end_turn_message()])
+
+    _ = [chunk async for chunk in base_agent.process_message_stream("do X")]
+
+    event_types = [event.event_type for event in store.journal(session.session_id).read_events()]
+    # Context messages: the volatile-context update at the start of the turn,
+    # then the nudge injected after the silent assistant response.
+    assert event_types[-6:] == [
+        "turn.started",
+        "context.message",
+        "assistant.message",
+        "context.message",
+        "assistant.message",
+        "turn.completed",
+    ]
+
+    replayed = [Message.from_dict(item) for item in store.load(session.session_id).history]
+    assert [message.role for message in replayed] == [message.role for message in base_agent.history]
+    assert any(STAGE_MARKERS[0] in message.get_text_content() for message in replayed if message.role == "user")
+
+
+@pytest.mark.asyncio
+async def test_sub_agent_silent_turn_is_nudged(tmp_path) -> None:
+    fake_llm = FakeLLM(token_script=[100], message_script=[_silent_turn_message(), _end_turn_message()])
+    agent, _ = build_agent(tmp_path, agent_cls=BaseAgent, sub_agent=True, llm=fake_llm)
+
+    _ = [chunk async for chunk in agent.process_message_stream("do X")]
+
+    assert fake_llm.stream.await_count == 2
+    assert any(STAGE_MARKERS[0] in text for text in _user_texts(agent))
+    assert await agent.recap_agent_outcome() == "done"


### PR DESCRIPTION
## Summary

Runtime half of the runaway think-then-stop fix (the prompt invariant shipped in #415). At high thinking effort a model can emit a huge reasoning block and end its turn with **no tool call and no visible text**; the loop finalized that as done — in plain `ask` mode the CLI printed nothing and exited 0, with no deliverable ever written.

- **Detection** (`BaseAgent._is_silent_turn`): no tool calls and no visible text on the streamed message — `ThinkingBlock` carries `.thinking`, not `.text`, so reasoning-only responses read as empty; detection runs before `Conversation.append_assistant` papers empty content over with a placeholder. Fires on any terminal stop reason, including `max_tokens` (the actual failure signature: reasoning ate the completion budget — a re-prompt grants a fresh one).
- **Scope is deliberately objective-only**: a turn that ends with prose and no tool call is never nudged. Distinguishing a final answer from narrated-but-undone work stays with the prompt invariant this guard backstops. `tool_choice` stays on auto.
- **Nudge**: an escalating `<system-reminder>` user message (3 stages, `auxiliary/agent_loop/silent_turn_nudge.user.md.j2`), injected via the same journal+append pattern as the Stop-hook keep-working path (now shared as `_record_context_user_message`). Capped at `MAX_SILENT_TURN_NUDGES = 3` **consecutive** silent responses — the counter resets after any productive iteration, mirroring the consecutive-only LLM retry budget. Each nudge surfaces as an `llm_status` info event (TUI activity line, diagnostics jsonl, `ask --json`).
- **Exhaustion** (4th consecutive silent response): the turn terminates with the failure surfaced, never an implied empty success — log warning, `llm_status` warning event, a journaled exhaustion notice (so session replay and sub-agent recaps show why the turn ended), and a labeled `[no output]` response chunk so plain `ask` prints the failure.
- **Interplay**: the guard runs before the Stop hook — a nudged iteration is not a turn end, and clearing `stop_reason` makes the stop-hook block skip itself; on exhaustion the `break` skips Stop hooks like the existing `should_stop_after_tools` path. Sub-agents get the guard too (their recap would otherwise report `""`).

## Testing

- New `tests/agent/test_silent_turn_guard.py` (9 tests, hermetic `FakeLLM` scripts): nudge-then-recover; cap exhaustion with escalation order, journaled notice, `[no output]` chunk, and status events; prose-only and tool-call turns never nudged; consecutive-counter reset; `max_tokens` and fully-empty variants; journal ordering + replay parity; sub-agent behavior.
- New test in `tests/agent/test_hooks_integration.py`: the Stop hook is skipped on the nudged iteration and fires exactly once on the real turn end.
- Targeted suites green: `test_silent_turn_guard.py` + `test_hooks_integration.py` (16 passed), plus queued-injection, runtime, prompts, empty-message, compaction-events, prompt-provider suites (91 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtZh8joiXeQyjEvdPi9V38
