### PR TITLE
feat(tools): gate resolve behind LSP switch and edit permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+### Changed
+
+- The `resolve` tool — which applies or discards a pending `lsp_edit(apply: false)`
+  preview — is now gated like the other LSP tools. With LSP disabled (via
+  settings, `KOLEGA_CODE_LSP`, or `--lsp off`) it is removed from the model's
+  toolset entirely, since pending actions can only be created while LSP is on.
+  Applying a pending action with `resolve` now also goes through the same
+  edit-permission prompt as `edit`, `lsp_edit`, and `write`.
+
 ## 0.26.10 - 2026-08-05
 
 ### Added

--- a/docs/src/content/docs/configuration/lsp.md
+++ b/docs/src/content/docs/configuration/lsp.md
@@ -9,11 +9,14 @@ project languages. LSP is enabled by default and is used for:
 - diagnostics after `edit`, `multi_edit`, and `write`;
 - the generic read-only `lsp` tool;
 - the permission-gated `lsp_edit` tool;
+- the `resolve` tool, which applies or discards a pending `lsp_edit(apply: false)` preview;
 - `/lsp` and the Settings screen's Tools status display.
 
 The `lsp` tool remains read-only. Mutating LSP operations are exposed through
 `lsp_edit`, which is treated like `edit`, `multi_edit`, and `write` for
-permission prompts. Kolega Code does not expose raw arbitrary LSP requests.
+permission prompts. `resolve` mutates files only when it applies a pending
+preview, so it is gated the same way. Kolega Code does not expose raw arbitrary
+LSP requests.
 
 ## Enabling and disabling
 
@@ -29,8 +32,10 @@ flag > environment > settings:
   `settings.json` as `lsp_enabled`.
 
 When LSP is disabled, no language servers are started, post-edit diagnostics
-are skipped, and the `lsp` and `lsp_edit` tools are removed from the model's
-toolset entirely.
+are skipped, and the `lsp`, `lsp_edit`, and `resolve` tools are removed from
+the model's toolset entirely. `resolve` is LSP-coupled: pending actions are
+only ever created by `lsp_edit(apply: false)`, so none can exist while LSP is
+off.
 
 ## Tool operations
 
@@ -59,7 +64,10 @@ The mutating `lsp_edit` tool supports:
 `lsp_edit` applies server-provided `WorkspaceEdit` payloads only. If the server
 does not advertise or return an edit for an operation, Kolega Code reports that
 the operation is unsupported instead of constructing a manual fallback edit.
-Pass `apply: false` to preview the LSP edit without writing files.
+Pass `apply: false` to preview the LSP edit without writing files; the preview
+is recorded as a pending action that the `resolve` tool then applies or
+discards (`resolve(action_id=..., decision="apply"|"discard")`), subject to the
+same edit-permission prompt as `lsp_edit` itself.
 
 ### External paths, permissions, and undo
 

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -2745,9 +2745,14 @@ class ToolCollection(LogMixin):
 
         # Settings gate: LSP can be disabled host-wide (AgentConfig.lsp.enabled, from
         # settings.json or the --lsp CLI flag). The manager is never built when
-        # disabled, so drop lsp/lsp_edit instead of advertising tools that can only
-        # reply "not available". Strict `is False` so Mock configs keep the default.
-        if method_name in ("lsp", "lsp_edit") and getattr(getattr(self.config, "lsp", None), "enabled", True) is False:
+        # disabled, so drop lsp/lsp_edit/resolve instead of advertising tools that
+        # can only reply "not available". resolve is LSP-coupled: pending actions
+        # are only ever created by lsp_edit(apply=false), so none can exist while
+        # LSP is off. Strict `is False` so Mock configs keep the default.
+        if (
+            method_name in ("lsp", "lsp_edit", "resolve")
+            and getattr(getattr(self.config, "lsp", None), "enabled", True) is False
+        ):
             return False
 
         if method_name in self.browser_tools:

--- a/kolega_code/permissions.py
+++ b/kolega_code/permissions.py
@@ -42,6 +42,7 @@ EDIT_PERMISSION_TOOLS = frozenset(
         "apply_patch",
         "lsp_edit",
         "multi_edit",
+        "resolve",
         "write",
     }
 )

--- a/tests/agent/test_agent_tools_inventory.py
+++ b/tests/agent/test_agent_tools_inventory.py
@@ -570,7 +570,7 @@ def test_eval_tool_hidden_when_disabled(project_path, mock_connection_manager, a
 
 
 def test_lsp_tools_hidden_when_disabled(project_path, mock_connection_manager, agent_config):
-    """AgentConfig.lsp.enabled=False removes lsp and lsp_edit from the registry."""
+    """AgentConfig.lsp.enabled=False removes lsp, lsp_edit, and resolve from the registry."""
     from kolega_code.services.lsp import LspConfig
 
     agent_config.lsp = LspConfig(enabled=False)
@@ -586,6 +586,9 @@ def test_lsp_tools_hidden_when_disabled(project_path, mock_connection_manager, a
     tool_names = {tool.name for tool in agent.tool_collection.get_tool_list()}
     assert "lsp" not in tool_names
     assert "lsp_edit" not in tool_names
+    # resolve applies/discards pending lsp_edit(apply=false) previews, so it is
+    # LSP-coupled: no pending action can exist while LSP is off.
+    assert "resolve" not in tool_names
 
 
 def _coder(project_path, mock_connection_manager, agent_config):

--- a/tests/agent/test_permissions.py
+++ b/tests/agent/test_permissions.py
@@ -280,6 +280,19 @@ def test_lsp_edit_permission_is_gated_as_edit():
     assert request.summary == "lsp_edit src/app.py"
 
 
+def test_resolve_permission_is_gated_as_edit():
+    """resolve mutates files (applies a pending lsp_edit preview), so it is an edit tool."""
+    request = permission_request_for_tool(
+        "resolve",
+        {"action_id": "act-123", "decision": "apply"},
+    )
+
+    assert request is not None
+    assert request.kind == PermissionKind.EDIT
+    # resolve has no path input; the pending action id stays visible in the inputs.
+    assert request.summary == "resolve"
+
+
 def test_lsp_edit_rename_file_permission_summary_includes_destination():
     request = permission_request_for_tool(
         "lsp_edit",

--- a/tests/cli/test_ask_lsp_flag.py
+++ b/tests/cli/test_ask_lsp_flag.py
@@ -3,8 +3,8 @@
 The switch has one job spread over two layers: resolve (flag > env > settings >
 enabled, cli/config.py) and carry (AgentConfig.lsp.enabled -> the registry gate
 in ToolCollection._should_include_tool). Disabling must actually remove the
-``lsp``/``lsp_edit`` tools from the model-facing toolset — not just null the
-manager — so the e2e tests drive a real ``CoderAgent`` through
+``lsp``/``lsp_edit``/``resolve`` tools from the model-facing toolset — not just
+null the manager — so the e2e tests drive a real ``CoderAgent`` through
 ``main(["ask", ...])`` and assert on the tool inventory.
 """
 
@@ -14,7 +14,7 @@ from kolega_code.agent.coder import CoderAgent
 from kolega_code.cli.config import CliConfigError, CliConfigOverrides, _lsp_enabled
 from kolega_code.cli.settings import CliSettings, SettingsStore
 
-LSP_TOOLS = {"lsp", "lsp_edit"}
+LSP_TOOLS = {"lsp", "lsp_edit", "resolve"}
 
 
 class RecordingCoderAgent(CoderAgent):
@@ -85,7 +85,7 @@ def test_overrides_dataclass_carries_the_mode():
 # --- end to end -------------------------------------------------------------------
 
 
-def test_ask_lsp_off_removes_both_tools(tmp_path, monkeypatch, isolated_cli_env):
+def test_ask_lsp_off_removes_gated_tools(tmp_path, monkeypatch, isolated_cli_env):
     main_module, project = _setup(tmp_path, monkeypatch)
 
     exit_code = main_module.main(["ask", "do the thing", "--project", str(project), "--lsp", "off"])
@@ -97,7 +97,7 @@ def test_ask_lsp_off_removes_both_tools(tmp_path, monkeypatch, isolated_cli_env)
 
 
 def test_ask_default_keeps_lsp_tools(tmp_path, monkeypatch, isolated_cli_env):
-    """No flag, no setting: today's inventory includes both LSP tools."""
+    """No flag, no setting: today's inventory includes all LSP-gated tools."""
     main_module, project = _setup(tmp_path, monkeypatch)
 
     exit_code = main_module.main(["ask", "do the thing", "--project", str(project)])


### PR DESCRIPTION
## Summary

`resolve` applies or discards pending `lsp_edit(apply: false)` previews, so it is LSP-coupled: pending actions are only ever created by `lsp_edit`, so none can exist while LSP is off. This PR brings it under the same two gates as the other LSP/edit tools:

- **LSP switch** (`kolega_code/agent/tools.py`): when LSP is disabled (`settings.json` `lsp_enabled`, `KOLEGA_CODE_LSP`, or `--lsp off`), `resolve` is removed from the model's toolset entirely, alongside `lsp`/`lsp_edit`, instead of being advertised when it can only reply "not found".
- **Edit permissions** (`kolega_code/permissions.py`): `resolve` is added to `EDIT_PERMISSION_TOOLS`, so applying a pending action goes through the same edit-permission prompt as `edit`/`lsp_edit`/`write`.

## Tests

- Registry inventory: `test_lsp_tools_hidden_when_disabled` now asserts `resolve` is dropped when `AgentConfig.lsp.enabled=False`.
- CLI e2e: `LSP_TOOLS` in `tests/cli/test_ask_lsp_flag.py` is now `{"lsp", "lsp_edit", "resolve"}`, so default-on presence and off removal are both covered through a real `CoderAgent`.
- Permissions: new `test_resolve_permission_is_gated_as_edit` (`kind=EDIT`, summary `resolve`).

Docs updated (`docs/src/content/docs/configuration/lsp.md`) plus a CHANGELOG entry.

## Verification

- Full fast suite: 4272 passed, 1 skipped, 0 failed
- `ruff check` / `ruff format` / `pyright` / pre-commit all pass
