### PR TITLE
feat(agent): export KOLEGA_SCRATCHPAD to shells and eval kernels

### DIFF
--- a/kolega_code/agent/eval/kernel.py
+++ b/kolega_code/agent/eval/kernel.py
@@ -414,20 +414,36 @@ class EvalKernelManager:
         thread_id: str,
         project_path: Path,
         config: object,
+        scratchpad_dir: Optional[Path] = None,
     ) -> "EvalKernelManager":
         """Shared manager for an agent session; sub-agents join the same one."""
         key = (workspace_id, thread_id)
         manager = cls._registry.get(key)
         if manager is None or manager._shutdown:
-            manager = cls(workspace_id=workspace_id, thread_id=thread_id, project_path=project_path, config=config)
+            manager = cls(
+                workspace_id=workspace_id,
+                thread_id=thread_id,
+                project_path=project_path,
+                config=config,
+                scratchpad_dir=scratchpad_dir,
+            )
             cls._registry[key] = manager
         return manager
 
-    def __init__(self, *, workspace_id: str, thread_id: str, project_path: Path, config: object) -> None:
+    def __init__(
+        self,
+        *,
+        workspace_id: str,
+        thread_id: str,
+        project_path: Path,
+        config: object,
+        scratchpad_dir: Optional[Path] = None,
+    ) -> None:
         self.workspace_id = workspace_id
         self.thread_id = thread_id
         self.project_path = Path(project_path)
         self.config = config
+        self.scratchpad_dir = Path(scratchpad_dir) if scratchpad_dir else None
         self.session_id = uuid.uuid4().hex
         self._kernels: Dict[str, BaseKernel] = {}
         self._locks: Dict[str, asyncio.Lock] = {}
@@ -436,6 +452,17 @@ class EvalKernelManager:
         self._shutdown = False
 
     # -- kernels ------------------------------------------------------------
+
+    def _kernel_child_env(self) -> Dict[str, str]:
+        """Base env for kernel subprocesses, shared by the py and js kernels.
+
+        KOLEGA_SCRATCHPAD matches the variable injected into terminal sessions,
+        so eval cells and shell commands share one durable session location.
+        """
+        env = build_child_env()
+        if self.scratchpad_dir is not None:
+            env["KOLEGA_SCRATCHPAD"] = str(self.scratchpad_dir)
+        return env
 
     def _env_manager_for_thread(self) -> EvalEnvironmentManager:
         if self._env_manager is None:
@@ -464,7 +491,7 @@ class EvalKernelManager:
 
         env_info = await self._ensure_env()
         bridge = await ToolBridge.ensure()
-        kernel_env = build_child_env()
+        kernel_env = self._kernel_child_env()
         kernel_env.update(
             {
                 "KOLEGA_TOOL_BRIDGE_URL": bridge.url,
@@ -502,7 +529,7 @@ class EvalKernelManager:
         package_json = js_home / "package.json"
         if not package_json.exists():
             package_json.write_text("{}\n", encoding="utf-8")
-        kernel_env = build_child_env()
+        kernel_env = self._kernel_child_env()
         npm_cmd = runtime.npm_install_cmd(js_home)
         kernel_env.update(
             {

--- a/kolega_code/agent/prompt_templates/extensions/cli/scratchpad.md.j2
+++ b/kolega_code/agent/prompt_templates/extensions/cli/scratchpad.md.j2
@@ -2,6 +2,8 @@ You have a private scratchpad working directory for this session at:
 
 `{{ scratchpad_path }}`
 
+This path is also exported as the environment variable `KOLEGA_SCRATCHPAD` in every shell command and eval kernel this session runs (login shells included), so in commands and scripts refer to it as `$KOLEGA_SCRATCHPAD` instead of re-declaring or retyping the literal path.
+
 Use it for throwaway work that must not touch the user's working tree: one-off scripts, ad-hoc virtual environments, downloaded files, extracted archives, generated intermediates, and log captures. This is the only location outside the working directory where you may create files without asking.
 
 Rules:

--- a/kolega_code/agent/prompt_templates/system/agents/coder_base.md.j2
+++ b/kolega_code/agent/prompt_templates/system/agents/coder_base.md.j2
@@ -91,6 +91,10 @@ Do not run destructive commands automatically. Treat commands that delete files,
 There is no user present to approve actions, so exercise judgment: do not run destructive commands — deleting files you did not create, rewriting git history, resetting the worktree, or making external state changes — unless the task explicitly requires them.
 {% endif %}
 
+## Reuse Results — Do Not Re-Derive
+
+Work you have already done is an asset: NEVER re-derive a result you already hold. Variables, imports, and loaded data stay live in the eval kernel across cells — reuse them instead of re-importing, re-opening, or re-parsing, and build on earlier command output instead of re-running it. The first time an expensive step succeeds — a parsed file, an extracted artifact, a setup ritual, an inline test harness — persist it as durable state: write intermediates and helper scripts to files (prefer the session scratchpad, exported as `$KOLEGA_SCRATCHPAD` in every shell when one is provided) and load or invoke them in later steps instead of retyping the work.
+
 ## Git Branches and Pull Requests
 
 When creating a branch or opening a pull request, follow repository or user conventions if provided; otherwise use Conventional Commits-style names. Use lowercase kebab-case branch names with a conventional type prefix, such as `feat/add-login-rate-limit` or `fix/navbar-overlap`. Use Conventional Commit PR titles, such as `feat(auth): add session timeout` or `fix: handle empty search results`. Keep names descriptive but not overly long{% if not interactive %}. Work in the checkout you were started in{% endif %}.

--- a/kolega_code/agent/tool_backend/eval_tool.py
+++ b/kolega_code/agent/tool_backend/eval_tool.py
@@ -104,6 +104,7 @@ class EvalTool(BaseTool):
                 thread_id=self.thread_id,
                 project_path=self.project_path,
                 config=self.config,
+                scratchpad_dir=getattr(self.caller, "scratchpad_dir", None),
             )
         return self._manager
 

--- a/kolega_code/agent/tool_backend/terminal_tool.py
+++ b/kolega_code/agent/tool_backend/terminal_tool.py
@@ -128,6 +128,18 @@ class TerminalTool(BaseTool):
 
     # -- model-facing unified-exec tools -----------------------------------
 
+    def _session_env(self) -> Optional[dict]:
+        """Per-session env overrides injected into every exec session.
+
+        The scratchpad path is documented to the model through the scratchpad
+        prompt extension, not the tool description, so the tool schema stays
+        byte-identical.
+        """
+        scratchpad_dir = getattr(self.caller, "scratchpad_dir", None)
+        if not scratchpad_dir:
+            return None
+        return {"KOLEGA_SCRATCHPAD": str(scratchpad_dir)}
+
     def _format_result(self, result: ExecResult, *, background: bool = False) -> str:
         payload = {
             "status": result.status,
@@ -215,6 +227,7 @@ class TerminalTool(BaseTool):
                 yield_time_ms=min(yield_time_ms, BACKGROUND_SETTLE_MS) if background else yield_time_ms,
                 max_output_tokens=max_output_tokens,
                 login=login,
+                env=self._session_env(),
                 background=background,
             )
         except Exception as exc:

--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -1201,8 +1201,9 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
         # composing it from settings, skills, hooks, and MCP configuration.
         self.session_runtime.adopt(self.agent)
         if scratchpad_extension is not None:
-            # Expose the resolved directory for the terminal safety checker; the
-            # prompt extension above is what the model sees.
+            # Expose the resolved directory for the KOLEGA_SCRATCHPAD session env
+            # and the terminal safety checker; the prompt extension above is what
+            # the model sees.
             self.agent.scratchpad_dir = scratchpad_dir_for(self.project_path, self.session.session_id)
         # Mid-turn queue delivery: the running turn drains composer messages
         # queued while it works (main agent only; sub-agents never get this).

--- a/kolega_code/services/terminal.py
+++ b/kolega_code/services/terminal.py
@@ -125,6 +125,21 @@ def build_child_env(extra: Optional[Dict[str, str]] = None) -> Dict[str, str]:
     return env
 
 
+def _export_prefix(extra: Optional[Dict[str, str]]) -> str:
+    """Shell prefix re-exporting per-session env overrides inside the command.
+
+    Overrides are already in the spawn environment (build_child_env), but a
+    login shell (``bash -lc``) sources profile files before the command string
+    runs, and a profile may reset or unset them. Re-exporting inside the command
+    string runs after any profile, so per-session overrides (e.g. the session
+    scratchpad path) hold in every shell. Values are quoted; names come from
+    internal callers and are shell-safe identifiers.
+    """
+    if not extra:
+        return ""
+    return "".join(f"export {name}={shlex.quote(value)}; " for name, value in extra.items())
+
+
 def _pick_shell() -> str:
     for shell in ("/bin/bash", "/bin/sh"):
         if os.path.exists(shell):
@@ -215,8 +230,9 @@ class PtySession:
         # Install the background-job warning ahead of everything else so it
         # survives venv activation and still fires if the command backgrounds
         # processes and exits (the trap is overwritten only if the command
-        # sets its own EXIT trap).
-        command = _BACKGROUND_JOB_TRAP + command
+        # sets its own EXIT trap). Session env overrides are re-exported before
+        # venv activation so an activate script still wins on conflicts.
+        command = _BACKGROUND_JOB_TRAP + _export_prefix(self.env) + command
 
         shell = _pick_shell()
         shell_args = ["-lc", command] if self.login else ["-c", command]
@@ -495,6 +511,9 @@ class DetachedSession:
             activate = os.path.join(str(self.workdir), _VENV_ACTIVATE_REL)
             if os.path.isfile(activate):
                 command = f"source {shlex.quote(activate)} 2>/dev/null; {command}"
+        # Same re-export as PtySession: session env overrides must survive
+        # login-shell profiles, and run before venv activation.
+        command = _export_prefix(self.env) + command
 
         shell = _pick_shell()
         shell_args = ["-lc", command] if self.login else ["-c", command]

--- a/tests/agent/eval/test_py_kernel.py
+++ b/tests/agent/eval/test_py_kernel.py
@@ -229,6 +229,22 @@ async def test_read_write_env_helpers(manager, tmp_path):
     assert (tmp_path / "sub" / "out.txt").read_text() == "line1\nline2\nline3\n"
 
 
+async def test_kernel_child_env_carries_scratchpad(tmp_path, config, monkeypatch):
+    # Shared by the py and js spawn paths; no kernel start needed.
+    monkeypatch.delenv("KOLEGA_SCRATCHPAD", raising=False)
+    with_scratchpad = EvalKernelManager(
+        workspace_id="test_ws",
+        thread_id="t-env",
+        project_path=tmp_path,
+        config=config,
+        scratchpad_dir=tmp_path / "scratchpad",
+    )
+    assert with_scratchpad._kernel_child_env()["KOLEGA_SCRATCHPAD"] == str(tmp_path / "scratchpad")
+
+    without = EvalKernelManager(workspace_id="test_ws", thread_id="t-env2", project_path=tmp_path, config=config)
+    assert "KOLEGA_SCRATCHPAD" not in without._kernel_child_env()
+
+
 async def test_sub_agent_shares_kernel_but_does_not_own_it(tmp_path, config, isolated_cli_env):
     thread_id = f"test-{uuid.uuid4().hex}"
     parent = EvalKernelManager.for_thread(

--- a/tests/agent/services/test_terminal.py
+++ b/tests/agent/services/test_terminal.py
@@ -255,6 +255,42 @@ async def test_child_shell_does_not_inherit_runtime_venv(manager, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_exec_command_session_env_override(manager):
+    # Values are shell-quoted, so spaces survive.
+    result = await manager.exec_command(
+        'echo "SP=$KOLEGA_SCRATCHPAD"', env={"KOLEGA_SCRATCHPAD": "/tmp/sp dir"}, yield_time_ms=5000
+    )
+    assert result.status == "exited"
+    assert result.exit_code == 0
+    assert "SP=/tmp/sp dir" in result.output
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("background", [False, True])
+async def test_session_env_override_survives_login_profile(manager, tmp_path, background):
+    # A login shell sources profile files before the command string runs, and a
+    # profile may reset or unset session overrides. The in-command re-export
+    # runs after any profile, so the override must win. Covers the PTY and
+    # detached session paths.
+    home = tmp_path / "home"
+    home.mkdir()
+    hostile = "export PROFILE_RAN=1\nexport KOLEGA_SCRATCHPAD=/clobbered\n"
+    for name in (".bash_profile", ".profile"):
+        (home / name).write_text(hostile)
+    result = await manager.exec_command(
+        'echo "RAN=${PROFILE_RAN:-0} SP=$KOLEGA_SCRATCHPAD"',
+        env={"KOLEGA_SCRATCHPAD": "/real/scratchpad", "HOME": str(home)},
+        login=True,
+        background=background,
+        yield_time_ms=10000,
+    )
+    assert result.status == "exited"
+    assert result.exit_code == 0
+    assert "RAN=1" in result.output  # the profile really ran...
+    assert "SP=/real/scratchpad" in result.output  # ...and still lost
+
+
+@pytest.mark.asyncio
 async def test_clean_env_overlay(manager):
     result = await manager.exec_command("echo $NO_COLOR-$TERM-$PAGER", yield_time_ms=3000)
     assert "1-dumb-cat" in result.output

--- a/tests/agent/test_prompts.py
+++ b/tests/agent/test_prompts.py
@@ -75,6 +75,33 @@ def test_scratchpad_prompt_renders_path_and_rules() -> None:
     assert "deliverables" in rendered
     assert "uniquely named files" in rendered
     assert ".kolega/worktrees/<safe-unique-slug>" in rendered
+    # The literal path stays (non-shell uses need it), and the prompt names the
+    # env var injected into every terminal session and eval kernel.
+    assert "`KOLEGA_SCRATCHPAD`" in rendered
+    assert "$KOLEGA_SCRATCHPAD" in rendered
+
+
+def test_scratchpad_env_var_documented_in_interactive_and_ask_modes() -> None:
+    from kolega_code.agent.prompt_provider import (
+        AgentMode,
+        AgentType,
+        PromptContext,
+        PromptExtension,
+        PromptProvider,
+    )
+    from kolega_code.scratchpad import SCRATCHPAD_PROMPT_EXTENSION_ID
+
+    extension = PromptExtension(
+        id=SCRATCHPAD_PROMPT_EXTENSION_ID,
+        title="Session Scratchpad",
+        markdown=prompts.build_scratchpad_prompt("/tmp/kolega-code-501/project-key/session-1/scratchpad"),
+    )
+    provider = PromptProvider()
+    for mode in (AgentMode.CLI, AgentMode.ASK):
+        rendered = provider.get_system_prompt(
+            AgentType.CODER, mode=mode, prompt_extensions=[extension], context=PromptContext()
+        )
+        assert "$KOLEGA_SCRATCHPAD" in rendered, mode
     assert "Never create a Git worktree in the scratchpad" in rendered
     assert "only when the user explicitly asks for it" in rendered
     assert "shared Git `info/exclude`" in rendered

--- a/tests/agent/tool_backend/test_eval_tool.py
+++ b/tests/agent/tool_backend/test_eval_tool.py
@@ -17,10 +17,11 @@ PNG_1PX = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADh
 pytestmark = pytest.mark.asyncio
 
 
-def make_tool(tmp_path, *, supports_vision=False, sub_agent=False, config=None):
+def make_tool(tmp_path, *, supports_vision=False, sub_agent=False, config=None, scratchpad_dir=None):
     caller = Mock()
     caller.sub_agent = sub_agent
     caller.supports_vision = supports_vision
+    caller.scratchpad_dir = scratchpad_dir
 
     async def execute_single_tool(tool_call):
         return ToolResult(
@@ -154,6 +155,16 @@ async def test_end_to_end_cell(tmp_path, isolated_cli_env):
         assert "custom interpreter" in text  # eval_python_path override note
         text = await tool.eval("py", "total + 1")
         assert "### result\n43" in text
+    finally:
+        await tool.shutdown_if_owner()
+
+
+async def test_end_to_end_kernel_env_has_scratchpad(tmp_path, isolated_cli_env):
+    scratchpad = tmp_path / "scratchpad"
+    tool = make_tool(tmp_path, scratchpad_dir=scratchpad)
+    try:
+        text = await tool.eval("py", "import os\nos.environ.get('KOLEGA_SCRATCHPAD', 'missing')")
+        assert f"### result\n'{scratchpad}'" in text
     finally:
         await tool.shutdown_if_owner()
 

--- a/tests/agent/tool_backend/test_terminal_tool.py
+++ b/tests/agent/tool_backend/test_terminal_tool.py
@@ -48,6 +48,9 @@ def agent_config():
 def mock_base_agent():
     mock = Mock()
     mock.agent_name = "test_agent"
+    # A bare Mock attribute would read as a truthy scratchpad dir; sessions
+    # without a scratchpad are the default in these tests.
+    mock.scratchpad_dir = None
     return mock
 
 
@@ -220,6 +223,50 @@ class TestUnifiedExecTools:
         data = json.loads(await terminal_tool.exec_command("pwd", workdir=".", yield_time_ms=5000))
         assert data["status"] == "exited"
         assert data["output"].strip().endswith(terminal_tool.project_path.name)
+
+    @pytest.mark.asyncio
+    async def test_exec_command_injects_scratchpad_env(self, terminal_tool, mock_base_agent, tmp_path):
+        mock_base_agent.scratchpad_dir = tmp_path / "scratchpad"
+        terminal_tool.terminal_manager = Mock()
+        terminal_tool.terminal_manager.exec_command = AsyncMock(
+            return_value=ExecResult(status="exited", exit_code=0, output="", duration_ms=1)
+        )
+
+        await terminal_tool.exec_command("env")
+        kwargs = terminal_tool.terminal_manager.exec_command.call_args.kwargs
+        assert kwargs["env"] == {"KOLEGA_SCRATCHPAD": str(tmp_path / "scratchpad")}
+
+    @pytest.mark.asyncio
+    async def test_exec_command_without_scratchpad_injects_nothing(self, terminal_tool):
+        terminal_tool.terminal_manager = Mock()
+        terminal_tool.terminal_manager.exec_command = AsyncMock(
+            return_value=ExecResult(status="exited", exit_code=0, output="", duration_ms=1)
+        )
+
+        await terminal_tool.exec_command("env")
+        kwargs = terminal_tool.terminal_manager.exec_command.call_args.kwargs
+        assert kwargs["env"] is None
+
+    @pytest.mark.asyncio
+    async def test_exec_command_end_to_end_scratchpad_env(self, terminal_tool, mock_base_agent, tmp_path):
+        # Real PTY: the model-facing session sees $KOLEGA_SCRATCHPAD.
+        mock_base_agent.scratchpad_dir = tmp_path / "scratchpad"
+        data = json.loads(await terminal_tool.exec_command('echo "SP=$KOLEGA_SCRATCHPAD"', yield_time_ms=5000))
+        assert data["status"] == "exited"
+        assert f"SP={tmp_path / 'scratchpad'}" in data["output"]
+
+    @pytest.mark.asyncio
+    async def test_write_stdin_session_keeps_scratchpad_env(self, terminal_tool, mock_base_agent, tmp_path):
+        # A session created by exec_command and driven with write_stdin keeps
+        # the env it was spawned with.
+        mock_base_agent.scratchpad_dir = tmp_path / "scratchpad"
+        data = json.loads(
+            await terminal_tool.exec_command('read line; echo "GOT=$KOLEGA_SCRATCHPAD"', yield_time_ms=300)
+        )
+        assert data["status"] == "running"
+        data = json.loads(await terminal_tool.write_stdin(data["session_id"], "go\n", yield_time_ms=5000))
+        assert data["status"] == "exited"
+        assert f"GOT={tmp_path / 'scratchpad'}" in data["output"]
 
     @pytest.mark.asyncio
     async def test_exec_command_passes_absolute_workdir_through(self, terminal_tool):


### PR DESCRIPTION
## Summary

The per-session scratchpad directory was advertised to the model only as a literal path string in the scratchpad prompt extension. Session transcripts show agents re-typing that path constantly — `SP=<path>`/`cd <path>` prefixes on most commands — and re-deriving results they already held (re-opening the same files, re-parsing the same data, retyping the same inline test harnesses) instead of reusing them.

- **`KOLEGA_SCRATCHPAD` env injection**: the scratchpad path is now present in the environment of every terminal session (foreground PTY and detached background, so `write_stdin`-driven sessions inherit it) and both eval kernels. Injection flows through the terminal managers' pre-existing `env=` parameter — no tool schema or description changes, and `SandboxTerminalManager`'s interface is untouched (it already forwards `env`).
- **Login-shell safety**: per-session env overrides are re-exported inside the command string, after profiles run, so `login: true` cannot lose them even when a sourced profile resets the environment.
- **Prompt extension**: the scratchpad section now tells the model the path is available as `$KOLEGA_SCRATCHPAD` in every shell; the literal path stays for non-shell uses.
- **New coder prompt section** "Reuse Results — Do Not Re-Derive" (interactive and ask modes): reuse live eval-kernel state, build on earlier command output, and persist expensive intermediates and test harnesses to files instead of retyping them.

## Testing

- Hermetic tests: env var present in `exec_command` sessions (mocked and real PTY), `write_stdin`-driven sessions, detached background sessions, and eval kernels; absent when no scratchpad exists; login-shell survival verified against a hostile profile that unsets and clobbers the var (parametrized over PTY + detached).
- Prompt renders: `$KOLEGA_SCRATCHPAD` documented in both interactive and ask modes; a render+diff pass confirms the ask/cli renders change only by the intended scratchpad sentence and the new section.
- Full pass over `tests/agent`, `tests/services`, `tests/cli`: **3693 passed, 5 skipped**.
- Live smoke (one headless `ask` run): the model referenced the scratchpad exclusively via `$KOLEGA_SCRATCHPAD` (5/5 commands, including `os.environ["KOLEGA_SCRATCHPAD"]` in inline Python), zero literal-path re-declarations, correct deliverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWBvYWykobnyhPw8gxgSNC