### PR TITLE
fix(deps): keep the Intel-mac install on prebuilt cryptography wheels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+### Fixed
+
+- Installing on an Intel Mac no longer fails with a `cryptography` source-build
+  error (`Failed to build cryptography==50.0.0` / missing OpenSSL). cryptography
+  49+ stopped publishing Intel-mac wheels, so the installer tried to compile it
+  with Rust and OpenSSL; Intel Macs now install the last release that ships a
+  prebuilt universal2 wheel. Other platforms are unaffected.
+
 ## 0.26.7 - 2026-08-03
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,10 @@ classifiers = [
 dependencies = [
     "anthropic==0.101.0",
     "beautifulsoup4==4.14.3",
+    # cryptography >=49 dropped Intel-mac wheels, so Intel Macs fall back to the
+    # sdist, which needs Rust + OpenSSL headers and fails the curl-install.
+    # Hold the last universal2 build there; other platforms resolve freely.
+    "cryptography==48.0.1; sys_platform == 'darwin' and platform_machine == 'x86_64'",
     "ddgs==9.14.4",
     # The session server ships to every user, so its stack is a core dependency.
     # starlette/uvicorn/websockets were already installed transitively (mcp pulls

--- a/tests/test_dependency_wheel_coverage.py
+++ b/tests/test_dependency_wheel_coverage.py
@@ -1,0 +1,123 @@
+"""Guard the end-user install against dependencies that drop platform wheels.
+
+CI resolves and syncs on Linux/arm64 runners, so a dependency that stops
+publishing wheels for another supported platform never fails here — it fails on
+a user's machine as a source build that needs Rust, OpenSSL, or a C toolchain
+(cryptography >= 49 dropping Intel-mac wheels broke the curl installer exactly
+this way). This test walks the runtime dependency graph in uv.lock as it
+resolves for such a platform and fails when a wheel-shipping package has no
+installable wheel there, so the gap surfaces at lock-bump time instead.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from collections import deque
+from pathlib import Path
+from typing import Any
+
+import pytest
+from packaging.markers import Marker
+from packaging.tags import Tag, compatible_tags, cpython_tags, mac_platforms
+from packaging.utils import parse_wheel_filename
+
+LOCK_PATH = Path(__file__).resolve().parents[1] / "uv.lock"
+
+# Interpreters uv realistically selects for `uv tool install kolega-code`.
+# 3.14 is excluded: onnxruntime publishes no sdist and no Intel-mac wheels for
+# it, so that combination fails resolution outright and predates this guard.
+PYTHONS = [(3, 11), (3, 12), (3, 13)]
+
+
+def _intel_mac_env(python: tuple[int, int]) -> dict[str, str]:
+    version = f"{python[0]}.{python[1]}"
+    return {
+        "implementation_name": "cpython",
+        "implementation_version": f"{version}.0",
+        "os_name": "posix",
+        "platform_machine": "x86_64",
+        "platform_python_implementation": "CPython",
+        "platform_release": "24.6.0",
+        "platform_system": "Darwin",
+        "python_full_version": f"{version}.0",
+        "python_version": version,
+        "sys_platform": "darwin",
+        "extra": "",
+    }
+
+
+def _intel_mac_tags(python: tuple[int, int]) -> set[Tag]:
+    platforms = list(mac_platforms((15, 0), "x86_64"))
+    return set(cpython_tags(python, None, platforms)) | set(compatible_tags(python, None, platforms))
+
+
+def _entry_applies(entry: dict[str, Any], env: dict[str, str]) -> bool:
+    markers = entry.get("resolution-markers")
+    if not markers:
+        return True
+    return any(Marker(marker).evaluate(env) for marker in markers)
+
+
+def _reachable_runtime_entries(env: dict[str, str]) -> list[dict[str, Any]]:
+    """Entries reachable from kolega-code's runtime dependencies under env."""
+    with LOCK_PATH.open("rb") as fh:
+        lock = tomllib.load(fh)
+
+    entries_by_name: dict[str, list[dict[str, Any]]] = {}
+    for entry in lock["package"]:
+        entries_by_name.setdefault(entry["name"], []).append(entry)
+
+    reached: dict[tuple[str, str], dict[str, Any]] = {}
+    seen: set[tuple[str, tuple[str, ...]]] = set()
+    queue: deque[tuple[str, tuple[str, ...]]] = deque([("kolega-code", ())])
+    while queue:
+        name, extras = queue.popleft()
+        if (name, extras) in seen:
+            continue
+        seen.add((name, extras))
+        for entry in entries_by_name.get(name, []):
+            if not _entry_applies(entry, env):
+                continue
+            if "editable" not in entry["source"]:
+                reached[(entry["name"], entry["version"])] = entry
+            edges = list(entry.get("dependencies", []))
+            optional = entry.get("optional-dependencies", {})
+            for extra in extras:
+                edges.extend(optional.get(extra, []))
+            for edge in edges:
+                marker = edge.get("marker")
+                if marker and not Marker(marker).evaluate(env):
+                    continue
+                queue.append((edge["name"], tuple(edge.get("extra", ()))))
+    return list(reached.values())
+
+
+def _has_installable_wheel(entry: dict[str, Any], supported: set[Tag]) -> bool:
+    for wheel in entry["wheels"]:
+        filename = wheel["url"].rsplit("/", 1)[-1]
+        _, _, _, tags = parse_wheel_filename(filename)
+        if not tags.isdisjoint(supported):
+            return True
+    return False
+
+
+@pytest.mark.parametrize("python", PYTHONS, ids=lambda p: f"cp{p[0]}{p[1]}")
+def test_runtime_dependencies_have_intel_mac_wheels(python: tuple[int, int]) -> None:
+    env = _intel_mac_env(python)
+    supported = _intel_mac_tags(python)
+
+    broken = [
+        f"{entry['name']}=={entry['version']}"
+        for entry in _reachable_runtime_entries(env)
+        # Sdist-only packages are pure source for every platform; a native one
+        # would already fail everywhere, including CI.
+        if entry.get("wheels") and not _has_installable_wheel(entry, supported)
+    ]
+
+    assert not broken, (
+        "These locked runtime dependencies ship wheels, but none installable on "
+        f"Intel macOS (CPython {python[0]}.{python[1]}), so `uv tool install "
+        f"kolega-code` there falls back to a native source build: {broken}. "
+        "Pin an older wheel-bearing release behind a platform marker in "
+        "pyproject.toml, like the cryptography pin."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-27T02:41:25.262267Z"
+exclude-newer = "2026-07-27T09:03:29.890831Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1536,6 +1536,7 @@ source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "beautifulsoup4" },
+    { name = "cryptography", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
     { name = "ddgs" },
     { name = "fastapi" },
     { name = "filelock" },
@@ -1593,6 +1594,7 @@ dev = [
 requires-dist = [
     { name = "anthropic", specifier = "==0.101.0" },
     { name = "beautifulsoup4", specifier = "==4.14.3" },
+    { name = "cryptography", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'", specifier = "==48.0.1" },
     { name = "ddgs", specifier = "==9.14.4" },
     { name = "fastapi", specifier = "==0.139.2" },
     { name = "filelock", specifier = "==3.20.3" },


### PR DESCRIPTION
## Problem

`curl -fsSL https://kolega.dev/install-kolega-code.sh | sh` fails on Intel Macs:

```
× Failed to build `cryptography==50.0.0`
├─▶ The build backend returned an error
╰─▶ Call to `maturin.build_wheel` failed (exit status: 1)
    ...
    Could not find directory of OpenSSL installation
```

cryptography ≥ 49 stopped publishing Intel macOS wheels (48.x was the last line with `macosx_10_9_universal2`; 49/50 ship `macosx_11_0_arm64` only). We don't constrain cryptography — it's transitive via `mcp` → `pyjwt[crypto]` — and `uv tool install` resolves fresh on the user's machine, ignoring our `uv.lock`. So Intel Macs resolve 50.0.0, fall back to the sdist, and the build dies needing Rust + OpenSSL headers + pkg-config.

## Fix

Pin `cryptography==48.0.1; sys_platform == 'darwin' and platform_machine == 'x86_64'` in `[project.dependencies]` — the same marker-pin pattern as the existing `onnxruntime` entry. Verified with `uv pip compile --python-platform x86_64-apple-darwin --python-version 3.12` that a fresh Intel-mac resolve now picks 48.0.1 (prebuilt universal2 wheel); arm macs and Linux keep resolving freely (49/50 with native wheels).

## Regression guard

CI resolves and syncs on Linux/arm runners, so a dependency dropping Intel-mac wheels never fails CI — it fails on user machines. New `tests/test_dependency_wheel_coverage.py` walks the runtime dependency graph in `uv.lock` as it resolves for Intel macOS on CPython 3.11/3.12/3.13 and fails if any reachable wheel-shipping package has no wheel installable there. Mutation-tested: with cryptography's mac wheels swapped to arm64-only in a lock copy, the test flags it.

## Caveats

- The guard covers the lock; end users resolve fresh, so a transitive dep dropping Intel wheels can still break installs until the next lock refresh surfaces it. Fully closing that gap would mean shipping a constraints file with the installer — left out of scope.
- Intel mac + CPython 3.14 remains unsupported regardless: `magika` hard-requires `onnxruntime`, which has no sdist and no Intel-mac wheels for 3.14 (fails at resolution, pre-existing; uv currently selects 3.11–3.13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N256mMGQdPPXc5FpYAWhez