### PR TITLE
fix(deepseek): stop truncating flash reasoning at 64k

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,17 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   always writes both — and a saved model that later leaves the catalog still degrades
   to the provider's default rather than blocking startup.
 
+### Fixed
+
+- `deepseek-v4-flash` no longer has its reasoning truncated mid-derivation. The
+  64000-token output cap added in 0.26.8 was measured on the chat API for
+  `deepseek-v4-pro` and applied to flash by assumption; flash actually runs to
+  at least 112990 output tokens in a single Responses call. Hard tasks that
+  reason for a long time before acting were cut off at the cap and produced no
+  tool call at all. flash now uses its full published output budget, while pro
+  and the fireworks/openrouter DeepSeek routes keep the 64000 cap where their
+  measured ceilings apply.
+
 ### Removed
 
 - The unreachable `DEFAULT_LONG_MODEL`, `DEFAULT_FAST_MODEL`, `DEFAULT_THINKING_MODEL`

--- a/kolega_code/llm/specs/accessors.py
+++ b/kolega_code/llm/specs/accessors.py
@@ -119,12 +119,14 @@ def preferred_edit_protocol(provider: str, model_name: str) -> Optional[str]:
 #     rejects or visibly clamps, so the client must send the cap it wants.
 # An explicit client cap below the ceiling is therefore both the only reliable
 # honest-truncation signal AND what unlocks the model's full output (uncapped,
-# flash delivers ~7k; capped, 64000). 64000 matches oh-my-pi's
-# OPENAI_MAX_OUTPUT_TOKENS and leaves margin under the measured 65536 ceiling.
-# Applied to DeepSeek models on every provider that offers them (first-party,
-# fireworks, ollama_cloud, openrouter) by _apply_deepseek_request_rules in
-# providers/openai.py and DeepSeekResponsesProvider._build_request.
+# flash delivers ~7k; capped, 64000). 64000 leaves margin under the 65536 ceiling
+# measured on the chat path, and applies only there: flash was separately measured
+# running to 112990 output tokens in a single Responses call (2026-08-03), so it
+# takes its catalog value instead.
 DEEPSEEK_WIRE_OUTPUT_CAP = 64000
+
+# Routes whose catalog max_completion_tokens is itself the real ceiling.
+_UNCLAMPED_DEEPSEEK_ROUTES = {("deepseek", "deepseek-v4-flash")}
 
 
 def is_deepseek_model(model_name: str) -> bool:
@@ -143,8 +145,12 @@ def deepseek_output_token_cap(provider: str, model_name: str, requested: Optiona
     ``DEEPSEEK_WIRE_OUTPUT_CAP``). Always returns a value — DeepSeek requests
     always carry an explicit cap, because the server truncates silently without
     one (see the block comment above). The min keeps smaller models honest: a
-    catalog entry with a cap below 64000 stays at its own cap.
+    catalog entry with a cap below 64000 stays at its own cap. Routes in
+    ``_UNCLAMPED_DEEPSEEK_ROUTES`` skip the clamp and pass their catalog value
+    through.
     """
-    specs = MODEL_SPECS.get((_provider_value(provider), model_name))
+    provider_value = _provider_value(provider)
+    specs = MODEL_SPECS.get((provider_value, model_name))
     ceiling = specs.get("max_completion_tokens") if specs else None
-    return min(value for value in (requested, ceiling, DEEPSEEK_WIRE_OUTPUT_CAP) if value is not None)
+    clamp = None if (provider_value, model_name) in _UNCLAMPED_DEEPSEEK_ROUTES else DEEPSEEK_WIRE_OUTPUT_CAP
+    return min(value for value in (requested, ceiling, clamp) if value is not None)

--- a/kolega_code/llm/specs/catalog/deepseek.py
+++ b/kolega_code/llm/specs/catalog/deepseek.py
@@ -10,11 +10,15 @@ from kolega_code.llm.specs.types import ThinkingEffortSpec
 #     length allowed for this chat interface") with a clean status="completed".
 #     With an explicit max_output_tokens=64000 it streams the full 64000 and
 #     reports the cap hit honestly (status="incomplete"/max_output_tokens).
-#     Family ceiling assumed equal to pro's measured 65536.
 #   - Over-ceiling caps (384000) are accepted silently on both paths.
-# Requests never send this value raw: both request paths clamp to
-# DEEPSEEK_WIRE_OUTPUT_CAP=64000 (specs/accessors.py), so the client cap always
-# fires before the server ceiling and truncation is reported honestly.
+# flash is 384000 (corrected from 65536, which was pro's measured chat ceiling
+# assumed to apply here): those probes only measured visible output, while a
+# reasoning-heavy call was later measured running to 112990 tokens in a single
+# Responses call.
+# pro never sends this value raw: the chat path clamps to
+# DEEPSEEK_WIRE_OUTPUT_CAP=64000 (specs/accessors.py) so the client cap fires
+# before the server ceiling and truncation is reported honestly. flash passes
+# through.
 DEEPSEEK_SPECS = {
     ("deepseek", "deepseek-v4-pro"): {
         "context_length": 1000000,
@@ -35,7 +39,7 @@ DEEPSEEK_SPECS = {
     # also correctly excludes flash from the flat reasoning_content replay path.
     ("deepseek", "deepseek-v4-flash"): {
         "context_length": 1000000,
-        "max_completion_tokens": 65536,
+        "max_completion_tokens": 384000,
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",

--- a/tests/agent/llm/test_deepseek_requests.py
+++ b/tests/agent/llm/test_deepseek_requests.py
@@ -162,8 +162,8 @@ def _responses_request(params) -> dict:
 
 def test_responses_build_request_emits_max_output_tokens() -> None:
     # The shared Responses builder omits the cap; the DeepSeek override must add
-    # it (clamped) — without one the server truncates silently.
+    # it — without one the server truncates at its own 65536 default.
     assert _responses_request(GenerationParams(max_completion_tokens=4096))["max_output_tokens"] == 4096
-    assert _responses_request(GenerationParams(max_completion_tokens=384000))["max_output_tokens"] == 64000
-    # No params at all (direct callers): always-emit pins the wire cap.
-    assert _responses_request(None)["max_output_tokens"] == 64000
+    # flash is unclamped: its catalog max_completion_tokens passes through.
+    assert _responses_request(GenerationParams(max_completion_tokens=384000))["max_output_tokens"] == 384000
+    assert _responses_request(None)["max_output_tokens"] == 384000

--- a/tests/agent/llm/test_model_specs.py
+++ b/tests/agent/llm/test_model_specs.py
@@ -125,15 +125,20 @@ def test_kimi_coding_k3_model_specs(model, context_length):
     assert specs["thinking_effort"].mode == "kimi_coding_effort"
 
 
-@pytest.mark.parametrize("model", ["deepseek-v4-pro", "deepseek-v4-flash"])
-def test_deepseek_model_specs(model: str):
+@pytest.mark.parametrize(
+    "model,max_completion_tokens",
+    [
+        # pro (chat): the MEASURED ceiling — the server cuts at exactly 65536.
+        ("deepseek-v4-pro", 65536),
+        # flash (Responses): no such cut; measured running to 112990 in one call.
+        ("deepseek-v4-flash", 384000),
+    ],
+)
+def test_deepseek_model_specs(model: str, max_completion_tokens: int):
     specs = get_model_specs("deepseek", model)
 
     assert specs["context_length"] == 1000000
-    # The MEASURED per-response output ceiling (server cuts at exactly 65536),
-    # not DeepSeek's published 384000 — see catalog/deepseek.py and
-    # test_deepseek_output_cap_live.py.
-    assert specs["max_completion_tokens"] == 65536
+    assert specs["max_completion_tokens"] == max_completion_tokens
     assert specs["default_temperature"] == 1.0
     assert specs["thinking_effort"].options == ("none", "high", "max")
     assert specs["thinking_effort"].default == "high"


### PR DESCRIPTION
## The bug

`DEEPSEEK_WIRE_OUTPUT_CAP = 64000` was cutting `deepseek-v4-flash` off mid-derivation, so tasks that reason for a long time before acting produced **no tool call at all**.

Observed on a reasoning-heavy task: four consecutive 64,001-token turns spent reasoning, no deliverable, 192,070 output tokens of which **99.98% were reasoning**.

## Why the cap was wrong

The 64000 clamp comes from a 65,536 hard cut measured on first-party **chat `v4-pro`**. The catalog carried that number to flash as an assumption — *"Family ceiling assumed equal to pro's measured 65536"* — and the probes behind it used a data-generation prompt, so they measured the ceiling on **visible output** and never saw reasoning-bound behaviour.

## The measurement

Replaying the failing call through the shipped request path, cap as the only variable:

| cap on the wire | output tokens | status | ended in |
|---|---|---|---|
| 64,000 (previously shipped) | 64,000 | `incomplete` / `max_output_tokens` | **nothing** |
| *none* | 65,535 | `incomplete` / `max_output_tokens` | **nothing** |
| 200,000 | **112,990** | `completed` | **`tool_use`** |
| 384,000 | **111,505** | `completed` | **`tool_use`** |

Past the wall the model finishes its derivation, calls a tool, and the loop collapses to small productive turns (82 / 87 / 72 tokens).

The uncapped row also shows this predates the clamp: the shared Responses builder never emitted `max_output_tokens`, so DeepSeek applied its own 65,536 default. The clamp didn't introduce the wall, it codified it.

## Why 384000 rather than a tighter number

Demand for the same call is highly variable — 56k, 60k, 110k, 112k, 117k across samples — so there is no percentile worth picking from a handful of measurements. Nothing rejects or clamps the larger request, and the model stops when it is done rather than at the cap (200,000 and 384,000 both peak ~112k). Bounding a runaway is the silent-turn guard's job; the cap's only job is to avoid truncating work the model would have finished.

## The change

- `catalog/deepseek.py`: flash `max_completion_tokens` **384000 ← 65536**; pro unchanged.
- `accessors.py`: the clamp is no longer family-wide — `_UNCLAMPED_DEEPSEEK_ROUTES` exempts first-party flash so its catalog value passes through.

Scoping is deliberate: chat `v4-pro` has a genuinely measured 65,536 cut, fireworks defaults to 32,768, and OpenRouter's routing filter drops providers that cannot serve the requested `max_tokens`.

One trap worth knowing: `deepseek_output_token_cap()` is a `min()` over (requested, catalog ceiling, clamp), so **both** the catalog value and the clamp had to move — raising either alone silently changes nothing.

## Tests

`test_deepseek_requests.py` and `test_model_specs.py` updated to the new contract. Existing suite green (598 passed).

The probe used to measure this is not included — each run streams 100k+ output tokens and takes 10–25 minutes, so it is kept as a local research tool rather than a repo test.

## Not proven here

Flash's true hard ceiling. At both 200,000 and 384,000 the model stopped voluntarily, so we only know it is above 112,990.