### PR TITLE
feat(cli): add skills switch

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -189,7 +189,10 @@ class KolegaCodeApp(
         )
         self.overrides = overrides or CliConfigOverrides()
         self.settings: CliSettings = CliSettings()
-        self.skill_catalog: SkillCatalog = discover_skills(self.active_project_path)
+        self.skills_enabled = config.skills_enabled if config is not None else True
+        self.skill_catalog: SkillCatalog = (
+            discover_skills(self.active_project_path) if self.skills_enabled else SkillCatalog()
+        )
         self.custom_agent_catalog: CustomAgentCatalog = discover_custom_agents(
             self.active_project_path,
             self.settings_store.root,
@@ -984,7 +987,7 @@ class KolegaCodeApp(
             return
         slash = composer.active_slash_query()
         if slash is not None:
-            commands = search_commands(slash[0], self.skill_catalog, limit=8)
+            commands = search_commands(slash[0], self.skill_catalog, limit=8, skills_enabled=self.skills_enabled)
             if not commands:
                 dropdown.close()
                 return

--- a/kolega_code/cli/config.py
+++ b/kolega_code/cli/config.py
@@ -73,6 +73,10 @@ LSP_MODE_ENV = "KOLEGA_CODE_LSP"
 # defer to settings.subagents_enabled, then the default (enabled).
 SUBAGENT_MODES = ("on", "off")
 SUBAGENTS_MODE_ENV = "KOLEGA_CODE_SUBAGENTS"
+# Agent Skills master switch: on or off. Absent means defer to
+# settings.skills_enabled, then the default (enabled).
+SKILL_MODES = ("on", "off")
+SKILLS_MODE_ENV = "KOLEGA_CODE_SKILLS"
 # Compression threshold override, in percent (10-100). Absent means defer to
 # settings.compression_threshold, then the agent's built-in default (80%).
 COMPRESSION_THRESHOLD_ENV = "KOLEGA_CODE_COMPRESSION_THRESHOLD"
@@ -103,6 +107,9 @@ class CliConfigOverrides:
     # Sub-agent dispatch override from the --subagents flag ("on"/"off"); None
     # defers to KOLEGA_CODE_SUBAGENTS, then settings.subagents_enabled.
     subagents_mode: Optional[str] = None
+    # Agent Skills override from the --skills flag ("on"/"off"); None defers
+    # to KOLEGA_CODE_SKILLS, then settings.skills_enabled.
+    skills_mode: Optional[str] = None
     # Compression threshold in percent, as typed on the command line; parsed and
     # validated in _compression_threshold.
     compression_threshold: Optional[str] = None
@@ -317,6 +324,23 @@ def _subagents_enabled(
         return mode == "on"
     if settings is not None and settings.subagents_enabled is not None:
         return bool(settings.subagents_enabled)
+    return True
+
+
+def _skills_enabled(
+    env: Mapping[str, str],
+    settings: Optional[CliSettings],
+    override: Optional[str],
+) -> bool:
+    """Resolve the Agent Skills master switch with flag-over-env-over-settings precedence."""
+    mode = (override or env.get(SKILLS_MODE_ENV) or "").strip().lower()
+    if mode:
+        if mode not in SKILL_MODES:
+            valid = ", ".join(SKILL_MODES)
+            raise CliConfigError(f"Unsupported skills mode '{mode}'. Valid modes: {valid}")
+        return mode == "on"
+    if settings is not None and settings.skills_enabled is not None:
+        return bool(settings.skills_enabled)
     return True
 
 
@@ -675,6 +699,7 @@ def build_agent_config(
             lsp_project_trusted=lsp_project_trusted,
             eval_enabled=(True if settings is None or settings.eval_enabled is None else bool(settings.eval_enabled)),
             subagents_enabled=_subagents_enabled(loaded_env, settings, overrides.subagents_mode),
+            skills_enabled=_skills_enabled(loaded_env, settings, overrides.skills_mode),
             history_compression_threshold=compression_threshold,
         )
     except ValueError as exc:

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -73,6 +73,7 @@ from .diagnostics import write_crash_log
 from .config import (
     DEPRECATED_THINKING_TOKENS_MESSAGE,
     LSP_MODES,
+    SKILL_MODES,
     SUBAGENT_MODES,
     WEB_SEARCH_MODES,
     CliConfigError,
@@ -80,6 +81,8 @@ from .config import (
     active_model_override_message,
     build_agent_config,
     config_summary,
+    load_cli_env,
+    _skills_enabled,
 )
 from .connection import CliConnectionManager
 from .mentions import build_file_attachments
@@ -347,6 +350,12 @@ def _add_tui_args(parser: argparse.ArgumentParser) -> None:
         help="Force sub-agent dispatch (dispatch_agent) on or off for this session "
         "(overrides settings.json; not persisted).",
     )
+    parser.add_argument(
+        "--skills",
+        choices=list(SKILL_MODES),
+        default=None,
+        help="Force Agent Skills on or off for this session (overrides settings.json; not persisted).",
+    )
     _add_session_args(parser, session_help="Legacy alias for --resume SESSION_ID.")
     _add_worktree_args(parser)
     _add_common_model_args(parser)
@@ -448,6 +457,12 @@ def _build_subcommand_parser() -> argparse.ArgumentParser:
         default=None,
         help="Force sub-agent dispatch (dispatch_agent) on or off for this session "
         "(overrides settings.json; not persisted).",
+    )
+    ask.add_argument(
+        "--skills",
+        choices=list(SKILL_MODES),
+        default=None,
+        help="Force Agent Skills on or off for this session (overrides settings.json; not persisted).",
     )
     ask.add_argument("--save", action="store_true", help="Persist the session after the prompt completes.")
     ask.add_argument("--json", action="store_true", help="Emit complete messages and events as JSON.")
@@ -663,6 +678,7 @@ def _overrides_from_args(args: argparse.Namespace) -> CliConfigOverrides:
         web_search_mode=getattr(args, "web_search", None),
         lsp_mode=getattr(args, "lsp", None),
         subagents_mode=getattr(args, "subagents", None),
+        skills_mode=getattr(args, "skills", None),
         compression_threshold=getattr(args, "compression_threshold", None),
     )
 
@@ -1210,7 +1226,11 @@ async def _run_ask(args: argparse.Namespace) -> int:
         if resumed_session is not None:
             _validate_session_project(resumed_session, launch_project_path)
             project_path = _active_project_for_resume(resumed_session, store)
-    skill_catalog = discover_skills(project_path)
+    settings_store = _settings_store_from_args(args)
+    settings = settings_store.load()
+    overrides = _overrides_from_args(args)
+    skills_enabled = _skills_enabled(load_cli_env(launch_project_path), settings, overrides.skills_mode)
+    skill_catalog = discover_skills(project_path) if skills_enabled else SkillCatalog()
     goal_condition = getattr(args, "goal", None)
     loop_interval = getattr(args, "loop", None)
     loop_cron = getattr(args, "loop_cron", None)
@@ -1253,10 +1273,11 @@ async def _run_ask(args: argparse.Namespace) -> int:
     skill_command = _parse_skill_prompt(raw_prompt, skill_catalog) if raw_prompt else None
 
     if skill_command and skill_command[0] == "skills":
+        catalog_text = skill_catalog.format_catalog() if skills_enabled else messages.SKILLS_DISABLED
         if args.json:
-            print(json.dumps({"kind": "skills", "data": skill_catalog.format_catalog()}, default=str))
+            print(json.dumps({"kind": "skills", "data": catalog_text}, default=str))
         else:
-            print(skill_catalog.format_catalog())
+            print(catalog_text)
         return 0
 
     if skill_command and skill_command[0] != "skills" and not skill_command[1] and not (args.save or args.session):
@@ -1278,8 +1299,6 @@ async def _run_ask(args: argparse.Namespace) -> int:
             print(activation_content)
         return 0
 
-    settings_store = _settings_store_from_args(args)
-    settings = settings_store.load()
     custom_agent_catalog = discover_custom_agents(project_path, settings_store.root)
     settings_changed = False
     if getattr(args, "trust_hooks", False):
@@ -1293,9 +1312,7 @@ async def _run_ask(args: argparse.Namespace) -> int:
         settings_changed = True
     if settings_changed:
         settings_store.save(settings)
-    config = build_agent_config(
-        launch_project_path, _overrides_from_args(args), settings=settings, settings_store=settings_store
-    )
+    config = build_agent_config(launch_project_path, overrides, settings=settings, settings_store=settings_store)
     custom_agent_catalog = validate_custom_agent_models(custom_agent_catalog, config).for_mode("build")
     if not args.json:
         for diagnostic in custom_agent_catalog.diagnostics:
@@ -1336,18 +1353,19 @@ async def _run_ask(args: argparse.Namespace) -> int:
     agent_ref: dict[str, CoderAgent] = {}
     prompt_extensions = []
     tool_extensions = []
-    skill_prompt_extension = build_skill_prompt_extension(
-        skill_catalog,
-        context_window_tokens=context_window_tokens_for_skill_budget(config, CoderAgent.agent_name),
-    )
-    skill_tool_extension = build_skill_tool_extension(
-        skill_catalog,
-        lambda: agent_ref["agent"].history if "agent" in agent_ref else [],
-    )
-    if skill_prompt_extension is not None:
-        prompt_extensions.append(skill_prompt_extension)
-    if skill_tool_extension is not None:
-        tool_extensions.append(skill_tool_extension)
+    if skills_enabled:
+        skill_prompt_extension = build_skill_prompt_extension(
+            skill_catalog,
+            context_window_tokens=context_window_tokens_for_skill_budget(config, CoderAgent.agent_name),
+        )
+        skill_tool_extension = build_skill_tool_extension(
+            skill_catalog,
+            lambda: agent_ref["agent"].history if "agent" in agent_ref else [],
+        )
+        if skill_prompt_extension is not None:
+            prompt_extensions.append(skill_prompt_extension)
+        if skill_tool_extension is not None:
+            tool_extensions.append(skill_tool_extension)
     mcp_config = getattr(config, "mcp_config", None)
     if not args.json and mcp_config is not None:
         for diagnostic in getattr(mcp_config, "diagnostics", []) or []:

--- a/kolega_code/cli/messages.py
+++ b/kolega_code/cli/messages.py
@@ -148,6 +148,7 @@ PLAN_REOFFERED = "No new plan captured. Reusing the last captured plan."
 PLAN_DISCUSSION_RESUMED = "Planning discussion resumed."
 SKILL_ACTIVATED = "Activated skill {name}."
 SKILLS_LISTED = "Listed agent skills."
+SKILLS_DISABLED = "Agent Skills are disabled for this session."
 
 # Mentions
 MENTIONS_NOT_FOUND = "Not found, sent as plain text: {mentions}"

--- a/kolega_code/cli/settings.py
+++ b/kolega_code/cli/settings.py
@@ -142,6 +142,9 @@ class CliSettings:
     # Additive optional field — absent in older files -> None -> sub-agent
     # dispatch (dispatch_agent) enabled.
     subagents_enabled: Optional[bool] = None
+    # Additive optional field — absent in older files -> None -> Agent Skills
+    # enabled.
+    skills_enabled: Optional[bool] = None
     # Context-window usage percent that triggers automatic history compression.
     # Additive optional field — absent in older files -> None -> the agent's
     # built-in default (80%).
@@ -192,6 +195,8 @@ class CliSettings:
             eval_enabled=data.get("eval_enabled"),
             # Additive optional field; absent in older files -> None (enabled).
             subagents_enabled=data.get("subagents_enabled"),
+            # Additive optional field; absent in older files -> None (enabled).
+            skills_enabled=data.get("skills_enabled"),
             # Additive optional field; absent in older files -> None (default 80%).
             compression_threshold=_coerce_compression_threshold(data.get("compression_threshold")),
         )
@@ -217,6 +222,7 @@ class CliSettings:
             "lsp_enabled": self.lsp_enabled,
             "eval_enabled": self.eval_enabled,
             "subagents_enabled": self.subagents_enabled,
+            "skills_enabled": self.skills_enabled,
             "compression_threshold": self.compression_threshold,
         }
 

--- a/kolega_code/cli/slash_commands.py
+++ b/kolega_code/cli/slash_commands.py
@@ -101,7 +101,9 @@ def agent_command_names() -> frozenset[str]:
     return frozenset(spec.name for spec in CommandProcessor.SPECS)
 
 
-def all_command_entries(skill_catalog: "SkillCatalog | None" = None) -> List[SlashCommandEntry]:
+def all_command_entries(
+    skill_catalog: "SkillCatalog | None" = None, *, skills_enabled: bool = True
+) -> List[SlashCommandEntry]:
     """All known slash commands: agent built-ins, TUI commands, then skills.
 
     De-duplicated by name; agent and TUI commands take precedence over a
@@ -114,10 +116,15 @@ def all_command_entries(skill_catalog: "SkillCatalog | None" = None) -> List[Sla
             SlashCommandEntry(record.name, record.description, CommandScope.SKILL)
             for record in skill_catalog.skills.values()
         )
-        if skill_catalog is not None
+        if skill_catalog is not None and skills_enabled
         else ()
     )
-    for entry in (*agent_command_entries(), *TUI_COMMAND_ENTRIES, *skill_entries):
+    tui_entries = (
+        TUI_COMMAND_ENTRIES
+        if skills_enabled
+        else tuple(entry for entry in TUI_COMMAND_ENTRIES if entry.token != SKILLS_LIST_COMMAND)
+    )
+    for entry in (*agent_command_entries(), *tui_entries, *skill_entries):
         if entry.name in seen:
             continue
         seen.add(entry.name)
@@ -125,14 +132,20 @@ def all_command_entries(skill_catalog: "SkillCatalog | None" = None) -> List[Sla
     return entries
 
 
-def search_commands(query: str, skill_catalog: "SkillCatalog | None" = None, limit: int = 8) -> List[SlashCommandEntry]:
+def search_commands(
+    query: str,
+    skill_catalog: "SkillCatalog | None" = None,
+    limit: int = 8,
+    *,
+    skills_enabled: bool = True,
+) -> List[SlashCommandEntry]:
     """Filter commands by ``query``: prefix matches first, then substring matches.
 
     An empty query returns all commands (capped at ``limit``). Results are
     alphabetical within each tier.
     """
     needle = query.lower()
-    entries = all_command_entries(skill_catalog)
+    entries = all_command_entries(skill_catalog, skills_enabled=skills_enabled)
     if not needle:
         return sorted(entries, key=lambda entry: entry.name)[:limit]
     prefix = [entry for entry in entries if entry.name.lower().startswith(needle)]

--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -43,6 +43,7 @@ from ..goal import (
 )
 from ..plan_artifacts import write_current_plan_artifact
 from ..skills import (
+    SkillCatalog,
     build_skill_prompt_extension,
     build_skill_tool_extension,
     context_window_tokens_for_skill_budget,
@@ -1091,7 +1092,8 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
             browser_visible=self.browser_visible,
         )
         agent_class = PlanningAgent if self.interaction_mode == tui_constants.PLAN_INTERACTION_MODE else CoderAgent
-        self.skill_catalog = discover_skills(self.active_project_path)
+        self.skills_enabled = config.skills_enabled
+        self.skill_catalog = discover_skills(self.active_project_path) if self.skills_enabled else SkillCatalog()
         self.custom_agent_catalog = validate_custom_agent_models(
             discover_custom_agents(self.active_project_path, self.settings_store.root),
             config,
@@ -1126,21 +1128,22 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
         scratchpad_extension = self._scratchpad_prompt_extension()
         if scratchpad_extension is not None:
             prompt_extensions.append(scratchpad_extension)
-        skill_prompt_extension = build_skill_prompt_extension(
-            self.skill_catalog,
-            context_window_tokens=context_window_tokens_for_skill_budget(
-                config,
-                getattr(agent_class, "agent_name", None),
-            ),
-        )
-        skill_tool_extension = build_skill_tool_extension(
-            self.skill_catalog,
-            lambda: self.agent.history if self.agent is not None else [],
-        )
-        if skill_prompt_extension is not None:
-            prompt_extensions.append(skill_prompt_extension)
-        if skill_tool_extension is not None:
-            tool_extensions.append(skill_tool_extension)
+        if self.skills_enabled:
+            skill_prompt_extension = build_skill_prompt_extension(
+                self.skill_catalog,
+                context_window_tokens=context_window_tokens_for_skill_budget(
+                    config,
+                    getattr(agent_class, "agent_name", None),
+                ),
+            )
+            skill_tool_extension = build_skill_tool_extension(
+                self.skill_catalog,
+                lambda: self.agent.history if self.agent is not None else [],
+            )
+            if skill_prompt_extension is not None:
+                prompt_extensions.append(skill_prompt_extension)
+            if skill_tool_extension is not None:
+                tool_extensions.append(skill_tool_extension)
         # Both modes can ask the user; only the framing differs. Plan mode treats a
         # question as cheap, build mode reserves it for decisions that are expensive
         # to get wrong.

--- a/kolega_code/cli/tui/app_base.py
+++ b/kolega_code/cli/tui/app_base.py
@@ -93,6 +93,7 @@ class KolegaAppBase(App):
         overrides: CliConfigOverrides
         settings: CliSettings
         skill_catalog: SkillCatalog
+        skills_enabled: bool
         file_index: WorkspaceFileIndex
         _file_index_refreshing: bool
         _diag: DiagnosticsLog | None

--- a/kolega_code/cli/tui/command_handlers.py
+++ b/kolega_code/cli/tui/command_handlers.py
@@ -1454,7 +1454,10 @@ class CommandHandlersMixin(tui_app_base.KolegaAppBase):
 
         if command_name == "skills":
             self._add_conversation_entry(
-                tui_state.ConversationEntry(kind="system", content=self.skill_catalog.format_catalog())
+                tui_state.ConversationEntry(
+                    kind="system",
+                    content=(self.skill_catalog.format_catalog() if self.skills_enabled else messages.SKILLS_DISABLED),
+                )
             )
             self._log_status(messages.SKILLS_LISTED, "ok")
             return True

--- a/kolega_code/cli/tui/settings_panel.py
+++ b/kolega_code/cli/tui/settings_panel.py
@@ -41,6 +41,7 @@ from kolega_code.mcp.state import MCPStatusStore, MCPOAuthTokenStore
 from .. import messages, theme
 from ..config import (
     COMPRESSION_THRESHOLD_ENV,
+    SKILLS_MODE_ENV,
     SUBAGENTS_MODE_ENV,
     CliConfigError,
     active_model_override_message,
@@ -513,6 +514,7 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         self._populate_mcp_controls()
         self._populate_lsp_controls()
         self._populate_subagents_controls()
+        self._populate_skills_controls()
         self._populate_compression_controls()
         self._update_settings_status()
 
@@ -1613,6 +1615,43 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             return
         self.settings.subagents_enabled = value == "true"
 
+    def _populate_skills_controls(self) -> None:
+        """Seed the Agent Skills toggle from saved settings."""
+        try:
+            skills_select = self._settings_query_one("#skills_enabled_select", Select)
+        except NoMatches:
+            return
+        enabled = self.settings.skills_enabled
+        if enabled is not None:
+            skills_select.value = "true" if enabled else "false"
+        self._update_skills_settings_status()
+
+    def _update_skills_settings_status(self) -> None:
+        """Note when a launch flag or env var pins Agent Skills for this session."""
+        try:
+            status = self._settings_query_one("#skills_status", Static)
+        except NoMatches:
+            return
+        flag_value = getattr(self.overrides, "skills_mode", None)
+        env_value = os.environ.get(SKILLS_MODE_ENV)
+        forced = flag_value or env_value
+        if forced:
+            source = "--skills" if flag_value else SKILLS_MODE_ENV
+            status.update(
+                f"Agent Skills are forced {forced} for this session by {source}; "
+                "the setting applies from the next launch."
+            )
+            return
+        status.update("")
+
+    def _collect_skills_from_ui(self) -> None:
+        """Read the Agent Skills toggle and save it into settings."""
+        try:
+            value = str(self._settings_query_one("#skills_enabled_select", Select).value)
+        except NoMatches:
+            return
+        self.settings.skills_enabled = value == "true"
+
     def _populate_compression_controls(self) -> None:
         """Seed the compression-threshold select from saved settings."""
         try:
@@ -1687,6 +1726,7 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             self._collect_web_search_from_ui()
             self._collect_lsp_from_ui()
             self._collect_subagents_from_ui()
+            self._collect_skills_from_ui()
             self._collect_compression_from_ui()
         finally:
             self.settings = original
@@ -2023,6 +2063,7 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
                 mcp_line,
                 f"LSP: {'enabled' if lsp_enabled else 'disabled'}",
                 f"Sub-agents: {'enabled' if self.settings.subagents_enabled is not False else 'disabled'}",
+                f"Agent Skills: {'enabled' if self.settings.skills_enabled is not False else 'disabled'}",
                 f"Theme: {theme_name}",
             ]
         )

--- a/kolega_code/cli/tui/settings_screen.py
+++ b/kolega_code/cli/tui/settings_screen.py
@@ -393,6 +393,20 @@ class SettingsScreen(ModalScreen[None]):
                     allow_blank=False,
                     value="true",
                 )
+            with Vertical(classes="settings-section", id="settings_skills") as skills_section:
+                skills_section.border_title = "Agent Skills"
+                yield Static(
+                    "Discover Agent Skills and expose their catalog and activation tool to the agent.",
+                    classes="settings-hint",
+                )
+                yield Static("", id="skills_status")
+                yield Label("Agent Skills")
+                yield Select(
+                    [("Enabled", "true"), ("Disabled", "false")],
+                    id="skills_enabled_select",
+                    allow_blank=False,
+                    value="true",
+                )
             with Vertical(classes="settings-section", id="settings_compression") as compression_section:
                 compression_section.border_title = "Context Compression"
                 yield Static(

--- a/kolega_code/config.py
+++ b/kolega_code/config.py
@@ -258,6 +258,10 @@ class AgentConfig(BaseModel):
     # eval_enabled) since it is resolved from settings.json / CLI flag at build.
     subagents_enabled: bool = Field(default=True, exclude=True, description="Enable the dispatch_agent sub-agent tool")
 
+    # CLI Agent Skills. This runtime-only switch controls whether CLI hosts add
+    # the skill catalog prompt and model-facing activation tool.
+    skills_enabled: bool = Field(default=True, exclude=True, description="Enable CLI Agent Skills")
+
     def model_config_for_agent(self, agent_name: Optional[str]) -> ModelConfig:
         """Return the model configuration an agent should use for its main loop.
 

--- a/tests/cli/test_app_skills_settings.py
+++ b/tests/cli/test_app_skills_settings.py
@@ -1,0 +1,108 @@
+"""TUI Agent Skills setting coverage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kolega_code.cli.config import CliConfigOverrides, build_agent_config, config_summary
+from kolega_code.cli.provider_registry import UI_DEFAULT_MODEL, UI_DEFAULT_PROVIDER
+from kolega_code.cli.session_store import SessionStore
+from kolega_code.cli.settings import CliSettings, SettingsStore
+
+from ._app_test_utils import install_fake_agents, open_settings_screen
+from .test_app_lsp_settings_status import _static_text
+
+
+def _configured_app(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    skills_enabled: bool | None = None,
+    overrides: CliConfigOverrides | None = None,
+):
+    pytest.importorskip("textual")
+    from kolega_code.cli.app import KolegaCodeApp
+
+    install_fake_agents(monkeypatch)
+    project = tmp_path / "project"
+    project.mkdir()
+    skill_dir = project / ".agents" / "skills" / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: demo\ndescription: Demo skill.\n---\n\nUse the demo.\n",
+        encoding="utf-8",
+    )
+    state_dir = tmp_path / "state"
+    settings_store = SettingsStore(state_dir)
+    settings = CliSettings(
+        active_provider=UI_DEFAULT_PROVIDER,
+        active_model=UI_DEFAULT_MODEL,
+        skills_enabled=skills_enabled,
+    )
+    settings.set_api_key(UI_DEFAULT_PROVIDER, "stored-key")
+    settings_store.save(settings)
+    config = build_agent_config(project, env={}, settings=settings, settings_store=settings_store, overrides=overrides)
+    store = SessionStore(state_dir)
+    session = store.create(project, "code", config_summary(config))
+    return (
+        KolegaCodeApp(
+            project_path=project,
+            config=config,
+            mode="code",
+            store=store,
+            settings_store=settings_store,
+            session=session,
+            overrides=overrides,
+        ),
+        settings_store,
+    )
+
+
+@pytest.mark.asyncio
+async def test_skills_select_seeded_from_saved_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from textual.widgets import Select
+
+    app, _ = _configured_app(tmp_path, monkeypatch, skills_enabled=False)
+    async with app.run_test() as pilot:
+        screen = await open_settings_screen(app, pilot, "tools")
+        assert str(screen.query_one("#skills_enabled_select", Select).value) == "false"
+        assert app.skills_enabled is False
+        assert app.skill_catalog.has_skills() is False
+        assert app.agent is not None
+        agent_kwargs = getattr(app.agent, "kwargs")
+        assert "cli-agent-skills" not in {extension.name for extension in agent_kwargs["tool_extensions"]}
+
+
+@pytest.mark.asyncio
+async def test_skills_status_notes_forced_launch_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from textual.widgets import Static
+
+    app, _ = _configured_app(tmp_path, monkeypatch, overrides=CliConfigOverrides(skills_mode="off"))
+    async with app.run_test() as pilot:
+        screen = await open_settings_screen(app, pilot, "tools")
+        text = _static_text(screen.query_one("#skills_status", Static))
+        assert "--skills" in text
+        assert "forced off" in text
+
+
+@pytest.mark.asyncio
+async def test_skills_save_persists_and_applies_disabled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from textual.widgets import Select
+
+    app, settings_store = _configured_app(tmp_path, monkeypatch)
+    async with app.run_test() as pilot:
+        screen = await open_settings_screen(app, pilot, "tools")
+        screen.query_one("#skills_enabled_select", Select).value = "false"
+        await pilot.pause()
+
+        await app._save_settings_from_ui()
+
+        assert settings_store.load().skills_enabled is False
+        assert app.skills_enabled is False
+        assert app.skill_catalog.has_skills() is False
+        assert app.agent is not None
+        agent_kwargs = getattr(app.agent, "kwargs")
+        assert "cli-agent-skills" not in {extension.id for extension in agent_kwargs["prompt_extensions"]}
+        assert "cli-agent-skills" not in {extension.name for extension in agent_kwargs["tool_extensions"]}

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -92,6 +92,13 @@ def test_parse_lsp_flag_on_both_parsers() -> None:
     assert parse_args(["ask", "hello"]).lsp is None
 
 
+def test_parse_skills_flag_on_both_parsers() -> None:
+    assert parse_args(["/tmp/project", "--skills", "off"]).skills == "off"
+    assert parse_args(["ask", "hello", "--skills", "on"]).skills == "on"
+    assert parse_args(["/tmp/project"]).skills is None
+    assert parse_args(["ask", "hello"]).skills is None
+
+
 def test_parse_tui_show_logs_flag() -> None:
     args = parse_args(["/tmp/project", "--show-logs"])
 
@@ -392,6 +399,24 @@ def test_ask_skills_lists_discovered_skills_without_api_key(tmp_path: Path, caps
     assert "Use this demo skill." in output
 
 
+def test_ask_skills_off_reports_disabled_without_discovery(
+    tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    from kolega_code.cli import main as main_module
+
+    project = tmp_path / "project"
+    project.mkdir()
+    write_skill(project)
+    discover = Mock(wraps=main_module.discover_skills)
+    monkeypatch.setattr(main_module, "discover_skills", discover)
+
+    exit_code = main_module.main(["ask", "/skills", "--project", str(project), "--skills", "off"])
+
+    assert exit_code == 0
+    assert "Agent Skills are disabled" in capsys.readouterr().out
+    discover.assert_not_called()
+
+
 def test_ask_skill_only_prints_activation_without_model_call(tmp_path: Path, capsys, isolated_cli_env: None) -> None:
     project = tmp_path / "project"
     project.mkdir()
@@ -462,6 +487,37 @@ def test_ask_skill_with_prompt_activates_before_dispatch(
     assert agent.messages == ["do the task"]
     assert '<skill_content name="demo-skill">' in agent.history[0].get_text_content()
     assert any(extension.name == "cli-agent-skills" for extension in agent.kwargs["tool_extensions"])
+
+
+def test_ask_skills_off_hides_prompt_and_tool_extensions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    from kolega_code.cli import main as main_module
+
+    class FakeCoderAgent(_FakeCoderAgent):
+        instances = []
+
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.__class__.instances.append(self)
+
+        async def process_message_stream(self, message):
+            yield {"type": "response", "content": "ok", "complete": True, "uuid": "response-1"}
+
+    project = tmp_path / "project"
+    project.mkdir()
+    write_skill(project)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("KOLEGA_CODE_PROVIDER", "anthropic")
+    monkeypatch.setenv("KOLEGA_CODE_MODEL", "claude-opus-5")
+    monkeypatch.setattr(main_module, "CoderAgent", FakeCoderAgent)
+
+    exit_code = main_module.main(["ask", "hello", "--project", str(project), "--skills", "off"])
+
+    assert exit_code == 0
+    agent = FakeCoderAgent.instances[0]
+    assert "cli-agent-skills" not in {extension.id for extension in agent.kwargs["prompt_extensions"]}
+    assert "cli-agent-skills" not in {extension.name for extension in agent.kwargs["tool_extensions"]}
 
 
 def test_ask_plain_handles_billing_error_without_traceback(

--- a/tests/cli/test_settings.py
+++ b/tests/cli/test_settings.py
@@ -59,6 +59,7 @@ def test_settings_store_missing_file_returns_empty_settings(tmp_path: Path) -> N
     assert settings.agent_models == {}
     assert settings.eval_enabled is None
     assert settings.subagents_enabled is None
+    assert settings.skills_enabled is None
 
 
 def test_settings_store_round_trips_eval_enabled(tmp_path: Path) -> None:
@@ -85,6 +86,20 @@ def test_settings_store_round_trips_subagents_enabled(tmp_path: Path) -> None:
     # Absent in older files -> None -> sub-agent dispatch stays enabled downstream.
     store.save(CliSettings())
     assert SettingsStore(tmp_path).load().subagents_enabled is None
+
+
+def test_settings_store_round_trips_skills_enabled(tmp_path: Path) -> None:
+    store = SettingsStore(tmp_path)
+    store.save(CliSettings(skills_enabled=False))
+
+    loaded = store.load()
+    assert loaded.skills_enabled is False
+    assert loaded.to_dict()["skills_enabled"] is False
+
+    # Absent in older files -> None -> Agent Skills stay enabled downstream.
+    data = CliSettings().to_dict()
+    del data["skills_enabled"]
+    assert CliSettings.from_dict(data).skills_enabled is None
 
 
 def test_settings_store_round_trips_agent_models(tmp_path: Path) -> None:

--- a/tests/cli/test_skills_switch.py
+++ b/tests/cli/test_skills_switch.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+
+from kolega_code.cli.config import CliConfigError, CliConfigOverrides, _skills_enabled, build_agent_config
+from kolega_code.cli.settings import CliSettings
+
+
+def test_skills_resolution_precedence() -> None:
+    settings = CliSettings(skills_enabled=True)
+    env = {"KOLEGA_CODE_SKILLS": "off"}
+
+    assert _skills_enabled(env, settings, "on") is True
+    assert _skills_enabled(env, settings, None) is False
+    assert _skills_enabled({}, settings, None) is True
+    assert _skills_enabled({}, CliSettings(skills_enabled=False), None) is False
+    assert _skills_enabled({}, None, None) is True
+
+
+def test_skills_resolution_rejects_unknown_value() -> None:
+    with pytest.raises(CliConfigError, match="Unsupported skills mode"):
+        _skills_enabled({"KOLEGA_CODE_SKILLS": "sideways"}, None, None)
+
+
+def test_build_agent_config_carries_resolved_skills_switch(tmp_path) -> None:
+    settings = CliSettings(
+        active_provider="anthropic",
+        active_model="claude-opus-5",
+        skills_enabled=False,
+    )
+    config = build_agent_config(tmp_path, settings=settings, env={"ANTHROPIC_API_KEY": "test-key"})
+    assert config.skills_enabled is False
+
+    forced = build_agent_config(
+        tmp_path,
+        CliConfigOverrides(skills_mode="on"),
+        settings=settings,
+        env={"ANTHROPIC_API_KEY": "test-key", "KOLEGA_CODE_SKILLS": "off"},
+    )
+    assert forced.skills_enabled is True

--- a/tests/cli/test_slash_commands.py
+++ b/tests/cli/test_slash_commands.py
@@ -107,5 +107,12 @@ def test_search_commands_includes_skills_dynamically():
     assert results[0].description == "Description of demo-skill"
 
 
+def test_search_commands_hides_all_skill_entries_when_disabled():
+    results = search_commands("skill", _catalog("demo-skill"), limit=100, skills_enabled=False)
+    names = {entry.name for entry in results}
+    assert "skills" not in names
+    assert "demo-skill" not in names
+
+
 def test_search_commands_no_match():
     assert search_commands("zzz", _catalog()) == []


### PR DESCRIPTION
## Summary

- add `--skills on|off` to TUI and ask modes
- resolve skill enablement through CLI flag, `KOLEGA_CODE_SKILLS`, persisted settings, then the enabled default
- add a persisted Agent Skills toggle to the TUI Tools settings
- skip skill discovery and hide both the catalog prompt and model-facing `skill` tool when disabled
- hide dynamic skill slash completions while retaining an informational disabled response for `/skills`

## User impact

Users can disable Agent Skills globally in TUI settings or per invocation with `--skills off`. Headless environments can use `KOLEGA_CODE_SKILLS=off`. A CLI or environment override does not overwrite the persisted preference.

## Validation

- full fast suite: 4,351 passed, 1 skipped
- focused skills/settings suite on updated `main`: 118 passed
- Ruff checks passed
- Pyright passed
- pre-commit hooks passed