### PR TITLE
fix(ci): extend docs deployment timeout

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -65,3 +65,6 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+        with:
+          # Pages deployments can remain queued beyond the action's 10-minute default.
+          timeout: 1200000


### PR DESCRIPTION
## Summary
- increase the `actions/deploy-pages` polling timeout from its 10-minute default to 20 minutes
- prevent slow GitHub Pages queues from failing otherwise successful docs deployments

## Context
The docs build for `bae50358ec55099637239873702823a40a5c5885` completed successfully, but the Pages deployment remained `deployment_queued` until the deploy action reached its default timeout and canceled it.

## Verification
- `cd docs && npm run build`
- `uv run pre-commit run --files .github/workflows/docs.yml --show-diff-on-failure`
- `git diff --check -- .github/workflows/docs.yml`