### PR TITLE
feat(tools): declarative param-alias layer at the dispatch choke point

### DIFF
--- a/kolega_code/agent/common.py
+++ b/kolega_code/agent/common.py
@@ -49,3 +49,13 @@ class LogMixin:
         """
         log_event = AgentEvent(event_type="log_message", sender=sender, content={"text": message, "level": "warning"})
         await self.connection_manager.broadcast_event(log_event, self.workspace_id, self.thread_id)
+
+    async def log_debug(self, message: str, sender: str = "agent") -> None:
+        """
+        Log a debug-level message to the logs panel.
+
+        Args:
+            message: The debug message to log
+        """
+        log_event = AgentEvent(event_type="log_message", sender=sender, content={"text": message, "level": "debug"})
+        await self.connection_manager.broadcast_event(log_event, self.workspace_id, self.thread_id)

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -706,6 +706,7 @@ class ToolCollection(LogMixin):
             "log_error",
             "log_warning",
             "log_info",
+            "log_debug",
         ]
         # Backend bindings, not these compatibility methods, own model-facing
         # memory schemas and capability registration.
@@ -1927,7 +1928,10 @@ class ToolCollection(LogMixin):
             command: Shell command line, executed via `bash -c`.
             workdir: Working directory for the command. Defaults to project root.
             yield_time_ms: How long to wait for output/exit before returning, in
-                           milliseconds (clamped to 250–30000).
+                           milliseconds (clamped to 250–30000). A `timeout`
+                           argument is accepted as an alias for this window
+                           (values under 1000 are read as seconds, larger
+                           values as milliseconds).
             max_output_tokens: Maximum tokens of output to return in this call.
             login: Run the shell as a login shell (sources profile). Default false.
             background: Launch detached and return after a short startup window
@@ -2636,7 +2640,12 @@ class ToolCollection(LogMixin):
             # child at a time. Ordinary delegation remains parallel-safe.
             parallel_safe=(method_name in (self.read_only_tools or []) or ordinary_parallel_dispatch)
             and not workflow_dispatch,
+            log_debug=self._log_alias_hit,
         )
+
+    async def _log_alias_hit(self, message: str) -> None:
+        """Debug log_message sink for Tool param-alias hits (trajectory mining)."""
+        await self.log_debug(message, sender=getattr(self.caller, "agent_name", "agent"))
 
     def has_tool(self, name: str) -> bool:
         """True if the named tool is currently enabled."""

--- a/kolega_code/tools/core.py
+++ b/kolega_code/tools/core.py
@@ -1,10 +1,14 @@
 """Tool: a definition paired with its implementation and execution metadata."""
 
 import inspect
+import logging
 from dataclasses import dataclass, field
-from typing import Any, Awaitable, Callable, Dict, FrozenSet
+from typing import Any, Awaitable, Callable, Dict, FrozenSet, Optional
 
 from ..llm.models import ToolDefinition
+from .param_aliases import resolve_param_aliases
+
+logger = logging.getLogger(__name__)
 
 
 class ToolError(Exception):
@@ -29,10 +33,29 @@ class Tool:
     # Safe to run concurrently with other parallel-safe tools in one batch
     # (read-only operations and independent sub-agent dispatches).
     parallel_safe: bool = False
+    # Debug-level log_message sink for param-alias hits, so trajectory mining
+    # sees which aliases fire. None falls back to stdlib logging.
+    log_debug: Optional[Callable[[str], Awaitable[None]]] = None
 
     async def call(self, **inputs: Any) -> Any:
+        inputs = await self._resolve_param_aliases(inputs)
         self._reject_malformed_call(inputs)
         return await self.handler(**inputs)
+
+    async def _resolve_param_aliases(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
+        """Map registered wrong-name arguments onto canonical parameters.
+
+        Runs before ``_reject_malformed_call`` so a registered alias can never
+        surface as an invalid-arguments error (or a raw ``TypeError``).
+        """
+        resolved, hits = resolve_param_aliases(self.name, inputs)
+        for hit in hits:
+            message = f"Param alias on `{hit.tool}`: `{hit.alias}` {hit.action}"
+            if self.log_debug is not None:
+                await self.log_debug(message)
+            else:
+                logger.debug(message)
+        return resolved
 
     def _reject_malformed_call(self, inputs: Dict[str, Any]) -> None:
         """Convert an argument-shape mismatch into a clean, public ``ToolError``.

--- a/kolega_code/tools/param_aliases.py
+++ b/kolega_code/tools/param_aliases.py
@@ -1,0 +1,128 @@
+"""Declarative param-alias registry for tool dispatch.
+
+Models regularly call tools with wrong-but-reasonable argument names, usually
+cross-contaminated from a sibling tool's signature (``exec_command(timeout=…)``
+borrowed from ``eval``; ``eval(command=…)`` borrowed from ``exec_command``).
+Each such call would be rejected and cost a recovery round-trip. This registry
+maps the known aliases onto the canonical parameter at the dispatch choke point
+(``Tool.call``), before argument validation, so the call succeeds first try.
+
+Measured basis: findings/tool-arg-cross-contamination-friction.md (~100
+rejections across ~820 benchmark trials; per-alias counts on each entry).
+
+Adding an alias requires exactly one entry here plus one case row in
+tests/agent/test_param_aliases.py. Unregistered unknown parameters still
+error exactly as before.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
+
+# Sentinel a transform may return when the value is unusable: the alias is then
+# dropped instead of erroring, because an alias hit must never fail the call.
+DROP = object()
+
+
+@dataclass(frozen=True)
+class ParamAlias:
+    """One accepted wrong-name spelling of a tool parameter.
+
+    ``canonical=None`` means accept-and-discard. ``transform`` (renames only)
+    adapts the alias value; returning ``DROP`` discards the alias instead.
+    """
+
+    canonical: Optional[str] = None
+    transform: Optional[Callable[[Any], Any]] = None
+
+
+@dataclass(frozen=True)
+class AliasHit:
+    """A resolved alias occurrence, surfaced for debug logging / trajectory mining."""
+
+    tool: str
+    alias: str
+    action: str
+
+
+def _timeout_to_yield_ms(value: Any) -> Any:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return DROP
+    # Unit heuristic: models mix two conventions — seconds (OpenAI-style bash
+    # tools: 5, 30, 120…) and milliseconds (Claude-Code-style: 5000, 120000…).
+    # Sub-second shell timeouts don't occur in practice, so values < 1000 read
+    # as seconds; anything larger is taken as milliseconds already. Seconds
+    # values that would exceed 1000 land at the 30000 ms clamp under either
+    # reading, so nothing meaningful is lost at the boundary.
+    return int(number * 1000) if number < 1000 else int(number)
+
+
+# tool name -> alias name -> action. Every entry is justified by observed model
+# behavior, with the measured count at the time it was added.
+PARAM_ALIASES: Dict[str, Dict[str, ParamAlias]] = {
+    "exec_command": {
+        # Seen 48×. Models mean "kill after N" (every other harness's bash
+        # tool has a timeout), but exec_command has no kill deadline —
+        # yield_time_ms means "yield back after N ms; the command keeps
+        # running". Mapping onto the yield window is the closest honest
+        # interpretation: the model regains control once its deadline passes
+        # (the terminal backend clamps to 250–30000 ms) and can still poll or
+        # kill the session. Units are guessed by magnitude (see the
+        # transform); non-numeric values are dropped so the call succeeds
+        # regardless.
+        "timeout": ParamAlias("yield_time_ms", transform=_timeout_to_yield_ms),
+        # Seen 9×, borrowed from eval's title. Purely cosmetic: discard.
+        "title": ParamAlias(),
+    },
+    "eval": {
+        # Seen 36× as eval "missing required argument: code" — exec-style
+        # cross-over of exec_command's payload name.
+        "command": ParamAlias("code"),
+    },
+    "find_files_by_pattern": {
+        # Seen 4×. The tool has no directory/root parameter; the glob pattern
+        # IS the scope, so a lone `path` serves best as the pattern (globs pass
+        # through unchanged; a bare directory resolves to that directory
+        # entry, confirming it exists). When `pattern` is also given it wins
+        # and `path` is dropped.
+        "path": ParamAlias("pattern"),
+    },
+    # search_codebase(path=…) (3×) and (max_results=…) (1×) were also measured,
+    # but both are canonical parameters of search_codebase since a58f99b — no
+    # alias needed.
+}
+
+
+def resolve_param_aliases(tool_name: str, inputs: Mapping[str, Any]) -> Tuple[Dict[str, Any], List[AliasHit]]:
+    """Map registered wrong-name arguments for ``tool_name`` onto canonical ones.
+
+    Returns the resolved inputs plus one ``AliasHit`` per alias consumed. When
+    both an alias and its canonical parameter are present, the canonical value
+    wins and the alias is dropped. Unregistered names pass through untouched
+    (and fail validation downstream exactly as before).
+    """
+    aliases = PARAM_ALIASES.get(tool_name)
+    if not aliases or not aliases.keys() & inputs.keys():
+        return dict(inputs), []
+    resolved: Dict[str, Any] = {}
+    hits: List[AliasHit] = []
+    for name, value in inputs.items():
+        alias = aliases.get(name)
+        if alias is None:
+            resolved[name] = value
+            continue
+        if alias.canonical is None:
+            hits.append(AliasHit(tool_name, name, "discarded"))
+            continue
+        if alias.canonical in inputs:
+            hits.append(AliasHit(tool_name, name, f"dropped (canonical `{alias.canonical}` also present)"))
+            continue
+        if alias.transform is not None:
+            value = alias.transform(value)
+            if value is DROP:
+                hits.append(AliasHit(tool_name, name, f"discarded (value unusable as `{alias.canonical}`)"))
+                continue
+        resolved[alias.canonical] = value
+        hits.append(AliasHit(tool_name, name, f"renamed to `{alias.canonical}`"))
+    return resolved, hits

--- a/tests/agent/test_param_aliases.py
+++ b/tests/agent/test_param_aliases.py
@@ -1,0 +1,133 @@
+"""Tests for the declarative param-alias layer (kolega_code.tools.param_aliases).
+
+Table-driven: every registry entry needs exactly one row in ALIAS_CASES (and a
+CANONICAL_WINS_CASES row for renames). The tests run the real dispatch choke
+point (Tool.call) against handlers carrying the real ToolCollection signatures,
+so an alias that would still trip argument validation fails here.
+"""
+
+import inspect
+
+import pytest
+
+from kolega_code.agent.tools import ToolCollection
+from kolega_code.llm.models import ToolDefinition
+from kolega_code.tools import Tool, ToolError
+from kolega_code.tools.param_aliases import PARAM_ALIASES
+
+# One row per registry alias: (tool, call kwargs, kwargs the handler receives).
+ALIAS_CASES = [
+    # timeout unit heuristic: < 1000 reads as seconds, >= 1000 as milliseconds
+    ("exec_command", {"command": "ls", "timeout": 60}, {"command": "ls", "yield_time_ms": 60000}),
+    ("exec_command", {"command": "ls", "timeout": 5000}, {"command": "ls", "yield_time_ms": 5000}),
+    ("exec_command", {"command": "ls", "title": "list files"}, {"command": "ls"}),
+    ("eval", {"command": "print(1)"}, {"code": "print(1)"}),
+    ("find_files_by_pattern", {"path": "src/**/*.py"}, {"pattern": "src/**/*.py"}),
+]
+
+# One row per rename alias: alias + canonical together -> canonical wins.
+CANONICAL_WINS_CASES = [
+    ("exec_command", {"command": "ls", "timeout": 60, "yield_time_ms": 500}, {"command": "ls", "yield_time_ms": 500}),
+    ("eval", {"command": "print(1)", "code": "print(2)"}, {"code": "print(2)"}),
+    ("find_files_by_pattern", {"path": "src", "pattern": "*.py"}, {"pattern": "*.py"}),
+]
+
+
+def _real_signature(tool_name: str) -> inspect.Signature:
+    """The model-facing signature: the ToolCollection method minus ``self``."""
+    signature = inspect.signature(getattr(ToolCollection, tool_name))
+    return signature.replace(parameters=[p for p in signature.parameters.values() if p.name != "self"])
+
+
+def _capture_tool(tool_name: str, received: dict) -> Tool:
+    """A Tool whose handler records its kwargs but binds like the real tool."""
+
+    async def handler(**kwargs):
+        received.update(kwargs)
+        return "ok"
+
+    handler.__signature__ = _real_signature(tool_name)
+    return Tool(
+        name=tool_name,
+        definition=ToolDefinition(name=tool_name, description=f"{tool_name} tool", parameters=[]),
+        handler=handler,
+    )
+
+
+def test_every_registry_entry_has_a_case_row():
+    registered = {(tool, alias) for tool, aliases in PARAM_ALIASES.items() for alias in aliases}
+    covered = {
+        (tool, alias)
+        for tool, call_kwargs, _ in ALIAS_CASES
+        for alias in call_kwargs
+        if alias in PARAM_ALIASES.get(tool, {})
+    }
+    assert registered == covered, "each PARAM_ALIASES entry needs exactly one ALIAS_CASES row"
+
+
+def test_aliases_target_real_parameters_and_never_shadow_them():
+    for tool_name, aliases in PARAM_ALIASES.items():
+        parameters = _real_signature(tool_name).parameters
+        for alias_name, alias in aliases.items():
+            # An alias that becomes a real parameter must be deleted from the
+            # registry, or it would silently rewrite legitimate calls.
+            assert alias_name not in parameters, f"alias {tool_name}.{alias_name} shadows a real parameter"
+            if alias.canonical is not None:
+                assert alias.canonical in parameters, f"{tool_name}.{alias_name} renames to unknown `{alias.canonical}`"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool_name, call_kwargs, expected_kwargs", ALIAS_CASES)
+async def test_aliased_call_behaves_as_canonical(tool_name, call_kwargs, expected_kwargs):
+    received = {}
+    tool = _capture_tool(tool_name, received)
+    assert await tool.call(**call_kwargs) == "ok"
+    assert received == expected_kwargs
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool_name, call_kwargs, expected_kwargs", CANONICAL_WINS_CASES)
+async def test_canonical_wins_over_alias(tool_name, call_kwargs, expected_kwargs):
+    received = {}
+    tool = _capture_tool(tool_name, received)
+    assert await tool.call(**call_kwargs) == "ok"
+    assert received == expected_kwargs
+
+
+@pytest.mark.asyncio
+async def test_unusable_alias_value_is_dropped_not_fatal():
+    received = {}
+    tool = _capture_tool("exec_command", received)
+    assert await tool.call(command="ls", timeout="a while") == "ok"
+    assert received == {"command": "ls"}
+
+
+@pytest.mark.asyncio
+async def test_unregistered_unknown_param_still_errors():
+    # Aliasing must not widen anything else: an unknown name outside the
+    # registry errors exactly as before, even on a tool that has aliases.
+    tool = _capture_tool("exec_command", {})
+    with pytest.raises(ToolError) as exc_info:
+        await tool.call(command="ls", bogus=1)
+    assert "unexpected keyword argument" in str(exc_info.value)
+    assert "Invalid arguments for `exec_command`" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_alias_hit_emits_debug_log():
+    messages = []
+
+    async def log_debug(message: str) -> None:
+        messages.append(message)
+
+    async def handler(code: str):
+        return code
+
+    tool = Tool(
+        name="eval",
+        definition=ToolDefinition(name="eval", description="eval tool", parameters=[]),
+        handler=handler,
+        log_debug=log_debug,
+    )
+    assert await tool.call(command="print(1)") == "print(1)"
+    assert messages == ["Param alias on `eval`: `command` renamed to `code`"]


### PR DESCRIPTION
## Summary

Adds a declarative param-alias layer to tool dispatch so common wrong-but-reasonable argument names from models are mapped to the canonical parameters instead of erroring. Measured basis: `findings/tool-arg-cross-contamination-friction.md` — ~100 of ~820 benchmark trials' tool calls were rejected for argument-shape errors, dominated by models mixing up kolega's own sibling tool signatures (`exec_command` has no `timeout`/`title`; its sibling `eval` has both and takes `code` where exec takes `command`). Models almost always recover, so each rejection is a pure round-trip tax; this removes it.

## Design

- One declarative registry: `kolega_code/tools/param_aliases.py` maps `(tool, alias) → action`, where an action is rename-to-canonical (with an optional value transform) or accept-and-discard.
- Applied once at the dispatch choke point — `Tool.call` in `kolega_code/tools/core.py`, immediately **before** `_reject_malformed_call` — so a registered alias can never surface as an invalid-arguments `ToolError` or a raw `TypeError`, on any dispatch path (`registry.call`, `ToolCollection.call`, direct `Tool.call`).
- If the model passes both the alias and the canonical parameter, the canonical value wins and the alias is dropped.
- Every alias hit is logged as a debug-level `log_message` AgentEvent (tool, alias, action) via a new `LogMixin.log_debug`, wired into each `Tool` by `ToolCollection._build_tool` — so trajectory mining shows which aliases fire and which new ones to add. Outside an agent context it falls back to stdlib `logging.debug`.
- Adding an alias requires exactly one registry entry + one test-table row (enforced by `test_every_registry_entry_has_a_case_row`).
- Unregistered unknown params still error exactly as before; tool schemas stay canonical.

## Initial table (from the measured failures)

| Tool | Alias | Action | Seen |
|---|---|---|---|
| `exec_command` | `timeout` | map → `yield_time_ms`, unit heuristic below | 48× |
| `exec_command` | `title` | discard | 9× |
| `eval` | `command` | rename → `code` | 36× |
| `find_files_by_pattern` | `path` | rename → `pattern` (the tool has no directory param; the glob **is** the scope, so globs pass through and `pattern` wins when both are given) | 4× |
| `search_codebase` | `path` / `max_results` | none needed — both became canonical params in a58f99b | 3× / 1× |

**`exec_command` timeout decision:** `yield_time_ms` means "yield back after N ms, command keeps running", not "kill after N", so this is not a clean rename — mapping onto the yield window is the closest honest interpretation (the model regains control at its deadline and can still poll/kill the session; the terminal backend clamps to 250–30000 ms). Units are guessed by magnitude: models mix a seconds convention (OpenAI-style bash tools: 5, 30, 120…) and a milliseconds convention (Claude-Code-style: 5000, 120000…), and sub-second shell timeouts don't occur in practice, so values < 1000 are read as seconds and larger values as milliseconds. Non-numeric values are dropped so the call succeeds regardless. Per the "state relaxed tool affordances" convention, the `exec_command` description now carries one terse line stating the alias is accepted.

## Tests

`tests/agent/test_param_aliases.py`, table-driven against the real `ToolCollection` signatures through the real choke point (`Tool.call`):
- every registry row: aliased call succeeds and the handler receives the canonical arguments;
- alias + canonical → canonical wins;
- unusable alias values (non-numeric `timeout`) are dropped, call still succeeds;
- unregistered unknown params still error exactly as today;
- alias hits emit the debug log line;
- registry hygiene: an alias may never shadow a real parameter, and every rename target must exist in the real signature (catches future signature drift).

```
$ ./.venv/bin/python -m pytest tests/agent/test_param_aliases.py tests/agent/test_tool_registry.py tests/tools -q
35 passed in 0.61s

$ ./.venv/bin/python -m pytest tests/session tests/tools tests/agent/tool_backend -q
541 passed, 3 warnings in 23.49s

$ ./.venv/bin/python -m pytest tests/agent -q -m "not integration and not slow and not e2e"
1926 passed, 121 deselected, 3 warnings in 119.26s (0:01:59)
```

Out of scope (per the finding): the read-before-edit guard and the sleep-duration cap — alias mapping only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01636H5Lofxmz53FDCkQCPFs
