### PR TITLE
fix(llm): enable parallel Responses tool calls

### DIFF
--- a/kolega_code/llm/providers/responses_common.py
+++ b/kolega_code/llm/providers/responses_common.py
@@ -915,7 +915,11 @@ class ResponsesProviderBase(OpenAIProvider):
             "input": to_responses_input(messages),
             "tools": responses_tools(params) or [],
             "tool_choice": "auto",
-            "parallel_tool_calls": False,
+            # The executor independently gates each returned batch using the
+            # tools' parallel_safe metadata. Allow capable Responses models to
+            # emit independent calls together so safe batches can actually run
+            # concurrently.
+            "parallel_tool_calls": True,
             "store": False,
             "stream": True,
             "prompt_cache_key": self._session_id,

--- a/tests/agent/llm/test_chatgpt_oauth_provider_generate.py
+++ b/tests/agent/llm/test_chatgpt_oauth_provider_generate.py
@@ -105,7 +105,7 @@ async def test_provider_generate_builds_codex_shaped_request(monkeypatch):
     # can be resent next turn (matches Codex; the cause of the long-thinking gap).
     assert kwargs["include"] == ["reasoning.encrypted_content"]
     assert kwargs["tool_choice"] == "auto"
-    assert kwargs["parallel_tool_calls"] is False
+    assert kwargs["parallel_tool_calls"] is True
     assert "prompt_cache_key" in kwargs
     # Codex never sends max_output_tokens; sending it triggers a 400.
     assert "max_output_tokens" not in kwargs

--- a/tests/agent/llm/test_deepseek_requests.py
+++ b/tests/agent/llm/test_deepseek_requests.py
@@ -183,7 +183,9 @@ def _responses_request(params) -> dict:
 def test_responses_build_request_emits_max_output_tokens() -> None:
     # The shared Responses builder omits the cap; the DeepSeek override must add
     # it — without one the server truncates at its own 65536 default.
-    assert _responses_request(GenerationParams(max_completion_tokens=4096))["max_output_tokens"] == 4096
+    request = _responses_request(GenerationParams(max_completion_tokens=4096))
+    assert request["parallel_tool_calls"] is True
+    assert request["max_output_tokens"] == 4096
     # flash is unclamped: its catalog max_completion_tokens passes through.
     assert _responses_request(GenerationParams(max_completion_tokens=384000))["max_output_tokens"] == 384000
     assert _responses_request(None)["max_output_tokens"] == 384000

--- a/tests/agent/llm/test_openai_responses_provider.py
+++ b/tests/agent/llm/test_openai_responses_provider.py
@@ -169,6 +169,7 @@ def test_build_request_is_responses_shaped_with_reasoning():
     assert request["stream"] is True
     assert request["store"] is False
     assert request["tool_choice"] == "auto"
+    assert request["parallel_tool_calls"] is True
     assert request["instructions"] == "sys"
     assert request["reasoning"] == {"effort": "high", "summary": "auto"}
     assert request["include"] == ["reasoning.encrypted_content"]

--- a/tests/agent/llm/test_parallel_tool_calls_live.py
+++ b/tests/agent/llm/test_parallel_tool_calls_live.py
@@ -1,0 +1,143 @@
+"""Credential-gated live coverage for parallel Responses tool calls.
+
+These tests prove that each Responses backend accepts ``parallel_tool_calls=true``
+and can return two independent function calls in one assistant message. They are
+skipped in CI and when the corresponding local credential is unavailable.
+
+Run with:
+
+    pytest -m integration tests/agent/llm/test_parallel_tool_calls_live.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from kolega_code.auth import constants as chatgpt_constants
+from kolega_code.auth.tokens import ChatGPTTokenManager, OAuthTokens
+from kolega_code.cli.settings import SettingsStore
+from kolega_code.llm.client import LLMClient
+from kolega_code.llm.exceptions import LLMBillingError, LLMRateLimitError
+from kolega_code.llm.models import Message, MessageHistory, TextBlock, ToolCall, ToolDefinition, ToolParameter
+
+pytestmark = pytest.mark.integration
+
+SKIP_IN_CI = bool(os.getenv("CI")) or bool(os.getenv("GITLAB_CI"))
+
+PROVIDERS = [
+    ("openai", "gpt-5.6-sol", "medium"),
+    ("openai_chatgpt", chatgpt_constants.DEFAULT_MODEL, "medium"),
+    ("deepseek", "deepseek-v4-flash", "high"),
+]
+
+TOOLS = [
+    ToolDefinition(
+        name="lookup_alpha",
+        description="Record the alpha probe. Call this whenever the user requests the alpha probe.",
+        parameters=[ToolParameter(name="token", type="string", description="Must be alpha", required=True)],
+    ),
+    ToolDefinition(
+        name="lookup_beta",
+        description="Record the beta probe. Call this whenever the user requests the beta probe.",
+        parameters=[ToolParameter(name="token", type="string", description="Must be beta", required=True)],
+    ),
+]
+
+SYSTEM = Message(
+    role="system",
+    content=[
+        TextBlock(
+            text=(
+                "When the user requests independent tool calls, emit every requested function call together "
+                "in the same assistant response before waiting for any result."
+            )
+        )
+    ],
+)
+
+
+def _chatgpt_tokens() -> OAuthTokens | None:
+    raw = os.getenv("KOLEGA_CODE_CHATGPT_TOKENS")
+    if raw:
+        try:
+            return OAuthTokens.model_validate(json.loads(raw))
+        except (TypeError, ValueError):
+            return None
+    stored = SettingsStore().load().get_oauth_token(chatgpt_constants.PROVIDER_KEY)
+    if stored:
+        try:
+            return OAuthTokens.model_validate(stored)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _client_for(provider: str, model: str) -> LLMClient:
+    if SKIP_IN_CI:
+        pytest.skip("Skipping live provider call in CI")
+    if provider == chatgpt_constants.PROVIDER_KEY:
+        tokens = _chatgpt_tokens()
+        if tokens is None:
+            pytest.skip("No ChatGPT OAuth tokens available")
+        return LLMClient(
+            provider=provider,
+            api_key="unused",
+            token_manager=ChatGPTTokenManager(tokens),
+            model=model,
+        )
+
+    env_name = "OPENAI_API_KEY" if provider == "openai" else "DEEPSEEK_API_KEY"
+    api_key = os.getenv(env_name)
+    if not api_key:
+        pytest.skip(f"{env_name} not set")
+    return LLMClient(provider=provider, api_key=api_key, model=model)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider,model,thinking", PROVIDERS, ids=[provider for provider, _, _ in PROVIDERS])
+async def test_live_responses_provider_returns_parallel_tool_calls(
+    provider: str,
+    model: str,
+    thinking: str,
+) -> None:
+    client = _client_for(provider, model)
+    try:
+        response = await client.generate(
+            messages=MessageHistory(
+                [
+                    Message(
+                        role="user",
+                        content=[
+                            TextBlock(
+                                text=(
+                                    "Call lookup_alpha with token alpha and lookup_beta with token beta now. "
+                                    "The calls are independent. Emit both calls in this response and no prose."
+                                )
+                            )
+                        ],
+                    )
+                ]
+            ),
+            system=SYSTEM,
+            model=model,
+            tools=TOOLS,
+            thinking=thinking,
+            temperature=1.0,
+        )
+    except (LLMRateLimitError, LLMBillingError) as exc:
+        pytest.skip(f"provider quota exhausted for this key: {exc}")
+
+    tool_calls = [block for block in response.content if isinstance(block, ToolCall)]
+    names = {call.name for call in tool_calls}
+    assert len(tool_calls) >= 2, (
+        f"{provider}/{model} returned fewer than two calls in one response: "
+        f"names={sorted(names)!r}, text={response.get_text_content()!r}"
+    )
+    assert names == {"lookup_alpha", "lookup_beta"}, (
+        f"{provider}/{model} did not return both calls in one response: "
+        f"names={sorted(names)!r}, text={response.get_text_content()!r}"
+    )
+    assert response.stop_reason == "tool_use"


### PR DESCRIPTION
## Summary

- allow shared Responses providers to request parallel tool calls
- add request-shape regression coverage for OpenAI, ChatGPT OAuth, and DeepSeek Responses transports
- add credential-gated live coverage requiring two independent `ToolCall` blocks in one assistant response

## Verification

- `uv run pre-commit run --all-files --show-diff-on-failure`
- 91 focused Responses-provider and parallel-executor tests passed
- live parallel-call test passed for:
  - `openai` / `gpt-5.6-sol`
  - `openai_chatgpt` / `gpt-5.6-sol`
  - `deepseek` / `deepseek-v4-flash`
- full fast suite reached 4,420 passing tests; the only three failures were unrelated Tinker live tests because this machine has `TINKER_API_KEY` configured without the optional `[tinker]` dependency. Confirmed those cases skip when the credential is explicitly disabled.
