### PR TITLE
fix(tests): wait for the turn worker before exiting run_test in mention tests

### DIFF
--- a/tests/cli/_app_test_utils.py
+++ b/tests/cli/_app_test_utils.py
@@ -140,6 +140,25 @@ def renderable_text(renderable) -> str:
     return capture.get()
 
 
+async def wait_for_turn_idle(app, pilot, timeout: float = 6.0) -> None:
+    """Wait until the submitted turn's worker has fully finished.
+
+    A test that submits a turn must not exit ``run_test`` while the worker is
+    still finalizing: app shutdown prunes the screen before workers are
+    cancelled, so the worker's UI cleanup (``_set_chat_enabled`` →
+    ``query_one("#composer")``) races teardown and can surface as
+    ``WorkerFailed: NoMatches`` under CI load. ``agent_worker`` is cleared at
+    the very end of ``_process_message``, strictly after that cleanup ran, so
+    waiting for it closes the race.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if app.agent_worker is None and not app._turn_active:
+            return
+        await pilot.pause(0.01)
+    raise AssertionError("Timed out waiting for the agent turn worker to finish")
+
+
 async def settle_changes_inspector(app, pilot, timeout: float = 5.0) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:

--- a/tests/cli/test_app_mention_dropdown.py
+++ b/tests/cli/test_app_mention_dropdown.py
@@ -42,6 +42,7 @@ from ._app_test_utils import (
     first_text_styles,
     question_payload,
     renderable_text,
+    wait_for_turn_idle,
 )
 
 
@@ -224,6 +225,7 @@ async def test_textual_app_submitting_mention_attaches_file_and_keeps_short_text
             entry.kind == "user" and entry.content == "summarize @src/alpha.py please"
             for entry in app.conversation_entries
         )
+        await wait_for_turn_idle(app, pilot)
 
 
 @pytest.mark.asyncio
@@ -252,3 +254,4 @@ async def test_textual_app_unresolved_mention_clears_hint_and_sends_plain_text(
         assert isinstance(app.agent, _MentionAgent)
         assert app.agent.messages == ["look at @does/not/exist.py"]
         assert app.agent.attachments == [None]
+        await wait_for_turn_idle(app, pilot)


### PR DESCRIPTION
## Summary

Fixes the CI flake seen on PR #419 ([failing job](https://github.com/kolega-ai/kolega-code/actions/runs/30794436091/job/91624730639?pr=419)):

```
FAILED tests/cli/test_app_mention_dropdown.py::test_textual_app_unresolved_mention_clears_hint_and_sends_plain_text
  - textual.worker.WorkerFailed: Worker raised exception: NoMatches("No nodes match '#composer' on Screen(id='_default')")
```

## Root cause

The test submits a turn (spawning the `kolega-turn` worker running `_process_message`) and exits `app.run_test()` right after its assertions. Those assertions check state that is recorded early in the turn, so under CI load the worker can still be finalizing (draining events, saving history) when the context manager exits.

Textual's shutdown ordering makes that a race: `App._shutdown()` prunes the screen **before** `workers.cancel_all()` runs (which only happens later, in `_process_messages`' `finally`). The worker's UI cleanup in `_run_turn_stream`'s `finally` block then calls `_set_chat_enabled` → `query_one("#composer")` against the already-pruned screen, raising `NoMatches`, which Textual converts to `WorkerFailed` and `run_test` re-raises at test exit. The CI traceback confirms the success path (`cancelled_by_user = False`) — the worker simply outlived the test body.

The flake was unrelated to #419's changes.

## Fix

Follow the suite's existing idle-wait convention (`_wait_for` predicates on `agent_worker`/`_turn_active` in the loop/goal test files): add a shared `wait_for_turn_idle` helper to `tests/cli/_app_test_utils.py` and call it before leaving `run_test` in both turn-submitting tests in `test_app_mention_dropdown.py`. `agent_worker` is cleared at the very end of `_process_message` — strictly after the `finally`-block UI cleanup ran — so once the wait returns, no worker code can race teardown.

## Testing

- `uv run pytest tests/cli/test_app_mention_dropdown.py` — 7 passed, stable across 15 consecutive runs
- `uv run pytest tests/cli -n 8` — 1261 passed; one unrelated pre-existing timing flake observed (`test_textual_app_history_save_runs_off_event_loop` asserts a 0.05s marker completes within a 0.1s wait, which xdist load can starve; passes in isolation, untouched by this PR)
- pre-commit (ruff, pyright, etc.) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXZBamj1qxG7dfa2QD6z91