### PR TITLE
fix(llm): treat kimi-family input_tokens=-1 as a zero cache sentinel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,18 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   `settings.json` is ignored on load. The active model's own thinking effort
   (`--thinking-effort`, `KOLEGA_CODE_THINKING_EFFORT`) is unaffected.
 
+### Fixed
+
+- Kimi-family usage is no longer dropped when a request is served entirely from
+  the provider's prompt cache. `kimi-for-coding` / `moonshot` report
+  `input_tokens: -1` as a sentinel for "no uncached input tokens" on a full
+  cache hit; the strict usage validator previously classified that as malformed
+  and nulled the whole record, silently removing both input and output tokens
+  from session accounting for those turns. The sentinel is now interpreted as
+  zero, and the inclusive input total is reconstructed from the cache fields
+  (verified live: `-1` + 33 cached = 33 total, matching the same prompt's
+  partial-cache report of 27 uncached + 6 cached).
+
 ## 0.26.10 - 2026-08-05
 
 ### Added

--- a/kolega_code/llm/usage.py
+++ b/kolega_code/llm/usage.py
@@ -57,6 +57,17 @@ OPENAI_USAGE_PROVIDERS = frozenset(
 )
 GOOGLE_USAGE_PROVIDERS = frozenset({"google"})
 
+# Live-verified exception: kimi-family APIs (kimi_coding, moonshot) return
+# ``input_tokens == -1`` as a sentinel for "no uncached input tokens" when the
+# prompt is served entirely from their server-side cache
+# (``cache_read_input_tokens`` then carries the full prompt; the same prompt
+# reports a real uncached count while only partially cached, e.g. 27 uncached +
+# 6 cached = 33 total). Without the mapping the negative core count poisons the
+# whole record and output tokens are dropped from accounting too. Treated as 0,
+# the inclusive-input arithmetic reconstructs the true total.
+_ZERO_INPUT_SENTINEL_PROVIDERS = frozenset({"kimi_coding", "moonshot"})
+_ZERO_INPUT_SENTINEL = -1
+
 # Live-verified exception: xAI's completion_tokens EXCLUDES reasoning_tokens and
 # its own total is prompt + completion + reasoning. Every other OpenAI-shaped
 # provider (including OpenRouter fronting Grok models) bills reasoning inside
@@ -241,6 +252,9 @@ def _normalize_anthropic(metadata: Mapping[str, Any], provider: str, model: Opti
     # Raw input_tokens excludes cache reads and writes (live-verified for all
     # four providers); reconstruct the inclusive value. Thinking is billed
     # inside output_tokens; moonshot additionally reports it as a subset.
+    if provider in _ZERO_INPUT_SENTINEL_PROVIDERS and metadata.get("input_tokens") == _ZERO_INPUT_SENTINEL:
+        # kimi-family cache-hit sentinel: no uncached input tokens were counted.
+        metadata = {**metadata, "input_tokens": 0}
     values, reason = _read_counts(
         metadata,
         core_keys=("input_tokens", "output_tokens"),

--- a/tests/agent/llm/test_normalized_usage.py
+++ b/tests/agent/llm/test_normalized_usage.py
@@ -82,6 +82,65 @@ def test_moonshot_thinking_subset_passthrough() -> None:
     assert usage.total_tokens == 124
 
 
+def test_kimi_zero_input_sentinel_reconstructs_cached_input() -> None:
+    # Live-verified: kimi-for-coding returns input_tokens=-1 as a sentinel for
+    # "no uncached input tokens" on a full server-side cache hit; the same
+    # prompt reports a real uncached count while only partially cached
+    # (27 uncached + 6 cached = 33), so the inclusive total is cache + 0.
+    usage = normalize_usage(
+        {
+            "input_tokens": -1,
+            "output_tokens": 35,
+            "cache_read_input_tokens": 33,
+            "cache_write_input_tokens": 0,
+        },
+        "kimi_coding",
+        "kimi-for-coding",
+    )
+    assert usage.reported is True
+    assert usage.input_tokens == 33
+    assert usage.output_tokens == 35
+    assert usage.total_tokens == 68
+    assert usage.cache_read_input_tokens == 33
+    assert usage.unavailable_reason is None
+
+
+def test_moonshot_zero_input_sentinel_reconstructs_cached_input() -> None:
+    usage = normalize_usage(
+        {
+            "input_tokens": -1,
+            "output_tokens": 43,
+            "cache_read_input_tokens": 33,
+            "cache_write_input_tokens": 0,
+            "reasoning_output_tokens": 40,
+        },
+        "moonshot",
+        "kimi-k3",
+    )
+    assert usage.reported is True
+    assert usage.input_tokens == 33
+    assert usage.output_tokens == 43
+    assert usage.reasoning_output_tokens == 40
+    assert usage.unavailable_reason is None
+
+
+def test_zero_input_sentinel_is_kimi_family_specific() -> None:
+    # The -1 sentinel interpretation must not widen: other Anthropic-family
+    # providers keep treating negative cores as malformed, and a nonsentinel
+    # negative on kimi itself (e.g. output) still poisons the record.
+    usage = normalize_usage({"input_tokens": -1, "output_tokens": 5}, "anthropic", None)
+    assert usage.reported is False
+    assert usage.unavailable_reason == REASON_MALFORMED
+
+    usage = normalize_usage(
+        {"input_tokens": 10, "output_tokens": -1},
+        "kimi_coding",
+        "kimi-for-coding",
+    )
+    assert usage.reported is False
+    assert usage.unavailable_reason == REASON_MALFORMED
+
+
 # --- openai family --------------------------------------------------------------
 
 


### PR DESCRIPTION
## Problem

`kimi-for-coding` and `moonshot` return `input_tokens: -1` from their Anthropic-compatible API whenever the request's prompt is served entirely from their server-side cache (`cache_read_input_tokens` then carries the full prompt). The strict usage validator (`_strict_nonneg_int` in `llm/usage.py`) classified the negative as malformed, which **poisoned the entire usage record** — dropping *both* input and output tokens from session accounting for every cache-warm kimi turn, and failing the live usage tests.

## Evidence (live probes)

- Partial cache hit: `input_tokens=27` (uncached) + `cache_read=6` = **33** total input
- Full cache hit: `input_tokens=-1` (uncached = 0) + `cache_read=33` = **33** total input — same prompt, same 33 tokens, consistently across six responses

The provider demonstrably knows the count (it reports the real 27 when partially cached), so `-1` means "no uncached input to count", not "unknown".

## Fix

In `_normalize_anthropic`, map `input_tokens == -1` to `0` **only for the kimi-family providers** (`kimi_coding`, `moonshot`). The existing inclusive-input arithmetic (`input = raw + cache_read + cache_write`) then reconstructs the true total (33). Scope is deliberately narrow:

- `anthropic` with `input_tokens=-1` still poisons (unit-tested)
- `kimi_coding` with a negative `output_tokens` still poisons (unit-tested)
- The raw `usage_metadata` keeps the provider's `-1` — only the normalized view interprets it

## Verification

- 3 new unit tests in `test_normalized_usage.py` (kimi sentinel, moonshot sentinel, scope guard)
- Live: all 6 kimi-family tests in `test_normalized_usage_live.py` now pass (previously `test_live_stream_attaches_reported_usage_idempotently[kimi_coding-kimi-for-coding]` failed)
- Full suite: 4198 passed, 0 failed