### PR TITLE
feat(cli): add --subagents on|off master switch for sub-agent dispatch

### DIFF
--- a/docs/src/content/docs/cli/ask.md
+++ b/docs/src/content/docs/cli/ask.md
@@ -25,6 +25,7 @@ kolega-code ask "<prompt>" [options]
 | `--permission-mode <auto\|ask>` | Shell/edit permission mode (default `auto`) |
 | `--web-search <auto\|hosted\|client\|off>` | Web tool mode: hosted server-side search, client tools, or none (default `auto`) |
 | `--lsp <on\|off>` | Force LSP tools on or off for this session (overrides settings; not persisted) |
+| `--subagents <on\|off>` | Force sub-agent dispatch (`dispatch_agent`) on or off for this session (overrides settings; not persisted; default on) |
 | `--compression-threshold PERCENT` | Context-window usage that triggers automatic history compression (`10`–`100`, default `80`; `100` effectively disables it). Overrides settings for the session; not persisted |
 | `--session <ID>` | Resume or create a specific session |
 | `--state-dir <PATH>` | Directory for CLI session state |

--- a/docs/src/content/docs/cli/overview.md
+++ b/docs/src/content/docs/cli/overview.md
@@ -46,6 +46,7 @@ kolega-code [PROJECT_PATH]
 | `--show-logs` | Show the optional diagnostic Logs side-panel tab. Hidden by default to avoid unnecessary log rendering work |
 | `--permission-mode <auto\|ask>` | Shell/edit permission mode. TUI sessions default to `ask` |
 | `--lsp <on\|off>` | Force LSP tools on or off for this session (overrides settings; not persisted) |
+| `--subagents <on\|off>` | Force sub-agent dispatch (`dispatch_agent`) on or off for this session (overrides settings; not persisted; default on) |
 | `--session <ID>` | Legacy alias for `--resume SESSION_ID` |
 
 See [Sessions & Resuming](../../tui/sessions-and-resume/) for the full session

--- a/docs/src/content/docs/concepts/tools.md
+++ b/docs/src/content/docs/concepts/tools.md
@@ -207,6 +207,16 @@ tool — see [Agents](../agents/) for the built-in `general`, `investigation`,
 join the `agent_type` choices when matching definitions are discovered. Only the
 agent types available in the current session are offered.
 
+Sub-agent dispatch is enabled by default and can be turned off at three levels,
+resolved as flag > environment > settings: the `--subagents <on|off>` launch
+flag (session override), `KOLEGA_CODE_SUBAGENTS=<on|off>`, or the Sub-agents
+toggle on the Settings screen's Tools tab (persisted in `settings.json` as
+`subagents_enabled`). When off, `dispatch_agent` is removed from the tool list
+entirely, so the model never sees it. Gigacode workflows are unaffected:
+`run_workflow` and the dispatch chain lent to workflow workers are governed by
+gigacode's own opt-in, and `list_subagent_models` stays visible whenever either
+gigacode or sub-agents are enabled.
+
 ## Read-only vs. full access
 
 Tools are gated by mode. In a read-only context — like [Plan mode](../../tui/modes/)

--- a/docs/src/content/docs/configuration/environment-variables.md
+++ b/docs/src/content/docs/configuration/environment-variables.md
@@ -118,6 +118,7 @@ with vision support.
 | `KOLEGA_CODE_ENVIRONMENT` | Environment label attached to tracing/metadata (default `development`) |
 | `KOLEGA_CODE_NO_DIAGNOSTICS` | Set to any value to disable the local [diagnostics](../../troubleshooting/diagnostics/) log and responsiveness watchdog |
 | `KOLEGA_CODE_COMPRESSION_THRESHOLD` | Context-window usage percent that triggers automatic history compression (`10`–`100`, default `80`; `100` effectively disables automatic compression) |
+| `KOLEGA_CODE_SUBAGENTS` | Sub-agent dispatch (`dispatch_agent`) master switch: `on` or `off` (default `on`). Useful for headless or CI runs; the `--subagents` flag takes precedence |
 
 ## Web search
 

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -2312,6 +2312,21 @@ class ToolCollection(LogMixin):
         Returns:
             True if the tool should be included, False otherwise
         """
+        # Settings gate: sub-agent dispatch can be disabled host-wide
+        # (AgentConfig.subagents_enabled, from settings.json or the --subagents
+        # flag). Placed first so it also beats the custom_tool_groups whitelist
+        # below (planning/investigation agents) and covers host extension
+        # dispatch tools appended to this instance's agent_dispatch_tools.
+        # Gigacode workflow workers are exempt: their dispatch chain is lent by
+        # run_workflow (a separate opt-in) and depth-narrowed below.
+        # Strict `is False` so Mock configs in tests keep the default (enabled).
+        if (
+            method_name in self.agent_dispatch_tools
+            and getattr(self.config, "subagents_enabled", True) is False
+            and not has_workflow_context_marker(getattr(self.caller, "sub_agent_context", None))
+        ):
+            return False
+
         # Gigacode delegation depth is scoped through sub_agent_context. It only
         # narrows a workflow worker's existing dispatch inventory; callers with no
         # workflow context retain their normal behavior.
@@ -2472,6 +2487,14 @@ class ToolCollection(LogMixin):
             dispatch_candidates.intersection_update(self.tool_config.allowed_tools)
         if "dispatch_agent" in dispatch_candidates and not self._available_agent_types():
             dispatch_candidates.discard("dispatch_agent")
+        # Sub-agent dispatch disabled host-wide (AgentConfig.subagents_enabled):
+        # no dispatch candidates remain, so the informational
+        # list_subagent_models tool drops out as well. Gigacode paths are
+        # unaffected: the top-level workflow-authoring branch above already
+        # qualified, and a workflow worker with delegation depth left keeps the
+        # dispatch chain lent by run_workflow.
+        if getattr(self.config, "subagents_enabled", True) is False and not has_workflow_context_marker(context):
+            dispatch_candidates.clear()
         return bool(dispatch_candidates)
 
     async def initialize(self) -> list[str]:

--- a/kolega_code/cli/config.py
+++ b/kolega_code/cli/config.py
@@ -66,6 +66,10 @@ SEARXNG_BASE_URL_ENV = "SEARXNG_BASE_URL"
 # LSP master switch: on or off. Absent means defer to settings.lsp_enabled.
 LSP_MODES = ("on", "off")
 LSP_MODE_ENV = "KOLEGA_CODE_LSP"
+# Sub-agent dispatch (dispatch_agent) master switch: on or off. Absent means
+# defer to settings.subagents_enabled, then the default (enabled).
+SUBAGENT_MODES = ("on", "off")
+SUBAGENTS_MODE_ENV = "KOLEGA_CODE_SUBAGENTS"
 # Compression threshold override, in percent (10-100). Absent means defer to
 # settings.compression_threshold, then the agent's built-in default (80%).
 COMPRESSION_THRESHOLD_ENV = "KOLEGA_CODE_COMPRESSION_THRESHOLD"
@@ -93,6 +97,9 @@ class CliConfigOverrides:
     edit_protocol: Optional[str] = None
     web_search_mode: Optional[str] = None
     lsp_mode: Optional[str] = None
+    # Sub-agent dispatch override from the --subagents flag ("on"/"off"); None
+    # defers to KOLEGA_CODE_SUBAGENTS, then settings.subagents_enabled.
+    subagents_mode: Optional[str] = None
     # Compression threshold in percent, as typed on the command line; parsed and
     # validated in _compression_threshold.
     compression_threshold: Optional[str] = None
@@ -282,6 +289,23 @@ def _lsp_enabled(
         return mode == "on"
     if settings is not None and settings.lsp_enabled is not None:
         return bool(settings.lsp_enabled)
+    return True
+
+
+def _subagents_enabled(
+    env: Mapping[str, str],
+    settings: Optional[CliSettings],
+    override: Optional[str],
+) -> bool:
+    """Resolve the sub-agent dispatch master switch with flag-over-env-over-settings precedence."""
+    mode = (override or env.get(SUBAGENTS_MODE_ENV) or "").strip().lower()
+    if mode:
+        if mode not in SUBAGENT_MODES:
+            valid = ", ".join(SUBAGENT_MODES)
+            raise CliConfigError(f"Unsupported subagents mode '{mode}'. Valid modes: {valid}")
+        return mode == "on"
+    if settings is not None and settings.subagents_enabled is not None:
+        return bool(settings.subagents_enabled)
     return True
 
 
@@ -637,6 +661,7 @@ def build_agent_config(
             lsp=LspConfig(enabled=_lsp_enabled(loaded_env, settings, overrides.lsp_mode)),
             lsp_project_trusted=lsp_project_trusted,
             eval_enabled=(True if settings is None or settings.eval_enabled is None else bool(settings.eval_enabled)),
+            subagents_enabled=_subagents_enabled(loaded_env, settings, overrides.subagents_mode),
             history_compression_threshold=compression_threshold,
         )
     except ValueError as exc:

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -73,6 +73,7 @@ from .diagnostics import write_crash_log
 from .config import (
     DEPRECATED_THINKING_TOKENS_MESSAGE,
     LSP_MODES,
+    SUBAGENT_MODES,
     WEB_SEARCH_MODES,
     CliConfigError,
     CliConfigOverrides,
@@ -339,6 +340,13 @@ def _add_tui_args(parser: argparse.ArgumentParser) -> None:
         default=None,
         help="Force LSP tools on or off for this session (overrides settings.json; not persisted).",
     )
+    parser.add_argument(
+        "--subagents",
+        choices=list(SUBAGENT_MODES),
+        default=None,
+        help="Force sub-agent dispatch (dispatch_agent) on or off for this session "
+        "(overrides settings.json; not persisted).",
+    )
     _add_session_args(parser, session_help="Legacy alias for --resume SESSION_ID.")
     _add_worktree_args(parser)
     _add_common_model_args(parser)
@@ -433,6 +441,13 @@ def _build_subcommand_parser() -> argparse.ArgumentParser:
         choices=list(LSP_MODES),
         default=None,
         help="Force LSP tools on or off for this session (overrides settings.json; not persisted).",
+    )
+    ask.add_argument(
+        "--subagents",
+        choices=list(SUBAGENT_MODES),
+        default=None,
+        help="Force sub-agent dispatch (dispatch_agent) on or off for this session "
+        "(overrides settings.json; not persisted).",
     )
     ask.add_argument("--save", action="store_true", help="Persist the session after the prompt completes.")
     ask.add_argument("--json", action="store_true", help="Emit complete messages and events as JSON.")
@@ -647,6 +662,7 @@ def _overrides_from_args(args: argparse.Namespace) -> CliConfigOverrides:
         edit_protocol=getattr(args, "edit_protocol", None),
         web_search_mode=getattr(args, "web_search", None),
         lsp_mode=getattr(args, "lsp", None),
+        subagents_mode=getattr(args, "subagents", None),
         compression_threshold=getattr(args, "compression_threshold", None),
     )
 

--- a/kolega_code/cli/settings.py
+++ b/kolega_code/cli/settings.py
@@ -139,6 +139,9 @@ class CliSettings:
     # Additive optional field — absent in older files -> None -> eval tool
     # enabled (persistent code kernels with the loopback tool bridge).
     eval_enabled: Optional[bool] = None
+    # Additive optional field — absent in older files -> None -> sub-agent
+    # dispatch (dispatch_agent) enabled.
+    subagents_enabled: Optional[bool] = None
     # Context-window usage percent that triggers automatic history compression.
     # Additive optional field — absent in older files -> None -> the agent's
     # built-in default (80%).
@@ -187,6 +190,8 @@ class CliSettings:
             lsp_enabled=data.get("lsp_enabled"),
             # Additive optional field; absent in older files -> None (enabled).
             eval_enabled=data.get("eval_enabled"),
+            # Additive optional field; absent in older files -> None (enabled).
+            subagents_enabled=data.get("subagents_enabled"),
             # Additive optional field; absent in older files -> None (default 80%).
             compression_threshold=_coerce_compression_threshold(data.get("compression_threshold")),
         )
@@ -211,6 +216,7 @@ class CliSettings:
             "permission_mode": _coerce_permission_mode(self.permission_mode),
             "lsp_enabled": self.lsp_enabled,
             "eval_enabled": self.eval_enabled,
+            "subagents_enabled": self.subagents_enabled,
             "compression_threshold": self.compression_threshold,
         }
 

--- a/kolega_code/cli/tui/settings_panel.py
+++ b/kolega_code/cli/tui/settings_panel.py
@@ -41,6 +41,7 @@ from kolega_code.mcp.state import MCPStatusStore, MCPOAuthTokenStore
 from .. import messages, theme
 from ..config import (
     COMPRESSION_THRESHOLD_ENV,
+    SUBAGENTS_MODE_ENV,
     CliConfigError,
     active_model_override_message,
     build_agent_config,
@@ -511,6 +512,7 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         self._populate_web_search_controls()
         self._populate_mcp_controls()
         self._populate_lsp_controls()
+        self._populate_subagents_controls()
         self._populate_compression_controls()
         self._update_settings_status()
 
@@ -1574,6 +1576,43 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             return
         self.settings.lsp_enabled = value == "true"
 
+    def _populate_subagents_controls(self) -> None:
+        """Seed the sub-agents toggle from saved settings."""
+        try:
+            subagents_select = self._settings_query_one("#subagents_enabled_select", Select)
+        except NoMatches:
+            return
+        enabled = self.settings.subagents_enabled
+        if enabled is not None:
+            subagents_select.value = "true" if enabled else "false"
+        self._update_subagents_settings_status()
+
+    def _update_subagents_settings_status(self) -> None:
+        """Note when a launch flag or env var pins sub-agent dispatch for this session."""
+        try:
+            status = self._settings_query_one("#subagents_status", Static)
+        except NoMatches:
+            return
+        flag_value = getattr(self.overrides, "subagents_mode", None)
+        env_value = os.environ.get(SUBAGENTS_MODE_ENV)
+        forced = flag_value or env_value
+        if forced:
+            source = "--subagents" if flag_value else SUBAGENTS_MODE_ENV
+            status.update(
+                f"Sub-agents are forced {forced} for this session by {source}; "
+                "the setting applies from the next launch."
+            )
+            return
+        status.update("")
+
+    def _collect_subagents_from_ui(self) -> None:
+        """Read the sub-agents toggle and save into settings."""
+        try:
+            value = str(self._settings_query_one("#subagents_enabled_select", Select).value)
+        except NoMatches:
+            return
+        self.settings.subagents_enabled = value == "true"
+
     def _populate_compression_controls(self) -> None:
         """Seed the compression-threshold select from saved settings."""
         try:
@@ -1647,6 +1686,7 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             self._collect_model_slots_from_ui()
             self._collect_web_search_from_ui()
             self._collect_lsp_from_ui()
+            self._collect_subagents_from_ui()
             self._collect_compression_from_ui()
         finally:
             self.settings = original
@@ -1982,6 +2022,7 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
                 f"Web search: {search_backend}",
                 mcp_line,
                 f"LSP: {'enabled' if lsp_enabled else 'disabled'}",
+                f"Sub-agents: {'enabled' if self.settings.subagents_enabled is not False else 'disabled'}",
                 f"Theme: {theme_name}",
             ]
         )

--- a/kolega_code/cli/tui/settings_screen.py
+++ b/kolega_code/cli/tui/settings_screen.py
@@ -379,6 +379,20 @@ class SettingsScreen(ModalScreen[None]):
                     allow_blank=False,
                     value="true",
                 )
+            with Vertical(classes="settings-section", id="settings_subagents") as subagents_section:
+                subagents_section.border_title = "Sub-agents"
+                yield Static(
+                    "Let the agent dispatch focused sub-agents (dispatch_agent) for parallel or isolated work.",
+                    classes="settings-hint",
+                )
+                yield Static("", id="subagents_status")
+                yield Label("Sub-agents")
+                yield Select(
+                    [("Enabled", "true"), ("Disabled", "false")],
+                    id="subagents_enabled_select",
+                    allow_blank=False,
+                    value="true",
+                )
             with Vertical(classes="settings-section", id="settings_compression") as compression_section:
                 compression_section.border_title = "Context Compression"
                 yield Static(

--- a/kolega_code/config.py
+++ b/kolega_code/config.py
@@ -250,6 +250,11 @@ class AgentConfig(BaseModel):
         default=None, exclude=True, description="JS runtime for the eval JS kernel: 'bun', 'node', or a path"
     )
 
+    # Sub-agent dispatch (the dispatch_agent tool). Additive with a default that
+    # enables the feature; excluded from serialization (parity with
+    # eval_enabled) since it is resolved from settings.json / CLI flag at build.
+    subagents_enabled: bool = Field(default=True, exclude=True, description="Enable the dispatch_agent sub-agent tool")
+
     def model_config_for_agent(self, agent_name: Optional[str]) -> ModelConfig:
         """Return the model configuration an agent should use for its main loop.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,10 @@ exclude-newer = "1 week"
 # cryptography 50.0.0 (released 2026-07-31) is the only release fixing
 # CVE-2026-69247/-69248/-69249 and sat inside the 1-week quarantine when the
 # advisories landed (2026-08-04); admit it without widening the global window.
-exclude-newer-package = { cryptography = "2026-08-01T00:00:00Z" }
+# h2 4.4.1 (released 2026-08-03) is the only release fixing GHSA-6hr6-w5qg-qmwg
+# (CVE-2026-71554, duplicate Host header request smuggling) and sits inside the
+# same quarantine; admit it the same way.
+exclude-newer-package = { cryptography = "2026-08-01T00:00:00Z", h2 = "2026-08-04T00:00:00Z" }
 
 [tool.pyright]
 include = ["kolega_code", "benchmarks", "tests"]

--- a/tests/agent/test_agent_tools_inventory.py
+++ b/tests/agent/test_agent_tools_inventory.py
@@ -592,6 +592,82 @@ def test_lsp_tools_hidden_when_disabled(project_path, mock_connection_manager, a
     assert "resolve" not in tool_names
 
 
+def test_dispatch_tools_hidden_when_subagents_disabled(project_path, mock_connection_manager, agent_config):
+    """AgentConfig.subagents_enabled=False removes dispatch_agent — and the
+    informational list_subagent_models — from the registry."""
+    agent_config.subagents_enabled = False
+    agent = CoderAgent(
+        project_path=project_path,
+        workspace_id="test_workspace",
+        thread_id=str(uuid.uuid4()),
+        connection_manager=mock_connection_manager,
+        config=agent_config,
+        agent_mode=AgentMode.CLI,
+    )
+
+    tool_names = {tool.name for tool in agent.tool_collection.get_tool_list()}
+    assert "dispatch_agent" not in tool_names
+    assert "list_subagent_models" not in tool_names
+    # The registry is the dispatch boundary: a hidden tool is unreachable.
+    assert agent.tool_collection.has_tool("dispatch_agent") is False
+
+
+def test_subagents_disabled_keeps_list_subagent_models_for_gigacode(
+    project_path, mock_connection_manager, agent_config
+):
+    """Gigacode workflow authoring keeps the model-catalog tool: the subagents
+    gate clears dispatch candidates but not the gigacode delegation branch."""
+    agent_config.subagents_enabled = False
+    agent = CoderAgent(
+        project_path=project_path,
+        workspace_id="test_workspace",
+        thread_id=str(uuid.uuid4()),
+        connection_manager=mock_connection_manager,
+        config=agent_config,
+        agent_mode=AgentMode.CLI,
+    )
+    agent.apply_gigacode(True)
+
+    tool_names = {tool.name for tool in agent.tool_collection.get_tool_list()}
+    assert "dispatch_agent" not in tool_names
+    assert "run_workflow" in tool_names
+    assert "list_subagent_models" in tool_names
+
+
+def test_subagents_gate_beats_planning_custom_group_whitelist(tmp_path, mock_connection_manager, agent_config):
+    """PlanningAgent's custom_agent_tools group is a whitelist checked before the
+    read-only filter, so the subagents gate must run before the group checks:
+    with a plan-mode custom agent registered, dispatch_agent is offered by
+    default and removed host-wide when subagents_enabled=False."""
+    from kolega_code.agent.custom_agents import discover_custom_agents
+
+    agents_dir = tmp_path / ".kolega" / "agents"
+    agents_dir.mkdir(parents=True)
+    (agents_dir / "planner.md").write_text(
+        "---\nname: planner\ndescription: Produces focused plans\nmode: plan\n---\n\nFollow the custom instructions.\n",
+        encoding="utf-8",
+    )
+    catalog = discover_custom_agents(tmp_path, tmp_path / "state").for_mode("plan")
+
+    def build():
+        return PlanningAgent(
+            project_path=tmp_path,
+            workspace_id="test_workspace",
+            thread_id=str(uuid.uuid4()),
+            connection_manager=mock_connection_manager,
+            config=agent_config,
+            agent_mode=AgentMode.CLI,
+            custom_agent_catalog=catalog,
+        )
+
+    assert "dispatch_agent" in {tool.name for tool in build().tool_collection.get_tool_list()}
+
+    agent_config.subagents_enabled = False
+    disabled = build()
+    assert "dispatch_agent" not in {tool.name for tool in disabled.tool_collection.get_tool_list()}
+    assert disabled.tool_collection.has_tool("dispatch_agent") is False
+
+
 def _coder(project_path, mock_connection_manager, agent_config):
     return CoderAgent(
         project_path=project_path,

--- a/tests/agent/test_gigacode_gating.py
+++ b/tests/agent/test_gigacode_gating.py
@@ -155,6 +155,70 @@ def test_nested_workflow_agent_at_max_depth_is_a_leaf(
     assert "run_workflow" not in names
 
 
+def test_workflow_worker_keeps_dispatch_and_model_catalog_when_subagents_disabled(
+    project_path: str,
+    mock_connection_manager: AgentConnectionManager,
+    agent_config: AgentConfig,
+) -> None:
+    """A workflow worker's dispatch chain is lent by run_workflow, so the
+    subagents master switch must not strip it: list_subagent_models stays
+    visible whenever gigacode or subagents is enabled."""
+    agent_config.subagents_enabled = False
+    agent = _coder(project_path, mock_connection_manager, agent_config, sub_agent=True)
+    agent.sub_agent_context = {
+        "workflow_run_id": "run-1",
+        "depth": 1,
+        "max_agent_depth": 2,
+    }
+
+    names = {tool.name for tool in agent.tool_collection.get_tool_list()}
+
+    assert "dispatch_agent" in names
+    assert "list_subagent_models" in names
+    assert "run_workflow" not in names
+
+
+@pytest.mark.asyncio
+async def test_gigacode_authoring_can_call_list_subagent_models_when_subagents_disabled(
+    project_path: str,
+    mock_connection_manager: AgentConnectionManager,
+) -> None:
+    """Workflow authoring picks per-step routes from list_subagent_models, so the
+    tool must not only register but answer when gigacode is on and subagents off."""
+    config = AgentConfig(anthropic_api_key="test-key", subagents_enabled=False)
+    agent = _coder(project_path, mock_connection_manager, config)
+    agent.apply_gigacode(True)
+
+    assert agent.tool_collection.has_tool("list_subagent_models")
+    assert agent.tool_collection.has_tool("dispatch_agent") is False
+
+    catalog = await agent.tool_collection.call("list_subagent_models")
+
+    assert "anthropic" in catalog
+
+
+def test_workflow_leaf_at_max_depth_stays_leaf_when_subagents_disabled(
+    project_path: str,
+    mock_connection_manager: AgentConnectionManager,
+    agent_config: AgentConfig,
+) -> None:
+    """A depth-exhausted workflow worker can neither dispatch nor author, so it
+    keeps nothing — the subagents exemption only covers live delegation depth."""
+    agent_config.subagents_enabled = False
+    agent = _coder(project_path, mock_connection_manager, agent_config, sub_agent=True)
+    agent.sub_agent_context = {
+        "workflow_run_id": "run-1",
+        "depth": 2,
+        "max_agent_depth": 2,
+    }
+
+    names = {tool.name for tool in agent.tool_collection.get_tool_list()}
+
+    assert not names.intersection(ToolCollection.agent_dispatch_tools)
+    assert "list_subagent_models" not in names
+    assert "run_workflow" not in names
+
+
 def test_general_agent_never_gets_run_workflow(project_path, mock_connection_manager, agent_config):
     """GeneralAgent (always a sub-agent) never exposes run_workflow."""
     agent = GeneralAgent(

--- a/tests/cli/test_app_subagents_settings.py
+++ b/tests/cli/test_app_subagents_settings.py
@@ -1,0 +1,107 @@
+"""Settings-tab Sub-agents toggle: seeding, forced-by-flag status, and persistence.
+
+Mirrors the LSP master-switch coverage: the Tools tab shows a Sub-agents select
+seeded from ``settings.subagents_enabled``, a status note appears when the
+``--subagents`` launch flag pins the value for the session, and saving with
+"Disabled" writes ``subagents_enabled=False`` to settings.json.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kolega_code.cli.config import CliConfigOverrides, build_agent_config, config_summary
+from kolega_code.cli.provider_registry import UI_DEFAULT_MODEL, UI_DEFAULT_PROVIDER
+from kolega_code.cli.session_store import SessionStore
+from kolega_code.cli.settings import CliSettings, SettingsStore
+
+from ._app_test_utils import install_fake_agents, open_settings_screen
+from .test_app_lsp_settings_status import _static_text
+
+
+def _configured_app(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    subagents_enabled: bool | None = None,
+    overrides: CliConfigOverrides | None = None,
+):
+    pytest.importorskip("textual")
+    from kolega_code.cli.app import KolegaCodeApp
+
+    install_fake_agents(monkeypatch)
+    project = tmp_path / "project"
+    project.mkdir()
+    state_dir = tmp_path / "state"
+    settings_store = SettingsStore(state_dir)
+    settings = CliSettings(
+        active_provider=UI_DEFAULT_PROVIDER,
+        active_model=UI_DEFAULT_MODEL,
+        subagents_enabled=subagents_enabled,
+    )
+    settings.set_api_key(UI_DEFAULT_PROVIDER, "stored-key")
+    settings_store.save(settings)
+    config = build_agent_config(project, env={}, settings=settings, settings_store=settings_store, overrides=overrides)
+    store = SessionStore(state_dir)
+    session = store.create(project, "code", config_summary(config))
+    return (
+        KolegaCodeApp(
+            project_path=project,
+            config=config,
+            mode="code",
+            store=store,
+            settings_store=settings_store,
+            session=session,
+            overrides=overrides,
+        ),
+        settings_store,
+    )
+
+
+@pytest.mark.asyncio
+async def test_subagents_select_seeded_from_saved_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from textual.widgets import Select
+
+    app, _ = _configured_app(tmp_path, monkeypatch, subagents_enabled=False)
+    async with app.run_test() as pilot:
+        screen = await open_settings_screen(app, pilot, "tools")
+        assert str(screen.query_one("#subagents_enabled_select", Select).value) == "false"
+
+
+@pytest.mark.asyncio
+async def test_subagents_status_notes_forced_launch_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from textual.widgets import Static
+
+    app, _ = _configured_app(tmp_path, monkeypatch, overrides=CliConfigOverrides(subagents_mode="off"))
+    async with app.run_test() as pilot:
+        screen = await open_settings_screen(app, pilot, "tools")
+        text = _static_text(screen.query_one("#subagents_status", Static))
+        assert "--subagents" in text
+        assert "forced off" in text
+
+
+@pytest.mark.asyncio
+async def test_subagents_status_quiet_without_forcing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from textual.widgets import Static
+
+    app, _ = _configured_app(tmp_path, monkeypatch)
+    async with app.run_test() as pilot:
+        screen = await open_settings_screen(app, pilot, "tools")
+        assert _static_text(screen.query_one("#subagents_status", Static)) == ""
+
+
+@pytest.mark.asyncio
+async def test_subagents_save_persists_disabled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from textual.widgets import Select
+
+    app, settings_store = _configured_app(tmp_path, monkeypatch)
+    async with app.run_test() as pilot:
+        screen = await open_settings_screen(app, pilot, "tools")
+        screen.query_one("#subagents_enabled_select", Select).value = "false"
+        await pilot.pause()
+
+        await app._save_settings_from_ui()
+
+        assert settings_store.load().subagents_enabled is False

--- a/tests/cli/test_ask_subagents_flag.py
+++ b/tests/cli/test_ask_subagents_flag.py
@@ -1,0 +1,140 @@
+"""Tests for the ``--subagents`` flag and the sub-agent dispatch master-switch plumbing.
+
+The switch has one job spread over two layers: resolve (flag > env > settings >
+enabled, cli/config.py) and carry (AgentConfig.subagents_enabled -> the registry
+gate in ToolCollection._should_include_tool). Disabling must actually remove the
+``dispatch_agent`` tool from the model-facing toolset — not just error at call
+time — so the e2e tests drive a real ``CoderAgent`` through ``main(["ask", ...])``
+and assert on the tool inventory.
+"""
+
+import pytest
+
+from kolega_code.agent.coder import CoderAgent
+from kolega_code.cli.config import CliConfigError, CliConfigOverrides, _subagents_enabled
+from kolega_code.cli.settings import CliSettings, SettingsStore
+
+DISPATCH_TOOLS = {"dispatch_agent"}
+
+
+class RecordingCoderAgent(CoderAgent):
+    """The real agent, minus the network turn, recording every instance built."""
+
+    instances: list["RecordingCoderAgent"] = []
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        RecordingCoderAgent.instances.append(self)
+
+    async def process_message_stream(self, message, attachments=None):
+        yield {"type": "response", "content": "done", "complete": True, "uuid": "response-1"}
+
+    def tool_names(self) -> set[str]:
+        assert self.tool_collection is not None
+        return {tool.name for tool in self.tool_collection.get_tool_list()}
+
+
+def _setup(tmp_path, monkeypatch):
+    from kolega_code.cli import main as main_module
+
+    RecordingCoderAgent.instances = []
+    monkeypatch.setattr(main_module, "CoderAgent", RecordingCoderAgent)
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("KOLEGA_CODE_PROVIDER", "anthropic")
+    monkeypatch.setenv("KOLEGA_CODE_MODEL", "claude-opus-5")
+    return main_module, project
+
+
+def _persist_subagents_disabled(tmp_path):
+    """Write subagents_enabled=False to the isolated settings.json the CLI will read."""
+    store = SettingsStore(tmp_path / "state")
+    settings = store.load()
+    settings.subagents_enabled = False
+    store.save(settings)
+
+
+# --- resolution -------------------------------------------------------------------
+
+
+def test_subagents_resolution_precedence():
+    settings = CliSettings(subagents_enabled=True)
+    env = {"KOLEGA_CODE_SUBAGENTS": "off"}
+    # flag > env > settings > default (enabled)
+    assert _subagents_enabled(env, settings, "on") is True
+    assert _subagents_enabled(env, settings, None) is False
+    assert _subagents_enabled({}, settings, None) is True
+    assert _subagents_enabled({}, CliSettings(subagents_enabled=False), None) is False
+    assert _subagents_enabled({}, None, None) is True
+
+
+def test_subagents_flag_forces_on_over_disabled_settings():
+    assert _subagents_enabled({}, CliSettings(subagents_enabled=False), "on") is True
+
+
+def test_subagents_resolution_rejects_unknown_env_value():
+    with pytest.raises(CliConfigError):
+        _subagents_enabled({"KOLEGA_CODE_SUBAGENTS": "sideways"}, None, None)
+
+
+def test_overrides_dataclass_carries_the_mode():
+    assert CliConfigOverrides(subagents_mode="off").subagents_mode == "off"
+
+
+# --- end to end -------------------------------------------------------------------
+
+
+def test_ask_subagents_off_removes_gated_tools(tmp_path, monkeypatch, isolated_cli_env):
+    main_module, project = _setup(tmp_path, monkeypatch)
+
+    exit_code = main_module.main(["ask", "do the thing", "--project", str(project), "--subagents", "off"])
+
+    assert exit_code == 0
+    agent = RecordingCoderAgent.instances[0]
+    assert not (DISPATCH_TOOLS & agent.tool_names())
+    # The informational model-catalog tool follows the dispatch gate.
+    assert "list_subagent_models" not in agent.tool_names()
+
+
+def test_ask_default_keeps_dispatch_tools(tmp_path, monkeypatch, isolated_cli_env):
+    """No flag, no setting: today's inventory includes the dispatch tool."""
+    main_module, project = _setup(tmp_path, monkeypatch)
+
+    exit_code = main_module.main(["ask", "do the thing", "--project", str(project)])
+
+    assert exit_code == 0
+    assert DISPATCH_TOOLS <= RecordingCoderAgent.instances[0].tool_names()
+
+
+def test_ask_disabled_settings_remove_tools_without_flag(tmp_path, monkeypatch, isolated_cli_env):
+    """settings.json subagents_enabled=false alone must drop the tool (registry gate)."""
+    main_module, project = _setup(tmp_path, monkeypatch)
+    _persist_subagents_disabled(tmp_path)
+
+    exit_code = main_module.main(["ask", "do the thing", "--project", str(project)])
+
+    assert exit_code == 0
+    assert not (DISPATCH_TOOLS & RecordingCoderAgent.instances[0].tool_names())
+
+
+def test_ask_flag_on_beats_disabled_settings(tmp_path, monkeypatch, isolated_cli_env):
+    main_module, project = _setup(tmp_path, monkeypatch)
+    _persist_subagents_disabled(tmp_path)
+
+    exit_code = main_module.main(["ask", "do the thing", "--project", str(project), "--subagents", "on"])
+
+    assert exit_code == 0
+    assert DISPATCH_TOOLS <= RecordingCoderAgent.instances[0].tool_names()
+
+
+def test_ask_env_off_removes_tools_and_flag_beats_env(tmp_path, monkeypatch, isolated_cli_env):
+    main_module, project = _setup(tmp_path, monkeypatch)
+    monkeypatch.setenv("KOLEGA_CODE_SUBAGENTS", "off")
+
+    assert main_module.main(["ask", "first", "--project", str(project)]) == 0
+    assert main_module.main(["ask", "second", "--project", str(project), "--subagents", "on"]) == 0
+
+    env_only, flag_wins = RecordingCoderAgent.instances
+    assert not (DISPATCH_TOOLS & env_only.tool_names())
+    assert DISPATCH_TOOLS <= flag_wins.tool_names()

--- a/tests/cli/test_settings.py
+++ b/tests/cli/test_settings.py
@@ -58,6 +58,7 @@ def test_settings_store_missing_file_returns_empty_settings(tmp_path: Path) -> N
     assert settings.api_keys == {}
     assert settings.agent_models == {}
     assert settings.eval_enabled is None
+    assert settings.subagents_enabled is None
 
 
 def test_settings_store_round_trips_eval_enabled(tmp_path: Path) -> None:
@@ -71,6 +72,19 @@ def test_settings_store_round_trips_eval_enabled(tmp_path: Path) -> None:
     # Absent in older files -> None -> the eval tool stays enabled downstream.
     store.save(CliSettings())
     assert SettingsStore(tmp_path).load().eval_enabled is None
+
+
+def test_settings_store_round_trips_subagents_enabled(tmp_path: Path) -> None:
+    store = SettingsStore(tmp_path)
+    store.save(CliSettings(subagents_enabled=False))
+
+    loaded = store.load()
+    assert loaded.subagents_enabled is False
+    assert loaded.to_dict()["subagents_enabled"] is False
+
+    # Absent in older files -> None -> sub-agent dispatch stays enabled downstream.
+    store.save(CliSettings())
+    assert SettingsStore(tmp_path).load().subagents_enabled is None
 
 
 def test_settings_store_round_trips_agent_models(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -22,6 +22,7 @@ exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
 cryptography = "2026-08-01T00:00:00Z"
+h2 = "2026-08-04T00:00:00Z"
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -1203,24 +1204,24 @@ wheels = [
 
 [[package]]
 name = "h2"
-version = "4.3.0"
+version = "4.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hpack" },
     { name = "hyperframe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/85/7c366e69d84c17bb778fe41419e1fbcce3033d5b7ce29bbffff0a98b859f/h2-4.4.1.tar.gz", hash = "sha256:4e866ffb1a869ae14dd9b5e6beb5c24a13da0495ad72b65925ded182521c1516", size = 2157281, upload-time = "2026-08-03T11:45:09.509Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/e85faf23bd72a92d1921e37d674ca56eb298a3c8be31fdecef0ff2b3aaac/h2-4.4.1-py3-none-any.whl", hash = "sha256:0e25f1462b23c9cb82d9eb02e28bc706dac2a68cb457c6a0d74d63c8a2a5d0e6", size = 62636, upload-time = "2026-08-03T11:44:59.164Z" },
 ]
 
 [[package]]
 name = "hpack"
-version = "4.1.0"
+version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz", hash = "sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0", size = 51300, upload-time = "2026-06-23T18:34:46.667Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
+    { url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl", hash = "sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986", size = 34246, upload-time = "2026-06-23T18:34:45.472Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add a user-facing master switch for sub-agents (the `dispatch_agent` tool), following the existing LSP/eval master-switch pattern end to end. Default is **on**.

- **CLI**: `--subagents on|off` on the `ask` and TUI launch parsers — a session override, resolved flag > `KOLEGA_CODE_SUBAGENTS` env > `settings.json` > enabled. The flag itself is not persisted.
- **Settings**: new additive-optional `subagents_enabled` key in `settings.json` (absent → on, no schema bump), editable from a new **Sub-agents** section on the TUI Settings → Tools tab, with a status note when a launch flag or env var pins the session value. The settings summary sidebar gains a `Sub-agents: enabled/disabled` line.
- **Registry gate**: `AgentConfig.subagents_enabled` is consumed in `ToolCollection._should_include_tool`, placed before the `custom_tool_groups` whitelist, so a disabled switch removes `dispatch_agent` from the model-facing toolset for every agent type (chat, planning, investigation, custom agents) instead of merely erroring at call time.
- **Gigacode is unaffected**: `run_workflow` keeps its own opt-in gate, workflow workers with delegation depth left keep their lent dispatch chain, and `list_subagent_models` stays visible whenever gigacode **or** sub-agents are enabled — workflow authoring picks per-step model routes from it. It is hidden only when neither path can delegate.

## Tests

- `tests/cli/test_ask_subagents_flag.py` — resolution precedence (flag > env > settings > default), invalid-mode rejection, and e2e through `main(["ask", ...])`: `--subagents off` removes `dispatch_agent`, persisted `subagents_enabled: false` removes it without a flag, `--subagents on` beats disabled settings, env `off` removed and flag beats env.
- `tests/agent/test_agent_tools_inventory.py` — gate coverage for `CoderAgent` (dispatch + `list_subagent_models` hidden, `has_tool` False) and `PlanningAgent` with a plan-mode custom agent registered, proving the gate beats the `custom_tool_groups` whitelist.
- `tests/agent/test_gigacode_gating.py` — workflow workers keep `dispatch_agent` + `list_subagent_models` when subagents are disabled, depth-exhausted leaves stay leaves, and a gigacode-enabled top-level agent can actually call `list_subagent_models` and get the model catalog with subagents off.
- `tests/cli/test_settings.py` — round-trip and absent-means-None defaults.
- `tests/cli/test_app_subagents_settings.py` — Tools-tab select seeded from saved settings, forced-by-flag status note, and saving "Disabled" persists `subagents_enabled=False`.

## Docs

`cli/ask.md` and `cli/overview.md` flag tables, `configuration/environment-variables.md` (`KOLEGA_CODE_SUBAGENTS`), and the Sub-agent dispatch section of `concepts/tools.md`.