### PR TITLE
feat(agent): write counts as read for the edit guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   `path` is accepted at the dispatch boundary as an alias for the canonical
   `file_path`.
 
+- A successful whole-file `write` (including `hashline_write` and `apply_patch`'s
+  Add File) now records the just-written contents as read, so the read-before-edit
+  guard accepts a subsequent edit without a fresh read — exactly as it would
+  right after a read. Staleness tracking is unchanged: a file modified after the
+  write still requires a fresh read before editing.
+
 ### Removed
 
 - The `read_entire_file` and `read_file_section` tools are gone, replaced by the

--- a/kolega_code/agent/tool_backend/edit_tool.py
+++ b/kolega_code/agent/tool_backend/edit_tool.py
@@ -67,6 +67,22 @@ class EditTool(BaseTool):
         if self.filesystem.exists(normalized) and self.filesystem.is_file(normalized):
             self._read_versions[normalized] = self._content_digest(self.filesystem.read_text(normalized))
 
+    def _write_file(self, path: str, content: str) -> None:
+        """Write ``content`` to ``path`` (creating parents) and record it as read-equivalent.
+
+        A successful whole-file write leaves the file's current contents known,
+        so the result is recorded through the same mechanism a model-facing
+        read uses (``observe_read``): the edit guard then accepts the file
+        exactly as it would accept a freshly read one, and still rejects it
+        once the file changes on disk. This is the single write path for every
+        edit protocol's write handler.
+        """
+        parent = self.filesystem.get_parent(path)
+        if parent and parent != "." and not self.filesystem.exists(parent):
+            self.filesystem.create_directory(parent)
+        self.filesystem.write_text(path, content)
+        self.observe_read(path)
+
     async def claude_edit(
         self,
         file_path: str,
@@ -119,10 +135,7 @@ class EditTool(BaseTool):
             return blocked_msg
 
         def _write() -> None:
-            parent = self.filesystem.get_parent(path)
-            if parent and parent != "." and not self.filesystem.exists(parent):
-                self.filesystem.create_directory(parent)
-            self.filesystem.write_text(path, updated_content)
+            self._write_file(path, updated_content)
 
         self._mutate_with_optional_snapshot(
             tool_name="edit",
@@ -140,7 +153,6 @@ class EditTool(BaseTool):
             tool_call_id=getattr(self.caller, "current_tool_execution_id", None),
             tool_name="edit",
         )
-        self._read_versions[path] = self._content_digest(self.filesystem.read_text(path))
         result = f"Edited {path}" if exists else f"Created {path}"
         diagnostics = await self._maybe_append_lsp_diagnostics(path)
         return result + diagnostics
@@ -169,10 +181,7 @@ class EditTool(BaseTool):
             return blocked_msg
 
         def _write() -> None:
-            parent = self.filesystem.get_parent(path)
-            if parent and parent != "." and not self.filesystem.exists(parent):
-                self.filesystem.create_directory(parent)
-            self.filesystem.write_text(path, content)
+            self._write_file(path, content)
 
         self._mutate_with_optional_snapshot(
             tool_name="write",
@@ -190,7 +199,6 @@ class EditTool(BaseTool):
             tool_call_id=getattr(self.caller, "current_tool_execution_id", None),
             tool_name="write",
         )
-        self._read_versions[path] = self._content_digest(self.filesystem.read_text(path))
         result = f"Wrote {path}"
         diagnostics = await self._maybe_append_lsp_diagnostics(path)
         return result + diagnostics
@@ -262,8 +270,6 @@ class EditTool(BaseTool):
                 except Exception:
                     old_content = None
 
-            parent_dir = self.filesystem.get_parent(path)
-
             # Preserve the file's dominant line ending on overwrite; new files
             # keep the line endings the caller provided (typically LF).
             if exists and old_content is not None:
@@ -271,9 +277,7 @@ class EditTool(BaseTool):
                 content = self._normalize_line_endings(content, line_ending)
 
             def _write() -> None:
-                if parent_dir and parent_dir != "." and not self.filesystem.exists(parent_dir):
-                    self.filesystem.create_directory(parent_dir)
-                self.filesystem.write_text(path, content)
+                self._write_file(path, content)
 
             self._mutate_with_optional_snapshot(
                 tool_name="write",
@@ -404,10 +408,7 @@ class EditTool(BaseTool):
         snapshot_paths = list(dict.fromkeys(snapshot_paths))
 
         def _write() -> None:
-            parent = self.filesystem.get_parent(target)
-            if parent and parent != "." and not self.filesystem.exists(parent):
-                self.filesystem.create_directory(parent)
-            self.filesystem.write_text(target, updated)
+            self._write_file(target, updated)
             if destination is not None and self.filesystem.exists(source):
                 self.filesystem.remove(source, missing_ok=True)
 
@@ -540,10 +541,7 @@ class EditTool(BaseTool):
             for path in sorted(
                 (item for item in changed if working[item] is not None), key=lambda item: len(Path(item).parts)
             ):
-                parent = self.filesystem.get_parent(path)
-                if parent and parent != "." and not self.filesystem.exists(parent):
-                    self.filesystem.create_directory(parent)
-                self.filesystem.write_text(path, working[path] or "")
+                self._write_file(path, working[path] or "")
 
         self._mutate_with_optional_snapshot(
             tool_name="apply_patch",
@@ -661,7 +659,7 @@ class EditTool(BaseTool):
                 tool_name=tool_name,
                 reason=f"{tool_name} {path}",
                 paths=[path],
-                mutate=lambda: self.filesystem.write_text(path, normalized_updated),
+                mutate=lambda: self._write_file(path, normalized_updated),
             )
 
             await self.send_edit_preview(

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -1620,8 +1620,9 @@ class ToolCollection(LogMixin):
     ) -> str:
         """Perform an exact string replacement in a file.
 
-        Read the file before editing it. ``old_string`` must match exactly and
-        be unique unless ``replace_all`` is true.
+        You must read the file first — or have just written it with write —
+        before editing. ``old_string`` must match exactly and be unique unless
+        ``replace_all`` is true.
 
         Args:
             file_path: Path to modify: project-relative, using ../ traversal, or absolute.

--- a/tests/agent/tool_backend/test_claude_edit.py
+++ b/tests/agent/tool_backend/test_claude_edit.py
@@ -176,3 +176,75 @@ async def test_claude_edit_snapshot_can_restore_change(edit_tool: EditTool, tmp_
     snapshots.restore_snapshot(record.snapshot_id)
 
     assert target.read_text() == "before\n"
+
+
+@pytest.mark.asyncio
+async def test_write_then_edit_without_read_succeeds(edit_tool: EditTool, tmp_path: Path) -> None:
+    """A successful write counts as read: the guard accepts a subsequent edit."""
+    target = tmp_path / "a.txt"
+
+    result = await edit_tool.write("a.txt", "before\nmiddle\nafter\n")
+    assert result == "Wrote a.txt"
+
+    assert await edit_tool.claude_edit("a.txt", "middle", "changed") == "Edited a.txt"
+    assert target.read_text() == "before\nchanged\nafter\n"
+
+
+@pytest.mark.asyncio
+async def test_write_overwrite_then_edit_without_read_succeeds(edit_tool: EditTool, tmp_path: Path) -> None:
+    """Overwriting an existing file with write also records the new contents."""
+    target = tmp_path / "a.txt"
+    target.write_text("original\n")
+
+    await edit_tool.write("a.txt", "new content\n")
+
+    assert await edit_tool.claude_edit("a.txt", "new content", "updated") == "Edited a.txt"
+    assert target.read_text() == "updated\n"
+
+
+@pytest.mark.asyncio
+async def test_write_then_external_modification_then_edit_is_blocked(edit_tool: EditTool, tmp_path: Path) -> None:
+    """Write grants no more than a read: external changes still go stale."""
+    target = tmp_path / "a.txt"
+    await edit_tool.write("a.txt", "before\nmiddle\nafter\n")
+
+    target.write_text("before\nEXTERNALLY CHANGED\nafter\n")
+
+    with pytest.raises(ValueError, match="has changed since it was read"):
+        await edit_tool.claude_edit("a.txt", "middle", "changed")
+
+
+@pytest.mark.asyncio
+async def test_hashline_write_then_edit_without_read_succeeds(edit_tool: EditTool, tmp_path: Path) -> None:
+    """hashline_write funnels through the same write path and records too."""
+    target = tmp_path / "a.txt"
+
+    assert await edit_tool.hashline_write("a.txt", "hello\n") == "Wrote a.txt"
+
+    assert await edit_tool.claude_edit("a.txt", "hello", "world") == "Edited a.txt"
+    assert target.read_text() == "world\n"
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_add_then_edit_without_read_succeeds(edit_tool: EditTool, tmp_path: Path) -> None:
+    """apply_patch's Add File writes through the shared path and records too."""
+    target = tmp_path / "a.txt"
+
+    result = await edit_tool.apply_patch("*** Begin Patch\n*** Add File: a.txt\n+hello\n*** End Patch\n")
+    assert "A a.txt" in result
+
+    assert await edit_tool.claude_edit("a.txt", "hello", "world") == "Edited a.txt"
+    assert target.read_text() == "world\n"
+
+
+@pytest.mark.asyncio
+async def test_search_replace_edit_then_claude_edit_without_read_succeeds(edit_tool: EditTool, tmp_path: Path) -> None:
+    """Search/replace edits write through the shared path, so their result is known."""
+    target = tmp_path / "a.txt"
+    target.write_text("before\nmiddle\nafter\n")
+
+    result = await edit_tool.edit("a.txt", "<<<<<<< SEARCH\nmiddle\n=======\nchanged\n>>>>>>> REPLACE")
+    assert result == "Edited a.txt"
+
+    assert await edit_tool.claude_edit("a.txt", "changed", "changed2") == "Edited a.txt"
+    assert target.read_text() == "before\nchanged2\nafter\n"

--- a/tests/agent/tool_backend/test_edit_tool.py
+++ b/tests/agent/tool_backend/test_edit_tool.py
@@ -57,6 +57,9 @@ class MemoryFileSystem(LocalFileSystem):
     def exists(self, path: str) -> bool:
         return path == "crlf.txt"
 
+    def is_file(self, path: str) -> bool:
+        return path == "crlf.txt"
+
     def read_text(self, path: str) -> str:
         return self.content
 


### PR DESCRIPTION
## Summary

Relaxes the read-before-edit guard: a file whose complete contents the agent
just wrote counts as read, so `write` → `edit` works without a fresh read.

## What changed

- New `EditTool._write_file` is the single shared write path (parent creation +
  write + `observe_read`, the same content-digest mechanism a real read uses);
  every write handler funnels through it: `write`, `claude_write`,
  `hashline_write`, `apply_patch`'s Add File, and the edit handlers whose
  duplicate inline digest recording was removed.
- Guard semantics are unchanged: digests are seeded from the just-written
  content, so a file modified after the write (e.g. via `exec_command`) still
  blocks with "File has changed since it was read" — writing grants no more
  than reading.
- `edit` tool description updated: "You must read the file first — or have just
  written it with write — before editing."
- Tests: write→edit without prior read succeeds (create + overwrite),
  `hashline_write`→edit, `apply_patch` Add File→edit, search/replace
  edit→`claude_edit`; write → external modification → edit still blocked.
  `MemoryFileSystem` test double gained the `is_file` override the shared path
  legitimately queries. CHANGELOG entry added.

## Verification

- Fast suite: 4216 passed, 1 skipped, 0 failed; slow agent tests: 69 passed, 4 skipped
- `pre-commit run --all-files` green
- Tool-definition render before/after diff: only the `edit` description sentence
  changed across all four edit protocols
