### PR TITLE
fix(docs): update nanoid security patch

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -5251,9 +5251,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

- update the docs lockfile from `nanoid` 3.3.16 to 3.3.18
- resolve Dependabot alert GHSA-2v37-7h3g-55p8
- leave the platform-specific `cryptography` pins unchanged

## Verification

- `npm audit` — 0 vulnerabilities
- `npm run build` — 35 pages built successfully
- CI-equivalent `uv audit` with the existing accepted cryptography exceptions — clean
- pre-commit hooks — passed