### PR TITLE
feat(ask): emit complete messages instead of streaming chunks in --json

### DIFF
--- a/docs/src/content/docs/cli/ask.md
+++ b/docs/src/content/docs/cli/ask.md
@@ -20,7 +20,7 @@ kolega-code ask "<prompt>" [options]
 | `--goal <condition>` | Set an autonomous completion goal and loop until it is met or capped (no prompt required) |
 | `--goal-max-turns <N>` | Maximum evaluation turns before an unmet goal gives up (default 50) |
 | `--save` | Persist the session after the prompt completes |
-| `--json` | Emit response chunks and events as JSON |
+| `--json` | Emit complete messages and events as JSON |
 | `--browser-visible` | Launch visible Playwright browser windows |
 | `--permission-mode <auto\|ask>` | Shell/edit permission mode (default `auto`) |
 | `--session <ID>` | Resume or create a specific session |
@@ -138,15 +138,15 @@ The stream includes:
 
 | `kind` | Meaning |
 | --- | --- |
-| `chunk` | A streamed piece of the response |
-| `event` | An agent event (sub-agent activity, tool calls, terminal output) |
+| `message` | A completed assistant message: `role`, `content` blocks (text, thinking, tool calls), `stop_reason`, and normalized `usage` when the provider reported it |
+| `event` | An agent event (sub-agent activity, tool calls, terminal output). Streaming text deltas are excluded — their content arrives as `message` lines |
 | `skill` | Skill activation metadata |
 | `goal_eval` | Emitted after each goal evaluation (with `--goal`): `met`, `turns`, `reason` |
 | `goal_result` | Final goal outcome (with `--goal`): `met`, `turns`, `reason` |
 | `loop_iteration` | Emitted before each loop iteration (with `--loop`): `iteration`, `scheduled_at`, `prompt_source` |
 | `loop_sleep` | Emitted before waiting for the next fire: `seconds`, `next_fire_at` |
 | `loop_result` | Final loop outcome: `iterations`, `reason` |
-| `summary` | A final object with the chunk count and `session_id` |
+| `summary` | A final object with the emitted `messages` count and `session_id` |
 
 In plain (non-JSON) mode, the answer is written to **stdout** while sub-agent and
 tool activity is reported on **stderr** — so piping stdout gives you just the

--- a/docs/src/content/docs/goal.md
+++ b/docs/src/content/docs/goal.md
@@ -170,7 +170,7 @@ With `--goal`, the exit code reflects the outcome:
 ## JSON output
 
 With `--json`, the command streams newline-delimited JSON objects as usual, plus
-two goal-specific `kind` values alongside the existing `chunk`, `event`, and
+two goal-specific `kind` values alongside the existing `message`, `event`, and
 `summary` kinds:
 
 | `kind` | Meaning |
@@ -181,12 +181,12 @@ two goal-specific `kind` values alongside the existing `chunk`, `event`, and
 Example stream (abbreviated):
 
 ```json
-{"kind": "chunk", "data": {"type": "response", "content": "Fixing the parser…"}}
+{"kind": "message", "data": {"role": "assistant", "content": [{"type": "text", "text": "Fixing the parser…"}], "stop_reason": "end_turn", "usage": {"provider": "anthropic", "input_tokens": 1200, "output_tokens": 85, "total_tokens": 1285}}}
 {"kind": "goal_eval", "data": {"met": false, "turns": 1, "reason": "test_parse_empty still fails"}}
-{"kind": "chunk", "data": {"type": "response", "content": "Added the empty-input guard…"}}
+{"kind": "message", "data": {"role": "assistant", "content": [{"type": "text", "text": "Added the empty-input guard…"}], "stop_reason": "end_turn", "usage": {"provider": "anthropic", "input_tokens": 1450, "output_tokens": 60, "total_tokens": 1510}}}
 {"kind": "goal_eval", "data": {"met": true, "turns": 2, "reason": ""}}
 {"kind": "goal_result", "data": {"met": true, "turns": 2, "reason": ""}}
-{"kind": "summary", "chunks": 4, "session_id": "abc123"}
+{"kind": "summary", "messages": 2, "session_id": "abc123"}
 ```
 
 ## Tips

--- a/docs/src/content/docs/loop.md
+++ b/docs/src/content/docs/loop.md
@@ -219,7 +219,7 @@ kolega-code ask --loop-cron "0 9 * * 1-5" --loop-fresh   # prompt from .kolega/l
 
 Progress goes to stderr (`[loop] iteration 3/12 (every 10m)`) so piped stdout stays
 the answers. With `--json` you get `loop_iteration`, `loop_sleep`, and
-`loop_result` records alongside the usual chunks. The command exits `0` when the
+`loop_result` records alongside the usual `message` and `event` lines. The command exits `0` when the
 loop ends at its cap or expiry.
 
 `--loop` cannot be combined with `--goal`. Unlike the TUI, a leading skill command

--- a/kolega_code/cli/ask_output.py
+++ b/kolega_code/cli/ask_output.py
@@ -1,0 +1,92 @@
+"""Machine-readable output for ``kolega-code ask --json``.
+
+The JSON contract emits one ``{"kind": "message", ...}`` line per completed
+assistant message instead of streaming chunks. Payloads are built from the
+agent's in-memory history — which BaseAgent appends to before yielding a
+message's final chunk — so each message is emitted complete, with its content
+blocks (including tool calls), stop reason, and normalized usage. Opaque
+provider state (thinking signatures, encrypted reasoning) is stripped: it is
+meaningless to consumers and only meaningful when replayed to the provider.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from typing import Any, Optional
+
+# Content-block fields that exist purely to be replayed to the provider.
+_OPAQUE_BLOCK_TYPES = {"redacted_thinking", "responses_reasoning"}
+_OPAQUE_BLOCK_FIELDS = {
+    "thinking": ("signature",),
+    "tool_call": ("thought_signature",),
+}
+
+
+def serialize_ask_message(message: Any) -> dict[str, Any]:
+    """Public ``message`` payload for one completed assistant message."""
+    data = copy.deepcopy(message.to_dict())
+    data.pop("usage_metadata", None)  # internal provider-shaped dict; `usage` is the contract
+    content = data.get("content")
+    if isinstance(content, list):
+        cleaned: list[Any] = []
+        for block in content:
+            if not isinstance(block, dict):
+                cleaned.append(block)
+                continue
+            block_type = block.get("type")
+            if block_type in _OPAQUE_BLOCK_TYPES:
+                continue
+            for field in _OPAQUE_BLOCK_FIELDS.get(block_type or "", ()):
+                block.pop(field, None)
+            block.pop("artifact_fields", None)
+            cleaned.append(block)
+        data["content"] = cleaned
+    return data
+
+
+def synthetic_text_message(text: str) -> dict[str, Any]:
+    """Payload for informational agent output that never enters history
+    (hook blocks, unsupported attachments, agent-command results, notices)."""
+    return {"role": "assistant", "content": [{"type": "text", "text": text}], "stop_reason": "end_turn"}
+
+
+class AskMessageEmitter:
+    """Emits each new assistant message from the agent's history exactly once.
+
+    ``drain()`` is called on every completed response chunk: BaseAgent appends
+    the assistant message to history before yielding its final chunk, so the
+    message is complete when we read it. Tracks a plain index into the live
+    history list; a shrinking history (``--loop-fresh`` clears) resets it.
+    """
+
+    def __init__(self, agent: Any) -> None:
+        self._agent = agent
+        self._seen = 0
+        self.emitted_total = 0
+
+    def drain(self, fallback_chunk: Optional[dict[str, Any]] = None) -> int:
+        history = self._agent.history
+        if len(history) < self._seen:
+            self._seen = 0
+        emitted = 0
+        for message in list(history[self._seen :]):
+            if getattr(message, "role", None) == "assistant":
+                self._emit(serialize_ask_message(message))
+                emitted += 1
+        self._seen = len(history)
+
+        if emitted == 0 and fallback_chunk is not None:
+            text = fallback_chunk.get("content")
+            if text and fallback_chunk.get("complete"):
+                self._emit(synthetic_text_message(str(text)))
+                emitted += 1
+        return emitted
+
+    def emit_text(self, text: str) -> None:
+        """Emit a synthetic informational message (e.g. skill activation)."""
+        self._emit(synthetic_text_message(text))
+
+    def _emit(self, payload: dict[str, Any]) -> None:
+        print(json.dumps({"kind": "message", "data": payload}, default=str))
+        self.emitted_total += 1

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -17,6 +17,7 @@ from kolega_code.agent import CoderAgent
 from kolega_code.config import EditProtocol
 from kolega_code.llm.ledger import UsageLedger
 
+from .ask_output import AskMessageEmitter, synthetic_text_message
 from .session_usage import SessionUsageSink
 from kolega_code.agent.custom_agents import discover_custom_agents, validate_custom_agent_models
 from kolega_code.agent.orchestration.guide import gigacode_prompt_extension
@@ -408,7 +409,7 @@ def _build_subcommand_parser() -> argparse.ArgumentParser:
         "Use for headless or benchmark runs where there is no durable memory store to read or write.",
     )
     ask.add_argument("--save", action="store_true", help="Persist the session after the prompt completes.")
-    ask.add_argument("--json", action="store_true", help="Emit response chunks and events as JSON.")
+    ask.add_argument("--json", action="store_true", help="Emit complete messages and events as JSON.")
     ask.add_argument("--browser-visible", action="store_true", help="Launch visible Playwright browser windows.")
     ask.add_argument(
         "--permission-mode",
@@ -1403,7 +1404,7 @@ async def _run_ask(args: argparse.Namespace) -> int:
         prompt = skill_prompt
         if not prompt:
             if args.json:
-                print(json.dumps({"kind": "chunk", "data": {"type": "response", "content": activation_content}}))
+                print(json.dumps({"kind": "message", "data": synthetic_text_message(activation_content)}))
             else:
                 print(activation_content)
             if args.save or args.session:
@@ -1505,17 +1506,29 @@ async def _run_ask(args: argparse.Namespace) -> int:
                 state.tokens_spent += delta.total_tokens
             usage_mark = current
 
+        # In --json mode, emit one line per COMPLETED assistant message rather
+        # than streaming chunks: the agent appends each message to history
+        # before yielding its final chunk, so a drain on every completed
+        # response chunk sees exactly the finished messages.
+        message_emitter = AskMessageEmitter(agent)
+
+        async def _consume_turn(stream) -> None:
+            async for chunk in stream:
+                response_chunks.append(chunk)
+                if args.json:
+                    if chunk.get("type") == "response" and chunk.get("complete"):
+                        message_emitter.drain(fallback_chunk=chunk)
+                elif chunk.get("type") == "response" and chunk.get("content"):
+                    print(chunk["content"], end="" if not chunk.get("complete") else "\n")
+            if args.json:
+                message_emitter.drain()
+
         stream = (
             agent.process_message_stream(turn_prompt, attachments)
             if attachments
             else agent.process_message_stream(turn_prompt)
         )
-        async for chunk in stream:
-            response_chunks.append(chunk)
-            if args.json:
-                print(json.dumps({"kind": "chunk", "data": chunk}, default=str))
-            elif chunk.get("type") == "response" and chunk.get("content"):
-                print(chunk["content"], end="" if not chunk.get("complete") else "\n")
+        await _consume_turn(stream)
 
         # --loop: keep re-running the prompt until the cap or the expiry is hit.
         if loop_state is not None:
@@ -1540,12 +1553,7 @@ async def _run_ask(args: argparse.Namespace) -> int:
                     if attachments
                     else agent.process_message_stream(turn_prompt)
                 )
-                async for chunk in stream:
-                    response_chunks.append(chunk)
-                    if args.json:
-                        print(json.dumps({"kind": "chunk", "data": chunk}, default=str))
-                    elif chunk.get("type") == "response" and chunk.get("content"):
-                        print(chunk["content"], end="" if not chunk.get("complete") else "\n")
+                await _consume_turn(stream)
                 _drain_tokens(loop_state)
                 loop_state.advance_after_completion()
             _emit_loop_finished(loop_state, args.json)
@@ -1579,13 +1587,7 @@ async def _run_ask(args: argparse.Namespace) -> int:
                     break
                 turns_remaining = goal_state.max_turns - goal_state.turns_evaluated
                 nudge = build_goal_nudge(goal_state.condition, verdict, turns_remaining)
-                stream = agent.process_message_stream(nudge)
-                async for chunk in stream:
-                    response_chunks.append(chunk)
-                    if args.json:
-                        print(json.dumps({"kind": "chunk", "data": chunk}, default=str))
-                    elif chunk.get("type") == "response" and chunk.get("content"):
-                        print(chunk["content"], end="" if not chunk.get("complete") else "\n")
+                await _consume_turn(agent.process_message_stream(nudge))
                 _drain_tokens(goal_state)
             # The loop above can exit on a met verdict or the turn cap; count the
             # final verifier either way.
@@ -1644,7 +1646,9 @@ async def _run_ask(args: argparse.Namespace) -> int:
         return exit_code
 
     if args.json:
-        print(json.dumps({"kind": "summary", "chunks": len(response_chunks), "session_id": session.session_id}))
+        print(
+            json.dumps({"kind": "summary", "messages": message_emitter.emitted_total, "session_id": session.session_id})
+        )
     return 0
 
 
@@ -1656,6 +1660,11 @@ async def _pump_ask_events(manager: CliConnectionManager, json_mode: bool) -> No
 
 def _print_ask_event(event, json_mode: bool) -> None:
     if json_mode:
+        # Streaming deltas duplicate prose that arrives as complete "message"
+        # lines; everything else (tools, sub-agents, workflows, lifecycle)
+        # stays on the event channel.
+        if event.event_type in ("assistant_delta", "thinking_delta"):
+            return
         print(json.dumps({"kind": "event", "data": event.model_dump()}, default=str))
         return
 

--- a/tests/cli/test_ask_json_messages.py
+++ b/tests/cli/test_ask_json_messages.py
@@ -1,0 +1,224 @@
+"""ask --json emits complete structured messages, never streaming chunks."""
+
+import json
+
+from kolega_code.llm.models import Message, TextBlock, ThinkingBlock, ToolCall
+from kolega_code.llm.usage import normalize_usage
+
+from ._app_test_utils import FakeCoderAgent
+
+
+def _usage(inp=100, out=20):
+    return normalize_usage({"input_tokens": inp, "output_tokens": out}, "anthropic", "claude-opus-5")
+
+
+class MessageAskFakeAgent(FakeCoderAgent):
+    """Simulates a real turn: a tool round-trip then a final answer, appending
+    complete Messages to history before yielding each message's final chunk —
+    the same ordering BaseAgent guarantees."""
+
+    agent_name = "coder"
+    instances: list["MessageAskFakeAgent"] = []
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        MessageAskFakeAgent.instances.append(self)
+
+    async def process_message_stream(self, message, attachments=None):
+        self.messages.append(message)
+        self.history.append(Message(role="user", content=[TextBlock(text=message)]))
+
+        # Message 1: thinking + text + a tool call (ends in tool_use).
+        first = Message(
+            role="assistant",
+            content=[
+                ThinkingBlock(thinking="let me look", signature="opaque-sig"),
+                TextBlock(text="Checking the tests."),
+                ToolCall(id="t1", name="exec_command", input={"command": "pytest -q"}),
+            ],
+            stop_reason="tool_use",
+            usage=_usage(100, 20),
+        )
+        yield {"type": "response", "content": "Checking the tests.", "complete": False, "uuid": "m1"}
+        self.history.append(first)
+        # The empty flush BaseAgent emits after a tool round.
+        yield {"type": "response", "content": "", "complete": True, "uuid": "m1"}
+
+        # Tool result (user role — must not be emitted).
+        self.history.append(Message(role="user", content=[TextBlock(text="[tool result]")]))
+
+        # Message 2: the final answer.
+        second = Message(
+            role="assistant",
+            content=[TextBlock(text="All green.")],
+            stop_reason="end_turn",
+            usage=_usage(150, 10),
+        )
+        self.history.append(second)
+        yield {"type": "response", "content": "All green.", "complete": True, "uuid": "m2"}
+
+    async def fire_hook(self, event, payload):
+        class Result:
+            additional_context = None
+            blocked = False
+            end_turn = False
+
+        return Result()
+
+
+class NoHistoryFakeAgent(MessageAskFakeAgent):
+    """Yields a terminal informational chunk without touching history —
+    the hook-block / agent-command / notice shape."""
+
+    async def process_message_stream(self, message, attachments=None):
+        self.messages.append(message)
+        yield {"type": "response", "content": "Prompt blocked by policy.", "complete": True, "uuid": "x"}
+
+
+def _setup(tmp_path, monkeypatch, agent_cls):
+    from kolega_code.cli import main as main_module
+
+    MessageAskFakeAgent.instances = []
+    monkeypatch.setattr(main_module, "CoderAgent", agent_cls)
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("KOLEGA_CODE_PROVIDER", "anthropic")
+    return main_module, project
+
+
+def _lines(capsys):
+    # Strict: every stdout line must be valid JSON.
+    return [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+
+
+def test_json_emits_one_line_per_completed_message(tmp_path, capsys, monkeypatch, isolated_cli_env):
+    main_module, project = _setup(tmp_path, monkeypatch, MessageAskFakeAgent)
+
+    exit_code = main_module.main(["ask", "run the tests", "--project", str(project), "--json"])
+    assert exit_code == 0
+
+    lines = _lines(capsys)
+    kinds = [line["kind"] for line in lines]
+    assert "chunk" not in kinds
+
+    messages = [line["data"] for line in lines if line["kind"] == "message"]
+    assert len(messages) == 2
+    assert all(m["role"] == "assistant" for m in messages)
+
+    first, second = messages
+    assert first["stop_reason"] == "tool_use"
+    block_types = [block["type"] for block in first["content"]]
+    assert block_types == ["thinking", "text", "tool_call"]
+    tool_call = first["content"][2]
+    assert tool_call["name"] == "exec_command"
+    assert tool_call["input"] == {"command": "pytest -q"}
+    assert first["usage"]["total_tokens"] == 120
+    # Opaque provider state stripped; raw provider metadata not exposed.
+    assert "signature" not in first["content"][0]
+    assert "usage_metadata" not in first
+
+    assert second["stop_reason"] == "end_turn"
+    assert second["content"] == [{"type": "text", "text": "All green."}]
+    assert second["usage"]["total_tokens"] == 160
+
+    summary = lines[-1]
+    assert summary["kind"] == "summary"
+    assert summary["messages"] == 2
+    assert "chunks" not in summary
+
+
+def test_json_suppresses_streaming_delta_events(tmp_path, capsys, monkeypatch, isolated_cli_env):
+    from kolega_code.events import AgentEvent
+
+    class DeltaEmittingFakeAgent(MessageAskFakeAgent):
+        async def process_message_stream(self, message, attachments=None):
+            manager = self.kwargs["connection_manager"]
+            await manager.broadcast_event(
+                AgentEvent(event_type="assistant_delta", sender="coder", content={"text": "dup", "complete": False}),
+                "ws",
+                "thread",
+            )
+            await manager.broadcast_event(
+                AgentEvent(event_type="chat_message", sender="coder", content={"message_type": "tool_call"}),
+                "ws",
+                "thread",
+            )
+            async for item in MessageAskFakeAgent.process_message_stream(self, message, attachments):
+                yield item
+
+    main_module, project = _setup(tmp_path, monkeypatch, DeltaEmittingFakeAgent)
+    exit_code = main_module.main(["ask", "go", "--project", str(project), "--json"])
+    assert exit_code == 0
+
+    lines = _lines(capsys)
+    event_types = [line["data"]["event_type"] for line in lines if line["kind"] == "event"]
+    assert "assistant_delta" not in event_types
+    assert "chat_message" in event_types
+
+
+def test_terminal_chunk_without_history_becomes_synthetic_message(tmp_path, capsys, monkeypatch, isolated_cli_env):
+    main_module, project = _setup(tmp_path, monkeypatch, NoHistoryFakeAgent)
+    exit_code = main_module.main(["ask", "anything", "--project", str(project), "--json"])
+    assert exit_code == 0
+
+    lines = _lines(capsys)
+    messages = [line["data"] for line in lines if line["kind"] == "message"]
+    assert messages == [
+        {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Prompt blocked by policy."}],
+            "stop_reason": "end_turn",
+        }
+    ]
+
+
+def test_plain_mode_output_is_unchanged(tmp_path, capsys, monkeypatch, isolated_cli_env):
+    main_module, project = _setup(tmp_path, monkeypatch, MessageAskFakeAgent)
+    exit_code = main_module.main(["ask", "run the tests", "--project", str(project)])
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    # Chunk-driven streaming to stdout, exactly as before: deltas concatenate
+    # (no newline until a completing chunk carries content), empty flushes
+    # print nothing.
+    assert captured.out == "Checking the tests.All green.\n"
+
+
+def test_loop_fresh_emitter_survives_history_clear(tmp_path, capsys, monkeypatch, isolated_cli_env):
+    from datetime import datetime, timedelta
+
+    from kolega_code.cli import loop as loop_module
+    from kolega_code.cli import main as main_module
+
+    _setup(tmp_path, monkeypatch, MessageAskFakeAgent)
+    project = tmp_path / "project"
+
+    clock = {"now": datetime(2026, 7, 27, 10, 0, 0)}
+    monkeypatch.setattr(loop_module, "now_local", lambda: clock["now"])
+
+    async def fake_sleep(seconds):
+        clock["now"] += timedelta(seconds=seconds)
+
+    monkeypatch.setattr(main_module.asyncio, "sleep", fake_sleep)
+
+    exit_code = main_module.main(
+        [
+            "ask",
+            "check",
+            "--project",
+            str(project),
+            "--json",
+            "--loop",
+            "5m",
+            "--loop-max-iterations",
+            "2",
+            "--loop-fresh",
+        ]
+    )
+    assert exit_code == 0
+
+    lines = _lines(capsys)
+    messages = [line for line in lines if line["kind"] == "message"]
+    # Two iterations x two assistant messages each, despite clear_history between.
+    assert len(messages) == 4
+    assert lines[-1]["messages"] == 4

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -811,9 +811,10 @@ def test_ask_json_interleaves_sub_agent_events(
     assert exit_code == 0
     lines = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
     kinds = [line["kind"] for line in lines]
+    assert "chunk" not in kinds  # the chunk protocol is gone
     event_index = kinds.index("event")
-    final_chunk_index = max(i for i, line in enumerate(lines) if line["kind"] == "chunk")
-    assert event_index < final_chunk_index, "sub-agent event should interleave before the final chunk"
+    message_index = kinds.index("message")
+    assert event_index < message_index, "sub-agent event should interleave before the completed message"
     event_line = lines[event_index]
     assert event_line["data"]["sub_agent_info"]["agent_name"] == "general-agent"
 


### PR DESCRIPTION
## Summary

PR 5 of the token-accounting train — **stacked on #430** (bases through #427/#423); retarget as the stack merges. (Stacked because #423/#427 also modify `_run_ask`; the feature itself only needs PR 1's `Message.usage`, already on `main`.)

**Deliberate breaking change to the `ask --json` contract**: instead of one line per streaming chunk (plus the same prose duplicated via `assistant_delta`/`thinking_delta` events), stdout now carries one **`{"kind": "message"}`** line per **completed assistant message**:

```json
{"kind": "message", "data": {
  "role": "assistant",
  "content": [
    {"type": "text", "text": "Checking the tests."},
    {"type": "tool_call", "id": "t1", "name": "exec_command", "input": {"command": "pytest -q"}}
  ],
  "stop_reason": "tool_use",
  "usage": {"provider": "anthropic", "input_tokens": 1200, "output_tokens": 85, "total_tokens": 1285, ...}
}}
```

- **Sourced from history, race-free.** `BaseAgent` appends each assistant message to history *before* yielding its final chunk, so the new `AskMessageEmitter` (`cli/ask_output.py`) drains completed messages on every completed response chunk — mid-turn tool-round messages emit as they finish, not at turn end. A `len < seen` reset makes it robust to `--loop-fresh` history clears.
- **Clean payloads.** Content blocks (text, thinking, tool calls), `stop_reason`, and PR 1's normalized `usage`; opaque provider state (thinking signatures, encrypted reasoning blocks, thought signatures) and the raw `usage_metadata` dict are stripped.
- **Nothing silently lost.** Informational terminal chunks that never enter history (hook blocks, agent-command results, silent-turn notices, unsupported attachments) become synthetic text messages; skill activation emits a `message` instead of the old pseudo-chunk.
- **Events keep signal, lose noise.** Tool/sub-agent/workflow/lifecycle events still stream; only the two prose-duplicating delta types are suppressed in json mode.
- `summary` now reports `messages` (emitted count) instead of `chunks`. **Plain (non-`--json`) output is byte-identical.** Docs updated: `ask.md` contract table, `goal.md` worked example, `loop.md`.

## Test plan

- [x] New `tests/cli/test_ask_json_messages.py` (5): two-message tool-round turn → exactly two ordered structured `message` lines (blocks/stop_reason/usage, opaque fields stripped, `usage_metadata` absent), zero chunks, strict JSONL; delta events suppressed while `chat_message` events pass; no-history terminal chunk → synthetic message; plain-mode byte-identical; `--loop-fresh` two iterations → four messages with correct summary count.
- [x] Rewrote the one structurally-breaking test (`test_main.py` event-ordering) against `message` lines.
- [x] All ask suites + full suite: **4072 passed, 0 failed**; ruff/pyright/pre-commit clean.
- [x] **Live end-to-end**: real `kolega-code ask --json` run — strict JSONL, one `message` line with normalized usage, 6 events with no deltas, `summary.messages: 1`, zero chunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014i5XzWgcpSWu5v85iXXiE5