### PR TITLE
perf(agent): drop duplicated Args docs from wire tool definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ### Changed
 
+- Tool definitions sent to model providers no longer duplicate parameter
+  documentation. Every tool docstring's `Args:` section is still parsed into
+  per-parameter schema descriptions, but the wire description no longer also
+  carries the whole section verbatim (and the schema descriptions no longer
+  include the raw docstring continuation-line indentation). Tools whose
+  parameters are not fully documented in their schema — freeform tools and
+  tools with enum-only schema properties such as the browser tools' `button`,
+  `action`, `level`, `part`, `image_type`, and `scale` — keep their `Args:`
+  block, since it is the only place those parameters are documented.
+
 - The per-type agent dispatch tools (`dispatch_general_agent`,
   `dispatch_investigation_agent`, `dispatch_browser_agent`,
   `dispatch_coding_agent`, and `dispatch_custom_agent`) are consolidated into a

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -7,7 +7,7 @@ from .common import LogMixin
 from kolega_code.config import AgentConfig, EditProtocol
 from kolega_code.llm.models import ImageBlock, ToolDefinition
 from kolega_code.memory import ProjectMemoryManager
-from kolega_code.tools import Tool, ToolRegistry, tool_definition_from_callable
+from kolega_code.tools import Tool, ToolRegistry, schema_has_property_descriptions, tool_definition_from_callable
 from kolega_code.services.file_system import FileSystem, LocalFileSystem
 from kolega_code.services.base import TerminalManager, BrowserManager
 from kolega_code.services.terminal import LocalTerminalManager
@@ -2078,8 +2078,24 @@ class ToolCollection(LogMixin):
         return self.terminal_manager.sandbox.get_host(port)  # pyright: ignore[reportAttributeAccessIssue]
 
     def _tool_definition_from_callable(self, method_name: str, method: Callable[..., Any]) -> ToolDefinition:
-        """Build a provider-agnostic tool definition from a Python callable."""
-        definition = tool_definition_from_callable(method_name, method)
+        """Build a provider-agnostic tool definition from a Python callable.
+
+        The wire description drops the docstring's ``Args:`` block because the
+        per-parameter schema carries the same text (``tool_definition_from_callable``
+        strips it unless asked to keep it). Two shapes keep the block: freeform
+        bindings, whose schema is a fallback ``input`` envelope rather than the
+        real parameters, and tools with an explicit input schema that does not
+        describe every property — in both cases the ``Args:`` block is the only
+        place their parameters are documented on the wire.
+        """
+        explicit_schema = self.extension_schemas.get(method_name)
+        freeform = method_name == "apply_patch"
+        definition = tool_definition_from_callable(
+            method_name,
+            method,
+            keep_args_in_description=freeform
+            or (explicit_schema is not None and not schema_has_property_descriptions(explicit_schema)),
+        )
         if method_name == "apply_patch":
             definition.description = (
                 "Use the `apply_patch` tool to edit files. This is a FREEFORM tool, so do not wrap the patch in JSON. "

--- a/kolega_code/tools/__init__.py
+++ b/kolega_code/tools/__init__.py
@@ -13,6 +13,7 @@ from .core import Tool, ToolError
 from .definitions import (
     ASK_USER_CHOICE_INPUT_SCHEMA,
     ASK_USER_CHOICE_SHAPE_HINT,
+    schema_has_property_descriptions,
     tool_definition_from_callable,
 )
 from .registry import ToolPolicy, ToolRegistry
@@ -24,5 +25,6 @@ __all__ = [
     "ToolError",
     "ToolPolicy",
     "ToolRegistry",
+    "schema_has_property_descriptions",
     "tool_definition_from_callable",
 ]

--- a/kolega_code/tools/definitions.py
+++ b/kolega_code/tools/definitions.py
@@ -3,6 +3,13 @@
 The callable's signature supplies the parameter schema and its docstring
 supplies the descriptions, so the code documenting a tool for developers is
 also what the model sees.
+
+The docstring's ``Args:`` section is parsed into per-parameter schema
+descriptions and is also removed from the wire description: keeping it would
+document every parameter twice in the API payload. Source docstrings are
+untouched; the deduplication happens here, where the ToolDefinition is built,
+so every provider serialization (to_anthropic/to_openai/to_google) inherits
+it.
 """
 
 import inspect
@@ -11,12 +18,54 @@ from typing import Any, Callable, Dict, Optional
 
 from ..llm.models import ToolDefinition, ToolParameter
 
+# A docstring ``Args:`` section: the header at column 0 (inspect.getdoc
+# dedents) through the next column-0 section line or the end of the text.
+# Parameter entries and continuation lines are indented, so any column-0 line
+# after ``Args:`` starts a new section (``Returns:``, ``Yields:``, ...).
+_ARGS_BLOCK_RE = re.compile(r"^Args:.*?(?=\n[^\s]|\Z)", re.DOTALL | re.MULTILINE)
+
+
+def strip_args_section(description: str) -> str:
+    """Remove the docstring ``Args:`` block from a wire description.
+
+    Everything before the block is kept verbatim, and any section after it
+    (``Returns:`` and friends) is kept with its natural separation. Text with
+    no ``Args:`` block is returned unchanged.
+    """
+    match = _ARGS_BLOCK_RE.search(description)
+    if match is None:
+        return description
+    start, end = match.span()
+    before = description[:start]
+    after = description[end:]
+    if not after.strip():
+        return before.rstrip()
+    return f"{before.rstrip()}\n\n{after.lstrip()}".strip()
+
+
+def schema_has_property_descriptions(schema: Dict[str, Any]) -> bool:
+    """Whether an explicit input schema documents every one of its properties.
+
+    Only top-level properties are checked: the docstring ``Args:`` block
+    documents the callable's parameters, which map one-to-one onto the
+    schema's top-level properties. If any property lacks a description, that
+    parameter's only documentation is the ``Args:`` block, so it must stay in
+    the description.
+    """
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        return True
+    return all(
+        isinstance(value, dict) and bool(str(value.get("description", "")).strip()) for value in properties.values()
+    )
+
 
 def tool_definition_from_callable(
     name: str,
     method: Callable[..., Any],
     *,
     description_overrides: Optional[Dict[str, str]] = None,
+    keep_args_in_description: bool = False,
 ) -> ToolDefinition:
     """Build a provider-agnostic tool definition from a Python callable."""
     signature = inspect.signature(method)
@@ -26,6 +75,8 @@ def tool_definition_from_callable(
 
     if description_overrides and name in description_overrides:
         description = description_overrides[name]
+    elif not keep_args_in_description:
+        description = strip_args_section(description)
 
     properties = {}
     required = []
@@ -42,7 +93,9 @@ def tool_definition_from_callable(
 
         param_doc_match = re.search(rf"{param_name}:\s*(.*?)(?:\n\s*\w+:|$)", docstring, re.DOTALL)
         if param_doc_match:
-            param_description = param_doc_match.group(1).strip()
+            # Collapse the whitespace runs that docstring continuation-line
+            # indentation leaves inside the captured description.
+            param_description = re.sub(r"\s+", " ", param_doc_match.group(1)).strip()
 
         if param.annotation != inspect.Parameter.empty:
             annotation = str(param.annotation)

--- a/tests/agent/test_agent_tools_inventory.py
+++ b/tests/agent/test_agent_tools_inventory.py
@@ -733,3 +733,53 @@ def test_get_host_present_with_sandbox_terminal_manager(project_path, mock_conne
     # The registered tool resolves the host from the sandbox, not localhost.
     host = asyncio.run(agent.tool_collection.call("get_host", port=8000))
     assert host == "stub-sandbox:8000"
+
+
+def test_wire_descriptions_document_parameters_only_in_schema(project_path, mock_connection_manager, agent_config):
+    """CLI coder definitions never carry the docstring Args block twice.
+
+    Every introspection-built definition documents its parameters in the
+    per-parameter schema; the wire description strips the parsed Args section,
+    so no description repeats it. Tools whose explicit schema leaves a property
+    undocumented (enum-only, e.g. browser button) keep their Args block — that
+    is the only place those parameters are documented.
+    """
+    agent = _coder(project_path, mock_connection_manager, agent_config)
+    definitions = {definition.name: definition for definition in agent.tool_collection.get_tool_list()}
+    assert "exec_command" in definitions
+
+    for name, definition in definitions.items():
+        assert not any(line.strip() == "Args:" for line in definition.description.splitlines()), name
+
+    # The same parameters are fully documented in the flat introspection schema.
+    schema = definitions["exec_command"].to_anthropic()["input_schema"]
+    assert schema["properties"]["command"]["description"]
+    assert schema["properties"]["yield_time_ms"]["description"]
+
+    # dispatch_agent's explicit schema describes every property, so its Args
+    # block is stripped too (the type catalog stays).
+    dispatch = definitions["dispatch_agent"]
+    assert not any(line.strip() == "Args:" for line in dispatch.description.splitlines())
+    assert "Available agent_type values:" in dispatch.description
+
+
+def test_browser_schema_without_property_descriptions_keeps_args_block(
+    project_path, mock_connection_manager, agent_config
+):
+    """Enum-only schema properties keep the Args block as their documentation."""
+    agent = BrowserAgent(
+        project_path=project_path,
+        workspace_id="test_workspace",
+        thread_id=str(uuid.uuid4()),
+        connection_manager=mock_connection_manager,
+        config=agent_config,
+    )
+    assert agent.tool_collection is not None
+    definitions = {definition.name: definition for definition in agent.tool_collection.get_tool_list()}
+
+    # browser_click's `button` and `modifiers` are enum/items-only in the
+    # schema, so its Args block must survive; browser_navigate documents every
+    # property and strips it.
+    assert any(line.strip() == "Args:" for line in definitions["browser_click"].description.splitlines())
+    assert "Mouse button: left, right, or middle." in definitions["browser_click"].description
+    assert not any(line.strip() == "Args:" for line in definitions["browser_navigate"].description.splitlines())

--- a/tests/tools/test_definitions.py
+++ b/tests/tools/test_definitions.py
@@ -236,3 +236,125 @@ def test_flat_definition_still_serializes_without_input_schema():
     assert google_params.type == genai_types.Type.OBJECT
     assert google_params.properties is not None
     assert set(google_params.properties) == {"query", "limit"}
+
+
+def test_wire_description_strips_args_block_keeps_preamble_and_returns():
+    """The parsed Args block is documented only in the schema, not the description."""
+
+    async def sample(query: str, limit: int) -> str:
+        """Do a thing.
+
+        Preamble prose that must survive.
+
+        Args:
+            query: The search text.
+            limit: Max results.
+
+        Returns:
+            A summary of results.
+        """
+        return ""
+
+    definition = tool_definition_from_callable("sample", sample)
+    description = definition.description
+    assert "Do a thing." in description
+    assert "Preamble prose that must survive." in description
+    assert "Returns:\n    A summary of results." in description
+    assert "Args:" not in description
+    assert "The search text." not in description
+    assert "Max results." not in description
+
+    # The parameters are documented in the schema instead.
+    schema = definition.to_anthropic()["input_schema"]
+    assert schema["properties"]["query"]["description"] == "The search text."
+    assert schema["properties"]["limit"]["description"] == "Max results."
+
+
+def test_keep_args_in_description_preserves_args_block():
+    """Freeform-style tools whose schema is a fallback envelope keep the block."""
+
+    async def sample(query: str) -> str:
+        """Do a thing.
+
+        Args:
+            query: The search text.
+
+        Returns:
+            A summary.
+        """
+        return ""
+
+    definition = tool_definition_from_callable("sample", sample, keep_args_in_description=True)
+    assert "Args:" in definition.description
+    assert "The search text." in definition.description
+    assert "Returns:\n    A summary." in definition.description
+
+
+def test_parameter_descriptions_collapse_continuation_indentation():
+    """Schema descriptions collapse docstring continuation-line whitespace."""
+
+    async def sample(query: str, timeout: int) -> str:
+        """Do a thing.
+
+        Args:
+            query: The search text that continues
+                   onto a deeply indented line.
+            timeout: Seconds to wait.
+        """
+        return ""
+
+    definition = tool_definition_from_callable("sample", sample)
+    query = next(parameter for parameter in definition.parameters if parameter.name == "query")
+    assert query.description == "The search text that continues onto a deeply indented line."
+    timeout = next(parameter for parameter in definition.parameters if parameter.name == "timeout")
+    assert timeout.description == "Seconds to wait."
+
+
+def test_raises_section_still_split_before_args_strip():
+    """The Raises split keeps its precedence over the Args-block strip."""
+
+    async def sample(query: str) -> str:
+        """Do a thing.
+
+        Args:
+            query: The search text.
+
+        Returns:
+            A summary.
+
+        Raises:
+            ValueError: When the query is empty.
+        """
+        return ""
+
+    definition = tool_definition_from_callable("sample", sample)
+    assert "Raises:" not in definition.description
+    assert "ValueError: When the query is empty." not in definition.description
+    assert "Args:" not in definition.description
+    assert "A summary." in definition.description
+
+
+def test_strip_args_section_edges():
+    from kolega_code.tools.definitions import strip_args_section
+
+    assert strip_args_section("No args here.") == "No args here."
+    assert strip_args_section("Preamble.\n\nArgs:\n    a: one\n") == "Preamble."
+    assert strip_args_section("Args:\n    a: one\n") == ""
+    assert strip_args_section("Preamble.\n\nArgs:\n    a: one\n\nReturns:\n    done.\n") == (
+        "Preamble.\n\nReturns:\n    done."
+    )
+
+
+def test_schema_has_property_descriptions():
+    from kolega_code.tools.definitions import schema_has_property_descriptions
+
+    described = {"type": "object", "properties": {"a": {"type": "string", "description": "x"}}}
+    assert schema_has_property_descriptions(described) is True
+    # An enum-only property has no description: the Args block stays.
+    enum_only = {"type": "object", "properties": {"a": {"type": "string", "enum": ["x", "y"]}}}
+    assert schema_has_property_descriptions(enum_only) is False
+    # No properties: nothing to document.
+    assert schema_has_property_descriptions({"type": "object", "properties": {}}) is True
+    assert schema_has_property_descriptions({"type": "object"}) is True
+    # Non-dict property values count as undocumented.
+    assert schema_has_property_descriptions({"type": "object", "properties": {"a": True}}) is False


### PR DESCRIPTION
## What

Tool definitions sent to model providers were double-documenting every parameter: `tool_definition_from_callable` parses a docstring's `Args:` section into per-parameter schema descriptions **and** left the whole block verbatim in the wire description (with raw continuation-line indentation in the schema copies). Other harnesses document parameters only in the schema.

- `tool_definition_from_callable` now strips the parsed `Args:` block from the description at definition-build time — everything before it and any `Returns:` section are kept, and the `Raises:` split keeps its existing precedence. Source docstrings are untouched, and all provider serializations (`to_anthropic`/`to_openai`/`to_google`) inherit the result.
- Extracted per-parameter schema descriptions collapse continuation-line whitespace runs into single spaces.
- One shared implementation covers every callable-built path: core tools, edit-protocol bindings, and `ToolExtension` tools (skill, TUI task list, `set_goal`, `switch_worktree`, `ask_user_choice`, MCP).

## Guards

- Freeform bindings (`apply_patch`) keep their `Args:` block — their schema is a fallback `input` envelope, not the real parameters.
- Tools with explicit `input_schema` dicts strip the block only when the schema describes every top-level property. Verified per schema: `dispatch_agent`, `lsp`, `lsp_edit`, `snapshot`, `resolve`, hashline `edit`, `run_workflow`, `ask_user_choice` all qualify. Five browser tools (`browser_click`, `browser_tabs`, `browser_console_messages`, `browser_network_request`, `browser_take_screenshot`) have enum-only properties (`button`, `action`, `level`, `part`, `image_type`, `scale`) and deliberately keep their `Args:` block — it is the only documentation those parameters have.

## Verification

- Full fast suite: 4,227 passed, 1 skipped, 0 failed; pre-commit CI parity (ruff, format, pyright, hooks) green.
- Rendered the complete tool-definition payload before/after (CoderAgent / CLI / claude_code protocol / sandbox / LSP-on): 10,244 → 9,003 cl100k tokens (−1,241). A strict per-field diff shows every change is exactly an `Args:`-block removal (19 tools) or a whitespace collapse (4 tools); nothing else differs, and no tool loses information its schema doesn't carry.
- New tests: `tests/tools/test_definitions.py` (strip/keep/whitespace/Raises-precedence/helper edges) and `tests/agent/test_agent_tools_inventory.py` (CLI coder wire descriptions carry no `Args:` block; browser tools keep theirs where the schema is enum-only).