### PR TITLE
Speed up CI: cache Playwright, scope coverage to 3.11, fix 59s kernel teardown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,17 +84,42 @@ jobs:
         if: needs.changes.outputs.coverage-badge-only != 'true'
         run: uv sync --extra dev --frozen
 
-      - name: Install Playwright Chromium
+      - name: Get Playwright version
         if: needs.changes.outputs.coverage-badge-only != 'true'
+        id: playwright-version
+        run: echo "version=$(uv run python -c "from importlib.metadata import version; print(version('playwright'))")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright Chromium
+        if: needs.changes.outputs.coverage-badge-only != 'true'
+        id: playwright-cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      # The system-deps half of this install (apt fetching font packages) has
+      # stalled for up to 10 minutes on flaky mirrors, so it only runs when the
+      # browser cache misses (i.e. on a Playwright version bump). On cache hits
+      # the runner image's preinstalled browser libraries cover Chromium.
+      - name: Install Playwright Chromium
+        if: needs.changes.outputs.coverage-badge-only != 'true' && steps.playwright-cache.outputs.cache-hit != 'true'
         run: uv run playwright install --with-deps chromium
 
       - name: Run pre-commit hooks
         if: needs.changes.outputs.coverage-badge-only != 'true'
         run: uv run pre-commit run --all-files --show-diff-on-failure
 
-      - name: Run fast tests with coverage
+      # Coverage runs on 3.11 only: it is the version whose coverage.xml the
+      # badge job consumes, and instrumenting the other matrix jobs costs
+      # minutes of wall time for artifacts nothing reads.
+      - name: Run fast tests
         if: needs.changes.outputs.coverage-badge-only != 'true'
-        run: ./run_tests.sh --coverage
+        run: |
+          if [ "${{ matrix.python-version }}" = "3.11" ]; then
+            ./run_tests.sh --coverage
+          else
+            ./run_tests.sh
+          fi
 
       - name: Build and verify bundled skill package data
         if: needs.changes.outputs.coverage-badge-only != 'true' && matrix.python-version == '3.11'
@@ -103,7 +128,7 @@ jobs:
           uv run python scripts/verify_bundled_skill_artifacts.py /tmp/kolega-code-dist/*
 
       - name: Upload coverage report
-        if: needs.changes.outputs.coverage-badge-only != 'true'
+        if: needs.changes.outputs.coverage-badge-only != 'true' && matrix.python-version == '3.11'
         uses: actions/upload-artifact@v6
         with:
           name: coverage-xml-python-${{ matrix.python-version }}

--- a/kolega_code/agent/eval/kernel.py
+++ b/kolega_code/agent/eval/kernel.py
@@ -184,8 +184,9 @@ class BaseKernel:
             try:
                 if proc.stdin is not None:
                     proc.stdin.write(encode_frame({"type": "exit"}))
-                    await proc.stdin.wait_closed()
-            except (BrokenPipeError, ConnectionError, RuntimeError):
+                    proc.stdin.close()
+                    await asyncio.wait_for(proc.stdin.wait_closed(), timeout=timeout)
+            except (BrokenPipeError, ConnectionError, RuntimeError, asyncio.TimeoutError):
                 pass
             try:
                 await asyncio.wait_for(proc.wait(), timeout=timeout)

--- a/kolega_code/agent/eval/runner.js
+++ b/kolega_code/agent/eval/runner.js
@@ -305,7 +305,14 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  emitError(CURRENT.id, err);
-  process.exit(1);
-});
+main()
+  .then(() => {
+    // Exit explicitly: an interrupted cell can leave timers or sockets in the
+    // event loop that would otherwise keep the process alive after the host
+    // asked it to exit. Flush stdout first so no result frame is truncated.
+    process.stdout.write("", () => process.exit(0));
+  })
+  .catch((err) => {
+    emitError(CURRENT.id, err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

PR CI runs took 10–21 minutes, with the wall time set by the slowest of the four matrix jobs. Step-level timings from the last five PR runs showed three sinks; this PR addresses all of them. Expected result: consistent ~6–9 minute PR runs once the browser cache is warm.

### 1. Playwright install stalled for 9–10 minutes in ~15% of jobs

The slow part was **not** the Chromium download — step logs show `apt-get` fetching font packages from `azure.archive.ubuntu.com` with individual stalls of 74–216s during the `--with-deps` half. CI now caches `~/.cache/ms-playwright` keyed on `runner.os` + Playwright version, and runs `playwright install --with-deps chromium` only on cache miss (i.e. on a Playwright version bump). On hits the step is skipped entirely; the runner image's preinstalled browser libraries cover Chromium's launch deps, and the web tests fail loudly if an image update ever changes that.

### 2. Coverage ran on all four Pythons, but only the 3.11 artifact is consumed

The badge job downloads only `coverage-xml-python-3.11`; the 3.12–3.14 jobs paid coverage tracing overhead to upload artifacts nothing read. Coverage (and its `--cov-fail-under=45` gate) now runs on the 3.11 job only; the others run the plain suite.

### 3. A 59-second test teardown pinned an xdist worker every run

`test_js_kernel.py::test_timeout_interrupts_and_kernel_survives` interrupts `await new Promise((resolve) => setTimeout(resolve, 60000))` after 1s. The interrupt settles the cell, but the orphaned 60s timer stays in node's event loop — so after the host's exit frame, the runner's `main()` returned and node waited out the timer before exiting, while the host blocked on an unbounded `proc.stdin.wait_closed()`. Beyond tests, a cell leaving a `setInterval` behind would have hung real kernel shutdowns indefinitely.

Fixed at both layers:
- `runner.js` exits explicitly (after flushing stdout) when its main loop ends, so leftover timers/sockets can't keep the kernel alive.
- `kernel.py` closes stdin and bounds the wait with `asyncio.wait_for`, so the existing kill-escalation can engage if a kernel wedges.

## Test plan

- [x] `tests/agent/eval/test_js_kernel.py` goes from 60.1s to 1.3s locally; the 59s teardown is gone
- [x] All 51 `tests/agent/eval/` tests pass (covers both JS and Python kernel shutdown paths)
- [x] pre-commit (ruff, pyright, yaml checks) passes on all changed files
- [ ] Observe CI on this PR: first run pays the cache fill; the badge job on main must still find `coverage-xml-python-3.11`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F953rYkftAq7R636rJ8S2h