### PR TITLE
feat(agent): gate get_host tool on injected sandbox host providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,16 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   `settings.json` is ignored on load. The active model's own thinking effort
   (`--thinking-effort`, `KOLEGA_CODE_THINKING_EFFORT`) is unaffected.
 
+- The `get_host` tool is gone from the local toolset. It needs a sandbox host
+  provider, so it is now offered only when a terminal manager carrying a
+  `sandbox` attribute is injected (cloud sandbox deployments), and the
+  localhost fallback branch in the handler is deleted — a registered
+  `get_host` always has a sandbox. The gate duck-types on the attribute rather
+  than `isinstance`, so kolega-code-e2b's injected `SandboxTerminalManager`
+  (possibly subclassed from a pinned older version) keeps qualifying. Existing
+  session histories that recorded `get_host` calls keep them as data and
+  render as-is (restore is name-agnostic).
+
 ### Fixed
 
 - Kimi-family usage is no longer dropped when a request is served entirely from

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -2191,45 +2191,14 @@ class ToolCollection(LogMixin):
         )
 
     async def get_host(self, port: int) -> str:
-        """
-        Get the hostname for accessing a service on the specified port.
-
-        This tool returns the appropriate hostname based on the environment:
-        - In local development: returns 'localhost:PORT'
-        - In cloud sandbox (e2b): returns the sandbox-specific hostname
-
-        When to use this tool:
-        - Before accessing any web service or development server
-        - When constructing URLs for HTTP requests
-        - When providing URLs to users or other tools
-        - When launching browsers to access local services
-
-        Usage notes:
-        1. Always call this tool before making HTTP requests to local services
-        2. The port parameter is required - specify the port your service is running on
-        3. Use the returned hostname to construct full URLs (e.g., http://{host}/api/endpoint)
-        4. This ensures your code works in both local and cloud sandbox environments
-
-        Args:
-            port: The port number where the service is running
-
-        Returns:
-            The full hostname including port (e.g., 'localhost:3000' or 'xxxx.e2b.dev')
-        """
-        # Check if we're using a SandboxTerminalManager (indicates sandbox mode).
-        # ``sandbox`` is only present on ``SandboxTerminalManager``; the base
-        # ``TerminalManager``/``LocalTerminalManager`` do not declare it, so access it
-        # via ``getattr`` rather than a direct attribute lookup.
-        sandbox = getattr(self.terminal_manager, "sandbox", None)
-        if sandbox is not None:
-            # We're in sandbox mode, get the host from the sandbox
-            # E2B AsyncSandbox has a get_host method that takes a port
-            # The method is synchronous and returns a string directly
-            host = sandbox.get_host(port)
-            return host
-        else:
-            # Local mode, return localhost
-            return f"localhost:{port}"
+        """Get the externally reachable hostname for a service listening on the given
+        port in this sandbox. Use it to construct URLs instead of localhost."""
+        # Terminal managers are injected at construction and never swapped
+        # mid-session, so registration-time gating in `_should_include_tool`
+        # guarantees a sandbox here. `sandbox` is intentionally duck-typed
+        # (the gate uses getattr, not isinstance), so the base-class type does
+        # not declare it.
+        return self.terminal_manager.sandbox.get_host(port)  # pyright: ignore[reportAttributeAccessIssue]
 
     def _tool_definition_from_callable(self, method_name: str, method: Callable[..., Any]) -> ToolDefinition:
         """Build a provider-agnostic tool definition from a Python callable."""
@@ -2484,6 +2453,15 @@ class ToolCollection(LogMixin):
         # Vision gate: read_image is only surfaced to vision-capable models.
         if method_name == "read_image":
             return bool(getattr(self.caller, "supports_vision", False))
+
+        # Sandbox gate: get_host needs a sandbox host provider, which only
+        # sandbox terminal managers carry. Duck-type via getattr (not
+        # isinstance) so kolega-code-e2b's injected SandboxTerminalManager —
+        # possibly subclassed from a pinned older version — keeps qualifying.
+        # Terminal managers are injected at construction and never swapped
+        # mid-session, so registration-time gating is sufficient.
+        if method_name == "get_host" and getattr(self.terminal_manager, "sandbox", None) is None:
+            return False
 
         # Web tool gate: the client-side web tools drop out when the agent's
         # web_search_mode resolved to hosted (the provider's server-side tool

--- a/tests/agent/test_agent_tools_inventory.py
+++ b/tests/agent/test_agent_tools_inventory.py
@@ -1,5 +1,6 @@
 """Tool inventory checks for shared agent classes."""
 
+import asyncio
 import uuid
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock
@@ -678,3 +679,50 @@ def test_shared_tool_names_are_well_formed(project_path, mock_connection_manager
             assert tool.name.replace("_", "").isalnum()
             assert tool.name.islower() or tool.name.replace("_", "").isalnum()
             assert tool.description
+
+
+class _StubSandbox:
+    def get_host(self, port: int) -> str:
+        return f"stub-sandbox:{port}"
+
+
+class _SandboxCarryingTerminalManager:
+    """Terminal-manager stand-in that carries a ``sandbox`` host provider.
+
+    Deliberately not an instance of ``SandboxTerminalManager``: the gate must
+    duck-type on the attribute (getattr), not isinstance, so kolega-code-e2b's
+    injected manager — possibly subclassed from a pinned older version — keeps
+    qualifying when they bump.
+    """
+
+    def __init__(self) -> None:
+        self.sandbox = _StubSandbox()
+
+
+def test_get_host_absent_without_sandbox_terminal_manager(project_path, mock_connection_manager, agent_config):
+    """get_host is a sandbox-only tool: the default local CLI coder does not get it."""
+    agent = _coder(project_path, mock_connection_manager, agent_config)
+    tool_names = {tool.name for tool in agent.tool_collection.get_tool_list()}
+    assert "get_host" not in tool_names
+    assert agent.tool_collection.has_tool("get_host") is False
+
+
+def test_get_host_present_with_sandbox_terminal_manager(project_path, mock_connection_manager, agent_config):
+    """get_host appears when the injected terminal manager carries a ``sandbox``."""
+    agent = CoderAgent(
+        project_path=project_path,
+        workspace_id="test_workspace",
+        thread_id=str(uuid.uuid4()),
+        connection_manager=mock_connection_manager,
+        config=agent_config,
+        agent_mode=AgentMode.CLI,
+        terminal_manager=_SandboxCarryingTerminalManager(),
+    )
+
+    tool_names = {tool.name for tool in agent.tool_collection.get_tool_list()}
+    assert "get_host" in tool_names
+    assert agent.tool_collection.has_tool("get_host") is True
+
+    # The registered tool resolves the host from the sandbox, not localhost.
+    host = asyncio.run(agent.tool_collection.call("get_host", port=8000))
+    assert host == "stub-sandbox:8000"

--- a/tests/agent/test_tool_collection_config.py
+++ b/tests/agent/test_tool_collection_config.py
@@ -25,6 +25,24 @@ INTERNAL_TOOL_NAMES = {
 }
 
 
+class _StubSandbox:
+    def get_host(self, port: int) -> str:
+        return f"stub-sandbox:{port}"
+
+
+class _SandboxCarryingTerminalManager:
+    """Terminal-manager stand-in that carries a ``sandbox`` host provider.
+
+    Deliberately not an instance of ``SandboxTerminalManager``: the gate must
+    duck-type on the attribute (getattr), not isinstance, so kolega-code-e2b's
+    injected manager — possibly subclassed from a pinned older version — keeps
+    qualifying when they bump.
+    """
+
+    def __init__(self) -> None:
+        self.sandbox = _StubSandbox()
+
+
 @pytest.fixture
 def mock_connection_manager() -> AsyncMock:
     return AsyncMock()
@@ -115,6 +133,61 @@ class TestToolCollection:
         assert INTERNAL_TOOL_NAMES.isdisjoint(tool_names)
         for excluded_tool in excluded_tools:
             assert excluded_tool not in tool_names
+
+    async def test_get_host_absent_without_sandbox_terminal_manager(
+        self,
+        project_path: Path,
+        mock_connection_manager: AgentConnectionManager,
+        agent_config: AgentConfig,
+        mock_base_agent: BaseAgent,
+    ) -> None:
+        """get_host needs a sandbox host provider; the default local manager drops it."""
+        tool_collection = ToolCollection(
+            project_path,
+            "test_workspace",
+            str(uuid.uuid4()),
+            mock_connection_manager,
+            agent_config,
+            mock_base_agent,
+        )
+
+        assert "get_host" not in [tool.name for tool in tool_collection.get_tool_list()]
+        assert tool_collection.has_tool("get_host") is False
+
+    async def test_get_host_present_with_sandbox_terminal_manager(
+        self,
+        project_path: Path,
+        mock_connection_manager: AgentConnectionManager,
+        agent_config: AgentConfig,
+        mock_base_agent: BaseAgent,
+    ) -> None:
+        """A terminal manager carrying a ``sandbox`` attribute unlocks get_host.
+
+        The gate is registration-time and duck-typed: the stub is not an
+        instance of ``SandboxTerminalManager``, mirroring kolega-code-e2b
+        injecting its own (possibly subclassed) manager.
+        """
+        tool_collection = ToolCollection(
+            project_path,
+            "test_workspace",
+            str(uuid.uuid4()),
+            mock_connection_manager,
+            agent_config,
+            mock_base_agent,
+            # The stub is deliberately not a TerminalManager subclass: the gate
+            # duck-types on the `sandbox` attribute, so pyright can't see it.
+            terminal_manager=_SandboxCarryingTerminalManager(),  # pyright: ignore[reportArgumentType]
+        )
+
+        definitions = {tool.name: tool for tool in tool_collection.get_tool_list()}
+        assert "get_host" in definitions
+        assert definitions["get_host"].description == (
+            "Get the externally reachable hostname for a service listening on the given\n"
+            "port in this sandbox. Use it to construct URLs instead of localhost."
+        )
+
+        host = await tool_collection.call("get_host", port=8000)
+        assert host == "stub-sandbox:8000"
 
     async def test_tool_collection_config_read_only(
         self,


### PR DESCRIPTION
## What

`get_host` needs a sandbox host provider, so it is now only offered to the model when a terminal manager carrying a `sandbox` attribute was injected at construction.

- `ToolCollection._should_include_tool` drops `get_host` when `getattr(self.terminal_manager, "sandbox", None) is None`. The gate is getattr duck-typing, **not** `isinstance`, so kolega-code-e2b's injected `SandboxTerminalManager` — possibly subclassed from a pinned older version — keeps qualifying when they bump.
- The handler is simplified: the localhost fallback branch and per-call getattr check are deleted, since a registered `get_host` always has a sandbox (terminal managers are injected at construction and never swapped mid-session, so registration-time gating is sufficient).
- The ~250-token docstring is replaced with a two-sentence description: *"Get the externally reachable hostname for a service listening on the given port in this sandbox. Use it to construct URLs instead of localhost."*
- CHANGELOG entry under Unreleased → Removed.

## Why

Locally there is no sandbox host provider, so advertising `get_host` — and answering with a fabricated `localhost:PORT` — was worse than useless: models trusted a hostname that doesn't exist. Only sandbox deployments (e2b) can answer truthfully, and they now do, via the injected manager's `sandbox`.

## Tests

- `tests/agent/test_agent_tools_inventory.py`: `get_host` absent for the default local CLI coder; present + dispatchable when a terminal manager with a `sandbox` attribute is supplied (stub is deliberately *not* a `SandboxTerminalManager`, proving duck-typing).
- `tests/agent/test_tool_collection_config.py`: same pair at the `ToolCollection` level, plus an exact-description assertion.
- Full suite: 4210 passed, 1 skipped (pre-existing key-gated browser test), 0 failed.
- Render diff of the default CLI toolset before/after: `get_host` is the only definition that disappears — every other tool definition is byte-identical.
- Verified end-to-end that sessions recorded with `get_host` calls restore and display through the real `SessionStore` + transcript entry builder (restore is name-agnostic; no shims).
