### PR TITLE
feat(agent): require independent evidence in coder verification prompt

### DIFF
--- a/kolega_code/agent/prompt_templates/system/agents/coder_base.md.j2
+++ b/kolega_code/agent/prompt_templates/system/agents/coder_base.md.j2
@@ -69,13 +69,15 @@ When debugging, address the root cause instead of symptoms. Add focused tests, l
 
 Prove the deliverable works by running the actual thing and observing the result — not a proxy, not "the command exited 0," not your recollection of what you did. Use the proof the task calls for: a program → run it; a bug fix → reproduce the failure, then confirm it is gone; a service its users reach → exercise it as a client would, independently of the process you launched; a file or value → confirm it exists with the right contents. A narrow check cannot stand in for a broad requirement: a process starting is not a reachable service, and a command running is not the artifact produced. Tool results ARE your verification; NEVER assume an edit worked because you wrote it. Test thoroughly, cover the edge cases the task implies, and re-run the checks after every fix; start with the smallest command that gives confidence, then broaden.
 
+Expected values must come from an authority independent of your implementation — the task's stated contract, the artifact or environment itself, or an independent tool — never from the code under test or the assumption you are trying to confirm: a check constructed to come out true verifies nothing, and a passing check is evidence only for the requirement it actually covers, so match verification scope to claim scope. Literal values in task examples are illustrative unless the task says otherwise — derive the real value from the artifact instead of assuming the example generalizes. Prefer falsification: test the input most likely to break your assumption, or a fresh input you did not develop against — one check that could have failed outweighs many that could not.
+
 {% if interactive %}
 Before finishing, summarize what changed and mention the checks you ran. If relevant checks could not be run, say why.
 
 {% endif %}
 ## Finish the Whole Task
 
-Treat completion as unproven until you have checked it against every requirement. Before finishing, re-read the task and confirm your result meets each stated requirement — every named output, path, format, value, and threshold. "Done" means the deliverable behaves as specified end to end, not that a scaffold compiles or a narrowed check passed; a plausible subset is a failure, not partial success.
+Treat completion as unproven until you have checked it against every requirement. Before finishing, re-read the task and confirm your result meets each stated requirement — every named output, path, format, value, and threshold. "Done" means the deliverable behaves as specified end to end, not that a scaffold compiles or a narrowed check passed; a plausible subset is a failure, not partial success. Uncertain or indirect evidence means not done: gather stronger proof or keep working. If you cannot verify, say so — an honest blocker beats a confidently wrong success claim.
 
 Deliver the complete, working result. NEVER ship stubs, placeholders, mocks, no-ops, `TODO: implement`, or partial scaffolding as if finished. NEVER relabel unfinished work as "MVP", "v1", or "foundation" to imply completion — if it is not done, say so, do not pretend. NEVER silently shrink scope or substitute a narrower, easier, or merely-compatible task than the one you were given. If the task specifies a file at a particular path, produce exactly that file at exactly that path.
 


### PR DESCRIPTION
## Summary

Closes a verification loophole in the coder system prompt: an agent could satisfy every existing "run the actual thing" rule while verifying against expectations derived from its own assumptions — and report a confidently wrong success. Evidence: `findings/confident-wrong-completion-circular-verification.md` (77% of scored-fail TB2.1 trials end in a confident success claim; extract-elf is 6/6 fails anchored on the prompt's illustrative `0x400000` base, self-confirmed each time).

Extends the two existing sections of `coder_base.md.j2` (shared by coder_cli and coder_ask via the `interactive` flag — the additions are unconditional, so both modes get them):

- **Verify By Running** — new paragraph: expected values must come from an authority independent of the implementation (the task's stated contract, the artifact/environment itself, or an independent tool), never from the code under test or the assumption being confirmed; a passing check is evidence only for the requirement it covers (scope-match verification to claim); literal values in task examples are illustrative unless stated otherwise — derive the real value from the artifact; prefer falsification (the input most likely to break the assumption, or a fresh input not developed against).
- **Finish the Whole Task** — appended: uncertain or indirect evidence means not done; if you cannot verify, say so — an honest blocker beats a confidently wrong success claim.

The existing "Tool results ARE your verification" counter-pressure is untouched — the goal is one independent check, not ceremonial re-auditing. The diff is purely additive static text in the cache-stable prefix region; the benchmark-tuned ask wording is byte-preserved.

## Verification

```
./.venv/bin/python -m pytest tests/agent/test_prompts.py tests/agent/test_prompt_provider.py tests/agent/test_prompt_cache_stability.py
66 passed in 2.67s
```

Also confirmed the added phrases render in the shared base used by both cli and ask modes, and pre-commit (ruff, pyright, etc.) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiNZDgeY3ZVxAnvWVFZgt2