### PR TITLE
feat(terminal): give detached background sessions a working stdin

### DIFF
--- a/docs/src/content/docs/concepts/tools.md
+++ b/docs/src/content/docs/concepts/tools.md
@@ -35,16 +35,16 @@ Run shell commands in the project and stream their output to the **Terminal** ta
 
 **Background processes & dev servers:** pass `background=true` to `exec_command`
 for dev servers, watchers, and long builds you want to keep running. It returns
-after a short startup window (~2s) with a `session_id`; the process keeps
-running until stopped. Poll output with `write_stdin`, stop it with
-`kill_command`, and see all running shells with `list_sessions` (background
-sessions are marked `background: true`). Avoid shell `&` instead — processes
-backgrounded that way are killed when the command that started them ends, and
-the result prints a warning when that happens. A command passed with
-`background=true` that exits within the startup window (e.g. port already in
-use) reports its real exit code and output. Processes started by the agent
-never outlive kolega-code: all sessions are terminated when the agent session
-ends, including on quit.
+after a short startup window (~2s) with a `session_id`. The process is launched
+detached: it keeps running until `kill_command` stops it — including after the
+agent session ends. Send it input or poll new output with `write_stdin` (input
+is not echoed, and its stdin never reaches EOF, so stdin-reading commands run
+until killed), stop it with `kill_command`, and see all running shells with
+`list_sessions` (background sessions are marked `background: true`). Avoid
+shell `&` instead — processes backgrounded that way are killed when the command
+that started them ends, and the result prints a warning when that happens. A
+command passed with `background=true` that exits within the startup window
+(e.g. port already in use) reports its real exit code and output.
 
 ### Code execution (eval)
 

--- a/kolega_code/agent/tool_backend/terminal_tool.py
+++ b/kolega_code/agent/tool_backend/terminal_tool.py
@@ -23,10 +23,12 @@ BACKGROUND_SETTLE_MS = 2000
 _BACKGROUND_NOTE = (
     "Running in background, detached: it keeps running after this command and even "
     "after the agent session ends, until you stop it with kill_command(session_id) "
-    "(or the environment goes away). It is poll-only — write_stdin(session_id) reads "
-    "new output but cannot send input. See all running shells with list_sessions. "
-    "Output may be buffered, so verify a server by reaching it as a client (e.g. curl), "
-    "not by waiting on this log."
+    "(or the environment goes away). write_stdin(session_id, chars) sends real input "
+    "to its stdin; write_stdin(session_id) polls new output. Input is not echoed and "
+    "its stdin never reaches EOF, so verify effects from the output (or as a client) "
+    "and stop stdin-reading commands with kill_command. See all running shells with "
+    "list_sessions. Output may be buffered, so verify a server by reaching it as a "
+    "client (e.g. curl), not by waiting on this log."
 )
 
 
@@ -166,11 +168,13 @@ class TerminalTool(BaseTool):
         process is launched detached, so it keeps running until you stop it with
         kill_command — including after this agent session ends (it does NOT die
         when you finish). Do NOT use shell `&` for this — processes backgrounded
-        that way are killed when the command that started them ends. Background
-        sessions are poll-only: use write_stdin to read new output (it cannot
-        send input to them), kill_command to stop, and list_sessions to see all
-        running shells. Always verify a server answers (e.g. curl) before handing
-        its URL to the browser agent — do not rely on its log, which may be buffered.
+        that way are killed when the command that started them ends. Drive
+        background sessions with write_stdin: chars sends real input, chars=""
+        polls new output. Input is not echoed (their stdin is not a TTY) and
+        never reaches EOF, so commands that read stdin run until kill_command
+        stops them. Use list_sessions to see all running shells. Always verify
+        a server answers (e.g. curl) before handing its URL to the browser
+        agent — do not rely on its log, which may be buffered.
 
         Args:
             command: Shell command line, executed via `bash -c`.
@@ -182,9 +186,10 @@ class TerminalTool(BaseTool):
             login: Run the shell as a login shell (sources profile). Default false.
             background: Launch detached and return after a short startup window
                         (~2s) with a session_id. The process outlives this call
-                        and the agent session until kill_command stops it; it is
-                        poll-only (no stdin). Commands that exit within the
-                        startup window report their real exit code.
+                        and the agent session until kill_command stops it; it
+                        accepts write_stdin input (no echo; stdin never reaches
+                        EOF). Commands that exit within the startup window
+                        report their real exit code.
 
         Returns:
             A JSON object: {"status": "exited"|"running", "exit_code",
@@ -230,6 +235,11 @@ class TerminalTool(BaseTool):
         trailing "\\n" to submit a line. Waits up to yield_time_ms (clamped to
         250–30000 when writing, 5000–300000 when polling) for more output or for
         the process to exit.
+
+        Works for background sessions too: input is delivered to their stdin
+        but not echoed, so verify the effect from the command's output; their
+        stdin never reaches EOF, so stop stdin-reading commands with
+        kill_command.
 
         Args:
             session_id: The id returned by exec_command when status == "running".

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -1911,13 +1911,17 @@ class ToolCollection(LogMixin):
 
         Running long-lived processes: pass background=true for dev servers,
         watchers, and long builds you want to keep running while you do other
-        work. It returns after a short startup window with a session_id; the
-        process keeps running until you stop it with kill_command or the agent
-        session ends. Do NOT use shell `&` for this — processes backgrounded
-        that way are killed when the command that started them ends. Manage
-        background sessions with write_stdin (poll output), kill_command
-        (stop), and list_sessions (see all running shells). Always verify a
-        server answers (e.g. curl) before handing its URL to the browser agent.
+        work. It returns after a short startup window with a session_id. The
+        process is launched detached, so it keeps running until you stop it with
+        kill_command — including after this agent session ends (it does NOT die
+        when you finish). Do NOT use shell `&` for this — processes backgrounded
+        that way are killed when the command that started them ends. Drive
+        background sessions with write_stdin: chars sends real input, chars=""
+        polls new output. Input is not echoed (their stdin is not a TTY) and
+        never reaches EOF, so commands that read stdin run until kill_command
+        stops them. Use list_sessions to see all running shells. Always verify
+        a server answers (e.g. curl) before handing its URL to the browser
+        agent — do not rely on its log, which may be buffered.
 
         Args:
             command: Shell command line, executed via `bash -c`.
@@ -1926,9 +1930,12 @@ class ToolCollection(LogMixin):
                            milliseconds (clamped to 250–30000).
             max_output_tokens: Maximum tokens of output to return in this call.
             login: Run the shell as a login shell (sources profile). Default false.
-            background: Keep the command running and return after a short
-                        startup window (~2s) with a session_id. Commands that
-                        exit within that window report their real exit code.
+            background: Launch detached and return after a short startup window
+                        (~2s) with a session_id. The process outlives this call
+                        and the agent session until kill_command stops it; it
+                        accepts write_stdin input (no echo; stdin never reaches
+                        EOF). Commands that exit within the startup window
+                        report their real exit code.
 
         Returns:
             A JSON object: {"status": "exited"|"running", "exit_code",
@@ -1960,6 +1967,11 @@ class ToolCollection(LogMixin):
         trailing "\\n" to submit a line. Waits up to yield_time_ms (clamped to
         250–30000 when writing, 5000–300000 when polling) for more output or for
         the process to exit.
+
+        Works for background sessions too: input is delivered to their stdin
+        but not echoed, so verify the effect from the command's output; their
+        stdin never reaches EOF, so stop stdin-reading commands with
+        kill_command.
 
         Args:
             session_id: The id returned by exec_command when status == "running".

--- a/kolega_code/sandbox/terminal.py
+++ b/kolega_code/sandbox/terminal.py
@@ -115,9 +115,10 @@ class SandboxTerminalManager(TerminalManager):
         env: Optional[Dict[str, str]] = None,
         background: bool = False,
     ) -> ExecResult:
-        # background is a lifetime hint for local PTYs; here the command runs in
-        # the sandbox's persistent terminal, which already outlives any single
-        # exec and lives until the sandbox is destroyed, so no special handling.
+        # background is a lifetime hint for the local backend; here the command
+        # runs in the sandbox's persistent terminal, which already outlives any
+        # single exec and lives until the sandbox is destroyed, so no special
+        # handling.
         _ = background
         yield_ms = clamp_yield(yield_time_ms, poll=False)
         terminal_id = await self._ensure_default_terminal()

--- a/kolega_code/services/base.py
+++ b/kolega_code/services/base.py
@@ -52,11 +52,13 @@ class TerminalManager(ABC):
         result has status "running" and a ``session_id`` that can be driven with
         ``write_stdin`` and stopped with ``kill_session``.
 
-        ``background`` launches a detached, poll-only session meant to outlive the
-        agent process (dev servers, watchers). Local backends spawn it with its
-        own session and file-backed output so it survives our exit; sandbox
-        backends run it in the sandbox's persistent terminal, which lives until
-        the sandbox is destroyed.
+        ``background`` launches a detached session meant to outlive the agent
+        process (dev servers, watchers). Local backends spawn it with its own
+        session, file-backed output, and FIFO-backed stdin, so it survives our
+        exit and still accepts ``write_stdin`` (input is not echoed, and its
+        stdin never reaches EOF, so stdin-draining commands run until killed);
+        sandbox backends run it in the sandbox's persistent terminal, which
+        lives until the sandbox is destroyed.
         """
 
     @abstractmethod

--- a/kolega_code/services/terminal.py
+++ b/kolega_code/services/terminal.py
@@ -424,20 +424,25 @@ class DetachedSession:
     """A ``background=true`` command that outlives the kolega-code process.
 
     Unlike :class:`PtySession`, this is spawned **detached** — ``setsid`` (its own
-    session, no controlling terminal), stdin from ``/dev/null``, and stdout+stderr
-    to a temp log file. That combination is what makes it durable:
+    session, no controlling terminal), stdin from a private FIFO the child holds
+    open O_RDWR as fd 0, and stdout+stderr to a temp log file. That combination
+    is what makes it durable:
 
     - No controlling TTY, so it never gets SIGHUP when our terminal/PTY goes away.
     - Output goes to a real file (never a pipe/PTY we hold), so a write can't fail
       with EIO once we exit.
     - It is not tracked by an asyncio child-transport, so nothing SIGKILLs it when
       our event loop tears down.
+    - Its stdin FIFO never loses its last writer (the child's own fd 0 is one), so
+      the child never reads EOF — blocking reads just wait, like an idle terminal,
+      including after we exit.
 
     The process therefore keeps running after the agent session ends (reparented
     to init) — matching claude-code's ``run_in_background``. It is stopped only by
     ``kill_command`` (SIGTERM/-KILL to its group) or by the container going away.
-    Because stdin is closed it is poll-only: ``write`` is a no-op and callers read
-    fresh output by polling the tailed log. Output may be block-buffered by the
+    ``write`` delivers real input through the FIFO; there is no echo (the FIFO is
+    not a TTY), and stdin-draining commands (``while read``, REPLs, bare ``cat``)
+    never see EOF, so they run until killed. Output may be block-buffered by the
     child (its stdout is a file, not a TTY), so verify a server as a client (curl)
     rather than waiting on its log.
     """
@@ -471,6 +476,7 @@ class DetachedSession:
         self.exit_code: Optional[int] = None
         self.start_time = time.monotonic()
         self.log_path: Optional[str] = None
+        self.stdin_path: Optional[str] = None
 
         self.exited = asyncio.Event()
         self._new_output = asyncio.Event()
@@ -495,8 +501,21 @@ class DetachedSession:
 
         fd, self.log_path = tempfile.mkstemp(prefix="kolega-bg-", suffix=".log")
         os.close(fd)
+        # stdin FIFO named after the log: the log path is unique (mkstemp), so
+        # "<log>.stdin" is too — mkfifo raises EEXIST rather than reusing.
+        self.stdin_path = self.log_path + ".stdin"
+        os.mkfifo(self.stdin_path, 0o600)
         self._reader = open(self.log_path, "rb")
         writer = open(self.log_path, "wb")
+        # The FIFO is opened O_RDWR and handed to the child as fd 0. O_RDWR never
+        # blocks waiting for a peer, and because the child's own fd 0 is then both
+        # a reader AND a writer, the FIFO never loses its last writer while the
+        # child (or any descendant that inherited fd 0) lives: the child never
+        # reads EOF on stdin — not at startup, not between write() calls, not
+        # after we exit. POSIX leaves O_RDWR-on-FIFO undefined; Linux documents it
+        # as non-blocking (fifo(7)) and macOS/BSD behaves the same — the only
+        # supported runtimes.
+        stdin_fd = os.open(self.stdin_path, os.O_RDWR)
         try:
             # start_new_session=True -> setsid in the child: its own session and
             # process group, no controlling terminal. plain Popen (not asyncio)
@@ -505,23 +524,27 @@ class DetachedSession:
                 [shell, *shell_args],
                 cwd=str(self.workdir),
                 env=env,
-                stdin=subprocess.DEVNULL,
+                stdin=stdin_fd,
                 stdout=writer,
                 stderr=subprocess.STDOUT,
                 start_new_session=True,
-                close_fds=True,
+                close_fds=True,  # std handles passed above are exempt
             )
         except Exception:
-            # Launch failed: don't leak the reader fd or the temp log.
+            # Launch failed: don't leak the reader fd or the temp files.
             with contextlib.suppress(OSError):
                 self._reader.close()
             self._reader = None
             with contextlib.suppress(OSError):
                 os.unlink(self.log_path)
             self.log_path = None
+            with contextlib.suppress(OSError):
+                os.unlink(self.stdin_path)
+            self.stdin_path = None
             raise
         finally:
             writer.close()  # the child holds its own dup of the fd
+            os.close(stdin_fd)  # ditto: the child's fd 0 keeps the FIFO alive
         self.pid = self._proc.pid
         self._pump_task = asyncio.create_task(self._pump())
 
@@ -591,8 +614,37 @@ class DetachedSession:
         return cap_tokens(text, max_output_tokens)
 
     async def write(self, chars: str) -> bool:
-        # Detached sessions have no stdin (closed to /dev/null); poll-only.
-        return False
+        """Deliver ``chars`` to the child's stdin FIFO.
+
+        Opens the FIFO O_WRONLY|O_NONBLOCK per call: POSIX guarantees this
+        succeeds while any process holds the read side (the child's own O_RDWR
+        fd 0, for its whole life) and fails with ENXIO once the child and its
+        fd-0 heirs are gone. There is no echo — the FIFO is not a TTY, so these
+        bytes appear in the log only if the child prints them. ``stdin_path`` is
+        always set between start() and close(), the only window in which the
+        manager calls write().
+        """
+        assert self.stdin_path is not None
+        try:
+            fd = os.open(self.stdin_path, os.O_WRONLY | os.O_NONBLOCK)
+        except OSError:
+            # ENXIO: no reader left — the child (and anything that inherited
+            # its fd 0) exited or closed stdin. Mirrors PtySession's False.
+            return False
+        try:
+            data = chars.encode()
+            while data:
+                # Loop for partial writes (payloads > PIPE_BUF: 512 on macOS,
+                # 4096 on Linux). CPython ignores SIGPIPE, so a lost-reader race
+                # raises BrokenPipeError here, not a signal; a full pipe (child
+                # not draining its backlog) raises BlockingIOError. Both are
+                # OSError -> False.
+                data = data[os.write(fd, data) :]
+            return True
+        except OSError:
+            return False
+        finally:
+            os.close(fd)
 
     async def kill(self, signame: str = "TERM") -> None:
         first = signal.SIGINT if signame == "INT" else signal.SIGTERM
@@ -621,11 +673,17 @@ class DetachedSession:
             with contextlib.suppress(OSError):
                 self._reader.close()
             self._reader = None
-        # Only drop the log once the process is gone; a survivor still writes to it.
-        if self.exited.is_set() and self.log_path:
-            with contextlib.suppress(OSError):
-                os.unlink(self.log_path)
-            self.log_path = None
+        # Only drop the log and stdin FIFO once the process is gone; a survivor
+        # still writes to the log and owns the FIFO through its own fd 0.
+        if self.exited.is_set():
+            if self.log_path:
+                with contextlib.suppress(OSError):
+                    os.unlink(self.log_path)
+                self.log_path = None
+            if self.stdin_path:
+                with contextlib.suppress(OSError):
+                    os.unlink(self.stdin_path)
+                self.stdin_path = None
 
     @property
     def running(self) -> bool:
@@ -794,6 +852,11 @@ class LocalTerminalManager(TerminalManager):
         yield_ms = clamp_yield(yield_time_ms, poll=(chars == ""))
         start = time.monotonic()
         if chars:
+            # Both session types return a success bool; it is intentionally
+            # discarded (parity between the PTY and detached paths). A write
+            # that failed because the process died surfaces as status="exited"
+            # in this same result: the drain below observes the exit well
+            # within the >=250ms write window.
             await session.write(chars)
         await session.drain(yield_ms)
         duration_ms = int((time.monotonic() - start) * 1000)

--- a/tests/agent/services/test_terminal.py
+++ b/tests/agent/services/test_terminal.py
@@ -367,6 +367,100 @@ async def test_foreground_long_runner_is_killed_by_cleanup_all(manager):
     assert not _process_alive(pid)
 
 
+@pytest.mark.asyncio
+async def test_background_write_stdin_delivers_input(manager):
+    result = await manager.exec_command(
+        'while read line; do echo "got:$line"; done', yield_time_ms=500, background=True
+    )
+    assert result.status == "running"
+    sid = result.session_id
+    out = (await manager.write_stdin(sid, "hello\n", yield_time_ms=500)).output
+    for _ in range(20):  # bounded: this suite has no pytest-timeout
+        if "got:hello" in out:
+            break
+        out += (await manager.write_stdin(sid, "hello\n", yield_time_ms=500)).output
+    assert "got:hello" in out
+    await manager.kill_session(sid, "TERM")
+
+
+@pytest.mark.asyncio
+async def test_background_multiple_writes_no_eof_between(manager):
+    # `while read` exits the moment stdin hits EOF, so three separate writes
+    # landing while the loop is still running proves the FIFO never delivers
+    # EOF between write_stdin calls.
+    result = await manager.exec_command(
+        'while read line; do echo "got:$line"; done', yield_time_ms=500, background=True
+    )
+    sid = result.session_id
+    out = ""
+    for word in ("one", "two", "three"):
+        out += (await manager.write_stdin(sid, f"{word}\n", yield_time_ms=500)).output
+    for _ in range(20):
+        if all(f"got:{w}" in out for w in ("one", "two", "three")):
+            break
+        out += (await manager.write_stdin(sid, "ping\n", yield_time_ms=500)).output
+    for word in ("one", "two", "three"):
+        assert f"got:{word}" in out
+    assert manager.sessions[sid].running is True, "reader loop exited — stdin saw EOF"
+    await manager.kill_session(sid, "TERM")
+
+
+@pytest.mark.asyncio
+async def test_background_stdin_reader_survives_cleanup_all(manager, tmp_path):
+    # A stdin-draining child would die the instant its stdin hit EOF; surviving
+    # cleanup_all proves the FIFO never loses its last writer when we exit.
+    marker = tmp_path / "lines.log"
+    cmd = f'while read line; do echo "$line" >> {marker}; done'
+    result = await manager.exec_command(cmd, yield_time_ms=500, background=True)
+    assert result.status == "running"
+    session = manager.sessions[result.session_id]
+    pid, fifo = session.pid, session.stdin_path
+    assert pid is not None and fifo is not None
+
+    await manager.write_stdin(result.session_id, "before\n", yield_time_ms=500)
+    await manager.cleanup_all()  # == kolega-code exit
+    assert len(manager.sessions) == 0
+
+    await asyncio.sleep(0.3)
+    try:
+        assert _process_alive(pid), "stdin-reading background process died on cleanup_all"
+        # Delivery is still possible after our exit: any writer can open the FIFO.
+        fd = os.open(fifo, os.O_WRONLY | os.O_NONBLOCK)
+        try:
+            os.write(fd, b"after\n")
+        finally:
+            os.close(fd)
+        for _ in range(40):
+            if marker.exists() and "after" in marker.read_text():
+                break
+            await asyncio.sleep(0.05)
+        text = marker.read_text()
+        assert "before" in text and "after" in text
+    finally:
+        # It really is a survivor, so we must clean it up ourselves.
+        with contextlib.suppress(OSError):
+            os.killpg(os.getpgid(pid), signal.SIGKILL)
+
+
+@pytest.mark.asyncio
+async def test_detached_write_true_then_false_after_exit(manager):
+    result = await manager.exec_command("read x; echo done-$x", yield_time_ms=500, background=True)
+    session = manager.sessions[result.session_id]
+    fifo = session.stdin_path
+    assert fifo is not None
+    assert await session.write("go\n") is True
+    for _ in range(100):  # bounded wait; the pump polls every 0.05s
+        if session.exited.is_set():
+            break
+        await asyncio.sleep(0.05)
+    assert session.exited.is_set()
+    assert await session.write("late\n") is False  # ENXIO: no reader left
+    final = await manager.write_stdin(result.session_id, "")  # exited -> drain returns instantly
+    assert final.status == "exited" and final.exit_code == 0
+    assert "done-go" in (result.output + final.output)
+    assert not os.path.exists(fifo)  # finished session unlinked its FIFO
+
+
 def test_signal_group_none_pid_is_noop():
     # Defensive: signalling before a process exists must not raise.
     _signal_group(None, signal.SIGTERM)


### PR DESCRIPTION
## Summary

`exec_command background=true` sessions (df09c71) were durable but poll-only: `write_stdin` tailed the log and silently dropped input. Foreground PTY sessions were the inverse — interactive but killed on exit. "Interact with a long-lived process, then leave it running" (qemu console setup, REPLs, servers that take commands) was therefore impossible with the session tools; on Terminal-Bench 2.1 qemu-alpine-ssh this measured 0/9 for kolega vs 3/5 for claude-code, which hand-rolled mkfifo + setsid.

This PR gives detached sessions a working stdin with no durability cost.

## Mechanism

`DetachedSession.start()` creates a FIFO at `<log>.stdin` and hands it to the child as fd 0, opened **O_RDWR**. Because the child's own stdin is both a reader and a writer of the FIFO, its writer count never drops to zero while the child (or any descendant that inherited fd 0) lives, so the child **never reads EOF on stdin** — not at startup, not between `write_stdin` calls, not after the agent exits. Blocking reads just wait, like an idle terminal. Stdin-draining commands (`while read`, REPLs, bare `cat`) run until `kill_command`.

`write()` opens the FIFO `O_WRONLY|O_NONBLOCK` per call — POSIX guarantees success while a reader exists and ENXIO once the child is gone (→ `False`, mirroring the PTY path) — and loops for partial writes past PIPE_BUF. The tool call is bounded at every step: non-blocking open, non-blocking writes, then the normal clamped yield window. `close()` unlinks the FIFO alongside the log only once the process has exited; survivors keep both files (the child owns them).

One unconditional code path on both platforms: Linux documents O_RDWR-on-FIFO as non-blocking (`fifo(7)`); macOS/BSD behaves identically.

## Compatibility

Zero signature or shape changes. The `TerminalManager` ABC is doc-only; `SandboxTerminalManager` gets a comment tweak (its `write_stdin` already delivered input via `send_stdin`) — safe for the kolega-code-e2b pin.

## Docs

Every "poll-only / cannot send input" statement is gone: `_BACKGROUND_NOTE`, the `exec_command`/`write_stdin` docstrings in both copies (`terminal_tool.py` and `tools.py` — the latter was still pre-df09c71), `base.py`, and the stale `docs/concepts/tools.md` paragraph. New contract stated everywhere: background sessions are durable AND accept `write_stdin` input; no terminal echo (verify effects via the output or as a client); stdin never reaches EOF, so stdin-reading commands run until `kill_command`.

Behavior note: a background command that reads stdin used to exit instantly on /dev/null's EOF; it now idles until killed. Intended and documented at the spawn site.

## Testing

- Four new tests in `tests/agent/services/test_terminal.py`: end-to-end input delivery to a `while read` loop; three sequential writes with no EOF between (loop still running); a stdin-reading child surviving `cleanup_all()` with input still deliverable through the FIFO afterward; `write()` True→False across child exit plus FIFO unlink on finish.
- Existing df09c71 survival/kill/foreground regressions untouched and green.
- macOS: `tests/agent/services/test_terminal.py` 36 passed; `tests/agent/tool_backend/test_terminal_tool.py` 24 passed.
- Linux (Docker, `ghcr.io/astral-sh/uv:python3.12-bookworm`): both suites, 60 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ha2hLYmLTQx8iETXi8L7m