### PR TITLE
feat: persist usage-bearing messages in the session journal + lifetime aggregate

### DIFF
--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -42,6 +42,7 @@ from kolega_code.llm.exceptions import (
     map_to_llm_error,
 )
 from kolega_code.llm.instrumented_client import get_output_tokens
+from kolega_code.llm.ledger import HISTORY_ORIGIN, LlmCallOrigin, helper_origin, llm_call_origin
 from kolega_code.llm.models import ImageBlock, Message, MessageHistory, TextBlock, ToolCall, ToolResult
 from kolega_code.llm.providers.models import TokenCount
 from kolega_code.llm.specs import get_model_specs, supports_vision as model_supports_vision
@@ -1399,6 +1400,27 @@ class BaseAgent(LogMixin):
     async def _log_hook_message(self, message: str) -> None:
         await self.log_warning(message, sender=self.agent_name)
 
+    def _main_loop_origin(self) -> LlmCallOrigin:
+        """Attribution for this agent's main-loop LLM calls.
+
+        HISTORY marks exactly the responses the session recorder journals as
+        ``assistant.message`` (the same ``session_recorder is not None``
+        condition guards ``record_assistant``), so the persistence sink skips
+        them and no response is ever journaled twice.
+        """
+        if self.session_recorder is not None:
+            return HISTORY_ORIGIN
+        if self.sub_agent:
+            context = getattr(self, "sub_agent_context", None) or {}
+            return LlmCallOrigin(
+                kind="sub_agent",
+                agent_name=self.agent_name,
+                agent_id=context.get("agent_id"),
+                parent_tool_call_id=context.get("parent_tool_call_id") or getattr(self, "parent_tool_call_id", None),
+                depth=context.get("depth"),
+            )
+        return LlmCallOrigin(kind="primary", agent_name=self.agent_name)
+
     async def _run_hook_prompt(self, prompt_text: str, model_hint: Optional[str]) -> str:
         """Run a `prompt` hook: a single completion on a chosen model slot.
 
@@ -1426,13 +1448,14 @@ class BaseAgent(LogMixin):
             token_manager=self.config.get_chatgpt_token_manager(),
             usage_ledger=self.usage_ledger,
         )
-        response = await client.generate(
-            model=model_config.model,
-            max_completion_tokens=512,
-            system=Message(role="system", content=[TextBlock(text=HOOK_DECISION_SYSTEM_PROMPT)]),
-            messages=MessageHistory([Message(role="user", content=[TextBlock(text=prompt_text)])]),
-            temperature=0.0,
-        )
+        with llm_call_origin(helper_origin("hook_prompt")):
+            response = await client.generate(
+                model=model_config.model,
+                max_completion_tokens=512,
+                system=Message(role="system", content=[TextBlock(text=HOOK_DECISION_SYSTEM_PROMPT)]),
+                messages=MessageHistory([Message(role="user", content=[TextBlock(text=prompt_text)])]),
+                temperature=0.0,
+            )
         return response.get_text_content() or ""
 
     async def _run_hook_agent(self, task: str) -> str:
@@ -2027,18 +2050,19 @@ class BaseAgent(LogMixin):
                 # provider is ``async def``, so the call is always a coroutine that we
                 # await into the context manager. Cast to the coroutine form for the type
                 # checker rather than awaiting the union directly.
-                stream_cm = await cast(
-                    Coroutine[Any, Any, AbstractAsyncContextManager[Any]],
-                    self.llm.stream(
-                        system=self.system_prompt,
-                        max_completion_tokens=self.model_completion_tokens,
-                        temperature=self.model_default_temperature,
-                        messages=fixed_history,
-                        model=self.primary_model_config.model,
-                        tools=self.tool_collection.get_tool_list(),
-                        thinking=self.primary_model_config.thinking_effort,
-                    ),
-                )
+                with llm_call_origin(self._main_loop_origin()):
+                    stream_cm = await cast(
+                        Coroutine[Any, Any, AbstractAsyncContextManager[Any]],
+                        self.llm.stream(
+                            system=self.system_prompt,
+                            max_completion_tokens=self.model_completion_tokens,
+                            temperature=self.model_default_temperature,
+                            messages=fixed_history,
+                            model=self.primary_model_config.model,
+                            tools=self.tool_collection.get_tool_list(),
+                            thinking=self.primary_model_config.thinking_effort,
+                        ),
+                    )
                 async with stream_cm as stream:
                     async for event in stream:
                         if event.type == "text":

--- a/kolega_code/agent/compression.py
+++ b/kolega_code/agent/compression.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Awaitable, Callable, Optional
 
 from .conversation import Conversation
+from kolega_code.llm.ledger import helper_origin, llm_call_origin
 from kolega_code.llm.models import Message, MessageHistory, TextBlock
 from .prompts import (
     build_compression_summary_user_prompt,
@@ -109,14 +110,16 @@ class HistoryCompressor:
             # Stream and drain rather than calling generate(): the Anthropic SDK
             # rejects non-streaming requests whose max_tokens is large enough to risk
             # a >10-minute response, which the model's full completion budget triggers.
-            async with await llm.stream(
-                messages=messages,
-                system=system_message,
-                temperature=temperature,
-                model=model,
-                max_completion_tokens=self.SUMMARY_MAX_TOKENS,
-                thinking=thinking,
-            ) as stream:
+            with llm_call_origin(helper_origin("compression")):
+                stream_cm = await llm.stream(
+                    messages=messages,
+                    system=system_message,
+                    temperature=temperature,
+                    model=model,
+                    max_completion_tokens=self.SUMMARY_MAX_TOKENS,
+                    thinking=thinking,
+                )
+            async with stream_cm as stream:
                 async for _event in stream:
                     pass
             response = await stream.get_final_message()

--- a/kolega_code/agent/tool_backend/terminal_tool.py
+++ b/kolega_code/agent/tool_backend/terminal_tool.py
@@ -8,6 +8,7 @@ from typing import Optional, Tuple, Union
 from .. import prompts
 from kolega_code.config import AgentConfig
 from kolega_code.llm.client import LLMClient
+from kolega_code.llm.ledger import helper_origin, llm_call_origin
 from kolega_code.llm.models import Message, MessageHistory, TextBlock
 from kolega_code.llm.specs import get_model_specs
 from kolega_code.events import AgentEvent
@@ -107,12 +108,13 @@ class TerminalTool(BaseTool):
                 ]
             )
 
-            response = await client.generate(
-                model=self.config.fast_config.model,
-                max_completion_tokens=model_specs["max_completion_tokens"],
-                system=system_message,
-                messages=messages,
-            )
+            with llm_call_origin(helper_origin("terminal_security")):
+                response = await client.generate(
+                    model=self.config.fast_config.model,
+                    max_completion_tokens=model_specs["max_completion_tokens"],
+                    system=system_message,
+                    messages=messages,
+                )
 
             response_text = response.get_text_content()
 

--- a/kolega_code/agent/tool_backend/think_hard_tool.py
+++ b/kolega_code/agent/tool_backend/think_hard_tool.py
@@ -5,6 +5,7 @@ from contextlib import AbstractAsyncContextManager
 from .. import prompts
 from kolega_code.llm.client import LLMClient
 from kolega_code.llm.instrumented_client import InstrumentedLLMClient
+from kolega_code.llm.ledger import helper_origin, llm_call_origin
 from kolega_code.llm.models import Message, MessageHistory, TextBlock, ThinkingBlock
 from kolega_code.llm.specs import get_model_specs
 from .streaming_tool import StreamingTool
@@ -101,16 +102,17 @@ class ThinkHardTool(StreamingTool):
             # ``LLMClient.stream`` is typed as ``AsyncContextManager | Coroutine``
             # because providers may define ``stream`` either way; every concrete
             # provider is ``async def``, so cast to the coroutine form before awaiting.
-            stream_cm = await cast(
-                Coroutine[Any, Any, AbstractAsyncContextManager[Any]],
-                client.stream(
-                    model=self.config.thinking_config.model,
-                    max_completion_tokens=max_completion,
-                    system=system_message,
-                    messages=messages,
-                    thinking=thinking_param,
-                ),
-            )
+            with llm_call_origin(helper_origin("think_hard")):
+                stream_cm = await cast(
+                    Coroutine[Any, Any, AbstractAsyncContextManager[Any]],
+                    client.stream(
+                        model=self.config.thinking_config.model,
+                        max_completion_tokens=max_completion,
+                        system=system_message,
+                        messages=messages,
+                        thinking=thinking_param,
+                    ),
+                )
             async with stream_cm as stream:
                 # Process chunks for streaming if we have a tool_call_id
                 if tool_call_id:

--- a/kolega_code/agent/tool_backend/web_fetch_tool.py
+++ b/kolega_code/agent/tool_backend/web_fetch_tool.py
@@ -8,6 +8,7 @@ from typing import Union
 from kolega_code.config import AgentConfig
 from kolega_code.llm.client import LLMClient
 from kolega_code.llm.instrumented_client import InstrumentedLLMClient
+from kolega_code.llm.ledger import helper_origin, llm_call_origin
 from kolega_code.llm.specs import get_model_specs
 from kolega_code.tools import ToolError
 
@@ -92,7 +93,10 @@ class WebFetchTool(StreamingTool):
                 context_length=int(specs["context_length"]),
                 max_completion_tokens=int(specs["max_completion_tokens"]),
             )
-            answer = await answerer.answer(instruction.strip(), web_content.content)
+            # Covers the answerer's chunk fan-out too: gathered child tasks copy
+            # the context (and so the origin) at creation.
+            with llm_call_origin(helper_origin("web_fetch")):
+                answer = await answerer.answer(instruction.strip(), web_content.content)
             if answer.insufficient:
                 result = self._format_content_fallback(
                     web_content,

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -61,6 +61,7 @@ from .session_event_store import FileArtifactStore, FileSessionEventStore
 from kolega_code.llm.ledger import UsageLedger
 
 from .goal import GoalState
+from .session_usage import SessionUsageSink
 from .loop import LOOP_TICK_SECONDS, LoopState
 from .diagnostics import DiagnosticsLog, ResponsivenessWatchdog
 from .file_index import WorkspaceFileIndex
@@ -281,8 +282,10 @@ class KolegaCodeApp(
         self._plan_decision_active = False
         self._gigacode_enabled = bool(self.session.gigacode_enabled)
         # Process-wide LLM usage accounting; every agent build (including
-        # rebuilds on model/settings changes) shares this one ledger.
+        # rebuilds on model/settings changes) shares this one ledger. The
+        # journal sink is attached in on_mount, once the UI loop exists.
         self._usage_ledger = UsageLedger()
+        self._usage_sink: Optional[SessionUsageSink] = None
         self._goal: Optional[GoalState] = GoalState.from_dict(self.session.goal) if self.session.goal else None
         # Checkpoint for goal token accounting: drains advance it, so a resumed
         # goal continues from the persisted tokens_spent without recounting.
@@ -460,6 +463,18 @@ class KolegaCodeApp(
 
     async def on_mount(self) -> None:
         self.settings = self.settings_store.load()
+        # Attach usage persistence before any turn can run: the sink journals
+        # every ledger-settled non-history response, and its start marker must
+        # precede the first covered turn so coverage boundaries are exact.
+        usage_sink = SessionUsageSink(
+            self.store.journal(self.session.session_id),
+            self._session_recorder,
+            self._usage_ledger,
+            mode="tui",
+        )
+        self._usage_sink = usage_sink
+        self._usage_ledger.observer = usage_sink
+        await usage_sink.start()
         # Local diagnostics: a per-turn timeline + a responsiveness watchdog that dumps the
         # blocking stack if the UI goes unresponsive. Local-only (shared only via /bug);
         # never let diagnostics setup break mount.
@@ -783,6 +798,7 @@ class KolegaCodeApp(
             gigacode_enabled=record.gigacode_enabled,
             goal=dict(record.goal),
             loop=dict(record.loop),
+            usage=dict(record.usage),
             active_project_path=record.active_project_path,
         )
 
@@ -1951,6 +1967,10 @@ class KolegaCodeApp(
                         pass
                 await self._save_session_history_async()
                 await self.agent.cleanup()
+            # After cleanup: cancelled streams settle their failures into the
+            # ledger first, so the drain below captures them.
+            if self._usage_sink is not None:
+                await self._usage_sink.aclose()
         finally:
             self._close_memory_manager()
             self.exit()

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -16,6 +16,8 @@ from typing import Any, Iterable, Optional
 from kolega_code.agent import CoderAgent
 from kolega_code.config import EditProtocol
 from kolega_code.llm.ledger import UsageLedger
+
+from .session_usage import SessionUsageSink
 from kolega_code.agent.custom_agents import discover_custom_agents, validate_custom_agent_models
 from kolega_code.agent.orchestration.guide import gigacode_prompt_extension
 from kolega_code.agent.prompt_provider import PromptExtension
@@ -1319,6 +1321,15 @@ async def _run_ask(args: argparse.Namespace) -> int:
         default=PermissionMode.AUTO,
     )
     usage_ledger = UsageLedger()
+    # When the session persists, journal every settled non-history response and
+    # failure. Attached before the SESSION_START hook below: hook prompts are
+    # paid LLM calls and must be covered from the first request.
+    usage_sink: Optional[SessionUsageSink] = None
+    if session_recorder is not None:
+        sink = SessionUsageSink(store.journal(session.session_id), session_recorder, usage_ledger, mode="ask")
+        usage_sink = sink
+        usage_ledger.observer = sink
+        await sink.start()
     agent = CoderAgent(
         project_path=project_path,
         workspace_id=session.workspace_id,
@@ -1399,6 +1410,8 @@ async def _run_ask(args: argparse.Namespace) -> int:
                 session.config = summary
                 store.save(session)
             await agent.cleanup()
+            if usage_sink is not None:
+                await usage_sink.aclose()
             return 0
 
     # --goal: apply the goal-aware prompt extension and synthesise the first
@@ -1624,6 +1637,8 @@ async def _run_ask(args: argparse.Namespace) -> int:
             except Exception:
                 pass
         await agent.cleanup()
+        if usage_sink is not None:
+            await usage_sink.aclose()
 
     if exit_code:
         return exit_code

--- a/kolega_code/cli/model_connection.py
+++ b/kolega_code/cli/model_connection.py
@@ -9,6 +9,7 @@ from typing import Any, Callable
 from kolega_code.config import AgentConfig
 from kolega_code.llm.client import LLMClient
 from kolega_code.llm.exceptions import LLMError, llm_error_message
+from kolega_code.llm.ledger import helper_origin, llm_call_origin
 from kolega_code.llm.models import Message, MessageHistory, TextBlock
 
 
@@ -20,6 +21,16 @@ CONNECTION_TEST_MAX_COMPLETION_TOKENS = 32
 class ModelConnectionResult:
     ok: bool
     message: str
+
+
+async def _probe_generate(client: Any, model: str, messages: MessageHistory) -> Any:
+    with llm_call_origin(helper_origin("model_connection")):
+        return await client.generate(
+            messages=messages,
+            model=model,
+            max_completion_tokens=CONNECTION_TEST_MAX_COMPLETION_TOKENS,
+            tools=[],
+        )
 
 
 async def test_model_connection(
@@ -52,12 +63,7 @@ async def test_model_connection(
         client = client_factory(**factory_kwargs)
         messages = MessageHistory([Message(role="user", content=[TextBlock(text="Reply with OK.")])])
         await asyncio.wait_for(
-            client.generate(
-                messages=messages,
-                model=model_config.model,
-                max_completion_tokens=CONNECTION_TEST_MAX_COMPLETION_TOKENS,
-                tools=[],
-            ),
+            _probe_generate(client, model_config.model, messages),
             timeout=timeout,
         )
     except asyncio.TimeoutError:

--- a/kolega_code/cli/session_store.py
+++ b/kolega_code/cli/session_store.py
@@ -22,6 +22,7 @@ from .session_journal import (
     SessionJournalError,
     SessionRecorder,
 )
+from .session_usage import derive_session_usage
 
 SCHEMA_VERSION = 1
 
@@ -43,6 +44,11 @@ class SessionRecord:
     config: dict[str, Any] = field(default_factory=dict)
     history: list[dict[str, Any]] = field(default_factory=list)
     compaction: dict[str, Any] = field(default_factory=dict)
+    # Lifetime usage aggregate, derived from journal events at load()/export
+    # time (see cli/session_usage.py). Like history/compaction it is excluded
+    # from to_metadata_dict, so it can never enter metadata.json or a metadata
+    # patch event — the journal stays canonical.
+    usage: dict[str, Any] = field(default_factory=dict)
     task_list_markdown: str = ""
     latest_plan_markdown: str = ""
     plan_pending: bool = False
@@ -100,6 +106,7 @@ class SessionRecord:
             config=data.get("config") or {},
             history=data.get("history") or [],
             compaction=data.get("compaction") or {},
+            usage=data.get("usage") or {},
             task_list_markdown=data.get("task_list_markdown") or "",
             latest_plan_markdown=latest_plan_markdown,
             plan_pending=plan_pending,
@@ -141,6 +148,7 @@ class SessionRecord:
             **self.to_metadata_dict(),
             "history": self.history,
             "compaction": self.compaction,
+            "usage": self.usage,
         }
 
 
@@ -320,7 +328,8 @@ class SessionStore:
             events = self.journal(session_id).read_events(repair_tail=True)
             metadata = self._metadata_projection(session_id, events)
             history, compaction = self._replay(events, self.journal(session_id))
-            return SessionRecord.from_dict({**metadata, "history": history, "compaction": compaction})
+            usage = derive_session_usage(events)
+            return SessionRecord.from_dict({**metadata, "history": history, "compaction": compaction, "usage": usage})
         except SessionStoreError:
             raise
         except SessionJournalError as exc:
@@ -396,7 +405,9 @@ class SessionStore:
             events = journal.read_events(repair_tail=True)
             metadata = self._metadata_projection(session_id, events)
             history, compaction = self._replay(events, journal, hydrate_artifacts=False)
-            projection = SessionRecord.from_dict({**metadata, "history": history, "compaction": compaction}).to_dict()
+            projection = SessionRecord.from_dict(
+                {**metadata, "history": history, "compaction": compaction, "usage": derive_session_usage(events)}
+            ).to_dict()
             events_jsonl = journal.raw_events()
         except SessionJournalError as exc:
             raise SessionStoreError(str(exc)) from exc

--- a/kolega_code/cli/session_usage.py
+++ b/kolega_code/cli/session_usage.py
@@ -1,0 +1,289 @@
+"""Journal persistence for LLM usage: internal messages and the lifetime aggregate.
+
+Two halves, both keyed to the append-only session journal:
+
+- :class:`SessionUsageSink` — a :class:`~kolega_code.llm.ledger.UsageLedger`
+  observer that persists every settled non-history response as an
+  ``llm.message`` event (full prepared Message + request/run ids + origin
+  attribution) and every failed invocation as ``llm.request_failed``. Top-level
+  main-loop responses are skipped: the session recorder already journals them
+  as ``assistant.message`` (with ``Message.usage`` inside), and the HISTORY
+  origin marks exactly those calls — so no response is ever written twice.
+  An ``llm.run_started`` marker written at attach time is the accounting-start
+  boundary: turns journaled before the first marker predate accounting and are
+  reported as uncovered history rather than as zero usage.
+
+- :func:`derive_session_usage` — the load-time fold that turns journaled
+  messages and failure events into the lifetime ``SessionRecord.usage``
+  aggregate. It scans every epoch and ignores rewinds: the journal is
+  append-only and provider billing is never reversed.
+
+Like the presentation stream (see kolega_code/session/recording.py), usage
+persistence is an enhancement, never a precondition: sink failures are counted
+on the ledger (``persist_failures``) and can never fail or re-issue a paid
+request. History-bearing events keep their stricter, terminal failure
+semantics through the session recorder.
+
+The ``llm.*`` events share the journal's single sequence space and are invisible
+to history replay by construction (``SessionStore._replay`` selects provider
+history by type) and to share export (which reads only ``ui.*`` events).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any, Iterable, Optional
+
+from kolega_code.llm.ledger import SettledRequest, UsageLedger
+from kolega_code.llm.usage import NormalizedUsage
+
+from .session_journal import SessionEvent, SessionJournal, SessionRecorder
+
+logger = logging.getLogger(__name__)
+
+LLM_MESSAGE_EVENT = "llm.message"
+LLM_REQUEST_FAILED_EVENT = "llm.request_failed"
+LLM_RUN_STARTED_EVENT = "llm.run_started"
+
+_CLOSE_TIMEOUT_SECONDS = 10.0
+
+_TOKEN_SUM_FIELDS = (
+    "input_tokens",
+    "output_tokens",
+    "total_tokens",
+    "cache_read_input_tokens",
+    "cache_write_input_tokens",
+    "reasoning_output_tokens",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _PendingEvent:
+    kind: str  # "message" | "failure"
+    turn_id: Optional[str]
+    payload: dict[str, Any]
+    message_dict: Optional[dict[str, Any]]
+
+
+class SessionUsageSink:
+    """Ledger observer that journals settled LLM requests off the event loop.
+
+    Notification is synchronous on the event loop and does only cheap work: a
+    ``message.to_dict()`` snapshot (the agent mutates the Message object after
+    settlement) plus a queue put. A single drainer task performs the blocking
+    journal writes via ``asyncio.to_thread`` in FIFO order, so journal order
+    matches settlement order and the journal's lock serializes us against the
+    session recorder.
+    """
+
+    def __init__(self, journal: SessionJournal, recorder: SessionRecorder, ledger: UsageLedger, *, mode: str) -> None:
+        self._journal = journal
+        self._recorder = recorder
+        self._ledger = ledger
+        self._mode = mode
+        self._queue: asyncio.Queue[Optional[_PendingEvent]] = asyncio.Queue()
+        self._drainer: Optional[asyncio.Task[None]] = None
+        self._closed = False
+
+    async def start(self) -> None:
+        """Write the accounting-start marker and begin draining.
+
+        The marker is written synchronously (awaited) so it lands before any
+        turn this run can journal — coverage boundaries are exact. A marker
+        failure is counted but does not prevent attaching: missing coverage
+        only ever under-reports, never fabricates.
+        """
+        try:
+            await asyncio.to_thread(
+                self._journal.append,
+                LLM_RUN_STARTED_EVENT,
+                actor="system",
+                payload={"run_id": self._ledger.run_id, "mode": self._mode},
+            )
+        except Exception:
+            self._ledger.note_persist_failure()
+            logger.exception("Failed to write the usage accounting-start marker")
+        self._drainer = asyncio.create_task(self._drain())
+
+    # -- ledger observer protocol (synchronous, event loop) -----------------
+
+    def on_response(self, settled: SettledRequest, message: Any) -> None:
+        if self._closed:
+            return
+        if settled.origin is not None and settled.origin.kind == "history":
+            return  # journaled as assistant.message by the session recorder
+        message_dict: Optional[dict[str, Any]] = None
+        if message is not None:
+            to_dict = getattr(message, "to_dict", None)
+            if callable(to_dict):
+                result = to_dict()
+                if isinstance(result, dict):
+                    message_dict = result
+        self._queue.put_nowait(
+            _PendingEvent(
+                kind="message",
+                turn_id=self._recorder.current_turn_id,
+                payload=self._base_payload(settled),
+                message_dict=message_dict,
+            )
+        )
+
+    def on_failure(self, settled: SettledRequest) -> None:
+        if self._closed:
+            return
+        # HISTORY failures are journaled too: a failed invocation never produces
+        # an assistant.message, so there is nothing to duplicate.
+        payload = self._base_payload(settled)
+        payload["error"] = settled.error or "unknown error"
+        self._queue.put_nowait(
+            _PendingEvent(kind="failure", turn_id=self._recorder.current_turn_id, payload=payload, message_dict=None)
+        )
+
+    async def aclose(self) -> None:
+        """Drain queued events and stop; bounded so quit never hangs on I/O."""
+        if self._closed:
+            return
+        self._closed = True
+        self._queue.put_nowait(None)
+        if self._drainer is None:
+            return
+        try:
+            await asyncio.wait_for(self._drainer, timeout=_CLOSE_TIMEOUT_SECONDS)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            self._drainer.cancel()
+
+    # -- internals ----------------------------------------------------------
+
+    def _base_payload(self, settled: SettledRequest) -> dict[str, Any]:
+        origin = settled.origin.to_payload() if settled.origin is not None else {"kind": "unknown"}
+        return {
+            "request_id": settled.request_id,
+            "run_id": settled.run_id,
+            "provider": settled.provider,
+            "model": settled.model,
+            "origin": origin,
+        }
+
+    async def _drain(self) -> None:
+        while True:
+            item = await self._queue.get()
+            if item is None:
+                return
+            try:
+                await asyncio.to_thread(self._write, item)
+            except Exception:
+                self._ledger.note_persist_failure()
+                logger.exception("Failed to journal a usage event; continuing")
+
+    def _write(self, item: _PendingEvent) -> None:
+        if item.kind == "message":
+            prepared: Optional[dict[str, Any]] = None
+            refs: list[dict[str, Any]] = []
+            if item.message_dict is not None:
+                prepared, refs = self._journal.prepare_message(item.message_dict)
+            self._journal.append(
+                LLM_MESSAGE_EVENT,
+                actor="assistant",
+                payload={**item.payload, "message": prepared},
+                turn_id=item.turn_id,
+                artifacts=refs,
+            )
+        else:
+            self._journal.append(
+                LLM_REQUEST_FAILED_EVENT,
+                actor="system",
+                payload=item.payload,
+                turn_id=item.turn_id,
+            )
+
+
+def derive_session_usage(events: Iterable[SessionEvent]) -> dict[str, Any]:
+    """Fold journaled usage into the lifetime session aggregate.
+
+    Scans every epoch and ignores rewinds — provider billing is never reversed
+    by editing history. Reads payload dicts directly (never Message.from_dict,
+    which rejects unknown content blocks) and parses usage only through the
+    tolerant NormalizedUsage.from_dict.
+
+    Coverage: turns journaled before the first ``llm.run_started`` marker
+    predate accounting; their top-level usage is deliberately excluded from the
+    sums (their nested calls are unrecoverable, and a blended total would read
+    as authoritative) and surfaced as ``coverage.pre_accounting_turns``.
+    """
+    event_list = list(events)
+    marker_seqs = [event.seq for event in event_list if event.event_type == LLM_RUN_STARTED_EVENT]
+    first_marker = min(marker_seqs) if marker_seqs else None
+
+    counts = {"requests": 0, "responses": 0, "reported": 0, "unreported": 0, "failed": 0}
+    sums = {name: 0 for name in _TOKEN_SUM_FIELDS}
+    detail = {
+        "reported_missing_cache_read": 0,
+        "reported_missing_cache_write": 0,
+        "reported_missing_reasoning": 0,
+    }
+    rows: dict[tuple[str, str], dict[str, int]] = {}
+    pre_accounting_turns = 0
+
+    def row_for(provider: str, model: str) -> dict[str, int]:
+        return rows.setdefault((provider, model), {**{k: 0 for k in counts}, **{k: 0 for k in sums}})
+
+    def fold_response(payload: dict[str, Any]) -> None:
+        message = payload.get("message")
+        usage_dict = message.get("usage") if isinstance(message, dict) else None
+        usage = NormalizedUsage.from_dict(usage_dict)
+        if usage is not None and usage.reported:
+            key = (usage.provider, usage.model or "unknown")
+            row = row_for(*key)
+            for target in (counts, row):
+                target["responses"] += 1
+                target["reported"] += 1
+            for name in _TOKEN_SUM_FIELDS:
+                value = getattr(usage, name) or 0
+                sums[name] += value
+                row[name] += value
+            if usage.cache_read_input_tokens is None:
+                detail["reported_missing_cache_read"] += 1
+            if usage.cache_write_input_tokens is None:
+                detail["reported_missing_cache_write"] += 1
+            if usage.reasoning_output_tokens is None:
+                detail["reported_missing_reasoning"] += 1
+        else:
+            key = (str(payload.get("provider") or "unknown"), str(payload.get("model") or "unknown"))
+            row = row_for(*key)
+            for target in (counts, row):
+                target["responses"] += 1
+                target["unreported"] += 1
+
+    for event in event_list:
+        if event.event_type == LLM_MESSAGE_EVENT:
+            fold_response(event.payload)
+        elif event.event_type == LLM_REQUEST_FAILED_EVENT:
+            key = (str(event.payload.get("provider") or "unknown"), str(event.payload.get("model") or "unknown"))
+            row = row_for(*key)
+            for target in (counts, row):
+                target["failed"] += 1
+        elif event.event_type == "assistant.message":
+            if first_marker is not None and event.seq > first_marker:
+                fold_response(event.payload)
+        elif event.event_type == "turn.started":
+            if first_marker is None or event.seq < first_marker:
+                pre_accounting_turns += 1
+
+    counts["requests"] = counts["responses"] + counts["failed"]
+    for row in rows.values():
+        row["requests"] = row["responses"] + row["failed"]
+
+    breakdown = [{"provider": provider, "model": model, **row} for (provider, model), row in sorted(rows.items())]
+    return {
+        **counts,
+        **sums,
+        "breakdown": breakdown,
+        "coverage": {
+            "accounted_runs": len(marker_seqs),
+            "pre_accounting_turns": pre_accounting_turns,
+            "full": bool(marker_seqs) and pre_accounting_turns == 0,
+        },
+        "detail": detail,
+    }

--- a/kolega_code/llm/client.py
+++ b/kolega_code/llm/client.py
@@ -326,7 +326,7 @@ class LLMClient:
                 # outer clause maps Exception only).
                 self._usage_ledger.record_failure(request_id, describe_error(exc))
                 raise
-            self._usage_ledger.record_response(request_id, getattr(message, "usage", None))
+            self._usage_ledger.record_response(request_id, getattr(message, "usage", None), message=message)
             return message
         except Exception as e:
             raise map_to_llm_error(e, self.provider_name) from e

--- a/kolega_code/llm/ledger.py
+++ b/kolega_code/llm/ledger.py
@@ -30,9 +30,11 @@ from __future__ import annotations
 
 import logging
 import uuid
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Generator, Optional
 
 from .usage import NormalizedUsage
 
@@ -61,6 +63,56 @@ def describe_error(error: BaseException | type[BaseException] | None) -> str:
     return f"{type(error).__name__}: {error}"[:_ERROR_TRUNCATION]
 
 
+@dataclass(frozen=True, slots=True)
+class LlmCallOrigin:
+    """Who made an LLM call, for persistence attribution.
+
+    ``kind`` values: "history" (the top-level agent's main loop, whose response
+    is recorded as ``assistant.message`` by the session recorder), "sub_agent",
+    "helper" (a named internal helper client), and "primary" (a top-level loop
+    with no session recorder, e.g. unsaved ask runs).
+    """
+
+    kind: str
+    agent_name: Optional[str] = None
+    agent_id: Optional[str] = None
+    parent_tool_call_id: Optional[str] = None
+    depth: Optional[int] = None
+    helper: Optional[str] = None
+
+    def to_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {"kind": self.kind}
+        for name in ("agent_name", "agent_id", "parent_tool_call_id", "depth", "helper"):
+            value = getattr(self, name)
+            if value is not None:
+                payload[name] = value
+        return payload
+
+
+HISTORY_ORIGIN = LlmCallOrigin(kind="history")
+
+
+def helper_origin(name: str) -> LlmCallOrigin:
+    return LlmCallOrigin(kind="helper", helper=name)
+
+
+_llm_call_origin: ContextVar[Optional[LlmCallOrigin]] = ContextVar("llm_call_origin", default=None)
+
+
+def current_llm_call_origin() -> Optional[LlmCallOrigin]:
+    return _llm_call_origin.get()
+
+
+@contextmanager
+def llm_call_origin(origin: LlmCallOrigin) -> Generator[None]:
+    """Attribute LLM calls begun within this scope (and child tasks) to ``origin``."""
+    token = _llm_call_origin.set(origin)
+    try:
+        yield
+    finally:
+        _llm_call_origin.reset(token)
+
+
 class _RequestState(Enum):
     OPEN = "open"
     RESPONDED = "responded"
@@ -71,8 +123,22 @@ class _RequestState(Enum):
 class _RequestRecord:
     provider: str
     model: Optional[str]
+    origin: Optional[LlmCallOrigin] = None
     state: _RequestState = _RequestState.OPEN
     usage: Optional[NormalizedUsage] = None
+    error: Optional[str] = None
+
+
+@dataclass(frozen=True, slots=True)
+class SettledRequest:
+    """Immutable handoff to a persistence observer at settlement time."""
+
+    request_id: str
+    run_id: str
+    provider: str
+    model: Optional[str]
+    origin: Optional[LlmCallOrigin]
+    usage: Optional[NormalizedUsage]
     error: Optional[str] = None
 
 
@@ -118,6 +184,9 @@ class UsageSnapshot:
     cache_read_input_tokens: int = 0
     cache_write_input_tokens: int = 0
     reasoning_output_tokens: int = 0
+    # Failed persistence-observer notifications/writes. Health of the journal
+    # sink, not of accounting itself — deliberately outside `complete`.
+    persist_failures: int = 0
     breakdown: tuple[ProviderModelUsage, ...] = field(default=())
 
     @property
@@ -137,6 +206,7 @@ class UsageSnapshot:
 
         deltas = {name: getattr(self, name) - getattr(earlier, name) for name in _COUNT_FIELDS}
         deltas["open"] = self.open
+        deltas["persist_failures"] = self.persist_failures - earlier.persist_failures
         sums = {name: getattr(self, name) - getattr(earlier, name) for name in _TOKEN_SUM_FIELDS}
 
         earlier_rows = {(row.provider, row.model): row for row in earlier.breakdown}
@@ -166,21 +236,30 @@ class UsageLedger:
     def __init__(self) -> None:
         self.run_id: str = uuid.uuid4().hex
         self._records: dict[str, _RequestRecord] = {}
+        # Optional persistence observer, duck-typed: on_response(settled, message)
+        # / on_failure(settled). Notified exactly once per request, inside the
+        # first-wins state transition. Observer errors are counted, never raised.
+        self.observer: Optional[Any] = None
+        self.persist_failures: int = 0
 
     def begin(self, provider: str, model: Optional[str]) -> str:
         """Register one invocation and return its request_id.
 
         Always returns a fresh id, even if internal bookkeeping fails — a later
-        settle for an unknown id is a logged no-op, never an error.
+        settle for an unknown id is a logged no-op, never an error. The ambient
+        LlmCallOrigin (if any) is captured here so attribution survives to
+        settlement regardless of which task finalizes the request.
         """
         request_id = uuid.uuid4().hex
         try:
-            self._records[request_id] = _RequestRecord(provider=str(provider), model=model)
+            self._records[request_id] = _RequestRecord(
+                provider=str(provider), model=model, origin=current_llm_call_origin()
+            )
         except Exception:
             logger.exception("UsageLedger.begin failed; request %s will be untracked", request_id)
         return request_id
 
-    def record_response(self, request_id: str, usage: Optional[NormalizedUsage]) -> None:
+    def record_response(self, request_id: str, usage: Optional[NormalizedUsage], message: Optional[Any] = None) -> None:
         """Settle a completed response. First settle wins; later calls no-op."""
         try:
             record = self._records.get(request_id)
@@ -191,6 +270,7 @@ class UsageLedger:
                 return
             record.state = _RequestState.RESPONDED
             record.usage = usage if isinstance(usage, NormalizedUsage) else None
+            self._notify(lambda observer: observer.on_response(self._settled(request_id, record), message))
         except Exception:
             logger.exception("UsageLedger.record_response failed for request %s", request_id)
 
@@ -205,8 +285,37 @@ class UsageLedger:
                 return
             record.state = _RequestState.FAILED
             record.error = str(error)[:_ERROR_TRUNCATION]
+            self._notify(lambda observer: observer.on_failure(self._settled(request_id, record)))
         except Exception:
             logger.exception("UsageLedger.record_failure failed for request %s", request_id)
+
+    def _settled(self, request_id: str, record: _RequestRecord) -> SettledRequest:
+        return SettledRequest(
+            request_id=request_id,
+            run_id=self.run_id,
+            provider=record.provider,
+            model=record.model,
+            origin=record.origin,
+            usage=record.usage,
+            error=record.error,
+        )
+
+    def _notify(self, call: Any) -> None:
+        observer = self.observer
+        if observer is None:
+            return
+        try:
+            call(observer)
+        except Exception:
+            self.persist_failures += 1
+            logger.exception("Usage observer notification failed")
+
+    def note_persist_failure(self) -> None:
+        """Record an asynchronous persistence failure (exception-proof)."""
+        try:
+            self.persist_failures += 1
+        except Exception:
+            pass
 
     def snapshot(self) -> UsageSnapshot:
         """Aggregate all records into an immutable snapshot."""
@@ -241,7 +350,9 @@ class UsageLedger:
                 ProviderModelUsage(provider=provider, model=model, **counts)
                 for (provider, model), counts in sorted(rows.items())
             )
-            return UsageSnapshot(run_id=self.run_id, breakdown=breakdown, **totals)
+            return UsageSnapshot(
+                run_id=self.run_id, persist_failures=self.persist_failures, breakdown=breakdown, **totals
+            )
         except Exception:
             logger.exception("UsageLedger.snapshot failed; returning empty snapshot")
             return UsageSnapshot(run_id=self.run_id)
@@ -293,7 +404,7 @@ class LedgerStreamAdapter:
         except BaseException as exc:
             self._ledger.record_failure(self._request_id, describe_error(exc))
             raise
-        self._ledger.record_response(self._request_id, getattr(message, "usage", None))
+        self._ledger.record_response(self._request_id, getattr(message, "usage", None), message=message)
         return message
 
     def __getattr__(self, name: str):

--- a/tests/agent/llm/test_client_ledger.py
+++ b/tests/agent/llm/test_client_ledger.py
@@ -292,3 +292,32 @@ async def test_adapter_passes_through_wrapper_attributes():
     stream_cm = await _open_stream(client)
     assert stream_cm.provider_name == "anthropic"
     assert hasattr(stream_cm, "get_final_message")
+
+
+@pytest.mark.asyncio
+async def test_settlements_pass_the_message_to_the_observer():
+    class _Observer:
+        def __init__(self):
+            self.messages = []
+
+        def on_response(self, settled, message):
+            self.messages.append(message)
+
+        def on_failure(self, settled):
+            pass
+
+    ledger = UsageLedger()
+    observer = _Observer()
+    ledger.observer = observer
+    provider = _FakeProvider()
+    client = _client(ledger, provider)
+
+    generated = await client.generate(messages=_messages())
+    assert observer.messages == [generated]
+
+    stream_cm = await _open_stream(client)
+    async with stream_cm as stream:
+        async for _ in stream:
+            pass
+    final = await stream.get_final_message()
+    assert observer.messages == [generated, final]

--- a/tests/agent/llm/test_usage_ledger.py
+++ b/tests/agent/llm/test_usage_ledger.py
@@ -190,3 +190,73 @@ async def test_concurrent_settlement_is_exact():
     assert snap.reported == 50
     assert snap.total_tokens == 50 * 15
     assert snap.complete is True
+
+
+class _RecordingObserver:
+    def __init__(self):
+        self.responses = []
+        self.failures = []
+
+    def on_response(self, settled, message):
+        self.responses.append((settled, message))
+
+    def on_failure(self, settled):
+        self.failures.append(settled)
+
+
+def test_observer_notified_exactly_once_with_origin_and_message():
+    from kolega_code.llm.ledger import helper_origin, llm_call_origin
+
+    ledger = UsageLedger()
+    observer = _RecordingObserver()
+    ledger.observer = observer
+
+    with llm_call_origin(helper_origin("compression")):
+        request_id = ledger.begin("anthropic", "m")
+    marker = object()
+    ledger.record_response(request_id, _usage(), message=marker)
+    ledger.record_response(request_id, _usage(), message=object())  # dedup: no second notify
+    ledger.record_failure(request_id, "late")  # settled: no notify
+
+    assert len(observer.responses) == 1 and not observer.failures
+    settled, message = observer.responses[0]
+    assert message is marker
+    assert settled.request_id == request_id
+    assert settled.run_id == ledger.run_id
+    assert settled.origin is not None and settled.origin.helper == "compression"
+    assert settled.usage is not None and settled.usage.reported
+
+
+def test_observer_failure_notification():
+    ledger = UsageLedger()
+    observer = _RecordingObserver()
+    ledger.observer = observer
+    request_id = ledger.begin("openai", None)
+    ledger.record_failure(request_id, "boom")
+    assert len(observer.failures) == 1
+    assert observer.failures[0].error == "boom"
+    assert observer.failures[0].origin is None
+
+
+def test_observer_exception_counts_persist_failure_and_never_raises():
+    class _Broken:
+        def on_response(self, settled, message):
+            raise RuntimeError("sink broke")
+
+        def on_failure(self, settled):
+            raise RuntimeError("sink broke")
+
+    ledger = UsageLedger()
+    ledger.observer = _Broken()
+    r1 = ledger.begin("anthropic", "m")
+    ledger.record_response(r1, _usage())
+    r2 = ledger.begin("anthropic", "m")
+    ledger.record_failure(r2, "x")
+
+    assert ledger.persist_failures == 2
+    snap = ledger.snapshot()
+    assert snap.persist_failures == 2
+    assert (snap.responses, snap.failed) == (1, 1)  # settlement itself unharmed
+    # since() subtracts persist_failures like the counters.
+    ledger.note_persist_failure()
+    assert ledger.snapshot().since(snap).persist_failures == 1

--- a/tests/agent/test_llm_call_origin.py
+++ b/tests/agent/test_llm_call_origin.py
@@ -1,0 +1,184 @@
+"""LLM call-origin attribution: the BaseAgent main-loop selector, the helper
+wraps, and ContextVar semantics (task inheritance, shadowing)."""
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from kolega_code.llm.ledger import (
+    HISTORY_ORIGIN,
+    UsageLedger,
+    current_llm_call_origin,
+    helper_origin,
+    llm_call_origin,
+)
+
+from .compaction_helpers import build_agent
+
+
+def test_main_loop_origin_history_iff_recorder_present(tmp_path):
+    agent, _ = build_agent(tmp_path)
+    agent.session_recorder = object()
+    assert agent._main_loop_origin() is HISTORY_ORIGIN
+
+    agent.session_recorder = None
+    origin = agent._main_loop_origin()
+    assert origin.kind == "primary"
+    assert origin.agent_name == agent.agent_name
+
+
+def test_main_loop_origin_sub_agent_uses_dispatch_context(tmp_path):
+    agent, _ = build_agent(tmp_path, sub_agent=True)
+    cast(Any, agent).sub_agent_context = {"agent_id": "a1", "parent_tool_call_id": "tc1", "depth": 2}
+    origin = agent._main_loop_origin()
+    assert origin.kind == "sub_agent"
+    assert (origin.agent_id, origin.parent_tool_call_id, origin.depth) == ("a1", "tc1", 2)
+    assert origin.agent_name == agent.agent_name
+
+
+def _current_helper() -> str:
+    origin = current_llm_call_origin()
+    assert origin is not None
+    return origin.helper or ""
+
+
+def test_origin_shadowing_and_reset():
+    assert current_llm_call_origin() is None
+    with llm_call_origin(helper_origin("outer")):
+        assert _current_helper() == "outer"
+        with llm_call_origin(helper_origin("inner")):
+            assert _current_helper() == "inner"
+        assert _current_helper() == "outer"
+    assert current_llm_call_origin() is None
+
+
+@pytest.mark.asyncio
+async def test_gathered_child_tasks_inherit_origin_at_begin():
+    ledger = UsageLedger()
+
+    async def child():
+        await asyncio.sleep(0)
+        return ledger.begin("anthropic", "m")
+
+    with llm_call_origin(helper_origin("web_fetch")):
+        request_ids = await asyncio.gather(*(child() for _ in range(3)))
+
+    for request_id in request_ids:
+        origin = ledger._records[request_id].origin
+        assert origin is not None and origin.helper == "web_fetch"
+
+
+@pytest.mark.asyncio
+async def test_hook_prompt_generate_runs_under_helper_origin(tmp_path, monkeypatch):
+    agent, _ = build_agent(tmp_path)
+    seen: list = []
+
+    class _Capturing:
+        def __init__(self, **kwargs):
+            pass
+
+        async def generate(self, **kwargs):
+            seen.append(current_llm_call_origin())
+            return SimpleNamespace(get_text_content=lambda: "ok")
+
+    monkeypatch.setattr("kolega_code.llm.client.LLMClient", _Capturing)
+    await agent._run_hook_prompt("check", None)
+    assert seen and seen[0].kind == "helper" and seen[0].helper == "hook_prompt"
+
+
+@pytest.mark.asyncio
+async def test_terminal_security_check_runs_under_helper_origin(monkeypatch, tmp_path):
+    from kolega_code.agent.tool_backend import terminal_tool as terminal_tool_module
+    from kolega_code.agent.tool_backend.terminal_tool import TerminalTool
+    from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
+
+    seen: list = []
+
+    class _Capturing:
+        def __init__(self, **kwargs):
+            pass
+
+        async def generate(self, **kwargs):
+            seen.append(current_llm_call_origin())
+            return SimpleNamespace(get_text_content=lambda: "safe")
+
+    tool = object.__new__(TerminalTool)
+    tool.config = AgentConfig(
+        anthropic_api_key="k",
+        fast_config=ModelConfig(provider=ModelProvider.ANTHROPIC, model="claude-opus-5", rate_limits=RateLimitConfig()),
+    )
+    tool.caller = SimpleNamespace(usage_ledger=None, scratchpad_dir=None, project_path=tmp_path)
+    monkeypatch.setattr(terminal_tool_module, "LLMClient", _Capturing)
+
+    ok, _ = await tool._run_command_security_check("ls")
+    assert ok is True
+    assert seen and seen[0].helper == "terminal_security"
+
+
+@pytest.mark.asyncio
+async def test_compression_summarizer_runs_under_helper_origin(tmp_path):
+    from tests.agent.compaction_helpers import FakeLLM, long_history
+
+    seen: list = []
+    llm = FakeLLM(summary_text="SUMMARY")
+    original_stream = llm._stream
+
+    async def capturing_stream(*args, **kwargs):
+        seen.append(current_llm_call_origin())
+        return await original_stream(*args, **kwargs)
+
+    llm.stream = AsyncMock(side_effect=capturing_stream)
+
+    agent, _ = build_agent(tmp_path, llm=llm)
+    agent.history = long_history(6)
+    result = await agent.compress_history()
+    assert result.ok
+    assert seen and seen[0] is not None and seen[0].helper == "compression"
+
+
+@pytest.mark.asyncio
+async def test_think_hard_runs_under_helper_origin(monkeypatch):
+    from kolega_code.agent.tool_backend import think_hard_tool as think_hard_module
+    from kolega_code.agent.tool_backend.think_hard_tool import ThinkHardTool
+    from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
+    from kolega_code.events import AgentConnectionManager
+
+    seen: list = []
+
+    class _Capturing:
+        def __init__(self, **kwargs):
+            pass
+
+        def stream(self, **kwargs):
+            async def _fail():
+                seen.append(current_llm_call_origin())
+                raise RuntimeError("stop here")
+
+            return _fail()
+
+    caller = Mock()
+    caller.agent_name = "t"
+    caller.usage_ledger = None
+    caller.llm = object()
+    tool = ThinkHardTool(
+        project_path="/tmp",
+        workspace_id="w",
+        thread_id="t",
+        connection_manager=AsyncMock(spec=AgentConnectionManager),
+        config=AgentConfig(
+            anthropic_api_key="k",
+            thinking_config=ModelConfig(
+                provider=ModelProvider.ANTHROPIC, model="claude-opus-5", rate_limits=RateLimitConfig()
+            ),
+        ),
+        caller=caller,
+    )
+    tool.log_info = AsyncMock()
+    tool.log_error = AsyncMock()
+    monkeypatch.setattr(think_hard_module, "LLMClient", _Capturing)
+
+    await tool.think_hard("problem")  # error swallowed into the tool result
+    assert seen and seen[0].helper == "think_hard"

--- a/tests/cli/test_app_agent_wiring.py
+++ b/tests/cli/test_app_agent_wiring.py
@@ -293,3 +293,52 @@ async def test_agent_rebuild_keeps_the_same_usage_ledger(
         assert app.agent is not first_agent
         assert cast(Any, app.agent).kwargs["usage_ledger"] is ledger
         assert ledger.run_id == run_id
+
+
+@pytest.mark.asyncio
+async def test_usage_sink_attached_on_mount_and_drained_on_quit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """on_mount writes the accounting marker and wires the ledger observer;
+    quit drains the sink; the snapshot helper carries the derived usage field."""
+    pytest.importorskip("textual")
+    from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.cli.config import config_summary
+    from kolega_code.cli.session_store import SessionStore
+    from kolega_code.cli.session_usage import LLM_MESSAGE_EVENT, LLM_RUN_STARTED_EVENT
+    from kolega_code.llm.ledger import LlmCallOrigin, llm_call_origin
+    from kolega_code.llm.models import Message
+    from kolega_code.llm.usage import normalize_usage
+
+    install_fake_agents(monkeypatch)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert app._usage_ledger.observer is app._usage_sink
+
+        ledger = app._usage_ledger
+        usage = normalize_usage({"input_tokens": 10, "output_tokens": 5}, "anthropic", "m")
+        with llm_call_origin(LlmCallOrigin(kind="sub_agent", agent_name="Investigator", agent_id="a1")):
+            request_id = ledger.begin("anthropic", "m")
+        ledger.record_response(request_id, usage, message=Message(role="assistant", content="s", usage=usage))
+
+        # Snapshot helper carries the derived field.
+        app.session.usage = {"total_tokens": 15}
+        async with app._persistence_lock:
+            snapshot = app._session_snapshot_locked()
+        assert snapshot.usage == {"total_tokens": 15}
+
+        await app.action_quit()
+
+    events = store.journal(session.session_id).read_events()
+    types = [e.event_type for e in events]
+    assert types.count(LLM_RUN_STARTED_EVENT) == 1
+    assert types.count(LLM_MESSAGE_EVENT) == 1

--- a/tests/cli/test_ask_usage_persistence.py
+++ b/tests/cli/test_ask_usage_persistence.py
@@ -1,0 +1,83 @@
+"""ask-mode usage persistence: with --session the journal gains the accounting
+marker and internal llm.* events; without persistence nothing attaches."""
+
+from kolega_code.cli.session_usage import LLM_MESSAGE_EVENT, LLM_RUN_STARTED_EVENT
+from kolega_code.llm.ledger import LlmCallOrigin, llm_call_origin
+from kolega_code.llm.models import Message
+from kolega_code.llm.usage import normalize_usage
+
+from ._app_test_utils import FakeCoderAgent
+
+
+class UsageRecordingAskAgent(FakeCoderAgent):
+    """Simulates a sub-agent settlement on the shared ledger during the turn."""
+
+    agent_name = "coder"
+    instances: list["UsageRecordingAskAgent"] = []
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        UsageRecordingAskAgent.instances.append(self)
+
+    async def process_message_stream(self, message, attachments=None):
+        ledger = self.kwargs["usage_ledger"]
+        usage = normalize_usage({"input_tokens": 10, "output_tokens": 5}, "anthropic", "m")
+        with llm_call_origin(LlmCallOrigin(kind="sub_agent", agent_name="Investigator", agent_id="a1")):
+            request_id = ledger.begin("anthropic", "m")
+        ledger.record_response(request_id, usage, message=Message(role="assistant", content="sub", usage=usage))
+        async for item in FakeCoderAgent.process_message_stream(self, message, attachments):
+            yield item
+
+    async def fire_hook(self, event, payload):
+        class Result:
+            additional_context = None
+            blocked = False
+            end_turn = False
+
+        return Result()
+
+
+def _setup(tmp_path, monkeypatch):
+    from kolega_code.cli import main as main_module
+
+    UsageRecordingAskAgent.instances = []
+    monkeypatch.setattr(main_module, "CoderAgent", UsageRecordingAskAgent)
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("KOLEGA_CODE_PROVIDER", "anthropic")
+    return main_module, project
+
+
+def test_ask_with_session_journals_marker_and_internal_events(tmp_path, monkeypatch, isolated_cli_env):
+    main_module, project = _setup(tmp_path, monkeypatch)
+
+    exit_code = main_module.main(["ask", "do the thing", "--project", str(project), "--session", "s1"])
+    assert exit_code == 0
+
+    from kolega_code.cli.session_store import SessionStore, default_state_dir
+
+    store = SessionStore(default_state_dir())
+    sessions = store.list()
+    assert len(sessions) == 1
+    events = store.journal(sessions[0].session_id).read_events()
+    types = [e.event_type for e in events]
+    assert types.count(LLM_RUN_STARTED_EVENT) == 1
+    # The marker precedes the turn it covers.
+    assert types.index(LLM_RUN_STARTED_EVENT) < types.index("turn.started")
+    llm_messages = [e for e in events if e.event_type == LLM_MESSAGE_EVENT]
+    assert len(llm_messages) == 1
+    assert llm_messages[0].payload["origin"]["agent_name"] == "Investigator"
+
+    record = store.load(sessions[0].session_id)
+    assert record.usage["responses"] >= 1
+    assert record.usage["coverage"]["full"] is True
+
+
+def test_ask_without_persistence_attaches_no_observer(tmp_path, monkeypatch, isolated_cli_env):
+    main_module, project = _setup(tmp_path, monkeypatch)
+
+    exit_code = main_module.main(["ask", "do the thing", "--project", str(project)])
+    assert exit_code == 0
+    agent = UsageRecordingAskAgent.instances[0]
+    assert agent.kwargs["usage_ledger"].observer is None

--- a/tests/cli/test_session_event_store.py
+++ b/tests/cli/test_session_event_store.py
@@ -174,3 +174,28 @@ async def test_tail_survives_a_partially_written_record(store: SessionStore, tmp
     assert [event.content["text"] for event in stored] == ["complete record"], (
         "a half-written trailing record must be ignored, not treated as corruption"
     )
+
+
+@pytest.mark.asyncio
+async def test_llm_events_are_invisible_to_the_presentation_stream(tmp_path):
+    """share export reads only ui.* events; llm.* journal records never leak."""
+    from kolega_code.cli.session_store import SessionStore
+    from kolega_code.cli.session_event_store import FileSessionEventStore
+
+    store = SessionStore(tmp_path / "state")
+    session = store.create(tmp_path / "proj", "code", {})
+    journal = store.journal(session.session_id)
+    journal.append(
+        "llm.message",
+        actor="assistant",
+        payload={
+            "request_id": "r",
+            "run_id": "x",
+            "provider": "p",
+            "model": "m",
+            "origin": {"kind": "helper"},
+            "message": None,
+        },
+    )
+    events = await FileSessionEventStore(journal).read(session.session_id)
+    assert events == []

--- a/tests/cli/test_session_usage_aggregate.py
+++ b/tests/cli/test_session_usage_aggregate.py
@@ -1,0 +1,200 @@
+"""derive_session_usage + SessionRecord.usage through load/export/bug export."""
+
+import json
+from pathlib import Path
+
+from kolega_code.cli.session_store import SessionStore
+from kolega_code.cli.session_usage import (
+    LLM_MESSAGE_EVENT,
+    LLM_REQUEST_FAILED_EVENT,
+    LLM_RUN_STARTED_EVENT,
+    derive_session_usage,
+)
+from kolega_code.llm.models import Message, TextBlock
+from kolega_code.llm.usage import normalize_usage
+
+
+def _usage_dict(inp=10, out=5, provider="anthropic", model="claude-opus-5"):
+    return normalize_usage({"input_tokens": inp, "output_tokens": out}, provider, model).to_dict()
+
+
+def _assistant_dict(inp=10, out=5):
+    message = Message(role="assistant", content=[TextBlock(text="ok")])
+    data = message.to_dict()
+    data["usage"] = _usage_dict(inp, out)
+    return data
+
+
+def _store(tmp_path: Path):
+    store = SessionStore(tmp_path / "state")
+    session = store.create(tmp_path / "proj", "code", {})
+    return store, session
+
+
+def _run_turn(recorder, inp=10, out=5):
+    recorder.start_turn(Message(role="user", content=[TextBlock(text="hi")]))
+    message = Message.from_dict(_assistant_dict(inp, out))
+    recorder.record_assistant(message)
+    recorder.finish_turn("completed")
+
+
+def _append_marker(journal, run_id="run1"):
+    journal.append(LLM_RUN_STARTED_EVENT, actor="system", payload={"run_id": run_id, "mode": "tui"})
+
+
+def _append_llm_message(journal, *, usage=None, provider="anthropic", model="m", request_id="r1"):
+    payload = {
+        "request_id": request_id,
+        "run_id": "run1",
+        "provider": provider,
+        "model": model,
+        "origin": {"kind": "helper", "helper": "compression"},
+        "message": {"role": "assistant", "content": "x", "usage": usage},
+    }
+    journal.append(LLM_MESSAGE_EVENT, actor="assistant", payload=payload)
+
+
+def test_pre_pr3_journal_reports_partial_coverage_not_zero_authority(tmp_path):
+    """A session written entirely by the pre-accounting recorder resumes with an
+    aggregate that admits its own incompleteness."""
+    store, session = _store(tmp_path)
+    recorder = store.recorder(session.session_id)
+    _run_turn(recorder)
+    _run_turn(recorder)
+
+    record = store.load(session.session_id)
+    assert record.usage["responses"] == 0
+    assert record.usage["total_tokens"] == 0
+    assert record.usage["coverage"] == {"accounted_runs": 0, "pre_accounting_turns": 2, "full": False}
+    # Resume is unchanged: full history replays.
+    assert len(record.history) == 4
+
+
+def test_post_marker_assistant_messages_counted_pre_marker_excluded(tmp_path):
+    store, session = _store(tmp_path)
+    recorder = store.recorder(session.session_id)
+    journal = store.journal(session.session_id)
+
+    _run_turn(recorder, inp=100, out=1)  # pre-marker: excluded from sums
+    _append_marker(journal)
+    _run_turn(recorder, inp=10, out=5)  # post-marker: counted
+
+    usage = store.load(session.session_id).usage
+    assert usage["responses"] == 1
+    assert usage["total_tokens"] == 15
+    assert usage["coverage"] == {"accounted_runs": 1, "pre_accounting_turns": 1, "full": False}
+
+
+def test_rewound_and_prior_epoch_usage_still_counted(tmp_path):
+    """Billing is never reversed: rewinds and thread resets don't subtract."""
+    store, session = _store(tmp_path)
+    recorder = store.recorder(session.session_id)
+    journal = store.journal(session.session_id)
+    _append_marker(journal)
+
+    _run_turn(recorder, inp=10, out=5)
+    turn_to_rewind = recorder.list_rewindable_turns()[-1]
+    _append_llm_message(journal, usage=_usage_dict(100, 50))
+    recorder.record_rewind(turn_to_rewind.turn_id)
+    recorder.start_epoch("thread_reset")
+    _run_turn(recorder, inp=1, out=1)
+
+    record = store.load(session.session_id)
+    # History only has the new epoch's turn...
+    assert len(record.history) == 2
+    # ...but usage keeps everything: rewound turn + llm.message + new turn.
+    assert record.usage["responses"] == 3
+    assert record.usage["total_tokens"] == 15 + 150 + 2
+
+
+def test_two_markers_and_failures_and_unreported(tmp_path):
+    store, session = _store(tmp_path)
+    journal = store.journal(session.session_id)
+    _append_marker(journal, "run1")
+    _append_llm_message(journal, usage=_usage_dict(10, 5), request_id="r1")
+    _append_llm_message(journal, usage=None, provider="openai", model="gpt", request_id="r2")
+    _append_llm_message(journal, usage={"junk": True}, provider="openai", model="gpt", request_id="r3")
+    journal.append(
+        LLM_REQUEST_FAILED_EVENT,
+        actor="system",
+        payload={
+            "request_id": "r4",
+            "run_id": "run1",
+            "provider": "xai",
+            "model": None,
+            "error": "boom",
+            "origin": {"kind": "history"},
+        },
+    )
+    _append_marker(journal, "run2")
+
+    usage = derive_session_usage(journal.read_events())
+    assert usage["requests"] == 4
+    assert usage["responses"] == 3
+    assert usage["reported"] == 1
+    assert usage["unreported"] == 2
+    assert usage["failed"] == 1
+    assert usage["total_tokens"] == 15
+    assert usage["coverage"]["accounted_runs"] == 2
+    keys = [(row["provider"], row["model"]) for row in usage["breakdown"]]
+    assert keys == sorted(keys)
+    assert ("xai", "unknown") in keys
+
+
+def test_detail_counters_track_missing_optional_fields(tmp_path):
+    store, session = _store(tmp_path)
+    journal = store.journal(session.session_id)
+    _append_marker(journal)
+    with_cache = normalize_usage(
+        {"input_tokens": 5, "output_tokens": 5, "cache_read_input_tokens": 3, "cache_write_input_tokens": 1},
+        "anthropic",
+        "m",
+    ).to_dict()
+    _append_llm_message(journal, usage=with_cache, request_id="r1")
+    _append_llm_message(journal, usage=_usage_dict(), request_id="r2")
+
+    usage = derive_session_usage(journal.read_events())
+    assert usage["detail"] == {
+        "reported_missing_cache_read": 1,
+        "reported_missing_cache_write": 1,
+        "reported_missing_reasoning": 2,
+    }
+    assert usage["cache_read_input_tokens"] == 3
+
+
+def test_exports_carry_usage_and_metadata_never_does(tmp_path):
+    store, session = _store(tmp_path)
+    journal = store.journal(session.session_id)
+    _append_marker(journal)
+    _append_llm_message(journal, usage=_usage_dict(10, 5))
+
+    exported = json.loads(store.export(session.session_id))
+    assert exported["usage"]["total_tokens"] == 15
+
+    bug = store.bug_export(session.session_id)
+    assert json.loads(bug.session_json)["usage"]["total_tokens"] == 15
+
+    record = store.load(session.session_id)
+    store.save(record)  # metadata-only save cycle
+    metadata = json.loads((store.session_dir_for(session.session_id) / "metadata.json").read_text())
+    assert "usage" not in metadata
+
+
+def test_listing_does_not_compute_usage(tmp_path):
+    store, session = _store(tmp_path)
+    journal = store.journal(session.session_id)
+    _append_marker(journal)
+    _append_llm_message(journal, usage=_usage_dict())
+
+    listed = [record for record in store.list() if record.session_id == session.session_id]
+    assert listed and listed[0].usage == {}
+
+
+def test_legacy_record_dict_without_usage_key_loads(tmp_path):
+    from kolega_code.cli.session_store import SessionRecord
+
+    store, session = _store(tmp_path)
+    data = store.load(session.session_id).to_dict()
+    data.pop("usage")
+    restored = SessionRecord.from_dict(data)
+    assert restored.usage == {}

--- a/tests/cli/test_session_usage_sink.py
+++ b/tests/cli/test_session_usage_sink.py
@@ -1,0 +1,245 @@
+"""SessionUsageSink: exactly-once journaling of ledger settlements."""
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from kolega_code.cli.session_store import SessionStore
+from kolega_code.cli.session_usage import (
+    LLM_MESSAGE_EVENT,
+    LLM_REQUEST_FAILED_EVENT,
+    LLM_RUN_STARTED_EVENT,
+    SessionUsageSink,
+)
+from kolega_code.llm.ledger import (
+    HISTORY_ORIGIN,
+    LedgerStreamAdapter,
+    LlmCallOrigin,
+    UsageLedger,
+    helper_origin,
+    llm_call_origin,
+)
+from kolega_code.llm.models import Message, TextBlock, ThinkingBlock
+from kolega_code.llm.usage import normalize_usage
+
+
+def _usage(inp=10, out=5):
+    return normalize_usage({"input_tokens": inp, "output_tokens": out}, "anthropic", "claude-opus-5")
+
+
+def _message(inp=10, out=5, content="ok"):
+    return Message(role="assistant", content=content, usage=_usage(inp, out))
+
+
+async def _harness(tmp_path: Path, *, mode="tui"):
+    store = SessionStore(tmp_path / "state")
+    session = store.create(tmp_path / "proj", "code", {})
+    recorder = store.recorder(session.session_id)
+    ledger = UsageLedger()
+    sink = SessionUsageSink(store.journal(session.session_id), recorder, ledger, mode=mode)
+    ledger.observer = sink
+    await sink.start()
+    return store, session, recorder, ledger, sink
+
+
+def _events(store, session):
+    return store.journal(session.session_id).read_events()
+
+
+@pytest.mark.asyncio
+async def test_marker_written_synchronously_before_any_event(tmp_path):
+    store, session, _recorder, ledger, sink = await _harness(tmp_path)
+    types = [e.event_type for e in _events(store, session)]
+    assert types[-1] == LLM_RUN_STARTED_EVENT
+    marker = _events(store, session)[-1]
+    assert marker.payload == {"run_id": ledger.run_id, "mode": "tui"}
+    await sink.aclose()
+
+
+@pytest.mark.asyncio
+async def test_settlements_journal_in_fifo_order(tmp_path):
+    store, session, _recorder, ledger, sink = await _harness(tmp_path)
+    with llm_call_origin(helper_origin("compression")):
+        first = ledger.begin("anthropic", "m")
+        second = ledger.begin("anthropic", "m")
+        third = ledger.begin("anthropic", "m")
+    ledger.record_response(first, _usage(), message=_message(content="one"))
+    ledger.record_failure(second, "boom")
+    ledger.record_response(third, _usage(), message=_message(content="three"))
+    await sink.aclose()
+
+    tail = [e for e in _events(store, session) if e.event_type.startswith("llm.")]
+    assert [e.event_type for e in tail] == [
+        LLM_RUN_STARTED_EVENT,
+        LLM_MESSAGE_EVENT,
+        LLM_REQUEST_FAILED_EVENT,
+        LLM_MESSAGE_EVENT,
+    ]
+    assert [e.payload.get("request_id") for e in tail[1:]] == [first, second, third]
+
+
+class _FakeStream:
+    def __init__(self, message):
+        self.message = message
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+    async def get_final_message(self):
+        return self.message
+
+
+@pytest.mark.asyncio
+async def test_triple_finalization_journals_exactly_once(tmp_path):
+    store, session, _recorder, ledger, sink = await _harness(tmp_path)
+    with llm_call_origin(LlmCallOrigin(kind="sub_agent", agent_name="Investigator", agent_id="a1")):
+        request_id = ledger.begin("anthropic", "claude-opus-5")
+    adapter = LedgerStreamAdapter(_FakeStream(_message()), ledger, request_id)
+    async with adapter as stream:
+        async for _ in stream:
+            pass
+    await stream.get_final_message()
+    await stream.get_final_message()
+    await stream.get_final_message()
+    await sink.aclose()
+
+    messages = [e for e in _events(store, session) if e.event_type == LLM_MESSAGE_EVENT]
+    assert len(messages) == 1
+    assert messages[0].payload["origin"] == {"kind": "sub_agent", "agent_name": "Investigator", "agent_id": "a1"}
+    assert messages[0].payload["message"]["usage"]["total_tokens"] == 15
+
+
+@pytest.mark.asyncio
+async def test_history_response_skipped_but_history_failure_journaled(tmp_path):
+    store, session, _recorder, ledger, sink = await _harness(tmp_path)
+    with llm_call_origin(HISTORY_ORIGIN):
+        ok = ledger.begin("anthropic", "m")
+        bad = ledger.begin("anthropic", "m")
+    ledger.record_response(ok, _usage(), message=_message())
+    ledger.record_failure(bad, "rate limited")
+    await sink.aclose()
+
+    tail = [e.event_type for e in _events(store, session) if e.event_type.startswith("llm.")]
+    assert LLM_MESSAGE_EVENT not in tail
+    failure = next(e for e in _events(store, session) if e.event_type == LLM_REQUEST_FAILED_EVENT)
+    assert failure.payload["origin"] == {"kind": "history"}
+    assert failure.payload["error"] == "rate limited"
+
+
+@pytest.mark.asyncio
+async def test_message_none_settlement_still_journaled(tmp_path):
+    store, session, _recorder, ledger, sink = await _harness(tmp_path)
+    with llm_call_origin(helper_origin("think_hard")):
+        request_id = ledger.begin("openai", "gpt-5.4-mini")
+    ledger.record_response(request_id, None)
+    await sink.aclose()
+
+    event = next(e for e in _events(store, session) if e.event_type == LLM_MESSAGE_EVENT)
+    assert event.payload["message"] is None
+    assert event.payload["provider"] == "openai"
+
+
+@pytest.mark.asyncio
+async def test_no_origin_journals_as_unknown(tmp_path):
+    store, session, _recorder, ledger, sink = await _harness(tmp_path)
+    request_id = ledger.begin("anthropic", "m")
+    ledger.record_response(request_id, _usage(), message=_message())
+    await sink.aclose()
+
+    event = next(e for e in _events(store, session) if e.event_type == LLM_MESSAGE_EVENT)
+    assert event.payload["origin"] == {"kind": "unknown"}
+
+
+@pytest.mark.asyncio
+async def test_turn_id_stamped_when_turn_open_and_none_otherwise(tmp_path):
+    store, session, recorder, ledger, sink = await _harness(tmp_path)
+    with llm_call_origin(helper_origin("compression")):
+        outside = ledger.begin("anthropic", "m")
+    ledger.record_response(outside, _usage(), message=_message())
+
+    turn_id = recorder.start_turn(Message(role="user", content=[TextBlock(text="hi")]))
+    with llm_call_origin(helper_origin("compression")):
+        inside = ledger.begin("anthropic", "m")
+    ledger.record_response(inside, _usage(), message=_message())
+    recorder.record_assistant(_message())
+    recorder.finish_turn("completed")
+    await sink.aclose()
+
+    by_request = {e.payload.get("request_id"): e for e in _events(store, session) if e.event_type == LLM_MESSAGE_EVENT}
+    assert by_request[outside].turn_id is None
+    assert by_request[inside].turn_id == turn_id
+
+
+@pytest.mark.asyncio
+async def test_write_failure_counts_and_drainer_continues(tmp_path, monkeypatch):
+    store, session, _recorder, ledger, sink = await _harness(tmp_path)
+    journal = store.journal(session.session_id)
+    original_append = journal.append
+    calls = {"n": 0}
+
+    def flaky_append(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise OSError("disk full")
+        return original_append(*args, **kwargs)
+
+    monkeypatch.setattr(journal, "append", flaky_append)
+    with llm_call_origin(helper_origin("compression")):
+        first = ledger.begin("anthropic", "m")
+        second = ledger.begin("anthropic", "m")
+    ledger.record_response(first, _usage(), message=_message())
+    ledger.record_response(second, _usage(), message=_message(content="second"))
+    await sink.aclose()
+
+    assert ledger.persist_failures == 1
+    messages = [e for e in _events(store, session) if e.event_type == LLM_MESSAGE_EVENT]
+    assert [e.payload["request_id"] for e in messages] == [second]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_settlements_each_journal_once(tmp_path):
+    store, session, _recorder, ledger, sink = await _harness(tmp_path)
+
+    async def one_call(index: int):
+        with llm_call_origin(LlmCallOrigin(kind="sub_agent", agent_name=f"agent-{index}", agent_id=str(index))):
+            request_id = ledger.begin("anthropic", "m")
+        await asyncio.sleep(0)
+        ledger.record_response(request_id, _usage(), message=_message())
+        return request_id
+
+    request_ids = await asyncio.gather(*(one_call(i) for i in range(8)))
+    await sink.aclose()
+
+    messages = [e for e in _events(store, session) if e.event_type == LLM_MESSAGE_EVENT]
+    assert sorted(e.payload["request_id"] for e in messages) == sorted(request_ids)
+    assert {e.payload["origin"]["agent_id"] for e in messages} == {str(i) for i in range(8)}
+
+
+@pytest.mark.asyncio
+async def test_opaque_provider_fields_externalized_like_assistant_message(tmp_path):
+    store, session, _recorder, ledger, sink = await _harness(tmp_path)
+    message = Message(
+        role="assistant",
+        content=[ThinkingBlock(thinking="secret reasoning", signature="opaque-signature"), TextBlock(text="done")],
+        usage=_usage(),
+    )
+    with llm_call_origin(helper_origin("think_hard")):
+        request_id = ledger.begin("anthropic", "m")
+    ledger.record_response(request_id, _usage(), message=message)
+    await sink.aclose()
+
+    event = next(e for e in _events(store, session) if e.event_type == LLM_MESSAGE_EVENT)
+    thinking_block = event.payload["message"]["content"][0]
+    assert thinking_block["signature"] == ""  # externalized, not inline
+    assert "signature" in thinking_block["artifact_fields"]
+    assert event.artifacts and event.artifacts[0]["purpose"] == "provider_signature"


### PR DESCRIPTION
## Summary

PR 3 of the token-accounting initiative — **stacked on #423** (the runtime `UsageLedger`); merge that first, then retarget/rebase this onto `main`.

Persists every ledger-settled model response as a usage-bearing message in the append-only session journal, and derives an auditable lifetime **`SessionRecord.usage`** aggregate at load/export — without changing conversation replay, without migration, and with **pre-existing sessions resuming byte-identically** while reporting partial historical coverage instead of fabricated zeros.

**Exactly-once journaling, inherited from exactly-once settlement.** The ledger gains a duck-typed observer notified *inside* the first-wins state transition — the Langfuse wrapper's triple `get_final_message()` structurally cannot double-write. Attribution rides a new `LlmCallOrigin` ContextVar captured at `begin()` (the `orchestration/accounting.py` precedent): `BaseAgent` marks its main loop **HISTORY** under exactly the `session_recorder is not None` condition that gates `record_assistant`, so top-level responses keep their existing `assistant.message` events (which already carry `Message.usage` since PR 1) and are never written twice. Sub-agents stamp their dispatch identity (`agent_id`/`parent_tool_call_id`/`depth`); compression, `think_hard`, hook prompts, terminal security checks, web-fetch answering (fan-out children inherit via task-context copies), and the model-connection probe carry named helper origins; a missing origin journals as `"unknown"` — never silently dropped.

**Three new journal event types** (envelope v1, no version bump — old CLIs ignore them; `_replay`'s allowlist keeps them out of history; share export reads only `ui.*`):
- `llm.message` — full `prepare_message()`-prepared Message + `request_id`/`run_id`/provider/model/origin. Full artifact/redaction parity with `assistant.message`: signatures and encrypted reasoning are externalized to purpose-tagged artifacts, bug bundles carry refs only, share bundles stay purpose-gated.
- `llm.request_failed` — including top-level failures (no `assistant.message` exists for a failure; truthful, never duplicated).
- `llm.run_started` — the accounting-start marker, written **synchronously at attach** so a fast first turn can't out-race coverage.

**`SessionUsageSink`** (new `cli/session_usage.py`): notify does only a `message.to_dict()` snapshot (the agent mutates the Message after settlement) + turn-id stamp + queue put; a single drainer task writes off-loop via `asyncio.to_thread` in FIFO order. Sink failures are counted on the ledger (`persist_failures`, surfaced in snapshots and deltas) and can never fail or re-issue a paid request — the enhancement-not-precondition pattern of the presentation stream. `aclose()` drains bounded on quit (TUI `action_quit` after `agent.cleanup()`; ask `finally` and the skill early-return). Ask without `--save/--session` attaches nothing.

**`derive_session_usage`** folds the whole journal — every epoch, ignoring rewinds (billing is never reversed) — into request/response/reported/unreported/failed counts, six token sums, a deterministic provider/model breakdown, optional-detail counters, and `coverage {accounted_runs, pre_accounting_turns, full}`. Pre-marker `assistant.message` usage is excluded from sums (nested historical calls are unrecoverable — no backfill as authoritative) and surfaced as uncovered turns. `SessionRecord.usage` follows the `history`/`compaction` derived-field pattern: computed in `load()`/`export()`/`bug_export()`, structurally excluded from `metadata.json` and metadata patches (the journal stays canonical), carried by `_session_snapshot_locked`, empty in listings (`_iter_records` stays cheap).

## Test plan

- [x] `tests/cli/test_session_usage_sink.py` (10): synchronous marker ordering, FIFO, exactly-once under triple finalization, HISTORY skip vs HISTORY-failure journaling, `message=None`, unknown origin, turn-id stamping incl. None, write-failure → `persist_failures` + drainer continues, 8 concurrent sub-agent settlements, opaque-field externalization parity.
- [x] `tests/cli/test_session_usage_aggregate.py` (8): pre-PR3 journal → zeros + partial coverage + unchanged replay; rewound/prior-epoch usage still counted; two markers; unreported/junk usage; pre/post-marker assistant messages; detail counters; exports carry usage while `metadata.json` never does; listings don't compute; legacy dict without the key loads.
- [x] `tests/agent/test_llm_call_origin.py` (8): HISTORY iff recorder present, sub-agent fields from dispatch context, shadowing/reset, gather inheritance, hook/terminal/compression/think_hard helper origins.
- [x] `tests/cli/test_ask_usage_persistence.py`: real `ask --session` run journals marker before the turn + attributed `llm.message`, aggregate `full=true`; unsaved ask attaches no observer.
- [x] Extensions: ledger observer notify-once/failure/exception-counting (+ snapshot/`since`), client passes the Message at both settlement sites, TUI on_mount attach + quit drain + snapshot field, `llm.*` invisible to the presentation stream.
- [x] Full suite: **4061 passed, 0 failed**; ruff, pyright, and all pre-commit hooks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014i5XzWgcpSWu5v85iXXiE5