### PR TITLE
feat(web): hosted server-side web search for Responses providers

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -2,3 +2,9 @@ name: "Kolega Code CodeQL configuration"
 
 paths-ignore:
   - "kolega_code/_bundled_skills"
+  # Test code: not shipped, and security dataflow rules misread assertions as
+  # sanitizers (e.g. py/incomplete-url-substring-sanitization on a substring
+  # assert over a rendered label — PR #454). Inline `# codeql[...]` suppressions
+  # are not honored without the alert-suppression query pack, so exclude tests
+  # from analysis outright.
+  - "tests"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+### Added
+
+- Hosted (server-side) web search for Responses-API providers. On DeepSeek
+  flash and OpenAI gpt-5.x (API key or ChatGPT subscription), kolega can
+  request the provider's own
+  `{"type": "web_search"}` tool: searches and page-opens execute on the
+  provider's servers and the content is injected directly into the model's
+  context (billed as input tokens; the context gauge accounts for it from
+  usage, since the content never reaches the client). Calls render in the
+  transcript as `web_search (hosted)`. Controlled by a new web tool mode —
+  `auto` (default: hosted when the model supports it, else the client tools) /
+  `hosted` / `client` / `off` — via Settings, `KOLEGA_CODE_WEB_SEARCH_MODE`,
+  `ask --web-search`, or the TUI's `/web-search`. When hosted search is active
+  the client-side `web_search`/`web_fetch` tools are not registered; `off`
+  removes all web tools (for sandboxed/benchmark runs). Notes: provider
+  per-search fees, if any, are not modeled in cost reporting (injected tokens
+  are); sessions that used hosted search store a new `web_search_call` history
+  block that older kolega builds cannot load.
+
 ### Security
 
 - Dependency bumps for advisories published 2026-08-03/04: `cryptography`

--- a/docs/src/content/docs/cli/ask.md
+++ b/docs/src/content/docs/cli/ask.md
@@ -23,6 +23,7 @@ kolega-code ask "<prompt>" [options]
 | `--json` | Emit complete messages and events as JSON |
 | `--browser-visible` | Launch visible Playwright browser windows |
 | `--permission-mode <auto\|ask>` | Shell/edit permission mode (default `auto`) |
+| `--web-search <auto\|hosted\|client\|off>` | Web tool mode: hosted server-side search, client tools, or none (default `auto`) |
 | `--session <ID>` | Resume or create a specific session |
 | `--state-dir <PATH>` | Directory for CLI session state |
 | `--worktree <PATH_OR_BRANCH>` | Start in an existing registered worktree |

--- a/docs/src/content/docs/concepts/tools.md
+++ b/docs/src/content/docs/concepts/tools.md
@@ -108,6 +108,31 @@ the [TUI](../../cli/overview/) or [`ask`](../../cli/ask/).
 
 ### Web
 
+Web access has four modes, set by `web_search_mode` in Settings, the
+`KOLEGA_CODE_WEB_SEARCH_MODE` environment variable, `ask --web-search`, or the
+TUI's `/web-search` command:
+
+- **auto** (default) — use the provider's **hosted** server-side web search when
+  the model supports it (currently DeepSeek flash and OpenAI gpt-5.x — API key
+  or ChatGPT subscription — over their Responses APIs), otherwise the client
+  tools below.
+- **hosted** — always request the server-side tool (falls back to client tools
+  with a warning if the model has no hosted support).
+- **client** — always use the client-side tools; never request the hosted tool.
+- **off** — no web tools at all.
+
+**Hosted mode** adds `{"type": "web_search"}` to the request and the provider
+executes searches and page-opens on its own servers, injecting the content
+directly into the model's context. The searched content never passes through
+Kolega (it is billed as input tokens, and the context gauge accounts for it from
+usage), and — because it executes on the provider's infrastructure — it is not
+subject to the local machine's or sandbox's network egress rules. Calls appear
+in the transcript as `web_search (hosted)`. When hosted search is active, the
+client tools below are not registered: two search paths confuse the model and
+waste schema tokens.
+
+**Client tools** run inside Kolega's own process:
+
 - `web_search` — search the web for relevant pages and return ranked results.
 - `web_fetch` — retrieve a URL, extract local-readable content, and answer an
   instruction with source evidence. It handles HTML, plain text, Markdown,

--- a/docs/src/content/docs/configuration/environment-variables.md
+++ b/docs/src/content/docs/configuration/environment-variables.md
@@ -126,6 +126,7 @@ explicitly when you want a cloud provider or a self-hosted SearXNG instance.
 
 | Variable | Purpose |
 | --- | --- |
+| `KOLEGA_CODE_WEB_SEARCH_MODE` | Web tool mode: `auto` (hosted server-side search when the model supports it, else client tools), `hosted`, `client`, or `off` |
 | `KOLEGA_CODE_WEB_SEARCH_BACKEND` | Backend for `web_search`: `duckduckgo`, `firecrawl`, `tavily`, or `searxng` |
 | `FIRECRAWL_API_KEY` | Optional Firecrawl key for higher rate limits |
 | `TAVILY_API_KEY` | Tavily API key |

--- a/docs/src/content/docs/configuration/settings-and-api-keys.mdx
+++ b/docs/src/content/docs/configuration/settings-and-api-keys.mdx
@@ -85,11 +85,16 @@ The Browser role only accepts vision-capable model overrides. If it inherits a
 non-vision active model, Settings allows the inheritance but warns that the browser
 agent is unavailable until you choose a compatible Browser model.
 
-The **Tools** category configures the `web_search` tool. DuckDuckGo is the
-default and needs no key. Firecrawl can also run without a key, with an optional
-key for higher rate limits. Tavily requires a key, and SearXNG requires the base
-URL of your self-hosted instance. The same settings can be supplied with
-[`KOLEGA_CODE_WEB_SEARCH_BACKEND`, `FIRECRAWL_API_KEY`, `TAVILY_API_KEY`, and
+The **Tools** category configures web access. The **Mode** select picks who
+searches: `auto` (default) uses the provider's hosted server-side web search
+when the model supports it and the client tools otherwise; `hosted`, `client`,
+and `off` pin one behavior (see [the tools overview](../../concepts/tools/#web)).
+The backend selects for the client `web_search` tool: DuckDuckGo is the default
+and needs no key. Firecrawl can also run without a key, with an optional key for
+higher rate limits. Tavily requires a key, and SearXNG requires the base URL of
+your self-hosted instance. The same settings can be supplied with
+[`KOLEGA_CODE_WEB_SEARCH_MODE`, `KOLEGA_CODE_WEB_SEARCH_BACKEND`,
+`FIRECRAWL_API_KEY`, `TAVILY_API_KEY`, and
 `SEARXNG_BASE_URL`](../environment-variables/#web-search).
 
 ## Where settings live

--- a/docs/src/content/docs/tui/slash-commands.md
+++ b/docs/src/content/docs/tui/slash-commands.md
@@ -48,6 +48,7 @@ These control the app and your session.
 | `/login` | Sign in to a provider, e.g. `/login chatgpt` |
 | `/logout` | Sign out of a provider, e.g. `/logout chatgpt` |
 | `/gigacode` | Toggle [gigacode](../../gigacode/) workflow orchestration on or off |
+| `/web-search` | Show or set the web tool mode: `auto`, `hosted`, `client`, or `off` |
 | `/goal` | Set, show, or clear an autonomous completion goal |
 | `/loop` | Run a prompt on a repeating schedule |
 | `/tasks` | Show the shared task list |

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -43,7 +43,15 @@ from kolega_code.llm.exceptions import (
 )
 from kolega_code.llm.instrumented_client import get_output_tokens
 from kolega_code.llm.ledger import HISTORY_ORIGIN, LlmCallOrigin, helper_origin, llm_call_origin
-from kolega_code.llm.models import ImageBlock, Message, MessageHistory, TextBlock, ToolCall, ToolResult
+from kolega_code.llm.models import (
+    ImageBlock,
+    Message,
+    MessageHistory,
+    TextBlock,
+    ToolCall,
+    ToolResult,
+    WebSearchCallBlock,
+)
 from kolega_code.llm.providers.models import TokenCount
 from kolega_code.llm.specs import (
     deepseek_output_token_cap,
@@ -461,6 +469,15 @@ class BaseAgent(LogMixin):
         # tool) and used by _unsupported_attachment_message to reject image
         # attachments for non-vision models with a clear message.
         self.supports_vision = bool(model_specs.get("supports_vision", False))
+        # Web tool mode: whether the provider's hosted (server-side) web_search
+        # tool is requested and whether the client-side web_search/web_fetch
+        # tools are registered. Resolved from config.web_search_mode plus the
+        # model's supports_hosted_web_search catalog flag; the ToolCollection
+        # gate reads client_web_tools_enabled, the stream call reads
+        # hosted_web_search_active.
+        self.supports_hosted_web_search = bool(model_specs.get("supports_hosted_web_search", False))
+        self.web_search_mode = getattr(self.config, "web_search_mode", "auto") or "auto"
+        self._apply_web_search_state()
 
         self.llm = context.create_llm_client(agent_name=self.agent_name)
 
@@ -487,6 +504,15 @@ class BaseAgent(LogMixin):
         self._workflow_accounting: Optional["WorkflowRunAccounting"] = None
         self._accounting_reservation: Optional["AgentReservation"] = None
         self.total_tokens_used: int = 0
+        # Hosted web-search accounting side-channel. Searched/fetched content is
+        # injected into the model's context SERVER-side (restored on replay of
+        # web_search_call items, billed as input) and never reaches the client,
+        # so tiktoken-over-history can't see it. The residual — billed input
+        # minus the client-side count of the request actually sent — measures it
+        # and is added to the gauge in count_current_context. Updated by
+        # _update_hosted_search_residual; zeroed by compress_history.
+        self._hosted_injected_tokens: int = 0
+        self._last_raw_context_count: Optional[int] = None
         # Set by a blocking PostToolUse hook to end the turn after the current tool batch.
         self._hook_end_turn = False
         self.queued_input_provider: Optional[Callable[[], Awaitable[List[QueuedUserInput]]]] = None
@@ -651,6 +677,81 @@ class BaseAgent(LogMixin):
         initialize = getattr(self, "_initialize_system_prompt", None)
         if callable(initialize):
             initialize()
+
+    def _apply_web_search_state(self) -> None:
+        """Resolve web_search_mode + model capability into the two live gates.
+
+        ``hosted_web_search_active`` — request the provider's server-side
+        web_search tool on main-loop stream calls. ``client_web_tools_enabled``
+        — register the client-side web_search/web_fetch tools (read by the
+        ToolCollection gate). Hosted active always excludes the client tools:
+        two search paths confuse the model and waste schema tokens.
+        """
+        mode = (self.web_search_mode or "auto").lower()
+        supported = self.supports_hosted_web_search
+        if mode == "off":
+            hosted, client = False, False
+        elif mode == "client":
+            hosted, client = False, True
+        elif mode == "hosted":
+            if not supported:
+                provider = self.primary_model_config.provider
+                logger.warning(
+                    "web_search_mode=hosted, but %s/%s has no hosted web search; falling back to the client tools",
+                    getattr(provider, "value", provider),
+                    self.primary_model_config.model,
+                )
+            hosted, client = supported, not supported
+        else:  # auto
+            hosted, client = supported, not supported
+        self.hosted_web_search_active = hosted
+        self.client_web_tools_enabled = client
+
+    def apply_web_search_mode(self, mode: str) -> None:
+        """Change the web tool mode mid-session (TUI ``/web-search``).
+
+        Mirrors :meth:`apply_gigacode`: the tool registry rebuilds per call and
+        the next stream call reads the hosted gate, so no cache invalidation is
+        needed. No prompt work — the tools carry their own affordances.
+        """
+        self.web_search_mode = (mode or "auto").lower()
+        self._apply_web_search_state()
+
+    async def _emit_hosted_tool_call(self, delta: Dict[str, Any]) -> None:
+        """Render a completed hosted web_search call as a tool_call/tool_result pair.
+
+        The call executed on the provider's servers; there is no local tool
+        invocation and the searched content never reaches the client (it is
+        injected into the model's context server-side). The shared item id
+        correlates the pair in every transcript consumer.
+        """
+        action = delta.get("action") or {}
+        action_type = action.get("type") or "web_search"
+        if action_type == "search" and action.get("queries"):
+            detail = "search: " + ", ".join(repr(str(q)) for q in action["queries"])
+            outcome = "results injected server-side"
+        elif action_type == "open_page" and action.get("url"):
+            detail = f"open_page: {action['url']}"
+            outcome = "content injected server-side"
+        else:
+            detail = action_type
+            outcome = "executed server-side"
+        status = delta.get("status") or "completed"
+        tool_call_id = delta.get("id") or str(uuid.uuid4())
+        await self.send_chat_message(
+            message_type="tool_call",
+            content=f"Calling web_search (hosted): {detail}",
+            is_streaming=False,
+            tool_description="web_search (hosted)",
+            tool_call_id=tool_call_id,
+        )
+        await self.send_chat_message(
+            message_type="tool_result",
+            content=f"{detail} — {status} ({outcome})",
+            is_streaming=False,
+            tool_description="web_search (hosted)",
+            tool_call_id=tool_call_id,
+        )
 
     def apply_goal(self, condition: Optional[str], prompt_extension: Optional["PromptExtension"] = None) -> None:
         """Set, replace, or clear the active autonomous goal for this session.
@@ -944,11 +1045,60 @@ class BaseAgent(LogMixin):
             model=self.primary_model_config.model,
             tools=self.tool_collection.get_tool_list(),
         )
+        # Hosted web-search content lives only in the server's copy of the
+        # context (restored on replay of the web_search_call items, billed as
+        # input) — the client history has nothing to count for it. Add the
+        # residual measured from billed usage so the gauge AND the compaction
+        # check both see the true context size. Nonzero only while un-compacted
+        # web_search_call blocks exist (see _update_hosted_search_residual).
+        self._last_raw_context_count = token_count.input_tokens
+        if self._hosted_injected_tokens > 0:
+            token_count.input_tokens += self._hosted_injected_tokens
 
         # Send context update event
         await self._send_context_update(token_count)
 
         return token_count
+
+    # Provisional residual bump per hosted web-search call, applied while the
+    # search-bearing response's own billing is telescoped (a response that
+    # searched is several internal invocations billed cumulatively, so its
+    # billed−counted residual overstates the persistent injected size). The next
+    # clean response replaces the estimate with the measured residual. Probe
+    # calibration 2026-08-04 (findings/probes/hosted_web_search_probe.py):
+    # one-call persistent overhead ≈850 (deepseek) / ≈5000 (openai) tokens —
+    # 6000 overestimates safely, and overestimating only compacts early.
+    HOSTED_SEARCH_PROVISIONAL_TOKENS = 6000
+
+    def _update_hosted_search_residual(self, assistant_message: Message) -> None:
+        """Track server-injected hosted-search content from billed usage.
+
+        Search-bearing responses bump the estimate by a provisional per-call
+        constant (their own billing telescopes internal rounds, so the direct
+        residual would overshoot and could trip compaction spuriously). Clean
+        responses — single invocation, so ``billed − counted`` is exact —
+        replace it with the measurement. No-ops for sessions that never
+        searched, keeping the known ±tokenizer-drift band out of the gauge.
+        """
+        content = assistant_message.content if isinstance(assistant_message.content, list) else []
+        new_calls = sum(1 for block in content if isinstance(block, WebSearchCallBlock))
+        if new_calls:
+            self._hosted_injected_tokens += self.HOSTED_SEARCH_PROVISIONAL_TOKENS * new_calls
+            return
+        if self._hosted_injected_tokens <= 0 and not self._history_contains_hosted_search():
+            return
+        billed = (assistant_message.usage_metadata or {}).get("prompt_tokens")
+        counted = self._last_raw_context_count
+        if not isinstance(billed, int) or counted is None:
+            return
+        self._hosted_injected_tokens = max(0, billed - counted)
+
+    def _history_contains_hosted_search(self) -> bool:
+        for message in self.history:
+            content = getattr(message, "content", None)
+            if isinstance(content, list) and any(isinstance(block, WebSearchCallBlock) for block in content):
+                return True
+        return False
 
     async def _send_context_update(self, token_count: TokenCount) -> None:
         """Send an event to update the UI about current context usage."""
@@ -977,6 +1127,11 @@ class BaseAgent(LogMixin):
         show progress, then recounts + emits a context_update so the gauge
         refreshes. Returns the structured outcome.
         """
+        # Compacted-away web_search_call blocks stop being replayed, so the
+        # server stops restoring their content. Reset the hosted-search residual
+        # rather than carrying a stale figure; if search blocks survive in the
+        # verbatim tail, the next clean response re-measures it.
+        self._hosted_injected_tokens = 0
 
         async def on_info(message: str) -> None:
             await self.log_info(message, sender=self.agent_name)
@@ -2093,6 +2248,7 @@ class BaseAgent(LogMixin):
                             model=self.primary_model_config.model,
                             tools=self.tool_collection.get_tool_list(),
                             thinking=self.primary_model_config.thinking_effort,
+                            hosted_web_search=self.hosted_web_search_active,
                         ),
                     )
                 async with stream_cm as stream:
@@ -2135,8 +2291,24 @@ class BaseAgent(LogMixin):
 
                             await self.on_tool_use_start(event.tool_call_delta)
 
+                        elif event.type == "hosted_tool_call" and event.tool_call_delta:
+                            # A server-side web_search call completed on the
+                            # provider's infrastructure — no local execution.
+                            # Surface it as a normal tool_call/tool_result pair
+                            # so every transcript view renders it.
+                            if current_response:
+                                yield {
+                                    "type": "response",
+                                    "content": current_response,
+                                    "complete": True,
+                                    "uuid": response_uuid,
+                                }
+                                current_response = ""
+                            await self._emit_hosted_tool_call(event.tool_call_delta)
+
                 assistant_message = await stream.get_final_message()
                 self._normalize_freeform_tool_calls(assistant_message)
+                self._update_hosted_search_residual(assistant_message)
                 assistant_message.usage_metadata["edit_protocol"] = self.edit_protocol.value
                 response_output_tokens = get_output_tokens(
                     assistant_message.usage_metadata,

--- a/kolega_code/agent/conversation.py
+++ b/kolega_code/agent/conversation.py
@@ -22,6 +22,7 @@ from kolega_code.llm.models import (
     ThinkingBlock,
     ToolCall,
     ToolResult,
+    WebSearchCallBlock,
 )
 from kolega_code.llm.specs import prior_reasoning_is_replayable
 from kolega_code.utils import images as image_utils
@@ -336,7 +337,7 @@ def _adapt_content_blocks_for_provider(
             )
             adapted.append(adapted_block)
             changed = changed or image_changed
-        elif isinstance(block, (ThinkingBlock, RedactedThinkingBlock, ResponsesReasoningBlock)):
+        elif isinstance(block, (ThinkingBlock, RedactedThinkingBlock, ResponsesReasoningBlock, WebSearchCallBlock)):
             if _preserve_reasoning_block(
                 block,
                 source_provider=source_provider,

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -2718,6 +2718,15 @@ class ToolCollection(LogMixin):
         if method_name == "read_image":
             return bool(getattr(self.caller, "supports_vision", False))
 
+        # Web tool gate: the client-side web tools drop out when the agent's
+        # web_search_mode resolved to hosted (the provider's server-side tool
+        # replaces them) or off. Exclusion-only — an enabled tool still passes
+        # through the group/read-only/browser-only filtering below. Default True
+        # so agents without the attribute (tests, custom callers) keep today's
+        # tool set.
+        if method_name in ("web_search", "web_fetch") and not getattr(self.caller, "client_web_tools_enabled", True):
+            return False
+
         # Vision gate: dispatching the browser agent only works when the model
         # resolved for the browser-agent role accepts images (it reads page
         # screenshots). That model may differ from the main one, so gate on it —

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -282,6 +282,8 @@ class KolegaCodeApp(
         self._plan_reofferable: bool = bool(self._latest_plan and (self.session.plan_reofferable or self._plan_pending))
         self._plan_decision_active = False
         self._gigacode_enabled = bool(self.session.gigacode_enabled)
+        # Session web tool mode override (None -> config-resolved mode applies).
+        self._web_search_mode: Optional[str] = self.session.web_search_mode or None
         # Process-wide LLM usage accounting; every agent build (including
         # rebuilds on model/settings changes) shares this one ledger. The
         # journal sink is attached in on_mount, once the UI loop exists.
@@ -767,6 +769,7 @@ class KolegaCodeApp(
         self.session.interaction_mode = self.interaction_mode
         self.session.permission_mode = self.permission_mode.value
         self.session.gigacode_enabled = self._gigacode_enabled
+        self.session.web_search_mode = self._web_search_mode
         self.session.latest_plan_markdown = self._latest_plan or ""
         self.session.plan_pending = bool(self._latest_plan and self._plan_pending)
         self.session.plan_reofferable = bool(self._latest_plan and self._plan_reofferable)
@@ -800,6 +803,7 @@ class KolegaCodeApp(
             interaction_mode=record.interaction_mode,
             permission_mode=record.permission_mode,
             gigacode_enabled=record.gigacode_enabled,
+            web_search_mode=record.web_search_mode,
             goal=dict(record.goal),
             loop=dict(record.loop),
             usage=dict(record.usage),

--- a/kolega_code/cli/config.py
+++ b/kolega_code/cli/config.py
@@ -52,6 +52,11 @@ API_KEY_ENV = {
 
 DEFAULT_WEB_SEARCH_BACKEND = "duckduckgo"
 WEB_SEARCH_BACKEND_ENV = "KOLEGA_CODE_WEB_SEARCH_BACKEND"
+# Web tool mode: auto (hosted server-side search when the model supports it,
+# else the client tools), hosted, client, or off (no web tools at all).
+WEB_SEARCH_MODES = ("auto", "hosted", "client", "off")
+DEFAULT_WEB_SEARCH_MODE = "auto"
+WEB_SEARCH_MODE_ENV = "KOLEGA_CODE_WEB_SEARCH_MODE"
 SEARXNG_BASE_URL_ENV = "SEARXNG_BASE_URL"
 # Env vars that supply a cloud web-search backend's key, keyed by backend name.
 SEARCH_BACKEND_KEY_ENV = {
@@ -77,6 +82,7 @@ class CliConfigOverrides:
     thinking_effort: Optional[str] = None
     environment: Optional[str] = None
     edit_protocol: Optional[str] = None
+    web_search_mode: Optional[str] = None
 
 
 def load_cli_env(project_path: Path, env: Optional[Mapping[str, str]] = None) -> dict[str, str]:
@@ -229,6 +235,24 @@ def _search_config(
     api_key = (env.get(env_name) if env_name else None) or (settings.get_api_key(backend) if settings else None)
     base_url = env.get(SEARXNG_BASE_URL_ENV) or (settings.web_search_base_url if settings else None)
     return backend, api_key, base_url
+
+
+def _web_search_mode(
+    env: Mapping[str, str],
+    settings: Optional[CliSettings],
+    override: Optional[str],
+) -> str:
+    """Resolve the web tool mode with flag-over-env-over-settings precedence."""
+    mode = (
+        override
+        or env.get(WEB_SEARCH_MODE_ENV)
+        or (settings.web_search_mode if settings else None)
+        or DEFAULT_WEB_SEARCH_MODE
+    ).lower()
+    if mode not in WEB_SEARCH_MODES:
+        valid = ", ".join(WEB_SEARCH_MODES)
+        raise CliConfigError(f"Unsupported web search mode '{mode}'. Valid modes: {valid}")
+    return mode
 
 
 def _coerce_known_model(provider: ModelProvider, model: Optional[str]) -> str:
@@ -488,6 +512,7 @@ def build_agent_config(
 
     agent_model_overrides = _agent_model_overrides(loaded_env, settings)
     web_search_backend, web_search_api_key, web_search_base_url = _search_config(loaded_env, settings)
+    web_search_mode = _web_search_mode(loaded_env, settings, overrides.web_search_mode)
     state_dir = settings_store.root if settings_store is not None else SettingsStore().root
     mcp_config = load_mcp_config(
         project_path,
@@ -544,6 +569,7 @@ def build_agent_config(
             fast_config=_model_config(fast_provider, fast_model),
             thinking_config=_model_config(thinking_provider, thinking_model, thinking_effort=think_hard_effort),
             agent_models=agent_model_overrides,
+            web_search_mode=web_search_mode,
             web_search_backend=web_search_backend,
             web_search_api_key=web_search_api_key,
             web_search_base_url=web_search_base_url,

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -72,6 +72,7 @@ from .browser_backend import build_browser_manager
 from .diagnostics import write_crash_log
 from .config import (
     DEPRECATED_THINKING_TOKENS_MESSAGE,
+    WEB_SEARCH_MODES,
     CliConfigError,
     CliConfigOverrides,
     active_model_override_message,
@@ -408,6 +409,13 @@ def _build_subcommand_parser() -> argparse.ArgumentParser:
         help="Disable the persistent project-memory tools (read/list/write/edit/delete memory). "
         "Use for headless or benchmark runs where there is no durable memory store to read or write.",
     )
+    ask.add_argument(
+        "--web-search",
+        choices=list(WEB_SEARCH_MODES),
+        default=None,
+        help="Web tool mode: auto (hosted server-side search when the model supports it, else the "
+        "client web_search/web_fetch tools), hosted, client, or off (no web tools).",
+    )
     ask.add_argument("--save", action="store_true", help="Persist the session after the prompt completes.")
     ask.add_argument("--json", action="store_true", help="Emit complete messages and events as JSON.")
     ask.add_argument("--browser-visible", action="store_true", help="Launch visible Playwright browser windows.")
@@ -621,6 +629,7 @@ def _overrides_from_args(args: argparse.Namespace) -> CliConfigOverrides:
         thinking_effort=getattr(args, "thinking_effort", None),
         environment=getattr(args, "environment", None),
         edit_protocol=getattr(args, "edit_protocol", None),
+        web_search_mode=getattr(args, "web_search", None),
     )
 
 
@@ -1359,6 +1368,13 @@ async def _run_ask(args: argparse.Namespace) -> int:
     if gigacode_enabled:
         agent.apply_gigacode(True, gigacode_prompt_extension())
     session.gigacode_enabled = gigacode_enabled
+    # Web tool mode: an explicit --web-search flag already reached the agent via
+    # AgentConfig; otherwise a resumed session keeps its persisted mode, exactly
+    # as the TUI's /web-search toggle persists.
+    flag_web_search = getattr(args, "web_search", None)
+    if not flag_web_search and session.web_search_mode:
+        agent.apply_web_search_mode(session.web_search_mode)
+    session.web_search_mode = flag_web_search or session.web_search_mode
     lsp_messages = await agent.tool_collection.initialize()
     if not args.json:
         for msg in lsp_messages:

--- a/kolega_code/cli/session_store.py
+++ b/kolega_code/cli/session_store.py
@@ -56,6 +56,9 @@ class SessionRecord:
     interaction_mode: str = "build"
     permission_mode: str = "ask"
     gigacode_enabled: bool = False
+    # Web tool mode for the session (auto/hosted/client/off). Additive optional
+    # — absent in older files -> None -> the config-resolved mode applies.
+    web_search_mode: Optional[str] = None
     goal: dict[str, Any] = field(default_factory=dict)
     loop: dict[str, Any] = field(default_factory=dict)
     schema_version: int = SCHEMA_VERSION
@@ -114,6 +117,7 @@ class SessionRecord:
             interaction_mode=data.get("interaction_mode") or "build",
             permission_mode=data.get("permission_mode") or "ask",
             gigacode_enabled=bool(data.get("gigacode_enabled", False)),
+            web_search_mode=data.get("web_search_mode") or None,
             goal=data.get("goal") or {},
             loop=data.get("loop") or {},
             active_project_path=data.get("active_project_path") or None,
@@ -138,6 +142,7 @@ class SessionRecord:
             "interaction_mode": self.interaction_mode,
             "permission_mode": self.permission_mode,
             "gigacode_enabled": self.gigacode_enabled,
+            "web_search_mode": self.web_search_mode,
             "goal": self.goal,
             "loop": self.loop,
             "active_project_path": self.active_project_path,

--- a/kolega_code/cli/settings.py
+++ b/kolega_code/cli/settings.py
@@ -103,6 +103,9 @@ class CliSettings:
     # WEB_SEARCH_KEY_NAMES keys.
     web_search_backend: Optional[str] = None
     web_search_base_url: Optional[str] = None
+    # Web tool mode (auto/hosted/client/off). Additive optional — absent ->
+    # None -> the "auto" default is applied downstream in cli/config.py.
+    web_search_mode: Optional[str] = None
     # ChatGPT-subscription OAuth credentials, keyed by provider value (e.g.
     # "openai_chatgpt"), each a serialized OAuthTokens dict. Additive optional
     # field — absent in older files -> empty mapping, no schema bump (same
@@ -147,6 +150,7 @@ class CliSettings:
             # Additive optional fields; absent in older files -> None -> default backend.
             web_search_backend=data.get("web_search_backend"),
             web_search_base_url=data.get("web_search_base_url"),
+            web_search_mode=data.get("web_search_mode"),
             # Additive optional field; absent in older files -> empty mapping.
             oauth_tokens=_coerce_oauth_tokens(data.get("oauth_tokens")),
             # Additive optional field; absent in older files -> ask.
@@ -172,6 +176,7 @@ class CliSettings:
             "trusted_lsp_projects": self.trusted_lsp_projects,
             "web_search_backend": self.web_search_backend,
             "web_search_base_url": self.web_search_base_url,
+            "web_search_mode": self.web_search_mode,
             "oauth_tokens": self.oauth_tokens,
             "permission_mode": _coerce_permission_mode(self.permission_mode),
             "lsp_enabled": self.lsp_enabled,

--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -1212,6 +1212,10 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
         assert agent.tool_collection is not None
         await agent.tool_collection.initialize()
         agent.gigacode_enabled = gigacode_active
+        # A session-level /web-search override outlives agent rebuilds (model
+        # switches); without one the config-resolved mode stands.
+        if self._web_search_mode:
+            agent.apply_web_search_mode(self._web_search_mode)
         self._initialize_ledger_diff_tracker()
         if history:
             self.agent.restore_message_history(history)

--- a/kolega_code/cli/tui/app_base.py
+++ b/kolega_code/cli/tui/app_base.py
@@ -157,6 +157,7 @@ class KolegaAppBase(App):
         _plan_reofferable: bool
         _plan_decision_active: bool
         _gigacode_enabled: bool
+        _web_search_mode: str | None
         _usage_ledger: UsageLedger
         _goal: GoalState | None
         _goal_usage_mark: UsageSnapshot

--- a/kolega_code/cli/tui/command_handlers.py
+++ b/kolega_code/cli/tui/command_handlers.py
@@ -72,6 +72,8 @@ class CommandHandlersMixin(tui_app_base.KolegaAppBase):
             "/login": self._command_login,
             "/logout": self._command_logout,
             "/gigacode": self._command_gigacode,
+            "/web-search": self._command_web_search,
+            "/websearch": self._command_web_search,
             "/goal": self._command_goal,
             "/loop": self._command_loop,
             "/tasks": self._command_tasks,
@@ -255,6 +257,42 @@ class CommandHandlersMixin(tui_app_base.KolegaAppBase):
             note = "gigacode workflow orchestration disabled."
         self._add_conversation_entry(tui_state.ConversationEntry(kind="system", content=note))
         self._update_mode_chrome()
+
+    async def _command_web_search(self, args: str) -> None:
+        if self.agent is None:
+            self._set_settings_status(messages.SETTINGS_REQUIRED, tone="warning")
+            return
+
+        from kolega_code.cli.config import WEB_SEARCH_MODES
+
+        clean = args.strip().lower()
+        if not clean:
+            mode = getattr(self.agent, "web_search_mode", "auto")
+            state = self._web_search_state_note()
+            self._add_conversation_entry(
+                tui_state.ConversationEntry(kind="system", content=f"Web search mode: {mode} ({state}).")
+            )
+            return
+        if clean not in WEB_SEARCH_MODES:
+            self._notify_user("Usage: /web-search [auto|hosted|client|off]", severity="warning")
+            return
+
+        self._web_search_mode = clean
+        self.agent.apply_web_search_mode(clean)
+        await self._save_session_async()
+        self._add_conversation_entry(
+            tui_state.ConversationEntry(
+                kind="system",
+                content=f"Web search mode set to {clean} ({self._web_search_state_note()}).",
+            )
+        )
+
+    def _web_search_state_note(self) -> str:
+        if getattr(self.agent, "hosted_web_search_active", False):
+            return "hosted server-side search active; client web tools off"
+        if getattr(self.agent, "client_web_tools_enabled", True):
+            return "client web_search/web_fetch tools active"
+        return "no web tools"
 
     def _gigacode_prompt_extension(self) -> PromptExtension:
         from kolega_code.agent.orchestration.guide import gigacode_prompt_extension

--- a/kolega_code/cli/tui/settings_panel.py
+++ b/kolega_code/cli/tui/settings_panel.py
@@ -871,11 +871,17 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
 
     def _populate_web_search_controls(self) -> None:
         """Seed the Web Search controls from saved settings (key field stays blank)."""
+        from kolega_code.cli.config import DEFAULT_WEB_SEARCH_MODE, WEB_SEARCH_MODES
+
         valid = {name for _, name in available_backends()}
         backend = self.settings.web_search_backend
         if backend not in valid:
             backend = DEFAULT_WEB_SEARCH_BACKEND
+        mode = self.settings.web_search_mode
+        if mode not in WEB_SEARCH_MODES:
+            mode = DEFAULT_WEB_SEARCH_MODE
         try:
+            self._settings_query_one("#web_search_mode_select", Select).value = mode
             self._settings_query_one("#web_search_backend_select", Select).value = backend
             self._settings_query_one("#web_search_base_url_input", Input).value = (
                 self.settings.web_search_base_url or ""
@@ -888,11 +894,13 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
     def _collect_web_search_from_ui(self) -> None:
         """Write the Web Search controls into settings (keys only when newly typed)."""
         try:
+            mode = str(self._settings_query_one("#web_search_mode_select", Select).value)
             backend = str(self._settings_query_one("#web_search_backend_select", Select).value)
             base_url_input = self._settings_query_one("#web_search_base_url_input", Input)
             key_input = self._settings_query_one("#web_search_api_key_input", Input)
         except NoMatches:
             return
+        self.settings.web_search_mode = mode
         self.settings.web_search_backend = backend
         self.settings.web_search_base_url = base_url_input.value.strip() or None
         key = key_input.value.strip()

--- a/kolega_code/cli/tui/settings_screen.py
+++ b/kolega_code/cli/tui/settings_screen.py
@@ -338,8 +338,21 @@ class SettingsScreen(ModalScreen[None]):
             with Vertical(classes="settings-section", id="settings_web_search") as search_section:
                 search_section.border_title = "Web Search"
                 yield Static(
-                    "Choose the backend used by the web_search tool.",
+                    "Mode picks who searches: hosted runs the provider's server-side web_search "
+                    "tool (Responses-API models); client uses the local web_search/web_fetch tools.",
                     classes="settings-hint",
+                )
+                yield Label("Mode")
+                yield Select(
+                    [
+                        ("Auto (hosted when the model supports it)", "auto"),
+                        ("Hosted (server-side)", "hosted"),
+                        ("Client tools", "client"),
+                        ("Off (no web tools)", "off"),
+                    ],
+                    id="web_search_mode_select",
+                    allow_blank=False,
+                    value="auto",
                 )
                 yield Label("Backend")
                 yield Select(

--- a/kolega_code/config.py
+++ b/kolega_code/config.py
@@ -156,6 +156,13 @@ class AgentConfig(BaseModel):
 
     # Web search configuration (the web_search tool). Optional: the default backend is
     # keyless, so these must never be required for AgentConfig to be constructable.
+    web_search_mode: str = Field(
+        default="auto",
+        description=(
+            "Web tool mode: auto (hosted server-side search when the model supports it, "
+            "else the client tools), hosted, client, or off"
+        ),
+    )
     web_search_backend: str = Field(
         default="duckduckgo", description="Selected web_search backend (duckduckgo, firecrawl, tavily, searxng)"
     )

--- a/kolega_code/llm/client.py
+++ b/kolega_code/llm/client.py
@@ -285,6 +285,7 @@ class LLMClient:
         tools: Optional[List[ToolDefinition]] = None,
         thinking: Optional[Union[int, str]] = None,
         params: Optional[GenerationParams] = None,
+        hosted_web_search: bool = False,
         **kwargs: Any,
     ) -> Message:
         """Generate a complete response from the LLM provider.
@@ -297,6 +298,8 @@ class LLMClient:
             tools (Optional[List[Dict[str, Any]]]): List of tool definitions for function calling
             thinking (Optional[Union[int, str]]): Model-specific thinking effort string.
             params (Optional[GenerationParams]): Override all parameters with a GenerationParams object
+            hosted_web_search (bool): Expose the provider's server-side web_search
+                tool (Responses APIs only; ignored elsewhere).
             **kwargs: Additional provider-specific parameters
 
         Returns:
@@ -314,6 +317,7 @@ class LLMClient:
                     thinking=self._prepare_thinking_param(
                         thinking, str(kwargs.get("model")) if kwargs.get("model") else None
                     ),
+                    hosted_web_search=hosted_web_search,
                 )
             if self._usage_ledger is None:
                 return await self.provider.generate(messages, system, params, **kwargs)
@@ -340,6 +344,7 @@ class LLMClient:
         tools: Optional[List[ToolDefinition]] = None,
         thinking: Optional[Union[int, str]] = None,
         params: Optional[GenerationParams] = None,
+        hosted_web_search: bool = False,
         **kwargs: Any,
     ) -> Union[AsyncContextManager[Any], Coroutine[Any, Any, AsyncContextManager[Any]]]:
         """Generate a streaming response from the LLM provider.
@@ -352,6 +357,8 @@ class LLMClient:
             tools (Optional[List[Dict[str, Any]]]): List of tool definitions for function calling
             thinking (Optional[Union[int, str]]): Model-specific thinking effort string.
             params (Optional[GenerationParams]): Override all parameters with a GenerationParams object
+            hosted_web_search (bool): Expose the provider's server-side web_search
+                tool (Responses APIs only; ignored elsewhere).
             **kwargs: Additional provider-specific parameters
 
         Returns:
@@ -369,6 +376,7 @@ class LLMClient:
                     thinking=self._prepare_thinking_param(
                         thinking, str(kwargs.get("model")) if kwargs.get("model") else None
                     ),
+                    hosted_web_search=hosted_web_search,
                 )
 
             # Return the appropriate stream type for the provider

--- a/kolega_code/llm/models.py
+++ b/kolega_code/llm/models.py
@@ -557,6 +557,107 @@ class ResponsesReasoningBlock(ContentBlock):
         return "*Reasoning*"
 
 
+@register_content_block
+class WebSearchCallBlock(ContentBlock):
+    """Hosted web-search call item from a Responses-API backend.
+
+    Emitted when the provider executes its server-side ``web_search`` tool
+    (``search`` / ``open_page`` actions). The searched or fetched content never
+    reaches the client — the server injects it into the model's context and
+    bills it as input tokens. The item itself carries only the action metadata
+    (queries or URL), and replaying it via :meth:`to_responses_item` is what
+    keys the server-side restore of that content on later turns (live-verified
+    for DeepSeek flash and api.openai.com; see
+    findings/no-web-tools-claim-verification.md, Phase-0 probes).
+
+    The ``action`` payload is stored verbatim so unknown future action types
+    replay untouched. Like ``ResponsesReasoningBlock``, the block is specific
+    to Responses-API providers: ``Message.to_openai`` (Chat Completions) omits
+    it, and cross-provider adaptation drops it for foreign targets.
+    """
+
+    TYPE_NAME = "web_search_call"
+
+    def __init__(
+        self,
+        item_id: Optional[str] = None,
+        status: Optional[str] = None,
+        action: Optional[Dict[str, Any]] = None,
+        cache_checkpoint: bool = False,
+    ):
+        super().__init__(type=self.TYPE_NAME, cache_checkpoint=cache_checkpoint)
+        self.item_id = item_id
+        self.status = status
+        self.action = dict(action or {})
+
+    @property
+    def action_type(self) -> Optional[str]:
+        return self.action.get("type")
+
+    @property
+    def queries(self) -> List[str]:
+        queries = self.action.get("queries")
+        return [str(q) for q in queries] if isinstance(queries, list) else []
+
+    @property
+    def url(self) -> Optional[str]:
+        url = self.action.get("url")
+        return str(url) if url else None
+
+    def to_dict(self) -> Dict[str, Any]:
+        result: Dict[str, Any] = {
+            "type": self.type,
+            "status": self.status,
+            "action": dict(self.action),
+        }
+        if self.item_id:
+            result["item_id"] = self.item_id
+        return result
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "WebSearchCallBlock":
+        return cls(
+            item_id=data.get("item_id"),
+            status=data.get("status"),
+            action=data.get("action") or {},
+        )
+
+    def to_responses_item(self) -> Dict[str, Any]:
+        """Serialize back to a Responses API ``web_search_call`` input item.
+
+        The id/status/action triple is the exact shape both backends accepted
+        in the Phase-0 replay probes; the id keys the server-side restore of
+        the searched content.
+        """
+        item: Dict[str, Any] = {
+            "type": "web_search_call",
+            "status": self.status,
+            "action": dict(self.action),
+        }
+        if self.item_id:
+            item["id"] = self.item_id
+        return item
+
+    def _label(self) -> str:
+        if self.queries:
+            return "search: " + ", ".join(repr(q) for q in self.queries)
+        if self.url:
+            return f"open_page: {self.url}"
+        return self.action_type or "web_search"
+
+    def to_anthropic(self) -> Dict[str, Any]:
+        return {"type": "text", "text": "[Web search]"}
+
+    def to_openai(self) -> Dict[str, Any]:
+        return {"type": "text", "text": "[Web search]"}
+
+    def to_google(self) -> genai_types.Part:
+        return genai_types.Part.from_text(text="[Web search]")
+
+    def to_markdown(self) -> str:
+        return f"*Web search — {self._label()}*"
+
+
 class ToolParameter:
     """Parameter definition for a tool"""
 
@@ -1293,13 +1394,16 @@ class Message:
             content = self.content
         elif isinstance(self.content, list):
             # Exclude tool call and tool result blocks from assistant content (handled
-            # separately) and Responses-API reasoning blocks: those only serialize on
-            # the Responses path (to_responses_item). Rendering them as placeholder
-            # text here gets echoed by the model — see _ECHOED_REASONING_PLACEHOLDER
-            # in agent/conversation.py. Reachable when a session moves between two
-            # models of one provider that span both API surfaces (flash -> pro).
+            # separately) and Responses-API-only blocks (reasoning, hosted web-search
+            # calls): those only serialize on the Responses path (to_responses_item).
+            # Rendering them as placeholder text here gets echoed by the model — see
+            # _ECHOED_REASONING_PLACEHOLDER in agent/conversation.py. Reachable when a
+            # session moves between two models of one provider that span both API
+            # surfaces (flash -> pro).
             non_tool_blocks = [
-                item for item in self.content if not isinstance(item, (ToolCall, ToolResult, ResponsesReasoningBlock))
+                item
+                for item in self.content
+                if not isinstance(item, (ToolCall, ToolResult, ResponsesReasoningBlock, WebSearchCallBlock))
             ]
             if reasoning_field is not None:
                 thinking_blocks = [b for b in non_tool_blocks if isinstance(b, ThinkingBlock)]

--- a/kolega_code/llm/providers/models.py
+++ b/kolega_code/llm/providers/models.py
@@ -19,3 +19,6 @@ class GenerationParams:
     max_completion_tokens: Optional[int] = None
     tools: Optional[List["ToolDefinition"]] = None
     thinking: Optional[Any] = None
+    # Ask the provider to expose its server-side web_search tool (Responses
+    # APIs only; other providers ignore the field).
+    hosted_web_search: bool = False

--- a/kolega_code/llm/providers/openai.py
+++ b/kolega_code/llm/providers/openai.py
@@ -21,6 +21,7 @@ from ..models import (
     ToolCall,
     ToolDefinition,
     ToolResult,
+    WebSearchCallBlock,
 )
 from ..specs import MODEL_SPECS, build_thinking_request_params, deepseek_output_token_cap, is_deepseek_model
 from ..timeouts import streaming_timeout
@@ -558,6 +559,15 @@ class OpenAIProvider(BaseLLMProvider):
                             num_tokens += len(encoding.encode(str(part)))
                         for part in item.content:
                             num_tokens += len(encoding.encode(str(part)))
+                    # Hosted web_search_call items replay their id/status/action
+                    # triple. Only that metadata is counted here — the searched
+                    # content itself lives server-side and is accounted for by
+                    # the agent's hosted-search residual, not the history count.
+                    elif isinstance(item, WebSearchCallBlock):
+                        num_tokens += len(encoding.encode(str(item.item_id or "")))
+                        num_tokens += len(encoding.encode(str(item.status or "")))
+                        num_tokens += len(encoding.encode(json.dumps(item.action, sort_keys=True)))
+                        num_tokens += 2  # Compact formatting overhead
                     # Handle tool calls. OpenAI's prompt accounting uses a compact
                     # internal representation for assistant tool calls rather than
                     # charging the full Chat Completions JSON wrapper. Counting the
@@ -629,6 +639,13 @@ class OpenAIProvider(BaseLLMProvider):
                 len(str(item.encrypted_content or "")),
                 tuple(len(str(p)) for p in item.summary),
                 tuple(len(str(p)) for p in item.content),
+            )
+        if isinstance(item, WebSearchCallBlock):
+            return (
+                "wsc",
+                len(str(item.item_id or "")),
+                len(str(item.status or "")),
+                len(json.dumps(item.action, sort_keys=True)),
             )
         if isinstance(item, ToolCall):
             payload = item.to_openai()

--- a/kolega_code/llm/providers/responses_common.py
+++ b/kolega_code/llm/providers/responses_common.py
@@ -33,6 +33,7 @@ from ..models import (
     TextBlock,
     ToolCall,
     ToolResult,
+    WebSearchCallBlock,
     safe_parse_tool_arguments,
 )
 from ..specs import build_thinking_request_params
@@ -142,6 +143,12 @@ def to_responses_input(messages: MessageHistory) -> List[Dict[str, Any]]:
                 # they belong to, which holds because the stream wrapper puts the
                 # reasoning block first in the assistant message.
                 items.append(block.to_responses_item())
+            elif isinstance(block, WebSearchCallBlock):
+                # Resend hosted web-search call items in stream order: the item
+                # id keys the server-side restore of the searched content, which
+                # is what keeps that content in the model's context (and billed
+                # as input) on later turns.
+                items.append(block.to_responses_item())
             elif isinstance(block, ToolCall):
                 # Collected, not emitted inline: the function_call items must be the
                 # LAST items of the assistant turn so the next message's
@@ -238,11 +245,17 @@ def instructions_from(system: Optional[Message], messages: MessageHistory) -> st
 
 
 def responses_tools(params: Optional[GenerationParams]) -> Optional[List[Dict[str, Any]]]:
-    """Flatten Chat-Completions tool defs into the Responses (un-nested) shape."""
-    if not params or not params.tools:
+    """Flatten Chat-Completions tool defs into the Responses (un-nested) shape.
+
+    When ``params.hosted_web_search`` is set, the provider's server-side
+    ``web_search`` tool is appended as well — a hosted tool with no client-side
+    schema (the bare ``{"type": "web_search"}`` shape both DeepSeek and OpenAI
+    accept).
+    """
+    if not params or not (params.tools or params.hosted_web_search):
         return None
     tools: List[Dict[str, Any]] = []
-    for definition in params.tools:
+    for definition in params.tools or []:
         if definition.input_kind == "freeform":
             tool: Dict[str, Any] = {
                 "type": "custom",
@@ -263,6 +276,8 @@ def responses_tools(params: Optional[GenerationParams]) -> Optional[List[Dict[st
                 "parameters": fn.get("parameters"),
             }
         )
+    if params.hosted_web_search:
+        tools.append({"type": "web_search"})
     return tools
 
 
@@ -380,10 +395,13 @@ class ResponsesStreamWrapper:
         self._summary_line_buffer: List[str] = []
         self._summary_seen_delta_parts: set[tuple[str, int]] = set()
         self._summary_finished_parts: set[tuple[str, int]] = set()
-        # Completed reasoning items (encrypted_content on OpenAI backends, plain
-        # reasoning_text content on DeepSeek flash), in stream order, so they can
-        # be resent next turn for chain-of-thought continuity.
-        self._reasoning_items: List[Dict[str, Any]] = []
+        # Completed assistant-prefix items in stream-arrival order: reasoning
+        # items (encrypted_content on OpenAI backends, plain reasoning_text
+        # content on DeepSeek flash) and hosted web_search_call items. Both are
+        # resent next turn — reasoning for chain-of-thought continuity, search
+        # calls because their ids key the server-side restore of the searched
+        # content. Tagged (kind, payload) records preserve the interleaving.
+        self._prefix_records: List[tuple[str, Dict[str, Any]]] = []
         self._final_response: Any = None
         self._function_calls: Dict[str, Dict[str, str]] = {}
         self._tool_execution_ids = ToolExecutionIdRegistry()
@@ -642,7 +660,23 @@ class ResponsesStreamWrapper:
                 # so it can be resent next turn for chain-of-thought continuity.
                 captured = self._reasoning_dict(item)
                 if captured:
-                    self._reasoning_items.append(captured)
+                    self._prefix_records.append(("reasoning", captured))
+            elif item_kind == "web_search_call":
+                # Hosted web search executed server-side. The searched content
+                # never arrives client-side — only this call item does. Capture
+                # it for replay (its id keys the server-side content restore)
+                # and surface one chunk so the agent can render the call.
+                captured = self._web_search_call_dict(item)
+                self._prefix_records.append(("web_search_call", captured))
+                return MessageChunk(
+                    type="hosted_tool_call",
+                    tool_call_delta={
+                        "id": captured.get("item_id") or "",
+                        "name": "web_search",
+                        "status": captured.get("status"),
+                        "action": captured.get("action") or {},
+                    },
+                )
             elif item_kind in ("function_call", "custom_tool_call"):
                 # The completed function_call item carries the final name +
                 # arguments; capture it so tool calls survive even if argument
@@ -707,42 +741,83 @@ class ResponsesStreamWrapper:
         if usage_metadata:
             usage_metadata["provider"] = self._provider_name
 
-        # Reasoning items lead the assistant turn (they precede the model's
-        # message/function_call output) so the backend continues the prior
-        # chain-of-thought when this message is resent next turn.
-        reasoning_blocks = self._collect_reasoning_blocks()
+        # Prefix items (reasoning + hosted web-search calls, in stream order)
+        # lead the assistant turn — they precede the model's message/
+        # function_call output — so the backend continues the prior
+        # chain-of-thought and restores searched content when this message is
+        # resent next turn.
+        prefix_blocks = self._collect_prefix_blocks()
         message = Message(
             role="assistant",
-            content=reasoning_blocks + content_blocks,
+            content=prefix_blocks + content_blocks,
             tool_calls=tool_use_blocks or None,
             stop_reason=stop_reason,
             usage_metadata=usage_metadata,
         )
         return attach_normalized_usage(message, self._provider_name, self._model)
 
-    def _collect_reasoning_blocks(self) -> list:
-        """Build the reasoning blocks to carry forward for continuity.
+    def _collect_prefix_blocks(self) -> list:
+        """Build the assistant-prefix blocks to carry forward, in stream order.
 
-        Prefers items captured from ``response.output_item.done`` events; falls
-        back to the final response output for backends that only populate
-        reasoning there.
+        Reasoning blocks give chain-of-thought continuity; web_search_call
+        blocks key the server-side restore of searched content. Prefers items
+        captured from ``response.output_item.done`` events; falls back to the
+        final response output for backends that only populate items there.
         """
-        items = list(self._reasoning_items)
-        if not items and self._final_response is not None:
+        records = list(self._prefix_records)
+        if not records and self._final_response is not None:
             for out in getattr(self._final_response, "output", None) or []:
-                if getattr(out, "type", None) == "reasoning":
+                out_type = getattr(out, "type", None)
+                if out_type == "reasoning":
                     captured = self._reasoning_dict(out)
                     if captured:
-                        items.append(captured)
-        return [
-            ResponsesReasoningBlock(
-                encrypted_content=item["encrypted_content"],
-                summary=item.get("summary") or [],
-                item_id=item.get("item_id"),
-                content=item.get("content") or [],
-            )
-            for item in items
-        ]
+                        records.append(("reasoning", captured))
+                elif out_type == "web_search_call":
+                    records.append(("web_search_call", self._web_search_call_dict(out)))
+        blocks: list = []
+        for kind, item in records:
+            if kind == "reasoning":
+                blocks.append(
+                    ResponsesReasoningBlock(
+                        encrypted_content=item["encrypted_content"],
+                        summary=item.get("summary") or [],
+                        item_id=item.get("item_id"),
+                        content=item.get("content") or [],
+                    )
+                )
+            else:
+                blocks.append(
+                    WebSearchCallBlock(
+                        item_id=item.get("item_id"),
+                        status=item.get("status"),
+                        action=item.get("action") or {},
+                    )
+                )
+        return blocks
+
+    @staticmethod
+    def _web_search_call_dict(item: Any) -> Dict[str, Any]:
+        """Extract the replayable fields from a web_search_call item.
+
+        The action payload is kept verbatim (dict form) so unknown action
+        types replay untouched; SDK objects are converted via model_dump.
+        """
+        action = getattr(item, "action", None)
+        if action is None:
+            action_dict: Dict[str, Any] = {}
+        elif isinstance(action, dict):
+            action_dict = dict(action)
+        elif hasattr(action, "model_dump"):
+            action_dict = action.model_dump(exclude_none=True)
+        else:
+            action_dict = {
+                key: value for key in ("type", "queries", "url") if (value := getattr(action, key, None)) is not None
+            }
+        return {
+            "item_id": getattr(item, "id", None),
+            "status": getattr(item, "status", None),
+            "action": action_dict,
+        }
 
     @staticmethod
     def _part_texts(parts: Any) -> List[str]:

--- a/kolega_code/llm/specs/__init__.py
+++ b/kolega_code/llm/specs/__init__.py
@@ -9,6 +9,7 @@ from .accessors import (
     preferred_edit_protocol,
     prior_reasoning_is_replayable,
     provider_has_featured_models,
+    supports_hosted_web_search,
     supports_vision,
     thinking_effort_options,
 )
@@ -27,6 +28,7 @@ __all__ = [
     "deepseek_output_token_cap",
     "is_deepseek_model",
     "get_model_specs",
+    "supports_hosted_web_search",
     "supports_vision",
     "get_thinking_effort_spec",
     "is_featured_model",

--- a/kolega_code/llm/specs/accessors.py
+++ b/kolega_code/llm/specs/accessors.py
@@ -39,6 +39,19 @@ def supports_vision(provider: str, model_name: str) -> bool:
     return get_model_specs(provider, model_name).get("supports_vision", False)
 
 
+def supports_hosted_web_search(provider: str, model_name: str) -> bool:
+    """Whether the model's API surface executes a hosted ``web_search`` tool.
+
+    True only for Responses-API models whose backend accepts
+    ``tools: [{"type": "web_search"}]`` and runs it server-side (verified per
+    provider by findings/probes/hosted_web_search_probe.py). Defaults to
+    ``False`` — including for unknown models — so the hosted tool is never
+    requested from a backend that would reject or ignore it.
+    """
+    specs = MODEL_SPECS.get((_provider_value(provider), model_name))
+    return bool(specs and specs.get("supports_hosted_web_search", False))
+
+
 def get_thinking_effort_spec(provider: str, model_name: str) -> Optional[ThinkingEffortSpec]:
     """Return the thinking effort spec for a model, if it supports a public control."""
     return get_model_specs(provider, model_name).get("thinking_effort")

--- a/kolega_code/llm/specs/catalog/deepseek.py
+++ b/kolega_code/llm/specs/catalog/deepseek.py
@@ -50,6 +50,11 @@ DEEPSEEK_SPECS = {
         "max_completion_tokens": 384000,
         "default_temperature": 1.0,
         "supports_vision": False,
+        # /responses executes {"type": "web_search"} server-side (search +
+        # open_page) and restores the searched content on replay of the
+        # web_search_call items, billed as input (verified live 2026-08-04,
+        # findings/probes/hosted_web_search_probe.py).
+        "supports_hosted_web_search": True,
         "preferred_edit_protocol": "claude_code",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "high", "max"),

--- a/kolega_code/llm/specs/catalog/openai.py
+++ b/kolega_code/llm/specs/catalog/openai.py
@@ -4,6 +4,12 @@ from kolega_code.llm.specs.types import ThinkingEffortSpec
 # The api-key `openai` provider now uses the Responses API (gpt-5.x reject
 # function tools + reasoning_effort on Chat Completions). These mirror the
 # ("openai_chatgpt", …) specs below: nested reasoning + no temperature.
+# supports_hosted_web_search: the Responses surface executes
+# {"type": "web_search"} server-side and restores searched content on replay
+# of the web_search_call items (verified live on gpt-5.6-sol 2026-08-04,
+# findings/probes/hosted_web_search_probe.py; documented for all gpt-5.x).
+# The ChatGPT-subscription backend (openai_chatgpt) carries the flag too,
+# verified through its own OAuth transport the same day.
 OPENAI_SPECS = {
     ("openai", "gpt-5.6-sol"): {
         "context_length": 1050000,
@@ -11,6 +17,7 @@ OPENAI_SPECS = {
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
+        "supports_hosted_web_search": True,
         "preferred_edit_protocol": "codex_apply_patch",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "low", "medium", "high", "xhigh", "max"),
@@ -24,6 +31,7 @@ OPENAI_SPECS = {
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
+        "supports_hosted_web_search": True,
         "preferred_edit_protocol": "codex_apply_patch",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "low", "medium", "high", "xhigh", "max"),
@@ -37,6 +45,7 @@ OPENAI_SPECS = {
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
+        "supports_hosted_web_search": True,
         "preferred_edit_protocol": "codex_apply_patch",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "low", "medium", "high", "xhigh", "max"),
@@ -50,6 +59,7 @@ OPENAI_SPECS = {
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
+        "supports_hosted_web_search": True,
         "preferred_edit_protocol": "codex_apply_patch",
         "thinking_effort": ThinkingEffortSpec(
             options=("minimal", "low", "medium", "high", "xhigh"),
@@ -63,6 +73,7 @@ OPENAI_SPECS = {
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
+        "supports_hosted_web_search": True,
         "preferred_edit_protocol": "codex_apply_patch",
         "thinking_effort": ThinkingEffortSpec(
             options=("minimal", "low", "medium", "high"),
@@ -76,6 +87,7 @@ OPENAI_SPECS = {
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
+        "supports_hosted_web_search": True,
         "preferred_edit_protocol": "codex_apply_patch",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "low", "medium", "high", "xhigh"),

--- a/kolega_code/llm/specs/catalog/openai_chatgpt.py
+++ b/kolega_code/llm/specs/catalog/openai_chatgpt.py
@@ -3,6 +3,12 @@ from kolega_code.llm.specs.types import ThinkingEffortSpec
 # OpenAI via ChatGPT subscription (Responses API, OAuth). Model slugs mirror
 # the Codex model picker; context/output limits mirror the API gpt-5.x specs
 # and are server-enforced (we never send max_output_tokens).
+# supports_hosted_web_search: the Codex backend executes {"type": "web_search"}
+# server-side and restores searched content on replay of the web_search_call
+# items — verified live through this OAuth transport 2026-08-04 (open_page
+# executed, replay accepted, ~4.4k tokens restored on a clean follow-up,
+# matching api.openai.com). Codex itself ships hosted search against this
+# backend, so every slug here gets the flag.
 # Note: The Codex backend advertises a 272K context window for GPT-5.6 and
 # GPT-5.5, despite the API models exposing a larger window. Keep the
 # subscription-specific values here so compression runs before backend limits.
@@ -13,6 +19,7 @@ OPENAI_CHATGPT_SPECS = {
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
+        "supports_hosted_web_search": True,
         "preferred_edit_protocol": "codex_apply_patch",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "low", "medium", "high", "xhigh", "max"),
@@ -26,6 +33,7 @@ OPENAI_CHATGPT_SPECS = {
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
+        "supports_hosted_web_search": True,
         "preferred_edit_protocol": "codex_apply_patch",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "low", "medium", "high", "xhigh", "max"),
@@ -39,6 +47,7 @@ OPENAI_CHATGPT_SPECS = {
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
+        "supports_hosted_web_search": True,
         "preferred_edit_protocol": "codex_apply_patch",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "low", "medium", "high", "xhigh", "max"),
@@ -52,6 +61,7 @@ OPENAI_CHATGPT_SPECS = {
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
+        "supports_hosted_web_search": True,
         "preferred_edit_protocol": "codex_apply_patch",
         "thinking_effort": ThinkingEffortSpec(
             options=("minimal", "low", "medium", "high", "xhigh"),
@@ -65,6 +75,7 @@ OPENAI_CHATGPT_SPECS = {
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
+        "supports_hosted_web_search": True,
         "preferred_edit_protocol": "codex_apply_patch",
         "thinking_effort": ThinkingEffortSpec(
             options=("minimal", "low", "medium", "high"),
@@ -78,6 +89,7 @@ OPENAI_CHATGPT_SPECS = {
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
+        "supports_hosted_web_search": True,
         "preferred_edit_protocol": "codex_apply_patch",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "low", "medium", "high", "xhigh"),
@@ -91,6 +103,7 @@ OPENAI_CHATGPT_SPECS = {
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
+        "supports_hosted_web_search": True,
         "preferred_edit_protocol": "codex_apply_patch",
         "thinking_effort": ThinkingEffortSpec(
             options=("minimal", "low", "medium"),

--- a/tests/agent/llm/test_hosted_web_search_live.py
+++ b/tests/agent/llm/test_hosted_web_search_live.py
@@ -1,0 +1,114 @@
+"""Live hosted web_search on the Responses providers (DeepSeek flash + OpenAI).
+
+Two requests per provider, mirroring the Phase-0 probe
+(findings/probes/hosted_web_search_probe.py, results 2026-08-04):
+
+1. force a search — `tools` gains `{"type": "web_search"}` via
+   ``GenerationParams(hosted_web_search=True)``; the stream wrapper must
+   capture the server-side ``web_search_call`` items as WebSearchCallBlocks.
+2. replay + follow-up — resending those blocks must be ACCEPTED (a 400 here
+   means the replay shape regressed) and must restore the searched content
+   server-side, observable as billed input exceeding the client-side count
+   (that surplus is exactly what BaseAgent's hosted-search residual feeds the
+   context gauge).
+
+Hermetic counterpart: tests/agent/llm/test_responses_hosted_web_search.py and
+tests/agent/test_hosted_search_accounting.py.
+"""
+
+import os
+
+import pytest
+
+from kolega_code.cli.config import API_KEY_ENV
+from kolega_code.config import ModelProvider
+from kolega_code.llm.models import (
+    Message,
+    MessageHistory,
+    TextBlock,
+    WebSearchCallBlock,
+)
+from kolega_code.llm.providers.deepseek_responses import DeepSeekResponsesProvider
+from kolega_code.llm.providers.models import GenerationParams
+from kolega_code.llm.providers.openai_responses import OpenAIResponsesProvider
+
+pytestmark = [pytest.mark.slow, pytest.mark.integration]
+
+SKIP_IN_CI = bool(os.getenv("CI")) or bool(os.getenv("GITLAB_CI"))
+
+SEARCH_PROMPT = (
+    "Use the web search tool to open https://blog.rust-lang.org/releases/ and "
+    "answer: what is the newest release version listed there? Reply with just "
+    "the version number."
+)
+FOLLOWUP_PROMPT = (
+    "Without searching or opening any page again, name two OTHER version "
+    "numbers (not the one you already gave) that appeared on the page you "
+    "opened. Reply with just the two version numbers."
+)
+
+# The replay turn's billed input must exceed the client count by at least the
+# restored search corpus. Probe floor: ~2.7k (deepseek) / ~3.5k (openai); a
+# conservative >1k asserts restoration without pinning provider internals. The
+# ceiling guards against runaway telescoped billing on a clean turn.
+MIN_RESTORED_TOKENS = 1_000
+MAX_RESTORED_TOKENS = 100_000
+
+PROVIDERS = {
+    "deepseek": (DeepSeekResponsesProvider, ModelProvider.DEEPSEEK, "deepseek-v4-flash", "high"),
+    "openai": (OpenAIResponsesProvider, ModelProvider.OPENAI, "gpt-5.6-sol", "low"),
+}
+
+
+def _provider_for(name):
+    if SKIP_IN_CI:
+        pytest.skip("Skipping live provider call in CI")
+    provider_cls, provider_enum, model, thinking = PROVIDERS[name]
+    env_name = API_KEY_ENV[provider_enum]
+    api_key = os.getenv(env_name)
+    if not api_key:
+        pytest.skip(f"{env_name} not set")
+    return provider_cls(api_key=api_key), model, thinking
+
+
+@pytest.mark.parametrize("provider_name", ["deepseek", "openai"])
+@pytest.mark.asyncio
+async def test_hosted_search_capture_replay_and_restore(provider_name):
+    provider, model, thinking = _provider_for(provider_name)
+    params = GenerationParams(hosted_web_search=True, thinking=thinking, max_completion_tokens=4000)
+    history = MessageHistory([Message(role="user", content=[TextBlock(text=SEARCH_PROMPT)])])
+
+    # --- turn 1: the model must actually search, and we must capture it ---
+    message = await provider.generate(history, system=None, params=params, model=model)
+    search_blocks = [b for b in message.content or [] if isinstance(b, WebSearchCallBlock)]
+    assert search_blocks, f"{provider_name} answered without a web_search_call — hosted tool not exposed?"
+    for block in search_blocks:
+        assert block.action_type in ("search", "open_page", "find_in_page"), block.action
+    answer_1 = message.get_text_content()
+    assert answer_1.strip(), "search turn produced no visible answer"
+    usage_1 = message.usage_metadata or {}
+    assert usage_1.get("prompt_tokens", 0) > 0
+
+    # --- turn 2: replay must be accepted and the searched content restored ---
+    history.append(message)
+    history.append(Message(role="user", content=[TextBlock(text=FOLLOWUP_PROMPT)]))
+    counted = await provider.count_tokens(messages=history, system=None, model=model, tools=[])
+    followup = await provider.generate(history, system=None, params=params, model=model)
+
+    answer_2 = followup.get_text_content()
+    assert answer_2.strip(), "follow-up produced no answer — replay may have been rejected"
+    new_searches = [b for b in followup.content or [] if isinstance(b, WebSearchCallBlock)]
+    billed = (followup.usage_metadata or {}).get("prompt_tokens", 0)
+    restored = billed - counted.input_tokens
+    print(
+        f"\nHOSTED-SEARCH-LIVE provider={provider_name} turn1_searches={len(search_blocks)} "
+        f"turn2_searches={len(new_searches)} billed={billed} counted={counted.input_tokens} "
+        f"restored={restored} answer2={answer_2[:80]!r}"
+    )
+    if not new_searches:
+        # Clean follow-up: the residual measures the restored corpus directly.
+        assert MIN_RESTORED_TOKENS < restored < MAX_RESTORED_TOKENS, (
+            f"billed−counted={restored}: outside the restore band — either the server stopped "
+            "restoring searched content on replay (gauge residual now overcounts nothing) or "
+            "billing semantics changed (residual would poison the gauge)"
+        )

--- a/tests/agent/llm/test_responses_hosted_web_search.py
+++ b/tests/agent/llm/test_responses_hosted_web_search.py
@@ -279,10 +279,13 @@ class TestRoundTrip:
         assert restored.url == "https://e.com"
 
     def test_markdown_label(self):
+        # Exact-match assertions: a `"https://…" in text` check here trips
+        # CodeQL's URL-substring-sanitization rule (it can't tell an assertion
+        # from a sanitizer), and equality pins the full label format anyway.
         search = WebSearchCallBlock(action={"type": "search", "queries": ["a", "b"]})
-        assert "'a', 'b'" in search.to_markdown()
+        assert search.to_markdown() == "*Web search — search: 'a', 'b'*"
         page = WebSearchCallBlock(action={"type": "open_page", "url": "https://e.com"})
-        assert "https://e.com" in page.to_markdown()
+        assert page.to_markdown() == "*Web search — open_page: https://e.com*"
 
 
 # --- token counting ---------------------------------------------------------------

--- a/tests/agent/llm/test_responses_hosted_web_search.py
+++ b/tests/agent/llm/test_responses_hosted_web_search.py
@@ -1,0 +1,360 @@
+"""Hosted web_search on the Responses providers: request, capture, replay, count.
+
+The provider's server-side web_search tool is requested with a bare
+``{"type": "web_search"}`` entry; the server executes ``search`` / ``open_page``
+actions and returns ``web_search_call`` output items whose content never
+reaches the client (it is injected server-side and billed as input). The
+wrapper captures those items in stream order as ``WebSearchCallBlock``s so
+``to_responses_input`` can replay them — the item id keys the server-side
+restore of the searched content (verified live 2026-08-04,
+findings/probes/hosted_web_search_probe.py).
+
+Hermetic: fake streams, no network. Live counterpart planned in
+test_hosted_web_search_live.py.
+"""
+
+from types import SimpleNamespace as _ns
+
+import pytest
+
+from kolega_code.llm.models import (
+    ContentBlock,
+    Message,
+    MessageHistory,
+    ResponsesReasoningBlock,
+    TextBlock,
+    ToolCall,
+    WebSearchCallBlock,
+)
+from kolega_code.llm.providers.deepseek_responses import DeepSeekResponsesProvider
+from kolega_code.llm.providers.models import GenerationParams
+from kolega_code.llm.providers.openai import OpenAIProvider
+from kolega_code.llm.providers.openai_responses import OpenAIResponsesProvider
+from kolega_code.llm.providers.responses_common import (
+    ResponsesStreamWrapper,
+    responses_tools,
+    to_responses_input,
+)
+from kolega_code.llm.providers._token_encoding import get_counting_encoding
+
+
+def _function_tool():
+    from kolega_code.llm.models import ToolDefinition, ToolParameter
+
+    return ToolDefinition(
+        name="read_file",
+        description="Read a file.",
+        parameters=[ToolParameter(name="path", type="string", description="Path", required=True)],
+    )
+
+
+class TestHostedToolInRequest:
+    def test_appended_after_function_tools_when_enabled(self):
+        params = GenerationParams(tools=[_function_tool()], hosted_web_search=True)
+        tools = responses_tools(params)
+        assert tools is not None
+        assert tools[-1] == {"type": "web_search"}
+        assert tools[0]["type"] == "function"
+
+    def test_absent_by_default(self):
+        tools = responses_tools(GenerationParams(tools=[_function_tool()]))
+        assert tools is not None
+        assert {"type": "web_search"} not in tools
+
+    def test_emitted_even_without_client_tools(self):
+        assert responses_tools(GenerationParams(hosted_web_search=True)) == [{"type": "web_search"}]
+
+    def test_no_tools_at_all_returns_none(self):
+        assert responses_tools(GenerationParams()) is None
+        assert responses_tools(None) is None
+
+    @pytest.mark.parametrize(
+        "provider_cls,model",
+        [
+            (DeepSeekResponsesProvider, "deepseek-v4-flash"),
+            (OpenAIResponsesProvider, "gpt-5.6-sol"),
+        ],
+    )
+    def test_build_request_carries_hosted_tool(self, provider_cls, model):
+        provider = provider_cls(api_key="sk-test")
+        request = provider._build_request(
+            MessageHistory([]),
+            None,
+            GenerationParams(hosted_web_search=True),
+            {"model": model},
+        )
+        assert {"type": "web_search"} in request["tools"]
+
+        request_off = provider._build_request(
+            MessageHistory([]),
+            None,
+            GenerationParams(),
+            {"model": model},
+        )
+        assert {"type": "web_search"} not in (request_off["tools"] or [])
+
+
+# --- stream capture ---------------------------------------------------------------
+
+
+class _FakeStream:
+    def __init__(self, events):
+        self._events = list(events)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._events:
+            raise StopAsyncIteration
+        return self._events.pop(0)
+
+    async def aclose(self):
+        pass
+
+
+def _reasoning_event(item_id="rs_1", text="Let me check the docs."):
+    return _ns(
+        type="response.output_item.done",
+        item=_ns(
+            type="reasoning",
+            id=item_id,
+            encrypted_content=None,
+            summary=[],
+            content=[_ns(type="reasoning_text", text=text)],
+        ),
+    )
+
+
+def _web_search_event(item_id="ws_1", action=None):
+    return _ns(
+        type="response.output_item.done",
+        item=_ns(
+            type="web_search_call",
+            id=item_id,
+            status="completed",
+            action=action if action is not None else {"type": "search", "queries": ["rust releases"]},
+        ),
+    )
+
+
+def _completed_event():
+    return _ns(
+        type="response.completed",
+        response=_ns(output=[], usage=None, status="completed", incomplete_details=None),
+    )
+
+
+async def _drain_with_chunks(wrapper):
+    chunks = []
+    async with wrapper as stream:
+        async for chunk in stream:
+            chunks.append(chunk)
+    return chunks, await wrapper.get_final_message()
+
+
+class TestStreamCapture:
+    @pytest.mark.asyncio
+    async def test_interleaved_items_captured_in_stream_order(self):
+        events = [
+            _reasoning_event("rs_1", "Search first."),
+            _web_search_event("ws_1", {"type": "search", "queries": ["a", "b"]}),
+            _reasoning_event("rs_2", "Now open the page."),
+            _web_search_event("ws_2", {"type": "open_page", "url": "https://example.com/x"}),
+            _completed_event(),
+        ]
+        chunks, message = await _drain_with_chunks(
+            ResponsesStreamWrapper(_FakeStream(events), provider_name="deepseek")
+        )
+
+        hosted = [c for c in chunks if c.type == "hosted_tool_call"]
+        assert [c.tool_call_delta["id"] for c in hosted] == ["ws_1", "ws_2"]
+        assert hosted[0].tool_call_delta["action"] == {"type": "search", "queries": ["a", "b"]}
+        assert hosted[0].tool_call_delta["name"] == "web_search"
+
+        kinds = [type(block).__name__ for block in message.content]
+        assert kinds == [
+            "ResponsesReasoningBlock",
+            "WebSearchCallBlock",
+            "ResponsesReasoningBlock",
+            "WebSearchCallBlock",
+        ]
+        ws = message.content[1]
+        assert ws.item_id == "ws_1"
+        assert ws.status == "completed"
+        assert ws.queries == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_namespace_action_converts_to_dict(self):
+        # SDK objects arrive as attribute bags, not dicts.
+        events = [
+            _web_search_event("ws_1", _ns(type="open_page", url="https://example.com/y", queries=None)),
+            _completed_event(),
+        ]
+        _, message = await _drain_with_chunks(ResponsesStreamWrapper(_FakeStream(events)))
+        ws = message.content[0]
+        assert isinstance(ws, WebSearchCallBlock)
+        assert ws.action == {"type": "open_page", "url": "https://example.com/y"}
+
+    @pytest.mark.asyncio
+    async def test_fallback_scan_of_final_response_output(self):
+        # Backends that only populate the final response (no item.done events).
+        final = _ns(
+            type="response.completed",
+            response=_ns(
+                output=[
+                    _ns(
+                        type="reasoning",
+                        id="rs_1",
+                        encrypted_content=None,
+                        summary=[],
+                        content=[_ns(type="reasoning_text", text="hm")],
+                    ),
+                    _ns(
+                        type="web_search_call",
+                        id="ws_9",
+                        status="completed",
+                        action={"type": "search", "queries": ["q"]},
+                    ),
+                ],
+                usage=None,
+                status="completed",
+                incomplete_details=None,
+            ),
+        )
+        _, message = await _drain_with_chunks(ResponsesStreamWrapper(_FakeStream([final])))
+        kinds = [type(block).__name__ for block in message.content]
+        assert kinds == ["ResponsesReasoningBlock", "WebSearchCallBlock"]
+        assert message.content[1].item_id == "ws_9"
+
+
+# --- replay -----------------------------------------------------------------------
+
+
+class TestReplay:
+    def test_to_responses_input_preserves_prefix_order_and_calls_last(self):
+        message = Message(
+            role="assistant",
+            content=[
+                ResponsesReasoningBlock(content=["think 1"], item_id="rs_1"),
+                WebSearchCallBlock(item_id="ws_1", status="completed", action={"type": "search", "queries": ["q"]}),
+                ResponsesReasoningBlock(content=["think 2"], item_id="rs_2"),
+                TextBlock(text="Found it."),
+                ToolCall(id="call_1", name="read_file", input={"path": "a.py"}, execution_id="te_1"),
+            ],
+        )
+        items = to_responses_input(MessageHistory([message]))
+        types = [item.get("type") or item.get("role") for item in items]
+        # Prefix in block order, assistant text next, function_call after it
+        # (its orphan-padding output trails, keeping the request valid).
+        assert types[:5] == ["reasoning", "web_search_call", "reasoning", "assistant", "function_call"]
+        ws_item = items[1]
+        assert ws_item == {
+            "type": "web_search_call",
+            "id": "ws_1",
+            "status": "completed",
+            "action": {"type": "search", "queries": ["q"]},
+        }
+        # function_call items stay last (before their padded output).
+        assert types.index("function_call") > types.index("assistant")
+
+    def test_item_id_omitted_when_unknown(self):
+        block = WebSearchCallBlock(status="completed", action={"type": "search", "queries": []})
+        assert "id" not in block.to_responses_item()
+
+
+# --- persistence round-trip -------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_dict_round_trip_via_registry(self):
+        block = WebSearchCallBlock(
+            item_id="ws_1", status="completed", action={"type": "open_page", "url": "https://e.com"}
+        )
+        restored = ContentBlock.from_dict(block.to_dict())
+        assert isinstance(restored, WebSearchCallBlock)
+        assert restored.item_id == "ws_1"
+        assert restored.status == "completed"
+        assert restored.action == {"type": "open_page", "url": "https://e.com"}
+        assert restored.url == "https://e.com"
+
+    def test_markdown_label(self):
+        search = WebSearchCallBlock(action={"type": "search", "queries": ["a", "b"]})
+        assert "'a', 'b'" in search.to_markdown()
+        page = WebSearchCallBlock(action={"type": "open_page", "url": "https://e.com"})
+        assert "https://e.com" in page.to_markdown()
+
+
+# --- token counting ---------------------------------------------------------------
+
+
+class TestTokenCounting:
+    def _provider(self):
+        return OpenAIProvider(api_key="sk-test")
+
+    def test_block_counts_nonzero_metadata_only(self):
+        provider = self._provider()
+        encoding = get_counting_encoding("o200k_base")
+        message = Message(
+            role="assistant",
+            content=[
+                WebSearchCallBlock(
+                    item_id="ws_1",
+                    status="completed",
+                    action={"type": "search", "queries": ["rust releases august"]},
+                )
+            ],
+        )
+        count = provider._count_message_tokens(encoding, message)
+        # More than the bare message overhead, far less than any page of content.
+        assert 5 < count < 200
+
+    def test_fingerprint_tracks_action_changes(self):
+        provider = self._provider()
+        block = WebSearchCallBlock(item_id="ws_1", status="completed", action={"type": "search", "queries": ["q"]})
+        before = provider._block_fingerprint(block)
+        assert before[0] == "wsc"
+        block.action["queries"] = ["a much longer query string"]
+        assert provider._block_fingerprint(block) != before
+
+
+# --- cross-provider handling ------------------------------------------------------
+
+
+class TestCrossProvider:
+    def _blocks(self):
+        return [
+            TextBlock(text="answer"),
+            WebSearchCallBlock(item_id="ws_1", status="completed", action={"type": "search", "queries": ["q"]}),
+        ]
+
+    def test_kept_for_same_provider(self):
+        from kolega_code.agent.conversation import _adapt_content_blocks_for_provider
+
+        adapted, _changed = _adapt_content_blocks_for_provider(
+            self._blocks(),
+            source_provider="deepseek",
+            target_provider="deepseek",
+            target_model="deepseek-v4-flash",
+            supports_vision=False,
+        )
+        assert any(isinstance(b, WebSearchCallBlock) for b in adapted)
+
+    def test_dropped_for_foreign_provider_without_placeholder(self):
+        from kolega_code.agent.conversation import _adapt_content_blocks_for_provider
+
+        adapted, changed = _adapt_content_blocks_for_provider(
+            self._blocks(),
+            source_provider="deepseek",
+            target_provider="anthropic",
+            target_model="claude-sonnet-4-5-20250929",
+            supports_vision=True,
+        )
+        assert changed
+        assert not any(isinstance(b, WebSearchCallBlock) for b in adapted)
+        assert not any("[Web search]" in getattr(b, "text", "") for b in adapted)
+
+    def test_message_to_openai_omits_block(self):
+        message = Message(role="assistant", content=self._blocks())
+        payload = message.to_openai()
+        assert "[Web search]" not in str(payload)

--- a/tests/agent/llm/test_responses_hosted_web_search.py
+++ b/tests/agent/llm/test_responses_hosted_web_search.py
@@ -279,13 +279,11 @@ class TestRoundTrip:
         assert restored.url == "https://e.com"
 
     def test_markdown_label(self):
-        # Exact-match assertions: a `"https://…" in text` check here trips
-        # CodeQL's URL-substring-sanitization rule (it can't tell an assertion
-        # from a sanitizer), and equality pins the full label format anyway.
         search = WebSearchCallBlock(action={"type": "search", "queries": ["a", "b"]})
-        assert search.to_markdown() == "*Web search — search: 'a', 'b'*"
+        assert "'a', 'b'" in search.to_markdown()
         page = WebSearchCallBlock(action={"type": "open_page", "url": "https://e.com"})
-        assert page.to_markdown() == "*Web search — open_page: https://e.com*"
+        # Not URL sanitization — a test assertion on a display label.
+        assert "https://e.com" in page.to_markdown()  # codeql[py/incomplete-url-substring-sanitization]
 
 
 # --- token counting ---------------------------------------------------------------

--- a/tests/agent/test_agent_tools_inventory.py
+++ b/tests/agent/test_agent_tools_inventory.py
@@ -569,6 +569,76 @@ def test_eval_tool_hidden_when_disabled(project_path, mock_connection_manager, a
     assert "eval" not in tool_names
 
 
+def _coder(project_path, mock_connection_manager, agent_config):
+    return CoderAgent(
+        project_path=project_path,
+        workspace_id="test_workspace",
+        thread_id=str(uuid.uuid4()),
+        connection_manager=mock_connection_manager,
+        config=agent_config,
+        agent_mode=AgentMode.CLI,
+    )
+
+
+def _with_hosted_support(monkeypatch):
+    """Mark the fixture model hosted-web-search-capable in the catalog."""
+    from kolega_code.llm.specs import MODEL_SPECS
+
+    key = ("anthropic", "claude-sonnet-4-5-20250929")
+    monkeypatch.setitem(MODEL_SPECS, key, {**MODEL_SPECS[key], "supports_hosted_web_search": True})
+
+
+def test_web_tools_present_when_auto_without_hosted_support(project_path, mock_connection_manager, agent_config):
+    """auto on a model without hosted search keeps the client web tools (today's set)."""
+    agent_config.web_search_mode = "auto"
+    agent = _coder(project_path, mock_connection_manager, agent_config)
+    tool_names = {tool.name for tool in agent.tool_collection.get_tool_list()}
+    assert {"web_search", "web_fetch"} <= tool_names
+    assert agent.hosted_web_search_active is False
+
+
+def test_web_tools_hidden_when_mode_off(project_path, mock_connection_manager, agent_config):
+    """off removes both client web tools and never requests the hosted tool."""
+    agent_config.web_search_mode = "off"
+    agent = _coder(project_path, mock_connection_manager, agent_config)
+    tool_names = {tool.name for tool in agent.tool_collection.get_tool_list()}
+    assert "web_search" not in tool_names
+    assert "web_fetch" not in tool_names
+    assert agent.hosted_web_search_active is False
+
+
+def test_web_tools_hidden_when_hosted_supported_on_auto(
+    project_path, mock_connection_manager, agent_config, monkeypatch
+):
+    """auto on a hosted-capable model swaps the client tools for the hosted one."""
+    _with_hosted_support(monkeypatch)
+    agent_config.web_search_mode = "auto"
+    agent = _coder(project_path, mock_connection_manager, agent_config)
+    tool_names = {tool.name for tool in agent.tool_collection.get_tool_list()}
+    assert "web_search" not in tool_names
+    assert "web_fetch" not in tool_names
+    assert agent.hosted_web_search_active is True
+
+
+def test_mode_hosted_unsupported_falls_back_to_client(project_path, mock_connection_manager, agent_config):
+    """hosted on a model without support degrades to the client tools, not to no-web."""
+    agent_config.web_search_mode = "hosted"
+    agent = _coder(project_path, mock_connection_manager, agent_config)
+    tool_names = {tool.name for tool in agent.tool_collection.get_tool_list()}
+    assert {"web_search", "web_fetch"} <= tool_names
+    assert agent.hosted_web_search_active is False
+
+
+def test_mode_client_wins_even_when_hosted_supported(project_path, mock_connection_manager, agent_config, monkeypatch):
+    """client pins today's behavior regardless of model capability."""
+    _with_hosted_support(monkeypatch)
+    agent_config.web_search_mode = "client"
+    agent = _coder(project_path, mock_connection_manager, agent_config)
+    tool_names = {tool.name for tool in agent.tool_collection.get_tool_list()}
+    assert {"web_search", "web_fetch"} <= tool_names
+    assert agent.hosted_web_search_active is False
+
+
 def test_shared_tool_names_are_well_formed(project_path, mock_connection_manager, agent_config):
     """Shared agent tool definitions have valid names and descriptions."""
     agents = [

--- a/tests/agent/test_hosted_search_accounting.py
+++ b/tests/agent/test_hosted_search_accounting.py
@@ -1,0 +1,135 @@
+"""Hosted web-search residual accounting: the gauge must read billed-true.
+
+Hosted search content is injected into the model context SERVER-side (restored
+on replay of web_search_call items, billed as input) and never reaches the
+client, so tiktoken-over-history undercounts. BaseAgent tracks the residual
+(billed − counted) as a side-channel: search-bearing responses bump a
+provisional per-call constant (their own billing telescopes internal rounds),
+clean responses replace it with the measured residual, compaction resets it.
+Live counterpart: the gauge-invariant test in
+tests/agent/llm/test_hosted_web_search_live.py.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from kolega_code.agent.coder import CoderAgent
+from kolega_code.agent.prompt_provider import AgentMode
+from kolega_code.config import AgentConfig
+from kolega_code.events import AgentConnectionManager
+from kolega_code.llm.models import ContentBlock, Message, TextBlock, WebSearchCallBlock
+from kolega_code.llm.providers.models import TokenCount
+
+
+@pytest.fixture
+def agent(tmp_path):
+    manager = Mock(spec=AgentConnectionManager)
+    manager.workspace_id = "test_workspace"
+    manager.send_message = AsyncMock()
+    config = Mock(spec=AgentConfig)
+    config.long_context_config = Mock()
+    config.long_context_config.provider = "anthropic"
+    config.long_context_config.model = "claude-sonnet-4-5-20250929"
+    config.openai_api_key = "test_key"
+    config.anthropic_api_key = "test_key"
+    config.browser_use_headless = True
+    config.agent_models = {}
+    config.web_search_mode = "auto"
+    config.model_config_for_agent.return_value = config.long_context_config
+    return CoderAgent(
+        project_path=str(tmp_path),
+        workspace_id="test_workspace",
+        thread_id=str(uuid.uuid4()),
+        connection_manager=manager,
+        config=config,
+        agent_mode=AgentMode.CLI,
+    )
+
+
+def _search_message(n_calls=1, billed=None):
+    content: list[ContentBlock] = [
+        WebSearchCallBlock(item_id=f"ws_{i}", status="completed", action={"type": "search", "queries": ["q"]})
+        for i in range(n_calls)
+    ]
+    usage = {"prompt_tokens": billed} if billed is not None else {}
+    return Message(role="assistant", content=content, usage_metadata=usage)
+
+
+def _clean_message(billed):
+    return Message(role="assistant", content=[TextBlock(text="ok")], usage_metadata={"prompt_tokens": billed})
+
+
+class TestResidualUpdates:
+    def test_search_bearing_response_adds_provisional_per_call(self, agent):
+        agent._last_raw_context_count = 1000
+        agent._update_hosted_search_residual(_search_message(n_calls=2, billed=50_000))
+        assert agent._hosted_injected_tokens == 2 * CoderAgent.HOSTED_SEARCH_PROVISIONAL_TOKENS
+
+    def test_clean_response_replaces_estimate_with_measurement(self, agent):
+        agent._hosted_injected_tokens = 12_000
+        agent._last_raw_context_count = 1_000
+        agent._update_hosted_search_residual(_clean_message(billed=3_800))
+        assert agent._hosted_injected_tokens == 2_800
+
+    def test_clean_response_without_any_search_history_is_a_noop(self, agent):
+        # Tokenizer drift (billed > counted) must not leak into the gauge for
+        # sessions that never searched.
+        agent._last_raw_context_count = 1_000
+        agent._update_hosted_search_residual(_clean_message(billed=1_400))
+        assert agent._hosted_injected_tokens == 0
+
+    def test_recovers_after_compaction_when_search_blocks_survive(self, agent):
+        # Post-compaction the residual is 0 but surviving web_search_call blocks
+        # keep the server restoring content — the next clean response re-measures.
+        agent.history.append(_search_message(n_calls=1))
+        agent._hosted_injected_tokens = 0
+        agent._last_raw_context_count = 1_000
+        agent._update_hosted_search_residual(_clean_message(billed=4_000))
+        assert agent._hosted_injected_tokens == 3_000
+
+    def test_negative_residual_clamps_to_zero(self, agent):
+        agent._hosted_injected_tokens = 5_000
+        agent._last_raw_context_count = 2_000
+        agent._update_hosted_search_residual(_clean_message(billed=1_500))
+        assert agent._hosted_injected_tokens == 0
+
+    def test_missing_usage_keeps_last_value(self, agent):
+        agent._hosted_injected_tokens = 5_000
+        agent._last_raw_context_count = 2_000
+        agent._update_hosted_search_residual(
+            Message(role="assistant", content=[TextBlock(text="ok")], usage_metadata={})
+        )
+        assert agent._hosted_injected_tokens == 5_000
+
+
+class TestGaugeApplication:
+    @pytest.mark.asyncio
+    async def test_count_current_context_adds_positive_residual(self, agent, monkeypatch):
+        monkeypatch.setattr(agent.llm, "count_tokens", AsyncMock(return_value=TokenCount(input_tokens=10_000)))
+        agent._hosted_injected_tokens = 2_500
+        token_count = await agent.count_current_context()
+        assert token_count.input_tokens == 12_500
+        # The raw (pre-residual) count is stashed for the next residual update.
+        assert agent._last_raw_context_count == 10_000
+
+    @pytest.mark.asyncio
+    async def test_count_current_context_untouched_without_residual(self, agent, monkeypatch):
+        monkeypatch.setattr(agent.llm, "count_tokens", AsyncMock(return_value=TokenCount(input_tokens=10_000)))
+        token_count = await agent.count_current_context()
+        assert token_count.input_tokens == 10_000
+
+    @pytest.mark.asyncio
+    async def test_compress_history_resets_the_residual(self, agent, monkeypatch):
+        from kolega_code.agent.compression import CompactionResult
+
+        agent._hosted_injected_tokens = 9_999
+        monkeypatch.setattr(agent.llm, "count_tokens", AsyncMock(return_value=TokenCount(input_tokens=100)))
+        monkeypatch.setattr(
+            agent.compressor,
+            "summarize",
+            AsyncMock(return_value=CompactionResult(ok=True, reason="ok", summarized_messages=0)),
+        )
+        await agent.compress_history()
+        assert agent._hosted_injected_tokens == 0

--- a/tests/cli/test_ask_json_messages.py
+++ b/tests/cli/test_ask_json_messages.py
@@ -245,6 +245,31 @@ def test_serialize_keeps_plain_reasoning_and_strips_opaque_fields():
     assert data["content"][1]["type"] == "text"
 
 
+def test_serialize_keeps_hosted_web_search_calls():
+    # Hosted web_search_call blocks carry only readable action metadata
+    # (queries/URL), so --json consumers (e.g. the benchmark jsonl census) get
+    # the whole block — nothing opaque to strip.
+    from kolega_code.cli.ask_output import serialize_ask_message
+    from kolega_code.llm.models import WebSearchCallBlock
+
+    message = Message(
+        role="assistant",
+        content=[
+            WebSearchCallBlock(item_id="ws_1", status="completed", action={"type": "search", "queries": ["q"]}),
+            TextBlock(text="the answer"),
+        ],
+        stop_reason="end_turn",
+    )
+    data = serialize_ask_message(message)
+    assert data["content"][0] == {
+        "type": "web_search_call",
+        "status": "completed",
+        "action": {"type": "search", "queries": ["q"]},
+        "item_id": "ws_1",
+    }
+    assert data["content"][1]["type"] == "text"
+
+
 def test_serialize_drops_encrypted_only_reasoning():
     # OpenAI/ChatGPT reasoning is an opaque blob; once stripped nothing readable
     # remains, so the whole block is dropped as before.

--- a/tests/cli/test_ask_web_search_mode.py
+++ b/tests/cli/test_ask_web_search_mode.py
@@ -1,0 +1,133 @@
+"""Tests for the ``kolega-code ask --web-search`` mode flag and its plumbing.
+
+The mode has one job spread over three layers: resolve (flag > env > settings >
+"auto", cli/config.py), carry (AgentConfig.web_search_mode -> BaseAgent gates),
+persist (SessionRecord / CliSettings round-trips). The e2e tests drive a real
+``CoderAgent`` through ``main(["ask", ...])`` with only the LLM turn stubbed,
+so a regression that sets the mode without flipping the tool gate fails here.
+"""
+
+import pytest
+
+from kolega_code.agent.coder import CoderAgent
+from kolega_code.cli.config import CliConfigError, CliConfigOverrides, _web_search_mode
+from kolega_code.cli.session_store import SessionRecord
+from kolega_code.cli.settings import CliSettings
+
+WEB_TOOLS = {"web_search", "web_fetch"}
+
+
+class RecordingCoderAgent(CoderAgent):
+    """The real agent, minus the network turn, recording every instance built."""
+
+    instances: list["RecordingCoderAgent"] = []
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        RecordingCoderAgent.instances.append(self)
+
+    async def process_message_stream(self, message, attachments=None):
+        yield {"type": "response", "content": "done", "complete": True, "uuid": "response-1"}
+
+    def tool_names(self) -> set[str]:
+        assert self.tool_collection is not None
+        return {tool.name for tool in self.tool_collection.get_tool_list()}
+
+
+def _setup(tmp_path, monkeypatch):
+    from kolega_code.cli import main as main_module
+
+    RecordingCoderAgent.instances = []
+    monkeypatch.setattr(main_module, "CoderAgent", RecordingCoderAgent)
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("KOLEGA_CODE_PROVIDER", "anthropic")
+    monkeypatch.setenv("KOLEGA_CODE_MODEL", "claude-opus-5")
+    return main_module, project
+
+
+# --- resolution -------------------------------------------------------------------
+
+
+def test_mode_resolution_precedence():
+    settings = CliSettings(web_search_mode="client")
+    env = {"KOLEGA_CODE_WEB_SEARCH_MODE": "hosted"}
+    # flag > env > settings > default
+    assert _web_search_mode(env, settings, "off") == "off"
+    assert _web_search_mode(env, settings, None) == "hosted"
+    assert _web_search_mode({}, settings, None) == "client"
+    assert _web_search_mode({}, None, None) == "auto"
+
+
+def test_mode_resolution_rejects_unknown():
+    with pytest.raises(CliConfigError):
+        _web_search_mode({}, None, "sideways")
+
+
+def test_overrides_dataclass_carries_the_mode():
+    assert CliConfigOverrides(web_search_mode="off").web_search_mode == "off"
+
+
+# --- persistence round-trips ------------------------------------------------------
+
+
+def test_settings_round_trip_is_additive_optional():
+    settings = CliSettings(web_search_mode="hosted")
+    assert CliSettings.from_dict(settings.to_dict()).web_search_mode == "hosted"
+    # Older files without the key load as None (default applied downstream).
+    data = CliSettings().to_dict()
+    del data["web_search_mode"]
+    assert CliSettings.from_dict(data).web_search_mode is None
+
+
+def test_session_record_round_trip(tmp_path):
+    record = SessionRecord.create(tmp_path, "code", {})
+    record.web_search_mode = "off"
+    restored = SessionRecord.from_dict(record.to_dict())
+    assert restored.web_search_mode == "off"
+    # Absent in older files -> None.
+    data = record.to_dict()
+    del data["web_search_mode"]
+    assert SessionRecord.from_dict(data).web_search_mode is None
+
+
+# --- end to end -------------------------------------------------------------------
+
+
+def test_ask_web_search_off_removes_both_client_tools(tmp_path, monkeypatch, isolated_cli_env):
+    main_module, project = _setup(tmp_path, monkeypatch)
+
+    exit_code = main_module.main(["ask", "do the thing", "--project", str(project), "--web-search", "off"])
+
+    assert exit_code == 0
+    agent = RecordingCoderAgent.instances[0]
+    assert agent.web_search_mode == "off"
+    assert not (WEB_TOOLS & agent.tool_names())
+    assert agent.hosted_web_search_active is False
+
+
+def test_ask_default_keeps_client_tools_on_non_hosted_model(tmp_path, monkeypatch, isolated_cli_env):
+    """No flag: auto on a model without hosted support is exactly today's inventory."""
+    main_module, project = _setup(tmp_path, monkeypatch)
+
+    exit_code = main_module.main(["ask", "do the thing", "--project", str(project)])
+
+    assert exit_code == 0
+    agent = RecordingCoderAgent.instances[0]
+    assert agent.web_search_mode == "auto"
+    assert WEB_TOOLS <= agent.tool_names()
+    assert agent.hosted_web_search_active is False
+
+
+def test_ask_mode_persists_and_resumes_with_the_session(tmp_path, monkeypatch, isolated_cli_env):
+    """--web-search sticks to a session; a resumed headless session inherits it."""
+    main_module, project = _setup(tmp_path, monkeypatch)
+
+    assert main_module.main(["ask", "first", "--project", str(project), "--session", "s1", "--web-search", "off"]) == 0
+    # No flag on the resume: the stored session state carries it.
+    assert main_module.main(["ask", "second", "--project", str(project), "--session", "s1"]) == 0
+
+    resumed = RecordingCoderAgent.instances[1]
+    assert resumed.web_search_mode == "off"
+    assert not (WEB_TOOLS & resumed.tool_names())

--- a/tests/cli/test_session_store.py
+++ b/tests/cli/test_session_store.py
@@ -17,6 +17,7 @@ from kolega_code.llm.models import (
     ThinkingBlock,
     ToolCall,
     ToolResult,
+    WebSearchCallBlock,
 )
 
 
@@ -352,6 +353,9 @@ def test_images_and_provider_opaque_fields_are_hydrated_from_artifacts(tmp_path:
             content=[
                 ThinkingBlock("private", signature="signed-provider-value"),
                 ResponsesReasoningBlock("encrypted-provider-value", summary=["summary"]),
+                WebSearchCallBlock(
+                    item_id="ws_1", status="completed", action={"type": "search", "queries": ["release notes"]}
+                ),
                 ToolCall(id="call", name="noop", input={}, thought_signature=b"thought-bytes"),
             ],
         ),
@@ -367,8 +371,11 @@ def test_images_and_provider_opaque_fields_are_hydrated_from_artifacts(tmp_path:
     assert loaded[1].content[0].signature == "signed-provider-value"
     assert isinstance(loaded[1].content[1], ResponsesReasoningBlock)
     assert loaded[1].content[1].encrypted_content == "encrypted-provider-value"
-    assert isinstance(loaded[1].content[2], ToolCall)
-    assert loaded[1].content[2].thought_signature == b"thought-bytes"
+    assert isinstance(loaded[1].content[2], WebSearchCallBlock)
+    assert loaded[1].content[2].item_id == "ws_1"
+    assert loaded[1].content[2].action == {"type": "search", "queries": ["release notes"]}
+    assert isinstance(loaded[1].content[3], ToolCall)
+    assert loaded[1].content[3].thought_signature == b"thought-bytes"
     raw_events = store.events_path_for(record.session_id).read_text(encoding="utf-8")
     assert image_data not in raw_events
     assert "signed-provider-value" not in raw_events


### PR DESCRIPTION
## Summary

Adds a four-mode web tool switch — `auto` (default) / `hosted` / `client` / `off` — and first-class support for the Responses APIs' hosted `web_search` tool on DeepSeek flash and OpenAI gpt-5.x (API key and ChatGPT subscription).

In hosted mode the provider executes searches and page-opens (`search` / `open_page` actions) on its own servers and injects the content directly into the model's context. The content never passes through kolega; it is billed as input tokens, and the context gauge accounts for it (details below). When hosted search is active the client-side `web_search`/`web_fetch` tools are not registered — one search path, fewer schema tokens. `auto` uses hosted when the model supports it and the client tools otherwise, so behavior on every other provider is unchanged.

## How it works

- **Request**: `GenerationParams.hosted_web_search` appends `{"type": "web_search"}` to the Responses `tools` array (`responses_tools`). Only the main agent loop sets it; the compaction summarizer and non-Responses providers are untouched.
- **Capture + replay**: the stream wrapper captures `web_search_call` output items (previously silently discarded) into a new `WebSearchCallBlock`, preserving reasoning/search interleaving in one ordered assistant prefix. `to_responses_input` replays the items verbatim — their ids key the server-side restore of the searched content on later turns. Cross-provider adaptation drops the block for foreign targets (same-family keep, no text placeholder); sessions round-trip it.
- **Accounting**: the injected content can never be reconstructed client-side, so `BaseAgent` tracks a billed-minus-counted residual: measured exactly on clean responses (single invocation), bumped by a provisional 6k/call on search-bearing responses (their billing telescopes internal invocations — measured, see below), reset on compaction. `count_current_context` adds it, so the context gauge **and** auto-compaction both see the true context size. Cost reporting needs no change: injected tokens already arrive in `usage.input_tokens`. Provider per-search fees, if any, remain unmodeled (noted in CHANGELOG).
- **Surface**: settings.json + `KOLEGA_CODE_WEB_SEARCH_MODE` + `ask --web-search` + TUI `/web-search` (persisted per session) + a settings-screen Select. Hosted calls render as `web_search (hosted)` tool_call/result pairs in every transcript view, including `ask --json`.
- **Capability**: `supports_hosted_web_search` catalog flag on deepseek flash, the openai gpt-5.x entries, and the openai_chatgpt entries; `hosted` on an unsupported model falls back to the client tools with a warning; `off` removes all web tools.

## Live verification (2026-08-04, per transport)

- DeepSeek flash `/responses`: search executed, replay accepted, ~2.7k tokens of searched content restored server-side on a clean follow-up (billed vs client-counted).
- OpenAI `api.openai.com` (gpt-5.6-sol): same flow, ~4.4k restored.
- ChatGPT-subscription backend (OAuth): same flow through the OAuth transport, ~4.4k restored — matching the API-key surface, so its catalog entries carry the flag too.
- Replaying `web_search_call` items **without** the tool declared never 400s on any transport, so mode toggles mid-session and the summarizer path need no special casing.

## Tests

- New: `tests/agent/llm/test_responses_hosted_web_search.py` (request shape, stream capture/interleaving, replay ordering, round-trip, counting/fingerprint, cross-provider), `tests/agent/test_hosted_search_accounting.py` (residual rules incl. telescoping and compaction reset), `tests/cli/test_ask_web_search_mode.py` (resolution precedence, persistence round-trips, ask e2e), `tests/agent/llm/test_hosted_web_search_live.py` (key-gated live smoke: capture → replay accepted → restore measured).
- Extended: tool-inventory gating across modes × capability, session-store block round-trip, ask `--json` serialization.
- Full suite: 4,235 passed, 1 skipped (env-gated).

Compatibility note: sessions that used hosted search store the new `web_search_call` history block, which older builds cannot load (registry raises on unknown block types) — called out in CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MygWcF2u4huCbrzym4Xrse