### PR TITLE
fix(web): render hosted web-search calls in true transcript order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+### Fixed
+
+- Hosted web-search calls now render in their true position in the TUI
+  transcript. Previously the rows mounted at the bottom and stayed pinned
+  there while post-search reasoning kept streaming into the thinking bubble
+  above them; the stream now closes the open thinking/response segment at
+  each hosted call, so reasoning after a search opens a new bubble below its
+  rows (think → search → think → answer). Resumed sessions now render hosted
+  `web_search (hosted)` rows from history too — previously they were dropped
+  from the restored transcript.
+
 ### Added
 
 - Hosted (server-side) web search for Responses-API providers. On DeepSeek

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   rows (think → search → think → answer). Resumed sessions now render hosted
   `web_search (hosted)` rows from history too — previously they were dropped
   from the restored transcript.
+- `ask --json` no longer emits spurious synthetic message fragments when
+  hosted web search flushes response text mid-stream: the lost-text fallback
+  now applies once at end of turn, and only when the turn produced no
+  assistant message.
 
 ### Added
 

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -725,31 +725,24 @@ class BaseAgent(LogMixin):
         injected into the model's context server-side). The shared item id
         correlates the pair in every transcript consumer.
         """
-        action = delta.get("action") or {}
-        action_type = action.get("type") or "web_search"
-        if action_type == "search" and action.get("queries"):
-            detail = "search: " + ", ".join(repr(str(q)) for q in action["queries"])
-            outcome = "results injected server-side"
-        elif action_type == "open_page" and action.get("url"):
-            detail = f"open_page: {action['url']}"
-            outcome = "content injected server-side"
-        else:
-            detail = action_type
-            outcome = "executed server-side"
-        status = delta.get("status") or "completed"
-        tool_call_id = delta.get("id") or str(uuid.uuid4())
+        block = WebSearchCallBlock(
+            item_id=delta.get("id") or None,
+            status=delta.get("status"),
+            action=delta.get("action") or {},
+        )
+        tool_call_id = block.item_id or str(uuid.uuid4())
         await self.send_chat_message(
             message_type="tool_call",
-            content=f"Calling web_search (hosted): {detail}",
+            content=f"Calling {WebSearchCallBlock.TOOL_LABEL}: {block.label()}",
             is_streaming=False,
-            tool_description="web_search (hosted)",
+            tool_description=WebSearchCallBlock.TOOL_LABEL,
             tool_call_id=tool_call_id,
         )
         await self.send_chat_message(
             message_type="tool_result",
-            content=f"{detail} — {status} ({outcome})",
+            content=block.result_summary(),
             is_streaming=False,
-            tool_description="web_search (hosted)",
+            tool_description=WebSearchCallBlock.TOOL_LABEL,
             tool_call_id=tool_call_id,
         )
 
@@ -2296,14 +2289,36 @@ class BaseAgent(LogMixin):
                             # provider's infrastructure — no local execution.
                             # Surface it as a normal tool_call/tool_result pair
                             # so every transcript view renders it.
-                            if current_response:
+                            #
+                            # Close the current thinking/response segment first
+                            # and rotate both uuids: transcript consumers key
+                            # streamed entries by uuid, so without rotation the
+                            # post-search reasoning folds into the bubble above
+                            # these rows instead of opening a new one below
+                            # them. Guards mirror the end-of-stream flushes: an
+                            # unopened thinking segment yields nothing, while
+                            # the response flush is unconditional (an empty
+                            # complete response chunk is a documented no-op for
+                            # every consumer) so a partially streamed response
+                            # entry is never stranded incomplete by rotation.
+                            if thinking_started or current_thinking:
                                 yield {
-                                    "type": "response",
-                                    "content": current_response,
+                                    "type": "thinking",
+                                    "content": current_thinking,
                                     "complete": True,
-                                    "uuid": response_uuid,
+                                    "uuid": thinking_uuid,
                                 }
-                                current_response = ""
+                                current_thinking = ""
+                                thinking_started = False
+                                thinking_uuid = str(uuid.uuid4())
+                            yield {
+                                "type": "response",
+                                "content": current_response,
+                                "complete": True,
+                                "uuid": response_uuid,
+                            }
+                            current_response = ""
+                            response_uuid = str(uuid.uuid4())
                             await self._emit_hosted_tool_call(event.tool_call_delta)
 
                 assistant_message = await stream.get_final_message()

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -1525,19 +1525,29 @@ async def _run_ask(args: argparse.Namespace) -> int:
         # In --json mode, emit one line per COMPLETED assistant message rather
         # than streaming chunks: the agent appends each message to history
         # before yielding its final chunk, so a drain on every completed
-        # response chunk sees exactly the finished messages.
+        # response chunk sees exactly the finished messages. Hosted web search
+        # also flushes a complete response chunk mid-stream (segment rotation
+        # at each web_search_call), before any message has landed — so the
+        # lost-text fallback applies only at end of turn, and only when the
+        # whole turn emitted no message; draining it mid-stream would emit the
+        # pre-search text twice (once synthetic, once inside the real message).
         message_emitter = AskMessageEmitter(agent)
 
         async def _consume_turn(stream) -> None:
+            emitted_before = message_emitter.emitted_total
+            last_text_chunk: Optional[dict] = None
             async for chunk in stream:
                 response_chunks.append(chunk)
                 if args.json:
                     if chunk.get("type") == "response" and chunk.get("complete"):
-                        message_emitter.drain(fallback_chunk=chunk)
+                        if chunk.get("content"):
+                            last_text_chunk = chunk
+                        message_emitter.drain()
                 elif chunk.get("type") == "response" and chunk.get("content"):
                     print(chunk["content"], end="" if not chunk.get("complete") else "\n")
             if args.json:
-                message_emitter.drain()
+                fallback = last_text_chunk if message_emitter.emitted_total == emitted_before else None
+                message_emitter.drain(fallback_chunk=fallback)
 
         stream = (
             agent.process_message_stream(turn_prompt, attachments)

--- a/kolega_code/cli/tui/transcript.py
+++ b/kolega_code/cli/tui/transcript.py
@@ -14,7 +14,7 @@ from rich.text import Text
 
 from kolega_code.agent import AgentEvent
 from kolega_code.events import KnownEventType
-from kolega_code.llm.models import Message, TextBlock, ToolCall, ToolResult
+from kolega_code.llm.models import Message, TextBlock, ToolCall, ToolResult, WebSearchCallBlock
 from kolega_code.services.lsp import extract_lsp_label
 
 from .. import messages, theme
@@ -195,6 +195,21 @@ class TranscriptRenderingMixin(tui_app_base.KolegaAppBase):
         for block in message.content:
             if isinstance(block, TextBlock):
                 pending_text.append(block.text)
+            elif isinstance(block, WebSearchCallBlock):
+                # Hosted web search executed on the provider's servers: there is
+                # no ToolResult in history, the block itself is the whole record.
+                # Render the same completed row the live stream produced.
+                flush_text()
+                summary = block.result_summary()
+                entries.append(
+                    ConversationEntry(
+                        kind="tool_result",
+                        content=self._tool_result_preview(summary),
+                        tool_name=WebSearchCallBlock.TOOL_LABEL,
+                        tool_call_id=block.item_id or None,
+                        full_content=self._capped_tool_text(summary),
+                    )
+                )
             elif isinstance(block, ToolCall):
                 flush_text()
                 entry = ConversationEntry(

--- a/kolega_code/llm/models.py
+++ b/kolega_code/llm/models.py
@@ -577,6 +577,9 @@ class WebSearchCallBlock(ContentBlock):
     """
 
     TYPE_NAME = "web_search_call"
+    # Display name for transcript rows; the live stream (BaseAgent) and
+    # restored sessions (TUI) must render hosted calls under the same tool name.
+    TOOL_LABEL = "web_search (hosted)"
 
     def __init__(
         self,
@@ -638,12 +641,26 @@ class WebSearchCallBlock(ContentBlock):
             item["id"] = self.item_id
         return item
 
-    def _label(self) -> str:
+    def label(self) -> str:
         if self.queries:
             return "search: " + ", ".join(repr(q) for q in self.queries)
         if self.url:
             return f"open_page: {self.url}"
         return self.action_type or "web_search"
+
+    def result_summary(self) -> str:
+        """One-line outcome for transcript tool rows.
+
+        The searched content never reaches the client, so the row can only
+        describe the action and where its output went.
+        """
+        if self.queries:
+            outcome = "results injected server-side"
+        elif self.url:
+            outcome = "content injected server-side"
+        else:
+            outcome = "executed server-side"
+        return f"{self.label()} — {self.status or 'completed'} ({outcome})"
 
     def to_anthropic(self) -> Dict[str, Any]:
         return {"type": "text", "text": "[Web search]"}
@@ -655,7 +672,7 @@ class WebSearchCallBlock(ContentBlock):
         return genai_types.Part.from_text(text="[Web search]")
 
     def to_markdown(self) -> str:
-        return f"*Web search — {self._label()}*"
+        return f"*Web search — {self.label()}*"
 
 
 class ToolParameter:

--- a/tests/agent/test_hosted_stream_segmentation.py
+++ b/tests/agent/test_hosted_stream_segmentation.py
@@ -1,0 +1,178 @@
+"""Stream-segment rotation around hosted web-search calls.
+
+Hosted web_search is the only tool that renders mid-stream: Responses
+providers interleave reasoning → web_search_call → reasoning inside one
+streamed response. Transcript consumers key streamed entries by chunk uuid,
+so at each hosted call the loop must close the open thinking/response
+segment (a ``complete: True`` flush) and rotate both uuids — otherwise
+post-search output folds into the entry rendered above the search rows
+instead of opening a new one below them. Hermetic: FakeLLM with a scripted
+event stream.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kolega_code.llm.models import Message, MessageChunk, TextBlock, WebSearchCallBlock
+
+from .compaction_helpers import FakeLLM, FakeStream
+
+# Above the 50-char flush threshold, so each event yields a chunk immediately.
+THINK_BEFORE = "reasoning before the search " + "a" * 40
+THINK_AFTER = "reasoning after the search " + "b" * 40
+ANSWER_BEFORE = "answer text before the search " + "c" * 40
+ANSWER_AFTER = "answer text after the search " + "d" * 40
+
+
+class _ScriptedStream(FakeStream):
+    """FakeStream that yields scripted MessageChunks before finishing."""
+
+    def __init__(self, events, final_message):
+        super().__init__(final_message)
+        self._events = list(events)
+
+    async def __anext__(self):
+        if self._events:
+            return self._events.pop(0)
+        raise StopAsyncIteration
+
+
+def _hosted_event(item_id: str = "ws_1") -> MessageChunk:
+    return MessageChunk(
+        type="hosted_tool_call",
+        tool_call_delta={
+            "id": item_id,
+            "name": "web_search",
+            "status": "completed",
+            "action": {"type": "search", "queries": ["kolega"]},
+        },
+    )
+
+
+def _configure(agent, events) -> None:
+    agent.system_prompt = Message(role="system", content=[TextBlock(text="sys")])
+    agent.tool_collection = MagicMock()
+    agent.tool_collection.get_tool_list = MagicMock(return_value=[])
+    agent.send_chat_message = AsyncMock()
+    agent.log_info = AsyncMock()
+    agent.log_error = AsyncMock()
+    agent.llm = FakeLLM(token_script=[100])
+    final = Message(role="assistant", content=[TextBlock(text="done")], stop_reason="end_turn")
+    agent.llm.stream = AsyncMock(side_effect=lambda *args, **kwargs: _ScriptedStream(events, final))
+
+
+async def _chunks(agent) -> list[dict]:
+    return [chunk async for chunk in agent.process_message_stream("go")]
+
+
+def _of_type(chunks: list[dict], kind: str) -> list[dict]:
+    return [chunk for chunk in chunks if chunk.get("type") == kind]
+
+
+def _hosted_pair_calls(agent) -> list[dict]:
+    return [
+        call.kwargs
+        for call in agent.send_chat_message.await_args_list
+        if call.kwargs.get("tool_description") == WebSearchCallBlock.TOOL_LABEL
+    ]
+
+
+@pytest.mark.asyncio
+async def test_thinking_uuid_rotates_across_hosted_call(base_agent) -> None:
+    _configure(
+        base_agent,
+        [
+            MessageChunk(type="thinking", thinking=THINK_BEFORE),
+            _hosted_event(),
+            MessageChunk(type="thinking", thinking=THINK_AFTER),
+        ],
+    )
+
+    thinking = _of_type(await _chunks(base_agent), "thinking")
+
+    uuid_before = thinking[0]["uuid"]
+    assert thinking[0] == {"type": "thinking", "content": THINK_BEFORE, "complete": False, "uuid": uuid_before}
+    # The pre-search segment is closed before the search rows are emitted...
+    assert thinking[1] == {"type": "thinking", "content": "", "complete": True, "uuid": uuid_before}
+    # ...and the post-search reasoning opens a fresh segment.
+    uuid_after = thinking[2]["uuid"]
+    assert uuid_after != uuid_before
+    assert thinking[2]["content"] == THINK_AFTER
+    assert all(chunk["uuid"] == uuid_after for chunk in thinking[2:])
+    assert thinking[-1]["complete"] is True
+
+
+@pytest.mark.asyncio
+async def test_response_uuid_rotates_across_hosted_call(base_agent) -> None:
+    _configure(
+        base_agent,
+        [
+            MessageChunk(type="text", text=ANSWER_BEFORE),
+            _hosted_event(),
+            MessageChunk(type="text", text=ANSWER_AFTER),
+        ],
+    )
+
+    response = _of_type(await _chunks(base_agent), "response")
+
+    uuid_before = response[0]["uuid"]
+    assert response[0] == {"type": "response", "content": ANSWER_BEFORE, "complete": False, "uuid": uuid_before}
+    assert response[1] == {"type": "response", "content": "", "complete": True, "uuid": uuid_before}
+    uuid_after = response[2]["uuid"]
+    assert uuid_after != uuid_before
+    assert response[2]["content"] == ANSWER_AFTER
+    assert all(chunk["uuid"] == uuid_after for chunk in response[2:])
+    assert response[-1]["complete"] is True
+
+
+@pytest.mark.asyncio
+async def test_hosted_call_without_prior_thinking_emits_no_thinking_chunk(base_agent) -> None:
+    _configure(
+        base_agent,
+        [
+            _hosted_event(),
+            MessageChunk(type="text", text=ANSWER_AFTER),
+        ],
+    )
+
+    chunks = await _chunks(base_agent)
+
+    # No thinking segment was open, so none is flushed — an empty complete
+    # thinking chunk would render a bare glyph line in the transcript.
+    assert _of_type(chunks, "thinking") == []
+    # The response flush is unconditional: the segment before the search is
+    # closed (empty no-op chunk) and the answer arrives under a fresh uuid.
+    response = _of_type(chunks, "response")
+    assert response[0]["complete"] is True
+    assert response[0]["content"] == ""
+    assert response[1]["uuid"] != response[0]["uuid"]
+    assert response[1]["content"] == ANSWER_AFTER
+
+
+@pytest.mark.asyncio
+async def test_each_hosted_call_rotates_again_and_emits_one_row_pair(base_agent) -> None:
+    _configure(
+        base_agent,
+        [
+            MessageChunk(type="thinking", thinking=THINK_BEFORE),
+            _hosted_event("ws_1"),
+            MessageChunk(type="thinking", thinking=THINK_AFTER),
+            _hosted_event("ws_2"),
+            MessageChunk(type="text", text=ANSWER_AFTER),
+        ],
+    )
+
+    chunks = await _chunks(base_agent)
+
+    thinking_uuids = [chunk["uuid"] for chunk in _of_type(chunks, "thinking")]
+    assert len(set(thinking_uuids)) == 2  # one segment per search boundary
+    pairs = _hosted_pair_calls(base_agent)
+    assert [(call["message_type"], call["tool_call_id"]) for call in pairs] == [
+        ("tool_call", "ws_1"),
+        ("tool_result", "ws_1"),
+        ("tool_call", "ws_2"),
+        ("tool_result", "ws_2"),
+    ]
+    assert pairs[0]["content"] == "Calling web_search (hosted): search: 'kolega'"
+    assert pairs[1]["content"] == "search: 'kolega' — completed (results injected server-side)"

--- a/tests/cli/test_app_persistence_history.py
+++ b/tests/cli/test_app_persistence_history.py
@@ -16,7 +16,7 @@ from kolega_code.llm.exceptions import (
     LLMError,
     LLMInternalServerError,
 )
-from kolega_code.llm.models import Message, TextBlock, ToolCall, ToolResult
+from kolega_code.llm.models import Message, TextBlock, ToolCall, ToolResult, WebSearchCallBlock
 from kolega_code.events import AgentEvent
 from kolega_code.agent.prompt_provider import AgentMode
 from kolega_code.cli.config import build_agent_config, config_summary
@@ -562,6 +562,69 @@ async def test_textual_app_renders_resumed_history_in_chat(tmp_path: Path, monke
             ("tool_result", tool_reminder, "read_file"),
             ("tool_error", "Permission denied", "write_file"),
             ("assistant", "Done.", None),
+        ]
+
+
+@pytest.mark.asyncio
+async def test_textual_app_restores_hosted_web_search_rows(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hosted web_search calls have no ToolResult in history — the
+    WebSearchCallBlock on the assistant message is the whole record, and a
+    resumed session must render it as the same completed row the live stream
+    produced, in its interleaved position between the text blocks."""
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.app import KolegaCodeApp
+
+    monkeypatch.setattr(agent_runtime_module, "CoderAgent", _RestoredHistoryFakeAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    history = [
+        Message(role="user", content=[TextBlock("Search the docs")]).to_dict(),
+        Message(
+            role="assistant",
+            content=[
+                TextBlock("Let me look."),
+                WebSearchCallBlock(
+                    item_id="ws_1", status="completed", action={"type": "search", "queries": ["kolega tui"]}
+                ),
+                WebSearchCallBlock(
+                    item_id="ws_2", status="completed", action={"type": "open_page", "url": "https://example.com/docs"}
+                ),
+                TextBlock("Found it."),
+            ],
+        ).to_dict(),
+    ]
+
+    _persist_history(store, session, history)
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test():
+        rows = [
+            (entry.kind, entry.content, entry.tool_name, entry.tool_call_id, entry.complete)
+            for entry in app.conversation_entries[1:]
+        ]
+        assert rows == [
+            ("user", "Search the docs", None, None, True),
+            ("assistant", "Let me look.", None, None, True),
+            (
+                "tool_result",
+                "search: 'kolega tui' — completed (results injected server-side)",
+                "web_search (hosted)",
+                "ws_1",
+                True,
+            ),
+            (
+                "tool_result",
+                "open_page: https://example.com/docs — completed (content injected server-side)",
+                "web_search (hosted)",
+                "ws_2",
+                True,
+            ),
+            ("assistant", "Found it.", None, None, True),
         ]
 
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -821,6 +821,82 @@ def test_ask_json_interleaves_sub_agent_events(
     assert event_line["data"]["sub_agent_info"]["agent_name"] == "general-agent"
 
 
+class _MidStreamFlushCoderAgent(_FakeCoderAgent):
+    """Streams like a hosted web-search turn: a complete response chunk flushes
+    mid-stream (segment rotation at the web_search_call boundary) before any
+    assistant message has landed in history; the real message — containing the
+    pre-search text — lands before the end-of-stream chunk, as BaseAgent does."""
+
+    agent_name = "coder"
+
+    async def process_message_stream(self, message):
+        from kolega_code.llm.models import Message, TextBlock
+
+        yield {"type": "response", "content": "Checking the web. ", "complete": True, "uuid": "r1"}
+        self.history.append(
+            Message(
+                role="assistant",
+                content=[TextBlock("Checking the web. The answer is 42.")],
+                stop_reason="end_turn",
+            )
+        )
+        yield {"type": "response", "content": "The answer is 42.", "complete": True, "uuid": "r2"}
+
+
+def test_ask_json_midstream_complete_flush_emits_message_once(
+    tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    from kolega_code.cli import main as main_module
+
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("KOLEGA_CODE_PROVIDER", "anthropic")
+    monkeypatch.setenv("KOLEGA_CODE_MODEL", "claude-opus-5")
+    monkeypatch.setattr(main_module, "CoderAgent", _MidStreamFlushCoderAgent)
+
+    exit_code = main_module.main(["ask", "look it up", "--project", str(project), "--json"])
+
+    assert exit_code == 0
+    lines = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    messages = [line["data"] for line in lines if line["kind"] == "message"]
+    assert len(messages) == 1, "the mid-stream flush must not emit a synthetic duplicate"
+    (text_part,) = messages[0]["content"]
+    assert text_part["text"] == "Checking the web. The answer is 42."
+
+
+class _NoHistoryCoderAgent(_FakeCoderAgent):
+    """Streams text but never lands an assistant message in history — the
+    lost-text case the end-of-turn fallback exists for."""
+
+    agent_name = "coder"
+
+    async def process_message_stream(self, message):
+        yield {"type": "response", "content": "orphaned text", "complete": True, "uuid": "r1"}
+
+
+def test_ask_json_lost_text_still_emitted_as_synthetic_message(
+    tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    from kolega_code.cli import main as main_module
+
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("KOLEGA_CODE_PROVIDER", "anthropic")
+    monkeypatch.setenv("KOLEGA_CODE_MODEL", "claude-opus-5")
+    monkeypatch.setattr(main_module, "CoderAgent", _NoHistoryCoderAgent)
+
+    exit_code = main_module.main(["ask", "say something", "--project", str(project), "--json"])
+
+    assert exit_code == 0
+    lines = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    messages = [line["data"] for line in lines if line["kind"] == "message"]
+    assert len(messages) == 1
+    (text_part,) = messages[0]["content"]
+    assert text_part["text"] == "orphaned text"
+
+
 def test_ask_plain_writes_sub_agent_lifecycle_to_stderr(
     tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
 ) -> None:


### PR DESCRIPTION
## Problem

Hosted web_search is the only tool that renders mid-stream: Responses providers interleave reasoning → `web_search_call` → reasoning inside one streamed response. The turn loop allocated one thinking/response uuid per LLM call, and transcript consumers key streamed entries by uuid, so post-search reasoning folded back into the bubble mounted **above** the search rows. Symptoms (as reported): the `web_search (hosted)` rows stick to the bottom of the TUI transcript, and thinking keeps scrolling above them after they're already green.

Two adjacent gaps fixed in the same PR:
- The TUI restore path skipped `WebSearchCallBlock` history items entirely, so hosted rows vanished from resumed sessions.
- `ask --json` emitted spurious synthetic message fragments on hosted-search turns: the lost-text fallback drained on every complete response chunk, and hosted search produces complete flushes mid-stream, before any assistant message has landed in history.

## Fix

- **Segment rotation** (`baseagent.py`): at each `hosted_tool_call` stream event, close the open segment and rotate both uuids — the thinking buffer flushes `complete: True` (guarded: an unopened segment yields nothing), the response flushes unconditionally (mirroring the end-of-stream flush, so a partially streamed response entry is never stranded incomplete). Post-search output opens a new bubble below its rows: think → search → think → answer.
- **Hosted rows on resume** (`transcript.py`): restored transcripts render `WebSearchCallBlock` items as the same completed rows the live stream produced.
- **Shared formatting** (`llm/models.py`): `WebSearchCallBlock` now carries `label()` / `result_summary()` / `TOOL_LABEL`, used by both the live emitter and the restore path — replaces the duplicated inline formatting in `_emit_hosted_tool_call`, so the two renders can't drift.
- **`--json` fallback scoped to end of turn** (`main.py`): mid-stream drains no longer pass `fallback_chunk`; the last non-empty complete chunk is tracked and applied only on the final drain, and only when the whole turn emitted no assistant message — the fallback's actual purpose (don't lose text from a turn that never lands a message).

No TUI stream-handling changes needed: `_accumulate_stream_entry` already opens a new entry for an unseen uuid, and `_mirror_stream_chunk` forwards uuids to event-stream consumers.

## Tests

- New `tests/agent/test_hosted_stream_segmentation.py`: uuid rotation across a hosted call with the pre-search segment closed first; no empty thinking chunk when no segment was open; consecutive searches rotate again; row-pair content/ids.
- New restore test in `test_app_persistence_history.py`: resumed sessions render search/open_page rows with exact content, tool name, and item ids, positioned between text entries.
- New `--json` tests in `test_main.py`: a mid-stream complete flush emits exactly one message (fails on the pre-fix code with 2 — verified by reverting), and orphaned text with no history message still surfaces as one synthetic message.
- Full fast suite: 4253 passed.

## Live verification (DeepSeek flash, hosted mode)

- TUI: a 5-search turn renders interleaved bubbles below completed green rows; quitting and resuming the session shows all rows.
- `ask --json` before/after on the same pre-search-text prompt: pre-fix binary emitted 4 message lines (three synthetic fragments + the real message), fixed binary emits exactly 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018S8zHaffxVeJGyc5LPG38v