### PR TITLE
fix(benchmarks): route DeepSeek Flash through Responses

### DIFF
--- a/benchmarks/edit_tools/runner.py
+++ b/benchmarks/edit_tools/runner.py
@@ -216,6 +216,7 @@ def _client(config: AgentConfig, provider: str) -> LLMClient:
     model_config = config.long_context_config
     return LLMClient(
         provider=provider,
+        model=model_config.model,  # route flash -> DeepSeekResponsesProvider (0731); without it, flash falls to the old Chat path
         api_key=config.get_api_key(ModelProvider(provider)) or "",
         max_retries=model_config.rate_limits.max_retries,
         requests_per_minute=model_config.rate_limits.requests_per_minute,

--- a/tests/benchmarks/test_edit_benchmark_runner.py
+++ b/tests/benchmarks/test_edit_benchmark_runner.py
@@ -9,10 +9,11 @@ from benchmarks.edit_tools.models import (
     SuiteSpec,
     TaskSpec,
 )
-from benchmarks.edit_tools.runner import _controlled_execution, plan_trials, run_benchmark
+from benchmarks.edit_tools.runner import _client, _controlled_execution, plan_trials, run_benchmark
 from benchmarks.edit_tools.workspace import materialize_task, verify_task
 from kolega_code.config import AgentConfig, EditProtocol, ModelConfig, ModelProvider
 from kolega_code.llm.models import Message, TextBlock, ToolCall
+from kolega_code.llm.providers.deepseek_responses import DeepSeekResponsesProvider
 from kolega_code.llm.specs import default_thinking_effort
 from kolega_code.services.lsp.config import LspConfig
 
@@ -72,6 +73,20 @@ def test_plan_uses_catalog_defaults_and_stable_trial_ids() -> None:
     )
     assert first[0].model_parameters["max_iterations"] == 17
     assert first[0].trial_id == second[0].trial_id
+
+
+def test_client_routes_deepseek_flash_from_benchmark_config() -> None:
+    model = ModelConfig(provider=ModelProvider.DEEPSEEK, model="deepseek-v4-flash")
+    config = AgentConfig(
+        deepseek_api_key="test",
+        long_context_config=model,
+        fast_config=model,
+        lsp=LspConfig(enabled=False),
+    )
+
+    client = _client(config, "deepseek")
+
+    assert isinstance(client.provider, DeepSeekResponsesProvider)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- pass the configured benchmark model into `LLMClient` so model-specific provider routing is selected during client construction
- add a regression test confirming DeepSeek Flash benchmark runs use the Responses provider

## Testing
- `PYTHONDONTWRITEBYTECODE=1 uv run pytest -q tests/benchmarks/test_edit_benchmark_runner.py tests/agent/llm/test_deepseek_responses_routing.py` (11 passed)
- `uv run ruff check benchmarks/edit_tools/runner.py tests/benchmarks/test_edit_benchmark_runner.py`
- `uv run ruff format --check benchmarks/edit_tools/runner.py tests/benchmarks/test_edit_benchmark_runner.py`
- `uv run pyright benchmarks/edit_tools/runner.py tests/benchmarks/test_edit_benchmark_runner.py`
- commit hooks passed
