### PR TITLE
fix(agent): bump compression SUMMARY_MAX_TOKENS from 2048 to 8192

### DIFF
--- a/kolega_code/agent/compression.py
+++ b/kolega_code/agent/compression.py
@@ -39,9 +39,12 @@ class HistoryCompressor:
     KEEP_RECENT_MESSAGES = 6
     # Don't bother summarizing a trivially short prefix.
     MIN_PREFIX_TO_SUMMARIZE = 3
-    # Cap the summary length: the prompt targets ~600 words (~900 tokens), so a
-    # small ceiling keeps it tight and avoids the model's full completion budget.
-    SUMMARY_MAX_TOKENS = 2048
+    # Cap the summary length. The prompt targets ~600 words, but reasoning
+    # models (deepseek-v4-flash Responses, etc.) can consume the entire budget
+    # on chain-of-thought and leave no room for text output, producing an empty
+    # summary. A generous ceiling gives reasoning headroom while still staying
+    # well under the model's full completion budget.
+    SUMMARY_MAX_TOKENS = 8192
 
     def __init__(self, threshold: float = 0.8) -> None:
         # Fraction of the model context window above which compression kicks in

--- a/tests/agent/test_base_agent_compaction.py
+++ b/tests/agent/test_base_agent_compaction.py
@@ -79,8 +79,10 @@ class TestBaseAgent:
         assert fake.stream.await_args is not None
         call_args = fake.stream.await_args.kwargs
         assert call_args["model"] == base_agent.primary_model_config.model
-        # Summary budget is capped small (we are not aiming for a gigantic summary).
-        assert call_args["max_completion_tokens"] <= 2048
+        # Summary budget is capped by HistoryCompressor.SUMMARY_MAX_TOKENS.
+        from kolega_code.agent.compression import HistoryCompressor
+
+        assert call_args["max_completion_tokens"] <= HistoryCompressor.SUMMARY_MAX_TOKENS
 
     @pytest.mark.asyncio
     async def testcompress_history_insufficient_history(self, base_agent):


### PR DESCRIPTION
Reasoning models (deepseek-v4-flash on the Responses API) can consume the entire output budget on chain-of-thought and leave no room for text output, producing an empty summary and the error "Compression produced an empty summary; history left unchanged."

8192 tokens gives reasoning headroom while staying well under the model's full completion budget.

**Verified**: compacted session `3dfe2cc51c9a4eaa9c31dab24c2e0018` (which originally hit this bug) — compaction now produces a non-empty structured summary.