### PR TITLE
feat(cli): split credentials into a Providers settings screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ### Changed
 
+- Settings gains a **Providers** category, first in the rail, holding every model
+  provider's API key and the ChatGPT sign-in, each row labelled with its live
+  credential status. **Model & Account** is renamed **Models** and keeps only what
+  runs. Keys now stage per provider, so credentials for a provider you are not
+  currently using — needed by a fast/thinking slot or an agent-role override — can be
+  entered without switching your main model and switching back. **Test Connection**
+  moves with them and probes the selected provider rather than the active model, so a
+  credential can be checked without running on that provider.
 - **Breaking:** provider and model are now always specified together. `--provider`
   without `--model` (and the per-role/per-slot equivalents such as
   `KOLEGA_CODE_FAST_PROVIDER`) is an error instead of silently selecting that

--- a/docs/src/content/docs/configuration/providers-and-models.mdx
+++ b/docs/src/content/docs/configuration/providers-and-models.mdx
@@ -150,13 +150,15 @@ resolves to, so an inherited slot is never a surprise.
 
 ## Set models per role
 
-In the TUI, open **Settings → Model & Account → Model Slots** (or `/model`) and
+In the TUI, open **Settings → Models → Model Slots** (or `/model`) and
 give the Fast or Thinking row a provider and model. Leave a row on
 *Default (inherit)* to keep it following the active model.
 
 A slot may use a **different provider** from your main model — for example a
-DeepSeek main model with Anthropic Haiku for fast utility calls. That provider
-needs its own API key, and Settings refuses to apply the change until it has one.
+DeepSeek main model with Anthropic Haiku for fast utility calls. That provider needs
+its own API key: add it under **Settings → Providers**, which lists every provider
+with its credential status and lets you set up more than one before applying.
+Settings refuses to apply a slot whose provider has no credential.
 
 Equivalently, from the command line:
 

--- a/docs/src/content/docs/configuration/settings-and-api-keys.mdx
+++ b/docs/src/content/docs/configuration/settings-and-api-keys.mdx
@@ -30,7 +30,8 @@ separates the controls into:
 
 | Category | What it configures |
 | --- | --- |
-| **Model & Account** | Provider, model, thinking effort, API key or ChatGPT sign-in, and connection testing |
+| **Providers** | API keys and ChatGPT sign-in for every model provider, plus per-provider connection testing |
+| **Models** | Provider, model, thinking effort, and the fast/thinking model slots |
 | **Agent Models** | Optional provider/model/effort override for each agent role |
 | **Tools** | Web-search backend and global LSP toggle |
 | **MCP Servers** | Global and trusted-project MCP server management |
@@ -43,12 +44,25 @@ the previous settings remain saved and the draft stays open for correction. Clos
 a changed draft asks before discarding it. Theme changes preview immediately but
 follow the same Apply/discard behavior.
 
+**Providers** lists every model provider with its current credential status —
+`present via <ENV_VAR>`, `present in local settings`, `signed in as …`, or `missing` —
+so you can see at a glance what you are set up for. Select a provider to edit its
+credential.
+
 The API-key input never echoes a saved secret. Leave it blank to retain the current
 key, paste a value to replace it, or select **Remove Stored Key** to stage its
 removal. Environment variables are only reported, never changed by the TUI.
-ChatGPT sign-in and sign-out are staged the same way. **Test Connection** uses the
-current draft and has the same small, potentially billable request behavior as the
-onboarding test.
+ChatGPT sign-in and sign-out are staged the same way.
+
+Keys are staged **per provider**, so you can set up several providers before pressing
+Apply — useful when a fast/thinking slot or an agent role runs on a provider other
+than your main model. Credentials are independent of model selection: changing the
+provider under **Models** does not touch any key.
+
+**Test Connection** probes the *selected* provider rather than the active model, using
+that provider's configured model where there is one and its default otherwise — so you
+can check a credential for a provider you are not currently running on. It has the same
+small, potentially billable request behavior as the onboarding test.
 
 MCP actions are the exception to the global Apply button: their server config,
 verification, enable/disable state, trust, and OAuth actions save immediately.

--- a/docs/src/content/docs/configuration/sign-in-with-chatgpt.mdx
+++ b/docs/src/content/docs/configuration/sign-in-with-chatgpt.mdx
@@ -56,8 +56,8 @@ model line-up:
 | `gpt-5.4-mini` | GPT-5.4 Mini — fast and economical |
 | `gpt-5.3-codex-spark` | GPT-5.3 Codex Spark — ultra-fast |
 
-Switch between them with [`/model`](../../tui/slash-commands/) or from **Model &
-Account** in the full Settings screen. Each model supports a reasoning **thinking
+Switch between them with [`/model`](../../tui/slash-commands/) or from **Models**
+in the full Settings screen. Each model supports a reasoning **thinking
 effort** you can set with [`/effort`](../../tui/slash-commands/).
 
 ## Where credentials live
@@ -87,7 +87,7 @@ To remove your stored ChatGPT credentials:
 /logout chatgpt
 ```
 
-You can also choose **Sign out** under **Settings → Model & Account**, then select
+You can also choose **Sign out** under **Settings → Providers**, then select
 **Apply Changes**. The token is not removed until the draft is applied.
 
 After signing out, switch to another provider — or sign in again with

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -1101,16 +1101,16 @@ class KolegaCodeApp(
         if event.button.id == "save_settings":
             await self._save_settings_from_ui()
             return
-        if event.button.id == "settings_chatgpt_login":
+        if event.button.id == "provider_chatgpt_login":
             await self._settings_login_chatgpt()
             return
-        if event.button.id == "settings_chatgpt_logout":
+        if event.button.id == "provider_chatgpt_logout":
             self._settings_logout_chatgpt()
             return
-        if event.button.id == "settings_remove_api_key":
+        if event.button.id == "provider_remove_api_key":
             self._settings_remove_api_key()
             return
-        if event.button.id == "settings_test_connection":
+        if event.button.id == "provider_test_connection":
             await self._test_settings_connection()
             return
         if event.button.id and event.button.id.startswith("mcp_"):

--- a/kolega_code/cli/config.py
+++ b/kolega_code/cli/config.py
@@ -584,6 +584,24 @@ def key_status(provider: str, project_path: Path, settings: Optional[CliSettings
     return "missing"
 
 
+def resolved_api_key(provider: str, project_path: Path, settings: Optional[CliSettings] = None) -> Optional[str]:
+    """The API key a provider would actually use: env var first, then stored settings.
+
+    The value counterpart to ``key_status``, which reports the same precedence in words.
+    """
+    return _api_key_for_provider(_provider(provider), load_cli_env(project_path), settings)
+
+
+def probe_token_manager(settings: Optional[CliSettings]) -> Optional[ChatGPTTokenManager]:
+    """A ChatGPT token manager for credential probes, deliberately non-persisting.
+
+    A probe runs against an unapplied Settings draft, so a token refresh triggered by it
+    must not write back to settings.json the way the session's own manager does.
+    """
+    tokens = _resolve_chatgpt_tokens(settings)
+    return ChatGPTTokenManager(tokens) if tokens is not None else None
+
+
 def active_model_override_message(
     config: AgentConfig,
     project_path: Path,

--- a/kolega_code/cli/messages.py
+++ b/kolega_code/cli/messages.py
@@ -249,6 +249,18 @@ BROWSER_MODEL_EXPLICIT_NO_VISION = (
 BROWSER_MODEL_PROVIDER_NO_VISION = (
     "Provider {provider} has no vision-capable Browser models. Choose another provider or Default (inherit)."
 )
+PROVIDERS_HINT = (
+    "Credentials for model providers. Select one to add, replace, or remove its key. "
+    "What actually runs is chosen under Models."
+)
+MODEL_CREDENTIAL_POINTER = "API keys and ChatGPT sign-in live under Providers."
+PROVIDER_CREDENTIAL_STATUS = "Credential status: {status}"
+PROVIDER_KEY_STAGED = "Key will be saved for {provider} when you Apply."
+PROVIDER_KEY_NOT_STORED = (
+    "There is no locally stored key for this provider. Environment credentials are not changed here."
+)
+PROVIDER_KEY_REMOVAL_STAGED = "The locally stored API key will be removed when you Apply."
+PROVIDER_TEST_RUNNING = "Testing {provider}/{model}…"
 MODEL_SLOT_INHERITED = "Using {provider}/{model} (inherited from the active model)."
 MODEL_SLOT_PINNED = "Using {provider}/{model}."
 MODEL_SLOT_HINT = (

--- a/kolega_code/cli/model_connection.py
+++ b/kolega_code/cli/model_connection.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
-from kolega_code.config import AgentConfig
+from kolega_code.config import ModelProvider, RateLimitConfig
 from kolega_code.llm.client import LLMClient
 from kolega_code.llm.exceptions import LLMError, llm_error_message
 from kolega_code.llm.ledger import helper_origin, llm_call_origin
@@ -34,27 +34,35 @@ async def _probe_generate(client: Any, model: str, messages: MessageHistory) -> 
 
 
 async def test_model_connection(
-    config: AgentConfig,
+    provider: ModelProvider,
+    model: str,
     *,
+    api_key: str = "",
+    token_manager: Any = None,
+    rate_limits: Optional[RateLimitConfig] = None,
     client_factory: Callable[..., Any] = LLMClient,
     timeout: float = CONNECTION_TEST_TIMEOUT_SECONDS,
     usage_ledger: Any = None,
 ) -> ModelConnectionResult:
-    """Send a tiny no-tool prompt through the selected model.
+    """Send a tiny no-tool prompt through one provider/model pair.
 
     This is intentionally opt-in: providers do not expose one uniform, free auth
     endpoint, so a real generation is the only dependable cross-provider probe.
+
+    The target is passed in rather than read off an ``AgentConfig`` so a credential can
+    be probed on its own — the Providers screen tests a key for a provider that may not
+    be in use, and must keep working when the rest of the model configuration is broken.
     """
 
-    model_config = config.long_context_config
+    limits = rate_limits or RateLimitConfig()
     try:
         factory_kwargs: dict[str, Any] = {
-            "provider": model_config.provider,
-            "api_key": config.get_api_key(model_config.provider) or "",
+            "provider": provider,
+            "api_key": api_key,
             "max_retries": 0,
-            "requests_per_minute": model_config.rate_limits.requests_per_minute,
-            "tokens_per_minute": model_config.rate_limits.tokens_per_minute,
-            "token_manager": config.get_chatgpt_token_manager(),
+            "requests_per_minute": limits.requests_per_minute,
+            "tokens_per_minute": limits.tokens_per_minute,
+            "token_manager": token_manager,
         }
         # The probe is a real paid request; account for it when the host has a
         # ledger. Omitted when None so injected fake factories keep their shape.
@@ -63,18 +71,15 @@ async def test_model_connection(
         client = client_factory(**factory_kwargs)
         messages = MessageHistory([Message(role="user", content=[TextBlock(text="Reply with OK.")])])
         await asyncio.wait_for(
-            _probe_generate(client, model_config.model, messages),
+            _probe_generate(client, model, messages),
             timeout=timeout,
         )
     except asyncio.TimeoutError:
         return ModelConnectionResult(False, f"Connection test timed out after {timeout:g} seconds.")
     except LLMError as exc:
-        return ModelConnectionResult(False, llm_error_message(exc, model=model_config.model))
+        return ModelConnectionResult(False, llm_error_message(exc, model=model))
     except Exception:
         return ModelConnectionResult(
             False, "The connection test failed unexpectedly. Check the provider and try again."
         )
-    return ModelConnectionResult(
-        True,
-        f"Connected to {model_config.provider.value}/{model_config.model}.",
-    )
+    return ModelConnectionResult(True, f"Connected to {provider.value}/{model}.")

--- a/kolega_code/cli/tui/onboarding_screen.py
+++ b/kolega_code/cli/tui/onboarding_screen.py
@@ -354,7 +354,16 @@ class OnboardingScreen(ModalScreen[None]):
             return
         button.disabled = True
         status.update("Testing connection…")
-        result = await test_model_connection(config, usage_ledger=getattr(self.owner, "_usage_ledger", None))
+        # The wizard probes exactly the pair the user just picked.
+        model_config = config.long_context_config
+        result = await test_model_connection(
+            model_config.provider,
+            model_config.model,
+            api_key=config.get_api_key(model_config.provider) or "",
+            token_manager=config.get_chatgpt_token_manager(),
+            rate_limits=model_config.rate_limits,
+            usage_ledger=getattr(self.owner, "_usage_ledger", None),
+        )
         status.update(result.message)
         button.disabled = False
         if result.ok:

--- a/kolega_code/cli/tui/settings_panel.py
+++ b/kolega_code/cli/tui/settings_panel.py
@@ -13,10 +13,12 @@ from urllib.parse import urlparse
 from textual.css.query import NoMatches
 from textual.widget import Widget
 from rich.text import Text
-from textual.widgets import Button, Input, Select, Static
+from textual.widgets import Button, Input, OptionList, Select, Static
+from textual.widgets.option_list import Option
 
 from kolega_code.auth import constants as chatgpt_constants
 from kolega_code.auth.chatgpt_oauth import run_login_flow
+from kolega_code.config import ModelProvider
 from kolega_code.agent.tool_backend.search_backends import (
     DEFAULT_BACKEND as DEFAULT_WEB_SEARCH_BACKEND,
     SearchBackendError,
@@ -36,10 +38,18 @@ from kolega_code.mcp.service import MCPService
 from kolega_code.mcp.state import MCPStatusStore, MCPOAuthTokenStore
 
 from .. import messages, theme
-from ..config import CliConfigError, active_model_override_message, build_agent_config, key_status
+from ..config import (
+    CliConfigError,
+    active_model_override_message,
+    build_agent_config,
+    key_status,
+    probe_token_manager,
+    resolved_api_key,
+)
 from ..model_connection import test_model_connection
 from ..provider_registry import (
     INHERIT_SENTINEL,
+    default_model_for_provider,
     UI_DEFAULT_MODEL,
     UI_DEFAULT_PROVIDER,
     get_ui_model,
@@ -307,17 +317,12 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
                 # mount-time Changed posted with the compose-time default, delivered
                 # after _populate_settings_controls restored the real provider).
                 return
+            # Purely a model choice now: credentials are edited on the Providers page,
+            # so changing the active provider no longer touches any key field.
             self._repopulate_model_select(provider, "model_select", "thinking_effort_select")
             self._update_browser_model_hint()
             self._update_slot_model_hints()
-            try:
-                api_key_input = self._settings_query_one("#api_key_input", Input)
-                api_key_input.placeholder = self._api_key_placeholder(provider)
-                # OAuth providers sign in via /login, so the key field is read-only.
-                api_key_input.disabled = provider == chatgpt_constants.PROVIDER_KEY
-            except NoMatches:
-                pass
-            self._update_model_auth_controls(provider)
+            self._update_settings_status()
             return
 
         if select_id == "model_select":
@@ -459,7 +464,6 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         provider_select = self._settings_query_one("#provider_select", Select)
         model_select = self._settings_query_one("#model_select", Select)
         effort_select = self._settings_query_one("#thinking_effort_select", Select)
-        api_key_input = self._settings_query_one("#api_key_input", Input)
 
         provider_select.value = provider
         model_select.set_options(model_options)
@@ -478,9 +482,7 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             if self.settings.active_theme in theme.available_themes()
             else theme.DEFAULT_THEME_NAME
         )
-        api_key_input.placeholder = self._api_key_placeholder(provider)
-        api_key_input.disabled = provider == chatgpt_constants.PROVIDER_KEY
-        self._update_model_auth_controls(provider)
+        self._populate_provider_rows()
         self._populate_agent_model_rows()
         self._populate_slot_model_rows()
         self._update_browser_model_hint()
@@ -490,20 +492,147 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         self._populate_lsp_controls()
         self._update_settings_status()
 
-    def _update_model_auth_controls(self, provider: str) -> None:
+    def _draft_credential_settings(self) -> CliSettings:
+        """Saved settings with the Providers page's unapplied edits layered on.
+
+        Removals are applied before staged keys, so re-typing a key for a provider you
+        just cleared wins — matching the order ``_settings_candidate_from_ui`` uses when
+        the same edits are actually written.
+        """
+        draft = deepcopy(self.settings)
+        screen = getattr(self, "_settings_screen", None)
+        if screen is None:
+            return draft
+        draft.oauth_tokens = deepcopy(screen.pending_oauth_tokens)
+        for removed_provider in screen.pending_api_key_removals:
+            draft.api_keys.pop(removed_provider, None)
+        for staged_provider, staged_key in screen.pending_api_keys.items():
+            draft.set_api_key(staged_provider, staged_key)
+        return draft
+
+    def _selected_credential_provider(self) -> Optional[str]:
+        """The provider whose credential the Providers page is editing."""
+        try:
+            provider_list = self._settings_query_one("#provider_list", OptionList)
+        except NoMatches:
+            return None
+        index = provider_list.highlighted
+        if index is None:
+            return None
+        try:
+            option = provider_list.get_option_at_index(index)
+        except IndexError:
+            return None
+        return (option.id or "").removeprefix("provider_row_") or None
+
+    def _provider_row_prompt(self, label: str, provider: str, draft: CliSettings) -> Text:
+        return Text.assemble(f"{label:<34}", (key_status(provider, self.project_path, draft), Color.MUTED))
+
+    def _populate_provider_rows(self) -> None:
+        """Build the provider list and open the active provider's credential editor."""
+        try:
+            provider_list = self._settings_query_one("#provider_list", OptionList)
+        except NoMatches:
+            return
+        draft = self._draft_credential_settings()
+        rows = ui_provider_options()
+        provider_list.clear_options()
+        provider_list.add_options(
+            [
+                Option(self._provider_row_prompt(label, value, draft), id=f"provider_row_{value}")
+                for label, value in rows
+            ]
+        )
+        values = [value for _, value in rows]
+        active = self.settings.active_provider
+        provider_list.highlighted = values.index(active) if active in values else 0
+        self._switch_provider_credential(self._selected_credential_provider() or values[0])
+
+    def _switch_provider_credential(self, provider: str) -> None:
+        """Point the credential editor at ``provider``.
+
+        The outgoing provider's typed key is banked first, then ``credential_provider``
+        moves, and only then is the Input rewritten — so the ``Changed`` that rewrite
+        posts is already filed against the incoming provider and cannot clobber the key
+        just banked for the outgoing one.
+        """
+        screen = getattr(self, "_settings_screen", None)
+        if screen is None or not provider:
+            return
+        if screen.credential_provider != provider:
+            self._commit_visible_api_key()
+            screen.credential_provider = provider
+            try:
+                self._settings_query_one("#provider_api_key_input", Input).value = screen.pending_api_keys.get(
+                    provider, ""
+                )
+            except NoMatches:
+                return
+        self._update_provider_credential_controls(provider)
+        self._refresh_provider_row_labels()
+
+    def _commit_visible_api_key(self) -> None:
+        """Bank whatever the key field holds against the provider it is showing."""
+        screen = getattr(self, "_settings_screen", None)
+        provider = getattr(screen, "credential_provider", None)
+        if screen is None or provider is None:
+            return
+        try:
+            typed = self._settings_query_one("#provider_api_key_input", Input).value.strip()
+        except NoMatches:
+            return
+        if typed:
+            screen.pending_api_keys[provider] = typed
+            # Typing a replacement supersedes a staged removal for the same provider.
+            screen.pending_api_key_removals.discard(provider)
+        else:
+            screen.pending_api_keys.pop(provider, None)
+        self._update_provider_credential_controls(provider)
+        self._refresh_provider_row_labels()
+
+    def _refresh_provider_row_labels(self) -> None:
+        """Restate row statuses in place.
+
+        Relabelling beats rebuilding: ``clear_options`` would drop the highlight and
+        post a fresh Highlighted event, which reloads the key Input mid-keystroke.
+        """
+        try:
+            provider_list = self._settings_query_one("#provider_list", OptionList)
+        except NoMatches:
+            return
+        draft = self._draft_credential_settings()
+        for label, value in ui_provider_options():
+            provider_list.replace_option_prompt(f"provider_row_{value}", self._provider_row_prompt(label, value, draft))
+
+    def _update_provider_credential_controls(self, provider: str) -> None:
+        """Swap the editor between API-key and ChatGPT sign-in shape, and restate status."""
         oauth = provider == chatgpt_constants.PROVIDER_KEY
-        for widget_id in ("settings_chatgpt_login", "settings_chatgpt_logout"):
+        for widget_id in ("provider_chatgpt_login", "provider_chatgpt_logout"):
             try:
                 self._settings_query_one(f"#{widget_id}").display = oauth
             except NoMatches:
                 pass
-        for widget_id in ("settings_api_key_label", "api_key_input"):
+        for widget_id in ("provider_api_key_label", "provider_api_key_input"):
             try:
                 self._settings_query_one(f"#{widget_id}").display = not oauth
             except NoMatches:
                 pass
         try:
-            remove_key = self._settings_query_one("#settings_remove_api_key", Button)
+            # The OAuth row is a Horizontal: hiding only its buttons would leave the
+            # empty band behind, so the container goes with them.
+            self._settings_query_one("#provider_chatgpt_row").display = oauth
+        except NoMatches:
+            pass
+        try:
+            self._settings_query_one("#provider_api_key_input", Input).placeholder = self._api_key_placeholder(provider)
+            section = self._settings_query_one("#settings_provider_credential")
+            # ui_provider_options() is (label, value); index it the other way round.
+            labels = {value: label for label, value in ui_provider_options()}
+            section.border_title = labels.get(provider, provider)
+        except NoMatches:
+            pass
+        try:
+            remove_key = self._settings_query_one("#provider_remove_api_key", Button)
         except NoMatches:
             return
         remove_key.display = not oauth
@@ -512,15 +641,14 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         remove_key.disabled = not self.settings.has_api_key(provider) or provider in pending_removals
         if screen is None:
             return
-        draft = deepcopy(self.settings)
-        draft.oauth_tokens = deepcopy(screen.pending_oauth_tokens)
-        for removed_provider in pending_removals:
-            draft.api_keys.pop(removed_provider, None)
+        draft = self._draft_credential_settings()
         try:
-            status = self._settings_query_one("#settings_connection_status", Static)
-            status.update(f"Credential status: {key_status(provider, self.project_path, draft)}")
-            login = self._settings_query_one("#settings_chatgpt_login", Button)
-            logout = self._settings_query_one("#settings_chatgpt_logout", Button)
+            status = self._settings_query_one("#provider_credential_status", Static)
+            status.update(
+                messages.PROVIDER_CREDENTIAL_STATUS.format(status=key_status(provider, self.project_path, draft))
+            )
+            login = self._settings_query_one("#provider_chatgpt_login", Button)
+            logout = self._settings_query_one("#provider_chatgpt_logout", Button)
             signed_in = draft.has_oauth_token(chatgpt_constants.PROVIDER_KEY)
             login.label = "Sign in again" if signed_in else "Sign in with ChatGPT"
             logout.disabled = not signed_in
@@ -1409,7 +1537,7 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             return
         self.settings.lsp_enabled = value == "true"
 
-    def _settings_candidate_from_ui(self) -> tuple[CliSettings, Input, str, str, str]:
+    def _settings_candidate_from_ui(self) -> tuple[CliSettings, str, str, str]:
         """Collect the mounted form into a detached settings candidate."""
         provider = str(self._settings_query_one("#provider_select", Select).value)
         model_value = str(self._settings_query_one("#model_select", Select).value)
@@ -1423,8 +1551,6 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         valid_efforts = {value for _, value in ui_thinking_effort_options(provider, model)}
         if effort not in valid_efforts:
             effort = default_ui_thinking_effort(provider, model) or ""
-        api_key_input = self._settings_query_one("#api_key_input", Input)
-
         original = self.settings
         candidate = deepcopy(original)
         screen = getattr(self, "_settings_screen", None)
@@ -1432,22 +1558,22 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             candidate.oauth_tokens = deepcopy(screen.pending_oauth_tokens)
             for removed_provider in screen.pending_api_key_removals:
                 candidate.api_keys.pop(removed_provider, None)
+            # Removals first, so re-typing a key for a provider you just cleared wins.
+            for staged_provider, staged_key in screen.pending_api_keys.items():
+                candidate.set_api_key(staged_provider, staged_key)
         self.settings = candidate
         try:
             candidate.active_provider = provider
             candidate.active_model = model
             candidate.active_thinking_effort = effort or default_ui_thinking_effort(provider, model)
             candidate.active_theme = str(self._settings_query_one("#theme_select", Select).value)
-            api_key = api_key_input.value.strip()
-            if api_key:
-                candidate.set_api_key(provider, api_key)
             self._collect_agent_models_from_ui()
             self._collect_model_slots_from_ui()
             self._collect_web_search_from_ui()
             self._collect_lsp_from_ui()
         finally:
             self.settings = original
-        return candidate, api_key_input, provider, model, effort
+        return candidate, provider, model, effort
 
     async def _save_settings_from_ui(self) -> None:
         if self._turn_active or self.agent_worker is not None:
@@ -1482,14 +1608,16 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             self._set_settings_status(error, "error")
             self._notify_user(error, severity="error")
             return
-        candidate, api_key_input, provider, _model, _effort = self._settings_candidate_from_ui()
+        candidate, provider, _model, _effort = self._settings_candidate_from_ui()
 
         ok, error = await self._apply_settings_candidate(candidate, rebuild=True)
         if not ok:
             self._set_settings_status(messages.SETTINGS_INCOMPLETE.format(error=error), "error")
             return
-        api_key_input.value = ""
-        api_key_input.placeholder = self._api_key_placeholder(provider)
+        try:
+            self._settings_query_one("#provider_api_key_input", Input).value = ""
+        except NoMatches:
+            pass
         try:
             self._settings_query_one("#web_search_api_key_input", Input).value = ""
         except NoMatches:
@@ -1498,7 +1626,10 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         if screen is not None:
             memory_applied = await screen.apply_memory_draft()
             screen.mark_clean(preserve_memory_draft=not memory_applied)
-            self._update_model_auth_controls(provider)
+            selected = self._selected_credential_provider()
+            if selected is not None:
+                self._update_provider_credential_controls(selected)
+            self._refresh_provider_row_labels()
             if not memory_applied:
                 self._set_settings_status(
                     "Other settings were saved, but project memory changes failed. Review and retry them.",
@@ -1552,18 +1683,19 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         if self._turn_active or self.agent_worker is not None:
             self._set_settings_status("Stop the active turn before changing credentials.", "warning")
             return
-        provider = str(self._settings_query_one("#provider_select", Select).value)
+        provider = self._selected_credential_provider()
+        status = self._settings_query_one("#provider_credential_status", Static)
+        if provider is None:
+            return
         if not self.settings.has_api_key(provider):
-            self._settings_query_one("#settings_connection_status", Static).update(
-                "There is no locally stored key for this provider. Environment credentials are not changed here."
-            )
+            status.update(messages.PROVIDER_KEY_NOT_STORED)
             return
         screen.pending_api_key_removals.add(provider)
-        self._settings_query_one("#api_key_input", Input).value = ""
-        self._update_model_auth_controls(provider)
-        self._settings_query_one("#settings_connection_status", Static).update(
-            "The locally stored API key will be removed when you Apply."
-        )
+        screen.pending_api_keys.pop(provider, None)
+        self._settings_query_one("#provider_api_key_input", Input).value = ""
+        self._update_provider_credential_controls(provider)
+        self._refresh_provider_row_labels()
+        status.update(messages.PROVIDER_KEY_REMOVAL_STAGED)
         screen._refresh_apply_label()
 
     async def _settings_login_chatgpt(self) -> None:
@@ -1573,8 +1705,8 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         screen = getattr(self, "_settings_screen", None)
         if screen is None:
             return
-        button = self._settings_query_one("#settings_chatgpt_login", Button)
-        status = self._settings_query_one("#settings_connection_status", Static)
+        button = self._settings_query_one("#provider_chatgpt_login", Button)
+        status = self._settings_query_one("#provider_credential_status", Static)
         button.disabled = True
         status.update("Opening your browser to sign in…")
 
@@ -1588,7 +1720,8 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             button.disabled = False
             return
         screen.pending_oauth_tokens[chatgpt_constants.PROVIDER_KEY] = tokens.model_dump(mode="json")
-        self._update_model_auth_controls(chatgpt_constants.PROVIDER_KEY)
+        self._update_provider_credential_controls(chatgpt_constants.PROVIDER_KEY)
+        self._refresh_provider_row_labels()
         status.update(f"Signed in as {tokens.email or 'your ChatGPT account'}. Apply to save this sign-in.")
         button.label = "Sign in again"
         button.disabled = False
@@ -1602,31 +1735,48 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             self._set_settings_status("Stop the active turn before signing out.", "warning")
             return
         removed = screen.pending_oauth_tokens.pop(chatgpt_constants.PROVIDER_KEY, None)
-        status = self._settings_query_one("#settings_connection_status", Static)
-        self._update_model_auth_controls(chatgpt_constants.PROVIDER_KEY)
+        status = self._settings_query_one("#provider_credential_status", Static)
+        self._update_provider_credential_controls(chatgpt_constants.PROVIDER_KEY)
+        self._refresh_provider_row_labels()
         status.update("ChatGPT sign-out will be saved when you Apply." if removed else "You are not signed in.")
         screen._refresh_apply_label()
 
+    def _credential_probe_model(self, provider: str) -> str:
+        """Which model to probe a provider's credential with.
+
+        The active model when it belongs to this provider — that is the one that
+        matters — otherwise the provider's registry default. This is a probe target,
+        not configuration: it pins nothing and is never written anywhere.
+        """
+        if self.settings.active_provider == provider and self.settings.active_model:
+            return self.settings.active_model
+        return default_model_for_provider(ModelProvider(provider))
+
     async def _test_settings_connection(self) -> None:
+        """Probe the highlighted provider's credential, independent of model config."""
         if self._turn_active or self.agent_worker is not None:
             self._set_settings_status("Stop the active turn before testing a connection.", "warning")
             return
-        status = self._settings_query_one("#settings_connection_status", Static)
-        button = self._settings_query_one("#settings_test_connection", Button)
+        status = self._settings_query_one("#provider_credential_status", Static)
+        button = self._settings_query_one("#provider_test_connection", Button)
+        provider = self._selected_credential_provider()
+        if provider is None:
+            return
+        draft = self._draft_credential_settings()
         try:
-            candidate, _api_key_input, _provider, _model, _effort = self._settings_candidate_from_ui()
-            config = build_agent_config(
-                self.project_path,
-                self.overrides,
-                settings=candidate,
-                settings_store=None,
-            )
-        except Exception as exc:
-            status.update(f"Configuration is incomplete: {exc}")
+            model = self._credential_probe_model(provider)
+        except ValueError as exc:
+            status.update(str(exc))
             return
         button.disabled = True
-        status.update("Testing connection…")
-        result = await test_model_connection(config, usage_ledger=getattr(self, "_usage_ledger", None))
+        status.update(messages.PROVIDER_TEST_RUNNING.format(provider=provider, model=model))
+        result = await test_model_connection(
+            ModelProvider(provider),
+            model,
+            api_key=resolved_api_key(provider, self.project_path, draft) or "",
+            token_manager=probe_token_manager(draft),
+            usage_ledger=getattr(self, "_usage_ledger", None),
+        )
         status.update(result.message)
         button.disabled = False
 

--- a/kolega_code/cli/tui/settings_screen.py
+++ b/kolega_code/cli/tui/settings_screen.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -38,7 +38,11 @@ if TYPE_CHECKING:
 
 
 SETTINGS_CATEGORIES = (
-    ("Model & Account", "model"),
+    # Credentials first, matching the order onboarding already walks users through
+    # (connection, then model). The "model" value is load-bearing: /model and
+    # action_open_settings(category=...) both key off it, so only the label changed.
+    ("Providers", "providers"),
+    ("Models", "model"),
     ("Agent Models", "agents"),
     ("Tools", "tools"),
     ("MCP Servers", "mcp"),
@@ -145,6 +149,14 @@ class SettingsScreen(ModalScreen[None]):
         self.pending_oauth_tokens = deepcopy(owner.settings.oauth_tokens)
         self._oauth_baseline = deepcopy(self.pending_oauth_tokens)
         self.pending_api_key_removals: set[str] = set()
+        # Keys typed on the Providers page, keyed by provider. The page lets several
+        # providers be edited before Apply, so staging cannot live in the Input alone —
+        # its value follows the highlighted row.
+        self.pending_api_keys: dict[str, str] = {}
+        # Which provider the key Input is currently showing. Staging targets this rather
+        # than the highlighted row: it is updated before the Input is rewritten, so the
+        # Changed event that rewrite posts can never be filed against the wrong provider.
+        self.credential_provider: Optional[str] = None
 
     def compose(self) -> ComposeResult:
         with Horizontal(id="settings_screen_header"):
@@ -156,6 +168,7 @@ class SettingsScreen(ModalScreen[None]):
                 id="settings_categories",
             )
             with Vertical(id="settings_screen_detail"):
+                yield from self._compose_providers_page()
                 yield from self._compose_model_page()
                 yield from self._compose_agent_page()
                 yield from self._compose_tools_page()
@@ -172,10 +185,48 @@ class SettingsScreen(ModalScreen[None]):
                     classes="solid-primary",
                 )
 
+    def _compose_providers_page(self) -> ComposeResult:
+        with VerticalScroll(id="settings_page_providers", classes="settings-page"):
+            with Vertical(classes="settings-section", id="settings_providers") as section:
+                section.border_title = "Providers"
+                yield Static(messages.PROVIDERS_HINT, classes="settings-hint")
+                yield OptionList(id="provider_list")
+            with Vertical(classes="settings-section", id="settings_provider_credential") as credential:
+                # Retitled to the highlighted provider by _update_provider_credential_controls.
+                credential.border_title = "Credential"
+                yield Label("API key", id="provider_api_key_label")
+                yield Input(password=True, id="provider_api_key_input")
+                yield Button(
+                    "Remove Stored Key",
+                    id="provider_remove_api_key",
+                    classes="quiet",
+                )
+                with Horizontal(classes="settings-button-row", id="provider_chatgpt_row"):
+                    yield Button(
+                        "Sign in with ChatGPT",
+                        id="provider_chatgpt_login",
+                        classes="quiet",
+                    )
+                    yield Button(
+                        "Sign out",
+                        id="provider_chatgpt_logout",
+                        classes="quiet",
+                    )
+                yield Button(
+                    "Test Connection",
+                    id="provider_test_connection",
+                    classes="quiet",
+                )
+                yield Static(
+                    "Connection testing sends a tiny, potentially billable model request.",
+                    classes="settings-hint",
+                )
+                yield Static("", id="provider_credential_status")
+
     def _compose_model_page(self) -> ComposeResult:
         with VerticalScroll(id="settings_page_model", classes="settings-page"):
             with Vertical(classes="settings-section", id="settings_model") as section:
-                section.border_title = "Model & Account"
+                section.border_title = "Models"
                 yield Label("Provider")
                 yield Select(
                     ui_provider_options(),
@@ -200,34 +251,7 @@ class SettingsScreen(ModalScreen[None]):
                     allow_blank=True,
                     value=default_ui_thinking_effort(UI_DEFAULT_PROVIDER, UI_DEFAULT_MODEL),
                 )
-                yield Label("API key", id="settings_api_key_label")
-                yield Input(password=True, id="api_key_input")
-                yield Button(
-                    "Remove Stored Key",
-                    id="settings_remove_api_key",
-                    classes="quiet",
-                )
-                with Horizontal(classes="settings-button-row"):
-                    yield Button(
-                        "Sign in with ChatGPT",
-                        id="settings_chatgpt_login",
-                        classes="quiet",
-                    )
-                    yield Button(
-                        "Sign out",
-                        id="settings_chatgpt_logout",
-                        classes="quiet",
-                    )
-                yield Button(
-                    "Test Connection",
-                    id="settings_test_connection",
-                    classes="quiet",
-                )
-                yield Static(
-                    "Connection testing sends a tiny, potentially billable model request.",
-                    classes="settings-hint",
-                )
-                yield Static("", id="settings_connection_status")
+                yield Static(messages.MODEL_CREDENTIAL_POINTER, classes="settings-hint")
             with Vertical(classes="settings-section", id="settings_model_slots") as slots_section:
                 slots_section.border_title = "Model Slots"
                 yield Static(messages.MODEL_SLOT_HINT, classes="settings-hint")
@@ -498,37 +522,32 @@ class SettingsScreen(ModalScreen[None]):
                 pass
 
     def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
-        if event.option_list.id != "settings_categories":
+        if event.option_list.id == "settings_categories":
+            event.stop()
+            self._show_category((event.option_id or "").removeprefix("settings_category_"))
+
+    def on_option_list_option_highlighted(self, event: OptionList.OptionHighlighted) -> None:
+        if event.option_list.id != "provider_list":
             return
         event.stop()
-        option_id = event.option_id or ""
-        self._show_category(option_id.removeprefix("settings_category_"))
+        self.owner._switch_provider_credential((event.option_id or "").removeprefix("provider_row_"))
 
     def on_select_changed(self, event: Select.Changed) -> None:
         if event.select.id == "agent_role_select":
             self._show_agent_role(str(event.value))
-        if event.select.id == "provider_select" and not self._initializing:
-            self.query_one("#api_key_input", Input).value = ""
-        if event.select.id in {"provider_select", "model_select", "thinking_effort_select"}:
-            self._reset_connection_status()
         self.call_after_refresh(self._refresh_apply_label)
 
     def on_input_changed(self, event: Input.Changed) -> None:
-        if event.input.id == "api_key_input":
+        if event.input.id == "provider_api_key_input":
             self._reset_connection_status()
-            if event.value.strip():
-                try:
-                    provider = str(self.query_one("#provider_select", Select).value)
-                    self.pending_api_key_removals.discard(provider)
-                except Exception:
-                    pass
+            self.owner._commit_visible_api_key()
         self.call_after_refresh(self._refresh_apply_label)
 
     def _reset_connection_status(self) -> None:
         if self._initializing:
             return
         try:
-            self.query_one("#settings_connection_status", Static).update("")
+            self.query_one("#provider_credential_status", Static).update("")
         except Exception:
             pass
 
@@ -538,7 +557,13 @@ class SettingsScreen(ModalScreen[None]):
             if not isinstance(widget, (Select, Input)):
                 continue
             widget_id = widget.id or ""
-            if not widget_id or widget_id.startswith("mcp_") or widget_id == "agent_role_select":
+            # provider_api_key_input follows the highlighted provider rather than holding
+            # one value, so its content is tracked in pending_api_keys, not the snapshot.
+            if (
+                not widget_id
+                or widget_id.startswith("mcp_")
+                or widget_id in {"agent_role_select", "provider_api_key_input"}
+            ):
                 continue
             value = widget.value
             if value is Select.NULL:
@@ -552,10 +577,12 @@ class SettingsScreen(ModalScreen[None]):
             self._snapshot() != self._baseline
             or self.pending_oauth_tokens != self._oauth_baseline
             or bool(self.pending_api_key_removals)
+            or bool(self.pending_api_keys)
         )
 
     def mark_clean(self, *, preserve_memory_draft: bool = False) -> None:
         self.pending_api_key_removals.clear()
+        self.pending_api_keys.clear()
         baseline = dict(self._snapshot())
         if preserve_memory_draft:
             previous = dict(self._baseline)

--- a/kolega_code/cli/tui/styles.tcss
+++ b/kolega_code/cli/tui/styles.tcss
@@ -473,8 +473,18 @@ SettingsScreen #settings_screen_actions Button {
     margin-left: 1;
 }
 
-SettingsScreen #settings_connection_status {
+SettingsScreen #provider_credential_status {
     height: auto;
+    margin-top: 1;
+}
+
+/* The provider roster sizes to its rows rather than filling the page, so the
+   credential editor beneath it stays visible without scrolling. */
+SettingsScreen #provider_list {
+    height: auto;
+    max-height: 16;
+    border: none;
+    background: $background;
     margin-top: 1;
 }
 

--- a/tests/cli/_app_test_utils.py
+++ b/tests/cli/_app_test_utils.py
@@ -321,6 +321,26 @@ async def open_settings_screen(app, pilot, category: str = "model"):
     return screen
 
 
+async def stage_provider_api_key(screen, pilot, provider: str, key: str) -> None:
+    """Type an API key for ``provider`` on the Providers page.
+
+    Mirrors the real interaction: highlight the provider's row, let the editor follow,
+    then type. Keys stage per provider and are only written on Apply.
+    """
+    from textual.widgets import Input, OptionList
+
+    provider_list = screen.query_one("#provider_list", OptionList)
+    provider_list.highlighted = provider_list.get_option_index(f"provider_row_{provider}")
+    # The highlight drives credential_provider through a posted message; wait for the
+    # editor to actually follow before typing, or the key lands on the previous row.
+    for _ in range(50):
+        await pilot.pause()
+        if screen.credential_provider == provider:
+            break
+    screen.query_one("#provider_api_key_input", Input).value = key
+    await pilot.pause()
+
+
 def _build_sub_agent_test_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, **app_kwargs):
     pytest.importorskip("textual")
 

--- a/tests/cli/test_app_bootstrap_settings.py
+++ b/tests/cli/test_app_bootstrap_settings.py
@@ -42,6 +42,7 @@ from ._app_test_utils import (
     open_settings_screen,
     question_payload,
     renderable_text,
+    stage_provider_api_key,
 )
 
 
@@ -547,7 +548,7 @@ async def test_textual_app_saves_settings_and_builds_agent(
     async with app.run_test() as pilot:
         assert app.agent is None
         screen = await open_settings_screen(app, pilot)
-        screen.query_one("#api_key_input", Input).value = "moonshot-key"
+        await stage_provider_api_key(screen, pilot, UI_DEFAULT_PROVIDER, "moonshot-key")
         await app._save_settings_from_ui()
 
         assert isinstance(app.agent, FakeCoderAgent)
@@ -597,7 +598,7 @@ async def test_textual_app_saves_deepseek_settings_and_builds_agent(
         model_select = screen.query_one("#model_select", Select)
         model_select.set_options([("DeepSeek V4 Pro", DEEPSEEK_DEFAULT_MODEL)])
         model_select.value = DEEPSEEK_DEFAULT_MODEL
-        screen.query_one("#api_key_input", Input).value = "deepseek-key"
+        await stage_provider_api_key(screen, pilot, ModelProvider.DEEPSEEK.value, "deepseek-key")
         await app._save_settings_from_ui()
 
         assert isinstance(app.agent, FakeCoderAgent)
@@ -634,7 +635,7 @@ async def test_save_settings_logs_on_success_without_toast(tmp_path: Path, monke
         monkeypatch.setattr(app, "_log_status", spy_log_status)
 
         screen = await open_settings_screen(app, pilot)
-        screen.query_one("#api_key_input", Input).value = "moonshot-key"
+        await stage_provider_api_key(screen, pilot, UI_DEFAULT_PROVIDER, "moonshot-key")
         await app._save_settings_from_ui()
 
         assert ("Settings saved.", "ok") in logged
@@ -722,7 +723,7 @@ async def test_agent_models_section_saves_override_and_builds_agent(
 
     async with app.run_test() as pilot:
         screen = await open_settings_screen(app, pilot)
-        screen.query_one("#api_key_input", Input).value = "moonshot-key"
+        await stage_provider_api_key(screen, pilot, UI_DEFAULT_PROVIDER, "moonshot-key")
         # Give the investigation role its own model (same provider keeps one API key).
         screen.query_one("#am_provider_investigation", Select).value = UI_DEFAULT_PROVIDER
         await pilot.pause()  # let the provider->model cascade settle

--- a/tests/cli/test_model_connection.py
+++ b/tests/cli/test_model_connection.py
@@ -5,22 +5,19 @@ from pathlib import Path
 
 import pytest
 
-from kolega_code.cli.config import build_agent_config, key_status
+from kolega_code.cli.config import key_status
 from kolega_code.cli.model_connection import test_model_connection as run_model_connection_probe
 from kolega_code.config import ModelProvider
 from kolega_code.llm.exceptions import LLMAuthenticationError
 from kolega_code.llm.models import Message, TextBlock
 
 
-def _config(project: Path):
-    return build_agent_config(
-        project,
-        env={
-            "ANTHROPIC_API_KEY": "test-key",
-            "KOLEGA_CODE_PROVIDER": "anthropic",
-            "KOLEGA_CODE_MODEL": "claude-opus-5",
-        },
-    )
+PROBE_MODEL = "claude-opus-5"
+
+
+async def _probe(**kwargs):
+    """Probe the Anthropic credential, the way the Providers page does."""
+    return await run_model_connection_probe(ModelProvider.ANTHROPIC, PROBE_MODEL, api_key="test-key", **kwargs)
 
 
 @pytest.mark.asyncio
@@ -36,11 +33,10 @@ async def test_model_connection_sends_a_tiny_tool_free_request(tmp_path: Path) -
         calls["factory"] = kwargs
         return FakeClient()
 
-    config = _config(tmp_path)
-    result = await run_model_connection_probe(config, client_factory=factory)
+    result = await _probe(client_factory=factory)
 
     assert result.ok is True
-    assert config.long_context_config.model in result.message
+    assert PROBE_MODEL in result.message
     factory_args = calls["factory"]
     assert isinstance(factory_args, dict)
     assert factory_args["provider"] == ModelProvider.ANTHROPIC
@@ -59,7 +55,7 @@ async def test_model_connection_normalizes_authentication_errors(tmp_path: Path)
     def factory(**_kwargs):
         raise LLMAuthenticationError("bad key", provider="anthropic")
 
-    result = await run_model_connection_probe(_config(tmp_path), client_factory=factory)
+    result = await _probe(client_factory=factory)
 
     assert result.ok is False
     assert "could not authenticate" in result.message
@@ -73,9 +69,7 @@ async def test_model_connection_times_out(tmp_path: Path) -> None:
             await asyncio.sleep(1)
             return Message(role="assistant", content=[TextBlock(text="OK")])
 
-    result = await run_model_connection_probe(
-        _config(tmp_path), client_factory=lambda **_kwargs: SlowClient(), timeout=0.001
-    )
+    result = await _probe(client_factory=lambda **_kwargs: SlowClient(), timeout=0.001)
 
     assert result.ok is False
     assert result.message == "Connection test timed out after 0.001 seconds."
@@ -99,10 +93,9 @@ async def test_model_connection_threads_usage_ledger_only_when_set(tmp_path: Pat
         calls.append(kwargs)
         return FakeClient()
 
-    config = _config(tmp_path)
-    await run_model_connection_probe(config, client_factory=factory)
+    await _probe(client_factory=factory)
     assert "usage_ledger" not in calls[0]
 
     ledger = UsageLedger()
-    await run_model_connection_probe(config, client_factory=factory, usage_ledger=ledger)
+    await _probe(client_factory=factory, usage_ledger=ledger)
     assert calls[1]["usage_ledger"] is ledger

--- a/tests/cli/test_tui_settings_screens.py
+++ b/tests/cli/test_tui_settings_screens.py
@@ -6,11 +6,11 @@ from pathlib import Path
 import pytest
 
 from kolega_code.cli.config import build_agent_config, config_summary
-from kolega_code.cli.provider_registry import UI_DEFAULT_MODEL, UI_DEFAULT_PROVIDER
+from kolega_code.cli.provider_registry import DEEPSEEK_DEFAULT_MODEL, UI_DEFAULT_MODEL, UI_DEFAULT_PROVIDER
 from kolega_code.cli.session_store import SessionStore
 from kolega_code.cli.settings import CliSettings, SettingsStore
 
-from ._app_test_utils import install_fake_agents, wait_for_onboarding_screen
+from ._app_test_utils import install_fake_agents, stage_provider_api_key, wait_for_onboarding_screen
 
 
 def _configured_app(
@@ -100,7 +100,7 @@ async def test_settings_screen_is_categorized_and_stages_credentials_atomically(
         assert isinstance(screen, SettingsScreen)
         await pilot.pause()
         assert screen.dirty is False
-        assert screen.query_one("#settings_categories", OptionList).option_count == 6
+        assert screen.query_one("#settings_categories", OptionList).option_count == 7
         assert screen.query_one("#settings_page_model").display is True
         assert screen.query_one("#settings_page_tools").display is False
         apply_button = screen.query_one("#save_settings", Button)
@@ -110,8 +110,11 @@ async def test_settings_screen_is_categorized_and_stages_credentials_atomically(
         assert screen.query_one("#settings_page_model").display is False
         assert screen.query_one("#settings_page_tools").display is True
 
-        screen._show_category("model")
-        remove_button = screen.query_one("#settings_remove_api_key", Button)
+        # Credentials live on their own page, opened on the active provider's row.
+        screen._show_category("providers")
+        await pilot.pause()
+        assert screen.credential_provider == UI_DEFAULT_PROVIDER
+        remove_button = screen.query_one("#provider_remove_api_key", Button)
         assert remove_button.disabled is False
         app._settings_remove_api_key()
         await pilot.pause()
@@ -123,20 +126,21 @@ async def test_settings_screen_is_categorized_and_stages_credentials_atomically(
         assert screen.dirty is True
         assert "Configuration incomplete" in str(screen.query_one("#settings_status").render())
 
-        screen.query_one("#api_key_input", Input).value = "replacement-key"
-        await pilot.pause()
+        await stage_provider_api_key(screen, pilot, UI_DEFAULT_PROVIDER, "replacement-key")
         assert UI_DEFAULT_PROVIDER not in screen.pending_api_key_removals
         await app._save_settings_from_ui()
 
         assert settings_store.load().get_api_key(UI_DEFAULT_PROVIDER) == "replacement-key"
-        assert screen.query_one("#api_key_input", Input).value == ""
+        assert screen.query_one("#provider_api_key_input", Input).value == ""
         assert screen.dirty is False
         assert apply_button.disabled is True
 
-        screen.query_one("#api_key_input", Input).value = "provider-specific-key"
+        # Decoupled: the Models provider picker no longer touches the key field.
+        await stage_provider_api_key(screen, pilot, UI_DEFAULT_PROVIDER, "still-here")
         screen.query_one("#provider_select", Select).value = "deepseek"
         await pilot.pause()
-        assert screen.query_one("#api_key_input", Input).value == ""
+        assert screen.query_one("#provider_api_key_input", Input).value == "still-here"
+        assert screen.pending_api_keys[UI_DEFAULT_PROVIDER] == "still-here"
 
 
 async def _wait_for_select_values(pilot, screen, expected: dict[str, str], *, attempts: int = 50) -> None:
@@ -239,10 +243,16 @@ async def test_settings_layout_uses_uniform_controls_and_quiet_actions(
         provider = screen.query_one("#provider_select", Select)
         model = screen.query_one("#model_select", Select)
         effort = screen.query_one("#thinking_effort_select", Select)
-        api_key = screen.query_one("#api_key_input")
         assert provider.region.width == model.region.width == effort.region.width == 46
+        assert provider.region.x == model.region.x == effort.region.x
+
+        # The Providers page shares the same control width.
+        screen._show_category("providers")
+        await pilot.pause()
+        api_key = screen.query_one("#provider_api_key_input")
         assert api_key.region.width == 46
-        assert provider.region.x == model.region.x == effort.region.x == api_key.region.x
+        screen._show_category("model")
+        await pilot.pause()
 
         # Quiet secondary vs one solid primary action in the footer band.
         close_button = screen.query_one("#close_settings", Button)
@@ -995,3 +1005,177 @@ async def test_model_slot_row_without_an_api_key_blocks_apply(
 
         assert settings_store.load().model_slots == {}
         assert "GOOGLE_API_KEY" in str(screen.query_one("#settings_status").render())
+
+
+@pytest.mark.asyncio
+async def test_providers_page_stages_keys_for_several_providers_at_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_cli_env: None,
+) -> None:
+    """The case that was impossible before: keys for providers you are not using."""
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+
+    app, settings_store = _configured_app(tmp_path, monkeypatch)
+
+    async with app.run_test(size=(100, 40)) as pilot:
+        app.action_open_settings("providers")
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+
+        await stage_provider_api_key(screen, pilot, "deepseek", "deepseek-key")
+        await stage_provider_api_key(screen, pilot, "google", "google-key")
+        assert screen.dirty is True
+
+        await app._save_settings_from_ui()
+
+        saved = settings_store.load()
+        assert saved.get_api_key("deepseek") == "deepseek-key"
+        assert saved.get_api_key("google") == "google-key"
+        # Neither was misfiled against the active model's provider.
+        assert saved.get_api_key(UI_DEFAULT_PROVIDER) == "stored-key"
+        assert saved.active_provider == UI_DEFAULT_PROVIDER
+        assert screen.pending_api_keys == {}
+
+
+@pytest.mark.asyncio
+async def test_staged_key_survives_moving_the_selection_away_and_back(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_cli_env: None,
+) -> None:
+    pytest.importorskip("textual")
+    from textual.widgets import Input, OptionList
+
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+
+    app, _ = _configured_app(tmp_path, monkeypatch)
+
+    async with app.run_test(size=(100, 40)) as pilot:
+        app.action_open_settings("providers")
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+        provider_list = screen.query_one("#provider_list", OptionList)
+
+        await stage_provider_api_key(screen, pilot, "deepseek", "deepseek-key")
+        # Move away: the field shows the other provider's (empty) staging...
+        provider_list.highlighted = provider_list.get_option_index("provider_row_google")
+        await pilot.pause()
+        assert screen.query_one("#provider_api_key_input", Input).value == ""
+        # ...and coming back restores what was typed rather than losing it.
+        provider_list.highlighted = provider_list.get_option_index("provider_row_deepseek")
+        await pilot.pause()
+        assert screen.query_one("#provider_api_key_input", Input).value == "deepseek-key"
+        assert screen.pending_api_keys == {"deepseek": "deepseek-key"}
+
+
+@pytest.mark.asyncio
+async def test_provider_rows_report_credential_status(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_cli_env: None,
+) -> None:
+    pytest.importorskip("textual")
+    from textual.widgets import OptionList
+
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+
+    monkeypatch.setenv("GOOGLE_API_KEY", "from-the-environment")
+    app, _ = _configured_app(tmp_path, monkeypatch)
+
+    async with app.run_test(size=(100, 40)) as pilot:
+        app.action_open_settings("providers")
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+        provider_list = screen.query_one("#provider_list", OptionList)
+
+        def row(provider: str) -> str:
+            index = provider_list.get_option_index(f"provider_row_{provider}")
+            return str(provider_list.get_option_at_index(index).prompt)
+
+        assert "present in local settings" in row(UI_DEFAULT_PROVIDER)
+        assert "present via GOOGLE_API_KEY" in row("google")
+        assert "missing" in row("deepseek")
+
+        # Staging a key updates the roster immediately, before Apply.
+        await stage_provider_api_key(screen, pilot, "deepseek", "deepseek-key")
+        assert "present in local settings" in row("deepseek")
+
+
+@pytest.mark.asyncio
+async def test_test_connection_probes_the_highlighted_provider(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_cli_env: None,
+) -> None:
+    """The probe follows the Providers selection, not the active model."""
+    pytest.importorskip("textual")
+    from textual.widgets import OptionList, Static
+
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+    from kolega_code.config import ModelProvider
+
+    app, _ = _configured_app(tmp_path, monkeypatch, extra_key_providers=("deepseek",))
+    probes: list[dict] = []
+
+    async def fake_probe(provider, model, **kwargs):
+        from kolega_code.cli.model_connection import ModelConnectionResult
+
+        probes.append({"provider": provider, "model": model, **kwargs})
+        return ModelConnectionResult(True, f"Connected to {provider.value}/{model}.")
+
+    monkeypatch.setattr("kolega_code.cli.tui.settings_panel.test_model_connection", fake_probe)
+
+    async with app.run_test(size=(100, 40)) as pilot:
+        app.action_open_settings("providers")
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+        provider_list = screen.query_one("#provider_list", OptionList)
+        provider_list.highlighted = provider_list.get_option_index("provider_row_deepseek")
+        await pilot.pause()
+
+        await app._test_settings_connection()
+
+        assert probes[-1]["provider"] == ModelProvider.DEEPSEEK
+        assert probes[-1]["api_key"] == "stored-key"
+        # Active model is moonshot's, so the probe falls back to deepseek's own default.
+        assert probes[-1]["model"] == DEEPSEEK_DEFAULT_MODEL
+        assert "deepseek" in str(screen.query_one("#provider_credential_status", Static).render())
+
+
+@pytest.mark.asyncio
+async def test_chatgpt_provider_row_offers_sign_in_instead_of_a_key_field(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_cli_env: None,
+) -> None:
+    pytest.importorskip("textual")
+    from textual.widgets import OptionList
+
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+
+    app, _ = _configured_app(tmp_path, monkeypatch)
+
+    async with app.run_test(size=(100, 40)) as pilot:
+        app.action_open_settings("providers")
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+        provider_list = screen.query_one("#provider_list", OptionList)
+
+        assert screen.query_one("#provider_api_key_input").display is True
+        assert screen.query_one("#provider_chatgpt_login").display is False
+
+        provider_list.highlighted = provider_list.get_option_index("provider_row_openai_chatgpt")
+        await pilot.pause()
+
+        assert screen.query_one("#provider_api_key_input").display is False
+        assert screen.query_one("#provider_remove_api_key").display is False
+        assert screen.query_one("#provider_chatgpt_login").display is True
+        assert screen.query_one("#provider_chatgpt_logout").display is True


### PR DESCRIPTION
> **Stacked on #444.** Base is `feat/tui-model-slot-selectors`, not `main` — both branches touch `settings_panel.py`, `settings_screen.py`, and `test_tui_settings_screens.py`. Merge #444 first and this retargets to `main` cleanly.

## Why

API keys were welded to the model picker. The single key `Input` was filed against whatever `#provider_select` held at Apply time (`settings_panel.py:1441-1443`), so **a key could only be entered for the provider you were already running on**.

That collides with everything cross-provider: the fast/thinking slots from #444, and the per-agent overrides that predate them, both need credentials for providers that are *not* your active one. The workaround was to switch your main provider, type the key, switch back.

Two supporting signs this was the wrong shape:

- `settings_screen.py:510-511` cleared the key input on *every* provider change — a guard that exists only because the field's meaning shifted underneath the user. It is deleted here.
- `key_status()` already returns a per-provider string, but the UI called it once, for the selected provider. Answering "what am I actually set up for?" meant clicking through the dropdown one entry at a time.

Credentials were also already scattered — web-search keys on Tools, MCP OAuth on MCP Servers — so "keys live next to their feature" was never the rule. And onboarding already sequences `("welcome", "connection", "model", "ready")`; a Providers-first rail makes Settings agree with it.

## What changed

**Providers**, first in the rail:

```
╭─ Providers ────────────────────────────────────────────────╮
│  Moonshot AI                   present in local settings   │
│  DeepSeek AI                   present in local settings   │
│  OpenAI                        missing                     │
│  OpenAI (ChatGPT subscription) signed in as you@ex (pro)   │
│  Google                        missing                     │
╰────────────────────────────────────────────────────────────╯
╭─ Google ───────────────────────────────────────────────────╮
│ API key   [ ························ ]                     │
│    Remove Stored Key      Test Connection                  │
│ Credential status: missing                                 │
╰────────────────────────────────────────────────────────────╯
```

**Keys stage per provider.** A new `pending_api_keys` map lets several providers be set up before one Apply, and the whole draft still writes atomically alongside `pending_api_key_removals` / `pending_oauth_tokens`.

**Test Connection is per-provider.** `test_model_connection` now takes provider and model explicitly instead of reading `config.long_context_config` (`model_connection.py:49`), so it probes the row you selected. Probe model = the active model when it belongs to that provider, else the provider's registry default — a probe target, never written anywhere.

**Model & Account → Models.** Label only; the `"model"` category value is load-bearing for `/model` and `action_open_settings(category=...)`.

Scope is model providers only — web-search keys stay on Tools, MCP OAuth on MCP Servers. Those authenticate tools, not models.

### One subtle bit worth reviewing

Staging targets the provider the field is *displaying* (`credential_provider`), not the highlighted row, and that pointer moves **before** the `Input` is rewritten. Otherwise the `Changed` event the rewrite posts is filed against the outgoing provider and clobbers the key just banked. The provider key input is also excluded from `_snapshot()` — its value follows the selection, so it would otherwise register as spurious dirt.

## Verification

`4185 passed, 1 skipped`. Ruff, format, pyright, and `pre-commit` all clean.

Driven live in a real TUI against an isolated `KOLEGA_CODE_STATE_DIR`:

| Check | Result |
|---|---|
| Roster statuses | truthful mix of `present in local settings` / `missing` / `signed in as …` |
| Key for a **non-active** provider | Google **and** OpenAI staged together, both landed in one Apply, active model untouched on `deepseek` |
| Roster updates while typing | row flipped `missing` → `present in local settings` before Apply |
| Remove Stored Key | staged; re-typing a key superseded the removal |
| Test Connection | probed `Google/gemini-3.1-pro-preview` while active was `deepseek/deepseek-v4-flash` |
| ChatGPT row | key field, its label, and Remove hidden; Sign in / Sign out shown |

5 new TUI tests cover multi-provider staging, staged keys surviving a selection change, roster status labels, the probe target, and the ChatGPT toggle. `test_settings_screen_is_categorized_and_stages_credentials_atomically` now also asserts the *decoupling*: changing the Models provider leaves a staged key alone.

## Corrected while verifying

I had written that Test Connection now works "even when the model configuration is incomplete" — true of the code, but unreachable in practice: with `config is None` the composer is disabled and Settings routes to onboarding. The docs and CHANGELOG say the accurate thing instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tx2HDRtwNKo7bELVLJzNvC