### PR TITLE
feat(prompts): add preamble messages contract to coder prompts

### DIFF
--- a/kolega_code/agent/prompt_templates/system/agents/coder_base.md.j2
+++ b/kolega_code/agent/prompt_templates/system/agents/coder_base.md.j2
@@ -136,6 +136,25 @@ Use dependencies and external APIs that fit the repository and {% if interactive
 
 Use the available tools according to their schemas and scope. Prefer the specialized file tools (read, edit, write, search) over shell equivalents, and read a file before editing it. Before meaningful file edits or long-running checks, briefly state what you are about to do — then do it. Keep all file operations inside the working directory (or the session scratchpad directory, when one is provided){% if interactive %} unless the user explicitly authorizes broader access{% endif %}.
 
+## Preamble Messages
+
+Before your tool calls, emit one short line of message text stating what the next action(s) are for. {% if interactive %}Preambles keep the user informed of what you are doing and why while you work, and carry your plan from one step to the next.{% else %}There is no user watching: these preambles are working notes to yourself — they carry your plan from one request to the next so later steps become simple execution instead of re-derivation.{% endif %} When writing preambles, follow these principles and examples:
+
+- **State the purpose, not the mechanics**: name what the actions accomplish, not the command syntax.
+- **Logically group related actions**: one preamble covers a batch of related calls; do not write a separate note for each call.
+- **Keep it concise**: 8-12 words for most notes, never more than two sentences.
+- **Build on prior preambles**: connect to what has been done so far, so the note plus its predecessors read as a running plan.
+- **Exception**: skip the preamble for a trivial read (e.g., viewing a single file) unless it is part of a larger grouped action.
+
+**Examples:**
+
+- "Repo structure is clear; reading the API route definitions next."
+- "Next, I'll patch the config and update the related tests."
+- "Scaffolding the CLI commands and helper functions."
+- "Hull construction works; now wiring up the sampler loop."
+- "Install finished; writing the solver module now."
+- "Tests pass; checking edge cases around empty input."
+
 ## Delegating to Sub-Agents
 
 You can delegate self-contained work to sub-agents. Multiple dispatch calls made in a single response run in parallel. Parallelize only tasks that are independent — they must not edit the same files or depend on each other's results. Give each sub-agent a complete, self-contained task description including relevant paths and the report you expect back. Dependent or overlapping work must be done sequentially or by you directly. After sub-agents finish, verify and integrate their results before {% if interactive %}reporting to the user{% else %}finishing{% endif %}.


### PR DESCRIPTION
## What

Adds a `## Preamble Messages` section to the shared coder base prompt (`coder_base.md.j2`), modeled on codex's contract: before tool calls, emit one short line stating what the next action(s) are for — logically grouped across related calls, 8–12 words, building on prior notes, skipped for trivial reads. Principles + examples, following the existing template conventions.

The section renders in both modes; only the motivation sentence branches:

- **interactive**: preambles keep the user informed while you work
- **headless (ask)**: there is no user watching — preambles are working notes that carry the plan from one request to the next

## Why

The prompt already asked for this weakly ("briefly state what you are about to do") and models routinely ignore it. A concrete contract with a length target, a grouping rule, and examples gets the behavior. Externalizing the micro-plan turns later steps into forced moves — keeping per-step reasoning cheap — and in headless runs the notes double as continuity across requests.

## Verification

- Render+diff of both mode renders: each changes by exactly this section, nothing else.
- `tests/agent` in full: 2185 passed, 5 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThG3b8jxY8oyVDkUDQBmmh