### PR TITLE
feat(cli): consolidate skill tools into single `skill` tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   guard accepts a subsequent edit without a fresh read — exactly as it would
   right after a read. Staleness tracking is unchanged: a file modified after the
   write still requires a fresh read before editing.
+- The three skill host tools (`list_skills`, `activate_skill`, and
+  `read_skill_resource`) are consolidated into a single `skill` tool with the
+  same contract as the old `activate_skill`: it takes the skill name (without a
+  leading slash) and returns the activation envelope with the skill's
+  instructions, its absolute directory, and the resource file list. Activating
+  an already-active skill short-circuits as before, and an unknown name now
+  lists close matches (prefix first, then fuzzy) from the catalog so a
+  mistyped activation self-corrects in one turn. The in-prompt skill roster
+  always lists every skill by name: description text is shed first when the
+  metadata budget binds, and skills are never omitted wholesale.
 
 ### Removed
 
@@ -83,6 +93,16 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   (possibly subclassed from a pinned older version) keeps qualifying. Existing
   session histories that recorded `get_host` calls keep them as data and
   render as-is (restore is name-agnostic).
+
+- The `list_skills`, `activate_skill`, and `read_skill_resource` host tools are
+  gone, replaced by the single `skill` tool above. Deleted:
+  `SkillCatalog.read_resource` and its truncation cap and traversal guard
+  (skill resources are read with the ordinary `read` tool, whose `file_path`
+  is relative to the absolute skill directory in the activation output), the
+  model-facing list query surface (`format_model_catalog`), and the
+  omitted-skills budget pathway in the prompt roster. Existing session
+  histories keep the old tool names as recorded data and render as-is
+  (restore is name-agnostic).
 
 ### Fixed
 

--- a/docs/src/content/docs/skills.mdx
+++ b/docs/src/content/docs/skills.mdx
@@ -88,9 +88,10 @@ paths **relative to the skill directory**, and the agent can read them on demand
   [`kolega-code ask`](../cli/ask/#skills).
 
 <Aside type="note">
-When a skill is active, the agent has helper tools to inspect and load skills —
-`list_skills`, `activate_skill`, and `read_skill_resource` — so it can pull in a
-skill's instructions and resources itself when a task calls for it.
+When a skill is active, the agent can call the `skill` tool to pull in a
+skill's instructions itself when a task calls for it. The activation output
+names the skill's absolute directory, and bundled resources are then read
+with the ordinary `read` tool.
 </Aside>
 
 ## Diagnostics

--- a/kolega_code/agent/prompt_templates/extensions/skills/catalog.md.j2
+++ b/kolega_code/agent/prompt_templates/extensions/skills/catalog.md.j2
@@ -1,6 +1,5 @@
 The CLI provides Agent Skills discovered from the project and user skill directories.
-Use `list_skills` to inspect available skills and `activate_skill` before applying a skill's workflow.
-Users can also activate skills explicitly with `/skill-name`.
+Activate with the `skill` tool before applying a skill's workflow; users can also invoke skills with `/skill-name`.
 
 Available skills:
 

--- a/kolega_code/cli/skills.py
+++ b/kolega_code/cli/skills.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import difflib
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -14,6 +15,7 @@ from kolega_code.agent.prompts import build_skill_catalog_prompt
 from kolega_code.agent.prompt_provider import AgentMode
 from kolega_code.llm.models import Message
 from kolega_code.llm.specs import get_model_specs
+from kolega_code.tools import ToolError
 
 
 PROJECT_SKILLS_DIR = Path(".agents") / "skills"
@@ -25,16 +27,15 @@ SKILL_SCOPE_PRECEDENCE = {
     "project": 2,
 }
 MAX_RESOURCE_FILES = 100
-MAX_RESOURCE_READ_CHARS = 100_000
 DEFAULT_SKILL_METADATA_CHAR_BUDGET = 8_000
 MAX_SKILL_METADATA_CHAR_BUDGET = 48_000
 SKILL_METADATA_CONTEXT_WINDOW_PERCENT = 2
 APPROX_CHARS_PER_TOKEN = 4
 SKILL_DESCRIPTION_TRUNCATION_SUFFIX = "..."
-LIST_SKILLS_DEFAULT_MAX_RESULTS = 50
-LIST_SKILLS_MAX_RESULTS = 100
 SKILL_NAME_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$")
 SKILL_CONTENT_RE = re.compile(r'<skill_content name="([^"]+)">')
+SKILL_SUGGESTION_MAX = 5
+SKILL_SUGGESTION_CUTOFF = 0.5
 
 
 @dataclass(frozen=True)
@@ -62,8 +63,6 @@ class SkillCatalogBudget:
 @dataclass(frozen=True)
 class SkillCatalogRenderReport:
     total_count: int
-    included_count: int
-    omitted_count: int
     truncated_description_count: int = 0
     truncated_description_chars: int = 0
 
@@ -139,52 +138,6 @@ class SkillCatalog:
         effective_budget = budget or SkillCatalogBudget.for_context_window(context_window_tokens)
         return build_skill_catalog_prompt(self.render_prompt_catalog(effective_budget).markdown)
 
-    def format_model_catalog(
-        self,
-        *,
-        query: str = "",
-        max_results: int = LIST_SKILLS_DEFAULT_MAX_RESULTS,
-        budget: Optional[SkillCatalogBudget] = None,
-    ) -> str:
-        """Return a bounded model-facing skill list with names and descriptions only."""
-        records = _filter_skill_records(list(self.skills.values()), query)
-        clean_query = query.strip()
-        if not records:
-            if clean_query:
-                return f"No Agent Skills matched query `{clean_query}`."
-            return "No Agent Skills found."
-
-        max_results = _clamp_max_results(max_results)
-        visible_records = records[:max_results]
-        render = _render_skill_metadata_records(
-            visible_records,
-            budget or SkillCatalogBudget.for_context_window(None),
-        )
-
-        if clean_query:
-            lines = [f"Available Agent Skills matching `{clean_query}` ({len(records)} total):"]
-        else:
-            lines = [f"Available Agent Skills ({len(records)} total):"]
-        if render.markdown:
-            lines.extend(["", render.markdown])
-
-        if render.report.truncated_description_count:
-            lines.extend(["", "Skill descriptions were shortened to fit the skill metadata budget."])
-
-        omitted_count = len(records) - render.report.included_count
-        if omitted_count > 0:
-            lines.extend(
-                [
-                    "",
-                    (
-                        f"{omitted_count} matching skills were not shown. "
-                        "Call `list_skills(query=...)` with a narrower query to inspect more."
-                    ),
-                ]
-            )
-
-        return "\n".join(lines)
-
     def activation_content(self, name: str, *, active_names: Optional[set[str]] = None) -> str:
         record = self._require_skill(name)
         active_names = active_names or set()
@@ -232,39 +185,11 @@ class SkillCatalog:
 
         return paths, False
 
-    def read_resource(self, name: str, relative_path: str, *, max_chars: int = MAX_RESOURCE_READ_CHARS) -> str:
-        record = self._require_skill(name)
-        clean_relative_path = relative_path.strip()
-        if not clean_relative_path:
-            raise ValueError("relative_path must not be empty.")
-        requested = Path(clean_relative_path)
-        if requested.is_absolute() or ".." in requested.parts:
-            raise ValueError("Skill resource path must stay inside the skill directory.")
-
-        root = record.skill_dir.resolve()
-        path = (record.skill_dir / requested).resolve()
-        try:
-            path.relative_to(root)
-        except ValueError as exc:
-            raise ValueError("Skill resource path must stay inside the skill directory.") from exc
-
-        if not path.is_file():
-            raise ValueError(f"Skill resource not found: {clean_relative_path}")
-
-        try:
-            content = path.read_text(encoding="utf-8")
-        except UnicodeDecodeError as exc:
-            raise ValueError(f"Skill resource is not UTF-8 text: {clean_relative_path}") from exc
-
-        if len(content) <= max_chars:
-            return content
-        return f"{content[:max_chars]}\n\n[truncated to first {max_chars} characters]"
-
     def _require_skill(self, name: str) -> SkillRecord:
         skill_name = name.strip()
         record = self.skills.get(skill_name)
         if record is None:
-            raise ValueError(f"Skill not found: {skill_name}")
+            raise ValueError(_skill_not_found_message(skill_name, self.skills.values()))
         return record
 
 
@@ -278,14 +203,14 @@ def _render_skill_metadata_records(
     if not records:
         return SkillCatalogRenderResult(
             markdown="",
-            report=SkillCatalogRenderReport(total_count=0, included_count=0, omitted_count=0),
+            report=SkillCatalogRenderReport(total_count=0),
         )
 
     full_lines = [_skill_metadata_line(record, _clean_description(record.description)) for record in records]
     if _joined_len(full_lines) <= budget.max_chars:
         return SkillCatalogRenderResult(
             markdown="\n".join(full_lines),
-            report=SkillCatalogRenderReport(total_count=total_count, included_count=total_count, omitted_count=0),
+            report=SkillCatalogRenderReport(total_count=total_count),
         )
 
     minimum_lines = [_skill_metadata_line(record, "") for record in records]
@@ -295,30 +220,19 @@ def _render_skill_metadata_records(
             markdown="\n".join(lines),
             report=SkillCatalogRenderReport(
                 total_count=total_count,
-                included_count=total_count,
-                omitted_count=0,
                 truncated_description_count=truncated_count,
                 truncated_description_chars=truncated_chars,
             ),
         )
 
-    included_lines: list[str] = []
-    included_records: list[SkillRecord] = []
-    for record in records:
-        line = _skill_metadata_line(record, "")
-        if not _line_fits(included_lines, line, budget.max_chars):
-            break
-        included_lines.append(line)
-        included_records.append(record)
-
+    # Even name-only lines exceed the budget: list every name anyway. The roster
+    # must never hide a skill name; description text is the only thing shed.
     return SkillCatalogRenderResult(
-        markdown="\n".join(included_lines),
+        markdown="\n".join(minimum_lines),
         report=SkillCatalogRenderReport(
             total_count=total_count,
-            included_count=len(included_lines),
-            omitted_count=total_count - len(included_lines),
-            truncated_description_count=sum(1 for record in included_records if _clean_description(record.description)),
-            truncated_description_chars=sum(len(_clean_description(record.description)) for record in included_records),
+            truncated_description_count=sum(1 for record in records if _clean_description(record.description)),
+            truncated_description_chars=sum(len(_clean_description(record.description)) for record in records),
         ),
     )
 
@@ -384,43 +298,45 @@ def _joined_len(lines: Sequence[str]) -> int:
     return len("\n".join(lines))
 
 
-def _line_fits(existing_lines: Sequence[str], new_line: str, max_chars: int) -> bool:
-    if not existing_lines:
-        return len(new_line) <= max_chars
-    return _joined_len([*existing_lines, new_line]) <= max_chars
-
-
 def _append_skill_metadata_notes(markdown: str, report: SkillCatalogRenderReport) -> str:
-    notes: list[str] = []
-    if report.truncated_description_count:
-        notes.append("Skill descriptions were shortened to fit the skill metadata budget.")
-    if report.omitted_count:
-        notes.append(f"{report.omitted_count} additional skills were omitted to fit the skill metadata budget.")
-    if not notes:
+    if not report.truncated_description_count:
         return markdown
-    note_block = "\n".join(f"- {note}" for note in notes)
+    note = "Skill descriptions were shortened to fit the skill metadata budget."
     if markdown:
-        return f"{markdown}\n\n{note_block}"
-    return note_block
+        return f"{markdown}\n\n- {note}"
+    return f"- {note}"
 
 
-def _filter_skill_records(records: Sequence[SkillRecord], query: str) -> list[SkillRecord]:
-    clean_query = query.strip().lower()
-    if not clean_query:
-        return list(records)
-    return [
-        record
-        for record in records
-        if clean_query in record.name.lower() or clean_query in _clean_description(record.description).lower()
+def _skill_not_found_message(name: str, records: Iterable[SkillRecord]) -> str:
+    message = f"Skill not found: {name}"
+    matches = close_skill_matches(name, records)
+    if matches:
+        suggestions = ", ".join(f"`{match}`" for match in matches)
+        message += f". Did you mean: {suggestions}?"
+    return message
+
+
+def close_skill_matches(
+    name: str,
+    records: Iterable[SkillRecord],
+    *,
+    max_matches: int = SKILL_SUGGESTION_MAX,
+) -> list[str]:
+    """Rank catalog names for a mistyped activation: prefix matches first, then fuzzy similarity."""
+    clean_name = name.strip().lower()
+    if not clean_name:
+        return []
+    catalog_names = [record.name for record in records]
+    exact = {candidate for candidate in catalog_names if candidate.lower() == clean_name}
+    prefix = [
+        candidate for candidate in catalog_names if candidate not in exact and candidate.lower().startswith(clean_name)
     ]
-
-
-def _clamp_max_results(max_results: int) -> int:
-    try:
-        value = int(max_results)
-    except (TypeError, ValueError):
-        value = LIST_SKILLS_DEFAULT_MAX_RESULTS
-    return max(1, min(value, LIST_SKILLS_MAX_RESULTS))
+    fuzzy = difflib.get_close_matches(clean_name, catalog_names, n=max_matches, cutoff=SKILL_SUGGESTION_CUTOFF)
+    ranked: list[str] = []
+    for candidate in prefix + fuzzy:
+        if candidate not in ranked:
+            ranked.append(candidate)
+    return ranked[:max_matches]
 
 
 def discover_skills(
@@ -516,28 +432,13 @@ def build_skill_tool_extension(
     if not catalog.has_skills():
         return None
 
-    async def list_skills(query: str = "", max_results: int = LIST_SKILLS_DEFAULT_MAX_RESULTS) -> str:
+    async def skill(name: str) -> str:
         """
-        Return Agent Skills available in this CLI session.
+        Activate an Agent Skill and load its full instructions.
 
-        Use this when choosing whether a specialized workflow is available. Pass a query to search by skill name or
-        description when the default result set is too broad.
-
-        Args:
-            query: Optional case-insensitive search text matched against skill names and descriptions.
-            max_results: Maximum number of matching skills to inspect. Values are clamped to a safe limit.
-
-        Returns:
-            A bounded Markdown list of skill names and descriptions.
-        """
-        return catalog.format_model_catalog(query=query, max_results=max_results)
-
-    async def activate_skill(name: str) -> str:
-        """
-        Load the full instructions for an Agent Skill.
-
-        Call this before using a skill's specialized workflow. The returned content explains where skill resources live
-        and lists bundled resources that can be read with `read_skill_resource`.
+        Call this before using a skill's specialized workflow. The returned content explains where skill resources
+        live and lists them; read any resource with the `read` tool, whose `file_path` is relative to the absolute
+        skill directory given in the output.
 
         Args:
             name: The skill name to activate, without a leading slash.
@@ -545,31 +446,17 @@ def build_skill_tool_extension(
         Returns:
             The activated skill instructions, or a note if the skill is already active.
         """
-        return catalog.activation_content(name, active_names=activated_skill_names(history_provider()))
-
-    async def read_skill_resource(name: str, relative_path: str) -> str:
-        """
-        Read a text resource bundled with an activated Agent Skill.
-
-        Args:
-            name: The skill name, without a leading slash.
-            relative_path: Path relative to the skill directory.
-
-        Returns:
-            UTF-8 text content from the requested skill resource, capped for context size.
-        """
-        return catalog.read_resource(name, relative_path)
+        try:
+            return catalog.activation_content(name, active_names=activated_skill_names(history_provider()))
+        except ValueError as exc:
+            raise ToolError(str(exc)) from None
 
     return ToolExtension(
         name="cli-agent-skills",
-        tools={
-            "list_skills": list_skills,
-            "activate_skill": activate_skill,
-            "read_skill_resource": read_skill_resource,
-        },
+        tools={"skill": skill},
         tool_groups={
-            "planning_tools": ["list_skills", "activate_skill", "read_skill_resource"],
-            "cli_skill_tools": ["list_skills", "activate_skill", "read_skill_resource"],
+            "planning_tools": ["skill"],
+            "cli_skill_tools": ["skill"],
         },
     )
 

--- a/tests/agent/test_prompts.py
+++ b/tests/agent/test_prompts.py
@@ -300,6 +300,8 @@ def test_skill_catalog_prompt_renders_catalog() -> None:
     rendered = prompts.build_skill_catalog_prompt("- `demo-skill`: Use demo workflow")
 
     assert "Agent Skills discovered" in rendered
+    assert "Activate with the `skill` tool before applying a skill's workflow" in rendered
+    assert "`/skill-name`" in rendered
     assert "- `demo-skill`: Use demo workflow" in rendered
     assert "{catalog}" in prompts.SKILL_CATALOG_PROMPT_TEMPLATE
 

--- a/tests/agent/test_tool_registry.py
+++ b/tests/agent/test_tool_registry.py
@@ -43,13 +43,13 @@ class TestToolRegistry:
 
         registry = ToolRegistry().add(
             Tool(
-                name="activate_skill",
-                definition=ToolDefinition(name="activate_skill", description="Activate a skill", parameters=[]),
+                name="sample_tool",
+                definition=ToolDefinition(name="sample_tool", description="A sample tool", parameters=[]),
                 handler=handler,
             )
         )
 
-        assert await registry.call("activate_skill", name="some-skill") == "activated:some-skill"
+        assert await registry.call("sample_tool", name="some-skill") == "activated:some-skill"
 
     @pytest.mark.asyncio
     async def test_call_allows_tool_input_named_tool_name(self):

--- a/tests/cli/test_app_agent_wiring.py
+++ b/tests/cli/test_app_agent_wiring.py
@@ -249,14 +249,14 @@ async def test_textual_app_passes_skill_extensions_to_build_and_plan_agents(
         skill_tools = extension_by_name(app.agent.kwargs["tool_extensions"], "cli-agent-skills").tools
 
         assert "demo-skill" in skill_prompt.markdown
-        assert {"list_skills", "activate_skill", "read_skill_resource"} == set(skill_tools)
-        assert "demo-skill" in await skill_tools["list_skills"]()
+        assert {"skill"} == set(skill_tools)
+        assert '<skill_content name="demo-skill">' in await skill_tools["skill"](name="demo-skill")
 
         await pilot.press("shift+tab")
 
         assert isinstance(app.agent, FakePlanningAgent)
         planning_skill_tools = extension_by_name(app.agent.kwargs["tool_extensions"], "cli-agent-skills")
-        assert "activate_skill" in planning_skill_tools.tools
+        assert "skill" in planning_skill_tools.tools
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_skills.py
+++ b/tests/cli/test_skills.py
@@ -8,9 +8,11 @@ from kolega_code.cli.skills import (
     activated_skill_names,
     build_skill_prompt_extension,
     build_skill_tool_extension,
+    close_skill_matches,
     discover_skills,
 )
 from kolega_code.llm.models import Message, TextBlock, ToolResult
+from kolega_code.tools import ToolError
 
 
 def write_skill(
@@ -106,7 +108,7 @@ def test_prompt_catalog_uses_only_names_and_descriptions(tmp_path: Path) -> None
     assert "(project)" not in prompt
 
 
-def test_prompt_catalog_truncates_descriptions_before_omitting_skills(tmp_path: Path) -> None:
+def test_prompt_catalog_truncates_descriptions_to_keep_all_names(tmp_path: Path) -> None:
     project = tmp_path / "project"
     user_home = tmp_path / "home"
     project.mkdir()
@@ -118,8 +120,7 @@ def test_prompt_catalog_truncates_descriptions_before_omitting_skills(tmp_path: 
     catalog = discover_skills(project, user_home=user_home, bundled_root=None)
     render = catalog.render_prompt_catalog(SkillCatalogBudget(max_chars=95))
 
-    assert render.report.included_count == 3
-    assert render.report.omitted_count == 0
+    assert render.report.total_count == 3
     assert render.report.truncated_description_count == 3
     assert "`alpha-skill`" in render.markdown
     assert "`beta-skill`" in render.markdown
@@ -128,7 +129,7 @@ def test_prompt_catalog_truncates_descriptions_before_omitting_skills(tmp_path: 
     assert long_description not in render.markdown
 
 
-def test_prompt_catalog_omits_overflow_when_names_exceed_budget(tmp_path: Path) -> None:
+def test_prompt_catalog_lists_every_name_when_budget_is_tiny(tmp_path: Path) -> None:
     project = tmp_path / "project"
     user_home = tmp_path / "home"
     project.mkdir()
@@ -139,12 +140,10 @@ def test_prompt_catalog_omits_overflow_when_names_exceed_budget(tmp_path: Path) 
     catalog = discover_skills(project, user_home=user_home, bundled_root=None)
     render = catalog.render_prompt_catalog(SkillCatalogBudget(max_chars=30))
 
-    assert render.report.included_count == 2
-    assert render.report.omitted_count == 8
-    assert "`skill-00`" in render.markdown
-    assert "`skill-01`" in render.markdown
-    assert "`skill-02`" not in render.markdown
-    assert "8 additional skills were omitted" in render.markdown
+    assert render.report.total_count == 10
+    for index in range(10):
+        assert f"`skill-{index:02d}`" in render.markdown
+    assert "omitted" not in render.markdown
 
 
 def test_build_skill_prompt_extension_uses_context_window_budget(tmp_path: Path) -> None:
@@ -192,30 +191,84 @@ def test_large_context_skill_prompt_extension_stays_bounded(tmp_path: Path) -> N
 
 
 @pytest.mark.asyncio
-async def test_list_skills_tool_is_bounded_and_queryable(tmp_path: Path) -> None:
+async def test_skill_tool_returns_activation_envelope(tmp_path: Path) -> None:
     project = tmp_path / "project"
     user_home = tmp_path / "home"
     project.mkdir()
     skills_root = project / ".agents" / "skills"
-    for index in range(60):
-        write_skill(skills_root, f"alpha-{index:02d}", f"Use alpha skill {index}.")
+    skill_dir = write_skill(skills_root, "demo-skill", "Use the demo skill.", body="# Demo steps")
+    (skill_dir / "references").mkdir()
+    (skill_dir / "references" / "guide.md").write_text("guide content", encoding="utf-8")
 
     catalog = discover_skills(project, user_home=user_home, bundled_root=None)
     extension = build_skill_tool_extension(catalog, lambda: [])
     assert extension is not None
-    list_skills = extension.tools["list_skills"]
+    assert set(extension.tools) == {"skill"}
+    assert extension.tool_groups["planning_tools"] == ["skill"]
+    assert extension.tool_groups["cli_skill_tools"] == ["skill"]
 
-    default_output = await list_skills()
-    assert "`alpha-00`" in default_output
-    assert "`alpha-49`" in default_output
-    assert "`alpha-59`" not in default_output
-    assert "10 matching skills were not shown" in default_output
-    assert "/alpha-00" not in default_output
-    assert "(project)" not in default_output
+    output = await extension.tools["skill"](name="demo-skill")
+    assert '<skill_content name="demo-skill">' in output
+    assert "# Demo steps" in output
+    assert "Skill directory:" in output
+    assert "<file>references/guide.md</file>" in output
 
-    queried_output = await list_skills(query="alpha-59")
-    assert "`alpha-59`" in queried_output
-    assert "Use alpha skill 59." in queried_output
+
+@pytest.mark.asyncio
+async def test_skill_tool_short_circuits_when_already_active(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    user_home = tmp_path / "home"
+    project.mkdir()
+    write_skill(project / ".agents" / "skills", "demo-skill", "Use the demo skill.", body="# Demo steps")
+
+    catalog = discover_skills(project, user_home=user_home, bundled_root=None)
+    history = [Message("user", [TextBlock('<skill_content name="demo-skill">body</skill_content>')])]
+    extension = build_skill_tool_extension(catalog, lambda: history)
+    assert extension is not None
+
+    output = await extension.tools["skill"](name="demo-skill")
+    assert "already active" in output
+    assert "# Demo steps" not in output
+
+
+@pytest.mark.asyncio
+async def test_skill_tool_unknown_name_lists_close_matches(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    user_home = tmp_path / "home"
+    project.mkdir()
+    skills_root = project / ".agents" / "skills"
+    for name in ("release-notes", "deep-research", "docx"):
+        write_skill(skills_root, name, f"Use {name}.")
+
+    catalog = discover_skills(project, user_home=user_home, bundled_root=None)
+    extension = build_skill_tool_extension(catalog, lambda: [])
+    assert extension is not None
+
+    with pytest.raises(ToolError, match=r"Skill not found: releas-note\..*`release-notes`"):
+        await extension.tools["skill"](name="releas-note")
+
+    with pytest.raises(ToolError, match=r"Skill not found: doc\..*`docx`"):
+        await extension.tools["skill"](name="doc")
+
+    with pytest.raises(ToolError, match=r"Skill not found: zzz$"):
+        await extension.tools["skill"](name="zzz")
+
+
+def test_close_skill_matches_ranks_prefix_before_fuzzy(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    user_home = tmp_path / "home"
+    project.mkdir()
+    skills_root = project / ".agents" / "skills"
+    for name in ("release-notes", "deep-research", "docx", "release-tag"):
+        write_skill(skills_root, name, f"Use {name}.")
+
+    catalog = discover_skills(project, user_home=user_home, bundled_root=None)
+
+    matches = close_skill_matches("release", catalog.skills.values())
+    assert matches == ["release-notes", "release-tag"]
+
+    matches = close_skill_matches("", catalog.skills.values())
+    assert matches == []
 
 
 def test_discover_skills_skips_missing_description_and_malformed_yaml(tmp_path: Path) -> None:
@@ -259,19 +312,6 @@ def test_activation_content_wraps_body_and_lists_resources(tmp_path: Path) -> No
     assert "name: resource-skill" not in content
 
 
-def test_read_resource_rejects_path_traversal_and_caps_content(tmp_path: Path) -> None:
-    project = tmp_path / "project"
-    user_home = tmp_path / "home"
-    skill_dir = write_skill(project / ".agents" / "skills", "read-skill")
-    (skill_dir / "big.txt").write_text("a" * 20, encoding="utf-8")
-
-    catalog = discover_skills(project, user_home=user_home, bundled_root=None)
-
-    assert catalog.read_resource("read-skill", "big.txt", max_chars=5).startswith("aaaaa\n\n[truncated")
-    with pytest.raises(ValueError, match="inside the skill directory"):
-        catalog.read_resource("read-skill", "../SKILL.md")
-
-
 def test_activated_skill_names_scans_text_and_tool_results() -> None:
     history = [
         Message("user", [TextBlock('<skill_content name="one">body</skill_content>')]),
@@ -282,7 +322,7 @@ def test_activated_skill_names_scans_text_and_tool_results() -> None:
                 ToolResult(
                     tool_use_id="toolu_123",
                     content=[TextBlock('<skill_content name="three">body</skill_content>')],
-                    name="activate_skill",
+                    name="skill",
                     is_error=False,
                 )
             ],


### PR DESCRIPTION
## Summary

Replaces the three host skill tools (`list_skills`, `activate_skill`, `read_skill_resource`) registered by the `cli-agent-skills` extension with a single `skill` tool that keeps `activate_skill`'s contract: name without a leading slash, returns the activation envelope with the skill's instructions, its absolute directory, and the resource file list. Already-active activations short-circuit as before. The in-prompt skill roster (via `extensions/skills/catalog.md.j2`) is unchanged in role — this only removes the redundant tool-side discovery.

## Changes

- **`skill` tool** (`kolega_code/cli/skills.py`): one tool with the old `activate_skill` contract; keeps `planning_tools` / `cli_skill_tools` group memberships.
- **Self-correcting errors**: an unknown name raises a `ToolError` listing close matches from the catalog (prefix matches first, then fuzzy), so a mistyped activation resolves in one turn.
- **Roster budget**: descriptions are dropped before names; the in-prompt roster always lists every skill by name. The omitted-skills pathway (`omitted_count`, "N additional skills were omitted" note, record-dropping branch) is removed, along with the `list_skills` query surface (`format_model_catalog`).
- **Resources**: `SkillCatalog.read_resource` is deleted with its truncation cap and traversal guard (intentionally not relocated); the activation output's absolute skill directory anchors relative paths for the ordinary `read` tool.
- **Prompt template**: `catalog.md.j2` now says "Activate with the `skill` tool before applying a skill's workflow; users can also invoke skills with `/skill-name`." — no prompt text names the removed tools.
- **Docs/tests/CHANGELOG**: `docs/src/content/docs/skills.mdx` Aside updated; skill tool tests rewritten for the new contract (activation envelope, already-active short-circuit, close matches, names-never-omitted); `test_app_agent_wiring.py`, `test_tool_registry.py`, `test_prompts.py` updated; CHANGELOG entries added.

## Verification

- Full test suite: 4218 passed, 1 skipped (needs `BROWSERLESS_API_KEY`), 0 failed.
- Before/after render diff of the system prompts and tool definitions: byte-identical except the catalog template wording and three tool definitions → one (`skill`).
- Pre-commit hooks (ruff, pyright, formatting): pass.
- Old sessions that called the removed tools still restore and display (restore is name-agnostic — no shims).
