### PR TITLE
feat(web): actionable connect-level errors for web_fetch/web_search

### DIFF
--- a/kolega_code/agent/tool_backend/network_status.py
+++ b/kolega_code/agent/tool_backend/network_status.py
@@ -1,0 +1,90 @@
+"""Session-level tracking and messaging for outbound connect failures.
+
+Shared by web_fetch retrieval and the web_search tool so that both surfaces emit the
+same causal, model-facing message when a connection never opens (TCP/DNS/TLS), and so
+that repeated failures across distinct hosts escalate to a clear "network unavailable"
+signal instead of encouraging retries against mirrors or other search engines.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+_TLS_MARKERS = ("ssl", "tls", "certificate", "handshake")
+
+# Wording seen from httpx/httpcore plus requests/urllib3 (SDK-based search backends).
+# Deliberately excludes bare "connect" and "connection reset": a mid-stream reset means
+# the server WAS reachable, and a false "unreachable" claim is worse than a generic one.
+_CONNECT_MARKERS = (
+    "connection refused",
+    "connection attempts failed",
+    "establish a new connection",
+    "name resolution",
+    "name or service not known",
+    "nodename nor servname",
+    "getaddrinfo",
+    "network is unreachable",
+    "no route to host",
+    "connect timeout",
+    "connection timed out",
+)
+
+_LOCAL_PREFERENCE_HINT = (
+    "Prefer resources available locally or hosts the task explicitly names instead of "
+    "retrying mirrors or other search engines."
+)
+
+
+class ConnectFailureTracker:
+    """Counts distinct endpoints that failed at the connect level in this session."""
+
+    def __init__(self) -> None:
+        self._subjects: set[str] = set()
+
+    def record(self, subject: str) -> int:
+        self._subjects.add(subject.strip().lower())
+        return len(self._subjects)
+
+    @property
+    def distinct_count(self) -> int:
+        return len(self._subjects)
+
+
+def looks_like_tls_failure(detail: str) -> bool:
+    lowered = detail.lower()
+    return any(marker in lowered for marker in _TLS_MARKERS)
+
+
+def looks_like_connect_failure(detail: str) -> bool:
+    lowered = detail.lower()
+    return any(marker in lowered for marker in _CONNECT_MARKERS)
+
+
+def connect_failure_message(subject: str, detail: Optional[str], distinct_failed: int) -> str:
+    """Compose the model-facing message for a connection that never opened."""
+    lead = f"Could not connect to {subject}"
+    if detail:
+        lead += f" ({detail})"
+    if distinct_failed >= 2:
+        middle = (
+            f"{distinct_failed} distinct external hosts have failed to connect in this "
+            "session — treat outbound network access as unavailable."
+        )
+    else:
+        middle = (
+            "This environment may restrict outbound network access to an allowlist, in "
+            "which case other external hosts will fail the same way."
+        )
+    return f"{lead}. {middle} {_LOCAL_PREFERENCE_HINT}"
+
+
+def secure_connection_failure_message(subject: str, detail: str) -> str:
+    """Compose the model-facing message for a TLS handshake or certificate failure."""
+    lead = f"Could not establish a secure connection to {subject}"
+    if detail:
+        lead += f" ({detail})"
+    return (
+        f"{lead}. The TLS handshake or certificate validation failed, so retrying will "
+        "not help; this could be a problem with the host's certificate or with a "
+        "TLS-intercepting proxy in this environment."
+    )

--- a/kolega_code/agent/tool_backend/search_backends/__init__.py
+++ b/kolega_code/agent/tool_backend/search_backends/__init__.py
@@ -16,6 +16,7 @@ from .errors import (
     SearchBackendNotConfigured,
     SearchBackendRateLimited,
     SearchBackendUnavailable,
+    SearchBackendUnreachable,
 )
 from .firecrawl import FirecrawlBackend
 from .models import SearchResponse, SearchResult
@@ -70,6 +71,7 @@ __all__ = [
     "SearchBackendNotConfigured",
     "SearchBackendRateLimited",
     "SearchBackendUnavailable",
+    "SearchBackendUnreachable",
     "SearchResponse",
     "SearchResult",
     "available_backends",

--- a/kolega_code/agent/tool_backend/search_backends/duckduckgo.py
+++ b/kolega_code/agent/tool_backend/search_backends/duckduckgo.py
@@ -8,8 +8,9 @@ from typing import List
 from ddgs import DDGS
 from ddgs.exceptions import DDGSException, RatelimitException, TimeoutException
 
+from ..network_status import looks_like_connect_failure
 from .base import DEFAULT_RESULTS, SearchBackend, clamp_results
-from .errors import SearchBackendRateLimited, SearchBackendUnavailable
+from .errors import SearchBackendRateLimited, SearchBackendUnavailable, SearchBackendUnreachable
 from .models import SearchResponse, SearchResult
 
 
@@ -30,11 +31,17 @@ class DuckDuckGoBackend(SearchBackend):
         except RatelimitException as exc:
             raise SearchBackendRateLimited(str(exc) or "rate-limited by DuckDuckGo") from exc
         except DDGSException as exc:
-            raise SearchBackendUnavailable(str(exc) or exc.__class__.__name__) from exc
+            message = str(exc) or exc.__class__.__name__
+            if looks_like_connect_failure(message):
+                # host=None: ddgs fans out over many engines, no single endpoint to name.
+                raise SearchBackendUnreachable(message) from exc
+            raise SearchBackendUnavailable(message) from exc
         except Exception as exc:  # defensive: ddgs has changed exception types across versions
             message = str(exc) or exc.__class__.__name__
             if "ratelimit" in exc.__class__.__name__.lower() or "202" in message or "429" in message:
                 raise SearchBackendRateLimited(message) from exc
+            if looks_like_connect_failure(message):
+                raise SearchBackendUnreachable(message) from exc
             raise SearchBackendUnavailable(message) from exc
 
         results = [

--- a/kolega_code/agent/tool_backend/search_backends/errors.py
+++ b/kolega_code/agent/tool_backend/search_backends/errors.py
@@ -19,5 +19,13 @@ class SearchBackendUnavailable(SearchBackendError):
     """Network failure, timeout, or a backend server error."""
 
 
+class SearchBackendUnreachable(SearchBackendUnavailable):
+    """The backend endpoint could not be reached at all (DNS, TCP, or TLS connect failure)."""
+
+    def __init__(self, message: str, *, host: str | None = None) -> None:
+        super().__init__(message)
+        self.host = host
+
+
 class SearchBackendRateLimited(SearchBackendError):
     """The backend rate-limited or blocked the request."""

--- a/kolega_code/agent/tool_backend/search_backends/firecrawl.py
+++ b/kolega_code/agent/tool_backend/search_backends/firecrawl.py
@@ -28,6 +28,7 @@ from .errors import (
     SearchBackendNotConfigured,
     SearchBackendRateLimited,
     SearchBackendUnavailable,
+    SearchBackendUnreachable,
 )
 from .models import SearchResponse, SearchResult
 
@@ -93,6 +94,8 @@ class FirecrawlBackend(SearchBackend):
                 response = await client.post(
                     FIRECRAWL_SEARCH_URL, json=body, headers={"Content-Type": "application/json"}
                 )
+        except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
+            raise SearchBackendUnreachable(str(exc) or "connection failed", host="api.firecrawl.dev") from exc
         except httpx.TimeoutException as exc:
             raise SearchBackendUnavailable(f"timed out after {self.timeout:.0f}s") from exc
         except httpx.HTTPError as exc:

--- a/kolega_code/agent/tool_backend/search_backends/searxng.py
+++ b/kolega_code/agent/tool_backend/search_backends/searxng.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from urllib.parse import urlsplit
+
 import httpx
 
 from .base import DEFAULT_RESULTS, SearchBackend, clamp_results
@@ -9,6 +11,7 @@ from .errors import (
     SearchBackendNotConfigured,
     SearchBackendRateLimited,
     SearchBackendUnavailable,
+    SearchBackendUnreachable,
 )
 from .models import SearchResponse, SearchResult
 
@@ -33,6 +36,9 @@ class SearxngBackend(SearchBackend):
         try:
             async with httpx.AsyncClient(timeout=self.timeout) as client:
                 response = await client.get(url, params=params)
+        except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
+            host = urlsplit(self.base_url).hostname or self.base_url
+            raise SearchBackendUnreachable(str(exc) or "connection failed", host=host) from exc
         except httpx.TimeoutException as exc:
             raise SearchBackendUnavailable(f"timed out after {self.timeout:.0f}s") from exc
         except httpx.HTTPError as exc:

--- a/kolega_code/agent/tool_backend/search_backends/tavily.py
+++ b/kolega_code/agent/tool_backend/search_backends/tavily.py
@@ -12,11 +12,13 @@ from tavily.errors import (
     UsageLimitExceededError,
 )
 
+from ..network_status import looks_like_connect_failure
 from .base import DEFAULT_RESULTS, SearchBackend, clamp_results
 from .errors import (
     SearchBackendNotConfigured,
     SearchBackendRateLimited,
     SearchBackendUnavailable,
+    SearchBackendUnreachable,
 )
 from .models import SearchResponse, SearchResult
 
@@ -43,7 +45,10 @@ class TavilyBackend(SearchBackend):
         except UsageLimitExceededError as exc:
             raise SearchBackendRateLimited(str(exc) or "Tavily usage limit exceeded.") from exc
         except Exception as exc:
-            raise SearchBackendUnavailable(str(exc) or exc.__class__.__name__) from exc
+            message = str(exc) or exc.__class__.__name__
+            if looks_like_connect_failure(message):
+                raise SearchBackendUnreachable(message, host="api.tavily.com") from exc
+            raise SearchBackendUnavailable(message) from exc
 
         rows = payload.get("results") or []
         results = [

--- a/kolega_code/agent/tool_backend/web_fetch/pipeline.py
+++ b/kolega_code/agent/tool_backend/web_fetch/pipeline.py
@@ -18,6 +18,7 @@ from bs4 import UnicodeDammit
 
 from .documents import DocumentConversionError, DocumentConverter, SUPPORTED_DOCUMENT_EXTENSIONS
 from .extractors import DEFAULT_EXTRACTOR, ExtractorAttempt, extract_html
+from ..network_status import ConnectFailureTracker
 from .retrieval import FetchAttempt, FetchedResource, RetrievalError, WebRetriever
 
 
@@ -114,8 +115,10 @@ class LocalWebContentPipeline:
         self,
         retriever: Optional[WebRetriever] = None,
         document_converter: Optional[DocumentConverter] = None,
+        *,
+        connect_failures: Optional[ConnectFailureTracker] = None,
     ) -> None:
-        self.retriever = retriever or WebRetriever()
+        self.retriever = retriever or WebRetriever(connect_failures=connect_failures)
         self.document_converter = document_converter or DocumentConverter()
 
     async def load(self, url: str, extractor_preference: str = DEFAULT_EXTRACTOR) -> WebContent:

--- a/kolega_code/agent/tool_backend/web_fetch/retrieval.py
+++ b/kolega_code/agent/tool_backend/web_fetch/retrieval.py
@@ -13,6 +13,13 @@ from urllib.parse import urlsplit, urlunsplit
 
 import httpx
 
+from ..network_status import (
+    ConnectFailureTracker,
+    connect_failure_message,
+    looks_like_tls_failure,
+    secure_connection_failure_message,
+)
+
 TEXT_MAX_BYTES = 10 * 1024 * 1024
 DOCUMENT_MAX_BYTES = 50 * 1024 * 1024
 OVERALL_TIMEOUT_SECONDS = 30.0
@@ -164,13 +171,20 @@ ClientFactory = Callable[..., httpx.AsyncClient]
 class WebRetriever:
     """Fetch one URL while bounding retries, elapsed time, redirects, and bytes."""
 
-    def __init__(self, client_factory: ClientFactory = httpx.AsyncClient) -> None:
+    def __init__(
+        self,
+        client_factory: ClientFactory = httpx.AsyncClient,
+        *,
+        connect_failures: Optional[ConnectFailureTracker] = None,
+    ) -> None:
         self._client_factory = client_factory
+        self.connect_failures = connect_failures or ConnectFailureTracker()
 
     async def fetch(self, url: str) -> FetchedResource:
         normalized = normalize_url(url)
         attempts: list[FetchAttempt] = []
         last_error = "unknown retrieval failure"
+        connect_failure: Optional[str] = None
         timeout = httpx.Timeout(connect=5.0, read=15.0, write=5.0, pool=5.0)
 
         try:
@@ -267,10 +281,25 @@ class WebRetriever:
                                     error=last_error,
                                 )
                             )
+                            if isinstance(exc, (httpx.ConnectError, httpx.ConnectTimeout, httpx.ProxyError)):
+                                # No connection ever opened, so rotating user agents cannot help.
+                                connect_failure = self._describe_connect_failure(normalized, exc)
+                                break
                             if attempt_number >= MAX_ATTEMPTS:
                                 break
                             await asyncio.sleep(min(2.0, 0.25 * (2 ** (attempt_number - 1))))
         except TimeoutError as exc:
             raise RetrievalError(f"Timed out fetching {normalized} after {OVERALL_TIMEOUT_SECONDS:g} seconds.") from exc
 
+        if connect_failure:
+            raise RetrievalError(connect_failure)
         raise RetrievalError(f"Failed to fetch {normalized}: {last_error}")
+
+    def _describe_connect_failure(self, normalized_url: str, exc: Exception) -> str:
+        host = urlsplit(normalized_url).hostname or normalized_url
+        detail = str(exc).strip()
+        if looks_like_tls_failure(detail):
+            return secure_connection_failure_message(host, detail)
+        if not detail and isinstance(exc, httpx.ConnectTimeout):
+            detail = "the connection attempt timed out"
+        return connect_failure_message(host, detail, self.connect_failures.record(host))

--- a/kolega_code/agent/tool_backend/web_fetch_tool.py
+++ b/kolega_code/agent/tool_backend/web_fetch_tool.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import time
 from pathlib import Path
-from typing import Union
+from typing import Optional, Union
 
 from kolega_code.config import AgentConfig
 from kolega_code.llm.client import LLMClient
@@ -11,6 +11,7 @@ from kolega_code.llm.instrumented_client import InstrumentedLLMClient
 from kolega_code.llm.specs import get_model_specs
 from kolega_code.tools import ToolError
 
+from .network_status import ConnectFailureTracker
 from .streaming_tool import StreamingTool
 from .web_fetch.answering import AnsweringError, WebContentAnswerer
 from .web_fetch.pipeline import LocalWebContentPipeline, WebContent, WebContentError
@@ -33,9 +34,11 @@ class WebFetchTool(StreamingTool):
         config: AgentConfig,
         caller,
         filesystem=None,
+        *,
+        connect_failures: Optional[ConnectFailureTracker] = None,
     ):
         super().__init__(project_path, workspace_id, thread_id, connection_manager, config, caller, filesystem)
-        self.content_pipeline = LocalWebContentPipeline()
+        self.content_pipeline = LocalWebContentPipeline(connect_failures=connect_failures)
 
     async def web_fetch(self, url: str, instruction: str) -> str:
         """Fetch URL content locally, follow an instruction, and return a grounded answer.

--- a/kolega_code/agent/tool_backend/web_search_tool.py
+++ b/kolega_code/agent/tool_backend/web_search_tool.py
@@ -1,14 +1,16 @@
 from pathlib import Path
-from typing import Union
+from typing import Optional, Union
 
 from kolega_code.config import AgentConfig
 
+from .network_status import ConnectFailureTracker, connect_failure_message
 from .search_backends import (
     DEFAULT_BACKEND,
     DEFAULT_RESULTS,
     SearchBackendError,
     SearchBackendNotConfigured,
     SearchBackendRateLimited,
+    SearchBackendUnreachable,
     SearchResponse,
     build_search_backend,
     clamp_results,
@@ -32,8 +34,11 @@ class WebSearchTool(StreamingTool):
         config: AgentConfig,
         caller,
         filesystem=None,
+        *,
+        connect_failures: Optional[ConnectFailureTracker] = None,
     ):
         super().__init__(project_path, workspace_id, thread_id, connection_manager, config, caller, filesystem)
+        self.connect_failures = connect_failures or ConnectFailureTracker()
 
     async def web_search(self, query: str, max_results: int = DEFAULT_RESULTS) -> str:
         """Search the web with the configured backend and return formatted results.
@@ -69,9 +74,13 @@ class WebSearchTool(StreamingTool):
             return await self._error(f"{exc} Configure it in Settings > Web Search.", tool_call_id)
         except SearchBackendRateLimited as exc:
             return await self._error(
-                f"{exc} The search backend is rate-limited; retry shortly or switch backends in Settings > Web Search.",
+                f"{exc} The search backend is rate-limited; retry shortly.",
                 tool_call_id,
             )
+        except SearchBackendUnreachable as exc:
+            subject = exc.host or f"the {backend_name} search backend"
+            count = self.connect_failures.record(subject)
+            return await self._error(connect_failure_message(subject, str(exc), count), tool_call_id)
         except SearchBackendError as exc:
             return await self._error(f"Web search failed ({backend_name}): {exc}", tool_call_id)
         except Exception as exc:  # pragma: no cover - defensive

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -22,6 +22,7 @@ from .tool_backend.glob_tool import GlobTool
 from .tool_backend.hashline_v2 import format_hash_lines, format_line_tag
 from .tool_backend.list_directory_tool import ListDirectoryTool
 from .tool_backend.memory_tool import MemoryTool
+from .tool_backend.network_status import ConnectFailureTracker
 from .tool_backend.read_file_tool import ReadFileTool
 from .tool_backend.read_image_tool import ReadImageTool
 from .tool_backend.search_codebase_tool import SearchCodebaseTool
@@ -880,6 +881,7 @@ class ToolCollection(LogMixin):
             self.caller,
             self.filesystem,
         )
+        connect_failures = ConnectFailureTracker()
         self.web_fetch_tool = WebFetchTool(
             self.project_path,
             self.workspace_id,
@@ -888,6 +890,7 @@ class ToolCollection(LogMixin):
             self.config,
             self.caller,
             self.filesystem,
+            connect_failures=connect_failures,
         )
         self.web_search_tool = WebSearchTool(
             self.project_path,
@@ -897,6 +900,7 @@ class ToolCollection(LogMixin):
             self.config,
             self.caller,
             self.filesystem,
+            connect_failures=connect_failures,
         )
         self.glob_tool = GlobTool(
             self.project_path,

--- a/tests/agent/tool_backend/test_network_status.py
+++ b/tests/agent/tool_backend/test_network_status.py
@@ -1,0 +1,53 @@
+from kolega_code.agent.tool_backend.network_status import (
+    ConnectFailureTracker,
+    connect_failure_message,
+    looks_like_connect_failure,
+    looks_like_tls_failure,
+    secure_connection_failure_message,
+)
+
+
+def test_tracker_counts_distinct_subjects_and_dedupes() -> None:
+    tracker = ConnectFailureTracker()
+    assert tracker.record("example.com") == 1
+    assert tracker.record("Example.com ") == 1
+    assert tracker.record("other.test") == 2
+    assert tracker.distinct_count == 2
+
+
+def test_connect_failure_message_first_host() -> None:
+    message = connect_failure_message("example.com", "connection refused", 1)
+    assert message.startswith("Could not connect to example.com (connection refused).")
+    assert "may restrict outbound network access" in message
+    assert "Prefer resources available locally" in message
+
+
+def test_connect_failure_message_omits_empty_detail() -> None:
+    message = connect_failure_message("example.com", "", 1)
+    assert message.startswith("Could not connect to example.com. ")
+    assert "()" not in message
+
+
+def test_connect_failure_message_escalates_at_two() -> None:
+    message = connect_failure_message("b.test", "connection refused", 2)
+    assert "2 distinct external hosts have failed to connect" in message
+    assert "treat outbound network access as unavailable" in message
+    assert "may restrict" not in message
+
+
+def test_secure_connection_message_has_no_egress_hint() -> None:
+    message = secure_connection_failure_message("example.com", "[SSL: CERTIFICATE_VERIFY_FAILED]")
+    assert message.startswith("Could not establish a secure connection to example.com")
+    assert "may restrict" not in message
+    assert "retrying will not help" in message
+
+
+def test_marker_sniffing() -> None:
+    assert looks_like_connect_failure("All connection attempts failed")
+    assert looks_like_connect_failure("Temporary failure in name resolution")
+    assert looks_like_connect_failure("[Errno 61] Connection refused")
+    # A mid-stream reset means the server WAS reachable — must not classify as unreachable.
+    assert not looks_like_connect_failure("connection reset by peer")
+    assert not looks_like_connect_failure("HTTP 502 Bad Gateway")
+    assert looks_like_tls_failure("[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed")
+    assert not looks_like_tls_failure("connection refused")

--- a/tests/agent/tool_backend/test_web_fetch_pipeline.py
+++ b/tests/agent/tool_backend/test_web_fetch_pipeline.py
@@ -14,6 +14,7 @@ from kolega_code.agent.tool_backend.web_fetch.extractors import (
     html_signals,
     quality_score,
 )
+from kolega_code.agent.tool_backend.network_status import ConnectFailureTracker
 from kolega_code.agent.tool_backend.web_fetch.pipeline import LocalWebContentPipeline, WebContentError
 from kolega_code.agent.tool_backend.web_fetch.retrieval import (
     TEXT_MAX_BYTES,
@@ -87,6 +88,104 @@ async def test_retriever_rejects_declared_oversized_text() -> None:
 
     with pytest.raises(RetrievalError, match="too large"):
         await WebRetriever(_client_factory(handler)).fetch("https://example.com/large")
+
+
+@pytest.mark.asyncio
+async def test_retriever_connect_error_single_attempt_and_causal_message() -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        raise httpx.ConnectError("All connection attempts failed", request=request)
+
+    sleep = AsyncMock()
+    with patch("kolega_code.agent.tool_backend.web_fetch.retrieval.asyncio.sleep", new=sleep):
+        with pytest.raises(RetrievalError) as excinfo:
+            await WebRetriever(_client_factory(handler)).fetch("https://example.com")
+    message = str(excinfo.value)
+    assert calls == 1
+    sleep.assert_not_awaited()
+    assert "Could not connect to example.com" in message
+    assert "may restrict outbound network access" in message
+    assert "ConnectError" not in message
+
+
+@pytest.mark.asyncio
+async def test_retriever_connect_timeout_and_proxy_error_single_attempt() -> None:
+    for exc_type in (httpx.ConnectTimeout, httpx.ProxyError):
+        calls = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal calls
+            calls += 1
+            raise exc_type("", request=request)
+
+        with pytest.raises(RetrievalError) as excinfo:
+            await WebRetriever(_client_factory(handler)).fetch("https://example.com")
+        assert calls == 1
+        assert "Could not connect to example.com" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_retriever_escalates_on_second_distinct_host_not_same_host() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=request)
+
+    tracker = ConnectFailureTracker()
+    retriever = WebRetriever(_client_factory(handler), connect_failures=tracker)
+    with pytest.raises(RetrievalError) as first:
+        await retriever.fetch("https://a.test")
+    assert "may restrict outbound network access" in str(first.value)
+    with pytest.raises(RetrievalError) as repeat:
+        await retriever.fetch("https://a.test")
+    assert "may restrict outbound network access" in str(repeat.value)
+    assert "distinct external hosts" not in str(repeat.value)
+    with pytest.raises(RetrievalError) as second:
+        await retriever.fetch("https://b.test")
+    assert "2 distinct external hosts have failed to connect" in str(second.value)
+    assert "treat outbound network access as unavailable" in str(second.value)
+
+
+@pytest.mark.asyncio
+async def test_retriever_tls_failure_gets_secure_message_and_is_not_counted() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed", request=request)
+
+    tracker = ConnectFailureTracker()
+    retriever = WebRetriever(_client_factory(handler), connect_failures=tracker)
+    with pytest.raises(RetrievalError) as excinfo:
+        await retriever.fetch("https://example.com")
+    message = str(excinfo.value)
+    assert "Could not establish a secure connection to example.com" in message
+    assert "may restrict outbound network access" not in message
+    assert tracker.distinct_count == 0
+
+
+@pytest.mark.asyncio
+async def test_retriever_http_404_message_unchanged() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, text="missing", request=request)
+
+    with pytest.raises(RetrievalError) as excinfo:
+        await WebRetriever(_client_factory(handler)).fetch("https://example.com")
+    assert str(excinfo.value) == "HTTP 404 while fetching https://example.com/."
+
+
+@pytest.mark.asyncio
+async def test_retriever_read_timeout_still_retries_with_unchanged_message() -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        raise httpx.ReadTimeout("boom", request=request)
+
+    with patch("kolega_code.agent.tool_backend.web_fetch.retrieval.asyncio.sleep", new=AsyncMock()):
+        with pytest.raises(RetrievalError) as excinfo:
+            await WebRetriever(_client_factory(handler)).fetch("https://example.com")
+    assert calls == 3
+    assert str(excinfo.value) == "Failed to fetch https://example.com/: boom"
 
 
 @pytest.mark.asyncio

--- a/tests/agent/tool_backend/test_web_fetch_tool.py
+++ b/tests/agent/tool_backend/test_web_fetch_tool.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from kolega_code.agent.tool_backend.network_status import ConnectFailureTracker
 from kolega_code.agent.tool_backend.web_fetch.answering import MAX_COMPLETION_TOKENS
 from kolega_code.agent.tool_backend.web_fetch.pipeline import WebContent, WebContentError
 from kolega_code.agent.tool_backend.web_fetch_tool import WebFetchTool
@@ -42,6 +43,14 @@ def caller():
 @pytest.fixture
 def tool(tmp_path, agent_config, caller):
     return WebFetchTool(tmp_path, "test_workspace", "test_thread", AsyncMock(), agent_config, caller)
+
+
+def test_web_fetch_tool_threads_shared_tracker(tmp_path, agent_config, caller) -> None:
+    tracker = ConnectFailureTracker()
+    tool = WebFetchTool(
+        tmp_path, "test_workspace", "test_thread", AsyncMock(), agent_config, caller, connect_failures=tracker
+    )
+    assert tool.content_pipeline.retriever.connect_failures is tracker
 
 
 def _content(text: str = "Extracted content with the important fact.", **kwargs) -> WebContent:

--- a/tests/agent/tool_backend/test_web_search_tool.py
+++ b/tests/agent/tool_backend/test_web_search_tool.py
@@ -4,12 +4,14 @@ from unittest.mock import AsyncMock, Mock, patch
 import httpx
 import pytest
 
+from kolega_code.agent.tool_backend.network_status import ConnectFailureTracker
 from kolega_code.agent.tool_backend.search_backends import (
     DEFAULT_BACKEND,
     SearchBackendError,
     SearchBackendNotConfigured,
     SearchBackendRateLimited,
     SearchBackendUnavailable,
+    SearchBackendUnreachable,
     SearchResponse,
     SearchResult,
     available_backends,
@@ -286,6 +288,36 @@ async def test_searxng_timeout_unavailable() -> None:
             await build_search_backend("searxng", base_url="https://s.test").search("q")
 
 
+# ---------------------------------------------------------------- connect-level failures
+
+
+@pytest.mark.asyncio
+async def test_searxng_connect_error_raises_unreachable_with_host() -> None:
+    with patch(
+        f"{_SEARX}.httpx.AsyncClient", _searx_client(get_exc=httpx.ConnectError("All connection attempts failed"))
+    ):
+        with pytest.raises(SearchBackendUnreachable) as excinfo:
+            await build_search_backend("searxng", base_url="https://s.test").search("q")
+    assert excinfo.value.host == "s.test"
+
+
+@pytest.mark.asyncio
+async def test_firecrawl_keyless_connect_error_raises_unreachable() -> None:
+    with patch(f"{_FIRE}.httpx.AsyncClient", _post_client(post_exc=httpx.ConnectError("connection refused"))):
+        with pytest.raises(SearchBackendUnreachable) as excinfo:
+            await build_search_backend("firecrawl").search("q")
+    assert excinfo.value.host == "api.firecrawl.dev"
+
+
+@pytest.mark.asyncio
+async def test_duckduckgo_connect_failure_sniffed_to_unreachable() -> None:
+    from ddgs.exceptions import DDGSException
+
+    with patch(f"{_DUCK}.DDGS", lambda: _DummyDDGS(exc=DDGSException("Temporary failure in name resolution"))):
+        with pytest.raises(SearchBackendUnreachable):
+            await build_search_backend("duckduckgo").search("q")
+
+
 # ------------------------------------------------------------------------- WebSearchTool
 
 
@@ -364,3 +396,51 @@ async def test_tool_never_raises_on_unexpected(tool) -> None:
     with patch("kolega_code.agent.tool_backend.web_search_tool.build_search_backend", return_value=backend):
         result = await tool.web_search("q")
     assert result.startswith("Error: web_search failed:")
+
+
+@pytest.mark.asyncio
+async def test_tool_unreachable_message_is_causal(tool) -> None:
+    backend = Mock()
+    backend.search = AsyncMock(side_effect=SearchBackendUnreachable("All connection attempts failed", host="s.test"))
+    with patch("kolega_code.agent.tool_backend.web_search_tool.build_search_backend", return_value=backend):
+        result = await tool.web_search("q")
+    assert result.startswith("Error: Could not connect to s.test")
+    assert "may restrict outbound network access" in result
+    assert "ConnectError" not in result
+
+
+@pytest.mark.asyncio
+async def test_tool_escalates_on_second_distinct_unreachable_host(tool) -> None:
+    def unreachable(host):
+        backend = Mock()
+        backend.search = AsyncMock(side_effect=SearchBackendUnreachable("connection refused", host=host))
+        return backend
+
+    with patch(
+        "kolega_code.agent.tool_backend.web_search_tool.build_search_backend", return_value=unreachable("a.test")
+    ):
+        first = await tool.web_search("q")
+    assert "may restrict outbound network access" in first
+    with patch(
+        "kolega_code.agent.tool_backend.web_search_tool.build_search_backend", return_value=unreachable("b.test")
+    ):
+        second = await tool.web_search("q")
+    assert "2 distinct external hosts have failed to connect" in second
+    assert "treat outbound network access as unavailable" in second
+
+
+@pytest.mark.asyncio
+async def test_tool_rate_limited_message_has_no_settings_hint(tool) -> None:
+    backend = Mock()
+    backend.search = AsyncMock(side_effect=SearchBackendRateLimited("too many requests"))
+    with patch("kolega_code.agent.tool_backend.web_search_tool.build_search_backend", return_value=backend):
+        result = await tool.web_search("q")
+    assert result.startswith("Error:")
+    assert "retry shortly" in result
+    assert "Settings > Web Search" not in result
+
+
+def test_tool_threads_shared_tracker(tmp_path, agent_config, caller) -> None:
+    tracker = ConnectFailureTracker()
+    tool = WebSearchTool(tmp_path, "ws", "th", AsyncMock(), agent_config, caller, connect_failures=tracker)
+    assert tool.connect_failures is tracker


### PR DESCRIPTION
## Problem

In sandboxed/benchmark environments with a network-egress allowlist, blocked hosts surface to the model as a bare exception name:

> web_fetch could not read <url>: Failed to fetch <url>: ConnectError

`str(httpx.ConnectError)` is often empty, so `last_error = str(exc) or type(exc).__name__` degrades to the class name. The model reads this as transient and cycles search engines and mirrors. Measured across the TB2.1 runs: 152 egress-blocked ConnectErrors, concentrated in timeout-bound trials (no scored failure attributable — this is friction removal, not a scoring fix).

## Changes

- **Classify connect-level failures at the retrieval layer** (`ConnectError`/`ConnectTimeout`/`ProxyError` — a connection that never produced an HTTP response). They now get **one attempt instead of three**: the user-agent-rotation retry loop exists for bot-blocking responses and cannot help a connection that never opens. Everything else (HTTP statuses, read/write/pool timeouts, redirects) keeps the existing retry behavior and messages, byte-identical.
- **Causal, model-facing message** composed in a new shared `network_status.py` module:
  > Could not connect to \<host\> (\<detail\>). This environment may restrict outbound network access to an allowlist, in which case other external hosts will fail the same way. Prefer resources available locally or hosts the task explicitly names instead of retrying mirrors or other search engines.
- **Escalation**: a `ConnectFailureTracker` shared by web_fetch and web_search (wired once in `ToolCollection`) counts distinct failed hosts per session. At >=2 the hedge is replaced with: *"N distinct external hosts have failed to connect in this session — treat outbound network access as unavailable."*
- **TLS/cert handshake failures** arrive as the same `httpx.ConnectError` type; detected by marker sniff they get an honest secure-connection message instead (no egress hint, not counted toward escalation, still single-attempt — UA rotation can't fix certificates).
- **web_search**: new `SearchBackendUnreachable(SearchBackendUnavailable)` carrying the endpoint host — raised type-precisely in searxng/firecrawl (raw httpx), via message sniff in duckduckgo (the vendored ddgs lib swallows per-engine errors; its concurrent engine fan-out is deliberately left unchanged) and tavily. The tool emits the same message shape via the shared composer, into the same tracker.
- **Rate-limit hint reworded**: no longer tells a headless agent to "switch backends in Settings > Web Search" — now just "retry shortly". The `SearchBackendNotConfigured` and firecrawl keyless-429 Settings pointers stay (those need a human regardless of surface).

No message the model sees contains an exception class name anymore.

## Tests

- New `test_network_status.py`: tracker dedupe/counting, message shapes, marker sniffing (including the negative case: "connection reset by peer" must NOT classify as unreachable — the server was reachable).
- `test_web_fetch_pipeline.py`: single-attempt + causal message for ConnectError/ConnectTimeout/ProxyError; escalation on second distinct host (and no double-count for a repeat host); TLS variant not counted; **regression pins for the previously untested transport branch** — HTTP 404 and read-timeout messages byte-identical, read timeouts still retry 3x.
- `test_web_search_tool.py`: backend-level `SearchBackendUnreachable` mapping for searxng/firecrawl/duckduckgo; tool-level causal message, cross-call escalation, rate-limit message no longer mentions the Settings UI.
- Full default suite: 4001 passed, 0 failed.

Live smoke (real DNS failure through the actual pipeline): first blocked host returns the causal message in ~0.09s (previously 3 attempts + backoff), second distinct host escalates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yZhBvFjGBg9TPST2aoyGg