### PR TITLE
feat(agent): consolidate agent dispatch tools into single `dispatch_agent` tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ### Changed
 
+- The per-type agent dispatch tools (`dispatch_general_agent`,
+  `dispatch_investigation_agent`, `dispatch_browser_agent`,
+  `dispatch_coding_agent`, and `dispatch_custom_agent`) are consolidated into a
+  single `dispatch_agent(agent_type, task, model_override?, browser_target?)`
+  tool. `agent_type` is an enum computed per session from the same conditions
+  that previously gated the individual tools: `general` and `investigation`
+  whenever dispatch is available, `browser` only when the browser-agent model
+  supports vision, `coding` where the coding dispatch was previously offered
+  (never for the coder itself), and custom agent names when definitions are
+  discovered. The description documents the shared dispatch mechanics once plus
+  one line per available agent type, and an unavailable `agent_type` returns an
+  error listing the valid values. Old sessions that used the removed tool names
+  still restore and display normally.
+
 - All terminal-capable agents (coder, planning, investigation, general) now
   share a terminal-tools prompt section with codex-style guidance: prefer
   `rg` / `rg --files` over `grep`/`find` when searching for text or files (it is

--- a/docs/src/content/docs/concepts/agents.md
+++ b/docs/src/content/docs/concepts/agents.md
@@ -20,12 +20,16 @@ agent can hand off to the others when a task benefits from focus.
 ## Dispatching sub-agents
 
 For larger jobs, the main agent can **dispatch** a sub-agent and incorporate its
-findings. The available dispatch targets include:
+findings. A single `dispatch_agent` tool takes an `agent_type` selecting the
+target; the built-in types are:
 
-- `dispatch_investigation_agent` — explore and report back, without making changes.
-- `dispatch_browser_agent` — perform a web task.
-- `dispatch_coding_agent` — hand off a self-contained coding task.
-- `dispatch_general_agent` — a general-purpose helper.
+- `investigation` — explore and report back, without making changes.
+- `browser` — perform a web task.
+- `coding` — hand off a self-contained coding task.
+- `general` — a general-purpose helper.
+
+[Custom agents](../../custom-agents/) add their names to the `agent_type`
+choices, and only the types available in the current session are offered.
 
 When [gigacode](../../gigacode/) is enabled, the main agent can also orchestrate
 **many** of these sub-agents at once through a workflow — running them in parallel
@@ -48,6 +52,7 @@ An ordinary dispatch accepts one complete object under `model_override`:
 
 ```json
 {
+  "agent_type": "investigation",
   "task": "Review the authentication design for subtle security flaws.",
   "model_override": {
     "provider": "anthropic",

--- a/docs/src/content/docs/concepts/tools.md
+++ b/docs/src/content/docs/concepts/tools.md
@@ -201,10 +201,11 @@ backend is unavailable, no memory tools or context are exposed.
 
 ### Sub-agent dispatch
 
-The agent can spawn focused sub-agents — see [Agents](../agents/) for
-`dispatch_investigation_agent`, `dispatch_browser_agent`, `dispatch_coding_agent`,
-and `dispatch_general_agent`. Named [custom agents](../../custom-agents/) are
-available through `dispatch_custom_agent` when matching definitions are discovered.
+The agent can spawn focused sub-agents through the single `dispatch_agent`
+tool — see [Agents](../agents/) for the built-in `general`, `investigation`,
+`browser`, and `coding` agent types. Named [custom agents](../../custom-agents/)
+join the `agent_type` choices when matching definitions are discovered. Only the
+agent types available in the current session are offered.
 
 ## Read-only vs. full access
 

--- a/docs/src/content/docs/custom-agents.mdx
+++ b/docs/src/content/docs/custom-agents.mdx
@@ -11,9 +11,9 @@ analysis, or migration planning—to a specialist with its own instructions and
 optional tool, model, and iteration limits.
 
 The active Build or Plan agent sees each available custom agent's name and
-description. It chooses one through `dispatch_custom_agent`, gives it a
-self-contained task, and incorporates the specialist's final report into the
-main conversation.
+description. It chooses one by passing its name as the `agent_type` of
+`dispatch_agent`, gives it a self-contained task, and incorporates the
+specialist's final report into the main conversation.
 
 ## Quick start
 

--- a/kolega_code/agent/coder.py
+++ b/kolega_code/agent/coder.py
@@ -123,27 +123,26 @@ class CoderAgent(BaseAgent, LogMixin):
             memory_enabled=memory_enabled,
         )
 
-        # Configure tool collection with custom coder agent tools
+        # Configure tool collection with custom coder agent tools. The
+        # coder_agent_tools dispatch group already omits the "coding"
+        # agent_type, so the coder never dispatches itself.
         tool_exclusions = [
             "execute_terminal_command",
             "get_tool_list",
             "log_error",
             "log_info",
-            # Exclude task-specific dispatch tools since coder shouldn't call itself or other agents
-            "dispatch_coding_agent",
         ]
         mode_value = self.agent_mode.value if isinstance(self.agent_mode, AgentMode) else self.agent_mode
         if mode_value in (AgentMode.CLI.value, AgentMode.ASK.value):
             tool_exclusions.extend(["build_backend", "build_frontend"])
-        if sub_agent:
-            # A dispatched coder must not fan out into further sub-agents
-            tool_exclusions.append("dispatch_general_agent")
 
         tool_config = ToolCollectionConfig(
             custom_tool_groups=["coder_agent_tools"],
             tool_exclusions=tool_exclusions,
             include_memory_tools=True,
             memory_write_access=True,
+            # A dispatched coder must not fan out into further general sub-agents
+            excluded_agent_types=["general"] if sub_agent else None,
         )
 
         self.tool_collection = ToolCollection(

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -1,7 +1,7 @@
 import inspect
 from pathlib import Path
 from dataclasses import dataclass, field
-from typing import Any, Callable, List, Optional, Union
+from typing import Any, Callable, List, Optional, Sequence, Union
 
 from .common import LogMixin
 from kolega_code.config import AgentConfig, EditProtocol
@@ -67,12 +67,17 @@ _ORDINARY_MODEL_OVERRIDE_SCHEMA: dict[str, Any] = {
 }
 
 
-def _dispatch_input_schema(
+def _dispatch_agent_input_schema(
+    agent_types: Sequence[str],
     *,
-    custom: bool = False,
     browser_targets: tuple[str, ...] = (),
 ) -> dict[str, Any]:
     properties: dict[str, Any] = {
+        "agent_type": {
+            "type": "string",
+            "enum": list(agent_types),
+            "description": "Which agent to dispatch. The tool description lists each value's role and tools.",
+        },
         "task": {
             "type": "string",
             "description": "Detailed, self-contained task for the sub-agent.",
@@ -80,44 +85,29 @@ def _dispatch_input_schema(
         "model_override": {
             **_ORDINARY_MODEL_OVERRIDE_SCHEMA,
             "description": (
-                'Usually omit this property entirely: a normal call is {"task": "..."}. '
+                'Usually omit this property entirely: a normal call is {"agent_type": "...", "task": "..."}. '
                 "Only include it after calling list_subagent_models and selecting one exact route. "
                 "Never send an empty object, blank strings, placeholder values, or a guessed provider/model. "
                 "When present, all three nested fields are required."
             ),
         },
     }
-    required = ["task"]
-    if browser_targets:
+    if "browser" in agent_types and len(browser_targets) > 1:
         properties["browser_target"] = {
             "type": "string",
             "enum": list(browser_targets),
             "description": (
-                "Browser backend for this task. Omit for Playwright; choose Chrome only when the user directs you "
+                'Only for agent_type "browser". Omit for Playwright; choose Chrome only when the user directs you '
                 "to use their configured Chrome browser."
             ),
         }
-    if custom:
-        properties = {
-            "agent": {"type": "string", "description": "Name of the custom agent to run."},
-            **properties,
-        }
-        required = ["agent", "task"]
     return {
         "type": "object",
         "additionalProperties": False,
         "properties": properties,
-        "required": required,
+        "required": ["agent_type", "task"],
     }
 
-
-_AGENT_DISPATCH_INPUT_SCHEMAS: dict[str, dict[str, Any]] = {
-    "dispatch_investigation_agent": _dispatch_input_schema(),
-    "dispatch_browser_agent": _dispatch_input_schema(),
-    "dispatch_coding_agent": _dispatch_input_schema(),
-    "dispatch_general_agent": _dispatch_input_schema(),
-    "dispatch_custom_agent": _dispatch_input_schema(custom=True),
-}
 
 # Explicit input schema for the generic ``lsp`` tool.  The ``operation`` parameter
 # is an enum that signature introspection cannot express.
@@ -445,6 +435,7 @@ class ToolCollectionConfig:
         restrict_to_tool_groups: bool = False,
         allowed_tools: Optional[List[str]] = None,
         memory_write_access: bool = False,
+        excluded_agent_types: Optional[List[str]] = None,
     ):
         """
         Initialize tool collection configuration.
@@ -452,7 +443,7 @@ class ToolCollectionConfig:
         Args:
             read_only: Whether to restrict to read-only tools
             browser_only: Whether to only include browser tools
-            include_agent_dispatch_tools: Whether to include agent dispatch tools (investigation, browser, coding)
+            include_agent_dispatch_tools: Whether to include the dispatch_agent tool (every agent_type)
             include_memory_tools: Whether to include memory management tools
             memory_write_access: Whether mutating memory tools (write/delete) may be exposed to this agent;
                 subagent scope still strips them regardless.
@@ -462,6 +453,8 @@ class ToolCollectionConfig:
             restrict_to_tool_groups: If True, ONLY include tools from specified groups, excluding all other core tools
             allowed_tools: Optional exact allowlist applied after hard runtime gates. None inherits normal behavior;
                 an empty list exposes no tools.
+            excluded_agent_types: dispatch_agent agent_type values to withhold from this
+                collection (e.g. "general" for a dispatched coder that must not fan out).
         """
         self.read_only = read_only
         self.browser_only = browser_only
@@ -472,6 +465,7 @@ class ToolCollectionConfig:
         self.custom_tool_groups = list(dict.fromkeys((custom_tool_groups or []) + (enabled_tool_groups or [])))
         self.restrict_to_tool_groups = restrict_to_tool_groups
         self.allowed_tools = None if allowed_tools is None else list(dict.fromkeys(allowed_tools))
+        self.excluded_agent_types = list(excluded_agent_types or [])
 
 
 class ToolCollection(LogMixin):
@@ -520,13 +514,11 @@ class ToolCollection(LogMixin):
         "browser_close",
     ]
 
-    # Agent dispatch tools group - includes all agent dispatch functionality
+    # Agent dispatch group - a single dispatch_agent tool routes to every
+    # dispatchable agent type; the agent_type enum it offers is computed per
+    # collection in _available_agent_types.
     agent_dispatch_tools = [
-        "dispatch_investigation_agent",
-        "dispatch_browser_agent",
-        "dispatch_coding_agent",
-        "dispatch_general_agent",
-        "dispatch_custom_agent",
+        "dispatch_agent",
     ]
 
     # Legacy name for backward compatibility
@@ -534,15 +526,22 @@ class ToolCollection(LogMixin):
 
     # CoderAgent specific dispatch tools
     coder_agent_tools = [
-        "dispatch_investigation_agent",
-        "dispatch_browser_agent",
-        "dispatch_general_agent",
-        "dispatch_custom_agent",
+        "dispatch_agent",
     ]
 
     custom_agent_tools = [
-        "dispatch_custom_agent",
+        "dispatch_agent",
     ]
+
+    # agent_type enum members each dispatch-enabled group admits. "custom"
+    # stands for the names in the custom-agent catalog. The coder group omits
+    # "coding" so the CoderAgent never dispatches itself.
+    _dispatch_group_agent_types = {
+        "agent_dispatch_tools": ("general", "investigation", "browser", "coding", "custom"),
+        "investigation_agent_tools": ("general", "investigation", "browser", "coding", "custom"),
+        "coder_agent_tools": ("general", "investigation", "browser", "custom"),
+        "custom_agent_tools": ("custom",),
+    }
 
     # Informational support for callers that can dispatch a child or author a
     # workflow. Inclusion is capability-gated separately so leaf agents never
@@ -917,10 +916,12 @@ class ToolCollection(LogMixin):
         self.extension_schemas["snapshot"] = _SNAPSHOT_INPUT_SCHEMA
         self.extension_schemas["resolve"] = _RESOLVE_INPUT_SCHEMA
         self.extension_schemas.update(BROWSER_TOOL_SCHEMAS)
-        self.extension_schemas.update(_AGENT_DISPATCH_INPUT_SCHEMAS)
-        browser_targets = tuple(getattr(self.browser_manager, "browser_targets", ()))
-        if len(browser_targets) > 1:
-            self.extension_schemas["dispatch_browser_agent"] = _dispatch_input_schema(browser_targets=browser_targets)
+        # dispatch_agent's schema is built at registration time in
+        # _tool_definition_from_callable: its agent_type enum depends on the
+        # custom-agent catalog and per-collection gates. browser_targets probes
+        # live host configuration, so snapshot it here like the rest of the
+        # construction-time tool surface.
+        self._browser_targets = tuple(getattr(self.browser_manager, "browser_targets", ()))
         self.browser_tool = BrowserTool(
             self.project_path,
             self.workspace_id,
@@ -1287,178 +1288,53 @@ class ToolCollection(LogMixin):
         """
         return await self.build_tool.build_frontend()
 
-    # Agent Dispatch Tools (available when include_agent_dispatch_tools is True)
-    async def dispatch_investigation_agent(self, task: str, model_override: Any = None) -> str:
-        """
-        Dispatch an investigation agent to perform a specific task with read-only access to the codebase.
-
-        This tool launches a specialized agent that can analyze code, search for patterns, and investigate
-        issues without modifying any files. The investigation agent has access to all read-only tools
-        and will return a comprehensive report on its findings.
-
-        When to use this tool:
-        - When you need to perform complex searches across multiple files
-        - When you need to analyze code patterns or understand how components interact
-        - When you need to trace through code execution paths
-        - When you need to gather information from multiple parts of the codebase
-
-        Usage notes:
-        1. Provide a detailed task description with specific questions or objectives for the agent
-        2. The agent will work autonomously and return a single comprehensive report
-        3. The agent cannot modify any files - it has read-only access to the codebase
-        4. For best results, specify exactly what information you want the agent to find and include in its report
-        5. The agent's report is not automatically shown to the user - you should summarize key findings
-
-        IMPORTANT: The agent can only use these tools:
-            - exec_command, write_stdin, kill_command, list_sessions — terminal access
-            - eval — persistent Python/JavaScript kernels
-            - lsp — language-server intelligence
-            - read — read file contents (offset/limit for sections)
-            - read_image — read images
-            - web_fetch, web_search — web access
-        If you need to do something that requires any other tool, you should call the tool directly.
-
-        Args:
-            task: A detailed description of the investigation task to perform
-            model_override: Optional complete provider/model/thinking_effort route. Call
-                list_subagent_models before selecting one; omit it to inherit defaults.
-
-        Returns:
-            A comprehensive report of the investigation findings
-        """
-        return await self.agent_tool.dispatch_investigation_agent(task, model_override)
-
-    async def dispatch_browser_agent(
+    # Agent dispatch (available when a dispatch-enabled tool group is active)
+    async def dispatch_agent(
         self,
+        agent_type: str,
         task: str,
         model_override: Any = None,
         browser_target: Optional[str] = None,
     ) -> str:
-        """
-        Dispatch a browser agent to perform web-based tasks and interactions.
+        """Dispatch an autonomous sub-agent to complete a self-contained task.
 
-        This tool launches a specialized agent that can navigate websites, interact with web elements,
-        and extract information from web pages. The browser agent has access to all browser-related tools
-        and will return a comprehensive report on its findings and actions.
+        The sub-agent works without further input and returns one final report. You
+        cannot see its intermediate steps or send follow-up messages, so each task
+        must be INDEPENDENT and SELF-CONTAINED: include the goal, relevant file
+        paths, constraints, and exactly what the final report should contain. The
+        report is not automatically shown to the user - summarize the key results.
+        Sub-agents cannot spawn further sub-agents.
 
-        Use this ONLY when the user explicitly asks to browse, open, visit, or interact with a web page/URL,
-        or explicitly requests a screenshot or web UI action. Do NOT use this for general research, docs lookup,
-        or exploration unless the user clearly requests browsing.
-
-
-        When to use this tool:
-        - When you need to navigate and interact with websites
-        - When you need to extract information from web pages
-        - When you need to test web applications or interfaces
-        - When you need to automate web-based workflows
-
-        Usage notes:
-        1. Provide a detailed task description with specific objectives for the browser agent
-        2. The agent will work autonomously and return a single comprehensive report
-        3. The agent can launch browsers, navigate pages, click elements, fill forms, and extract content
-        4. For best results, specify exactly what information you want the agent to find or what actions to perform
-        5. The agent's report is not automatically shown to the user - you should summarize key findings
-
-        IMPORTANT: The browser agent specializes in these tools:
-            - browser_navigate, browser_snapshot, and browser_find
-            - browser_click, browser_type, browser_fill_form, and browser_select_option
-            - browser_scroll, browser_press_key, and browser_wait_for
-            - browser_tabs, browser_handle_dialog, and browser_file_upload
-            - browser_console_messages, browser_network_requests, and browser_take_screenshot
-            - browser_close
-
-        On a page too large to snapshot in one call the snapshot is truncated and
-        says so, prioritising what is near the viewport. Treat that as an
-        instruction to narrow the scope: pass a target to browser_snapshot, or
-        browser_scroll and snapshot again. It does not mean the page is unreadable.
+        PARALLEL EXECUTION: multiple dispatch_agent calls issued in a single
+        response run CONCURRENTLY. Use this to fan out independent work, but never
+        give two parallel agents work that could overlap on the same files. Do
+        tasks that depend on each other's output sequentially or yourself, and
+        skip dispatch for small tasks you can do directly with a couple of tool
+        calls or anything needing back-and-forth with the user.
 
         Args:
-            task: A detailed description of the browser task to perform
-            model_override: Optional complete provider/model/thinking_effort route. Call
-                list_subagent_models before selecting one; the model must support vision.
-            browser_target: Optional configured browser backend. Omit for Playwright;
-                choose Chrome only when the user asks to use their Chrome browser.
-
-        Returns:
-            A comprehensive report of the browser agent's findings and actions
-        """
-        return await self.agent_tool.dispatch_browser_agent(task, model_override, browser_target)
-
-    async def dispatch_coding_agent(self, task: str, model_override: Any = None) -> str:
-        """
-        Dispatch a coding agent for processing coding-related tasks with streaming output.
-
-        Args:
-            task: A detailed description of the coding task to perform
-            model_override: Optional complete provider/model/thinking_effort route. Call
-                list_subagent_models before selecting one; omit it to inherit defaults.
-
-        Returns:
-            A summary of the coding process outcome
-        """
-        return await self.agent_tool.dispatch_coding_agent(task, model_override)
-
-    async def dispatch_general_agent(self, task: str, model_override: Any = None) -> str:
-        """
-        Dispatch an autonomous general-purpose agent to complete a self-contained task.
-
-        This tool launches a sub-agent with the full set of workspace tools (read, search,
-        edit files, run commands). It works autonomously on the task you give it and returns
-        a single final report. You will not see its intermediate steps, and you cannot send
-        it follow-up messages, so the task description must contain everything it needs.
-
-        PARALLEL EXECUTION: If you issue multiple dispatch_general_agent calls in a single
-        response, the agents run CONCURRENTLY. Use this to fan out work that can proceed
-        independently (e.g., "update module A's tests" and "update module B's tests").
-
-        When to use this tool:
-        - The work splits into independent subtasks that do not touch the same files
-        - A subtask is large or noisy (broad searches, mechanical multi-file edits) and you
-          only need the outcome, not every intermediate step
-        - You want several independent investigations or changes done at once
-
-        When NOT to use this tool:
-        - Tasks that depend on each other's output or edit the same files - do those
-          yourself sequentially, or dispatch them one at a time
-        - Small tasks you can do directly with one or two tool calls
-        - Anything requiring back-and-forth with the user
-
-        Usage notes:
-        1. Each task must be INDEPENDENT and SELF-CONTAINED: include the goal, relevant
-           file paths, constraints, and exactly what the final report should contain.
-        2. Never dispatch two parallel agents whose work could overlap on the same files.
-        3. The agent cannot spawn further sub-agents.
-        4. The agent's report is not automatically shown to the user - you should summarize
-           the key results.
-
-        Args:
+            agent_type: Which agent to dispatch, from the listed values.
             task: A detailed, self-contained description of the task to perform
             model_override: Optional complete provider/model/thinking_effort route. Call
                 list_subagent_models before selecting one; omit it to inherit defaults.
+            browser_target: Only for agent_type "browser". Omit for Playwright; choose
+                Chrome only when the user asks to use their Chrome browser.
 
         Returns:
-            The agent's final report on the completed task
+            The sub-agent's final report
         """
-        return await self.agent_tool.dispatch_general_agent(task, model_override)
-
-    async def dispatch_custom_agent(self, agent: str, task: str, model_override: Any = None) -> str:
-        """Dispatch a named custom agent defined in project or user Markdown.
-
-        Select an agent whose description matches a self-contained task. The agent
-        runs in a fresh context, cannot spawn other agents, and returns one final
-        report. Its tools can only be a subset of the tools available in this
-        session. Multiple independent calls may run in parallel.
-
-        Args:
-            agent: Name of the custom agent to run.
-            task: Detailed, self-contained task including relevant context and expected output.
-            model_override: Optional complete provider/model/thinking_effort route. A runtime
-                override replaces the custom definition route as one atomic selection.
-
-        Returns:
-            The custom agent's final report.
-        """
-        return await self.agent_tool.dispatch_custom_agent(agent, task, model_override)
+        if agent_type not in self._available_agent_types():
+            available = ", ".join(self._available_agent_types()) or "none"
+            raise ValueError(f"Unknown or unavailable agent_type `{agent_type}`. Valid values: {available}.")
+        if agent_type == "general":
+            return await self.agent_tool.dispatch_general_agent(task, model_override)
+        if agent_type == "investigation":
+            return await self.agent_tool.dispatch_investigation_agent(task, model_override)
+        if agent_type == "browser":
+            return await self.agent_tool.dispatch_browser_agent(task, model_override, browser_target)
+        if agent_type == "coding":
+            return await self.agent_tool.dispatch_coding_agent(task, model_override)
+        return await self.agent_tool.dispatch_custom_agent(agent_type, task, model_override)
 
     async def list_subagent_models(self, provider: Optional[str] = None) -> str:
         """List configured models available for ordinary and Gigacode sub-agents.
@@ -2217,32 +2093,85 @@ class ToolCollection(LogMixin):
             }
         if method_name == "edit" and self.edit_protocol == EditProtocol.HASHLINE_V2:
             definition.input_schema = _HASHLINE_V2_INPUT_SCHEMA
-        if method_name == "dispatch_custom_agent":
+        if method_name == "dispatch_agent":
+            agent_types = self._available_agent_types()
+            definition.description = f"{definition.description}\n\n{self._dispatch_agent_type_catalog(agent_types)}"
+            definition.input_schema = _dispatch_agent_input_schema(agent_types, browser_targets=self._browser_targets)
+        return definition
+
+    # One accurate line per built-in agent_type, appended to dispatch_agent's
+    # description for the types this collection actually offers.
+    _DISPATCH_AGENT_TYPE_LINES = {
+        "general": (
+            "- general: full workspace toolset (read, search, edit files, run commands). The default for "
+            "independent subtasks such as broad searches or mechanical multi-file edits."
+        ),
+        "investigation": (
+            "- investigation: read-only file access plus terminal commands and eval kernels (it can run and "
+            "test code but has no file-editing tools), with lsp and web access. Use it to analyze code, "
+            "trace execution paths, and gather findings into a report."
+        ),
+        "browser": (
+            "- browser: navigates and interacts with web pages via the browser_* tools (snapshot, click, "
+            "type, screenshot, ...). Use ONLY when the user explicitly asks to browse, visit, or interact "
+            "with a web page or requests a screenshot - not for general research or docs lookup."
+        ),
+        "coding": "- coding: a full coding agent for coding tasks, with streaming output.",
+    }
+
+    def _dispatch_agent_type_catalog(self, agent_types: Sequence[str]) -> str:
+        """Render the per-type description lines for the available agent_type values."""
+        lines = ["Available agent_type values:"]
+        custom_names = set(agent_types) - self._DISPATCH_AGENT_TYPE_LINES.keys()
+        lines.extend(
+            self._DISPATCH_AGENT_TYPE_LINES[agent_type]
+            for agent_type in agent_types
+            if agent_type in self._DISPATCH_AGENT_TYPE_LINES
+        )
+        if custom_names:
+            catalog = self.caller.custom_agent_catalog
+            lines.append(
+                "Custom agents (run in a fresh context with a subset of this session's tools; "
+                "pick one whose description matches the task):"
+            )
+            lines.append(catalog.model_catalog())
+        return "\n".join(lines)
+
+    def _available_agent_types(self) -> list[str]:
+        """agent_type enum members dispatch_agent currently offers.
+
+        Computed from the same conditions that used to gate whole per-type
+        dispatch tools: which dispatch-enabled groups the config activates,
+        config-level agent-type exclusions, the browser-agent vision gate, and
+        the custom-agent catalog (never offered to sub-agents).
+        """
+        enabled_groups = set(self.tool_config.custom_tool_groups or [])
+        if self.tool_config.include_agent_dispatch_tools:
+            enabled_groups.add("agent_dispatch_tools")
+        admitted: set[str] = set()
+        for group_name in enabled_groups:
+            admitted.update(self._dispatch_group_agent_types.get(group_name, ()))
+        admitted.difference_update(self.tool_config.excluded_agent_types)
+
+        agent_types = [agent_type for agent_type in ("general", "investigation") if agent_type in admitted]
+        if "browser" in admitted:
+            from kolega_code.agent.browseragent import BrowserAgent
+
+            # Vision gate: the browser agent reads page screenshots, so gate on
+            # the model resolved for the browser-agent role (which may differ
+            # from the main one), not caller.supports_vision, rather than offer
+            # a value that can only fail at dispatch.
+            if BrowserAgent.resolved_model_supports_vision(self.config):
+                agent_types.append("browser")
+        if "coding" in admitted:
+            agent_types.append("coding")
+        if "custom" in admitted and not getattr(self.caller, "sub_agent", False):
             catalog = getattr(self.caller, "custom_agent_catalog", None)
             if catalog is not None and catalog.has_agents():
-                routing_catalog = catalog.model_catalog()
-                definition.description = f"{definition.description}\n\nAvailable custom agents:\n{routing_catalog}"
-                definition.input_schema = {
-                    "type": "object",
-                    "properties": {
-                        "agent": {
-                            "type": "string",
-                            "enum": catalog.names(),
-                            "description": "Name of the custom agent to run.",
-                        },
-                        "task": {
-                            "type": "string",
-                            "description": (
-                                "Detailed, self-contained task including relevant context and expected output."
-                            ),
-                        },
-                        "model_override": _AGENT_DISPATCH_INPUT_SCHEMAS["dispatch_custom_agent"]["properties"][
-                            "model_override"
-                        ],
-                    },
-                    "required": ["agent", "task"],
-                }
-        return definition
+                # Built-in type names always win in routing, so a custom agent
+                # shadowed by one never enters the enum as a dead value.
+                agent_types.extend(name for name in catalog.names() if name not in self._DISPATCH_AGENT_TYPE_LINES)
+        return agent_types
 
     def _hashline_output_enabled(self) -> bool:
         """Whether this collection actually exposes the Hashline edit binding."""
@@ -2348,29 +2277,12 @@ class ToolCollection(LogMixin):
         explicit_schema = self.extension_schemas.get(method_name)
         if explicit_schema is not None:
             definition.input_schema = explicit_schema
-        if method_name == "dispatch_custom_agent":
-            catalog = getattr(self.caller, "custom_agent_catalog", None)
-            if catalog is not None and catalog.has_agents():
-                custom_schema = definition.input_schema or {"type": "object", "properties": {}}
-                definition.input_schema = {
-                    **custom_schema,
-                    "properties": {
-                        **custom_schema.get("properties", {}),
-                        "agent": {
-                            "type": "string",
-                            "enum": catalog.names(),
-                            "description": "Name of the custom agent to run.",
-                        },
-                    },
-                }
         context = getattr(self.caller, "sub_agent_context", None)
         workflow_dispatch = method_name in self.agent_dispatch_tools and (
             validated_workflow_depth(context) is not None or has_workflow_context_marker(context)
         )
         ordinary_parallel_dispatch = (
-            method_name in self.agent_dispatch_tools
-            and method_name not in self._legacy_only_extension_dispatch_tools
-            and method_name != "dispatch_browser_agent"
+            method_name in self.agent_dispatch_tools and method_name not in self._legacy_only_extension_dispatch_tools
         )
         return Tool(
             name=method_name,
@@ -2431,10 +2343,10 @@ class ToolCollection(LogMixin):
         if method_name in self.delegation_tools and not self._caller_can_delegate_or_author_workflow():
             return False
 
-        if method_name == "dispatch_custom_agent":
-            catalog = getattr(self.caller, "custom_agent_catalog", None)
-            if getattr(self.caller, "sub_agent", False) or catalog is None or not catalog.has_agents():
-                return False
+        # dispatch_agent only surfaces when it has at least one agent_type to
+        # offer; the per-type gates live in _available_agent_types.
+        if method_name == "dispatch_agent" and not self._available_agent_types():
+            return False
 
         if self.tool_config.allowed_tools is not None and method_name not in self.tool_config.allowed_tools:
             return False
@@ -2472,17 +2384,6 @@ class ToolCollection(LogMixin):
         # tool set.
         if method_name in ("web_search", "web_fetch") and not getattr(self.caller, "client_web_tools_enabled", True):
             return False
-
-        # Vision gate: dispatching the browser agent only works when the model
-        # resolved for the browser-agent role accepts images (it reads page
-        # screenshots). That model may differ from the main one, so gate on it —
-        # not caller.supports_vision — rather than offer a call that can only
-        # fail at dispatch.
-        if method_name == "dispatch_browser_agent":
-            from kolega_code.agent.browseragent import BrowserAgent
-
-            if not BrowserAgent.resolved_model_supports_vision(self.config):
-                return False
 
         # Settings gate: eval can be disabled host-wide (AgentConfig.eval_enabled).
         # Strict `is False` so Mock configs in tests keep the default (enabled).
@@ -2584,10 +2485,8 @@ class ToolCollection(LogMixin):
         dispatch_candidates.difference_update(self.tool_exclusions)
         if self.tool_config.allowed_tools is not None:
             dispatch_candidates.intersection_update(self.tool_config.allowed_tools)
-        if "dispatch_custom_agent" in dispatch_candidates:
-            catalog = getattr(self.caller, "custom_agent_catalog", None)
-            if getattr(self.caller, "sub_agent", False) or catalog is None or not catalog.has_agents():
-                dispatch_candidates.discard("dispatch_custom_agent")
+        if "dispatch_agent" in dispatch_candidates and not self._available_agent_types():
+            dispatch_candidates.discard("dispatch_agent")
         return bool(dispatch_candidates)
 
     async def initialize(self) -> list[str]:

--- a/tests/agent/llm/test_anthropic_token_counting.py
+++ b/tests/agent/llm/test_anthropic_token_counting.py
@@ -116,7 +116,6 @@ def real_tools(tmp_path):
             "log_error",
             "log_info",
             "run_command",
-            "dispatch_coding_agent",
         ],
     )
 

--- a/tests/agent/llm/test_openai_token_counting.py
+++ b/tests/agent/llm/test_openai_token_counting.py
@@ -113,7 +113,6 @@ def real_tools(tmp_path):
             "log_error",
             "log_info",
             "run_command",
-            "dispatch_coding_agent",
         ],
     )
 

--- a/tests/agent/test_agent_tools_inventory.py
+++ b/tests/agent/test_agent_tools_inventory.py
@@ -26,6 +26,12 @@ def assert_internal_tools_not_exposed(tool_names):
     assert INTERNAL_TOOL_NAMES.isdisjoint(tool_names)
 
 
+def dispatch_agent_types(tool_collection):
+    """agent_type enum offered by the collection's dispatch_agent tool."""
+    definition = next(tool for tool in tool_collection.get_tool_list() if tool.name == "dispatch_agent")
+    return definition.input_schema["properties"]["agent_type"]["enum"]
+
+
 @pytest.fixture
 def mock_connection_manager():
     """Create a mock connection manager."""
@@ -235,7 +241,7 @@ def test_non_cli_coder_agent_keeps_manifest_build_tools(project_path, mock_conne
     assert "build_frontend" in tool_names
 
 
-def test_coder_agent_exposes_dispatch_general_agent(project_path, mock_connection_manager, agent_config):
+def test_coder_agent_dispatches_general_but_not_coding_agents(project_path, mock_connection_manager, agent_config):
     """CoderAgent can dispatch general sub-agents but still not coding agents."""
     agent = CoderAgent(
         project_path=project_path,
@@ -249,9 +255,11 @@ def test_coder_agent_exposes_dispatch_general_agent(project_path, mock_connectio
     tool_names = {tool.name for tool in agent.tool_collection.get_tool_list()}
 
     assert_internal_tools_not_exposed(tool_names)
-    assert "dispatch_general_agent" in tool_names
-    assert "dispatch_investigation_agent" in tool_names
-    assert "dispatch_coding_agent" not in tool_names
+    assert "dispatch_agent" in tool_names
+    agent_types = dispatch_agent_types(agent.tool_collection)
+    assert "general" in agent_types
+    assert "investigation" in agent_types
+    assert "coding" not in agent_types
     assert "list_subagent_models" in tool_names
     assert not tool_names.intersection(ToolCollection.browser_tools)
 
@@ -295,17 +303,15 @@ def test_memory_enabled_false_gates_tools_and_prompt_for_top_level_agents(
     assert disabled.build_prompt_context().memory_policy == ""
 
 
-def test_dispatch_browser_agent_gated_on_browser_agent_model_vision(
-    project_path, mock_connection_manager, agent_config
-):
-    """dispatch_browser_agent is offered iff the model *resolved for the browser-agent
+def test_browser_agent_type_gated_on_browser_agent_model_vision(project_path, mock_connection_manager, agent_config):
+    """The "browser" agent_type is offered iff the model *resolved for the browser-agent
     role* is vision-capable — independent of the main coding model."""
     main = agent_config.long_context_config  # claude-sonnet — vision-capable
 
     vision_browser = Mock(provider="anthropic", model="claude-sonnet-4-5-20250929")
     blind_browser = Mock(provider="deepseek", model="deepseek-v4-flash")
 
-    def tools_with_browser_model(browser_model):
+    def agent_types_with_browser_model(browser_model):
         agent_config.model_config_for_agent.side_effect = lambda name: (
             browser_model if name == "browser-agent" else main
         )
@@ -317,16 +323,16 @@ def test_dispatch_browser_agent_gated_on_browser_agent_model_vision(
             config=agent_config,
             agent_mode=AgentMode.CLI,
         )
-        return {tool.name for tool in agent.tool_collection.get_tool_list()}
+        return dispatch_agent_types(agent.tool_collection)
 
     # Vision-capable browser-agent model -> offered even if we later flip the main model.
-    assert "dispatch_browser_agent" in tools_with_browser_model(vision_browser)
+    assert "browser" in agent_types_with_browser_model(vision_browser)
     # Vision-less browser-agent model -> not offered, so the model can't waste a turn on it.
-    assert "dispatch_browser_agent" not in tools_with_browser_model(blind_browser)
+    assert "browser" not in agent_types_with_browser_model(blind_browser)
 
 
 def test_sub_agent_coder_cannot_dispatch_general_agent(project_path, mock_connection_manager, agent_config):
-    """A dispatched CoderAgent must not fan out into further sub-agents."""
+    """A dispatched CoderAgent must not fan out into further general sub-agents."""
     agent = CoderAgent(
         project_path=project_path,
         workspace_id="test_workspace",
@@ -337,9 +343,10 @@ def test_sub_agent_coder_cannot_dispatch_general_agent(project_path, mock_connec
         sub_agent=True,
     )
 
-    tool_names = {tool.name for tool in agent.tool_collection.get_tool_list()}
+    agent_types = dispatch_agent_types(agent.tool_collection)
 
-    assert "dispatch_general_agent" not in tool_names
+    assert "general" not in agent_types
+    assert "investigation" in agent_types
 
 
 def test_general_agent_tool_inventory(project_path, mock_connection_manager, agent_config):

--- a/tests/agent/test_browser_capabilities.py
+++ b/tests/agent/test_browser_capabilities.py
@@ -22,7 +22,7 @@ _EXTENSION_ORIGIN = "chrome-extension://edihigldhbmimflgjkohkgnjefmhngdn/"
 
 def _agent_config() -> AgentConfig:
     # A real vision-capable model: the browser agent requires image support, and
-    # dispatch_browser_agent is now gated on the browser-agent model's vision.
+    # the "browser" agent_type is gated on the browser-agent model's vision.
     model = ModelConfig(
         provider=ModelProvider.ANTHROPIC, model="claude-sonnet-4-5-20250929", rate_limits=RateLimitConfig()
     )
@@ -88,15 +88,17 @@ def test_configured_chrome_target_is_offered_on_browser_dispatch(tmp_path: Path)
         manager = build_browser_manager(tmp_path, "session-1")
         collection = _collection(tmp_path, manager, dispatch=True)
 
-    dispatch = collection.registry().get("dispatch_browser_agent")
+    dispatch = collection.registry().get("dispatch_agent")
     assert dispatch.definition.input_schema is not None
-    assert dispatch.definition.input_schema["required"] == ["task"]
+    assert dispatch.definition.input_schema["required"] == ["agent_type", "task"]
+    assert "browser" in dispatch.definition.input_schema["properties"]["agent_type"]["enum"]
     assert dispatch.definition.input_schema["properties"]["browser_target"]["enum"] == [
         "playwright",
         "chrome",
     ]
-    assert dispatch.parallel_safe is False
-    assert collection.registry().get("dispatch_investigation_agent").parallel_safe is True
+    # Ordinary dispatch stays parallel-safe; concurrent browser dispatches
+    # serialize on the browser manager's agent lock instead.
+    assert dispatch.parallel_safe is True
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_custom_agents.py
+++ b/tests/agent/test_custom_agents.py
@@ -303,13 +303,14 @@ def test_custom_agent_catalog_filters_build_plan_and_all_modes(
         custom_agent_catalog=catalog.for_mode("plan"),
     )
 
-    coder_tool = next(tool for tool in coder.tool_collection.get_tool_list() if tool.name == "dispatch_custom_agent")
-    planning_tool = next(
-        tool for tool in planning.tool_collection.get_tool_list() if tool.name == "dispatch_custom_agent"
-    )
-    assert coder_tool.input_schema["properties"]["agent"]["enum"] == ["reviewer", "shared"]
-    assert planning_tool.input_schema["properties"]["agent"]["enum"] == ["planner", "shared"]
-    assert planning_tool.input_schema["required"] == ["agent", "task"]
+    coder_tool = next(tool for tool in coder.tool_collection.get_tool_list() if tool.name == "dispatch_agent")
+    planning_tool = next(tool for tool in planning.tool_collection.get_tool_list() if tool.name == "dispatch_agent")
+    coder_types = coder_tool.input_schema["properties"]["agent_type"]["enum"]
+    assert [name for name in coder_types if name in {"reviewer", "planner", "shared"}] == ["reviewer", "shared"]
+    # The planning agent only enables the custom dispatch group, so its enum is
+    # exactly the plan-mode catalog.
+    assert planning_tool.input_schema["properties"]["agent_type"]["enum"] == ["planner", "shared"]
+    assert planning_tool.input_schema["required"] == ["agent_type", "task"]
     override_schema = planning_tool.input_schema["properties"]["model_override"]
     assert override_schema["required"] == ["provider", "model", "thinking_effort"]
     assert {"type": "null"} in override_schema["properties"]["thinking_effort"]["anyOf"]
@@ -338,7 +339,7 @@ def test_planning_agent_hides_dispatch_when_no_definition_opts_into_plan(
         custom_agent_catalog=catalog,
     )
 
-    assert "dispatch_custom_agent" not in {tool.name for tool in planning.tool_collection.get_tool_list()}
+    assert "dispatch_agent" not in {tool.name for tool in planning.tool_collection.get_tool_list()}
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_gigacode_gating.py
+++ b/tests/agent/test_gigacode_gating.py
@@ -126,11 +126,14 @@ def test_workflow_coder_at_depth_one_can_use_existing_dispatch_tools_when_max_is
 
     names = {tool.name for tool in agent.tool_collection.get_tool_list()}
 
-    assert "dispatch_investigation_agent" in names
-    assert "dispatch_browser_agent" in names
-    assert agent.tool_collection.registry().get("dispatch_investigation_agent").parallel_safe is False
+    assert "dispatch_agent" in names
+    dispatch = agent.tool_collection.registry().get("dispatch_agent")
+    agent_types = dispatch.definition.input_schema["properties"]["agent_type"]["enum"]
+    assert "investigation" in agent_types
+    assert "browser" in agent_types
+    assert dispatch.parallel_safe is False
     # The depth policy cannot add capabilities excluded by the CoderAgent itself.
-    assert "dispatch_general_agent" not in names
+    assert "general" not in agent_types
     assert "run_workflow" not in names
 
 

--- a/tests/agent/test_parallel_tool_calls.py
+++ b/tests/agent/test_parallel_tool_calls.py
@@ -167,11 +167,11 @@ class TestParallelToolCalls:
 
             def get_tool_list(self) -> list[SimpleNamespace]:
                 return [
-                    SimpleNamespace(name="dispatch_general_agent"),
+                    SimpleNamespace(name="dispatch_agent"),
                     SimpleNamespace(name="read"),
                 ]
 
-            async def dispatch_general_agent(self, task: str) -> str:
+            async def dispatch_agent(self, task: str) -> str:
                 await tracker.run()
                 return task
 
@@ -181,9 +181,9 @@ class TestParallelToolCalls:
 
         base_agent.tool_collection = cast(Any, Tools())
         blocks = [
-            make_tool_call("dispatch_general_agent", 0),
+            make_tool_call("dispatch_agent", 0),
             make_tool_call("read", 1),
-            make_tool_call("dispatch_general_agent", 2),
+            make_tool_call("dispatch_agent", 2),
         ]
 
         results = await base_agent.process_tool_calls(blocks)
@@ -201,9 +201,9 @@ class TestParallelToolCalls:
                 self.calls = 0
 
             def get_tool_list(self):
-                return [SimpleNamespace(name="dispatch_general_agent")]
+                return [SimpleNamespace(name="dispatch_agent")]
 
-            async def dispatch_general_agent(self, task: str):
+            async def dispatch_agent(self, task: str):
                 if "task 0" in task:
                     first_started.set()
                     # Deadlocks unless the second call runs concurrently
@@ -214,12 +214,12 @@ class TestParallelToolCalls:
                 return "second done"
 
         base_agent.tool_collection = Tools()
-        blocks = [make_tool_call("dispatch_general_agent", i) for i in range(2)]
+        blocks = [make_tool_call("dispatch_agent", i) for i in range(2)]
 
         results = await asyncio.wait_for(base_agent.process_tool_calls(blocks), timeout=5)
 
         assert [r.content for r in results] == ["first done", "second done"]
-        assert [r.tool_use_id for r in results] == ["dispatch_general_agent_0", "dispatch_general_agent_1"]
+        assert [r.tool_use_id for r in results] == ["dispatch_agent_0", "dispatch_agent_1"]
         assert not any(r.is_error for r in results)
 
     @pytest.mark.asyncio
@@ -229,11 +229,11 @@ class TestParallelToolCalls:
         class Tools(FakeToolCollection):
             def get_tool_list(self):
                 return [
-                    SimpleNamespace(name="dispatch_general_agent"),
+                    SimpleNamespace(name="dispatch_agent"),
                     SimpleNamespace(name="read"),
                 ]
 
-            async def dispatch_general_agent(self, task: str):
+            async def dispatch_agent(self, task: str):
                 await tracker.run()
                 return "dispatched"
 
@@ -244,7 +244,7 @@ class TestParallelToolCalls:
         base_agent.tool_collection = Tools()
         blocks = [
             make_tool_call("read", 0),
-            make_tool_call("dispatch_general_agent", 1),
+            make_tool_call("dispatch_agent", 1),
             make_tool_call("read", 2),
         ]
 
@@ -260,11 +260,11 @@ class TestParallelToolCalls:
         class Tools(FakeToolCollection):
             def get_tool_list(self):
                 return [
-                    SimpleNamespace(name="dispatch_general_agent"),
+                    SimpleNamespace(name="dispatch_agent"),
                     SimpleNamespace(name="write"),
                 ]
 
-            async def dispatch_general_agent(self, task: str):
+            async def dispatch_agent(self, task: str):
                 await tracker.run()
                 return "dispatched"
 
@@ -274,7 +274,7 @@ class TestParallelToolCalls:
 
         base_agent.tool_collection = Tools()
         blocks = [
-            make_tool_call("dispatch_general_agent", 0),
+            make_tool_call("dispatch_agent", 0),
             make_tool_call("write", 1),
         ]
 
@@ -290,14 +290,14 @@ class TestParallelToolCalls:
 
         class Tools(FakeToolCollection):
             def get_tool_list(self):
-                return [SimpleNamespace(name="dispatch_general_agent")]
+                return [SimpleNamespace(name="dispatch_agent")]
 
-            async def dispatch_general_agent(self, task: str):
+            async def dispatch_agent(self, task: str):
                 await tracker.run()
                 return "done"
 
         base_agent.tool_collection = Tools()
-        blocks = [make_tool_call("dispatch_general_agent", i) for i in range(total)]
+        blocks = [make_tool_call("dispatch_agent", i) for i in range(total)]
 
         results = await base_agent.process_tool_calls(blocks)
 
@@ -311,23 +311,23 @@ class TestParallelToolCalls:
 
         class Tools(FakeToolCollection):
             def get_tool_list(self):
-                return [SimpleNamespace(name="dispatch_general_agent")]
+                return [SimpleNamespace(name="dispatch_agent")]
 
-            async def dispatch_general_agent(self, task: str):
+            async def dispatch_agent(self, task: str):
                 # Yield so concurrent executions interleave before reading the ID
                 await asyncio.sleep(0.01)
                 captured[task] = base_agent.current_tool_execution_id
                 return "done"
 
         base_agent.tool_collection = Tools()
-        blocks = [make_tool_call("dispatch_general_agent", i) for i in range(3)]
+        blocks = [make_tool_call("dispatch_agent", i) for i in range(3)]
 
         await base_agent.process_tool_calls(blocks)
 
         assert captured == {
-            "task 0": "exec_dispatch_general_agent_0",
-            "task 1": "exec_dispatch_general_agent_1",
-            "task 2": "exec_dispatch_general_agent_2",
+            "task 0": "exec_dispatch_agent_0",
+            "task 1": "exec_dispatch_agent_1",
+            "task 2": "exec_dispatch_agent_2",
         }
         assert base_agent.current_tool_call_id is None
         assert base_agent.current_tool_execution_id is None
@@ -359,9 +359,9 @@ class TestParallelToolCalls:
 
         class ParentTools(FakeToolCollection):
             def get_tool_list(self):
-                return [SimpleNamespace(name="dispatch_general_agent")]
+                return [SimpleNamespace(name="dispatch_agent")]
 
-            async def dispatch_general_agent(self, task: str):
+            async def dispatch_agent(self, task: str):
                 # Simulate a sub-agent running its own tool within the same asyncio task
                 await nested_agent.execute_single_tool(make_tool_call("read", 99))
                 observed["parent_id"] = base_agent.current_tool_execution_id
@@ -369,6 +369,6 @@ class TestParallelToolCalls:
 
         base_agent.tool_collection = ParentTools()
 
-        await base_agent.process_tool_calls([make_tool_call("dispatch_general_agent", 0)])
+        await base_agent.process_tool_calls([make_tool_call("dispatch_agent", 0)])
 
-        assert observed["parent_id"] == "exec_dispatch_general_agent_0"
+        assert observed["parent_id"] == "exec_dispatch_agent_0"

--- a/tests/agent/test_prompt_provider.py
+++ b/tests/agent/test_prompt_provider.py
@@ -172,7 +172,7 @@ class TestPromptProvider:
 
         assert "memory bank" not in prompt_lower
         assert "kolega-memory-bank" not in prompt
-        assert "dispatch_investigation_agent" not in prompt
+        assert "dispatch_" not in prompt
         assert "Test Task Detection" not in prompt
         assert "Scope Boundary Management" not in prompt
 

--- a/tests/agent/test_tool_collection_config.py
+++ b/tests/agent/test_tool_collection_config.py
@@ -276,33 +276,51 @@ class TestToolCollection:
         # Should exclude explicitly excluded tools
         assert "web_search" not in tool_names
 
-        # Should include investigation tools
-        assert "dispatch_investigation_agent" in tool_names
-        assert "dispatch_browser_agent" in tool_names
+        # Should include the dispatch tool with the full built-in agent_type enum
+        assert "dispatch_agent" in tool_names
         assert "list_subagent_models" in tool_names
 
-        dispatch_names = [
-            "dispatch_investigation_agent",
-            "dispatch_browser_agent",
-            "dispatch_coding_agent",
-            "dispatch_general_agent",
-        ]
         definitions = {tool.name: tool for tool in tool_list}
-        for name in dispatch_names:
-            schema = definitions[name].input_schema
-            assert schema is not None
-            assert schema["required"] == ["task"]
-            override = schema["properties"]["model_override"]
-            assert override["required"] == ["provider", "model", "thinking_effort"]
-            assert override["additionalProperties"] is False
-            assert override["properties"]["provider"]["minLength"] == 1
-            assert override["properties"]["model"]["minLength"] == 1
-            effort_options = override["properties"]["thinking_effort"]["anyOf"]
-            assert {"type": "string", "minLength": 1} in effort_options
-            assert {"type": "null"} in effort_options
+        schema = definitions["dispatch_agent"].input_schema
+        assert schema is not None
+        assert schema["required"] == ["agent_type", "task"]
+        assert schema["properties"]["agent_type"]["enum"] == ["general", "investigation", "browser", "coding"]
+        override = schema["properties"]["model_override"]
+        assert override["required"] == ["provider", "model", "thinking_effort"]
+        assert override["additionalProperties"] is False
+        assert override["properties"]["provider"]["minLength"] == 1
+        assert override["properties"]["model"]["minLength"] == 1
+        effort_options = override["properties"]["thinking_effort"]["anyOf"]
+        assert {"type": "string", "minLength": 1} in effort_options
+        assert {"type": "null"} in effort_options
 
         discovery = tool_collection.registry().get("list_subagent_models")
         assert discovery.parallel_safe is True
+
+    async def test_dispatch_agent_rejects_unavailable_agent_type(
+        self,
+        project_path: Path,
+        mock_connection_manager: AgentConnectionManager,
+        agent_config: AgentConfig,
+        mock_base_agent: BaseAgent,
+    ) -> None:
+        """An unknown or gated-off agent_type fails with the valid values listed."""
+        config = ToolCollectionConfig(include_agent_dispatch_tools=True, excluded_agent_types=["coding"])
+        tool_collection = ToolCollection(
+            project_path,
+            "test_workspace",
+            str(uuid.uuid4()),
+            mock_connection_manager,
+            agent_config,
+            mock_base_agent,
+            tool_config=config,
+        )
+
+        for agent_type in ("nonexistent", "coding"):
+            with pytest.raises(ValueError) as exc_info:
+                await tool_collection.dispatch_agent(agent_type, "do something")
+            assert agent_type in str(exc_info.value)
+            assert "general, investigation, browser" in str(exc_info.value)
 
     async def test_workflow_depth_gate_cannot_be_bypassed_by_dispatch_extension_group(
         self,


### PR DESCRIPTION
## Summary

Replaces the five per-type dispatch tools (`dispatch_general_agent`, `dispatch_investigation_agent`, `dispatch_browser_agent`, `dispatch_coding_agent`, `dispatch_custom_agent`) with a single **`dispatch_agent(agent_type, task, model_override?, browser_target?)`** tool.

- **`agent_type` enum computed at registration** from the same conditions that previously gated whole tools, via the new `_available_agent_types()`:
  - `general` / `investigation` whenever a dispatch-enabled group is active
  - `browser` only when the model resolved for the browser-agent role supports vision
  - `coding` only via the `include_agent_dispatch_tools` host flag — the coder's group mapping omits it, so the coder still can't dispatch itself (the redundant `tool_exclusions` entry is gone)
  - custom agent names join the enum when the catalog is non-empty (never for sub-agents); the tool drops out entirely when the enum would be empty (e.g. planning agent with no custom agents)
- **Recursion guards preserved**: a dispatched coder drops `general` via the new `ToolCollectionConfig(excluded_agent_types=...)`; general/custom sub-agents still exclude the dispatch group wholesale.
- **Schema carried over unchanged**: nested `model_override` (provider/model/thinking_effort, all required when present, nullable effort); `browser_target` appears only when more than one browser backend is configured, snapshotted at construction as before.
- **Description**: shared dispatch mechanics once, then one accurate line per available type — investigation's line now states its terminal/eval access (the old docstring omitted it) — plus the `list_subagent_models` pointer. 2,105 chars vs 3,799 for the old general+investigation pair alone.
- **Errors**: an unknown or currently-unavailable `agent_type` returns a clear error listing the valid values.
- **Internal machinery untouched**: the handler switches on `agent_type` into the existing `AgentTool` backend methods; per-type agent classes, `sub_agent_info` event routing, and propagation rules are unchanged.
- Sweep: docs (`concepts/tools.md`, `concepts/agents.md`, `custom-agents.mdx`), CHANGELOG, and the inventory/dispatch/config/browser/gigacode/parallel-call/prompt tests; `_AGENT_DISPATCH_INPUT_SCHEMAS` removed.

## Intentional deltas

- `dispatch_agent` is parallel-safe even when dispatching a browser agent; concurrent browser dispatches serialize on the backend's `browser_manager_agent_lock` instead of forcing the whole batch sequential.
- A custom agent named exactly like a built-in type (`general`, `investigation`, `browser`, `coding`) is kept out of the enum, since built-in names win in routing.

## Verification

- Full fast suite: **4219 passed, 1 skipped** (env-gated browserless test, same as main).
- Render harness diffed main vs. this branch across nine agent shapes (coder CLI / sub-agent / with custom agents, planning ± catalog, general, investigation, browser, host-flag collection): all six system prompts and every non-dispatch tool definition **byte-identical**; the only delta is the dispatch fold. Per-shape enums: coder `[general, investigation, browser]`, sub-agent coder `[investigation, browser]`, host-flag `[general, investigation, browser, coding]`, planning `[<custom names>]`.
- Old-session restore is name-agnostic (recording/projection key on `sub_agent_info`, history loads verbatim); the player-rendering test replaying a recorded `dispatch_investigation_agent` call passes unchanged — no shims.
- New test pins the error path: `test_dispatch_agent_rejects_unavailable_agent_type`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Etcq5v5zrziHYQwWqdR21r