### PR TITLE
fix: traceback on Ctrl+Q while a question prompt is pending

### DIFF
--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -228,15 +228,20 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
             self._log_status(messages.FINISHED, "ok")
         except asyncio.CancelledError:
             cancelled_by_user = True
-            self._cancel_pending_question()
-            self._cancel_pending_approval()
-            await self._drain_pending_events()
-            self._start_session_diff_refresh()
-            self._finalize_sub_agent_activities()
-            self._finalize_workflow_activities()
-            await self._save_session_history_async()
-            self._finish_turn_progress(messages.STOPPED_BY_USER, tui_state.TurnState.STOPPED)
-            self._log_status(messages.STOPPED_BY_USER, "warn")
+            # When the app is quitting, action_quit already settled open
+            # prompts (control lease release) and saved the session, and the
+            # widget tree is being torn down — skip the cleanup that would
+            # repaint it.
+            if not self._exit:
+                self._cancel_pending_question()
+                self._cancel_pending_approval()
+                await self._drain_pending_events()
+                self._start_session_diff_refresh()
+                self._finalize_sub_agent_activities()
+                self._finalize_workflow_activities()
+                await self._save_session_history_async()
+                self._finish_turn_progress(messages.STOPPED_BY_USER, tui_state.TurnState.STOPPED)
+                self._log_status(messages.STOPPED_BY_USER, "warn")
         except LLMError as exc:
             self._cancel_pending_question()
             self._cancel_pending_approval()
@@ -261,18 +266,19 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
             self._log_status(messages.STOPPED_WITH_ERROR.format(error=exc), "error")
             raise
         finally:
-            self._flush_terminal_output()
-            self._flush_log_output()
-            self._flush_conversation_render()
             self._active_progress_entry = None
             self._turn_active = False
-            if self._plan_decision_active:
-                self._set_composer_status(messages.PLAN_READY_PLACEHOLDER)
-            else:
-                self._restore_composer_placeholder()
-            self._set_chat_enabled(self.agent is not None and not self._plan_decision_active)
-            if cancelled_by_user:
-                self._schedule_primary_focus_restore()
+            if not self._exit:
+                self._flush_terminal_output()
+                self._flush_log_output()
+                self._flush_conversation_render()
+                if self._plan_decision_active:
+                    self._set_composer_status(messages.PLAN_READY_PLACEHOLDER)
+                else:
+                    self._restore_composer_placeholder()
+                self._set_chat_enabled(self.agent is not None and not self._plan_decision_active)
+                if cancelled_by_user:
+                    self._schedule_primary_focus_restore()
         return cancelled_by_user
 
     async def _process_message(

--- a/kolega_code/cli/tui/widgets.py
+++ b/kolega_code/cli/tui/widgets.py
@@ -820,7 +820,11 @@ class PromptPanel(Vertical):
 
     def hide(self) -> None:
         self.display = False
-        self.actions.hide()
+        # App teardown prunes children before their ancestors, and the turn
+        # worker's cancellation cleanup can run mid-teardown — tolerate an
+        # already-removed ActionList.
+        for actions in self.query(ActionList):
+            actions.hide()
 
 
 class ChatComposer(TextArea):

--- a/tests/cli/test_app_planning_questions.py
+++ b/tests/cli/test_app_planning_questions.py
@@ -428,3 +428,99 @@ async def test_build_and_plan_modes_get_different_question_guidance(
 
         assert "cli-planning-questions" in prompt_ids()
         assert "cli-build-questions" not in prompt_ids()
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_question_survives_pruned_action_list(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """App teardown prunes the ActionList before the turn worker's cancellation
+    cleanup runs; _cancel_pending_question must tolerate the missing child."""
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.tools import ToolError
+
+    class FakeBaseAgent(FakeCoderAgent):
+        instances: list["FakeBaseAgent"] = []
+
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.__class__.instances.append(self)
+
+    install_fake_agents(monkeypatch, coder_cls=FakeBaseAgent, planning_cls=FakeBaseAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test() as pilot:
+        await app.action_toggle_interaction_mode()
+        ask_user_choice = extension_by_name(
+            FakeBaseAgent.instances[-1].kwargs["tool_extensions"], "cli-planning-questions"
+        ).tools["ask_user_choice"]
+
+        app._turn_active = True
+        answer_task = asyncio.create_task(
+            ask_user_choice(
+                questions=question_payload(
+                    "Which approach should we use?",
+                    [("Keep state local", "Store in memory"), ("Persist it", "Write to disk")],
+                    header="Approach",
+                )
+            )
+        )
+        question_actions = await wait_for_question_prompt(app, pilot)
+
+        await question_actions.remove()
+        await pilot.pause()
+
+        app._cancel_pending_question()
+
+        assert app._pending_question is None
+        with pytest.raises(ToolError):
+            await asyncio.wait_for(answer_task, timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_turn_skips_ui_cleanup_when_app_is_exiting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Once exit() has been requested, a cancelled turn must not repaint the
+    dying widget tree (the source of NoMatches tracebacks on Ctrl+Q)."""
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.app import KolegaCodeApp
+
+    install_fake_agents(monkeypatch, coder_cls=FakeCoderAgent, planning_cls=FakeCoderAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test():
+        calls: list[str] = []
+        monkeypatch.setattr(app, "_cancel_pending_question", lambda: calls.append("question"))
+        monkeypatch.setattr(app, "_cancel_pending_approval", lambda: calls.append("approval"))
+
+        async def cancelled_stream():
+            raise asyncio.CancelledError
+            yield  # pragma: no cover
+
+        app._exit = True
+        try:
+            cancelled = await app._run_turn_stream(lambda: cancelled_stream())
+        finally:
+            app._exit = False
+        assert cancelled is True
+        assert calls == []
+
+        cancelled = await app._run_turn_stream(lambda: cancelled_stream())
+        assert cancelled is True
+        assert calls == ["question", "approval"]


### PR DESCRIPTION
## Problem

Quitting the TUI (Ctrl+Q) while a planning question prompt is on screen prints a traceback after the app exits:

```
NoMatches: No nodes match 'ActionList' on PromptPanel(id='question_prompt')
```

Reproduced live (tmux, real agent turn): present a question in `/plan` mode, press Ctrl+Q while it waits for an answer.

## Root cause

`action_quit` settles the pending prompt (control-lease release) and calls `exit()`. Textual's shutdown then cancels the agent-turn worker **without awaiting it** while it prunes the widget tree, so the worker's `except asyncio.CancelledError` cleanup in `_run_turn_stream` runs mid-teardown. `_cancel_pending_question()` unconditionally hides the question panel, and `PromptPanel.hide()` re-queries its `ActionList` child — already pruned — raising `NoMatches`. The panel lookup in `prompt_flows.py` was guarded; this second, child-level query was not. The approval prompt shares `PromptPanel.hide()`, so quit-during-approval had the identical bug.

## Fix

- **`PromptPanel.hide()`** tolerates an already-pruned `ActionList` (`for actions in self.query(ActionList)`), covering the question and approval panels for every caller. The `actions` property stays strict for the show path, where a missing child is a real bug.
- **`_run_turn_stream`**: the `CancelledError` cleanup body and the widget-touching part of the `finally` block are gated on `not self._exit`. When quitting, `action_quit` has already settled prompts and saved the session — repainting the dying DOM (`_drain_pending_events`, `_start_session_diff_refresh`'s `run_worker`, progress/composer updates) was wasted work and each call a further teardown-race candidate.

## Testing

- Two regression tests in `tests/cli/test_app_planning_questions.py`; **both fail with the fixes reverted**:
  - pruned-child test deterministically recreates the crash state (`NoMatches` pre-fix),
  - exit-gate test asserts a cancelled turn skips UI cleanup when `_exit` is set (and still runs it when not).
- Full suite: 4042 passed, 1 skipped (env-gated browser test).
- Live end-to-end: 3× quit-during-question in tmux → clean exit, no traceback. Ctrl+C cancel ("Stopped by user", composer restored) and the answer-a-question happy path verified unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMGYkjXyq6sEnWg2RtXcz3