### PR TITLE
chore: release v0.26.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.26.9 - 2026-08-03
+
 ### Added
 
 - Settings → Model & Account gains a **Model Slots** section for pinning the fast
@@ -14,6 +16,8 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   silently inherited the active model — every `web_fetch` answering call ran on
   the main coding model. Slots still inherit by default, and each row now shows
   which model it currently resolves to.
+- The README now includes a direct invitation to the Kolega Code Discord
+  community.
 
 ### Changed
 

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.26.8"
+__version__ = "0.26.9"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.26.8"
+__version__ = "0.26.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.26.8"
+version = "0.26.9"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-27T12:17:13.394155Z"
+exclude-newer = "2026-07-27T17:48:41.801491Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -1531,7 +1531,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.26.8"
+version = "0.26.9"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Release v0.26.9

- Adds configurable fast and thinking model slots in Settings.
- Separates provider credential management into a dedicated Settings screen.
- Fixes `deepseek-v4-flash` reasoning truncation by using its supported output budget.

Validated with the fast suite on Python 3.11 and 3.12, CI-equivalent pre-commit hooks, locked dependency audit, and wheel/sdist smoke tests.