### PR TITLE
fix: flip turn status instantly and make session-diff checkpoints fast

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -1305,7 +1305,12 @@ class KolegaCodeApp(
         self._start_session_diff_refresh()
 
     def _initialize_session_diff_tracker(self, baseline_label: str = "") -> None:
-        """Set up git-only net diff tracking for the Changes inspector."""
+        """Set up git-only net diff tracking for the Changes inspector.
+
+        Tracker creation is one fast ``git rev-parse``; the baseline capture
+        can read every dirty file, so it runs in a worker. Until it finishes,
+        the tracker has no checkpoint 0 and turn checkpoints skip themselves.
+        """
         self._session_diff_generation += 1
         self._session_diff_tracker = tui_session_diff.GitSessionDiffTracker.create(self.active_project_path)
         self._session_diff_files = []
@@ -1313,12 +1318,38 @@ class KolegaCodeApp(
         if self._session_diff_tracker is None:
             return
         try:
-            self._session_diff_tracker.capture_baseline(baseline_label)
+            self.run_worker(
+                self._session_diff_baseline_worker(
+                    self._session_diff_tracker, self._session_diff_generation, baseline_label
+                ),
+                name="kolega-diff-baseline",
+                group="session-diff-baseline",
+            )
         except Exception:
             self._session_diff_tracker = None
             self._session_diff_files = []
+
+    async def _session_diff_baseline_worker(
+        self, tracker: tui_session_diff.SessionDiffTrackerBase, generation: int, label: str
+    ) -> None:
+        try:
+            started = time.monotonic()
+            await asyncio.to_thread(self._tracker_capture_baseline, tracker, label)
+            if self.show_logs:
+                self._write_log(f"Session diff baseline captured in {time.monotonic() - started:.2f}s", "debug")
+        except Exception:
+            if generation == self._session_diff_generation and tracker is self._session_diff_tracker:
+                self._session_diff_tracker = None
+                self._session_diff_files = []
+            return
+        if generation != self._session_diff_generation or tracker is not self._session_diff_tracker:
             return
         self._start_scope_probe()
+
+    def _tracker_capture_baseline(self, tracker: tui_session_diff.SessionDiffTrackerBase, label: str) -> None:
+        """Capture the session baseline under the tracker lock. Worker threads only."""
+        with self._session_diff_lock:
+            tracker.capture_baseline(label)
 
     async def _confirm_worktree_switch(self, new_root: Path, branch: str, old_root: Path) -> tuple[bool, str]:
         """Ask the user to approve an agent-initiated workspace switch.

--- a/kolega_code/cli/messages.py
+++ b/kolega_code/cli/messages.py
@@ -41,6 +41,7 @@ ATTACH_CLIPBOARD_EMPTY = (
 
 # Turn progress
 WORKING = "Working…"
+PREPARING_CHECKPOINT = "Preparing checkpoint…"
 GENERATING = "Generating…"
 THINKING = "Thinking…"
 READING_RESPONSE = "Reading model response…"

--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 
 from kolega_code.agent import (
     AgentConfig,
@@ -183,8 +184,21 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
         tracker = self._session_diff_tracker
         if tracker is None:
             return
+        excerpt = checkpoint_excerpt(label)
+
+        def _capture() -> None:
+            with self._session_diff_lock:
+                if not tracker.checkpoints():
+                    # The startup baseline worker lost the race; skip rather
+                    # than fabricate checkpoint 0 out of a mid-session state.
+                    return
+                tracker.capture_checkpoint(excerpt)
+
         try:
-            await asyncio.to_thread(tracker.capture_checkpoint, checkpoint_excerpt(label))
+            started = time.monotonic()
+            await asyncio.to_thread(_capture)
+            if self.show_logs:
+                self._write_log(f"Checkpoint captured in {time.monotonic() - started:.2f}s", "debug")
         except Exception:
             pass
 
@@ -211,19 +225,35 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
                 if content and self.show_logs:
                     self._write_log(content, "debug")
 
-    async def _run_turn_stream(self, stream_factory) -> bool:
-        """Run one agent stream and return whether it was cancelled by the user."""
+    async def _finalize_turn_output(self, *, cancel_pending: bool) -> None:
+        """Settle transcript state common to every turn outcome, before the final status."""
+        if cancel_pending:
+            self._cancel_pending_question()
+            self._cancel_pending_approval()
+        await self._drain_pending_events()
+        self._start_session_diff_refresh()
+        self._finalize_sub_agent_activities()
+        self._finalize_workflow_activities()
+
+    async def _run_turn_stream(self, stream_factory, *, checkpoint_label: str | None = None) -> bool:
+        """Run one agent stream and return whether it was cancelled by the user.
+
+        When ``checkpoint_label`` is given, the session-diff checkpoint is
+        captured after progress begins, so the status strip flips off the
+        previous turn's result immediately and Esc during a slow capture
+        resolves through the normal cancelled path.
+        """
         cancelled_by_user = False
-        self._begin_turn_progress()
-        self._log_status(messages.GENERATING, "ok")
+        self._begin_turn_progress(messages.PREPARING_CHECKPOINT if checkpoint_label is not None else messages.WORKING)
         try:
+            if checkpoint_label is not None:
+                await self._record_turn_checkpoint(checkpoint_label)
+                self._update_progress(messages.WORKING, complete=False, state=tui_state.TurnState.GENERATING)
+            self._log_status(messages.GENERATING, "ok")
             await self._consume_agent_stream(stream_factory())
-            await self._drain_pending_events()
-            self._start_session_diff_refresh()
-            self._finalize_sub_agent_activities()
-            self._finalize_workflow_activities()
-            await self._save_session_history_async()
+            await self._finalize_turn_output(cancel_pending=False)
             self._finish_turn_progress(messages.FINISHED, tui_state.TurnState.IDLE)
+            await self._save_session_history_async()
             await self._capture_completed_plan()
             self._log_status(messages.FINISHED, "ok")
         except asyncio.CancelledError:
@@ -233,36 +263,21 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
             # widget tree is being torn down — skip the cleanup that would
             # repaint it.
             if not self._exit:
-                self._cancel_pending_question()
-                self._cancel_pending_approval()
-                await self._drain_pending_events()
-                self._start_session_diff_refresh()
-                self._finalize_sub_agent_activities()
-                self._finalize_workflow_activities()
-                await self._save_session_history_async()
+                await self._finalize_turn_output(cancel_pending=True)
                 self._finish_turn_progress(messages.STOPPED_BY_USER, tui_state.TurnState.STOPPED)
+                await self._save_session_history_async()
                 self._log_status(messages.STOPPED_BY_USER, "warn")
         except LLMError as exc:
-            self._cancel_pending_question()
-            self._cancel_pending_approval()
-            await self._drain_pending_events()
-            self._start_session_diff_refresh()
-            self._finalize_sub_agent_activities()
-            self._finalize_workflow_activities()
-            await self._save_session_history_async()
+            await self._finalize_turn_output(cancel_pending=True)
             model = self.config.long_context_config.model if self.config is not None else None
             message_text = llm_error_message(exc, model=model)
             self._finish_turn_progress(message_text, tui_state.TurnState.ERROR)
+            await self._save_session_history_async()
             self._log_status(message_text, "error")
         except Exception as exc:
-            self._cancel_pending_question()
-            self._cancel_pending_approval()
-            await self._drain_pending_events()
-            self._start_session_diff_refresh()
-            self._finalize_sub_agent_activities()
-            self._finalize_workflow_activities()
-            await self._save_session_history_async()
+            await self._finalize_turn_output(cancel_pending=True)
             self._finish_turn_progress(messages.STOPPED_WITH_ERROR.format(error=exc), tui_state.TurnState.ERROR)
+            await self._save_session_history_async()
             self._log_status(messages.STOPPED_WITH_ERROR.format(error=exc), "error")
             raise
         finally:
@@ -294,8 +309,10 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
         try:
             if self.agent is None:
                 return False
-            await self._record_turn_checkpoint(turn_label or message)
-            cancelled_by_user = await self._run_turn_stream(lambda: self._agent_turn_stream(message, attachments))
+            cancelled_by_user = await self._run_turn_stream(
+                lambda: self._agent_turn_stream(message, attachments),
+                checkpoint_label=turn_label or message,
+            )
             # A committed workspace switch applies between turns: the agent is
             # rebuilt in the new checkout, then handed one continuation turn so
             # the work that prompted the switch resumes there. A cancelled turn
@@ -304,9 +321,9 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
                 continuation = await self._apply_pending_workspace_switch()
                 if cancelled_by_user or continuation is None:
                     break
-                await self._record_turn_checkpoint(continuation)
                 cancelled_by_user = await self._run_turn_stream(
-                    lambda prompt=continuation: self._agent_turn_stream(prompt)
+                    lambda prompt=continuation: self._agent_turn_stream(prompt),
+                    checkpoint_label=continuation,
                 )
             if cancelled_by_user:
                 self._schedule_maybe_start_queued_message()

--- a/kolega_code/cli/tui/app_base.py
+++ b/kolega_code/cli/tui/app_base.py
@@ -23,6 +23,7 @@ ScreenResultT = TypeVar("ScreenResultT")
 
 if TYPE_CHECKING:
     import asyncio
+    import threading
 
     from datetime import datetime
     from pathlib import Path
@@ -38,6 +39,7 @@ if TYPE_CHECKING:
     from kolega_code.memory import ProjectMemoryManager
     from kolega_code.permissions import PermissionDecision, PermissionMode, PermissionRequest
 
+    from .. import messages
     from ..config import CliConfigOverrides
     from kolega_code.session.control import ControlChannel
     from kolega_code.session.recording import RecordingConnectionManager
@@ -131,6 +133,9 @@ class KolegaAppBase(App):
         _session_file_changes: list[tui_state.SessionFileChange]
         _pending_workspace_switch: tui_state.PendingWorkspaceSwitch | None
         _session_diff_tracker: SessionDiffTrackerBase | None
+        #: Serializes tracker mutations (baseline, checkpoint, refresh, scope)
+        #: across worker threads; tracker methods are not thread-safe.
+        _session_diff_lock: threading.Lock
         _session_diff_files: list[SessionDiffFile]
         _session_diff_scope: DiffScope | None
         _session_diff_dirty: bool
@@ -384,7 +389,7 @@ class KolegaAppBase(App):
         def _apply_stream_chunk(self, chunk: dict, *, kind: str) -> None: ...
         def _apply_sub_agent_edit_preview(self, event: AgentEvent) -> None: ...
         def _apply_tool_streaming_update(self, content: dict) -> None: ...
-        def _begin_turn_progress(self) -> None: ...
+        def _begin_turn_progress(self, activity: str = messages.WORKING) -> None: ...
         def _finalize_sub_agent_activities(self, status: str = "stopped") -> None: ...
         def _finalize_workflow_activities(self, status: str = "stopped") -> None: ...
         def _finish_turn_progress(

--- a/kolega_code/cli/tui/session_diff.py
+++ b/kolega_code/cli/tui/session_diff.py
@@ -23,6 +23,7 @@ import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
+from stat import S_ISREG
 from subprocess import DEVNULL, PIPE, CompletedProcess, run as subprocess_run
 from typing import TYPE_CHECKING, Iterable, Literal, Optional, Sequence
 
@@ -182,6 +183,9 @@ class SessionDiffTrackerBase:
         self._content_intern: dict[str, tuple[bytes, Optional[str]]] = {}
         self._diff_cache: dict[str, tuple[Optional[tuple[int, int]], Optional[SessionDiffFile]]] = {}
         self._diff_cache_checkpoint_id: Optional[int] = None
+        # repo_path -> (stat signature, baseline): shared by capture and refresh
+        # so a file is read and hashed once per content version, then stat-only.
+        self._snapshot_cache: dict[str, tuple[tuple[int, int], FileBaseline]] = {}
 
     # ---- checkpoints ---------------------------------------------------------
 
@@ -192,6 +196,7 @@ class SessionDiffTrackerBase:
         self._content_intern = {}
         self._diff_cache = {}
         self._diff_cache_checkpoint_id = None
+        self._snapshot_cache = {}
         self.capture_checkpoint(label)
 
     def capture_checkpoint(self, label: str) -> TurnCheckpoint:
@@ -398,13 +403,24 @@ class SessionDiffTrackerBase:
 
     def _snapshot_repo_path(self, repo_path: str) -> FileBaseline:
         abs_path = self._abs_path(repo_path)
-        if not abs_path.exists() or not abs_path.is_file():
+        try:
+            st = os.stat(abs_path)
+        except OSError:
+            st = None
+        if st is None or not S_ISREG(st.st_mode):
+            self._snapshot_cache.pop(repo_path, None)
             return FileBaseline(path=repo_path, exists=False)
+        sig = (st.st_mtime_ns, st.st_size)
+        cached = self._snapshot_cache.get(repo_path)
+        if cached is not None and cached[0] == sig:
+            return cached[1]
         try:
             data = abs_path.read_bytes()
         except OSError:
             return FileBaseline(path=repo_path, exists=True, binary_or_unreadable=True)
-        return self._baseline_from_bytes(repo_path, data, exists=True)
+        baseline = self._baseline_from_bytes(repo_path, data, exists=True)
+        self._snapshot_cache[repo_path] = (sig, baseline)
+        return baseline
 
     @staticmethod
     def _baseline_from_bytes(repo_path: str, data: bytes, *, exists: bool) -> FileBaseline:
@@ -487,6 +503,9 @@ class GitSessionDiffTracker(SessionDiffTrackerBase):
     def __init__(self, project_path: Path, git_root: Path) -> None:
         super().__init__(project_path)
         self.git_root = git_root.resolve()
+        # repo_path -> verdict: _is_under_project resolves symlinks, which is
+        # too slow to repeat for tens of thousands of status paths per capture.
+        self._under_project_cache: dict[str, bool] = {}
         self._commit_cache: dict[tuple[str, str], FileBaseline] = {}
         # (old_sha, new_sha) -> paths that transition changed. Immutable by
         # construction, so entries never need invalidating.
@@ -556,10 +575,19 @@ class GitSessionDiffTracker(SessionDiffTrackerBase):
 
     # ---- provider hooks ------------------------------------------------------
 
+    def _dirty_paths(self) -> set[str]:
+        """Status paths the session can ever display or restore.
+
+        Sibling-worktree and out-of-project paths are dropped before any file
+        is read: they are unreachable from diff and restore output anyway.
+        """
+        return {
+            path for path in self._without_sibling_worktrees(self._git_status_paths()) if self._is_under_project(path)
+        }
+
     def _capture_dirty_baselines(self) -> dict[str, FileBaseline]:
         return {
-            repo_path: self._intern_baseline(self._snapshot_repo_path(repo_path))
-            for repo_path in self._git_status_paths()
+            repo_path: self._intern_baseline(self._snapshot_repo_path(repo_path)) for repo_path in self._dirty_paths()
         }
 
     def _candidate_paths(self, checkpoint: TurnCheckpoint, event_paths: Iterable[str]) -> set[str]:
@@ -657,11 +685,16 @@ class GitSessionDiffTracker(SessionDiffTrackerBase):
             return repo_path
 
     def _is_under_project(self, repo_path: str) -> bool:
+        cached = self._under_project_cache.get(repo_path)
+        if cached is not None:
+            return cached
         try:
             (self.git_root / repo_path).resolve(strict=False).relative_to(self.project_path)
-            return True
+            verdict = True
         except ValueError:
-            return False
+            verdict = False
+        self._under_project_cache[repo_path] = verdict
+        return verdict
 
     # ---- git helpers ---------------------------------------------------------
 

--- a/kolega_code/cli/tui/transcript.py
+++ b/kolega_code/cli/tui/transcript.py
@@ -329,7 +329,7 @@ class TranscriptRenderingMixin(tui_app_base.KolegaAppBase):
         if entry is not None:
             self._invalidate_conversation(entry)
 
-    def _begin_turn_progress(self) -> None:
+    def _begin_turn_progress(self, activity: str = messages.WORKING) -> None:
         self._close_sub_agent_inspector()
         self._tool_entries = {}
         self._tool_stream_buffers = {}
@@ -341,9 +341,9 @@ class TranscriptRenderingMixin(tui_app_base.KolegaAppBase):
         self._turn_active = True
         self._set_chat_enabled(True)
         self._set_composer_status(messages.QUEUE_PLACEHOLDER)
-        self._start_turn_timer(messages.WORKING)
-        self._set_status_activity(messages.WORKING, turn_state=TurnState.GENERATING)
-        self._update_progress(messages.WORKING, complete=False, state=TurnState.GENERATING)
+        self._start_turn_timer(activity)
+        self._set_status_activity(activity, turn_state=TurnState.GENERATING)
+        self._update_progress(activity, complete=False, state=TurnState.GENERATING)
 
     def _update_progress(self, content: str, complete: bool, state: Optional[TurnState] = None) -> None:
         if complete:

--- a/tests/cli/_app_test_utils.py
+++ b/tests/cli/_app_test_utils.py
@@ -1,4 +1,5 @@
 # ruff: noqa: F401,F811,E402
+import asyncio
 import time
 from pathlib import Path
 from typing import Any
@@ -179,6 +180,22 @@ async def wait_for_question_prompt(app, pilot, timeout: float = 6.0):
                 return question_actions
         await pilot.pause(0.01)
     raise AssertionError("Timed out waiting for the planning question to be presented")
+
+
+async def wait_for_session_diff_baseline(app, timeout: float = 5.0) -> None:
+    """The session-diff baseline is captured in a worker; wait for checkpoint 0.
+
+    Needed before asserting on tracker state from the event loop. Work that
+    reaches the tracker through ``_session_diff_lock`` (turn checkpoints,
+    refresh, scope) serializes behind the baseline on its own.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        tracker = app._session_diff_tracker
+        if tracker is not None and tracker.checkpoints():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("Timed out waiting for the session-diff baseline")
 
 
 async def settle_changes_inspector(app, pilot, timeout: float = 5.0) -> None:

--- a/tests/cli/test_app_session_diff_async.py
+++ b/tests/cli/test_app_session_diff_async.py
@@ -7,7 +7,7 @@ import pytest
 from kolega_code.cli import app as cli_app_module
 from kolega_code.events import AgentEvent
 
-from ._app_test_utils import _build_sub_agent_test_app, settle_changes_inspector
+from ._app_test_utils import _build_sub_agent_test_app, settle_changes_inspector, wait_for_session_diff_baseline
 from .test_app_changes_inspector import _file_edit_preview_event, _init_git_project
 
 
@@ -265,3 +265,87 @@ async def test_start_session_diff_refresh_runs_with_inspector_closed(
         assert len(calls) == 1
         assert app._changes_inspector is None
         assert {change.path for change in app._session_diff_files} == {"src/a.py"}
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_capture_runs_under_session_diff_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+    _init_git_project(app.project_path)
+
+    async with app.run_test():
+        await wait_for_session_diff_baseline(app)
+        tracker = app._session_diff_tracker
+        assert tracker is not None
+        original = tracker.capture_checkpoint
+        lock_held: list[bool] = []
+
+        def capture(label):
+            lock_held.append(app._session_diff_lock.locked())
+            return original(label)
+
+        monkeypatch.setattr(tracker, "capture_checkpoint", capture)
+
+        await app._process_message("hello")
+
+        assert lock_held == [True]
+
+
+@pytest.mark.asyncio
+async def test_startup_baseline_runs_off_ui_thread(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The baseline reads every dirty file, so it must never run on the event loop."""
+    from kolega_code.cli.tui.session_diff import GitSessionDiffTracker
+
+    ui_thread = threading.get_ident()
+    baseline_threads: list[int] = []
+    original = GitSessionDiffTracker.capture_baseline
+
+    def capture_baseline(self, label=""):
+        baseline_threads.append(threading.get_ident())
+        return original(self, label)
+
+    monkeypatch.setattr(GitSessionDiffTracker, "capture_baseline", capture_baseline)
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+    _init_git_project(app.project_path)
+
+    async with app.run_test() as pilot:
+        # The scope probe only starts after the baseline worker succeeds, so a
+        # populated scope proves the ordering as well as the thread.
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline and app._session_diff_scope is None:
+            await pilot.pause(0.01)
+
+        assert baseline_threads
+        assert ui_thread not in baseline_threads
+        assert app._session_diff_scope is not None
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_skipped_on_unbaselined_tracker(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A turn racing the startup baseline must not fabricate checkpoint 0."""
+    from kolega_code.cli.tui.session_diff import GitSessionDiffTracker
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+    _init_git_project(app.project_path)
+
+    async with app.run_test():
+        fresh = GitSessionDiffTracker.create(app.project_path)
+        assert fresh is not None
+        original = fresh.capture_checkpoint
+        captures: list[str] = []
+
+        def capture(label):
+            captures.append(label)
+            return original(label)
+
+        monkeypatch.setattr(fresh, "capture_checkpoint", capture)
+        app._session_diff_tracker = fresh
+
+        await app._record_turn_checkpoint("racing turn")
+        assert captures == []
+        assert fresh.checkpoints() == []
+
+        # Once the baseline lands, the same path captures normally again.
+        fresh.capture_baseline()
+        await app._record_turn_checkpoint("later turn")
+        assert len(captures) == 2  # capture_baseline() itself + the turn checkpoint
+        assert [checkpoint.label for checkpoint in fresh.checkpoints()] == ["", "later turn"]

--- a/tests/cli/test_app_turn_checkpoint.py
+++ b/tests/cli/test_app_turn_checkpoint.py
@@ -1,0 +1,154 @@
+"""Turn-checkpoint UX: the status strip must flip the moment a turn starts.
+
+The session-diff checkpoint can read every dirty file in the repo, so it runs
+inside ``_run_turn_stream`` *after* progress begins. These tests pin the
+ordering (strip shows "Preparing checkpoint…" while the capture is in flight),
+the Esc path during a slow capture, and the goal-nudge turn that deliberately
+takes no checkpoint.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from kolega_code.cli import messages
+from kolega_code.cli.tui import state as tui_state
+
+from ._app_test_utils import (
+    FakeCoderAgent,
+    _build_sub_agent_test_app,
+    install_fake_agents,
+    wait_for_session_diff_baseline,
+    wait_for_turn_idle,
+)
+from .test_app_changes_inspector import _init_git_project
+
+
+pytestmark = pytest.mark.usefixtures("hermetic_git_config")
+
+
+class GatedStreamAgent(FakeCoderAgent):
+    """Holds the response stream until the test releases it."""
+
+    stream_gate: asyncio.Event | None = None
+
+    async def process_message_stream(self, message, attachments=None):
+        gate = type(self).stream_gate
+        if gate is not None:
+            await gate.wait()
+        async for chunk in super().process_message_stream(message, attachments):
+            yield chunk
+
+
+async def _wait_for_thread_event(pilot, event: threading.Event, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if event.is_set():
+            return
+        await pilot.pause(0.01)
+    raise AssertionError("Timed out waiting for the checkpoint capture to start")
+
+
+def _gate_checkpoint_capture(monkeypatch: pytest.MonkeyPatch, tracker):
+    """Make capture_checkpoint block until released; returns (started, release)."""
+    started = threading.Event()
+    release = threading.Event()
+    original = tracker.capture_checkpoint
+
+    def capture(label):
+        started.set()
+        if not release.wait(timeout=5.0):
+            raise AssertionError("Timed out waiting to release the checkpoint capture")
+        return original(label)
+
+    monkeypatch.setattr(tracker, "capture_checkpoint", capture)
+    return started, release
+
+
+@pytest.mark.asyncio
+async def test_status_flips_before_checkpoint_capture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    GatedStreamAgent.stream_gate = asyncio.Event()
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+    # _build_sub_agent_test_app installs the plain fake; the agent is only
+    # constructed on mount, so overriding again here makes the gate stick.
+    install_fake_agents(monkeypatch, coder_cls=GatedStreamAgent)
+    _init_git_project(app.project_path)
+
+    async with app.run_test() as pilot:
+        await wait_for_session_diff_baseline(app)
+        tracker = app._session_diff_tracker
+        assert tracker is not None
+        started, release = _gate_checkpoint_capture(monkeypatch, tracker)
+
+        app.agent_worker = app.run_worker(app._process_message("hello"), name="kolega-turn", group="turns")
+        await _wait_for_thread_event(pilot, started)
+
+        # The capture is still blocked, yet the previous turn's result is gone
+        # and the spinner is already running with a truthful activity.
+        assert app._turn_active is True
+        assert app._turn_started_at is not None
+        assert app._turn_status_text == messages.PREPARING_CHECKPOINT
+
+        release.set()
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline and app._turn_status_text != messages.WORKING:
+            await pilot.pause(0.01)
+        assert app._turn_status_text == messages.WORKING
+
+        GatedStreamAgent.stream_gate.set()
+        await wait_for_turn_idle(app, pilot)
+        assert app._turn_final_text.startswith("Done in")
+
+
+@pytest.mark.asyncio
+async def test_esc_during_checkpoint_finalizes_stopped_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+    _init_git_project(app.project_path)
+
+    async with app.run_test() as pilot:
+        await wait_for_session_diff_baseline(app)
+        tracker = app._session_diff_tracker
+        assert tracker is not None
+        started, release = _gate_checkpoint_capture(monkeypatch, tracker)
+
+        app.agent_worker = app.run_worker(app._process_message("hello"), name="kolega-turn", group="turns")
+        await _wait_for_thread_event(pilot, started)
+
+        app.action_cancel_generation()
+        release.set()
+        await wait_for_turn_idle(app, pilot)
+
+        agent = app.agent
+        assert isinstance(agent, FakeCoderAgent)
+        assert app._turn_final_state is tui_state.TurnState.STOPPED
+        assert app._turn_final_text.startswith("Stopped after")
+        assert app._turn_active is False
+        assert app.agent_worker is None
+        assert agent.messages == []  # the stream never started
+
+
+@pytest.mark.asyncio
+async def test_goal_nudge_turn_takes_no_checkpoint(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+    _init_git_project(app.project_path)
+
+    async with app.run_test():
+        await wait_for_session_diff_baseline(app)
+        tracker = app._session_diff_tracker
+        assert tracker is not None
+        agent = app.agent
+        assert isinstance(agent, FakeCoderAgent)
+        captures: list[str] = []
+        monkeypatch.setattr(tracker, "capture_checkpoint", lambda label: captures.append(label))
+
+        cancelled = await app._run_turn_stream(lambda: agent.process_message_stream("nudge"))
+
+        assert cancelled is False
+        assert captures == []
+        # Progress still began and completed normally without a checkpoint.
+        assert app._turn_final_text.startswith("Done in")

--- a/tests/cli/test_app_worktree_switch.py
+++ b/tests/cli/test_app_worktree_switch.py
@@ -18,7 +18,13 @@ from kolega_code.permissions import PERMISSIONS_RELATIVE_PATH, allow_rule_option
 from kolega_code.services.terminal import LocalTerminalManager
 from kolega_code.tools import ToolError
 
-from ._app_test_utils import FakeCoderAgent, build_test_config, extension_by_name, install_fake_agents
+from ._app_test_utils import (
+    FakeCoderAgent,
+    build_test_config,
+    extension_by_name,
+    install_fake_agents,
+    wait_for_session_diff_baseline,
+)
 
 
 pytestmark = pytest.mark.usefixtures("hermetic_git_config")
@@ -209,6 +215,7 @@ async def test_tui_resume_constructs_agent_and_changes_tracker_in_persisted_acti
         _assert_agent_root(app.agent, linked)
         assert app._session_diff_tracker is not None
         assert app._session_diff_tracker.project_path == linked
+        await wait_for_session_diff_baseline(app)
         assert app._session_diff_tracker.checkpoints()[0].checkpoint_id == 0
         assert mcp_roots == [linked]
 
@@ -542,6 +549,7 @@ async def test_apply_pending_switch_rebuilds_workspace_and_returns_continuation(
         assert app._session_diff_tracker is not tracker_before
         assert app._session_diff_tracker is not None
         assert app._session_diff_tracker.project_path == linked
+        await wait_for_session_diff_baseline(app)
         checkpoints = app._session_diff_tracker.checkpoints()
         assert len(checkpoints) == 1
         assert checkpoints[0].checkpoint_id == 0

--- a/tests/cli/test_session_diff.py
+++ b/tests/cli/test_session_diff.py
@@ -608,3 +608,154 @@ def test_returning_head_to_the_baseline_hides_nothing(tmp_path: Path) -> None:
     # UI must not claim otherwise.
     assert tracker.refresh() == []
     assert tracker.scope().history_moved is False
+
+
+# ---- snapshot cache and capture filtering ------------------------------------
+
+
+def test_capture_checkpoint_reuses_unchanged_snapshots(tmp_path: Path, monkeypatch) -> None:
+    project = tmp_path / "repo"
+    project.mkdir()
+    _init_repo(project)
+    (project / "a.py").write_text("old\n", encoding="utf-8")
+    _commit_all(project)
+    (project / "dirty.py").write_text("dirty\n", encoding="utf-8")
+
+    tracker = GitSessionDiffTracker.create(project)
+    assert tracker is not None
+    tracker.capture_baseline()
+
+    read_calls = _count_method_calls(monkeypatch, tracker, "_baseline_from_bytes")
+    checkpoint = tracker.capture_checkpoint("turn 1")
+
+    assert read_calls["count"] == 0
+    assert checkpoint.dirty["dirty.py"].content == "dirty\n"
+
+
+def test_capture_checkpoint_rereads_when_signature_changes(tmp_path: Path, monkeypatch) -> None:
+    project = tmp_path / "repo"
+    project.mkdir()
+    _init_repo(project)
+    (project / "a.py").write_text("old\n", encoding="utf-8")
+    _commit_all(project)
+    (project / "dirty.py").write_text("dirty\n", encoding="utf-8")
+
+    tracker = GitSessionDiffTracker.create(project)
+    assert tracker is not None
+    tracker.capture_baseline()
+
+    read_calls = _count_method_calls(monkeypatch, tracker, "_baseline_from_bytes")
+    (project / "dirty.py").write_text("dirty but longer\n", encoding="utf-8")
+    checkpoint = tracker.capture_checkpoint("turn 1")
+
+    assert read_calls["count"] == 1
+    assert checkpoint.dirty["dirty.py"].content == "dirty but longer\n"
+
+
+def test_refresh_then_capture_shares_snapshot_cache(tmp_path: Path, monkeypatch) -> None:
+    project = tmp_path / "repo"
+    project.mkdir()
+    _init_repo(project)
+    (project / "a.py").write_text("old\n", encoding="utf-8")
+    _commit_all(project)
+
+    tracker = GitSessionDiffTracker.create(project)
+    assert tracker is not None
+    tracker.capture_baseline()
+
+    (project / "new.py").write_text("new\n", encoding="utf-8")
+    assert _by_path(tracker.refresh())["new.py"].status == "added"
+
+    read_calls = _count_method_calls(monkeypatch, tracker, "_baseline_from_bytes")
+    checkpoint = tracker.capture_checkpoint("turn 1")
+
+    assert read_calls["count"] == 0
+    assert checkpoint.dirty["new.py"].content == "new\n"
+
+
+def test_capture_baseline_resets_snapshot_cache(tmp_path: Path, monkeypatch) -> None:
+    project = tmp_path / "repo"
+    project.mkdir()
+    _init_repo(project)
+    (project / "a.py").write_text("old\n", encoding="utf-8")
+    _commit_all(project)
+    (project / "dirty.py").write_text("dirty\n", encoding="utf-8")
+
+    tracker = GitSessionDiffTracker.create(project)
+    assert tracker is not None
+    tracker.capture_baseline()
+
+    read_calls = _count_method_calls(monkeypatch, tracker, "_baseline_from_bytes")
+    tracker.capture_baseline()
+
+    assert read_calls["count"] == 1
+
+
+def test_capture_skips_sibling_worktree_paths(tmp_path: Path, monkeypatch) -> None:
+    project = tmp_path / "repo"
+    project.mkdir()
+    _init_repo(project)
+    (project / "shared.txt").write_text("base\n", encoding="utf-8")
+    _commit_all(project)
+    # No exclude rule: the nested worktree is visible to the parent's git status.
+    worktree_b = _add_worktree(project, "b", "feat-b", ignore=False)
+
+    tracker = GitSessionDiffTracker.create(project)
+    assert tracker is not None
+    tracker.capture_baseline()
+
+    (worktree_b / "b_only.py").write_text("b\n", encoding="utf-8")
+    (project / "mine.py").write_text("mine\n", encoding="utf-8")
+
+    snapshot_calls = _count_method_calls(monkeypatch, tracker, "_snapshot_repo_path")
+    checkpoint = tracker.capture_checkpoint("turn 1")
+
+    assert set(checkpoint.dirty) == {"mine.py"}
+    assert snapshot_calls["count"] == 1
+
+
+def test_capture_skips_paths_outside_project(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    project = repo / "pkg"
+    project.mkdir(parents=True)
+    _init_repo(repo)
+    (project / "a.py").write_text("old\n", encoding="utf-8")
+    _commit_all(repo)
+
+    tracker = GitSessionDiffTracker.create(project)
+    assert tracker is not None
+    tracker.capture_baseline()
+
+    (repo / "outside.py").write_text("outside\n", encoding="utf-8")
+    (project / "inside.py").write_text("inside\n", encoding="utf-8")
+    checkpoint = tracker.capture_checkpoint("turn 1")
+
+    assert set(checkpoint.dirty) == {"pkg/inside.py"}
+    assert _by_path(tracker.refresh())["inside.py"].status == "added"
+
+
+def test_capture_never_touches_gitignored_paths(tmp_path: Path, monkeypatch) -> None:
+    project = tmp_path / "repo"
+    project.mkdir()
+    _init_repo(project)
+    (project / ".gitignore").write_text("ignored/\n*.log\n", encoding="utf-8")
+    (project / "a.py").write_text("old\n", encoding="utf-8")
+    _commit_all(project)
+
+    tracker = GitSessionDiffTracker.create(project)
+    assert tracker is not None
+    tracker.capture_baseline()
+
+    (project / "ignored").mkdir()
+    (project / "ignored" / "big.bin").write_text("ignored\n", encoding="utf-8")
+    (project / "noise.log").write_text("ignored too\n", encoding="utf-8")
+    (project / "kept.py").write_text("kept\n", encoding="utf-8")
+
+    snapshot_calls = _count_method_calls(monkeypatch, tracker, "_snapshot_repo_path")
+    checkpoint = tracker.capture_checkpoint("turn 1")
+
+    # git status never reports ignored files, so they are neither read nor
+    # recorded; only the real untracked file is captured.
+    assert set(checkpoint.dirty) == {"kept.py"}
+    assert snapshot_calls["count"] == 1
+    assert {change.path for change in tracker.refresh()} == {"kept.py"}


### PR DESCRIPTION
## Problem

Submitting a message in the TUI left the status strip showing the previous turn's `✓ Done in Xs` for seconds before flipping to `⠹ Working…`. The cause: `_process_message` awaited the session-diff checkpoint **before** `_run_turn_stream` called `_begin_turn_progress()` — and the capture read + sha256-hashed every dirty/untracked file with no filtering or reuse. Measured while dogfooding in the kolega-code repo itself (17,066 untracked paths under `runs/` + `terminal-bench-2-1/`): 6.6 GB read, ~7.7 s per submit — delaying both the indicator *and* the agent turn. The same scan ran synchronously on the UI thread at startup and worktree switch, freezing the app.

## Changes

**Instant status feedback**
- The checkpoint moved inside `_run_turn_stream`, after `_begin_turn_progress`: the spinner starts at submit with a truthful `Preparing checkpoint…`, then flips to `Working…`. Esc during a slow capture now resolves through the normal cancelled path to a clean `Stopped after Xs` (previously it stranded the strip). The goal-nudge caller passes no label and is unchanged.
- Turn-end finishes the status strip **before** awaiting session-history persistence, so `Done in Xs` appears immediately (shared `_finalize_turn_output` helper dedupes the four outcome branches).

**Fast captures**
- Snapshot cache keyed by `(mtime_ns, size)`, shared by capture and refresh: each file is read+hashed once per content version, then stat-only — the same staleness policy `_collect_changes` already used for its diff cache. Cleared on `capture_baseline`.
- Capture filters sibling-worktree and out-of-project paths *before* reading (they were already unreachable from diff/restore output).
- `_is_under_project` memoized (its per-path `resolve()` cost 0.9 s per capture at 17k paths); `_snapshot_repo_path` does a single `os.stat` instead of stat + `is_file()`.
- Gitignored files were never captured (`git status` doesn't list them) — now pinned by a test.

**Concurrency**
- `capture_checkpoint` runs under `_session_diff_lock`; previously it could scan concurrently with the end-of-turn refresh (two multi-GB scans at once).
- The startup/worktree-switch baseline runs in a worker instead of blocking the UI thread. A turn checkpoint that wins the race before the baseline lands skips itself (guarded) rather than fabricating checkpoint 0; anything reaching the tracker through the lock serializes behind the baseline naturally.

## Measurements (pathological repo: 17k untracked files, 6.6 GB)

| Operation | Before | After |
|---|---|---|
| Per-turn checkpoint (steady state) | ~7.7 s, 6.6 GB read | ~1.0 s, zero reads (~half is `git status` itself) |
| Indicator flip on submit | after checkpoint (~8 s) | immediate |
| Startup baseline | UI frozen for the full scan | background; UI responsive immediately |

On a repo with a normal .gitignore the capture is a few ms. Memory note: the snapshot cache holds at most the latest version per dirty path, and unchanged entries are the same interned objects checkpoints already retain.

## Tests

- New `tests/cli/test_app_turn_checkpoint.py`: strip shows `Preparing checkpoint…` while a gated capture is in flight, then `Working…`; Esc during capture finalizes STOPPED cleanly; goal-nudge turn takes no checkpoint.
- `test_session_diff.py`: capture reuses unchanged snapshots (zero reads), re-reads on signature change, refresh warms the cache for capture, baseline resets the cache, capture skips sibling-worktree/out-of-project/gitignored paths.
- `test_app_session_diff_async.py`: capture runs under the lock; startup baseline runs off the UI thread then kicks the scope probe; checkpoint skipped on an un-baselined tracker.
- Two worktree-switch tests now wait for the async baseline via a shared `wait_for_session_diff_baseline` helper.

Full suite: 4017 passed. Verified end-to-end in tmux against the dirty repo (instant flip, ~1 s checkpoint window, clean Esc).

**Deferred follow-up**: a size gate so >8 MB files aren't read even once per content version — it changes `_same_state`/preview semantics, so it needs its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cz18e3yYpGBHaDoCkQBSBN