### PR TITLE
feat(cli): make the history-compression threshold configurable

### DIFF
--- a/docs/src/content/docs/cli/ask.md
+++ b/docs/src/content/docs/cli/ask.md
@@ -25,6 +25,7 @@ kolega-code ask "<prompt>" [options]
 | `--permission-mode <auto\|ask>` | Shell/edit permission mode (default `auto`) |
 | `--web-search <auto\|hosted\|client\|off>` | Web tool mode: hosted server-side search, client tools, or none (default `auto`) |
 | `--lsp <on\|off>` | Force LSP tools on or off for this session (overrides settings; not persisted) |
+| `--compression-threshold PERCENT` | Context-window usage that triggers automatic history compression (`10`–`100`, default `80`; `100` effectively disables it). Overrides settings for the session; not persisted |
 | `--session <ID>` | Resume or create a specific session |
 | `--state-dir <PATH>` | Directory for CLI session state |
 | `--worktree <PATH_OR_BRANCH>` | Start in an existing registered worktree |

--- a/docs/src/content/docs/cli/overview.md
+++ b/docs/src/content/docs/cli/overview.md
@@ -118,6 +118,7 @@ for the run.
 | `--thinking-effort` | Model-specific thinking effort, such as `auto`, `medium`, `high`, or `max` |
 | `--edit-protocol` | Override the model-facing edit language with `search_replace`, `codex_apply_patch`, or `claude_code` |
 | `--environment` | Environment label for tracing/metadata |
+| `--compression-threshold PERCENT` | Context-window usage that triggers automatic history compression (`10`–`100`, default `80`; `100` effectively disables it). Overrides settings for the session; not persisted |
 
 ## Session-state options
 

--- a/docs/src/content/docs/concepts/how-it-works.md
+++ b/docs/src/content/docs/concepts/how-it-works.md
@@ -21,9 +21,11 @@ The agent owns three things worth knowing about:
 
 - **Conversation** — the running message history.
 - **History compression** — when the conversation grows large, older context is
-  compressed to stay within the model's budget. You can trigger this manually with
-  [`/compress`](../../tui/slash-commands/) and inspect the current size with
-  `/context`.
+  compressed to stay within the model's budget. Automatic compression kicks in
+  once context usage crosses a threshold (80% by default — configurable in
+  Settings → Tools or with `--compression-threshold`). You can also trigger it
+  manually with [`/compress`](../../tui/slash-commands/) and inspect the current
+  size with `/context`.
 - **Events** — the agent emits a stream of typed events (chat messages, tool
   activity, terminal output, status updates, sub-agent lifecycle). The TUI renders
   these live; `ask --json` prints them.

--- a/docs/src/content/docs/configuration/environment-variables.md
+++ b/docs/src/content/docs/configuration/environment-variables.md
@@ -117,6 +117,7 @@ with vision support.
 | `KOLEGA_CODE_STATE_DIR` | Override where settings and sessions are stored |
 | `KOLEGA_CODE_ENVIRONMENT` | Environment label attached to tracing/metadata (default `development`) |
 | `KOLEGA_CODE_NO_DIAGNOSTICS` | Set to any value to disable the local [diagnostics](../../troubleshooting/diagnostics/) log and responsiveness watchdog |
+| `KOLEGA_CODE_COMPRESSION_THRESHOLD` | Context-window usage percent that triggers automatic history compression (`10`–`100`, default `80`; `100` effectively disables automatic compression) |
 
 ## Web search
 

--- a/docs/src/content/docs/configuration/settings-and-api-keys.mdx
+++ b/docs/src/content/docs/configuration/settings-and-api-keys.mdx
@@ -33,7 +33,7 @@ separates the controls into:
 | **Providers** | API keys and ChatGPT sign-in for every model provider, plus per-provider connection testing |
 | **Models** | Provider, model, thinking effort, and the fast model slot |
 | **Agent Models** | Optional provider/model/effort override for each agent role |
-| **Tools** | Web-search backend and global LSP toggle |
+| **Tools** | Web-search backend, global LSP toggle, and the history-compression threshold |
 | **MCP Servers** | Global and trusted-project MCP server management |
 | **Appearance** | TUI theme |
 
@@ -96,6 +96,13 @@ your self-hosted instance. The same settings can be supplied with
 [`KOLEGA_CODE_WEB_SEARCH_MODE`, `KOLEGA_CODE_WEB_SEARCH_BACKEND`,
 `FIRECRAWL_API_KEY`, `TAVILY_API_KEY`, and
 `SEARXNG_BASE_URL`](../environment-variables/#web-search).
+
+The **Tools** category also holds the **history-compression threshold**: the
+context-window usage percent at which older conversation history is summarized
+automatically (default `80%`). Choose `100%` to effectively disable automatic
+compression — `/compress` always works manually. For one session only, override
+it with `--compression-threshold PERCENT` or `KOLEGA_CODE_COMPRESSION_THRESHOLD`;
+the editor notes when a launch flag or environment variable has pinned the value.
 
 ## Where settings live
 

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -439,6 +439,12 @@ class BaseAgent(LogMixin):
         # Counts consecutive transient LLM failures (rate-limit / overload) so the turn loop
         # backs off and eventually gives up instead of retrying forever; reset on any good turn.
         self._consecutive_llm_retries = 0
+        # Host-configured compression threshold (fraction of the context window) shadows
+        # the class default when the config carries one; every read below and in
+        # _send_context_update goes through the instance attribute.
+        config_threshold = getattr(self.config, "history_compression_threshold", None)
+        if config_threshold is not None:
+            self.history_compression_threshold = config_threshold
         self.compressor = HistoryCompressor(threshold=self.history_compression_threshold)
         self.emitter = AgentEventEmitter(
             connection_manager=self.connection_manager,

--- a/kolega_code/cli/config.py
+++ b/kolega_code/cli/config.py
@@ -16,7 +16,12 @@ from kolega_code.mcp.config import load_mcp_config
 from kolega_code.services.lsp.config import LspConfig
 
 from .provider_registry import default_model_for_provider
-from .settings import CliSettings, SettingsStore
+from .settings import (
+    COMPRESSION_THRESHOLD_MAX_PERCENT,
+    COMPRESSION_THRESHOLD_MIN_PERCENT,
+    CliSettings,
+    SettingsStore,
+)
 
 # Providers authenticated by an OAuth sign-in instead of a static API key.
 OAUTH_PROVIDERS = frozenset({ModelProvider.OPENAI_CHATGPT})
@@ -61,6 +66,9 @@ SEARXNG_BASE_URL_ENV = "SEARXNG_BASE_URL"
 # LSP master switch: on or off. Absent means defer to settings.lsp_enabled.
 LSP_MODES = ("on", "off")
 LSP_MODE_ENV = "KOLEGA_CODE_LSP"
+# Compression threshold override, in percent (10-100). Absent means defer to
+# settings.compression_threshold, then the agent's built-in default (80%).
+COMPRESSION_THRESHOLD_ENV = "KOLEGA_CODE_COMPRESSION_THRESHOLD"
 # Env vars that supply a cloud web-search backend's key, keyed by backend name.
 SEARCH_BACKEND_KEY_ENV = {
     "firecrawl": "FIRECRAWL_API_KEY",
@@ -85,6 +93,9 @@ class CliConfigOverrides:
     edit_protocol: Optional[str] = None
     web_search_mode: Optional[str] = None
     lsp_mode: Optional[str] = None
+    # Compression threshold in percent, as typed on the command line; parsed and
+    # validated in _compression_threshold.
+    compression_threshold: Optional[str] = None
 
 
 def load_cli_env(project_path: Path, env: Optional[Mapping[str, str]] = None) -> dict[str, str]:
@@ -272,6 +283,48 @@ def _lsp_enabled(
     if settings is not None and settings.lsp_enabled is not None:
         return bool(settings.lsp_enabled)
     return True
+
+
+def _compression_threshold(
+    env: Mapping[str, str],
+    settings: Optional[CliSettings],
+    override: Optional[str],
+) -> Optional[float]:
+    """Resolve the compression threshold with flag-over-env-over-settings precedence.
+
+    User-facing surfaces carry a percent (10-100); the returned value is the
+    fraction the agent compares against, or None for the built-in default (80%).
+    Explicit flag/env values are validated strictly (a typo must fail loudly);
+    settings values were already range-coerced at load."""
+    # Resolve presence per layer instead of via _explicit_value, whose truthiness
+    # check treats an explicit empty value as absent; here it is invalid input to
+    # reject, not a missing layer to fall through.
+    explicit: Optional[str] = None
+    source: Optional[str] = None
+    if override is not None:
+        explicit, source = override, "--compression-threshold"
+    elif COMPRESSION_THRESHOLD_ENV in env:
+        explicit, source = env[COMPRESSION_THRESHOLD_ENV], COMPRESSION_THRESHOLD_ENV
+    percent: Optional[float] = None
+    if explicit is not None:
+        try:
+            percent = float(explicit)
+        except ValueError:
+            percent = None
+        if (
+            percent is None
+            or percent < COMPRESSION_THRESHOLD_MIN_PERCENT
+            or percent > COMPRESSION_THRESHOLD_MAX_PERCENT
+        ):
+            raise CliConfigError(
+                f"Unsupported compression threshold '{explicit}' from {source}. "
+                f"Valid range: {COMPRESSION_THRESHOLD_MIN_PERCENT}-{COMPRESSION_THRESHOLD_MAX_PERCENT} (percent)."
+            )
+    elif settings is not None and settings.compression_threshold is not None:
+        percent = settings.compression_threshold
+    if percent is None:
+        return None
+    return percent / 100.0
 
 
 def _coerce_known_model(provider: ModelProvider, model: Optional[str]) -> str:
@@ -519,6 +572,7 @@ def build_agent_config(
     agent_model_overrides = _agent_model_overrides(loaded_env, settings)
     web_search_backend, web_search_api_key, web_search_base_url = _search_config(loaded_env, settings)
     web_search_mode = _web_search_mode(loaded_env, settings, overrides.web_search_mode)
+    compression_threshold = _compression_threshold(loaded_env, settings, overrides.compression_threshold)
     state_dir = settings_store.root if settings_store is not None else SettingsStore().root
     mcp_config = load_mcp_config(
         project_path,
@@ -583,6 +637,7 @@ def build_agent_config(
             lsp=LspConfig(enabled=_lsp_enabled(loaded_env, settings, overrides.lsp_mode)),
             lsp_project_trusted=lsp_project_trusted,
             eval_enabled=(True if settings is None or settings.eval_enabled is None else bool(settings.eval_enabled)),
+            history_compression_threshold=compression_threshold,
         )
     except ValueError as exc:
         raise CliConfigError(str(exc)) from exc

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -242,6 +242,13 @@ def _add_common_model_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--thinking-tokens", dest="deprecated_thinking_tokens", type=int, help=argparse.SUPPRESS)
     parser.add_argument("--environment", help="Environment label for tracing/metadata.")
     parser.add_argument(
+        "--compression-threshold",
+        metavar="PERCENT",
+        help="Context-window usage percentage that triggers automatic history compression "
+        "(10-100; default 80). Overrides settings.json for this session; not persisted. "
+        "100 effectively disables automatic compression.",
+    )
+    parser.add_argument(
         "--edit-protocol",
         choices=[protocol.value for protocol in EditProtocol],
         help="File edit protocol exposed to coding models.",
@@ -640,6 +647,7 @@ def _overrides_from_args(args: argparse.Namespace) -> CliConfigOverrides:
         edit_protocol=getattr(args, "edit_protocol", None),
         web_search_mode=getattr(args, "web_search", None),
         lsp_mode=getattr(args, "lsp", None),
+        compression_threshold=getattr(args, "compression_threshold", None),
     )
 
 

--- a/kolega_code/cli/settings.py
+++ b/kolega_code/cli/settings.py
@@ -75,6 +75,25 @@ def _coerce_permission_mode(raw: object) -> str:
         return PermissionMode.ASK.value
 
 
+# Valid range (inclusive) for the user-facing compression threshold, in percent.
+COMPRESSION_THRESHOLD_MIN_PERCENT = 10
+COMPRESSION_THRESHOLD_MAX_PERCENT = 100
+
+
+def _coerce_compression_threshold(raw: object) -> Optional[float]:
+    """Normalize a stored compression-threshold percent, dropping invalid values.
+
+    Tolerant of hand-edits: anything that is not a number in the valid range
+    becomes None (the built-in default) instead of failing startup. Note bool is
+    a subclass of int, so it must be rejected explicitly."""
+    if raw is None or isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        return None
+    value = float(raw)
+    if COMPRESSION_THRESHOLD_MIN_PERCENT <= value <= COMPRESSION_THRESHOLD_MAX_PERCENT:
+        return value
+    return None
+
+
 @dataclass
 class CliSettings:
     active_provider: Optional[str] = None
@@ -120,6 +139,10 @@ class CliSettings:
     # Additive optional field — absent in older files -> None -> eval tool
     # enabled (persistent code kernels with the loopback tool bridge).
     eval_enabled: Optional[bool] = None
+    # Context-window usage percent that triggers automatic history compression.
+    # Additive optional field — absent in older files -> None -> the agent's
+    # built-in default (80%).
+    compression_threshold: Optional[float] = None
     schema_version: int = SETTINGS_SCHEMA_VERSION
 
     @classmethod
@@ -164,6 +187,8 @@ class CliSettings:
             lsp_enabled=data.get("lsp_enabled"),
             # Additive optional field; absent in older files -> None (enabled).
             eval_enabled=data.get("eval_enabled"),
+            # Additive optional field; absent in older files -> None (default 80%).
+            compression_threshold=_coerce_compression_threshold(data.get("compression_threshold")),
         )
 
     def to_dict(self) -> dict:
@@ -186,6 +211,7 @@ class CliSettings:
             "permission_mode": _coerce_permission_mode(self.permission_mode),
             "lsp_enabled": self.lsp_enabled,
             "eval_enabled": self.eval_enabled,
+            "compression_threshold": self.compression_threshold,
         }
 
     def get_api_key(self, provider: str) -> Optional[str]:

--- a/kolega_code/cli/tui/settings_panel.py
+++ b/kolega_code/cli/tui/settings_panel.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import shlex
 from copy import deepcopy
@@ -39,6 +40,7 @@ from kolega_code.mcp.state import MCPStatusStore, MCPOAuthTokenStore
 
 from .. import messages, theme
 from ..config import (
+    COMPRESSION_THRESHOLD_ENV,
     CliConfigError,
     active_model_override_message,
     build_agent_config,
@@ -78,6 +80,9 @@ MCP_TRANSPORT_OPTIONS = [
 MCP_ENABLED_OPTIONS = [("Enabled", "true"), ("Disabled", "false")]
 MCP_STATUS_MESSAGE_MAX = 96
 MCP_STATUS_NAME_MAX = 34
+# Compression threshold select: "default" maps to None (the agent's built-in 80%).
+COMPRESSION_THRESHOLD_DEFAULT_VALUE = "default"
+COMPRESSION_THRESHOLD_PRESET_PERCENTS = (50, 60, 70, 80, 90, 95, 100)
 MCP_ATTENTION_STATUSES = {"failed", "stale", "unverified"}
 MCP_TRANSPORT_LABELS = {
     "streamable_http": "HTTP",
@@ -143,6 +148,22 @@ def _row_for_widget(widget_id: str) -> Optional[_OverrideRow]:
             if rest.startswith(field):
                 return build(rest[len(field) :])
     return None
+
+
+def _compression_threshold_option_value(percent: float) -> str:
+    """Select value for a threshold percent: integral values stay bare ("80")."""
+    return str(int(percent)) if float(percent).is_integer() else str(percent)
+
+
+def compression_threshold_options(saved: Optional[float] = None) -> list[tuple[str, str]]:
+    """Select options for the compression threshold, presets plus any saved off-list value."""
+    options: list[tuple[str, str]] = [("Default (80%)", COMPRESSION_THRESHOLD_DEFAULT_VALUE)]
+    options.extend((f"{percent}%", str(percent)) for percent in COMPRESSION_THRESHOLD_PRESET_PERCENTS)
+    if saved is not None:
+        saved_value = _compression_threshold_option_value(saved)
+        if saved_value not in {value for _, value in options}:
+            options.append((f"{saved_value}%", saved_value))
+    return options
 
 
 def _mcp_separator() -> str:
@@ -490,6 +511,7 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         self._populate_web_search_controls()
         self._populate_mcp_controls()
         self._populate_lsp_controls()
+        self._populate_compression_controls()
         self._update_settings_status()
 
     def _draft_credential_settings(self) -> CliSettings:
@@ -1552,6 +1574,45 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             return
         self.settings.lsp_enabled = value == "true"
 
+    def _populate_compression_controls(self) -> None:
+        """Seed the compression-threshold select from saved settings."""
+        try:
+            select = self._settings_query_one("#compression_threshold_select", Select)
+        except NoMatches:
+            return
+        saved = self.settings.compression_threshold
+        select.set_options(compression_threshold_options(saved))
+        select.value = (
+            COMPRESSION_THRESHOLD_DEFAULT_VALUE if saved is None else _compression_threshold_option_value(saved)
+        )
+        self._update_compression_settings_status()
+
+    def _update_compression_settings_status(self) -> None:
+        """Note when a launch flag or env var pins the threshold for this session."""
+        try:
+            status = self._settings_query_one("#compression_status", Static)
+        except NoMatches:
+            return
+        flag_value = getattr(self.overrides, "compression_threshold", None)
+        env_value = os.environ.get(COMPRESSION_THRESHOLD_ENV)
+        forced = flag_value or env_value
+        if forced:
+            source = "--compression-threshold" if flag_value else COMPRESSION_THRESHOLD_ENV
+            status.update(
+                f"Compression threshold is forced to {forced}% for this session by {source}; "
+                "the setting applies from the next launch."
+            )
+            return
+        status.update("")
+
+    def _collect_compression_from_ui(self) -> None:
+        """Read the compression-threshold select and save into settings."""
+        try:
+            value = str(self._settings_query_one("#compression_threshold_select", Select).value)
+        except NoMatches:
+            return
+        self.settings.compression_threshold = None if value == COMPRESSION_THRESHOLD_DEFAULT_VALUE else float(value)
+
     def _settings_candidate_from_ui(self) -> tuple[CliSettings, str, str, str]:
         """Collect the mounted form into a detached settings candidate."""
         provider = str(self._settings_query_one("#provider_select", Select).value)
@@ -1586,6 +1647,7 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             self._collect_model_slots_from_ui()
             self._collect_web_search_from_ui()
             self._collect_lsp_from_ui()
+            self._collect_compression_from_ui()
         finally:
             self.settings = original
         return candidate, provider, model, effort

--- a/kolega_code/cli/tui/settings_screen.py
+++ b/kolega_code/cli/tui/settings_screen.py
@@ -379,6 +379,21 @@ class SettingsScreen(ModalScreen[None]):
                     allow_blank=False,
                     value="true",
                 )
+            with Vertical(classes="settings-section", id="settings_compression") as compression_section:
+                compression_section.border_title = "Context Compression"
+                yield Static(
+                    "Summarize older conversation history once context-window usage crosses this "
+                    "threshold. 100% effectively disables automatic compression; /compress stays manual.",
+                    classes="settings-hint",
+                )
+                yield Static("", id="compression_status")
+                yield Label("Threshold")
+                yield Select(
+                    settings_panel.compression_threshold_options(),
+                    id="compression_threshold_select",
+                    allow_blank=False,
+                    value=settings_panel.COMPRESSION_THRESHOLD_DEFAULT_VALUE,
+                )
 
     def _compose_mcp_page(self) -> ComposeResult:
         with VerticalScroll(id="settings_page_mcp", classes="settings-page"):

--- a/kolega_code/config.py
+++ b/kolega_code/config.py
@@ -218,6 +218,16 @@ class AgentConfig(BaseModel):
     # runtime-resolved trust flag, not user-editable config.
     lsp_project_trusted: bool = Field(default=False, exclude=True, description="Project LSP config trust flag")
 
+    # Fraction of the model context window above which automatic history
+    # compression kicks in (e.g. 0.8 = compress once input tokens exceed 80%).
+    # None = the agent's built-in default (BaseAgent.history_compression_threshold).
+    history_compression_threshold: Optional[float] = Field(
+        default=None,
+        gt=0,
+        le=1.0,
+        description="Context-window fraction that triggers automatic history compression",
+    )
+
     # eval tool (persistent code kernels with a loopback tool bridge). All fields
     # are additive with defaults that enable the feature; excluded from
     # serialization since they carry local paths (parity with lsp/mcp_config).

--- a/tests/cli/test_app_compression_settings.py
+++ b/tests/cli/test_app_compression_settings.py
@@ -1,0 +1,154 @@
+"""TUI coverage for the compression-threshold settings control.
+
+The select restores from persisted settings (including saved values outside the
+preset list), collects back into a settings candidate ("default" -> None,
+otherwise the percent), and reports when a launch flag or env var forces the
+threshold for the session.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from ._app_test_utils import build_test_config, install_fake_agents, open_settings_screen
+from .test_app_lsp_settings_status import _static_text
+from kolega_code.cli.tui.settings_panel import compression_threshold_options
+
+
+def _make_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, overrides=None, settings=None):
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.cli.config import config_summary
+    from kolega_code.cli.session_store import SessionStore
+    from kolega_code.cli.settings import SettingsStore
+
+    install_fake_agents(monkeypatch)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    if settings is not None:
+        SettingsStore(tmp_path / "state").save(settings)
+    session = store.create(project, "code", config_summary(config))
+    return KolegaCodeApp(
+        project_path=project, config=config, mode="code", store=store, session=session, overrides=overrides
+    )
+
+
+async def _wait_for_init(screen, pilot, timeout: float = 6.0) -> None:
+    """Wait out the settings screen's restore pass before asserting select values."""
+    deadline = time.monotonic() + timeout
+    while screen._initializing and time.monotonic() < deadline:
+        await pilot.pause(0.05)
+    assert not screen._initializing
+
+
+@pytest.mark.asyncio
+async def test_compression_select_defaults_to_default_option(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from textual.widgets import Select
+
+    app = _make_app(tmp_path, monkeypatch)
+    async with app.run_test() as pilot:
+        screen = await open_settings_screen(app, pilot, "tools")
+        await _wait_for_init(screen, pilot)
+        select = screen.query_one("#compression_threshold_select", Select)
+        assert str(select.value) == "default"
+
+
+@pytest.mark.asyncio
+async def test_compression_select_restores_saved_preset(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from textual.widgets import Select
+
+    from kolega_code.cli.settings import CliSettings
+
+    app = _make_app(tmp_path, monkeypatch, settings=CliSettings(compression_threshold=90.0))
+    async with app.run_test() as pilot:
+        screen = await open_settings_screen(app, pilot, "tools")
+        await _wait_for_init(screen, pilot)
+        select = screen.query_one("#compression_threshold_select", Select)
+        assert str(select.value) == "90"
+
+
+@pytest.mark.asyncio
+async def test_compression_select_restores_saved_off_preset_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from textual.widgets import Select
+
+    from kolega_code.cli.settings import CliSettings
+
+    app = _make_app(tmp_path, monkeypatch, settings=CliSettings(compression_threshold=85.0))
+    async with app.run_test() as pilot:
+        screen = await open_settings_screen(app, pilot, "tools")
+        await _wait_for_init(screen, pilot)
+        select = screen.query_one("#compression_threshold_select", Select)
+        assert str(select.value) == "85"
+        # The off-preset saved value was added as an extra option so the select can hold it.
+        assert "85" in {value for _, value in compression_threshold_options(85.0)}
+
+
+@pytest.mark.asyncio
+async def test_compression_collect_maps_select_values(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """ "default" collects to None; any other option collects to its percent."""
+    from textual.widgets import Select
+
+    app = _make_app(tmp_path, monkeypatch)
+    async with app.run_test() as pilot:
+        screen = await open_settings_screen(app, pilot, "tools")
+        await _wait_for_init(screen, pilot)
+        select = screen.query_one("#compression_threshold_select", Select)
+
+        select.value = "default"
+        app._collect_compression_from_ui()
+        assert app.settings.compression_threshold is None
+
+        select.value = "90"
+        app._collect_compression_from_ui()
+        assert app.settings.compression_threshold == 90.0
+
+
+@pytest.mark.asyncio
+async def test_compression_status_reports_forced_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """--compression-threshold pins the session; the settings note must say so."""
+    from textual.widgets import Static
+
+    from kolega_code.cli.config import CliConfigOverrides
+
+    app = _make_app(tmp_path, monkeypatch, overrides=CliConfigOverrides(compression_threshold="70"))
+    async with app.run_test() as pilot:
+        screen = await open_settings_screen(app, pilot, "tools")
+        await _wait_for_init(screen, pilot)
+        text = _static_text(screen.query_one("#compression_status", Static))
+        assert "forced to 70%" in text
+        assert "--compression-threshold" in text
+
+
+@pytest.mark.asyncio
+async def test_compression_status_reports_forced_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from textual.widgets import Static
+
+    monkeypatch.setenv("KOLEGA_CODE_COMPRESSION_THRESHOLD", "65")
+    app = _make_app(tmp_path, monkeypatch)
+    async with app.run_test() as pilot:
+        screen = await open_settings_screen(app, pilot, "tools")
+        await _wait_for_init(screen, pilot)
+        text = _static_text(screen.query_one("#compression_status", Static))
+        assert "forced to 65%" in text
+        assert "KOLEGA_CODE_COMPRESSION_THRESHOLD" in text
+
+
+@pytest.mark.asyncio
+async def test_compression_status_blank_without_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from textual.widgets import Static
+
+    app = _make_app(tmp_path, monkeypatch)
+    async with app.run_test() as pilot:
+        screen = await open_settings_screen(app, pilot, "tools")
+        await _wait_for_init(screen, pilot)
+        text = _static_text(screen.query_one("#compression_status", Static))
+        assert "forced" not in text

--- a/tests/cli/test_compression_threshold.py
+++ b/tests/cli/test_compression_threshold.py
@@ -1,0 +1,142 @@
+"""Tests for the configurable history-compression threshold.
+
+Mirrors the LSP master-switch plumbing: resolution (flag > env > settings >
+built-in default, cli/config.py) and carry (AgentConfig.history_compression_threshold
+-> BaseAgent instance attribute -> HistoryCompressor). The e2e tests drive a real
+``CoderAgent`` through ``main(["ask", ...])`` and assert on the compressor the
+agent actually built.
+
+User-facing surfaces carry a percent (10-100); the agent compares a fraction,
+so every assertion below crosses that conversion exactly once.
+"""
+
+import pytest
+
+from kolega_code.agent.coder import CoderAgent
+from kolega_code.cli.config import CliConfigError, CliConfigOverrides, _compression_threshold
+from kolega_code.cli.settings import CliSettings, SettingsStore
+
+
+class RecordingCoderAgent(CoderAgent):
+    """The real agent, minus the network turn, recording every instance built."""
+
+    instances: list["RecordingCoderAgent"] = []
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        RecordingCoderAgent.instances.append(self)
+
+    async def process_message_stream(self, message, attachments=None):
+        yield {"type": "response", "content": "done", "complete": True, "uuid": "response-1"}
+
+
+def _setup(tmp_path, monkeypatch):
+    from kolega_code.cli import main as main_module
+
+    RecordingCoderAgent.instances = []
+    monkeypatch.setattr(main_module, "CoderAgent", RecordingCoderAgent)
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("KOLEGA_CODE_PROVIDER", "anthropic")
+    monkeypatch.setenv("KOLEGA_CODE_MODEL", "claude-opus-5")
+    return main_module, project
+
+
+def _persist_threshold(tmp_path, percent: float):
+    """Write compression_threshold to the isolated settings.json the CLI will read."""
+    store = SettingsStore(tmp_path / "state")
+    settings = store.load()
+    settings.compression_threshold = percent
+    store.save(settings)
+
+
+# --- resolution -------------------------------------------------------------------
+
+
+def test_compression_resolution_precedence():
+    settings = CliSettings(compression_threshold=65.0)
+    env = {"KOLEGA_CODE_COMPRESSION_THRESHOLD": "70"}
+    # flag > env > settings > default (None -> the agent's built-in 0.8)
+    assert _compression_threshold(env, settings, "90") == pytest.approx(0.9)
+    assert _compression_threshold(env, settings, None) == pytest.approx(0.7)
+    assert _compression_threshold({}, settings, None) == pytest.approx(0.65)
+    assert _compression_threshold({}, None, None) is None
+
+
+def test_compression_resolution_accepts_range_boundaries():
+    assert _compression_threshold({}, None, "10") == pytest.approx(0.1)
+    assert _compression_threshold({}, None, "100") == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize("raw", ["abc", "5", "101", "0", "-20", ""])
+def test_compression_resolution_rejects_invalid_flag_values(raw):
+    with pytest.raises(CliConfigError, match="compression threshold"):
+        _compression_threshold({}, None, raw)
+
+
+@pytest.mark.parametrize("raw", ["lots", "200"])
+def test_compression_resolution_rejects_invalid_env_values(raw):
+    with pytest.raises(CliConfigError, match="KOLEGA_CODE_COMPRESSION_THRESHOLD"):
+        _compression_threshold({"KOLEGA_CODE_COMPRESSION_THRESHOLD": raw}, None, None)
+
+
+def test_overrides_dataclass_carries_the_threshold():
+    assert CliConfigOverrides(compression_threshold="85").compression_threshold == "85"
+
+
+# --- end to end -------------------------------------------------------------------
+
+
+def test_ask_default_keeps_builtin_threshold(tmp_path, monkeypatch, isolated_cli_env):
+    main_module, project = _setup(tmp_path, monkeypatch)
+
+    exit_code = main_module.main(["ask", "do the thing", "--project", str(project)])
+
+    assert exit_code == 0
+    agent = RecordingCoderAgent.instances[0]
+    assert agent.history_compression_threshold == pytest.approx(0.8)
+    assert agent.compressor.threshold == pytest.approx(0.8)
+
+
+def test_ask_flag_sets_threshold(tmp_path, monkeypatch, isolated_cli_env):
+    main_module, project = _setup(tmp_path, monkeypatch)
+
+    exit_code = main_module.main(["ask", "do the thing", "--project", str(project), "--compression-threshold", "60"])
+
+    assert exit_code == 0
+    agent = RecordingCoderAgent.instances[0]
+    assert agent.history_compression_threshold == pytest.approx(0.6)
+    assert agent.compressor.threshold == pytest.approx(0.6)
+
+
+def test_ask_settings_threshold_applies_without_flag(tmp_path, monkeypatch, isolated_cli_env):
+    main_module, project = _setup(tmp_path, monkeypatch)
+    _persist_threshold(tmp_path, 85.0)
+
+    exit_code = main_module.main(["ask", "do the thing", "--project", str(project)])
+
+    assert exit_code == 0
+    assert RecordingCoderAgent.instances[0].compressor.threshold == pytest.approx(0.85)
+
+
+def test_ask_flag_beats_env_and_settings(tmp_path, monkeypatch, isolated_cli_env):
+    main_module, project = _setup(tmp_path, monkeypatch)
+    _persist_threshold(tmp_path, 85.0)
+    monkeypatch.setenv("KOLEGA_CODE_COMPRESSION_THRESHOLD", "70")
+
+    assert main_module.main(["ask", "first", "--project", str(project)]) == 0
+    assert main_module.main(["ask", "second", "--project", str(project), "--compression-threshold", "50"]) == 0
+
+    env_and_settings, flag_wins = RecordingCoderAgent.instances
+    assert env_and_settings.compressor.threshold == pytest.approx(0.7)
+    assert flag_wins.compressor.threshold == pytest.approx(0.5)
+
+
+def test_ask_invalid_flag_fails_loudly(tmp_path, monkeypatch, isolated_cli_env):
+    main_module, project = _setup(tmp_path, monkeypatch)
+
+    exit_code = main_module.main(["ask", "do the thing", "--project", str(project), "--compression-threshold", "500"])
+
+    assert exit_code == 2
+    assert RecordingCoderAgent.instances == []

--- a/tests/cli/test_settings.py
+++ b/tests/cli/test_settings.py
@@ -362,6 +362,61 @@ def test_permission_mode_absent_in_old_file_defaults_to_ask() -> None:
     assert settings.permission_mode == "ask"
 
 
+def test_settings_store_round_trips_compression_threshold(tmp_path: Path) -> None:
+    store = SettingsStore(tmp_path)
+    store.save(CliSettings(compression_threshold=85.0))
+
+    loaded = store.load()
+    assert loaded.compression_threshold == 85.0
+    assert loaded.to_dict()["compression_threshold"] == 85.0
+
+    # Absent in older files -> None -> the agent's built-in default (80%) applies.
+    store.save(CliSettings())
+    assert SettingsStore(tmp_path).load().compression_threshold is None
+
+
+def test_compression_threshold_absent_in_old_file_defaults_to_none() -> None:
+    settings = CliSettings.from_dict(
+        {
+            "schema_version": 3,
+            "active_provider": UI_DEFAULT_PROVIDER,
+            "active_model": UI_DEFAULT_MODEL,
+            "api_keys": {UI_DEFAULT_PROVIDER: "k"},
+        }
+    )
+
+    assert settings.compression_threshold is None
+
+
+@pytest.mark.parametrize("raw", [200, 5, 0, -10, 3.5, "90", "high", True, [80], {"percent": 80}])
+def test_invalid_compression_threshold_coerced_to_none(raw: object) -> None:
+    """Hand-edited settings must degrade to the default, never crash startup."""
+    settings = CliSettings.from_dict(
+        {
+            "schema_version": 3,
+            "active_provider": UI_DEFAULT_PROVIDER,
+            "active_model": UI_DEFAULT_MODEL,
+            "compression_threshold": raw,
+        }
+    )
+
+    assert settings.compression_threshold is None
+
+
+@pytest.mark.parametrize("raw,expected", [(10, 10.0), (80, 80.0), (100, 100.0), (65.5, 65.5)])
+def test_valid_compression_threshold_loads(raw: object, expected: float) -> None:
+    settings = CliSettings.from_dict(
+        {
+            "schema_version": 3,
+            "active_provider": UI_DEFAULT_PROVIDER,
+            "active_model": UI_DEFAULT_MODEL,
+            "compression_threshold": raw,
+        }
+    )
+
+    assert settings.compression_threshold == expected
+
+
 def test_invalid_permission_mode_defaults_to_ask() -> None:
     settings = CliSettings.from_dict(
         {


### PR DESCRIPTION
## Summary

Automatic history compression used to kick in at a hardcoded 80% of the model context window (`BaseAgent.history_compression_threshold`). This makes it configurable end to end:

- **Settings → Tools**: new Context Compression threshold select (presets 50–100 plus Default 80%), persisted to `settings.json` as an additive optional field (no schema bump; old files load as the default).
- **`--compression-threshold PERCENT`** (TUI launch and `ask`) plus **`KOLEGA_CODE_COMPRESSION_THRESHOLD`** override the setting for the session without persisting it. `100` effectively disables automatic compression; `/compress` stays manual.
- **`AgentConfig.history_compression_threshold`** carries the resolved fraction to every agent (sub-agents included); `BaseAgent` shadows the class default before building its `HistoryCompressor`, so the status gauge, the `context_update` event, and the compressor itself all use the configured value.

Invalid explicit flag/env values fail loudly at startup (exit 2, naming the source and valid range); invalid hand-edited `settings.json` values degrade to the default rather than crashing. When a flag or env var pins the session, the settings page says so instead of implying the saved value is live.

## Test plan

- `tests/cli/test_compression_threshold.py` (new): resolution precedence (flag > env > settings > default), range boundaries, invalid-value rejection, and end-to-end runs through `main(["ask", ...])` asserting the real agent's `HistoryCompressor` threshold (flag-only, settings-only, flag-beats-env-and-settings, invalid flag exits 2).
- `tests/cli/test_app_compression_settings.py` (new): TUI select restores saved values (including off-preset ones as a dynamic option), collects "default"→`None`/"90"→`90.0`, and shows the forced-by-flag/env status note.
- `tests/cli/test_settings.py`: round-trip, absent-in-old-file, and hand-edit coercion cases.
- Verified: focused set 158 passed, full `tests/cli/` 1412 passed, full `tests/agent/` 2118 passed (one pre-existing live-provider quota failure unrelated to this change), `pre-commit run` clean on all touched files.
- Docs updated: `cli/overview.md`, `cli/ask.md`, `configuration/environment-variables.md`, `configuration/settings-and-api-keys.mdx`, `concepts/how-it-works.md`.