### PR TITLE
chore: release v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.27.0 - 2026-08-06
+
 ### Changed
 
 - The `eval`, `exec_command`, and `lsp` tool descriptions shipped to model
@@ -113,6 +115,14 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   allowlists naming the removed tools must be updated to the terminal tools
   (`exec_command`, `write_stdin`, `kill_command`, `list_sessions`). Existing
   session histories keep the old tool names as recorded data and render as-is.
+
+- The `sleep` tool is gone from the agent toolset: its blind wall-clock wait is
+  strictly dominated by `write_stdin`'s empty-input poll, which waits for more
+  output or process exit and returns early when the process finishes. The
+  `yield_time_ms` clamp semantics (250–30000 ms when writing, 5000–300000 ms
+  when polling) moved from the `write_stdin` docstring body into its parameter
+  description so the poll path stays discoverable. Existing session histories
+  keep the old tool name as recorded data and render as-is.
 
 - The `think_hard` tool is gone from the agent toolset, along with the thinking
   model slot that powered it. Deleted: the `ThinkHardTool` backend and its

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -151,4 +151,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.26.10"
+__version__ = "0.27.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.26.10"
+__version__ = "0.27.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.26.10"
+version = "0.27.0"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -1566,7 +1566,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.26.10"
+version = "0.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## What

Release **v0.27.0** — a minor release carrying the tool-surface consolidation work merged since v0.26.10.

## Changes in this release

- **Added**: `write(path=…)` alias under the claude_code protocol; successful writes count as reads for the edit guard; `get_host` gated behind injected sandbox host providers.
- **Changed**: single consolidated `read` tool (merges `read_entire_file` + `read_file_section`); single `dispatch_agent` tool (merges the five per-type dispatch tools); single `skill` tool (merges `list_skills` / `activate_skill` / `read_skill_resource`); `resolve` gated behind the LSP switch and edit permissions; terminal-tools prompt guidance; slimmer wire tool descriptions (eval/exec_command/lsp, ~450 cl100k tokens) and de-duplicated `Args:` docs.
- **Removed**: `glob` + `search_codebase` (file discovery now terminal-first with `rg`), `think_hard` + the thinking model slot, `sleep`, `read_entire_file` / `read_file_section` names.
- **Fixed**: Kimi-family `input_tokens: -1` full-cache-hit sentinel no longer drops session usage accounting.

## Release process

- Version bumped in `pyproject.toml`, `uv.lock`, `kolega_code/__init__.py`, `kolega_code/agent/__init__.py`.
- `CHANGELOG.md` Unreleased section moved to `0.27.0 - 2026-08-06` (plus a missing `sleep`-tool removal entry), empty Unreleased section left above.
- Local checks in the disposable `.venv-release` environment: `uv sync --extra dev --frozen`, `./run_tests.sh` (4232 passed, 1 skipped), `pre-commit run --all-files` — all green.

Tag `v0.27.0` will be created after merge, per `RELEASING.md`.