### PR TITLE
docs(skills): document the Agent Skills master switch

### DIFF
--- a/docs/src/content/docs/cli/ask.md
+++ b/docs/src/content/docs/cli/ask.md
@@ -26,6 +26,7 @@ kolega-code ask "<prompt>" [options]
 | `--web-search <auto\|hosted\|client\|off>` | Web tool mode: hosted server-side search, client tools, or none (default `auto`) |
 | `--lsp <on\|off>` | Force LSP tools on or off for this session (overrides settings; not persisted) |
 | `--subagents <on\|off>` | Force sub-agent dispatch (`dispatch_agent`) on or off for this session (overrides settings; not persisted; default on) |
+| `--skills <on\|off>` | Force [Agent Skills](../../skills/) on or off for this session (overrides settings; not persisted; default on). When off, skills are not discovered and the `skill` tool is not exposed |
 | `--compression-threshold PERCENT` | Context-window usage that triggers automatic history compression (`10`–`100`, default `80`; `100` effectively disables it). Overrides settings for the session; not persisted |
 | `--session <ID>` | Resume or create a specific session |
 | `--state-dir <PATH>` | Directory for CLI session state |
@@ -86,6 +87,11 @@ it against the project's [Agent Skills](../../skills/):
   prints the skill's activation content.
 - `kolega-code ask "/my-skill do the thing"` activates the skill and runs the
   remaining prompt.
+
+When Agent Skills are disabled (`--skills off`, `KOLEGA_CODE_SKILLS=off`, or the
+saved `skills_enabled` setting), `/skills` reports that Agent Skills are disabled
+and `/skill-name` prompts are sent to the model as plain text instead of being
+activated.
 
 ## Goal mode
 

--- a/docs/src/content/docs/cli/overview.md
+++ b/docs/src/content/docs/cli/overview.md
@@ -47,6 +47,7 @@ kolega-code [PROJECT_PATH]
 | `--permission-mode <auto\|ask>` | Shell/edit permission mode. TUI sessions default to `ask` |
 | `--lsp <on\|off>` | Force LSP tools on or off for this session (overrides settings; not persisted) |
 | `--subagents <on\|off>` | Force sub-agent dispatch (`dispatch_agent`) on or off for this session (overrides settings; not persisted; default on) |
+| `--skills <on\|off>` | Force [Agent Skills](../../skills/) on or off for this session (overrides settings; not persisted; default on). When off, skills are not discovered and the `skill` tool is not exposed |
 | `--session <ID>` | Legacy alias for `--resume SESSION_ID` |
 
 See [Sessions & Resuming](../../tui/sessions-and-resume/) for the full session

--- a/docs/src/content/docs/configuration/environment-variables.md
+++ b/docs/src/content/docs/configuration/environment-variables.md
@@ -120,6 +120,7 @@ with vision support.
 | `KOLEGA_CODE_NO_DIAGNOSTICS` | Set to any value to disable the local [diagnostics](../../troubleshooting/diagnostics/) log and responsiveness watchdog |
 | `KOLEGA_CODE_COMPRESSION_THRESHOLD` | Context-window usage percent that triggers automatic history compression (`10`–`100`, default `80`; `100` effectively disables automatic compression) |
 | `KOLEGA_CODE_SUBAGENTS` | Sub-agent dispatch (`dispatch_agent`) master switch: `on` or `off` (default `on`). Useful for headless or CI runs; the `--subagents` flag takes precedence |
+| `KOLEGA_CODE_SKILLS` | [Agent Skills](../../skills/) master switch: `on` or `off` (default `on`). When `off`, skills are not discovered, the `skill` tool is not exposed, and `/skills` reports that Agent Skills are disabled; the `--skills` flag takes precedence |
 
 ## Web search
 

--- a/docs/src/content/docs/configuration/settings-and-api-keys.mdx
+++ b/docs/src/content/docs/configuration/settings-and-api-keys.mdx
@@ -33,7 +33,7 @@ separates the controls into:
 | **Providers** | API keys and ChatGPT sign-in for every model provider, plus per-provider connection testing |
 | **Models** | Provider, model, thinking effort, and the fast model slot |
 | **Agent Models** | Optional provider/model/effort override for each agent role |
-| **Tools** | Web-search backend, global LSP toggle, and the history-compression threshold |
+| **Tools** | Web-search backend, global LSP toggle, the Agent Skills toggle, and the history-compression threshold |
 | **MCP Servers** | Global and trusted-project MCP server management |
 | **Appearance** | TUI theme |
 
@@ -139,7 +139,8 @@ The file looks like this:
     }
   },
   "web_search_backend": "tavily",
-  "web_search_base_url": null
+  "web_search_base_url": null,
+  "skills_enabled": true
 }
 ```
 
@@ -148,6 +149,10 @@ The file looks like this:
 model. The field is optional and older `schema_version` files load unchanged.
 Cloud web-search keys are stored in `api_keys` under their backend names
 (`firecrawl` or `tavily`); `web_search_base_url` is used by SearXNG.
+`skills_enabled` is the saved [Agent Skills](../../skills/) master switch (`true`
+or `false`); the key is optional and absent means enabled. A `--skills` CLI flag
+or `KOLEGA_CODE_SKILLS` environment variable overrides it for the session without
+changing the saved value.
 
 <Aside type="caution" title="Keys are stored in plaintext">
 API keys are written to `settings.json` in plaintext, but the file is created with

--- a/docs/src/content/docs/skills.mdx
+++ b/docs/src/content/docs/skills.mdx
@@ -94,6 +94,28 @@ names the skill's absolute directory, and bundled resources are then read
 with the ordinary `read` tool.
 </Aside>
 
+## Disabling Agent Skills
+
+Agent Skills can be switched off entirely. With skills disabled, Kolega Code
+skips skill discovery, the skills catalog is absent from the agent's prompt, the
+model-facing `skill` tool is not declared, `/skill-name` completions and
+activation are unavailable, and `/skills` reports that Agent Skills are disabled.
+
+The switch resolves in this order — the first value that is set wins:
+
+1. `--skills <on|off>` on `kolega-code` or `kolega-code ask`
+2. `KOLEGA_CODE_SKILLS=on|off`
+3. the saved `skills_enabled` value in `settings.json`
+4. default: **enabled**
+
+The CLI flag and environment variable apply to the current session only and never
+overwrite the saved preference. In the TUI, the persisted setting lives under
+**Tools → Agent Skills** in the [Settings screen](../configuration/settings-and-api-keys/),
+defaults to enabled for existing setups, and applies immediately when you apply
+your settings. When a flag or environment variable forces the switch for the
+session, the Settings screen shows a status note explaining that the saved
+setting takes effect from the next launch.
+
 ## Diagnostics
 
 If a `SKILL.md` is malformed or a name doesn't follow the conventions above, the

--- a/docs/src/content/docs/tui/slash-commands.md
+++ b/docs/src/content/docs/tui/slash-commands.md
@@ -196,3 +196,7 @@ against a specific request:
 ```
 
 Use `/skills` at any time to see what's available in the current project.
+
+When [Agent Skills are disabled](../../skills/#disabling-agent-skills), `/skills`
+reports that Agent Skills are disabled and no `/skill-name` commands are
+available or listed in the completion dropdown.


### PR DESCRIPTION
## What

Documents the Agent Skills master switch added in #500 (`agent/add-skills-switch`), which shipped without user-facing docs. The site build was verified (`npm run build`, 35 pages, no errors).

## Changes

- **`skills.mdx`** — new "Disabling Agent Skills" section: resolution order (`--skills` flag → `KOLEGA_CODE_SKILLS` env → saved `skills_enabled` → default enabled), what is hidden when disabled (discovery, catalog prompt, `skill` tool, `/skill-name` and `/skills` behavior), and the TUI **Tools → Agent Skills** setting with its flag/env override status note.
- **`cli/overview.md` / `cli/ask.md`** — `--skills <on|off>` rows in the flag tables, plus disabled behavior of `/skills` and `/skill-name` in `ask`.
- **`configuration/environment-variables.md`** — `KOLEGA_CODE_SKILLS` row next to `KOLEGA_CODE_SUBAGENTS`.
- **`configuration/settings-and-api-keys.mdx`** — Tools category now lists the Agent Skills toggle; `skills_enabled` documented in the `settings.json` example and prose.
- **`tui/slash-commands.md`** — note that `/skills` reports disabled and no `/skill-name` commands appear when skills are off.

## Verification

- `cd docs && npm run build` → `35 page(s) built` with no errors; rendered pages checked for the new content and `#disabling-agent-skills` anchor.
- Pre-commit (ruff, format, whitespace, yaml, secrets, pyright) all passed on commit.
- No code changes; docs only.