### PR TITLE
feat(tools): accept write(path=) under claude_code via signature-aware aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,13 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   `path` is accepted at the dispatch boundary as an alias for the canonical
   `file_path`.
 
+- `write(path=…)` now also succeeds under the claude_code edit protocol, where
+  `write` binds to `claude_write(file_path, content)`: `path` is accepted at
+  the dispatch boundary as an alias for `file_path`, matching every other file
+  tool. Under the search/replace protocol `path` stays the canonical
+  parameter and passes through untouched — alias resolution is signature-aware
+  and never rewrites an argument name the bound tool itself accepts.
+
 - A successful whole-file `write` (including `hashline_write` and `apply_patch`'s
   Add File) now records the just-written contents as read, so the read-before-edit
   guard accepts a subsequent edit without a fresh read — exactly as it would

--- a/kolega_code/tools/core.py
+++ b/kolega_code/tools/core.py
@@ -36,6 +36,20 @@ class Tool:
     # Debug-level log_message sink for param-alias hits, so trajectory mining
     # sees which aliases fire. None falls back to stdlib logging.
     log_debug: Optional[Callable[[str], Awaitable[None]]] = None
+    # Parameter names the bound handler accepts, computed once at construction
+    # via ``inspect``. Alias resolution treats a registered alias as real only
+    # when the binding does NOT accept the name: a name the handler itself
+    # accepts is a legitimate argument for this binding, never a misspelling.
+    accepted_params: FrozenSet[str] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        try:
+            parameters = inspect.signature(self.handler).parameters
+        except (TypeError, ValueError):
+            accepted: FrozenSet[str] = frozenset()
+        else:
+            accepted = frozenset(parameters)
+        object.__setattr__(self, "accepted_params", accepted)
 
     async def call(self, **inputs: Any) -> Any:
         inputs = await self._resolve_param_aliases(inputs)
@@ -48,7 +62,7 @@ class Tool:
         Runs before ``_reject_malformed_call`` so a registered alias can never
         surface as an invalid-arguments error (or a raw ``TypeError``).
         """
-        resolved, hits = resolve_param_aliases(self.name, inputs)
+        resolved, hits = resolve_param_aliases(self.name, inputs, accepted_params=self.accepted_params)
         for hit in hits:
             message = f"Param alias on `{hit.tool}`: `{hit.alias}` {hit.action}"
             if self.log_debug is not None:

--- a/kolega_code/tools/param_aliases.py
+++ b/kolega_code/tools/param_aliases.py
@@ -10,13 +10,22 @@ maps the known aliases onto the canonical parameter at the dispatch choke point
 Measured basis: findings/tool-arg-cross-contamination-friction.md (~100
 rejections across ~820 benchmark trials; per-alias counts on each entry).
 
+Resolution is signature-aware: an argument name is only treated as an alias
+when the bound callable does NOT itself accept that name. ``Tool`` computes
+the accepted parameter names once at construction (via ``inspect``), and
+``resolve_param_aliases`` skips any registered alias the binding accepts — a
+name the tool itself accepts is a real parameter there, never a misspelling.
+This lets one entry serve a tool name bound to different callables per edit
+protocol (``write``: ``path`` is canonical under search_replace and an alias
+under claude_code) without ever rewriting a legitimate call.
+
 Adding an alias requires exactly one entry here plus one case row in
 tests/agent/test_param_aliases.py. Unregistered unknown parameters still
 error exactly as before.
 """
 
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
+from typing import Any, Callable, Dict, FrozenSet, List, Mapping, Optional, Tuple
 
 # Sentinel a transform may return when the value is unusable: the alias is then
 # dropped instead of erroring, because an alias hit must never fail the call.
@@ -88,6 +97,18 @@ PARAM_ALIASES: Dict[str, Dict[str, ParamAlias]] = {
     "read": {
         "path": ParamAlias("file_path"),
     },
+    # The tool NAME ``write`` binds to different callables per edit protocol:
+    # under claude_code it is claude_write(file_path, content) — where the
+    # misses happened — and under search_replace it is write(path, content),
+    # where ``path`` is the CANONICAL parameter. Seen 15×: models borrowed
+    # ``path`` from every sibling file tool (edit, lsp, snapshot, …); record:
+    # findings/harness-tool-surface-census.md ("still open" item). The
+    # signature guard above skips an alias on any binding that itself accepts
+    # the name, so this entry is a rename under claude_code and a no-op under
+    # search_replace.
+    "write": {
+        "path": ParamAlias("file_path"),
+    },
     # ``search_codebase`` (path=…, max_results=…) and ``find_files_by_pattern``
     # (path→pattern) aliases were removed with the file-discovery tools
     # themselves — both were merged into ``glob`` and then deleted in favor of
@@ -95,8 +116,21 @@ PARAM_ALIASES: Dict[str, Dict[str, ParamAlias]] = {
 }
 
 
-def resolve_param_aliases(tool_name: str, inputs: Mapping[str, Any]) -> Tuple[Dict[str, Any], List[AliasHit]]:
+def resolve_param_aliases(
+    tool_name: str,
+    inputs: Mapping[str, Any],
+    *,
+    accepted_params: FrozenSet[str],
+) -> Tuple[Dict[str, Any], List[AliasHit]]:
     """Map registered wrong-name arguments for ``tool_name`` onto canonical ones.
+
+    ``accepted_params`` is the set of parameter names the bound callable
+    accepts (computed once per Tool at construction, via ``inspect``). An
+    argument name is only treated as an alias when the binding does NOT itself
+    accept that name: a registered alias the binding accepts is a real
+    parameter there, so it passes through untouched — this is what lets a
+    single entry serve a tool name bound to different callables per edit
+    protocol without ever rewriting a legitimate call.
 
     Returns the resolved inputs plus one ``AliasHit`` per alias consumed. When
     both an alias and its canonical parameter are present, the canonical value
@@ -111,6 +145,11 @@ def resolve_param_aliases(tool_name: str, inputs: Mapping[str, Any]) -> Tuple[Di
     for name, value in inputs.items():
         alias = aliases.get(name)
         if alias is None:
+            resolved[name] = value
+            continue
+        if name in accepted_params:
+            # The binding itself accepts this name — it is a real parameter
+            # here, not a wrong-name spelling. Pass through untouched.
             resolved[name] = value
             continue
         if alias.canonical is None:

--- a/tests/agent/test_edit_protocol_tools.py
+++ b/tests/agent/test_edit_protocol_tools.py
@@ -5,7 +5,7 @@ import pytest
 
 from kolega_code.agent.tools import ToolCollection, ToolCollectionConfig
 from kolega_code.config import AgentConfig, EditProtocol, ModelConfig, ModelProvider
-from kolega_code.tools import ToolRegistry
+from kolega_code.tools import ToolError, ToolRegistry
 
 
 def assert_external_path_description(description: str) -> None:
@@ -38,6 +38,7 @@ def collection(
     caller.supports_vision = False
     caller.sub_agent = False
     caller.session_id = "session"
+    caller.current_tool_execution_id = None
     return ToolCollection(
         tmp_path,
         "workspace",
@@ -56,6 +57,24 @@ def test_default_protocol_keeps_search_replace_tools(tmp_path: Path) -> None:
     assert "apply_patch" not in registry
     for tool_name in ("edit", "multi_edit", "write"):
         assert_external_path_description(parameter_description(registry, tool_name, "path"))
+
+
+@pytest.mark.asyncio
+async def test_claude_write_accepts_path_alias_at_dispatch(tmp_path: Path) -> None:
+    tools = collection(tmp_path, EditProtocol.CLAUDE_CODE)
+    result = await tools.call("write", path="aliased.txt", content="hello\n")
+    assert result.startswith("Wrote ")
+    assert (tmp_path / "aliased.txt").read_text() == "hello\n"
+
+
+@pytest.mark.asyncio
+async def test_search_replace_write_keeps_path_canonical_at_dispatch(tmp_path: Path) -> None:
+    tools = collection(tmp_path, EditProtocol.SEARCH_REPLACE)
+    result = await tools.call("write", path="direct.txt", content="hello\n")
+    assert result.startswith("Wrote ")
+    assert (tmp_path / "direct.txt").read_text() == "hello\n"
+    with pytest.raises(ToolError):
+        await tools.call("write", file_path="nope.txt", content="hello\n")
 
 
 def test_codex_protocol_replaces_ordinary_write_tools(tmp_path: Path) -> None:

--- a/tests/agent/test_param_aliases.py
+++ b/tests/agent/test_param_aliases.py
@@ -3,54 +3,86 @@
 Table-driven: every registry entry needs exactly one row in ALIAS_CASES (and a
 CANONICAL_WINS_CASES row for renames). The tests run the real dispatch choke
 point (Tool.call) against handlers carrying the real ToolCollection signatures,
-so an alias that would still trip argument validation fails here.
+so an alias that would still trip argument validation fails here. Rows carry
+the binding method whose signature the handler adopts, since resolution is
+signature-aware.
 """
 
 import inspect
 
 import pytest
 
+from kolega_code.agent.edit_protocols import EDIT_PROTOCOL_SPECS
 from kolega_code.agent.tools import ToolCollection
 from kolega_code.llm.models import ToolDefinition
 from kolega_code.tools import Tool, ToolError
 from kolega_code.tools.param_aliases import PARAM_ALIASES
 
-# One row per registry alias: (tool, call kwargs, kwargs the handler receives).
+# One row per registry alias: (binding method, tool name, call kwargs, kwargs the handler receives).
 ALIAS_CASES = [
-    # timeout unit heuristic: < 1000 reads as seconds, >= 1000 as milliseconds
-    ("exec_command", {"command": "ls", "timeout": 60}, {"command": "ls", "yield_time_ms": 60000}),
-    ("exec_command", {"command": "ls", "timeout": 5000}, {"command": "ls", "yield_time_ms": 5000}),
-    ("exec_command", {"command": "ls", "title": "list files"}, {"command": "ls"}),
-    ("eval", {"command": "print(1)"}, {"code": "print(1)"}),
-    ("read", {"path": "a.py"}, {"file_path": "a.py"}),
+    ("exec_command", "exec_command", {"command": "ls", "timeout": 60}, {"command": "ls", "yield_time_ms": 60000}),
+    ("exec_command", "exec_command", {"command": "ls", "timeout": 5000}, {"command": "ls", "yield_time_ms": 5000}),
+    ("exec_command", "exec_command", {"command": "ls", "title": "list files"}, {"command": "ls"}),
+    ("eval", "eval", {"command": "print(1)"}, {"code": "print(1)"}),
+    ("read", "read", {"path": "a.py"}, {"file_path": "a.py"}),
+    ("claude_write", "write", {"path": "a.py", "content": "hello"}, {"file_path": "a.py", "content": "hello"}),
 ]
 
 # One row per rename alias: alias + canonical together -> canonical wins.
 CANONICAL_WINS_CASES = [
-    ("exec_command", {"command": "ls", "timeout": 60, "yield_time_ms": 500}, {"command": "ls", "yield_time_ms": 500}),
-    ("eval", {"command": "print(1)", "code": "print(2)"}, {"code": "print(2)"}),
-    ("read", {"path": "a.py", "file_path": "b.py"}, {"file_path": "b.py"}),
+    (
+        "exec_command",
+        "exec_command",
+        {"command": "ls", "timeout": 60, "yield_time_ms": 500},
+        {"command": "ls", "yield_time_ms": 500},
+    ),
+    ("eval", "eval", {"command": "print(1)", "code": "print(2)"}, {"code": "print(2)"}),
+    ("read", "read", {"path": "a.py", "file_path": "b.py"}, {"file_path": "b.py"}),
+    (
+        "claude_write",
+        "write",
+        {"path": "a.py", "content": "x", "file_path": "b.py"},
+        {"file_path": "b.py", "content": "x"},
+    ),
 ]
 
 
-def _real_signature(tool_name: str) -> inspect.Signature:
+def _real_signature(method_name: str) -> inspect.Signature:
     """The model-facing signature: the ToolCollection method minus ``self``."""
-    signature = inspect.signature(getattr(ToolCollection, tool_name))
+    signature = inspect.signature(getattr(ToolCollection, method_name))
     return signature.replace(parameters=[p for p in signature.parameters.values() if p.name != "self"])
 
 
-def _capture_tool(tool_name: str, received: dict) -> Tool:
+def _binding_signatures(tool_name: str) -> list[inspect.Signature]:
+    """Signatures of every callable the tool name can bind to across edit protocols."""
+    binding_names = [
+        binding.handler_name
+        for spec in EDIT_PROTOCOL_SPECS.values()
+        for binding in spec.tools
+        if binding.name == tool_name
+    ] or [tool_name]
+    return [_real_signature(name) for name in dict.fromkeys(binding_names)]
+
+
+def _capture_tool(
+    tool_name: str,
+    received: dict,
+    *,
+    binding_name: str | None = None,
+    log_debug=None,
+) -> Tool:
     """A Tool whose handler records its kwargs but binds like the real tool."""
 
     async def handler(**kwargs):
         received.update(kwargs)
         return "ok"
 
-    handler.__signature__ = _real_signature(tool_name)
+    handler.__signature__ = _real_signature(binding_name or tool_name)
     return Tool(
         name=tool_name,
         definition=ToolDefinition(name=tool_name, description=f"{tool_name} tool", parameters=[]),
         handler=handler,
+        log_debug=log_debug,
     )
 
 
@@ -58,7 +90,7 @@ def test_every_registry_entry_has_a_case_row():
     registered = {(tool, alias) for tool, aliases in PARAM_ALIASES.items() for alias in aliases}
     covered = {
         (tool, alias)
-        for tool, call_kwargs, _ in ALIAS_CASES
+        for _, tool, call_kwargs, _ in ALIAS_CASES
         for alias in call_kwargs
         if alias in PARAM_ALIASES.get(tool, {})
     }
@@ -67,31 +99,47 @@ def test_every_registry_entry_has_a_case_row():
 
 def test_aliases_target_real_parameters_and_never_shadow_them():
     for tool_name, aliases in PARAM_ALIASES.items():
-        parameters = _real_signature(tool_name).parameters
+        signatures = _binding_signatures(tool_name)
         for alias_name, alias in aliases.items():
-            # An alias that becomes a real parameter must be deleted from the
-            # registry, or it would silently rewrite legitimate calls.
-            assert alias_name not in parameters, f"alias {tool_name}.{alias_name} shadows a real parameter"
+            assert any(alias_name not in signature.parameters for signature in signatures), (
+                f"alias {tool_name}.{alias_name} is accepted by every binding; the guard would skip it everywhere"
+            )
             if alias.canonical is not None:
-                assert alias.canonical in parameters, f"{tool_name}.{alias_name} renames to unknown `{alias.canonical}`"
+                assert any(alias.canonical in signature.parameters for signature in signatures), (
+                    f"{tool_name}.{alias_name} renames to unknown `{alias.canonical}`"
+                )
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("tool_name, call_kwargs, expected_kwargs", ALIAS_CASES)
-async def test_aliased_call_behaves_as_canonical(tool_name, call_kwargs, expected_kwargs):
+@pytest.mark.parametrize("binding_name, tool_name, call_kwargs, expected_kwargs", ALIAS_CASES)
+async def test_aliased_call_behaves_as_canonical(binding_name, tool_name, call_kwargs, expected_kwargs):
     received = {}
-    tool = _capture_tool(tool_name, received)
+    tool = _capture_tool(tool_name, received, binding_name=binding_name)
     assert await tool.call(**call_kwargs) == "ok"
     assert received == expected_kwargs
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("tool_name, call_kwargs, expected_kwargs", CANONICAL_WINS_CASES)
-async def test_canonical_wins_over_alias(tool_name, call_kwargs, expected_kwargs):
+@pytest.mark.parametrize("binding_name, tool_name, call_kwargs, expected_kwargs", CANONICAL_WINS_CASES)
+async def test_canonical_wins_over_alias(binding_name, tool_name, call_kwargs, expected_kwargs):
     received = {}
-    tool = _capture_tool(tool_name, received)
+    tool = _capture_tool(tool_name, received, binding_name=binding_name)
     assert await tool.call(**call_kwargs) == "ok"
     assert received == expected_kwargs
+
+
+@pytest.mark.asyncio
+async def test_write_path_passes_through_when_binding_accepts_path():
+    received = {}
+    messages = []
+
+    async def log_debug(message: str) -> None:
+        messages.append(message)
+
+    tool = _capture_tool("write", received, binding_name="write", log_debug=log_debug)
+    assert await tool.call(path="a.py", content="hello") == "ok"
+    assert received == {"path": "a.py", "content": "hello"}
+    assert messages == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Benchmark mining measured 15 rejected `write(path=…)` calls — models borrowing the `path` spelling every sibling file tool uses. The complication: the tool name `write` binds to different callables per edit protocol, so a blind `path` → `file_path` alias would corrupt legitimate search_replace calls.

- **Signature-aware alias resolution**: `Tool` computes the accepted parameter names once at construction (via `inspect`) and `resolve_param_aliases` skips any registered alias the binding itself accepts. General semantic — "an alias is only an alias when the tool doesn't accept the name" — not a write-specific special case.
- **Registry entry**: `"write": {"path": ParamAlias("file_path")}` — a rename under claude_code (`claude_write(file_path, content)`) and a no-op under search_replace (`write(path, content)`, where `path` is canonical). Alias hits remain debug-logged only; nothing is advertised in tool descriptions.
- **Tests**: table-driven alias cases now carry the binding method; new rows cover the claude_code rename, canonical-wins, and search_replace pass-through (no rename, no alias hit logged). Dispatch-level tests exercise both protocols through a real `ToolCollection` (claude_code `path=` succeeds and writes; search_replace `path=` passes through and `file_path=` still raises `ToolError`).
- **CHANGELOG** entry under Unreleased.

## Verification

- Full test suite: 4232 passed, 1 skipped (env-dependent), 0 failed.
- Complete tool-definition payload rendered before/after under claude_code, search_replace, and hashline_v2: byte-identical — pure dispatch behavior, the wire surface does not move.
- `pre-commit run --all-files` (ruff, pyright, and the rest): all pass.