### PR TITLE
chore: release v0.26.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.26.8 - 2026-08-03
+
+### Added
+
+- Completed model messages now carry normalized token usage across supported
+  providers. Session usage is persisted across resume, exported with provider
+  and model breakdowns, and shown in a dedicated Usage card on the Status tab.
+- `kolega-code ask --json` now emits complete, replay-safe messages instead of
+  streaming prose chunks, including normalized usage and an explicit final
+  summary.
+- Detached background terminal sessions now keep stdin open, so callers can
+  send multiple inputs to long-running processes with `write_stdin`.
+
+### Changed
+
+- Build and ask agents now share stronger act-first and independent-verification
+  guidance. Silent reasoning-only turns are retried with escalating prompts,
+  and visible responses cut off at the output limit are asked to continue.
+- Tool dispatch accepts common parameter aliases for `exec_command`, `eval`,
+  and `find_files_by_pattern`, while canonical arguments still take precedence.
+- Turn status now appears immediately while checkpoints are prepared, and
+  session-diff baseline/checkpoint work is asynchronous and caches unchanged
+  files for faster turns.
+- Switching between Plan and Build with existing history now gives the model a
+  hidden toolset-change notice so it does not attempt tools from the old mode.
+- Web connection failures now distinguish unreachable hosts, TLS failures,
+  rate limits, and retryable errors, with guidance that reflects whether
+  outbound access is available.
+
 ### Fixed
 
 - Installing on an Intel Mac no longer fails with a `cryptography` source-build
@@ -31,6 +60,10 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 - The non-streaming chat `generate()` path now maps `finish_reason` (it lives
   on the choice, not the message), so its responses carry a real stop reason
   instead of `None`.
+- Quitting while a question or approval is pending no longer raises a Textual
+  teardown traceback.
+- JavaScript eval kernels no longer wait for orphaned cell timers during
+  shutdown.
 
 ### Removed
 

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.26.7"
+__version__ = "0.26.8"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.26.7"
+__version__ = "0.26.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.26.7"
+version = "0.26.8"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-27T09:03:29.890831Z"
+exclude-newer = "2026-07-27T12:17:13.394155Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1531,7 +1531,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.26.7"
+version = "0.26.8"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- bump the package and lockfile version to 0.26.8
- publish the user-facing changes since v0.26.7 in the changelog
- include the latest eval-kernel shutdown fix merged in #440

## Verification

- `PYTHONDONTWRITEBYTECODE=1 UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" ./run_tests.sh` — 4162 passed, 1 credential-gated skip
- `PYTHONDONTWRITEBYTECODE=1 UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" uv run pre-commit run --all-files --show-diff-on-failure` — passed
- release smoke test for `v0.26.7..main` — ready with environmental caveats
