### PR TITLE
fix(tests): deflake planning-question presentation waits

### DIFF
--- a/tests/cli/_app_test_utils.py
+++ b/tests/cli/_app_test_utils.py
@@ -159,6 +159,28 @@ async def wait_for_turn_idle(app, pilot, timeout: float = 6.0) -> None:
     raise AssertionError("Timed out waiting for the agent turn worker to finish")
 
 
+async def wait_for_question_prompt(app, pilot, timeout: float = 6.0):
+    """Wait until a pending ask_user_choice question is presented in the UI.
+
+    Presenting a question crosses several event-loop hops (the tool task
+    records the pending question, then the app populates and shows
+    ``#question_actions``), so a single ``pilot.pause()`` after creating the
+    tool task intermittently loses the race under CI load and asserts against
+    an empty option list. Waiting for the populated, visible list closes the
+    race. Returns the ``ActionList`` for convenience.
+    """
+    from kolega_code.cli.tui.widgets import ActionList
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if app._pending_question is not None:
+            question_actions = app.query_one("#question_actions", ActionList)
+            if question_actions.display and question_actions.option_count > 0:
+                return question_actions
+        await pilot.pause(0.01)
+    raise AssertionError("Timed out waiting for the planning question to be presented")
+
+
 async def settle_changes_inspector(app, pilot, timeout: float = 5.0) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:

--- a/tests/cli/test_app_planning_questions.py
+++ b/tests/cli/test_app_planning_questions.py
@@ -41,6 +41,7 @@ from ._app_test_utils import (
     install_fake_agents,
     question_payload,
     renderable_text,
+    wait_for_question_prompt,
 )
 
 
@@ -88,11 +89,10 @@ async def test_textual_app_planning_question_tool_accepts_option_list_answer(
                 )
             )
         )
-        await pilot.pause()
+        question_actions = await wait_for_question_prompt(app, pilot)
 
         assert app._pending_question is not None
         assert app.query_one("#composer", ChatComposer).disabled is False
-        question_actions = app.query_one("#question_actions", ActionList)
         assert question_actions.display is True
         assert app.focused is question_actions
         assert question_actions.highlighted == 0
@@ -151,9 +151,7 @@ async def test_textual_app_planning_question_supports_arrow_and_digit_selection(
         answer_task = asyncio.create_task(
             ask_user_choice(questions=question_payload("Pick one of four?", options, header="Pick"))
         )
-        await pilot.pause()
-
-        question_actions = app.query_one("#question_actions", ActionList)
+        question_actions = await wait_for_question_prompt(app, pilot)
         assert question_actions.option_count == 4
         assert app.focused is question_actions
 
@@ -164,7 +162,7 @@ async def test_textual_app_planning_question_supports_arrow_and_digit_selection(
         answer_task = asyncio.create_task(
             ask_user_choice(questions=question_payload("Pick again?", options, header="Pick"))
         )
-        await pilot.pause()
+        await wait_for_question_prompt(app, pilot)
 
         assert app.focused is app.query_one("#question_actions", ActionList)
         await pilot.press("4")
@@ -205,9 +203,7 @@ async def test_textual_app_planning_question_tool_accepts_custom_text_answer(
         answer_task = asyncio.create_task(
             ask_user_choice(questions=question_payload("Which scope?", ["Small fix", "Full workflow"], header="Scope"))
         )
-        await pilot.pause()
-
-        question_actions = app.query_one("#question_actions", ActionList)
+        question_actions = await wait_for_question_prompt(app, pilot)
         assert question_actions.get_option("question_option_0").prompt == "1. Small fix — details"
 
         composer = app.query_one("#composer", ChatComposer)
@@ -258,17 +254,15 @@ async def test_textual_app_planning_question_tool_asks_multiple_questions_sequen
             "Second?", ["A2", "B2"], header="Second"
         )
         answer_task = asyncio.create_task(ask_user_choice(questions=questions))
-        await pilot.pause()
 
         # First question is presented; answer it, then the second appears.
-        question_actions = app.query_one("#question_actions", ActionList)
+        question_actions = await wait_for_question_prompt(app, pilot)
         assert question_actions.option_count == 2
         selected = question_actions.get_option("question_option_0")
         await app.on_option_list_option_selected(OptionList.OptionSelected(question_actions, selected, 0))
-        await pilot.pause()
 
+        question_actions = await wait_for_question_prompt(app, pilot)
         assert app._pending_question is not None
-        question_actions = app.query_one("#question_actions", ActionList)
         selected = question_actions.get_option("question_option_1")
         await app.on_option_list_option_selected(OptionList.OptionSelected(question_actions, selected, 1))
 
@@ -387,10 +381,9 @@ async def test_question_tool_answers_in_build_mode(tmp_path: Path, monkeypatch: 
                 )
             )
         )
-        await pilot.pause()
+        question_actions = await wait_for_question_prompt(app, pilot)
 
         assert app._pending_question is not None
-        question_actions = app.query_one("#question_actions", ActionList)
         assert question_actions.display is True
 
         await app._answer_question_option(1)


### PR DESCRIPTION
## Summary

Deflakes `tests/cli/test_app_planning_questions.py`, seen failing on Python 3.12 in the PR #422 CI run: `test_textual_app_planning_question_supports_arrow_and_digit_selection` asserted `option_count == 4` but saw 0.

The ask_user_choice tests created the tool task, did a single `pilot.pause()`, and immediately asserted against `#question_actions`. Presenting a question crosses several event-loop hops (the tool task records the pending question, then the app populates and shows the list), so under CI load one pause intermittently loses the race.

## Fix

- New shared `wait_for_question_prompt(app, pilot)` helper in `tests/cli/_app_test_utils.py` — same spirit as `wait_for_turn_idle` from #421 — that waits (6s deadline) until the pending question is recorded and `#question_actions` is visible and populated, returning the list.
- Applied at all seven task-then-pause presentation sites in the file, including the second-question waits in the sequential test, which had the same structural race.

No production code changes.

## Tests

```
$ ./.venv/bin/python -m pytest tests/cli/test_app_planning_questions.py -q
7 passed in 4.89s

# formerly flaky tests, 15 consecutive runs
failures: 0/15

$ ./.venv/bin/python -m pytest tests/cli -q -m "not integration and not slow and not e2e"
1262 passed, 4 warnings in 365.58s (0:06:05)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01636H5Lofxmz53FDCkQCPFs