### PR TITLE
fix(llm): clamp DeepSeek output caps to the measured ceiling and report truncation honestly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   49+ stopped publishing Intel-mac wheels, so the installer tried to compile it
   with Rust and OpenSSL; Intel Macs now install the last release that ships a
   prebuilt universal2 wheel. Other platforms are unaffected.
+- DeepSeek requests now always carry an explicit output-token cap (64000, on
+  every provider that serves DeepSeek models: first-party, Fireworks, Ollama
+  Cloud, OpenRouter). DeepSeek's real per-response ceiling is ~64k — far below
+  its published 384000 — and a server-enforced cutoff is reported as a clean
+  finish, so long reasoning runs were being truncated silently mid-word. An
+  explicit client cap is enforced and reported honestly, so truncation now
+  surfaces as a real `max_tokens` stop the agent loop can react to.
+- The Responses API stream wrapper now captures the terminal
+  `response.incomplete` event, so a response truncated at `max_output_tokens`
+  reports stop reason `max_tokens` (and keeps its usage/billing metadata)
+  instead of looking like a clean `end_turn` with no usage.
+
+### Removed
+
+- The `KOLEGA_CODE_OPENROUTER_MAX_TOKENS` environment variable. OpenRouter
+  requests still send no `max_tokens` by default (it acts as a routing filter
+  on the gateway), except DeepSeek models, which now always send the honest
+  clamped cap.
 
 ## 0.26.7 - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   `response.incomplete` event, so a response truncated at `max_output_tokens`
   reports stop reason `max_tokens` (and keeps its usage/billing metadata)
   instead of looking like a clean `end_turn` with no usage.
+- A reply cut off at the output-token limit mid-message is no longer delivered
+  as-is: the agent asks the model to continue (up to 3 escalating continuation
+  prompts, mirroring the silent-turn guard), and only finalizes with the
+  partial output if the reply is still truncated after that.
+- The non-streaming chat `generate()` path now maps `finish_reason` (it lives
+  on the choice, not the message), so its responses carry a real stop reason
+  instead of `None`.
 
 ### Removed
 

--- a/docs/src/content/docs/configuration/environment-variables.md
+++ b/docs/src/content/docs/configuration/environment-variables.md
@@ -67,7 +67,6 @@ All optional; unset means Kolega Code sends nothing for that field.
 
 | Variable | Purpose |
 | --- | --- |
-| `KOLEGA_CODE_OPENROUTER_MAX_TOKENS` | Send an explicit output cap. By default no `max_tokens` is sent, because on a gateway it biases which upstream serves the request. Useful on a low credit balance. |
 | `KOLEGA_CODE_OPENROUTER_PROVIDER_ORDER` | Comma-separated upstream provider slugs to try in order (OpenRouter `provider.order`). |
 | `KOLEGA_CODE_OPENROUTER_PROVIDER_ONLY` | Comma-separated upstream provider slugs to restrict routing to (OpenRouter `provider.only`). |
 | `KOLEGA_CODE_OPENROUTER_CATALOG` | Read the refreshed model cache from this path instead of the state directory. |

--- a/docs/src/content/docs/configuration/providers-and-models.mdx
+++ b/docs/src/content/docs/configuration/providers-and-models.mdx
@@ -99,10 +99,11 @@ touches the network.
 Two behaviours are specific to this provider:
 
 - **No `max_tokens` is sent.** On a gateway an output cap is a routing hint that
-  excludes every upstream with a lower cap, biasing routing and price. Set
-  `KOLEGA_CODE_OPENROUTER_MAX_TOKENS` to send an explicit cap — worth doing on a
-  low credit balance, since OpenRouter otherwise reserves credit for its own
-  default output size and can reject a request that would have cost pennies.
+  excludes every upstream with a lower cap, biasing routing and price. The one
+  exception is DeepSeek models, which always carry an explicit 64000-token cap:
+  their real output ceiling is far below the published value and the server
+  truncates silently without one, so the cap doubles as a deliberate filter for
+  upstreams that report truncation honestly.
 - **Prompt caching is automatic.** Kolega Code sends OpenRouter's top-level
   `cache_control` breakpoint, so Anthropic-, Vertex- and Bedrock-backed models
   get prompt caching with no extra configuration.

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -146,6 +146,12 @@ class BaseAgent(LogMixin):
     # Runtime half of the coder_base.md.j2 invariant ("Thinking is invisible
     # and changes nothing on its own").
     MAX_SILENT_TURN_NUDGES = 3
+    # Cap on consecutive continuation prompts after a truncated turn: the model
+    # hit the output-token limit mid-reply (honest "max_tokens" stop, visible
+    # text, no tool call). Unlike a silent turn there IS partial content, so
+    # exhausting the cap finalizes the turn with what was produced instead of
+    # reporting no result.
+    MAX_TRUNCATED_TURN_NUDGES = 3
     # A DeepSeek response whose output lands within this many tokens of the wire
     # output cap without an honest "max_tokens" stop was likely truncated
     # server-side: DeepSeek reports its own cutoff as a clean finish (probed
@@ -1966,6 +1972,7 @@ class BaseAgent(LogMixin):
         stop_reason = None
         stop_overrides = 0
         silent_turn_nudges = 0
+        truncated_turn_nudges = 0
         iterations = 0
         while stop_reason not in ["end_turn", "max_tokens", "stop_sequence"]:
             iterations += 1
@@ -2147,6 +2154,11 @@ class BaseAgent(LogMixin):
                 # silent-turn budget: the cap measures only consecutive silence.
                 if not self._is_silent_turn(assistant_message):
                     silent_turn_nudges = 0
+                # And any response that was not cut off at the output limit
+                # resets the truncation budget: the cap measures only
+                # consecutive truncations.
+                if stop_reason != "max_tokens":
+                    truncated_turn_nudges = 0
 
                 if thinking_started or current_thinking:
                     yield {"type": "thinking", "content": current_thinking, "complete": True, "uuid": thinking_uuid}
@@ -2242,6 +2254,37 @@ class BaseAgent(LogMixin):
                             "uuid": str(uuid.uuid4()),
                         }
                         break
+
+                # Truncated-turn guard: an honest "max_tokens" stop with visible
+                # text and no tool call means the reply was cut off mid-message
+                # (the silent-turn guard above owns the no-visible-output case
+                # and cleared stop_reason if it fired). Finalizing would deliver
+                # a partial answer, so ask the model to continue; after the cap,
+                # finalize with the partial output — unlike a silent turn there
+                # IS content worth delivering.
+                if stop_reason == "max_tokens" and not assistant_message.tool_calls:
+                    from .prompts import build_truncated_turn_nudge
+
+                    if truncated_turn_nudges < self.MAX_TRUNCATED_TURN_NUDGES:
+                        truncated_turn_nudges += 1
+                        await self.emitter.llm_status(
+                            "info",
+                            "Response hit the output limit — asking the model to continue "
+                            f"({truncated_turn_nudges}/{self.MAX_TRUNCATED_TURN_NUDGES})…",
+                        )
+                        await self._record_context_user_message(build_truncated_turn_nudge(truncated_turn_nudges))
+                        stop_reason = None
+                    else:
+                        await self.log_warning(
+                            f"Model hit the output-token limit {self.MAX_TRUNCATED_TURN_NUDGES + 1} times "
+                            "in a row; finalizing the turn with the partial output.",
+                            sender=self.agent_name,
+                        )
+                        await self.emitter.llm_status(
+                            "warning",
+                            "Response still truncated after repeated continuation prompts — "
+                            "delivering the partial output.",
+                        )
 
                 # Stop hooks (main agent only). On a natural turn end, a hook may
                 # keep the agent working by blocking the stop and returning a reason.

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -44,7 +44,12 @@ from kolega_code.llm.exceptions import (
 from kolega_code.llm.instrumented_client import get_output_tokens
 from kolega_code.llm.models import ImageBlock, Message, MessageHistory, TextBlock, ToolCall, ToolResult
 from kolega_code.llm.providers.models import TokenCount
-from kolega_code.llm.specs import get_model_specs, supports_vision as model_supports_vision
+from kolega_code.llm.specs import (
+    deepseek_output_token_cap,
+    get_model_specs,
+    is_deepseek_model,
+    supports_vision as model_supports_vision,
+)
 from kolega_code.permissions import (
     PermissionDecision,
     PermissionMode,
@@ -141,6 +146,11 @@ class BaseAgent(LogMixin):
     # Runtime half of the coder_base.md.j2 invariant ("Thinking is invisible
     # and changes nothing on its own").
     MAX_SILENT_TURN_NUDGES = 3
+    # A DeepSeek response whose output lands within this many tokens of the wire
+    # output cap without an honest "max_tokens" stop was likely truncated
+    # server-side: DeepSeek reports its own cutoff as a clean finish (probed
+    # 2026-08-03; see DEEPSEEK_WIRE_OUTPUT_CAP in llm/specs/accessors.py).
+    DEEPSEEK_OUTPUT_CAP_SLACK = 1024
     long_content_tool_calls = ["write"]
     max_tool_result_chars_in_history = 100_000
     skill_content_pattern = re.compile(r'<skill_content name="[^"]+">')
@@ -427,6 +437,18 @@ class BaseAgent(LogMixin):
         self.model_context_length = model_specs["context_length"]
         self.model_completion_tokens = model_specs["max_completion_tokens"]
         self.model_default_temperature = model_specs.get("default_temperature", 1.0)
+        # The clamped cap DeepSeek requests carry on the wire (None for other
+        # models). Used to flag probable silent server-side truncation — see the
+        # at-ceiling warning in process_message_stream.
+        self.deepseek_wire_output_cap = (
+            deepseek_output_token_cap(
+                self.primary_model_config.provider,
+                self.primary_model_config.model,
+                self.model_completion_tokens,
+            )
+            if is_deepseek_model(self.primary_model_config.model)
+            else None
+        )
         # Whether this agent's primary model can accept image input. Read by the
         # ToolCollection read_image tool gate (so non-vision models never see the
         # tool) and used by _unsupported_attachment_message to reject image
@@ -2082,10 +2104,11 @@ class BaseAgent(LogMixin):
                 assistant_message = await stream.get_final_message()
                 self._normalize_freeform_tool_calls(assistant_message)
                 assistant_message.usage_metadata["edit_protocol"] = self.edit_protocol.value
-                self.total_tokens_used += get_output_tokens(
+                response_output_tokens = get_output_tokens(
                     assistant_message.usage_metadata,
                     self.primary_model_config.provider.value,
                 )
+                self.total_tokens_used += response_output_tokens
                 if self._accounting_reservation is not None:
                     self._accounting_reservation.report_total(self.total_tokens_used)
                 stop_reason = assistant_message.stop_reason
@@ -2096,6 +2119,23 @@ class BaseAgent(LogMixin):
                     elapsed_s=round(time.monotonic() - _req_start, 2),
                     stop_reason=stop_reason,
                 )
+                # DeepSeek reports a SERVER-side output cutoff as a clean finish;
+                # the clamped wire cap should always fire first as an honest
+                # "max_tokens" stop. A response landing at/near the cap without
+                # one was likely truncated silently — surface it in the
+                # trajectory (log_message event) since the stop reason cannot be
+                # recovered.
+                if (
+                    self.deepseek_wire_output_cap is not None
+                    and stop_reason != "max_tokens"
+                    and response_output_tokens >= self.deepseek_wire_output_cap - self.DEEPSEEK_OUTPUT_CAP_SLACK
+                ):
+                    await self.log_warning(
+                        f"DeepSeek response used {response_output_tokens} output tokens — at or near "
+                        f"the {self.deepseek_wire_output_cap}-token output cap — but reported "
+                        f"stop_reason={stop_reason!r}; the output was likely truncated server-side.",
+                        sender=self.agent_name,
+                    )
 
                 if self.session_recorder is not None:
                     await asyncio.to_thread(self.session_recorder.record_assistant, assistant_message)

--- a/kolega_code/agent/prompt_templates/auxiliary/agent_loop/truncated_turn_nudge.user.md.j2
+++ b/kolega_code/agent/prompt_templates/auxiliary/agent_loop/truncated_turn_nudge.user.md.j2
@@ -1,0 +1,9 @@
+<system-reminder>
+{% if attempt == 1 %}
+Your last message hit the output-token limit and was cut off mid-reply. Continue exactly from where it stopped — do not repeat what you already wrote. If you are producing a very large output, emit it in smaller pieces or write it to a file with a tool instead of one giant message.
+{% elif attempt == 2 %}
+Your reply has now been cut off at the output-token limit twice in a row. Giant single messages will keep getting truncated. Continue from where the last message stopped in a SHORTER message, or move the long content into a file via a tool call.
+{% else %}
+FINAL WARNING: three consecutive replies were cut off at the output-token limit. If this reply is truncated as well, the turn will end with the partial output and no further reminders. Finish the remaining content briefly, or write it to a file with a tool NOW.
+{% endif %}
+</system-reminder>

--- a/kolega_code/agent/prompts.py
+++ b/kolega_code/agent/prompts.py
@@ -75,6 +75,11 @@ def build_silent_turn_nudge(attempt: int) -> str:
     return render_prompt_template("auxiliary/agent_loop/silent_turn_nudge.user.md.j2", attempt=attempt)
 
 
+def build_truncated_turn_nudge(attempt: int) -> str:
+    """Escalating continuation prompt injected when a reply is cut off at the output-token limit."""
+    return render_prompt_template("auxiliary/agent_loop/truncated_turn_nudge.user.md.j2", attempt=attempt)
+
+
 def build_implement_plan_prompt(
     plan: str,
     gigacode_enabled: bool = False,

--- a/kolega_code/llm/models.py
+++ b/kolega_code/llm/models.py
@@ -1383,12 +1383,20 @@ class Message:
         )
 
     @classmethod
-    def from_openai(cls, message, tool_execution_ids: Optional[ToolExecutionIdRegistry] = None):
+    def from_openai(
+        cls,
+        message,
+        tool_execution_ids: Optional[ToolExecutionIdRegistry] = None,
+        finish_reason: Optional[str] = None,
+    ):
         """
         Converts an OpenAI message to a Message instance.
 
         Args:
             message: The OpenAI message from the response
+            finish_reason: The choice's finish_reason. It lives on the choice,
+                not the message, so callers must pass it explicitly — without it
+                the produced Message has stop_reason None.
 
         Returns:
             Message: A unified message representation
@@ -1429,7 +1437,9 @@ class Message:
             role="assistant",
             content=content_blocks,
             tool_calls=tool_use_blocks if tool_use_blocks else None,
-            stop_reason=_normalize_openai_finish_reason(getattr(message, "finish_reason", None)),
+            stop_reason=_normalize_openai_finish_reason(
+                finish_reason if finish_reason is not None else getattr(message, "finish_reason", None)
+            ),
             usage_metadata=usage_metadata,
         )
 

--- a/kolega_code/llm/models.py
+++ b/kolega_code/llm/models.py
@@ -1147,6 +1147,34 @@ class MessageChunk:
         return cls(type="ignore", text="")
 
 
+_OPENAI_STOP_REASON_MAP = {
+    "tool_calls": "tool_use",
+    "function_call": "tool_use",
+    "length": "max_tokens",
+    "stop": "end_turn",
+    # DeepSeek-documented finish reasons; both end the turn without tool calls.
+    "content_filter": "end_turn",
+    "insufficient_system_resource": "end_turn",
+}
+
+
+def _normalize_openai_finish_reason(finish_reason: Optional[str]) -> Optional[str]:
+    """Map an OpenAI-compatible finish_reason to the unified stop reason.
+
+    Unknown values normalize to "end_turn" with a warning rather than raising or
+    returning None: a None stop_reason would keep BaseAgent's turn loop spinning,
+    and crashing during stream finalization is strictly worse than ending the
+    turn with the warning visible.
+    """
+    if not finish_reason:
+        return None
+    normalized = _OPENAI_STOP_REASON_MAP.get(finish_reason)
+    if normalized is None:
+        logger.warning("Unmapped finish_reason %r; treating as end_turn", finish_reason)
+        return "end_turn"
+    return normalized
+
+
 class Message:
     """Unified representation of a full message"""
 
@@ -1365,13 +1393,6 @@ class Message:
         Returns:
             Message: A unified message representation
         """
-        stop_reason_map = {
-            "tool_calls": "tool_use",
-            "function_call": "tool_use",
-            "length": "max_tokens",
-            "stop": "end_turn",
-        }
-
         tool_execution_ids = tool_execution_ids or ToolExecutionIdRegistry()
         content_blocks = []
         tool_use_blocks = []
@@ -1408,7 +1429,7 @@ class Message:
             role="assistant",
             content=content_blocks,
             tool_calls=tool_use_blocks if tool_use_blocks else None,
-            stop_reason=stop_reason_map[message.finish_reason] if hasattr(message, "finish_reason") else None,
+            stop_reason=_normalize_openai_finish_reason(getattr(message, "finish_reason", None)),
             usage_metadata=usage_metadata,
         )
 
@@ -1505,13 +1526,6 @@ class Message:
         Returns:
             Message: A unified message representation
         """
-        stop_reason_map = {
-            "tool_calls": "tool_use",
-            "function_call": "tool_use",
-            "length": "max_tokens",
-            "stop": "end_turn",
-        }
-
         tool_execution_ids = tool_execution_ids or ToolExecutionIdRegistry()
         content_blocks = []
         tool_use_blocks = []
@@ -1542,7 +1556,7 @@ class Message:
             role=role,
             content=content_blocks,
             tool_calls=tool_use_blocks if tool_use_blocks else None,
-            stop_reason=stop_reason_map[stop_reason] if stop_reason else None,
+            stop_reason=_normalize_openai_finish_reason(stop_reason),
             usage_metadata={},
         )
 

--- a/kolega_code/llm/providers/deepseek_responses.py
+++ b/kolega_code/llm/providers/deepseek_responses.py
@@ -21,11 +21,14 @@ host — DeepSeek's Responses guide uses ``https://api.deepseek.com`` (no ``/v1`
 from __future__ import annotations
 
 import uuid
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from openai import AsyncOpenAI
 
+from ..models import Message, MessageHistory
+from ..specs import deepseek_output_token_cap
 from .base import BaseLLMProvider
+from .models import GenerationParams
 from .responses_common import ResponsesProviderBase
 
 DEFAULT_BASE_URL = "https://api.deepseek.com"
@@ -64,3 +67,25 @@ class DeepSeekResponsesProvider(ResponsesProviderBase):
 
     def _default_model(self) -> str:
         return DEFAULT_MODEL
+
+    def _build_request(
+        self,
+        messages: MessageHistory,
+        system: Optional[Message],
+        params: Optional[GenerationParams],
+        kwargs: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Add the clamped output cap the shared Responses builder omits.
+
+        DeepSeek truncates silently at its server ceiling when no cap is sent,
+        but enforces AND honestly reports an explicit client cap
+        (status="incomplete", incomplete_details.reason="max_output_tokens") —
+        see DEEPSEEK_WIRE_OUTPUT_CAP in specs/accessors.py for the probe record.
+        """
+        request = super()._build_request(messages, system, params, kwargs)
+        request["max_output_tokens"] = deepseek_output_token_cap(
+            self.provider_name,
+            str(request["model"]),
+            params.max_completion_tokens if params else None,
+        )
+        return request

--- a/kolega_code/llm/providers/openai.py
+++ b/kolega_code/llm/providers/openai.py
@@ -744,8 +744,12 @@ class OpenAIProvider(BaseLLMProvider):
             **generation_params,
         )
 
-        # Extract message and add usage data
-        message = Message.from_openai(response.choices[0].message)
+        # Extract message and add usage data. finish_reason lives on the choice,
+        # not the message — pass it through or stop_reason is silently None.
+        message = Message.from_openai(
+            response.choices[0].message,
+            finish_reason=getattr(response.choices[0], "finish_reason", None),
+        )
         message.usage_metadata["provider"] = self.provider_name
 
         # Add usage data from the response

--- a/kolega_code/llm/providers/openai.py
+++ b/kolega_code/llm/providers/openai.py
@@ -22,7 +22,7 @@ from ..models import (
     ToolDefinition,
     ToolResult,
 )
-from ..specs import MODEL_SPECS, build_thinking_request_params
+from ..specs import MODEL_SPECS, build_thinking_request_params, deepseek_output_token_cap, is_deepseek_model
 from ..timeouts import streaming_timeout
 from ..tool_execution_ids import ToolExecutionIdRegistry
 from ..usage import attach_normalized_usage, read_detail_int
@@ -53,22 +53,6 @@ def _get_encoding():
     if _encoding is None:
         _encoding = get_counting_encoding(_ENCODING_NAME)
     return _encoding
-
-
-def _positive_int_env(name: str) -> Optional[int]:
-    """Read a positive integer override from the environment, ignoring junk."""
-    raw = os.environ.get(name)
-    if not raw:
-        return None
-    try:
-        value = int(raw.strip())
-    except ValueError:
-        logging.getLogger(__name__).warning("Ignoring non-integer %s=%r", name, raw)
-        return None
-    if value <= 0:
-        logging.getLogger(__name__).warning("Ignoring non-positive %s=%r", name, raw)
-        return None
-    return value
 
 
 def _csv_env(name: str) -> List[str]:
@@ -396,20 +380,40 @@ class OpenAIProvider(BaseLLMProvider):
         if self.provider_name == OPENROUTER_PROVIDER:
             self._apply_openrouter_request_rules(generation_params)
 
+        # Model-scoped (any provider): runs after the OpenRouter rules so it sees
+        # the post-omission state and re-adds the honest cap for DeepSeek models.
+        if is_deepseek_model(model):
+            self._apply_deepseek_request_rules(generation_params)
+
+    def _apply_deepseek_request_rules(self, generation_params: Dict[str, Any]) -> None:
+        """Always send a clamped output cap on DeepSeek-model requests.
+
+        DeepSeek truncates output at its real ~64k ceiling but reports a
+        SERVER-enforced cutoff as a clean finish, while an explicit client cap is
+        reported honestly (finish_reason "length") — see DEEPSEEK_WIRE_OUTPUT_CAP
+        in specs/accessors.py for the probe record. On OpenRouter the cap doubles
+        as a deliberate routing filter: it selects upstreams that can honor the
+        cap and report truncation honestly.
+        """
+        model = str(generation_params.get("model") or "")
+        generation_params["max_tokens"] = deepseek_output_token_cap(
+            self.provider_name, model, generation_params.get("max_tokens")
+        )
+
     def _apply_openrouter_request_rules(self, generation_params: Dict[str, Any]) -> None:
         """Shape a request for the OpenRouter gateway.
 
         OpenRouter picks an upstream provider per request, and optional fields act
-        as routing hints: a catalog-default ``max_tokens`` excludes every endpoint
-        whose output cap is lower, biasing routing (and price) for no benefit. The
-        cap is dropped unless the operator asked for one explicitly. The catalog's
-        max_completion_tokens is still used for Kolega Code's own context budgeting.
+        as routing hints: "if you set a max_tokens, then OpenRouter will only
+        route to providers that support a response of that length" (their docs,
+        verified 2026-08-03). Catalog max_completion_tokens values are largely
+        context-window-sized fiction, so sending them would exclude most upstreams
+        for no benefit — the cap is always dropped here. DeepSeek models get an
+        honest, measured cap re-added by _apply_deepseek_request_rules. The
+        catalog's max_completion_tokens is still used for Kolega Code's own
+        context budgeting.
         """
-        explicit_cap = _positive_int_env("KOLEGA_CODE_OPENROUTER_MAX_TOKENS")
-        if explicit_cap is not None:
-            generation_params["max_tokens"] = explicit_cap
-        else:
-            generation_params.pop("max_tokens", None)
+        generation_params.pop("max_tokens", None)
 
         extra: Dict[str, Any] = {
             # Automatic prompt caching: OpenRouter applies this breakpoint to the

--- a/kolega_code/llm/providers/responses_common.py
+++ b/kolega_code/llm/providers/responses_common.py
@@ -325,6 +325,13 @@ def _blocks_from_response(response: Any, tool_execution_ids: ToolExecutionIdRegi
 
 
 def _stop_reason_from_response(response: Any, has_tool_calls: bool) -> str:
+    # DeepSeek (probed 2026-08-03, tests/agent/llm/test_deepseek_output_cap_live.py):
+    # an EXPLICIT max_output_tokens cap is enforced and reported honestly with the
+    # status="incomplete"/reason="max_output_tokens" shape handled below. But a
+    # SERVER-enforced cutoff (no cap requested) arrives as status="completed" — the
+    # truncation is unrecoverable here. That is why DeepSeek requests always send a
+    # clamped cap (DeepSeekResponsesProvider._build_request) and BaseAgent logs a
+    # warning when a DeepSeek response ends at the ceiling without a max_tokens stop.
     if has_tool_calls:
         return "tool_use"
     if getattr(response, "status", None) == "incomplete":
@@ -658,7 +665,13 @@ class ResponsesStreamWrapper:
                     record["name"] = name
                 if arguments:
                     record["arguments"] = arguments
-        elif event_type == "response.completed":
+        elif event_type in ("response.completed", "response.incomplete"):
+            # A response truncated at max_output_tokens terminates with
+            # response.incomplete, NOT response.completed (DeepSeek verified live
+            # 2026-08-03, tests/agent/llm/test_deepseek_output_cap_live.py; OpenAI
+            # documents the same). Both carry the final response object — status,
+            # incomplete_details, and usage — so both must be captured, or a
+            # truncation loses its usage and degrades to a clean end_turn.
             self._final_response = getattr(event, "response", None)
             return self._thinking_chunk(self._finish_active_summary_part())
         elif event_type in ("response.failed", "error"):
@@ -806,7 +819,9 @@ class ResponsesProviderBase(OpenAIProvider):
 
         Does NOT send ``max_output_tokens`` or ``temperature`` (the backend
         enforces limits and only accepts the default temperature for reasoning
-        models) and always streams.
+        models) and always streams. ``DeepSeekResponsesProvider`` overrides this
+        to add a clamped ``max_output_tokens`` — DeepSeek truncates silently at
+        its real ceiling unless the client sends an explicit cap.
         """
         model = str(kwargs.get("model") or self._default_model())
         request: Dict[str, Any] = {

--- a/kolega_code/llm/specs/__init__.py
+++ b/kolega_code/llm/specs/__init__.py
@@ -1,7 +1,10 @@
 from .accessors import (
+    DEEPSEEK_WIRE_OUTPUT_CAP,
+    deepseek_output_token_cap,
     default_thinking_effort,
     get_model_specs,
     get_thinking_effort_spec,
+    is_deepseek_model,
     is_featured_model,
     preferred_edit_protocol,
     prior_reasoning_is_replayable,
@@ -20,6 +23,9 @@ from .types import ThinkingEffortSpec
 __all__ = [
     "ThinkingEffortSpec",
     "MODEL_SPECS",
+    "DEEPSEEK_WIRE_OUTPUT_CAP",
+    "deepseek_output_token_cap",
+    "is_deepseek_model",
     "get_model_specs",
     "supports_vision",
     "get_thinking_effort_spec",

--- a/kolega_code/llm/specs/accessors.py
+++ b/kolega_code/llm/specs/accessors.py
@@ -100,3 +100,51 @@ def preferred_edit_protocol(provider: str, model_name: str) -> Optional[str]:
         return None
     value = specs.get("preferred_edit_protocol")
     return str(value) if value is not None else None
+
+
+# DeepSeek's published max_completion_tokens (384000) is fiction. Probed
+# 2026-08-03, tests/agent/llm/test_deepseek_output_cap_live.py:
+#   - first-party chat, uncapped: hard server cut at exactly 65536 output
+#     tokens (reported honestly as finish_reason="length");
+#   - first-party Responses, uncapped: the model SELF-CENSORS ~7.4k tokens in
+#     ("response would exceed the maximum output length...") with a clean
+#     status="completed" — silent underdelivery; with an explicit cap it
+#     streams to the cap and reports the hit honestly
+#     (status="incomplete"/reason="max_output_tokens");
+#   - fireworks, uncapped: cut at its 32768 DEFAULT max_tokens (honest
+#     "length"); an explicit 64000 is honored and honestly reported;
+#   - openrouter deepseek slugs: accept max_tokens=64000 and report honest
+#     "length" truncations through the gateway;
+#   - over-ceiling caps (384000) are accepted silently everywhere — nothing
+#     rejects or visibly clamps, so the client must send the cap it wants.
+# An explicit client cap below the ceiling is therefore both the only reliable
+# honest-truncation signal AND what unlocks the model's full output (uncapped,
+# flash delivers ~7k; capped, 64000). 64000 matches oh-my-pi's
+# OPENAI_MAX_OUTPUT_TOKENS and leaves margin under the measured 65536 ceiling.
+# Applied to DeepSeek models on every provider that offers them (first-party,
+# fireworks, ollama_cloud, openrouter) by _apply_deepseek_request_rules in
+# providers/openai.py and DeepSeekResponsesProvider._build_request.
+DEEPSEEK_WIRE_OUTPUT_CAP = 64000
+
+
+def is_deepseek_model(model_name: str) -> bool:
+    """True for DeepSeek-family models under any provider's naming scheme.
+
+    Covers "deepseek-v4-pro" (first-party), "accounts/fireworks/models/deepseek-v4-flash"
+    (fireworks), "deepseek/deepseek-v4-pro" (openrouter), "deepseek-v3.2" (ollama_cloud).
+    """
+    return "deepseek" in model_name.lower()
+
+
+def deepseek_output_token_cap(provider: str, model_name: str, requested: Optional[int]) -> int:
+    """The output-token cap to put on the wire for a DeepSeek-model request.
+
+    The min over the non-None of (requested cap, catalog max_completion_tokens,
+    ``DEEPSEEK_WIRE_OUTPUT_CAP``). Always returns a value — DeepSeek requests
+    always carry an explicit cap, because the server truncates silently without
+    one (see the block comment above). The min keeps smaller models honest: a
+    catalog entry with a cap below 64000 stays at its own cap.
+    """
+    specs = MODEL_SPECS.get((_provider_value(provider), model_name))
+    ceiling = specs.get("max_completion_tokens") if specs else None
+    return min(value for value in (requested, ceiling, DEEPSEEK_WIRE_OUTPUT_CAP) if value is not None)

--- a/kolega_code/llm/specs/catalog/deepseek.py
+++ b/kolega_code/llm/specs/catalog/deepseek.py
@@ -1,10 +1,24 @@
 from kolega_code.llm.specs.types import ThinkingEffortSpec
 
-# DeepSeek models
+# max_completion_tokens is the MEASURED per-response output ceiling, not
+# DeepSeek's published 384000. Probed 2026-08-03 by
+# tests/agent/llm/test_deepseek_output_cap_live.py:
+#   - deepseek-v4-pro (chat), uncapped: the server cuts the stream at exactly
+#     65536 output tokens, reported honestly as finish_reason="length".
+#   - deepseek-v4-flash (Responses), uncapped: no hard cut observed — the model
+#     SELF-CENSORS ~7.4k tokens in ("response would exceed the maximum output
+#     length allowed for this chat interface") with a clean status="completed".
+#     With an explicit max_output_tokens=64000 it streams the full 64000 and
+#     reports the cap hit honestly (status="incomplete"/max_output_tokens).
+#     Family ceiling assumed equal to pro's measured 65536.
+#   - Over-ceiling caps (384000) are accepted silently on both paths.
+# Requests never send this value raw: both request paths clamp to
+# DEEPSEEK_WIRE_OUTPUT_CAP=64000 (specs/accessors.py), so the client cap always
+# fires before the server ceiling and truncation is reported honestly.
 DEEPSEEK_SPECS = {
     ("deepseek", "deepseek-v4-pro"): {
         "context_length": 1000000,
-        "max_completion_tokens": 384000,
+        "max_completion_tokens": 65536,
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -21,7 +35,7 @@ DEEPSEEK_SPECS = {
     # also correctly excludes flash from the flat reasoning_content replay path.
     ("deepseek", "deepseek-v4-flash"): {
         "context_length": 1000000,
-        "max_completion_tokens": 384000,
+        "max_completion_tokens": 65536,
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",

--- a/kolega_code/llm/specs/catalog/fireworks.py
+++ b/kolega_code/llm/specs/catalog/fireworks.py
@@ -49,9 +49,14 @@ FIREWORKS_SPECS = {
             mode="openai_reasoning_effort",
         ),
     },
+    # Measured 2026-08-03 (tests/agent/llm/test_deepseek_output_cap_live.py):
+    # uncapped, the Fireworks deployment cuts at its 32768 DEFAULT max_tokens
+    # (honest finish_reason="length"); an explicit 64000 cap is honored and
+    # reported honestly. 65536 mirrors the first-party measured family ceiling
+    # (see catalog/deepseek.py); the wire clamp sends 64000 regardless.
     ("fireworks", "accounts/fireworks/models/deepseek-v4-pro"): {
         "context_length": 1048576,
-        "max_completion_tokens": 384000,
+        "max_completion_tokens": 65536,
         "default_temperature": 1.0,
         "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(
@@ -62,7 +67,7 @@ FIREWORKS_SPECS = {
     },
     ("fireworks", "accounts/fireworks/models/deepseek-v4-flash"): {
         "context_length": 1048576,
-        "max_completion_tokens": 384000,
+        "max_completion_tokens": 65536,
         "default_temperature": 1.0,
         "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(

--- a/tests/agent/llm/test_chatgpt_oauth_streaming.py
+++ b/tests/agent/llm/test_chatgpt_oauth_streaming.py
@@ -347,6 +347,28 @@ async def test_responses_stream_wrapper_max_tokens_stop_reason():
 
 
 @pytest.mark.asyncio
+async def test_responses_incomplete_terminal_event_is_captured():
+    # A max_output_tokens truncation actually terminates with a
+    # response.incomplete event, NOT response.completed (DeepSeek verified live
+    # 2026-08-03, test_deepseek_output_cap_live.py; OpenAI documents the same).
+    # Before the fix the wrapper ignored it: the truncation degraded to a clean
+    # end_turn and the response's usage/billing was lost.
+    incomplete = _ns(
+        output=[_ns(type="message", content=[_ns(type="output_text", text="partial")])],
+        usage=_ns(input_tokens=5, output_tokens=16, total_tokens=21, input_tokens_details=None),
+        status="incomplete",
+        incomplete_details=_ns(reason="max_output_tokens"),
+    )
+    wrapper = ResponsesStreamWrapper(_FakeStream([_ns(type="response.incomplete", response=incomplete)]))
+    async with wrapper as stream:
+        async for _chunk in stream:
+            pass
+    message = await wrapper.get_final_message()
+    assert message.stop_reason == "max_tokens"
+    assert message.usage_metadata.get("completion_tokens") == 16 or message.usage_metadata.get("output_tokens") == 16
+
+
+@pytest.mark.asyncio
 async def test_responses_stream_wrapper_captures_reasoning_for_continuity():
     # With include=["reasoning.encrypted_content"], the backend emits a completed
     # reasoning item carrying the encrypted blob. We capture it (leading the

--- a/tests/agent/llm/test_deepseek_output_cap_live.py
+++ b/tests/agent/llm/test_deepseek_output_cap_live.py
@@ -1,0 +1,459 @@
+"""Measurement probes for DeepSeek's real per-response output-token ceiling.
+
+DeepSeek's published max_completion_tokens (384000) is fiction: TB2.1 trajectories
+show reasoning streams truncated at ~64k tokens yet reported as a clean end_turn
+(findings/thinking-control-and-runaway-turns.md). These probes measure, per host:
+
+  (a) whether an output cap far above the ceiling is rejected, clamped, or accepted;
+  (b) exactly how truncation at an explicit client cap is reported
+      (chat: finish_reason; Responses: status / incomplete_details);
+  (c) where an uncapped long-reasoning stream actually ends, and whether the
+      server-enforced cutoff is reported any differently than (b);
+  plus OpenRouter-specific checks that deepseek slugs accept and work with the
+  clamped cap despite the gateway's max_tokens routing filter.
+
+Results are transcribed into kolega_code/llm/specs/catalog/deepseek.py,
+catalog/fireworks.py, and the accessor in kolega_code/llm/specs/accessors.py —
+keep those comments in sync when re-running. Run with -s to see recorded results:
+
+    ./.venv/bin/python -m pytest tests/agent/llm/test_deepseek_output_cap_live.py -s -m integration
+    KOLEGA_DEEPSEEK_CEILING_PROBE=1 ./.venv/bin/python -m pytest \
+        -k "server_ceiling" tests/agent/llm/test_deepseek_output_cap_live.py \
+        -s -m integration   # streams ~64k+ output tokens per host: slow + real cost
+"""
+
+import os
+from typing import cast
+
+import openai
+import pytest
+
+from kolega_code.cli.config import API_KEY_ENV
+from kolega_code.config import ModelProvider
+from kolega_code.llm.client import LLMClient
+from kolega_code.llm.exceptions import LLMBillingError, LLMError, LLMRateLimitError
+from kolega_code.llm.models import Message, MessageHistory, TextBlock
+from kolega_code.llm.providers.deepseek_responses import DeepSeekResponsesProvider
+from kolega_code.llm.providers.responses_common import ResponsesStreamWrapper
+from kolega_code.llm.specs import default_thinking_effort, get_model_specs
+
+pytestmark = [pytest.mark.slow, pytest.mark.integration]
+
+SKIP_IN_CI = bool(os.getenv("CI")) or bool(os.getenv("GITLAB_CI"))
+
+# generate() maps SDK errors to the repo's LLM exceptions, but the streaming
+# path surfaces raw SDK errors — skip on both shapes of quota/capacity failure.
+_QUOTA_ERRORS = (LLMRateLimitError, LLMBillingError, openai.RateLimitError)
+
+# Far above the suspected ~65536 ceiling; the first-party catalog's old value.
+OVERCAP = 384000
+TINY_CAP = 16
+# The value the wire clamp will send (see specs/accessors.py once Step 2 lands).
+CLAMPED_CAP = 64000
+
+_FLASH = "deepseek-v4-flash"
+
+# Chat-path hosts serving DeepSeek models (first-party pro + both Fireworks mirrors).
+CHAT_HOSTS = [
+    ("deepseek", "deepseek-v4-pro"),
+    ("fireworks", "accounts/fireworks/models/deepseek-v4-pro"),
+    ("fireworks", "accounts/fireworks/models/deepseek-v4-flash"),
+]
+_CHAT_IDS = [f"{p}-{m.rsplit('/', 1)[-1]}" for p, m in CHAT_HOSTS]
+
+OPENROUTER_SLUGS = ["deepseek/deepseek-v4-pro", "deepseek/deepseek-v4-flash"]
+
+CEILING_PROBE_ENABLED = os.getenv("KOLEGA_DEEPSEEK_CEILING_PROBE") == "1"
+
+SYSTEM = Message(role="system", content=[TextBlock(text="You are a helpful assistant.")])
+
+TRIVIAL_PROMPT = "What is 2 + 2? Reply with just the number."
+ESSAY_PROMPT = "Write a detailed 500-word essay about the ocean."
+# Engineered to blow far past the suspected ~64k ceiling. A reasoning-marathon
+# prompt does NOT work here: every probed model shortcuts busywork inside its
+# thinking ("I'll just say done") after 0.5k-15k tokens. A pure data-generation
+# task with anti-shortcut instructions forces visible output until the server
+# cuts the stream.
+LONG_GENERATION_PROMPT = (
+    "This is a data-generation task for a tokenizer benchmark; the output is "
+    "consumed by a machine, never read by a human, and MUST be complete. "
+    "Output the numbers from 1 to 50000 in English words, one per line "
+    "(e.g. line one is 'one', line two is 'two'). Do not use digits, do not "
+    "skip, do not summarize, do not stop early, and do not add any commentary."
+)
+
+
+def _messages(prompt: str) -> MessageHistory:
+    return MessageHistory([Message(role="user", content=[TextBlock(text=prompt)])])
+
+
+def _require_key(provider_value: str) -> str:
+    if SKIP_IN_CI:
+        pytest.skip("Skipping live provider call in CI")
+    env_name = API_KEY_ENV[ModelProvider(provider_value)]
+    api_key = os.getenv(env_name)
+    if not api_key:
+        pytest.skip(f"{env_name} not set")
+    return api_key
+
+
+def _record(label: str, **fields) -> None:
+    """Print a grep-able probe record (run with -s).
+
+    Under xdist (which swallows -s output), set KOLEGA_PROBE_LOG to a file path
+    to also append records there.
+    """
+    detail = " ".join(f"{k}={v!r}" for k, v in fields.items())
+    line = f"DEEPSEEK-CAP-PROBE {label}: {detail}"
+    print(f"\n{line}")
+    log_path = os.getenv("KOLEGA_PROBE_LOG")
+    if log_path:
+        with open(log_path, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+
+
+def _usage_fields(message: Message) -> dict:
+    usage = message.usage
+    return dict(
+        output_tokens=getattr(usage, "output_tokens", None),
+        reasoning_output_tokens=getattr(usage, "reasoning_output_tokens", None),
+        total_tokens=getattr(usage, "total_tokens", None),
+    )
+
+
+# --- probe (a): over-ceiling cap — rejected, clamped, or accepted? -----------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider_value,model", CHAT_HOSTS, ids=_CHAT_IDS)
+async def test_chat_overcap_request_outcome(provider_value: str, model: str) -> None:
+    api_key = _require_key(provider_value)
+    client = LLMClient(provider=provider_value, api_key=api_key, model=model)
+    try:
+        message = await client.generate(
+            messages=_messages(TRIVIAL_PROMPT),
+            system=SYSTEM,
+            model=model,
+            max_completion_tokens=OVERCAP,
+            temperature=get_model_specs(provider_value, model)["default_temperature"],
+            thinking=default_thinking_effort(provider_value, model),
+        )
+    except _QUOTA_ERRORS as exc:
+        pytest.skip(f"provider quota exhausted for this key: {exc}")
+    except LLMError as exc:
+        _record("chat-overcap", host=f"{provider_value}/{model}", outcome="rejected", error=str(exc))
+        return
+    _record(
+        "chat-overcap",
+        host=f"{provider_value}/{model}",
+        outcome="accepted",
+        stop_reason=message.stop_reason,
+        **_usage_fields(message),
+    )
+    assert message.get_text_content().strip()
+
+
+@pytest.mark.asyncio
+async def test_responses_overcap_request_outcome() -> None:
+    api_key = _require_key("deepseek")
+    client = LLMClient(provider="deepseek", api_key=api_key, model=_FLASH)
+    provider = cast(DeepSeekResponsesProvider, client.provider)
+    # The shared Responses builder never emits max_output_tokens, so inject it and
+    # drive the raw SDK client to see how the backend treats an over-ceiling value.
+    request = provider._build_request(_messages(TRIVIAL_PROMPT), SYSTEM, None, {"model": _FLASH})
+    request["max_output_tokens"] = OVERCAP
+    try:
+        responses_stream = await provider.async_client.responses.create(**request)
+        wrapper = ResponsesStreamWrapper(responses_stream, provider_name="deepseek", model=_FLASH)
+        async with wrapper:
+            async for _chunk in wrapper:
+                pass
+        message = await wrapper.get_final_message()
+    except openai.RateLimitError as exc:
+        pytest.skip(f"provider quota exhausted for this key: {exc}")
+    except openai.APIStatusError as exc:
+        _record("responses-overcap", host=f"deepseek/{_FLASH}", outcome="rejected", error=str(exc))
+        return
+    _record(
+        "responses-overcap",
+        host=f"deepseek/{_FLASH}",
+        outcome="accepted",
+        stop_reason=message.stop_reason,
+        status=getattr(wrapper._final_response, "status", None),
+        **_usage_fields(message),
+    )
+    assert message.get_text_content().strip()
+
+
+# --- probe (b): tiny explicit cap — exact truncation reporting shape ---------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider_value,model", CHAT_HOSTS, ids=_CHAT_IDS)
+async def test_chat_tiny_cap_truncation_reporting(provider_value: str, model: str) -> None:
+    api_key = _require_key(provider_value)
+    client = LLMClient(provider=provider_value, api_key=api_key, model=model)
+    try:
+        stream_cm = client.stream(
+            messages=_messages(ESSAY_PROMPT),
+            system=SYSTEM,
+            model=model,
+            max_completion_tokens=TINY_CAP,
+            temperature=get_model_specs(provider_value, model)["default_temperature"],
+            thinking=default_thinking_effort(provider_value, model),
+        )
+        async with await stream_cm as stream:  # type: ignore[misc]
+            async for _ in stream:
+                pass
+        message = await stream.get_final_message()
+    except _QUOTA_ERRORS as exc:
+        pytest.skip(f"provider quota exhausted for this key: {exc}")
+    _record(
+        "chat-tiny-cap",
+        host=f"{provider_value}/{model}",
+        stop_reason=message.stop_reason,
+        **_usage_fields(message),
+    )
+    # The wire shape under test: an explicit client cap must surface as an honest
+    # truncation (finish_reason "length" -> normalized "max_tokens").
+    assert message.stop_reason == "max_tokens", (
+        f"{provider_value}/{model}: explicit tiny cap reported stop_reason="
+        f"{message.stop_reason!r}, expected 'max_tokens'"
+    )
+
+
+@pytest.mark.asyncio
+async def test_responses_tiny_cap_truncation_reporting() -> None:
+    api_key = _require_key("deepseek")
+    client = LLMClient(provider="deepseek", api_key=api_key, model=_FLASH)
+    provider = cast(DeepSeekResponsesProvider, client.provider)
+    request = provider._build_request(_messages(ESSAY_PROMPT), SYSTEM, None, {"model": _FLASH})
+    request["max_output_tokens"] = TINY_CAP
+    # Iterate the RAW event stream (not the wrapper) so the terminal event type is
+    # observable: the first probe run showed the wrapper sees no response.completed
+    # at all on a cap-hit, suggesting DeepSeek terminates with response.incomplete.
+    event_types: list[str] = []
+    final = None
+    try:
+        responses_stream = await provider.async_client.responses.create(**request)
+        async for event in responses_stream:
+            etype = str(getattr(event, "type", ""))
+            if not event_types or event_types[-1] != etype:
+                event_types.append(etype)
+            if etype in ("response.completed", "response.incomplete", "response.failed"):
+                final = getattr(event, "response", None)
+    except openai.RateLimitError as exc:
+        pytest.skip(f"provider quota exhausted for this key: {exc}")
+    details = getattr(final, "incomplete_details", None)
+    usage = getattr(final, "usage", None)
+    _record(
+        "responses-tiny-cap",
+        host=f"deepseek/{_FLASH}",
+        event_types=event_types,
+        status=getattr(final, "status", None),
+        incomplete_reason=getattr(details, "reason", None) if details is not None else None,
+        output_tokens=getattr(usage, "output_tokens", None),
+    )
+    # Lenient: the printed shape drives the Step-3 normalization decision. A
+    # terminal event of some kind must have arrived.
+    assert final is not None, f"no terminal response event; saw {event_types}"
+
+
+# --- probe (c): uncapped long reasoning — where does the server actually stop? -----
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider_value,model", CHAT_HOSTS, ids=_CHAT_IDS)
+async def test_uncapped_long_generation_server_ceiling(provider_value: str, model: str) -> None:
+    """Where does the SERVER actually cut an uncapped chat stream, and how is it
+    reported? Drives the raw SDK client with NO max_tokens — the shipped request
+    rules always inject the clamp, so the client path cannot measure this."""
+    if not CEILING_PROBE_ENABLED:
+        pytest.skip("Set KOLEGA_DEEPSEEK_CEILING_PROBE=1 to run (streams ~64k+ tokens; slow + real cost)")
+    api_key = _require_key(provider_value)
+    client = LLMClient(provider=provider_value, api_key=api_key, model=model)
+    raw = cast(openai.AsyncOpenAI, client.provider.async_client)
+    finish_reason = None
+    usage = None
+    tail = ""
+    try:
+        stream = await raw.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": LONG_GENERATION_PROMPT}],
+            stream=True,
+            stream_options={"include_usage": True},
+        )
+        async for chunk in stream:
+            if chunk.choices:
+                choice = chunk.choices[0]
+                if choice.finish_reason:
+                    finish_reason = choice.finish_reason
+                delta = getattr(choice.delta, "content", None) or ""
+                if delta:
+                    tail = (tail + delta)[-100:]
+            if getattr(chunk, "usage", None) is not None:
+                usage = chunk.usage
+    except openai.RateLimitError as exc:
+        pytest.skip(f"provider quota exhausted for this key: {exc}")
+    _record(
+        "uncapped-ceiling",
+        host=f"{provider_value}/{model}",
+        finish_reason=finish_reason,
+        completion_tokens=getattr(usage, "completion_tokens", None),
+        text_tail=tail[-80:],
+    )
+    # Lenient by design: completion_tokens IS the measurement. If the server cut
+    # the stream with finish_reason != "length", it truncated silently.
+    assert tail, "no content streamed"
+
+
+@pytest.mark.asyncio
+async def test_uncapped_long_generation_responses_server_ceiling() -> None:
+    """The flash/Responses variant: raw event stream with max_output_tokens
+    REMOVED from the built request. Shows whether the server's own cutoff emits
+    a terminal response.incomplete (honest, once the wrapper captures it) or
+    just drops the stream (truly silent)."""
+    if not CEILING_PROBE_ENABLED:
+        pytest.skip("Set KOLEGA_DEEPSEEK_CEILING_PROBE=1 to run (streams ~64k+ tokens; slow + real cost)")
+    api_key = _require_key("deepseek")
+    client = LLMClient(provider="deepseek", api_key=api_key, model=_FLASH)
+    provider = cast(DeepSeekResponsesProvider, client.provider)
+    request = provider._build_request(_messages(LONG_GENERATION_PROMPT), SYSTEM, None, {"model": _FLASH})
+    request.pop("max_output_tokens", None)  # the override always adds it; measure WITHOUT
+    event_types: list[str] = []
+    final = None
+    tail = ""
+    try:
+        responses_stream = await provider.async_client.responses.create(**request)
+        async for event in responses_stream:
+            etype = str(getattr(event, "type", ""))
+            if not event_types or event_types[-1] != etype:
+                event_types.append(etype)
+            delta = getattr(event, "delta", None)
+            if etype == "response.output_text.delta" and delta:
+                tail = (tail + delta)[-100:]
+            if etype in ("response.completed", "response.incomplete", "response.failed"):
+                final = getattr(event, "response", None)
+    except openai.RateLimitError as exc:
+        pytest.skip(f"provider quota exhausted for this key: {exc}")
+    details = getattr(final, "incomplete_details", None)
+    usage = getattr(final, "usage", None)
+    _record(
+        "uncapped-ceiling-responses",
+        host=f"deepseek/{_FLASH}",
+        terminal_events=event_types[-3:],
+        status=getattr(final, "status", None),
+        incomplete_reason=getattr(details, "reason", None) if details is not None else None,
+        output_tokens=getattr(usage, "output_tokens", None),
+        text_tail=tail[-80:],
+    )
+    assert tail, "no content streamed"
+
+
+# --- OpenRouter: do deepseek slugs accept and work with the clamped cap? -----------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("slug", OPENROUTER_SLUGS)
+async def test_openrouter_deepseek_accepts_clamped_cap(slug: str) -> None:
+    api_key = _require_key("openrouter")
+    client = LLMClient(provider="openrouter", api_key=api_key, model=slug)
+    # Drive the raw SDK client: the gateway rule pops max_tokens at the LLMClient
+    # level (pre-clamp code), and OpenRouter's routing filter is exactly what we
+    # need to observe ("if you set a max_tokens, then OpenRouter will only route
+    # to providers that support a response of that length").
+    raw = cast(openai.AsyncOpenAI, client.provider.async_client)
+
+    def _served_by(resp) -> object:
+        return getattr(resp, "provider", None) or (getattr(resp, "model_extra", None) or {}).get("provider")
+
+    # 64000 — the value the wire clamp will send. This MUST route and complete.
+    try:
+        resp = await raw.chat.completions.create(
+            model=slug,
+            messages=[{"role": "user", "content": TRIVIAL_PROMPT}],
+            max_tokens=CLAMPED_CAP,
+        )
+    except openai.RateLimitError as exc:
+        pytest.skip(f"provider quota exhausted for this key: {exc}")
+    choice = resp.choices[0]
+    _record(
+        "openrouter-clamped-cap",
+        slug=slug,
+        max_tokens=CLAMPED_CAP,
+        outcome="accepted",
+        served_by=_served_by(resp),
+        finish_reason=choice.finish_reason,
+        completion_tokens=getattr(resp.usage, "completion_tokens", None),
+    )
+    assert (choice.message.content or "").strip(), f"{slug}: empty completion at max_tokens={CLAMPED_CAP}"
+
+    # 16 — truncation honesty through the gateway: must be an honest "length".
+    resp = await raw.chat.completions.create(
+        model=slug,
+        messages=[{"role": "user", "content": ESSAY_PROMPT}],
+        max_tokens=TINY_CAP,
+    )
+    choice = resp.choices[0]
+    _record(
+        "openrouter-tiny-cap",
+        slug=slug,
+        max_tokens=TINY_CAP,
+        served_by=_served_by(resp),
+        finish_reason=choice.finish_reason,
+    )
+    assert choice.finish_reason == "length", (
+        f"{slug}: tiny cap reported finish_reason={choice.finish_reason!r}, expected 'length'"
+    )
+
+    # 384000 — the routing-filter check: expect no-providers/4xx; record either way.
+    try:
+        resp = await raw.chat.completions.create(
+            model=slug,
+            messages=[{"role": "user", "content": TRIVIAL_PROMPT}],
+            max_tokens=OVERCAP,
+        )
+    except openai.APIStatusError as exc:
+        _record("openrouter-overcap", slug=slug, max_tokens=OVERCAP, outcome="rejected", error=str(exc))
+    else:
+        _record(
+            "openrouter-overcap",
+            slug=slug,
+            max_tokens=OVERCAP,
+            outcome="accepted",
+            served_by=_served_by(resp),
+            finish_reason=resp.choices[0].finish_reason,
+        )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_end_to_end_with_clamped_cap() -> None:
+    # Post-Step-2 validation: through LLMClient with no caller cap, the deepseek
+    # request rule emits the clamped max_tokens by itself. Proves the shipped
+    # path against the real gateway, not just the raw SDK.
+    slug = "deepseek/deepseek-v4-pro"
+    api_key = _require_key("openrouter")
+    client = LLMClient(provider="openrouter", api_key=api_key, model=slug)
+    try:
+        stream_cm = client.stream(
+            messages=_messages(TRIVIAL_PROMPT),
+            system=SYSTEM,
+            model=slug,
+            max_completion_tokens=None,
+            temperature=get_model_specs("openrouter", slug)["default_temperature"],
+            thinking=default_thinking_effort("openrouter", slug),
+        )
+        async with await stream_cm as stream:  # type: ignore[misc]
+            async for _ in stream:
+                pass
+        message = await stream.get_final_message()
+    except _QUOTA_ERRORS as exc:
+        pytest.skip(f"provider quota exhausted for this key: {exc}")
+    _record(
+        "openrouter-end-to-end",
+        slug=slug,
+        stop_reason=message.stop_reason,
+        **_usage_fields(message),
+    )
+    assert message.get_text_content().strip()
+    assert message.stop_reason in ("end_turn", "max_tokens", "tool_use")

--- a/tests/agent/llm/test_deepseek_requests.py
+++ b/tests/agent/llm/test_deepseek_requests.py
@@ -1,0 +1,169 @@
+"""DeepSeek output-token cap: the model-keyed wire clamp on every provider.
+
+DeepSeek's real per-response output ceiling (~64k) is far below its published
+max_completion_tokens, and the server reports its own cutoff as a clean finish
+(silent truncation) while enforcing AND honestly reporting an explicit client
+cap — measured live by test_deepseek_output_cap_live.py (2026-08-03). These
+tests pin the clamp (specs/accessors.py + the request rules) without touching
+the network. Both ``stream`` and ``generate`` share ``_apply_model_request_rules``
+("kept in one place so stream and generate cannot diverge"), so the stream-path
+transport tests cover both entry points.
+"""
+
+import asyncio
+
+import pytest
+
+from kolega_code.llm.models import MessageHistory
+from kolega_code.llm.providers.deepseek_responses import DeepSeekResponsesProvider
+from kolega_code.llm.providers.models import GenerationParams
+from kolega_code.llm.providers.openai import OpenAIProvider
+from kolega_code.llm.specs import (
+    DEEPSEEK_WIRE_OUTPUT_CAP,
+    deepseek_output_token_cap,
+    is_deepseek_model,
+)
+
+FLASH = "deepseek-v4-flash"
+
+
+class _Recorder:
+    """Minimal AsyncOpenAI stand-in that captures the request kwargs."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self.chat = self
+        self.completions = self
+
+    async def create(self, **kwargs):
+        self.calls.append(kwargs)
+
+        class _Stream:
+            async def __anext__(self):
+                raise StopAsyncIteration
+
+            async def aclose(self):
+                return None
+
+        return _Stream()
+
+    @property
+    def last(self) -> dict:
+        assert self.calls, "no request was issued"
+        return self.calls[-1]
+
+
+def _stream_request(monkeypatch, *, provider_name: str, model: str, max_completion_tokens=None) -> dict:
+    provider = OpenAIProvider(api_key="sk-test", provider_name=provider_name)
+    recorder = _Recorder()
+    monkeypatch.setattr(provider, "async_client", recorder)
+
+    async def run():
+        await provider.stream(
+            MessageHistory([]),
+            params=GenerationParams(temperature=1.0, max_completion_tokens=max_completion_tokens),
+            model=model,
+        )
+
+    asyncio.run(run())
+    return recorder.last
+
+
+# --- the accessor -----------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "deepseek-v4-pro",  # first-party
+        "accounts/fireworks/models/deepseek-v4-flash",  # fireworks path prefix
+        "deepseek/deepseek-v4-pro",  # openrouter slug
+        "deepseek-v3.2",  # ollama_cloud tag
+        "DeepSeek-R1",  # case-insensitive
+    ],
+)
+def test_is_deepseek_model_positive(model: str) -> None:
+    assert is_deepseek_model(model)
+
+
+@pytest.mark.parametrize("model", ["gpt-5.5", "qwen3p7-plus", "accounts/fireworks/models/kimi-k2p7-code"])
+def test_is_deepseek_model_negative(model: str) -> None:
+    assert not is_deepseek_model(model)
+
+
+def test_deepseek_output_token_cap_branches() -> None:
+    # Oversized request (the catalog's old fiction) clamps to the wire cap.
+    assert deepseek_output_token_cap("deepseek", "deepseek-v4-pro", 384000) == DEEPSEEK_WIRE_OUTPUT_CAP
+    # A below-cap request passes through untouched.
+    assert deepseek_output_token_cap("deepseek", "deepseek-v4-pro", 4096) == 4096
+    # No requested cap -> always emit (the wire cap; catalog is higher).
+    assert deepseek_output_token_cap("deepseek", "deepseek-v4-pro", None) == DEEPSEEK_WIRE_OUTPUT_CAP
+    # A catalog entry BELOW the wire cap wins the min (older/smaller models).
+    assert deepseek_output_token_cap("ollama_cloud", "deepseek-v3.2", None) == 32768
+    assert deepseek_output_token_cap("ollama_cloud", "deepseek-v3.2", 384000) == 32768
+    # Unknown overlay model: no catalog entry, wire cap still applies.
+    assert deepseek_output_token_cap("deepseek", "deepseek-experimental", None) == DEEPSEEK_WIRE_OUTPUT_CAP
+    assert deepseek_output_token_cap("deepseek", "deepseek-experimental", 384000) == DEEPSEEK_WIRE_OUTPUT_CAP
+    assert deepseek_output_token_cap("deepseek", "deepseek-experimental", 4096) == 4096
+
+
+# --- chat path (first-party, fireworks, ollama_cloud) -----------------------------
+
+
+@pytest.mark.parametrize(
+    "provider_name,model,expected",
+    [
+        ("deepseek", "deepseek-v4-pro", 64000),
+        ("fireworks", "accounts/fireworks/models/deepseek-v4-pro", 64000),
+        ("fireworks", "accounts/fireworks/models/deepseek-v4-flash", 64000),
+        ("ollama_cloud", "deepseek-v3.2", 32768),
+    ],
+)
+def test_chat_stream_sends_clamped_cap_on_wire(monkeypatch, provider_name: str, model: str, expected: int) -> None:
+    # No caller-supplied cap: DeepSeek models still always get one (always-emit).
+    request = _stream_request(monkeypatch, provider_name=provider_name, model=model)
+    assert request["max_tokens"] == expected
+
+
+def test_chat_oversized_request_is_clamped(monkeypatch) -> None:
+    request = _stream_request(
+        monkeypatch, provider_name="deepseek", model="deepseek-v4-pro", max_completion_tokens=384000
+    )
+    assert request["max_tokens"] == 64000
+
+
+def test_chat_below_cap_request_passes_through(monkeypatch) -> None:
+    request = _stream_request(
+        monkeypatch, provider_name="deepseek", model="deepseek-v4-pro", max_completion_tokens=4096
+    )
+    assert request["max_tokens"] == 4096
+
+
+def test_chat_non_deepseek_model_on_same_provider_unaffected(monkeypatch) -> None:
+    request = _stream_request(
+        monkeypatch,
+        provider_name="fireworks",
+        model="accounts/fireworks/models/kimi-k2p7-code",
+        max_completion_tokens=4096,
+    )
+    assert request["max_tokens"] == 4096
+
+    request = _stream_request(monkeypatch, provider_name="fireworks", model="accounts/fireworks/models/kimi-k2p7-code")
+    assert "max_tokens" not in request
+
+
+# --- Responses path (first-party flash) -------------------------------------------
+
+
+def _responses_request(params) -> dict:
+    provider = DeepSeekResponsesProvider(api_key="sk-test")
+    return provider._build_request(MessageHistory([]), None, params, {"model": FLASH})
+
+
+def test_responses_build_request_emits_max_output_tokens() -> None:
+    # The shared Responses builder omits the cap; the DeepSeek override must add
+    # it (clamped) — without one the server truncates silently.
+    assert _responses_request(GenerationParams(max_completion_tokens=4096))["max_output_tokens"] == 4096
+    assert _responses_request(GenerationParams(max_completion_tokens=384000))["max_output_tokens"] == 64000
+    # No params at all (direct callers): always-emit pins the wire cap.
+    assert _responses_request(None)["max_output_tokens"] == 64000

--- a/tests/agent/llm/test_model_specs.py
+++ b/tests/agent/llm/test_model_specs.py
@@ -125,11 +125,15 @@ def test_kimi_coding_k3_model_specs(model, context_length):
     assert specs["thinking_effort"].mode == "kimi_coding_effort"
 
 
-def test_deepseek_v4_pro_model_specs():
-    specs = get_model_specs("deepseek", "deepseek-v4-pro")
+@pytest.mark.parametrize("model", ["deepseek-v4-pro", "deepseek-v4-flash"])
+def test_deepseek_model_specs(model: str):
+    specs = get_model_specs("deepseek", model)
 
     assert specs["context_length"] == 1000000
-    assert specs["max_completion_tokens"] == 384000
+    # The MEASURED per-response output ceiling (server cuts at exactly 65536),
+    # not DeepSeek's published 384000 — see catalog/deepseek.py and
+    # test_deepseek_output_cap_live.py.
+    assert specs["max_completion_tokens"] == 65536
     assert specs["default_temperature"] == 1.0
     assert specs["thinking_effort"].options == ("none", "high", "max")
     assert specs["thinking_effort"].default == "high"
@@ -140,8 +144,8 @@ def test_fireworks_serverless_model_specs():
         "accounts/fireworks/models/glm-5p2": (1048576, 131072),
         "accounts/fireworks/models/glm-5p1": (202800, 131072),
         "accounts/fireworks/models/kimi-k2p7-code": (262144, 262144),
-        "accounts/fireworks/models/deepseek-v4-pro": (1048576, 384000),
-        "accounts/fireworks/models/deepseek-v4-flash": (1048576, 384000),
+        "accounts/fireworks/models/deepseek-v4-pro": (1048576, 65536),
+        "accounts/fireworks/models/deepseek-v4-flash": (1048576, 65536),
         "accounts/fireworks/models/minimax-m3": (512000, 512000),
         "accounts/fireworks/models/qwen3p7-plus": (262144, 65536),
     }

--- a/tests/agent/llm/test_openai_message_conversion.py
+++ b/tests/agent/llm/test_openai_message_conversion.py
@@ -278,3 +278,53 @@ def test_openai_provider_generate_stamps_ollama_cloud_provider_name_without_usag
     assert message.content[0].thinking == "ollama reasoning"
     assert isinstance(message.content[1], TextBlock)
     assert message.content[1].text == "final answer"
+
+
+def test_from_openai_maps_choice_finish_reason():
+    class OpenAIMessage:
+        content = "partial answer"
+        tool_calls = None
+
+    # finish_reason lives on the CHOICE, not the message; callers pass it in.
+    message = Message.from_openai(OpenAIMessage(), finish_reason="length")
+    assert message.stop_reason == "max_tokens"
+
+    message = Message.from_openai(OpenAIMessage(), finish_reason="stop")
+    assert message.stop_reason == "end_turn"
+
+    # Without it there is nothing to map (the message has no finish_reason attr).
+    assert Message.from_openai(OpenAIMessage()).stop_reason is None
+
+
+def test_generate_maps_finish_reason_from_choice(monkeypatch):
+    # The non-streaming generate() path passes choice.finish_reason through to
+    # from_openai — it used to drop it, leaving stop_reason None.
+    from types import SimpleNamespace as _ns
+
+    provider = OpenAIProvider(api_key="sk-test", provider_name="deepseek")
+    response = _ns(
+        choices=[
+            _ns(
+                message=_ns(content="partial answer", tool_calls=None, reasoning_content=None),
+                finish_reason="length",
+            )
+        ],
+        usage=_ns(prompt_tokens=5, completion_tokens=16, total_tokens=21),
+    )
+
+    class _Fake:
+        def __init__(self):
+            self.chat = self
+            self.completions = self
+
+        async def create(self, **kwargs):
+            return response
+
+    monkeypatch.setattr(provider, "async_client", _Fake())
+
+    async def run():
+        return await provider.generate(MessageHistory([]), model="deepseek-v4-pro")
+
+    message = asyncio.run(run())
+    assert message.stop_reason == "max_tokens"
+    assert message.get_text_content() == "partial answer"

--- a/tests/agent/llm/test_openai_responses_provider.py
+++ b/tests/agent/llm/test_openai_responses_provider.py
@@ -175,7 +175,9 @@ def test_build_request_is_responses_shaped_with_reasoning():
     assert request["tools"][0]["type"] == "function"
     assert request["tools"][0]["name"] == "read_file"
     assert request["input"] == [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}]
-    # The Responses path must NOT send Chat-Completions-only fields.
+    # The Responses path must NOT send Chat-Completions-only fields. The absent
+    # max_output_tokens also guards the non-DeepSeek builders: only
+    # DeepSeekResponsesProvider overrides _build_request to add a clamped cap.
     assert "temperature" not in request
     assert "max_completion_tokens" not in request
     assert "max_output_tokens" not in request

--- a/tests/agent/llm/test_openai_stream_accumulation.py
+++ b/tests/agent/llm/test_openai_stream_accumulation.py
@@ -109,3 +109,40 @@ async def test_empty_stream_yields_empty_buffers():
             pass
         assert stream.final_content == ""
         assert stream.final_reasoning_content == ""
+
+
+# --- finish_reason normalization --------------------------------------------------
+
+
+def test_deepseek_documented_finish_reasons_map_explicitly(caplog):
+    import logging
+
+    from kolega_code.llm.models import Message
+
+    # An explicit client cap is reported as "length" (probed live 2026-08-03,
+    # test_deepseek_output_cap_live.py) and must normalize to the honest
+    # "max_tokens" the turn loop and silent-turn guard key on.
+    with caplog.at_level(logging.WARNING, logger="kolega_code.llm.models"):
+        assert Message.from_openai_stream("assistant", "x", stop_reason="length").stop_reason == "max_tokens"
+        # DeepSeek-documented terminal reasons with no dedicated stop reason end
+        # the turn deliberately (mapped, not unknown) — no warning.
+        assert Message.from_openai_stream("assistant", "x", stop_reason="content_filter").stop_reason == "end_turn"
+        assert (
+            Message.from_openai_stream("assistant", "x", stop_reason="insufficient_system_resource").stop_reason
+            == "end_turn"
+        )
+    assert not caplog.records
+
+
+def test_unknown_finish_reason_stops_as_end_turn_with_warning(caplog):
+    import logging
+
+    from kolega_code.llm.models import Message
+
+    # Direct dict indexing used to raise KeyError during stream finalization on
+    # any unmapped finish_reason; unknown values now end the turn with a visible
+    # warning (None would keep the turn loop spinning).
+    with caplog.at_level(logging.WARNING, logger="kolega_code.llm.models"):
+        message = Message.from_openai_stream("assistant", "x", stop_reason="mystery_reason")
+    assert message.stop_reason == "end_turn"
+    assert any("mystery_reason" in record.getMessage() for record in caplog.records)

--- a/tests/agent/llm/test_openrouter_requests.py
+++ b/tests/agent/llm/test_openrouter_requests.py
@@ -8,8 +8,6 @@ without touching the network.
 
 import asyncio
 
-import pytest
-
 from kolega_code.llm.client import LLMClient
 from kolega_code.llm.models import Message, MessageHistory
 from kolega_code.llm.providers.models import GenerationParams
@@ -103,23 +101,22 @@ def test_caching_and_usage_accounting_are_requested(monkeypatch) -> None:
     assert set(extra_body) == {"reasoning", "cache_control", "usage"}
 
 
-def test_max_tokens_is_omitted_unless_an_operator_opts_in(monkeypatch) -> None:
-    # A catalog-default cap excludes every upstream whose output cap is lower,
-    # biasing routing and price for no benefit.
+def test_max_tokens_is_always_omitted(monkeypatch) -> None:
+    # A catalog-default cap excludes every upstream whose output cap is lower
+    # ("if you set a max_tokens, then OpenRouter will only route to providers
+    # that support a response of that length"), biasing routing and price for
+    # no benefit — and catalog output caps are largely fiction anyway.
     request = _stream_request(monkeypatch, model=REASONING_MODEL)
     assert "max_tokens" not in request
     assert "max_completion_tokens" not in request
 
-    monkeypatch.setenv("KOLEGA_CODE_OPENROUTER_MAX_TOKENS", "8192")
-    request = _stream_request(monkeypatch, model=REASONING_MODEL)
-    assert request["max_tokens"] == 8192
 
-
-@pytest.mark.parametrize("value", ["0", "-5", "not-a-number", ""])
-def test_invalid_max_tokens_override_falls_back_to_omitting(monkeypatch, value: str) -> None:
-    monkeypatch.setenv("KOLEGA_CODE_OPENROUTER_MAX_TOKENS", value)
-    request = _stream_request(monkeypatch, model=REASONING_MODEL)
-    assert "max_tokens" not in request
+def test_deepseek_slug_gets_clamped_cap_despite_gateway_omission(monkeypatch) -> None:
+    # DeepSeek models are the exception: their real output ceiling (~64k) is far
+    # below the catalog value and the server truncates silently, so the honest
+    # clamped cap is always sent — the routing-filter effect is deliberate.
+    request = _stream_request(monkeypatch, model="deepseek/deepseek-v4-pro")
+    assert request["max_tokens"] == 64000
 
 
 def test_temperature_follows_the_catalog_capability_flag(monkeypatch) -> None:

--- a/tests/agent/test_deepseek_truncation_warning.py
+++ b/tests/agent/test_deepseek_truncation_warning.py
@@ -1,0 +1,127 @@
+"""The at-ceiling truncation warning for DeepSeek models.
+
+DeepSeek reports a SERVER-side output cutoff as a clean finish (probed
+2026-08-03, tests/agent/llm/test_deepseek_output_cap_live.py), so BaseAgent
+flags any DeepSeek response that lands at/near the wire output cap without an
+honest "max_tokens" stop — a probable silent truncation, surfaced as a
+log_message warning that lands in trajectory jsonl. Hermetic: the LLM is
+scripted with FakeLLM and the wire cap is set directly on the agent.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kolega_code.llm.models import Message, TextBlock, ToolCall, ToolResult
+
+from .compaction_helpers import FakeLLM
+
+CAP = 64000
+SLACK = 1024
+
+
+def _usage(output_tokens: int) -> dict:
+    # get_output_tokens reads the provider stamped on the metadata, so the
+    # fixture agent's (anthropic) primary config does not matter here.
+    return {"provider": "deepseek", "prompt_tokens": 10, "completion_tokens": output_tokens}
+
+
+def _message(stop_reason: str, output_tokens: int | None, text: str = "partial answer that was cut of") -> Message:
+    return Message(
+        role="assistant",
+        content=[TextBlock(text=text)],
+        stop_reason=stop_reason,
+        usage_metadata=_usage(output_tokens) if output_tokens is not None else None,
+    )
+
+
+def _configure(agent, message_script: list[Message], cap: int | None = CAP) -> None:
+    agent.system_prompt = Message(role="system", content=[TextBlock(text="sys")])
+    agent.tool_collection = MagicMock()
+    agent.tool_collection.get_tool_list = MagicMock(return_value=[])
+    agent.llm = FakeLLM(token_script=[100], message_script=message_script)
+    agent.log_info = AsyncMock()
+    agent.log_error = AsyncMock()
+    agent.log_warning = AsyncMock()
+    agent.deepseek_wire_output_cap = cap
+
+
+def _warnings(agent) -> list[str]:
+    return [call.args[0] for call in agent.log_warning.await_args_list]
+
+
+@pytest.mark.asyncio
+async def test_at_ceiling_end_turn_warns(base_agent) -> None:
+    _configure(base_agent, [_message("end_turn", CAP - 100)])
+
+    _ = [chunk async for chunk in base_agent.process_message_stream("do X")]
+
+    warnings = _warnings(base_agent)
+    assert len(warnings) == 1
+    assert "truncated" in warnings[0]
+    assert str(CAP) in warnings[0]
+    assert "'end_turn'" in warnings[0]
+
+
+@pytest.mark.asyncio
+async def test_at_ceiling_tool_use_warns(base_agent) -> None:
+    # A tool call assembled at the ceiling likely has truncated arguments, so
+    # tool_use stops warn too.
+    tool_call = ToolCall(id="tool-1", name="read_file", input={})
+    truncated = Message(
+        role="assistant",
+        content=[tool_call],
+        stop_reason="tool_use",
+        tool_calls=[tool_call],
+        usage_metadata=_usage(CAP - 100),
+    )
+    _configure(base_agent, [truncated, _message("end_turn", 50)])
+    base_agent.process_tool_calls = AsyncMock(
+        return_value=[ToolResult(tool_use_id=tool_call.id, name=tool_call.name, content="ok", is_error=False)]
+    )
+
+    _ = [chunk async for chunk in base_agent.process_message_stream("do X")]
+
+    warnings = _warnings(base_agent)
+    assert len(warnings) == 1
+    assert "truncated" in warnings[0]
+
+
+@pytest.mark.asyncio
+async def test_honest_max_tokens_stop_does_not_warn(base_agent) -> None:
+    # An honest truncation needs no warning: the stop reason already tells the
+    # truth and the loop/guard react to it.
+    _configure(base_agent, [_message("max_tokens", CAP)])
+
+    _ = [chunk async for chunk in base_agent.process_message_stream("do X")]
+
+    assert _warnings(base_agent) == []
+
+
+@pytest.mark.asyncio
+async def test_below_threshold_does_not_warn(base_agent) -> None:
+    _configure(base_agent, [_message("end_turn", CAP - SLACK - 1)])
+
+    _ = [chunk async for chunk in base_agent.process_message_stream("do X")]
+
+    assert _warnings(base_agent) == []
+
+
+@pytest.mark.asyncio
+async def test_non_deepseek_model_never_warns(base_agent) -> None:
+    # deepseek_wire_output_cap is None for every non-DeepSeek model (set in
+    # __init__ from is_deepseek_model), which disables the check entirely.
+    _configure(base_agent, [_message("end_turn", CAP - 100)], cap=None)
+
+    _ = [chunk async for chunk in base_agent.process_message_stream("do X")]
+
+    assert _warnings(base_agent) == []
+
+
+@pytest.mark.asyncio
+async def test_missing_usage_does_not_warn(base_agent) -> None:
+    _configure(base_agent, [_message("end_turn", None)])
+
+    _ = [chunk async for chunk in base_agent.process_message_stream("do X")]
+
+    assert _warnings(base_agent) == []

--- a/tests/agent/test_deepseek_truncation_warning.py
+++ b/tests/agent/test_deepseek_truncation_warning.py
@@ -90,8 +90,9 @@ async def test_at_ceiling_tool_use_warns(base_agent) -> None:
 @pytest.mark.asyncio
 async def test_honest_max_tokens_stop_does_not_warn(base_agent) -> None:
     # An honest truncation needs no warning: the stop reason already tells the
-    # truth and the loop/guard react to it.
-    _configure(base_agent, [_message("max_tokens", CAP)])
+    # truth and the truncated-turn guard reacts to it (the second scripted
+    # message answers the guard's continuation prompt).
+    _configure(base_agent, [_message("max_tokens", CAP), _message("end_turn", 50)])
 
     _ = [chunk async for chunk in base_agent.process_message_stream("do X")]
 

--- a/tests/agent/test_silent_turn_guard.py
+++ b/tests/agent/test_silent_turn_guard.py
@@ -166,6 +166,44 @@ async def test_max_tokens_silent_turn_is_nudged(base_agent) -> None:
 
 
 @pytest.mark.asyncio
+async def test_deepseek_shaped_max_tokens_stop_reasoning_only_is_nudged(base_agent) -> None:
+    # The exact measured DeepSeek runaway signature (TB2.1 trajectories): one
+    # huge reasoning-only stream truncated mid-word at the output cap, no tool
+    # call, no visible text. Once the wire cap makes the stop reason an honest
+    # "max_tokens", this must land in the guard rather than finalize.
+    truncated = Message(
+        role="assistant",
+        content=[ThinkingBlock(thinking="step 4096 of the proof: therefo")],
+        stop_reason="max_tokens",
+        usage_metadata={"provider": "deepseek", "prompt_tokens": 10, "completion_tokens": 64000},
+    )
+    _configure_agent(base_agent, [truncated, _end_turn_message()])
+
+    _ = [chunk async for chunk in base_agent.process_message_stream("do X")]
+
+    assert base_agent.llm.stream.await_count == 2
+    assert any(STAGE_MARKERS[0] in text for text in _user_texts(base_agent))
+
+
+@pytest.mark.asyncio
+async def test_max_tokens_stop_with_partial_text_finalizes_without_nudge(base_agent) -> None:
+    # Characterization: the silent-turn guard only catches invisible output. A
+    # truncation that cut off mid-sentence in the VISIBLE answer has text, fails
+    # _is_silent_turn, and finalizes as a completed turn. Recovery for this case
+    # is deliberately out of scope (report the truth only) — the honest
+    # "max_tokens" stop reason and the at-ceiling warning make it visible.
+    truncated = Message(role="assistant", content=[TextBlock(text="The fix is to chan")], stop_reason="max_tokens")
+    _configure_agent(base_agent, [truncated])
+
+    _ = [chunk async for chunk in base_agent.process_message_stream("do X")]
+
+    assert base_agent.llm.stream.await_count == 1
+    assert not any(STAGE_MARKERS[0] in text for text in _user_texts(base_agent))
+    assert base_agent.history[-1].role == "assistant"
+    assert base_agent.history[-1].get_text_content() == "The fix is to chan"
+
+
+@pytest.mark.asyncio
 async def test_empty_content_silent_turn_is_nudged(base_agent) -> None:
     empty = Message(role="assistant", content=[], stop_reason="end_turn")
     _configure_agent(base_agent, [empty, _end_turn_message()])

--- a/tests/agent/test_silent_turn_guard.py
+++ b/tests/agent/test_silent_turn_guard.py
@@ -20,10 +20,19 @@ STAGE_MARKERS = [
     "FINAL WARNING",
 ]
 EXHAUSTED_MARKER = "terminated by the runtime"
+TRUNCATED_MARKERS = [
+    "cut off mid-reply",
+    "twice in a row",
+    "three consecutive replies",
+]
 
 
 def _silent_turn_message(stop_reason: str = "end_turn") -> Message:
     return Message(role="assistant", content=[ThinkingBlock(thinking="pondering...")], stop_reason=stop_reason)
+
+
+def _truncated_text_message() -> Message:
+    return Message(role="assistant", content=[TextBlock(text="The fix is to chan")], stop_reason="max_tokens")
 
 
 def _end_turn_message(text: str = "done") -> Message:
@@ -186,21 +195,66 @@ async def test_deepseek_shaped_max_tokens_stop_reasoning_only_is_nudged(base_age
 
 
 @pytest.mark.asyncio
-async def test_max_tokens_stop_with_partial_text_finalizes_without_nudge(base_agent) -> None:
-    # Characterization: the silent-turn guard only catches invisible output. A
-    # truncation that cut off mid-sentence in the VISIBLE answer has text, fails
-    # _is_silent_turn, and finalizes as a completed turn. Recovery for this case
-    # is deliberately out of scope (report the truth only) — the honest
-    # "max_tokens" stop reason and the at-ceiling warning make it visible.
-    truncated = Message(role="assistant", content=[TextBlock(text="The fix is to chan")], stop_reason="max_tokens")
-    _configure_agent(base_agent, [truncated])
+async def test_max_tokens_stop_with_partial_text_is_nudged_then_recovers(base_agent) -> None:
+    # The truncated-turn guard: a truncation that cut off mid-sentence in the
+    # VISIBLE answer (honest "max_tokens", text, no tool call) gets a
+    # continuation prompt instead of finalizing the partial reply.
+    truncated = _truncated_text_message()
+    _configure_agent(base_agent, [truncated, _end_turn_message()])
 
     _ = [chunk async for chunk in base_agent.process_message_stream("do X")]
 
-    assert base_agent.llm.stream.await_count == 1
+    assert base_agent.llm.stream.await_count == 2
+    assert any(TRUNCATED_MARKERS[0] in text for text in _user_texts(base_agent))
     assert not any(STAGE_MARKERS[0] in text for text in _user_texts(base_agent))
+    assert base_agent.history[-1].get_text_content() == "done"
+
+
+@pytest.mark.asyncio
+async def test_truncated_turns_exhaust_cap_and_finalize_with_partial_output(
+    base_agent, mock_connection_manager
+) -> None:
+    # Unlike a silent turn there IS content: after the cap the turn finalizes
+    # with the partial output rather than reporting "[no output]".
+    _configure_agent(base_agent, [_truncated_text_message() for _ in range(4)])
+
+    chunks = [chunk async for chunk in base_agent.process_message_stream("do X")]
+
+    # Initial attempt + one per nudge; the fourth truncation exhausts the cap.
+    assert base_agent.llm.stream.await_count == 4
+    user_texts = _user_texts(base_agent)
+    for marker in TRUNCATED_MARKERS:
+        assert sum(1 for text in user_texts if marker in text) == 1, f"expected exactly one nudge with {marker!r}"
+    assert not any("[no output]" in chunk.get("content", "") for chunk in chunks)
     assert base_agent.history[-1].role == "assistant"
     assert base_agent.history[-1].get_text_content() == "The fix is to chan"
+
+    statuses = _llm_status_events(mock_connection_manager)
+    assert sum(1 for event in statuses if event.content.get("status") == "warning") == 1
+
+
+@pytest.mark.asyncio
+async def test_truncated_counter_resets_after_productive_turn(base_agent) -> None:
+    tool_call = ToolCall(id="tool-1", name="read_file", input={})
+    _configure_agent(
+        base_agent,
+        [
+            _truncated_text_message(),
+            _tool_call_message(tool_call),
+            _truncated_text_message(),
+            _truncated_text_message(),
+            _truncated_text_message(),
+            _end_turn_message(),
+        ],
+    )
+    base_agent.process_tool_calls = AsyncMock(return_value=[_tool_result(tool_call)])
+
+    _ = [chunk async for chunk in base_agent.process_message_stream("do X")]
+
+    # Without the reset after the productive tool-call iteration, the fourth
+    # truncation overall would have exhausted the cap and finalized early.
+    assert base_agent.llm.stream.await_count == 6
+    assert base_agent.history[-1].get_text_content() == "done"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

DeepSeek's catalog `max_completion_tokens` (384000) is fiction, and truncation was invisible three different ways (all measured live — probes in `tests/agent/llm/test_deepseek_output_cap_live.py`, results transcribed into the catalog/accessor comments):

1. **First-party chat's real hard ceiling is exactly 65536** output tokens. We sent `max_tokens: 384000` on every v4-pro request.
2. **Uncapped, flash self-censors** at ~7.4k tokens ("response would exceed the maximum output length allowed for this chat interface") with a clean `status="completed"` — silent underdelivery. With an explicit 64000 cap, the same model streams the full 64000 and reports the cap-hit honestly.
3. **Our Responses stream wrapper dropped the terminal `response.incomplete` event** (it only captured `response.completed`), so even honest cap-hit truncations degraded to a clean `end_turn` and lost their usage/billing metadata. This affected every Responses backend, ChatGPT included, and accounts for much of the TB2.1 "reasoning stream ends mid-word as clean end_turn" signature.

## Changes

- **Catalogs**: first-party + Fireworks deepseek entries → 65536 (measured; Fireworks uncapped defaults to 32768 but honors an explicit 64000).
- **Wire**: DeepSeek models on every provider (first-party, fireworks, ollama_cloud, openrouter) always carry an explicit output cap, clamped via `deepseek_output_token_cap()` to `DEEPSEEK_WIRE_OUTPUT_CAP = 64000` — below the server ceiling, so the client cap always fires first and is reported honestly. Chat rule in `openai.py`; `_build_request` override in `deepseek_responses.py`. The `min()` keeps smaller catalog caps (e.g. ollama v3.x at 32768) intact; non-DeepSeek models are untouched.
- **Responses wrapper**: capture `response.incomplete` as a terminal event (stop reason + usage preserved on truncation).
- **finish_reason maps**: deduped into `_normalize_openai_finish_reason`; DeepSeek-documented `content_filter`/`insufficient_system_resource` mapped explicitly; unknown reasons end the turn with a warning instead of raising KeyError during stream finalization.
- **BaseAgent**: logs a warning (trajectory-visible `log_message` event) when a DeepSeek response lands at/near the wire cap without an honest `max_tokens` stop.
- **Removed `KOLEGA_CODE_OPENROUTER_MAX_TOKENS`**: OpenRouter always drops `max_tokens` for non-DeepSeek models (routing-filter rationale, verified against OpenRouter docs); DeepSeek slugs get the honest clamp — the routing-filter effect is deliberate there. Verified live: OpenRouter routes `max_tokens=64000` fine (Alibaba upstream) and reports honest `length` truncations.

- **Truncated-turn guard** (follow-up promoted into this PR): an honest `max_tokens` stop with visible text and no tool call gets an escalating continuation prompt (`truncated_turn_nudge.user.md.j2`, mirroring the silent-turn nudge) up to 3 consecutive truncations, then finalizes with the partial output. Counter resets on any non-truncated response.
- **Chat `generate()` finish_reason** (follow-up promoted into this PR): `finish_reason` lives on the choice, not the message — `Message.from_openai` now takes it explicitly and `generate()` passes it through, so non-streaming responses carry a real stop reason instead of `None`.

Turn-level handling: a reasoning-only `max_tokens` truncation lands in the existing silent-turn guard (regression-tested); a partial-visible-text truncation gets the new truncated-turn guard above.

## Tests

- Hermetic: 532 passed (`tests/agent/llm/`), 1941 passed (`tests/agent/`); new suites for the accessor/wire (`test_deepseek_requests.py`), the at-ceiling warning (`test_deepseek_truncation_warning.py`), the wrapper's `response.incomplete` capture, the finish_reason hardening, and two silent-turn-guard regressions.
- Live (skippable without `DEEPSEEK_API_KEY`/`FIREWORKS_API_KEY`/`OPENROUTER_API_KEY`): 11 passed against the final code; the two expensive uncapped-ceiling probes are additionally gated behind `KOLEGA_DEEPSEEK_CEILING_PROBE=1`.

## Follow-ups (out of scope)

- OpenRouter deepseek catalog mirrors (393216/384000) still fiction — wire-clamped, context budgeting only.
- General catalog output-cap audit (many entries are context-window-sized); could enable honest caps on OpenRouter for all models.
- Generalizing the at-ceiling warning beyond DeepSeek.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zs5yVmhn5B13YFp9Xaz4D

