### PR TITLE
feat(terminal): spill oversized command output

### DIFF
--- a/kolega_code/agent/prompt_templates/tools/exec_command.md
+++ b/kolega_code/agent/prompt_templates/tools/exec_command.md
@@ -16,7 +16,12 @@ ends. Verify a server answers (e.g. curl) before handing its URL to the
 browser agent — its log may be buffered.
 
 Returns:
-    A JSON object: {"status": "exited"|"running", "exit_code",
-    "session_id", "output", "truncated", "original_token_count",
-    "duration_ms"}. Background launches that are still running also
-    include "background": true and a "note" with management hints.
+    Structured text with status, session id, exit code, duration, and
+    model-visible output. `max_output_tokens` is a requested budget and
+    is always clamped to the global 10,000-token terminal-result limit.
+    Oversized streams are represented by a bounded head/tail preview;
+    the result reports truncation statistics and an ordinary `Full
+    output:` filesystem path containing the complete normalized stream.
+    Individual preview lines are capped so one huge line cannot consume
+    the result. Background launches that are still running also report
+    `Background: true` and management guidance.

--- a/kolega_code/agent/prompt_templates/tools/kill_command.md
+++ b/kolega_code/agent/prompt_templates/tools/kill_command.md
@@ -4,4 +4,5 @@ Sends SIGTERM (then SIGKILL after a short grace period). Use
 signal="INT" to send Ctrl-C (SIGINT) instead.
 
 Returns:
-    A JSON object describing the final state of the session.
+    Structured text describing the final state of the session, including
+    bounded final output and spill-file metadata when applicable.

--- a/kolega_code/agent/prompt_templates/tools/list_sessions.md
+++ b/kolega_code/agent/prompt_templates/tools/list_sessions.md
@@ -4,5 +4,6 @@ Includes sessions started with exec_command background=true, annotated
 with "background": true.
 
 Returns:
-    A JSON object mapping each running session id to its command,
-    working directory, runtime in seconds, and background flag.
+    Structured text listing each running session id, command, working
+    directory, runtime in seconds, and background flag. Returns `No
+    running sessions.` when the registry is empty.

--- a/kolega_code/agent/prompt_templates/tools/write_stdin.md
+++ b/kolega_code/agent/prompt_templates/tools/write_stdin.md
@@ -12,4 +12,6 @@ stdin never reaches EOF, so stop stdin-reading commands with
 kill_command.
 
 Returns:
-    A JSON object with the same shape as exec_command.
+    Structured text with the same bounded output and spill-file metadata
+    as exec_command. `max_output_tokens` is a requested budget and is
+    always clamped to the global 10,000-token terminal-result limit.

--- a/kolega_code/agent/tool_backend/terminal_tool.py
+++ b/kolega_code/agent/tool_backend/terminal_tool.py
@@ -91,7 +91,9 @@ class TerminalTool(BaseTool):
             scratchpad_dir = getattr(self.caller, "scratchpad_dir", None)
             if isinstance(scratchpad_dir, (str, os.PathLike)) and str(scratchpad_dir):
                 root = Path(scratchpad_dir).expanduser().resolve() / "terminal-output"
-        self.terminal_manager.configure_output_spill(root)
+        configure_output_spill = getattr(self.terminal_manager, "configure_output_spill", None)
+        if callable(configure_output_spill):
+            configure_output_spill(root)
 
     async def _run_command_security_check(self, command: str) -> Tuple[bool, str]:
         provider = self.config.fast_config.provider

--- a/kolega_code/agent/tool_backend/terminal_tool.py
+++ b/kolega_code/agent/tool_backend/terminal_tool.py
@@ -1,6 +1,5 @@
 import asyncio
-import json
-import os.path
+import os
 import re
 from pathlib import Path
 from typing import Optional, Tuple, Union
@@ -12,8 +11,13 @@ from kolega_code.llm.ledger import helper_origin, llm_call_origin
 from kolega_code.llm.models import Message, MessageHistory, TextBlock
 from kolega_code.llm.specs import get_model_specs
 from kolega_code.events import AgentEvent
-from kolega_code.services.base import ExecResult
+from kolega_code.services.base import ExecResult, TerminalCommandCancelled
 from kolega_code.services.terminal import LocalTerminalManager, build_child_env
+from kolega_code.services.terminal_buffer import (
+    GLOBAL_MAX_TOOL_OUTPUT_TOKENS,
+    cap_chars,
+    clamp_output_tokens,
+)
 from .base_tool import BaseTool
 
 # Startup window for background=true launches: long enough to capture a dev
@@ -73,6 +77,21 @@ class TerminalTool(BaseTool):
                 connection_manager=connection_manager,
                 default_workdir=self.project_path,
             )
+        self._configure_terminal_spill()
+
+    def _configure_terminal_spill(self) -> None:
+        """Bind terminal output to durable session storage when available."""
+        root: Optional[Path] = None
+        recorder = getattr(self.caller, "session_recorder", None)
+        journal = getattr(recorder, "journal", None)
+        session_dir = getattr(journal, "session_dir", None)
+        if isinstance(session_dir, (str, os.PathLike)) and str(session_dir):
+            root = Path(session_dir).expanduser().resolve() / "terminal-output"
+        else:
+            scratchpad_dir = getattr(self.caller, "scratchpad_dir", None)
+            if isinstance(scratchpad_dir, (str, os.PathLike)) and str(scratchpad_dir):
+                root = Path(scratchpad_dir).expanduser().resolve() / "terminal-output"
+        self.terminal_manager.configure_output_spill(root)
 
     async def _run_command_security_check(self, command: str) -> Tuple[bool, str]:
         provider = self.config.fast_config.provider
@@ -140,20 +159,92 @@ class TerminalTool(BaseTool):
             return None
         return {"KOLEGA_SCRATCHPAD": str(scratchpad_dir)}
 
-    def _format_result(self, result: ExecResult, *, background: bool = False) -> str:
-        payload = {
-            "status": result.status,
-            "exit_code": result.exit_code,
-            "session_id": result.session_id,
-            "output": result.output,
-            "truncated": result.truncated,
-            "original_token_count": result.original_token_count,
-            "duration_ms": result.duration_ms,
-        }
+    def _format_result(
+        self,
+        result: ExecResult,
+        *,
+        background: bool = False,
+        max_output_tokens: int = GLOBAL_MAX_TOOL_OUTPUT_TOKENS,
+    ) -> str:
+        effective_tokens = clamp_output_tokens(max_output_tokens)
+        original_tokens = result.original_token_count or ((len(result.output) + 3) // 4 if result.output else 0)
+        truncated = result.truncated
+        capped = None
+        output_prefix = ""
+
+        for _ in range(2):
+            header = self._result_header(
+                result,
+                truncated=truncated,
+                original_tokens=original_tokens,
+                background=background,
+            )
+            output_prefix = f"{header}\n\nOutput:\n"
+            # Recovery metadata is more important than honoring an unusually
+            # tiny requested budget. It may exceed that tiny request, but the
+            # complete tool result always remains below the 10,000-token global
+            # ceiling and the ordinary spill path is never shortened.
+            global_chars = GLOBAL_MAX_TOOL_OUTPUT_TOKENS * 4
+            requested_chars = effective_tokens * 4
+            total_budget = min(global_chars, max(requested_chars, len(output_prefix)))
+            capped = cap_chars(
+                result.output,
+                max(0, total_budget - len(output_prefix)),
+                marker=f"\n[... output truncated to fit {effective_tokens} tokens ...]\n",
+                original_token_count=original_tokens,
+            )
+            final_truncated = result.truncated or capped.truncated
+            if final_truncated == truncated:
+                return output_prefix + capped.text
+            truncated = final_truncated
+
+        assert capped is not None
+        return output_prefix + capped.text
+
+    @staticmethod
+    def _result_header(
+        result: ExecResult,
+        *,
+        truncated: bool,
+        original_tokens: int,
+        background: bool,
+    ) -> str:
+        lines = [
+            f"Status: {result.status}",
+            f"Exit code: {result.exit_code if result.exit_code is not None else 'none'}",
+            f"Session: {result.session_id or 'none'}",
+            f"Duration: {result.duration_ms} ms",
+            f"Output truncated: {'yes' if truncated else 'no'}",
+            f"Original output: ~{original_tokens:,} tokens",
+        ]
+        if result.spill_path:
+            lines.extend(
+                [
+                    f"Full output: {result.spill_path}",
+                    f"Spill size: {result.spill_bytes:,} bytes",
+                ]
+            )
+        if result.preview_omitted_bytes:
+            lines.append(
+                "Preview middle omitted: "
+                f"{result.preview_omitted_bytes:,} bytes across "
+                f"{result.preview_omitted_lines:,} "
+                f"{'line' if result.preview_omitted_lines == 1 else 'lines'}"
+            )
+        if result.line_truncated_count or result.line_truncated_bytes:
+            lines.append(
+                "Long lines shortened: "
+                f"{result.line_truncated_count:,} "
+                f"{'line' if result.line_truncated_count == 1 else 'lines'}, "
+                f"{result.line_truncated_bytes:,} bytes omitted"
+            )
         if background and result.status == "running" and result.session_id is not None:
-            payload["background"] = True
-            payload["note"] = _BACKGROUND_NOTE
-        return json.dumps(payload)
+            lines.extend(["Background: true", f"Note: {_BACKGROUND_NOTE}"])
+        return "\n".join(lines)
+
+    @staticmethod
+    def _format_error(error: object) -> str:
+        return f"Status: error\nError: {error}"
 
     async def exec_command(
         self,
@@ -207,10 +298,11 @@ class TerminalTool(BaseTool):
                         report their real exit code.
 
         Returns:
-            A JSON object: {"status": "exited"|"running", "exit_code",
-            "session_id", "output", "truncated", "original_token_count",
-            "duration_ms"}. Background launches that are still running also
-            include "background": true and a "note" with management hints.
+            Structured text with status, session id, exit code, duration,
+            truncation metadata, and model-visible output. Oversized streams
+            include an ordinary ``Full output:`` filesystem path. Background
+            launches that are still running also include ``Background: true``
+            and management guidance.
         """
         if self.security_check_enabled:
             allowed, denied_reason = await self._run_command_security_check(command)
@@ -220,21 +312,28 @@ class TerminalTool(BaseTool):
         # Resolve relative workdirs against the project root (same contract as
         # the file tools), never against this process's cwd.
         wd = os.path.normpath(str(self.project_path / workdir)) if workdir else str(self.project_path)
+        effective_max_tokens = clamp_output_tokens(max_output_tokens)
         try:
             result = await self.terminal_manager.exec_command(
                 command,
                 workdir=wd,
                 yield_time_ms=min(yield_time_ms, BACKGROUND_SETTLE_MS) if background else yield_time_ms,
-                max_output_tokens=max_output_tokens,
+                max_output_tokens=effective_max_tokens,
                 login=login,
                 env=self._session_env(),
                 background=background,
             )
+        except TerminalCommandCancelled as exc:
+            return self._format_result(
+                exc.result,
+                background=background,
+                max_output_tokens=effective_max_tokens,
+            )
         except Exception as exc:
-            return json.dumps({"status": "error", "error": str(exc)})
+            return self._format_error(exc)
         if background and result.status == "running" and result.session_id is not None:
             self._background_sessions.add(result.session_id)
-        return self._format_result(result, background=background)
+        return self._format_result(result, background=background, max_output_tokens=effective_max_tokens)
 
     async def write_stdin(
         self,
@@ -265,15 +364,25 @@ class TerminalTool(BaseTool):
             max_output_tokens: Maximum tokens of output to return in this call.
 
         Returns:
-            A JSON object with the same shape as exec_command.
+            Structured text with the same fields and spill behavior as
+            exec_command.
         """
+        effective_max_tokens = clamp_output_tokens(max_output_tokens)
         try:
             result = await self.terminal_manager.write_stdin(
-                session_id, chars, yield_time_ms=yield_time_ms, max_output_tokens=max_output_tokens
+                session_id,
+                chars,
+                yield_time_ms=yield_time_ms,
+                max_output_tokens=effective_max_tokens,
+            )
+        except TerminalCommandCancelled as exc:
+            return self._format_result(
+                exc.result,
+                max_output_tokens=effective_max_tokens,
             )
         except KeyError as exc:
-            return json.dumps({"status": "error", "error": str(exc)})
-        return self._format_result(result)
+            return self._format_error(exc)
+        return self._format_result(result, max_output_tokens=effective_max_tokens)
 
     async def kill_command(self, session_id: str, signal: str = "TERM") -> str:
         """Terminate a running session and its process group.
@@ -286,12 +395,12 @@ class TerminalTool(BaseTool):
             signal: "TERM" (default, graceful) or "INT" (Ctrl-C).
 
         Returns:
-            A JSON object describing the final state of the session.
+            Structured text describing the final state of the session.
         """
         try:
             result = await self.terminal_manager.kill_session(session_id, signal)
         except KeyError as exc:
-            return json.dumps({"status": "error", "error": str(exc)})
+            return self._format_error(exc)
         self._background_sessions.discard(session_id)
         return self._format_result(result)
 
@@ -302,14 +411,41 @@ class TerminalTool(BaseTool):
         with "background": true.
 
         Returns:
-            A JSON object mapping each running session id to its command,
-            working directory, runtime in seconds, and background flag.
+            Structured text listing each running session id, command, working
+            directory, runtime in seconds, and background flag. Returns
+            ``No running sessions.`` when the registry is empty.
         """
         sessions = await self.terminal_manager.list_sessions()
         self._background_sessions.intersection_update(sessions)
+        if not sessions:
+            return "No running sessions."
+
+        lines = [f"Running terminal sessions: {len(sessions)}"]
         for session_id, info in sessions.items():
-            info["background"] = session_id in self._background_sessions
-        return json.dumps({"sessions": sessions})
+            command = str(info.get("command", ""))
+            command_lines = command.splitlines() or [""]
+            lines.extend(
+                [
+                    "",
+                    f"Session: {session_id}",
+                    f"  Command: {command_lines[0]}",
+                ]
+            )
+            lines.extend(f"           {line}" for line in command_lines[1:])
+            lines.extend(
+                [
+                    f"  Workdir: {info.get('workdir') or 'unknown'}",
+                    f"  Runtime: {info.get('runtime_s', 0)} s",
+                    f"  Running: {'true' if info.get('running', True) else 'false'}",
+                    f"  Background: {'true' if session_id in self._background_sessions else 'false'}",
+                ]
+            )
+        text = "\n".join(lines)
+        return cap_chars(
+            text,
+            GLOBAL_MAX_TOOL_OUTPUT_TOKENS * 4,
+            marker="\n[... additional sessions omitted ...]\n",
+        ).text
 
     # -- internal one-shot helper (not exposed to the model) ---------------
 

--- a/kolega_code/agent/tool_backend/terminal_tool.py
+++ b/kolega_code/agent/tool_backend/terminal_tool.py
@@ -91,9 +91,7 @@ class TerminalTool(BaseTool):
             scratchpad_dir = getattr(self.caller, "scratchpad_dir", None)
             if isinstance(scratchpad_dir, (str, os.PathLike)) and str(scratchpad_dir):
                 root = Path(scratchpad_dir).expanduser().resolve() / "terminal-output"
-        configure_output_spill = getattr(self.terminal_manager, "configure_output_spill", None)
-        if callable(configure_output_spill):
-            configure_output_spill(root)
+        self.terminal_manager.configure_output_spill(root)
 
     async def _run_command_security_check(self, command: str) -> Tuple[bool, str]:
         provider = self.config.fast_config.provider

--- a/kolega_code/agent/tool_definitions.py
+++ b/kolega_code/agent/tool_definitions.py
@@ -578,7 +578,8 @@ BUILTIN_TOOL_SPECS: dict[str, BuiltinToolSpec] = {
                 },
                 "max_output_tokens": {
                     "type": "integer",
-                    "description": "Maximum tokens of output to return in this call.",
+                    "description": "Requested output budget for this call. Values are hard-clamped "
+                    "to the global 10,000-token terminal-result ceiling.",
                 },
                 "login": {
                     "type": "boolean",
@@ -756,7 +757,8 @@ BUILTIN_TOOL_SPECS: dict[str, BuiltinToolSpec] = {
                 },
                 "max_output_tokens": {
                     "type": "integer",
-                    "description": "Maximum tokens of output to return in this call.",
+                    "description": "Requested output budget for this call. Values are hard-clamped "
+                    "to the global 10,000-token terminal-result ceiling.",
                 },
             },
             "required": ["session_id"],

--- a/kolega_code/cli/session_store.py
+++ b/kolega_code/cli/session_store.py
@@ -212,6 +212,10 @@ class SessionStore:
     def events_path_for(self, session_id: str) -> Path:
         return self.session_dir_for(session_id) / "events.jsonl"
 
+    def terminal_output_dir_for(self, session_id: str) -> Path:
+        """Return the session-owned directory for recoverable terminal streams."""
+        return self.session_dir_for(session_id) / "terminal-output"
+
     def legacy_path_for(self, session_id: str) -> Path:
         return self.sessions_dir / f"{_validate_session_id(session_id)}.json"
 
@@ -230,6 +234,7 @@ class SessionStore:
             raise SessionStoreError(f"Session already exists: {record.session_id}")
         ensure_private_dir(session_dir)
         ensure_private_dir(session_dir / "artifacts")
+        ensure_private_dir(self.terminal_output_dir_for(record.session_id))
         journal = self.journal(record.session_id)
         epoch_id = str(uuid.uuid4())
         try:

--- a/kolega_code/sandbox/serializer.py
+++ b/kolega_code/sandbox/serializer.py
@@ -102,7 +102,7 @@ class TerminalStateSerializer:
 
         # Restore outputs
         for terminal_id, outputs in state.outputs.items():
-            terminal_manager.outputs[terminal_id] = [
+            restored_outputs = [
                 {
                     "type": output.type,
                     "data": output.data,
@@ -113,6 +113,8 @@ class TerminalStateSerializer:
                 for output in outputs
                 if output.type != "truncation"  # Skip truncation notices
             ]
+            output_buffer_type = getattr(type(terminal_manager), "output_buffer_type", list)
+            terminal_manager.outputs[terminal_id] = output_buffer_type(restored_outputs)
 
         # Restore default terminal ID
         if hasattr(terminal_manager, "_default_terminal_id"):

--- a/kolega_code/sandbox/terminal.py
+++ b/kolega_code/sandbox/terminal.py
@@ -1,20 +1,59 @@
 """Terminal manager implementation for sandbox environments."""
 
-import uuid
 import asyncio
-import re
+import base64
 import os
+import re
+import shlex
 import time
+import uuid
+from pathlib import Path
 from typing import Any, Dict, Optional, Callable, Awaitable
 from datetime import datetime, timezone
 
-from ..services.base import ExecResult, TerminalManager
-from ..services.terminal_buffer import cap_tokens, clamp_yield
+from ..services.base import ExecResult, TerminalCommandCancelled, TerminalManager
+from ..services.terminal_buffer import (
+    GLOBAL_MAX_TOOL_OUTPUT_TOKENS,
+    TerminalOutputAccumulator,
+    TerminalSpillStore,
+    clamp_output_tokens,
+    clamp_yield,
+)
 from kolega_code.events import AgentEvent
+
+
+class BoundedTerminalOutputs(list):
+    """List-compatible terminal history with a hard in-memory byte ceiling."""
+
+    MAX_BYTES = 1_000_000
+
+    def __init__(self, values=()):
+        super().__init__()
+        self._bytes = 0
+        self.extend(values)
+
+    @staticmethod
+    def _item_bytes(item: Any) -> int:
+        if not isinstance(item, dict):
+            return 0
+        return len(str(item.get("data", "")).encode("utf-8"))
+
+    def append(self, item: Any) -> None:
+        super().append(item)
+        self._bytes += self._item_bytes(item)
+        while self._bytes > self.MAX_BYTES and len(self) > 1:
+            removed = super().pop(0)
+            self._bytes -= self._item_bytes(removed)
+
+    def extend(self, values) -> None:
+        for value in values:
+            self.append(value)
 
 
 class SandboxTerminalManager(TerminalManager):
     """Terminal manager that operates within a sandbox."""
+
+    output_buffer_type = BoundedTerminalOutputs
 
     def __init__(self, sandbox: Any, workspace_id: str, thread_id: str, connection_manager: Any = None):
         """
@@ -33,10 +72,23 @@ class SandboxTerminalManager(TerminalManager):
         self.terminals: Dict[str, Dict[str, Any]] = {}
         self.outputs: Dict[str, list] = {}
         self._default_terminal_id: Optional[str] = None
+        self._spill_store: Optional[TerminalSpillStore] = None
+        self._output_accumulators: Dict[str, TerminalOutputAccumulator] = {}
+        self._command_tasks: Dict[str, asyncio.Task] = {}
 
         # Track commands and their status (for interface parity)
         self.command_history: Dict[str, Dict[str, Any]] = {}
         self.command_counter = 0
+
+    def configure_output_spill(self, root: Optional[Path]) -> None:
+        if root is None:
+            return
+        resolved = Path(root)
+        if self._spill_store is not None and self._spill_store.root == resolved:
+            return
+        if any(info.get("status") == "running" for info in self.command_history.values()):
+            raise RuntimeError("Cannot change terminal spill storage while sessions are running")
+        self._spill_store = TerminalSpillStore(resolved)
 
     def set_connection_manager(self, connection_manager: Any) -> None:
         """
@@ -71,20 +123,73 @@ class SandboxTerminalManager(TerminalManager):
                 return
             await asyncio.sleep(0.05)
 
-    def _render_delta(self, terminal_id: str, start_index: int, max_output_tokens: int):
-        parts = []
-        for entry in self.outputs.get(terminal_id, [])[start_index:]:
-            if entry.get("type") in ("stdout", "stderr"):
-                parts.append(entry.get("data", ""))
-        return cap_tokens("".join(parts), max_output_tokens)
+    def _render_delta(self, command_id: str, max_output_tokens: int):
+        accumulator = self._output_accumulators.get(command_id)
+        if accumulator is None:
+            return TerminalOutputAccumulator(None).read_delta(max_output_tokens)
+        return accumulator.read_delta(max_output_tokens)
 
-    def _exec_result(
-        self, command_id: str, terminal_id: str, start_index: int, max_output_tokens: int, duration_ms: int
-    ) -> ExecResult:
-        capped = self._render_delta(terminal_id, start_index, max_output_tokens)
+    async def _sync_sandbox_spill(self, command_id: str, capped) -> None:
+        """Mirror newly persisted normalized bytes to a sandbox-readable file."""
+        if not capped.spill_path:
+            return
+        info = self.command_history.get(command_id)
+        if info is None:
+            return
+
+        remote_path = info.get("sandbox_spill_path")
+        if remote_path is None:
+            remote_path = f"/home/user/.kolega/terminal-output/{uuid.uuid4().hex}.exec_command.log"
+            parent = os.path.dirname(remote_path)
+            result = await self.sandbox.commands.run(
+                f"mkdir -p {shlex.quote(parent)} && : > {shlex.quote(remote_path)}",
+                timeout=60,
+            )
+            if getattr(result, "exit_code", 1) != 0:
+                return
+            info["sandbox_spill_path"] = remote_path
+            info["sandbox_spill_bytes"] = 0
+
+        synced_bytes = int(info.get("sandbox_spill_bytes", 0))
+        target_bytes = capped.spill_bytes
+        if target_bytes > synced_bytes:
+            try:
+                with Path(capped.spill_path).open("rb") as source:
+                    source.seek(synced_bytes)
+                    while synced_bytes < target_bytes:
+                        chunk = source.read(min(48 * 1024, target_bytes - synced_bytes))
+                        if not chunk:
+                            break
+                        encoded = base64.b64encode(chunk).decode("ascii")
+                        result = await self.sandbox.commands.run(
+                            (f"printf %s {shlex.quote(encoded)} | base64 -d >> {shlex.quote(remote_path)}"),
+                            timeout=60,
+                        )
+                        if getattr(result, "exit_code", 1) != 0:
+                            return
+                        synced_bytes += len(chunk)
+                        info["sandbox_spill_bytes"] = synced_bytes
+            except OSError:
+                return
+
+        if synced_bytes < target_bytes:
+            return
+        capped.spill_path = remote_path
+        if info.get("status") in ("completed", "failed", "terminated"):
+            result = await self.sandbox.commands.run(
+                f"chmod 0400 {shlex.quote(remote_path)}",
+                timeout=60,
+            )
+            if getattr(result, "exit_code", 1) != 0:
+                return
+
+    async def _exec_result(self, command_id: str, max_output_tokens: int, duration_ms: int) -> ExecResult:
+        capped = self._render_delta(command_id, max_output_tokens)
+        await self._sync_sandbox_spill(command_id, capped)
         info = self.command_history.get(command_id) or {}
         status = info.get("status")
         if status in ("completed", "failed", "terminated") or status is None:
+            self._output_accumulators.pop(command_id, None)
             return ExecResult(
                 status="exited",
                 session_id=None,
@@ -93,6 +198,12 @@ class SandboxTerminalManager(TerminalManager):
                 truncated=capped.truncated,
                 original_token_count=capped.original_token_count,
                 duration_ms=duration_ms,
+                spill_path=capped.spill_path,
+                spill_bytes=capped.spill_bytes,
+                line_truncated_count=capped.line_truncated_count,
+                line_truncated_bytes=capped.line_truncated_bytes,
+                preview_omitted_bytes=capped.preview_omitted_bytes,
+                preview_omitted_lines=capped.preview_omitted_lines,
             )
         return ExecResult(
             status="running",
@@ -102,6 +213,12 @@ class SandboxTerminalManager(TerminalManager):
             truncated=capped.truncated,
             original_token_count=capped.original_token_count,
             duration_ms=duration_ms,
+            spill_path=capped.spill_path,
+            spill_bytes=capped.spill_bytes,
+            line_truncated_count=capped.line_truncated_count,
+            line_truncated_bytes=capped.line_truncated_bytes,
+            preview_omitted_bytes=capped.preview_omitted_bytes,
+            preview_omitted_lines=capped.preview_omitted_lines,
         )
 
     async def exec_command(
@@ -120,6 +237,7 @@ class SandboxTerminalManager(TerminalManager):
         # single exec and lives until the sandbox is destroyed, so no special
         # handling.
         _ = background
+        max_output_tokens = clamp_output_tokens(max_output_tokens)
         yield_ms = clamp_yield(yield_time_ms, poll=False)
         terminal_id = await self._ensure_default_terminal()
         info = self.terminals[terminal_id]
@@ -132,14 +250,18 @@ class SandboxTerminalManager(TerminalManager):
             merged.update(env)
             info["env"] = merged
 
-        start_index = len(self.outputs.get(terminal_id, []))
         start = time.monotonic()
         command_id = await self.send_command_tracked(terminal_id, command, timeout=0)
         if command_id is None:
             return ExecResult(status="exited", session_id=None, exit_code=1, output="Failed to start command")
-        await self._wait_for_command(command_id, yield_ms)
+        try:
+            await self._wait_for_command(command_id, yield_ms)
+        except asyncio.CancelledError:
+            killed = await asyncio.shield(self.kill_session(command_id, "TERM"))
+            killed.status = "cancelled"
+            raise TerminalCommandCancelled(killed) from None
         duration_ms = int((time.monotonic() - start) * 1000)
-        return self._exec_result(command_id, terminal_id, start_index, max_output_tokens, duration_ms)
+        return await self._exec_result(command_id, max_output_tokens, duration_ms)
 
     async def write_stdin(
         self,
@@ -152,9 +274,9 @@ class SandboxTerminalManager(TerminalManager):
         info = self.command_history.get(session_id)
         if not info:
             raise KeyError(f"No such session: {session_id}")
+        max_output_tokens = clamp_output_tokens(max_output_tokens)
         terminal_id = info["terminal_id"]
         yield_ms = clamp_yield(yield_time_ms, poll=(chars == ""))
-        start_index = len(self.outputs.get(terminal_id, []))
         start = time.monotonic()
         if chars:
             try:
@@ -162,18 +284,23 @@ class SandboxTerminalManager(TerminalManager):
             except ValueError:
                 # The command may have just finished; report its final status.
                 pass
-        await self._wait_for_command(session_id, yield_ms)
+        try:
+            await self._wait_for_command(session_id, yield_ms)
+        except asyncio.CancelledError:
+            killed = await asyncio.shield(self.kill_session(session_id, "TERM"))
+            killed.status = "cancelled"
+            raise TerminalCommandCancelled(killed) from None
         duration_ms = int((time.monotonic() - start) * 1000)
-        return self._exec_result(session_id, terminal_id, start_index, max_output_tokens, duration_ms)
+        return await self._exec_result(session_id, max_output_tokens, duration_ms)
 
     async def kill_session(self, session_id: str, signal: str = "TERM") -> ExecResult:
         info = self.command_history.get(session_id)
         if not info:
             raise KeyError(f"No such session: {session_id}")
         terminal_id = info["terminal_id"]
-        start_index = len(self.outputs.get(terminal_id, []))
         pid = info.get("pid")
         handle = info.get("handle")
+        info["kill_requested"] = signal
         # e2b exposes a single kill; for INT, best-effort send Ctrl-C via stdin.
         if signal == "INT" and pid is not None:
             try:
@@ -185,6 +312,12 @@ class SandboxTerminalManager(TerminalManager):
                 await handle.kill()
             except Exception:
                 pass
+        task = self._command_tasks.get(session_id)
+        if task is not None:
+            try:
+                await asyncio.wait_for(asyncio.shield(task), timeout=5)
+            except (asyncio.TimeoutError, asyncio.CancelledError):
+                pass
         if info.get("status") == "running":
             info["status"] = "terminated"
             if info.get("return_code") is None:
@@ -192,7 +325,12 @@ class SandboxTerminalManager(TerminalManager):
         active = self.terminals.get(terminal_id, {}).get("active_commands")
         if active is not None:
             active.pop(session_id, None)
-        capped = self._render_delta(terminal_id, start_index, 10000)
+        accumulator = self._output_accumulators.get(session_id)
+        if accumulator is not None:
+            accumulator.finalize()
+        capped = self._render_delta(session_id, GLOBAL_MAX_TOOL_OUTPUT_TOKENS)
+        await self._sync_sandbox_spill(session_id, capped)
+        self._output_accumulators.pop(session_id, None)
         return ExecResult(
             status="exited",
             session_id=None,
@@ -200,6 +338,12 @@ class SandboxTerminalManager(TerminalManager):
             output=capped.text,
             truncated=capped.truncated,
             original_token_count=capped.original_token_count,
+            spill_path=capped.spill_path,
+            spill_bytes=capped.spill_bytes,
+            line_truncated_count=capped.line_truncated_count,
+            line_truncated_bytes=capped.line_truncated_bytes,
+            preview_omitted_bytes=capped.preview_omitted_bytes,
+            preview_omitted_lines=capped.preview_omitted_lines,
         )
 
     async def list_sessions(self) -> Dict[str, Any]:
@@ -280,7 +424,12 @@ class SandboxTerminalManager(TerminalManager):
         # Update the terminal's stored working directory
         terminal_info["cwd"] = new_working_dir
 
-    async def _create_output_handler(self, terminal_id: str, output_type: str) -> Callable[[str], Awaitable[None]]:
+    async def _create_output_handler(
+        self,
+        terminal_id: str,
+        output_type: str,
+        command_id: Optional[str] = None,
+    ) -> Callable[[str], Awaitable[None]]:
         """
         Create an async output handler for streaming.
 
@@ -297,6 +446,10 @@ class SandboxTerminalManager(TerminalManager):
             self.outputs[terminal_id].append(
                 {"type": output_type, "data": data, "timestamp": datetime.now(timezone.utc)}
             )
+            if command_id is not None:
+                accumulator = self._output_accumulators.get(command_id)
+                if accumulator is not None:
+                    accumulator.append_text(data)
 
             # Broadcast output immediately for streaming
             if self.connection_manager:
@@ -424,7 +577,7 @@ class SandboxTerminalManager(TerminalManager):
             "last_command_purpose": "",
             "active_commands": {},  # Track commands for this terminal
         }
-        self.outputs[terminal_id] = []
+        self.outputs[terminal_id] = BoundedTerminalOutputs()
 
         return terminal_id
 
@@ -677,7 +830,9 @@ class SandboxTerminalManager(TerminalManager):
             "return_code": None,
             "pid": None,
             "handle": None,
+            "kill_requested": None,
         }
+        self._output_accumulators[command_id] = TerminalOutputAccumulator(self._spill_store)
 
         # Also track in terminal's active commands
         self.terminals[terminal_id]["active_commands"][command_id] = self.command_history[command_id]
@@ -696,7 +851,8 @@ class SandboxTerminalManager(TerminalManager):
             await self._broadcast_output(terminal_id, f"$ {command}\n")
 
         # Start command execution asynchronously without waiting
-        asyncio.create_task(self._execute_command_async(command_id, terminal_id, command, working_dir, timeout))
+        task = asyncio.create_task(self._execute_command_async(command_id, terminal_id, command, working_dir, timeout))
+        self._command_tasks[command_id] = task
 
         return command_id
 
@@ -713,8 +869,8 @@ class SandboxTerminalManager(TerminalManager):
             env = self.terminals.get(terminal_id, {}).get("env") or {}
 
             # Create streaming output handlers
-            stdout_handler = await self._create_output_handler(terminal_id, "stdout")
-            stderr_handler = await self._create_output_handler(terminal_id, "stderr")
+            stdout_handler = await self._create_output_handler(terminal_id, "stdout", command_id)
+            stderr_handler = await self._create_output_handler(terminal_id, "stderr", command_id)
 
             # Determine timeout settings
             sandbox_timeout = timeout if timeout is not None else 0  # Default to no timeout
@@ -734,6 +890,8 @@ class SandboxTerminalManager(TerminalManager):
                     )
                     self.command_history[command_id]["pid"] = handle.pid
                     self.command_history[command_id]["handle"] = handle
+                    if self.command_history[command_id].get("kill_requested"):
+                        await handle.kill()
                     result = await handle.wait()
                 else:
                     handle = await self.sandbox.commands.run(
@@ -748,6 +906,8 @@ class SandboxTerminalManager(TerminalManager):
                     )
                     self.command_history[command_id]["pid"] = handle.pid
                     self.command_history[command_id]["handle"] = handle
+                    if self.command_history[command_id].get("kill_requested"):
+                        await handle.kill()
                     result = await asyncio.wait_for(
                         handle.wait(),
                         timeout=sandbox_timeout + 5,  # Give 5 seconds more than the sandbox timeout
@@ -756,8 +916,15 @@ class SandboxTerminalManager(TerminalManager):
                 # If the sandbox itself times out or hangs
                 raise Exception(f"Command execution timed out after {sandbox_timeout + 5} seconds")
 
+            accumulator = self._output_accumulators.get(command_id)
+            if accumulator is not None:
+                accumulator.finalize()
+
             # Command completed
-            self.command_history[command_id]["status"] = "completed"
+            if self.command_history[command_id].get("kill_requested"):
+                self.command_history[command_id]["status"] = "terminated"
+            else:
+                self.command_history[command_id]["status"] = "completed"
             self.command_history[command_id]["return_code"] = result.exit_code
             self.command_history[command_id]["end_time"] = datetime.now(timezone.utc)
 
@@ -783,7 +950,6 @@ class SandboxTerminalManager(TerminalManager):
             # Remove from active commands
             if terminal_id in self.terminals:
                 self.terminals[terminal_id]["active_commands"].pop(command_id, None)
-
         except Exception as e:
             # Command failed
             self.command_history[command_id]["status"] = "failed"
@@ -795,6 +961,10 @@ class SandboxTerminalManager(TerminalManager):
             self.outputs[terminal_id].append(
                 {"type": "stderr", "data": error_msg, "timestamp": datetime.now(timezone.utc)}
             )
+            accumulator = self._output_accumulators.get(command_id)
+            if accumulator is not None:
+                accumulator.append_text(error_msg)
+                accumulator.finalize()
 
             # Broadcast error
             if self.connection_manager:
@@ -817,6 +987,8 @@ class SandboxTerminalManager(TerminalManager):
             # Remove from active commands
             if terminal_id in self.terminals:
                 self.terminals[terminal_id]["active_commands"].pop(command_id, None)
+        finally:
+            self._command_tasks.pop(command_id, None)
 
     def read_output(self, terminal_id: str, num_chars: int = 1024, offset: int = 0) -> str:
         """
@@ -948,9 +1120,13 @@ class SandboxTerminalManager(TerminalManager):
                 print(f"Closed terminal {terminal_id}")
             except Exception as e:
                 print(f"Error closing terminal {terminal_id}: {e}")
+        for accumulator in self._output_accumulators.values():
+            accumulator.finalize()
         self.terminals.clear()
         self.outputs.clear()
         self.command_history.clear()
+        self._output_accumulators.clear()
+        self._command_tasks.clear()
 
     def _handle_output(self, terminal_id: str, data: str, stream: str):
         """Handle output from process."""
@@ -1013,6 +1189,13 @@ class SandboxTerminalManager(TerminalManager):
             raise KeyError(f"Terminal {terminal_id} not found")
 
         # Clean up
+        for command_id in list(self.terminals[terminal_id]["active_commands"]):
+            try:
+                await self.kill_session(command_id, "TERM")
+            except Exception:
+                accumulator = self._output_accumulators.pop(command_id, None)
+                if accumulator is not None:
+                    accumulator.finalize()
         del self.terminals[terminal_id]
         del self.outputs[terminal_id]
 
@@ -1021,6 +1204,10 @@ class SandboxTerminalManager(TerminalManager):
         terminal_ids = list(self.terminals.keys())
         for terminal_id in terminal_ids:
             await self.close_terminal(terminal_id)
+        for accumulator in self._output_accumulators.values():
+            accumulator.finalize()
+        self._output_accumulators.clear()
+        self._command_tasks.clear()
 
     async def list_terminals(self) -> Dict[str, Any]:
         """

--- a/kolega_code/services/base.py
+++ b/kolega_code/services/base.py
@@ -1,6 +1,7 @@
 import asyncio
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 
@@ -11,8 +12,10 @@ class ExecResult:
     A "session" is one running process. ``status`` is "exited" when the process
     has finished (``exit_code`` is set) or "running" when it is still alive
     (``session_id`` is set so it can be driven with write_stdin / kill_session).
-    ``output`` is the head-tail-truncated, token-capped delta produced since the
-    previous read for this session.
+    ``output`` is the line-capped, head-tail-previewed, hard-token-capped delta
+    produced since the previous read. ``spill_path`` is an ordinary filesystem
+    path containing the complete normalized stream when the command crossed the
+    terminal spill threshold.
     """
 
     status: str
@@ -22,16 +25,34 @@ class ExecResult:
     truncated: bool = False
     original_token_count: int = 0
     duration_ms: int = 0
+    spill_path: Optional[str] = None
+    spill_bytes: int = 0
+    line_truncated_count: int = 0
+    line_truncated_bytes: int = 0
+    preview_omitted_bytes: int = 0
+    preview_omitted_lines: int = 0
+
+
+class TerminalCommandCancelled(asyncio.CancelledError):
+    """Cancellation carrying the bounded final terminal result."""
+
+    def __init__(self, result: ExecResult):
+        super().__init__("Terminal command cancelled")
+        self.result = result
 
 
 class TerminalManager(ABC):
     """Abstract base class for terminal managers (codex-style unified exec).
 
     Each command runs as its own process (a session). Implementations stream
-    output into a bounded buffer, report real exit codes, support writing stdin
-    to a running session, and signal/kill sessions. Local backends allocate a
-    PTY; sandbox backends run non-TTY background commands.
+    output into a recoverable bounded buffer, report real exit codes, support
+    writing stdin to a running session, and signal/kill sessions. Local backends
+    allocate a PTY; sandbox backends run non-TTY background commands.
     """
+
+    def configure_output_spill(self, root: Optional[Path]) -> None:
+        """Configure ordinary filesystem storage for oversized terminal output."""
+        _ = root
 
     @abstractmethod
     async def exec_command(

--- a/kolega_code/services/terminal.py
+++ b/kolega_code/services/terminal.py
@@ -22,17 +22,20 @@ import sys
 import tempfile
 import termios
 import time
+from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
 from ..events import AgentConnectionManager
 from ..events import AgentEvent
-from .base import ExecResult, TerminalManager
+from .base import ExecResult, TerminalCommandCancelled, TerminalManager
 from .terminal_buffer import (
     DEFAULT_YIELD_MS,
-    MAX_POLL_MS,
+    GLOBAL_MAX_TOOL_OUTPUT_TOKENS,
     MAX_YIELD_MS,
-    HeadTailBuffer,
-    cap_tokens,
+    MIN_YIELD_MS,
+    TerminalOutputAccumulator,
+    TerminalSpillStore,
+    clamp_output_tokens,
     clamp_yield,
 )
 
@@ -192,6 +195,8 @@ class PtySession:
         login: bool = False,
         env: Optional[Dict[str, str]] = None,
         auto_activate_venv: bool = True,
+        spill_store: Optional[TerminalSpillStore] = None,
+        retain_full_delta: bool = False,
     ):
         self.session_id = session_id
         self.command = command
@@ -210,7 +215,7 @@ class PtySession:
 
         self.exited = asyncio.Event()
         self._new_output = asyncio.Event()
-        self._buffer = HeadTailBuffer()  # output since the last read (delta)
+        self._output = TerminalOutputAccumulator(spill_store, retain_full_delta=retain_full_delta)
         self._display_decoder = codecs.getincrementaldecoder("utf-8")("replace")
         self._broadcast_queue: asyncio.Queue[tuple[str, str] | None] = asyncio.Queue()
         self._broadcast_task: Optional[asyncio.Task] = None
@@ -286,12 +291,13 @@ class PtySession:
         if not data:
             self._handle_eof()
             return
-        self._buffer.append(data)
+        self._output.append_bytes(data)
         self._new_output.set()
         self._broadcast(data)
 
     def _handle_eof(self) -> None:
         self._remove_reader()
+        self._output.finalize()
         self._flush_display_decoder()
         self._reap()
         self._new_output.set()
@@ -374,10 +380,8 @@ class PtySession:
         except asyncio.TimeoutError:
             pass
 
-    def read_delta(self, max_output_tokens: int):
-        text = self._buffer.text()
-        self._buffer.reset()
-        return cap_tokens(text, max_output_tokens)
+    def read_delta(self, max_output_tokens: int, *, hard_limit: bool = True):
+        return self._output.read_delta(max_output_tokens, hard_limit=hard_limit)
 
     async def write(self, chars: str) -> bool:
         if self.master_fd is None:
@@ -419,6 +423,7 @@ class PtySession:
             except OSError:
                 pass
             self.master_fd = None
+        self._output.finalize()
         if self._broadcast_task is not None:
             with contextlib.suppress(Exception):
                 await asyncio.wait_for(self._broadcast_queue.join(), timeout=0.5)
@@ -477,6 +482,8 @@ class DetachedSession:
         login: bool = False,
         env: Optional[Dict[str, str]] = None,
         auto_activate_venv: bool = True,
+        spill_store: Optional[TerminalSpillStore] = None,
+        retain_full_delta: bool = False,
     ):
         self.session_id = session_id
         self.command = command
@@ -487,6 +494,8 @@ class DetachedSession:
         self.login = login
         self.env = env or {}
         self.auto_activate_venv = auto_activate_venv
+        self.spill_store = spill_store
+        self.retain_full_delta = retain_full_delta
 
         self.pid: Optional[int] = None
         self.exit_code: Optional[int] = None
@@ -496,7 +505,7 @@ class DetachedSession:
 
         self.exited = asyncio.Event()
         self._new_output = asyncio.Event()
-        self._buffer = HeadTailBuffer()
+        self._output: Optional[TerminalOutputAccumulator] = None
         self._proc: Optional[subprocess.Popen] = None
         self._reader = None
         self._read_offset = 0
@@ -518,11 +527,24 @@ class DetachedSession:
         shell = _pick_shell()
         shell_args = ["-lc", command] if self.login else ["-c", command]
 
+        # The child writes raw bytes to an internal OS-temp spool. The pump
+        # incrementally normalizes those bytes before the accumulator decides
+        # whether to create a session-owned recoverable spill.
         fd, self.log_path = tempfile.mkstemp(prefix="kolega-bg-", suffix=".log")
         os.close(fd)
-        # stdin FIFO named after the log: the log path is unique (mkstemp), so
-        # "<log>.stdin" is too — mkfifo raises EEXIST rather than reusing.
-        self.stdin_path = self.log_path + ".stdin"
+        self._output = TerminalOutputAccumulator(
+            self.spill_store,
+            retain_full_delta=self.retain_full_delta,
+        )
+
+        # Keep the detached stdin FIFO in OS temp storage. The session-owned log
+        # may be deleted with its owning session; unlinking this pathname does
+        # not disrupt the child's already-open fd 0, but it would prevent a
+        # later write_stdin from reconnecting to a still-running process.
+        fifo_fd, fifo_name = tempfile.mkstemp(prefix="kolega-bg-", suffix=".stdin")
+        os.close(fifo_fd)
+        os.unlink(fifo_name)
+        self.stdin_path = fifo_name
         os.mkfifo(self.stdin_path, 0o600)
         self._reader = open(self.log_path, "rb")
         writer = open(self.log_path, "wb")
@@ -560,6 +582,9 @@ class DetachedSession:
             with contextlib.suppress(OSError):
                 os.unlink(self.stdin_path)
             self.stdin_path = None
+            if self._output is not None:
+                self._output.finalize()
+                self._output = None
             raise
         finally:
             writer.close()  # the child holds its own dup of the fd
@@ -606,18 +631,25 @@ class DetachedSession:
         while True:
             chunk = self._read_new_bytes()
             if chunk:
-                self._buffer.append(chunk)
+                assert self._output is not None
+                self._output.append_bytes(chunk)
                 self._new_output.set()
                 await self._broadcast(chunk)
             rc = self._proc.poll() if self._proc else 0
             if rc is not None:
                 tail = self._read_new_bytes()
                 if tail:
-                    self._buffer.append(tail)
+                    assert self._output is not None
+                    self._output.append_bytes(tail)
                     self._new_output.set()
                     await self._broadcast(tail)
+                assert self._output is not None
+                self._output.finalize()
                 self.exit_code = rc if rc >= 0 else 128 + (-rc)
                 self.exited.set()
+                if self._closed:
+                    self._cleanup_finished_files()
+                self._pump_task = None
                 return
             await asyncio.sleep(_DETACHED_POLL_INTERVAL)
 
@@ -627,10 +659,9 @@ class DetachedSession:
         except asyncio.TimeoutError:
             pass
 
-    def read_delta(self, max_output_tokens: int):
-        text = self._buffer.text()
-        self._buffer.reset()
-        return cap_tokens(text, max_output_tokens)
+    def read_delta(self, max_output_tokens: int, *, hard_limit: bool = True):
+        assert self._output is not None
+        return self._output.read_delta(max_output_tokens, hard_limit=hard_limit)
 
     async def write(self, chars: str) -> bool:
         """Deliver ``chars`` to the child's stdin FIFO.
@@ -681,28 +712,31 @@ class DetachedSession:
         if self._closed:
             return
         self._closed = True
-        # Detached: never signal the process here — surviving our exit is the
-        # whole point. Just stop tailing and release our read handle.
+        # Detached sessions are not signalled on manager close. Keep the pump
+        # alive as a reaper/normalizer until the child exits, then remove the
+        # internal raw spool and FIFO. This avoids zombies and preserves every
+        # byte emitted after the session registry lets go of the command.
+        if not self.exited.is_set():
+            return
         if self._pump_task is not None:
-            self._pump_task.cancel()
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await self._pump_task
             self._pump_task = None
+        self._cleanup_finished_files()
+
+    def _cleanup_finished_files(self) -> None:
         if self._reader is not None:
             with contextlib.suppress(OSError):
                 self._reader.close()
             self._reader = None
-        # Only drop the log and stdin FIFO once the process is gone; a survivor
-        # still writes to the log and owns the FIFO through its own fd 0.
-        if self.exited.is_set():
-            if self.log_path:
-                with contextlib.suppress(OSError):
-                    os.unlink(self.log_path)
-                self.log_path = None
-            if self.stdin_path:
-                with contextlib.suppress(OSError):
-                    os.unlink(self.stdin_path)
-                self.stdin_path = None
+        if self.log_path:
+            with contextlib.suppress(OSError):
+                os.unlink(self.log_path)
+            self.log_path = None
+        if self.stdin_path:
+            with contextlib.suppress(OSError):
+                os.unlink(self.stdin_path)
+            self.stdin_path = None
 
     @property
     def running(self) -> bool:
@@ -723,6 +757,7 @@ class LocalTerminalManager(TerminalManager):
         thread_id: str,
         connection_manager: AgentConnectionManager,
         default_workdir: Optional[Union[str, os.PathLike]] = None,
+        spill_root: Optional[Union[str, os.PathLike]] = None,
     ):
         self.workspace_id = workspace_id
         self.thread_id = thread_id
@@ -734,6 +769,18 @@ class LocalTerminalManager(TerminalManager):
         # that serve a project should pass its root; the process cwd is only a
         # fallback for standalone use.
         self.default_workdir = str(default_workdir) if default_workdir else os.getcwd()
+        self._spill_store = TerminalSpillStore(Path(spill_root)) if spill_root is not None else None
+
+    def configure_output_spill(self, root: Optional[Path]) -> None:
+        """Set the session-owned root used for subsequent terminal sessions."""
+        if root is None:
+            return
+        resolved = Path(root)
+        if self._spill_store is not None and self._spill_store.root == resolved:
+            return
+        if self.sessions:
+            raise RuntimeError("Cannot change terminal spill storage while sessions are running")
+        self._spill_store = TerminalSpillStore(resolved)
 
     def _next_session_id(self) -> str:
         self._counter += 1
@@ -786,8 +833,15 @@ class LocalTerminalManager(TerminalManager):
         except Exception:
             pass
 
-    def _result_from(self, session: Session, max_output_tokens: int, duration_ms: int) -> ExecResult:
-        capped = session.read_delta(max_output_tokens)
+    def _result_from(
+        self,
+        session: Session,
+        max_output_tokens: int,
+        duration_ms: int,
+        *,
+        hard_limit: bool = True,
+    ) -> ExecResult:
+        capped = session.read_delta(max_output_tokens, hard_limit=hard_limit)
         if session.exited.is_set():
             return ExecResult(
                 status="exited",
@@ -797,6 +851,12 @@ class LocalTerminalManager(TerminalManager):
                 truncated=capped.truncated,
                 original_token_count=capped.original_token_count,
                 duration_ms=duration_ms,
+                spill_path=capped.spill_path,
+                spill_bytes=capped.spill_bytes,
+                line_truncated_count=capped.line_truncated_count,
+                line_truncated_bytes=capped.line_truncated_bytes,
+                preview_omitted_bytes=capped.preview_omitted_bytes,
+                preview_omitted_lines=capped.preview_omitted_lines,
             )
         return ExecResult(
             status="running",
@@ -806,6 +866,12 @@ class LocalTerminalManager(TerminalManager):
             truncated=capped.truncated,
             original_token_count=capped.original_token_count,
             duration_ms=duration_ms,
+            spill_path=capped.spill_path,
+            spill_bytes=capped.spill_bytes,
+            line_truncated_count=capped.line_truncated_count,
+            line_truncated_bytes=capped.line_truncated_bytes,
+            preview_omitted_bytes=capped.preview_omitted_bytes,
+            preview_omitted_lines=capped.preview_omitted_lines,
         )
 
     async def _finish_if_exited(self, session: Session) -> None:
@@ -824,6 +890,30 @@ class LocalTerminalManager(TerminalManager):
         env: Optional[Dict[str, str]] = None,
         background: bool = False,
     ) -> ExecResult:
+        return await self._exec_command(
+            command,
+            workdir=workdir,
+            yield_time_ms=yield_time_ms,
+            max_output_tokens=max_output_tokens,
+            login=login,
+            env=env,
+            background=background,
+            hard_limit=True,
+        )
+
+    async def _exec_command(
+        self,
+        command: str,
+        *,
+        workdir: Optional[str],
+        yield_time_ms: int,
+        max_output_tokens: int,
+        login: bool,
+        env: Optional[Dict[str, str]],
+        background: bool,
+        hard_limit: bool,
+    ) -> ExecResult:
+        max_output_tokens = clamp_output_tokens(max_output_tokens) if hard_limit else max(1, int(max_output_tokens))
         yield_ms = clamp_yield(yield_time_ms, poll=False)
         # workdir should be absolute; a relative path would chdir relative to
         # this process's cwd, not default_workdir.
@@ -844,14 +934,21 @@ class LocalTerminalManager(TerminalManager):
             login=login,
             env=env,
             auto_activate_venv=self.auto_activate_venv,
+            spill_store=self._spill_store,
+            retain_full_delta=not hard_limit,
         )
         start = time.monotonic()
         await session.start()
         self.sessions[session_id] = session
 
-        await session.drain(yield_ms)
+        try:
+            await session.drain(yield_ms)
+        except asyncio.CancelledError:
+            killed = await asyncio.shield(self._kill_session(session_id, "TERM", hard_limit=hard_limit))
+            killed.status = "cancelled"
+            raise TerminalCommandCancelled(killed) from None
         duration_ms = int((time.monotonic() - start) * 1000)
-        result = self._result_from(session, max_output_tokens, duration_ms)
+        result = self._result_from(session, max_output_tokens, duration_ms, hard_limit=hard_limit)
         if result.status == "exited":
             await self._finish_if_exited(session)
         return result
@@ -864,11 +961,33 @@ class LocalTerminalManager(TerminalManager):
         yield_time_ms: int = DEFAULT_YIELD_MS,
         max_output_tokens: int = 10000,
     ) -> ExecResult:
+        return await self._write_stdin(
+            session_id,
+            chars,
+            yield_time_ms=yield_time_ms,
+            max_output_tokens=max_output_tokens,
+            hard_limit=True,
+        )
+
+    async def _write_stdin(
+        self,
+        session_id: str,
+        chars: str,
+        *,
+        yield_time_ms: int,
+        max_output_tokens: int,
+        hard_limit: bool,
+        enforce_poll_minimum: bool = True,
+    ) -> ExecResult:
+        max_output_tokens = clamp_output_tokens(max_output_tokens) if hard_limit else max(1, int(max_output_tokens))
         session = self.sessions.get(session_id)
         if session is None:
             raise KeyError(f"No such session: {session_id}")
 
-        yield_ms = clamp_yield(yield_time_ms, poll=(chars == ""))
+        yield_ms = clamp_yield(
+            yield_time_ms,
+            poll=(chars == "" and enforce_poll_minimum),
+        )
         start = time.monotonic()
         if chars:
             # Both session types return a success bool; it is intentionally
@@ -877,21 +996,38 @@ class LocalTerminalManager(TerminalManager):
             # in this same result: the drain below observes the exit well
             # within the >=250ms write window.
             await session.write(chars)
-        await session.drain(yield_ms)
+        try:
+            await session.drain(yield_ms)
+        except asyncio.CancelledError:
+            killed = await asyncio.shield(self._kill_session(session_id, "TERM", hard_limit=hard_limit))
+            killed.status = "cancelled"
+            raise TerminalCommandCancelled(killed) from None
         duration_ms = int((time.monotonic() - start) * 1000)
-        result = self._result_from(session, max_output_tokens, duration_ms)
+        result = self._result_from(session, max_output_tokens, duration_ms, hard_limit=hard_limit)
         if result.status == "exited":
             await self._finish_if_exited(session)
         return result
 
     async def kill_session(self, session_id: str, signal: str = "TERM") -> ExecResult:
+        return await self._kill_session(session_id, signal, hard_limit=True)
+
+    async def _kill_session(
+        self,
+        session_id: str,
+        signal: str,
+        *,
+        hard_limit: bool,
+    ) -> ExecResult:
         session = self.sessions.get(session_id)
         if session is None:
             raise KeyError(f"No such session: {session_id}")
         start = time.monotonic()
         await session.kill(signal)
         duration_ms = int((time.monotonic() - start) * 1000)
-        capped = session.read_delta(10000)
+        capped = session.read_delta(
+            GLOBAL_MAX_TOOL_OUTPUT_TOKENS if hard_limit else 200_000,
+            hard_limit=hard_limit,
+        )
         exit_code = session.exit_code
         await self._emit_output(session_id, f"[exited {exit_code}]\n")
         await session.close()
@@ -904,6 +1040,12 @@ class LocalTerminalManager(TerminalManager):
             truncated=capped.truncated,
             original_token_count=capped.original_token_count,
             duration_ms=duration_ms,
+            spill_path=capped.spill_path,
+            spill_bytes=capped.spill_bytes,
+            line_truncated_count=capped.line_truncated_count,
+            line_truncated_bytes=capped.line_truncated_bytes,
+            preview_omitted_bytes=capped.preview_omitted_bytes,
+            preview_omitted_lines=capped.preview_omitted_lines,
         )
 
     async def list_sessions(self) -> Dict[str, Any]:
@@ -935,13 +1077,34 @@ class LocalTerminalManager(TerminalManager):
         through the session model, accumulating output across poll windows.
         """
         deadline = time.monotonic() + (timeout if timeout and timeout > 0 else 600)
-        result = await self.exec_command(command, workdir=cwd, yield_time_ms=MAX_YIELD_MS, max_output_tokens=200000)
+        initial_yield_ms = min(
+            MAX_YIELD_MS,
+            max(MIN_YIELD_MS, int((deadline - time.monotonic()) * 1000)),
+        )
+        result = await self._exec_command(
+            command,
+            workdir=cwd,
+            yield_time_ms=initial_yield_ms,
+            max_output_tokens=200000,
+            login=False,
+            env=None,
+            background=False,
+            hard_limit=False,
+        )
         parts = [result.output]
         session_id = result.session_id
         while result.status == "running" and session_id is not None and time.monotonic() < deadline:
-            result = await self.write_stdin(session_id, "", yield_time_ms=MAX_POLL_MS, max_output_tokens=200000)
+            remaining_ms = max(1, int((deadline - time.monotonic()) * 1000))
+            result = await self._write_stdin(
+                session_id,
+                "",
+                yield_time_ms=min(MAX_YIELD_MS, remaining_ms),
+                max_output_tokens=200000,
+                hard_limit=False,
+                enforce_poll_minimum=False,
+            )
             parts.append(result.output)
         if result.status == "running" and session_id is not None:
-            killed = await self.kill_session(session_id, "TERM")
+            killed = await self._kill_session(session_id, "TERM", hard_limit=False)
             parts.append(killed.output)
         return "".join(parts)

--- a/kolega_code/services/terminal_buffer.py
+++ b/kolega_code/services/terminal_buffer.py
@@ -1,21 +1,37 @@
-"""Bounded output buffering and token-capping for terminal sessions.
-
-Replaces the previous fast-LLM "compression" of terminal output with a
-deterministic head-tail buffer (codex-style): keep the beginning and end of
-the output, drop the middle with a marker, and cap the returned text to a
-token budget. No model calls, fast and deterministic.
-"""
+"""Bounded, recoverable model-facing output for terminal sessions."""
 
 from __future__ import annotations
 
+import codecs
+import os
+import re
+import threading
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional, cast
 
-# Byte caps for the rolling per-read buffer. We keep the first HEAD_BYTES and
-# the last TAIL_BYTES of whatever a command emits between reads; anything in
-# between is dropped with a marker. This bounds memory regardless of how much a
-# command prints.
-HEAD_BYTES = 512 * 1024
-TAIL_BYTES = 512 * 1024
+from kolega_code.local_state import ensure_private_dir, ensure_private_file
+
+# A model may request less, but never more, from exec_command/write_stdin.
+GLOBAL_MAX_TOOL_OUTPUT_TOKENS = 10_000
+
+# Complete normalized terminal streams spill once they cross this threshold.
+SPILL_THRESHOLD_BYTES = 50 * 1024
+
+# Model-visible terminal deltas retain an approximately 20 KiB / 30 KiB
+# head-tail preview before the final token cap.
+PREVIEW_HEAD_BYTES = 20 * 1024
+PREVIEW_TAIL_BYTES = 30 * 1024
+
+# A single logical terminal line, including its explicit marker, may contribute
+# at most this many UTF-8 bytes to model-visible output.
+LINE_CAP_BYTES = 1024
+LINE_TRUNCATION_MARKER = "… [line truncated]"
+
+# Backwards-compatible names for callers/tests that construct HeadTailBuffer
+# without explicit caps. Terminal sessions now use the smaller preview limits.
+HEAD_BYTES = PREVIEW_HEAD_BYTES
+TAIL_BYTES = PREVIEW_TAIL_BYTES
 
 # Yield-time clamps (milliseconds). A write/exec waits up to MAX_YIELD_MS for
 # output or exit; an empty poll may wait much longer.
@@ -24,6 +40,8 @@ MAX_YIELD_MS = 30_000
 MIN_POLL_MS = 5_000
 MAX_POLL_MS = 300_000
 DEFAULT_YIELD_MS = 10_000
+
+_SPILL_NAME_RE = re.compile(r"^(?P<id>[0-9]+)\.[^.]+\.log$")
 
 
 def clamp_yield(value, *, poll: bool) -> int:
@@ -39,25 +57,36 @@ def clamp_yield(value, *, poll: bool) -> int:
     return max(low, min(high, millis))
 
 
-def _omitted_marker(num_bytes: int) -> str:
-    return f"\n[... omitted {num_bytes:,} bytes ...]\n"
+def clamp_output_tokens(value: object) -> int:
+    """Return the effective terminal output budget for a model-facing call."""
+    try:
+        tokens = int(cast(Any, value))
+    except (TypeError, ValueError):
+        tokens = GLOBAL_MAX_TOOL_OUTPUT_TOKENS
+    return max(1, min(tokens, GLOBAL_MAX_TOOL_OUTPUT_TOKENS))
+
+
+def _omitted_marker(num_bytes: int, num_lines: int) -> str:
+    noun = "line" if num_lines == 1 else "lines"
+    return f"\n[... omitted {num_bytes:,} bytes across {num_lines:,} {noun} ...]\n"
 
 
 class HeadTailBuffer:
-    """Accumulates bytes, retaining only the head and tail past a size cap."""
+    """Accumulate bytes while retaining a bounded head and rolling tail."""
 
     def __init__(self, head_bytes: int = HEAD_BYTES, tail_bytes: int = TAIL_BYTES):
         self._head_cap = head_bytes
         self._tail_cap = tail_bytes
         self._head = bytearray()
         self._tail = bytearray()
+        self._omitted_line_breaks = 0
+        self._omitted_ends_newline = False
         self.total_bytes = 0
 
     def append(self, data: bytes) -> None:
         if not data:
             return
         self.total_bytes += len(data)
-        # Fill the head first (it never changes once full).
         if len(self._head) < self._head_cap:
             take = self._head_cap - len(self._head)
             self._head += data[:take]
@@ -66,35 +95,68 @@ class HeadTailBuffer:
             self._tail += data
             excess = len(self._tail) - self._tail_cap
             if excess > 0:
+                removed = bytes(self._tail[:excess])
+                self._omitted_line_breaks += removed.count(b"\n")
+                self._omitted_ends_newline = removed.endswith(b"\n")
                 del self._tail[:excess]
 
     @property
     def omitted_bytes(self) -> int:
-        return max(0, self.total_bytes - len(self._head) - len(self._tail))
+        return self.view().omitted_bytes
+
+    @property
+    def omitted_lines(self) -> int:
+        return self.view().omitted_lines
+
+    def view(self) -> "HeadTailView":
+        """Return valid UTF-8 retained regions and exact omitted accounting."""
+        raw_omitted = max(0, self.total_bytes - len(self._head) - len(self._tail))
+        if raw_omitted == 0:
+            text = (bytes(self._head) + bytes(self._tail)).decode("utf-8")
+            return HeadTailView(head=text, tail="")
+
+        head = bytes(self._head).decode("utf-8", errors="ignore")
+        tail = bytes(self._tail).decode("utf-8", errors="ignore")
+        retained_bytes = len(head.encode("utf-8")) + len(tail.encode("utf-8"))
+        omitted_bytes = max(0, self.total_bytes - retained_bytes)
+        skipped_tail_bytes = len(self._tail) - len(tail.encode("utf-8"))
+        omitted_ends_newline = self._omitted_ends_newline if skipped_tail_bytes == 0 else False
+        omitted_lines = self._omitted_line_breaks + (0 if omitted_ends_newline else 1)
+        return HeadTailView(
+            head=head,
+            tail=tail,
+            omitted_bytes=omitted_bytes,
+            omitted_newlines=self._omitted_line_breaks,
+            omitted_ends_newline=omitted_ends_newline,
+            omitted_lines=max(1, omitted_lines),
+        )
 
     def text(self) -> str:
-        """Render the retained bytes, with a marker for any dropped middle.
-
-        Decoded with errors="replace" so a multibyte character split at the
-        head/tail boundary degrades gracefully instead of raising.
-        """
-        omitted = self.omitted_bytes
-        if omitted == 0:
-            return (bytes(self._head) + bytes(self._tail)).decode("utf-8", errors="replace")
-        head = bytes(self._head).decode("utf-8", errors="replace")
-        tail = bytes(self._tail).decode("utf-8", errors="replace")
-        return head + _omitted_marker(omitted) + tail
+        """Render retained valid UTF-8 with a middle-elision marker."""
+        view = self.view()
+        if view.omitted_bytes == 0:
+            return view.head
+        return view.head + _omitted_marker(view.omitted_bytes, view.omitted_lines) + view.tail
 
     def reset(self) -> None:
         self._head.clear()
         self._tail.clear()
+        self._omitted_line_breaks = 0
+        self._omitted_ends_newline = False
         self.total_bytes = 0
 
     def __len__(self) -> int:
         return self.total_bytes
 
 
-# --- token capping ---------------------------------------------------------
+@dataclass(frozen=True)
+class HeadTailView:
+    head: str
+    tail: str
+    omitted_bytes: int = 0
+    omitted_newlines: int = 0
+    omitted_ends_newline: bool = False
+    omitted_lines: int = 0
 
 
 @dataclass
@@ -102,34 +164,424 @@ class CappedOutput:
     text: str
     truncated: bool
     original_token_count: int
+    spill_path: Optional[str] = None
+    spill_bytes: int = 0
+    line_truncated_count: int = 0
+    line_truncated_bytes: int = 0
+    preview_omitted_bytes: int = 0
+    preview_omitted_lines: int = 0
 
 
 def _truncation_marker(max_tokens: int) -> str:
     return f"\n[... output truncated to fit {max_tokens} tokens ...]\n"
 
 
-def cap_tokens(text: str, max_tokens: int) -> CappedOutput:
-    """Cap ``text`` to ``max_tokens``, dropping the middle if needed.
+def _estimated_tokens(char_count: int) -> int:
+    return 0 if char_count <= 0 else (char_count + 3) // 4
 
-    Returns the (possibly truncated) text, whether truncation happened, and the
-    estimated original token count so callers can tell the model there is more
-    output.
 
-    Token counts here are estimated with a ~4-chars/token heuristic rather than a
-    tiktoken encoding. This is a soft budget for fitting shell output into the
-    context window — not billing — so the approximation is fine, and it avoids
-    loading the o200k_base encoding (~76MB resident, and the only tiktoken table a
-    typical session would otherwise load). Truncation drops the middle and the
-    marker signals to the model that output was elided.
+def cap_chars(
+    text: str,
+    budget_chars: int,
+    *,
+    marker: str,
+    original_token_count: Optional[int] = None,
+) -> CappedOutput:
+    """Cap text to an exact character budget with a deterministic head/tail."""
+    budget = max(0, int(budget_chars))
+    original = original_token_count if original_token_count is not None else _estimated_tokens(len(text))
+    if len(text) <= budget:
+        return CappedOutput(text, False, original)
+    if budget == 0:
+        return CappedOutput("", True, original)
+    if len(marker) >= budget:
+        return CappedOutput(marker[:budget], True, original)
+    available = budget - len(marker)
+    head = available // 2
+    tail = available - head
+    capped = text[:head] + marker + (text[-tail:] if tail else "")
+    return CappedOutput(capped, True, original)
+
+
+def cap_tokens(
+    text: str,
+    max_tokens: int,
+    *,
+    protected_suffix: str = "",
+    original_token_count: Optional[int] = None,
+    hard_limit: bool = True,
+) -> CappedOutput:
+    """Hard-cap terminal text while preserving a recovery suffix when possible.
+
+    The four-characters-per-token estimate is intentionally deterministic and
+    dependency-free. Unlike the previous implementation, the truncation marker
+    itself is included in the character budget, so the returned ``text`` never
+    exceeds ``effective_max_tokens * 4`` characters.
     """
-    if max_tokens <= 0:
-        max_tokens = 1
+    effective_max_tokens = clamp_output_tokens(max_tokens) if hard_limit else max(1, int(max_tokens))
+    original = original_token_count if original_token_count is not None else _estimated_tokens(len(text))
+    full = text + protected_suffix
+    budget_chars = effective_max_tokens * 4
+    if len(full) <= budget_chars:
+        return CappedOutput(full, original > effective_max_tokens, original)
 
-    approx = max(1, (len(text) + 3) // 4)
-    if approx <= max_tokens:
-        return CappedOutput(text, False, approx)
-    budget_chars = max_tokens * 4
-    head = budget_chars // 2
-    tail = budget_chars - head
-    capped = text[:head] + _truncation_marker(max_tokens) + (text[-tail:] if tail else "")
-    return CappedOutput(capped, True, approx)
+    marker = _truncation_marker(effective_max_tokens)
+    suffix = protected_suffix if len(protected_suffix) <= budget_chars else ""
+    available = max(0, budget_chars - len(marker) - len(suffix))
+    if available == 0:
+        # ``spill_path`` is also a structured result field, so an exceptionally
+        # small caller-requested budget may omit the prose footer without losing
+        # the recovery path.
+        capped = suffix[-budget_chars:] if suffix else ""
+    else:
+        content = cap_chars(
+            text,
+            available + len(marker),
+            marker=marker,
+            original_token_count=original,
+        ).text
+        capped = content + suffix
+    return CappedOutput(capped[:budget_chars], True, original)
+
+
+def _write_all(fd: int, data: bytes) -> None:
+    view = memoryview(data)
+    while view:
+        written = os.write(fd, view)
+        if written <= 0:
+            raise OSError("short write while persisting terminal output")
+        view = view[written:]
+
+
+class TerminalSpillStore:
+    """Allocate collision-safe terminal spill files under one session directory."""
+
+    def __init__(self, root: Path):
+        self.root = Path(root)
+        self._lock = threading.Lock()
+        self._next_id: Optional[int] = None
+
+    def allocate_path(self, tool_name: str = "exec_command") -> Path:
+        safe_tool = re.sub(r"[^a-z0-9_-]+", "-", tool_name.lower()).strip("-") or "terminal"
+        with self._lock:
+            ensure_private_dir(self.root)
+            if self._next_id is None:
+                existing_ids = [
+                    int(match.group("id"))
+                    for path in self.root.iterdir()
+                    if path.is_file() and (match := _SPILL_NAME_RE.match(path.name))
+                ]
+                self._next_id = max(existing_ids, default=0) + 1
+            while True:
+                spill_id = self._next_id
+                self._next_id += 1
+                path = self.root / f"{spill_id:06d}.{safe_tool}.log"
+                try:
+                    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+                except FileExistsError:
+                    continue
+                os.close(fd)
+                ensure_private_file(path)
+                return path
+
+
+class _SpillWriter:
+    """Buffer up to the threshold, then persist every normalized byte."""
+
+    def __init__(
+        self,
+        store: Optional[TerminalSpillStore],
+        *,
+        tool_name: str,
+        backing_path: Optional[Path] = None,
+    ) -> None:
+        self.store = store
+        self.tool_name = tool_name
+        self.backing_path = backing_path
+        self.total_bytes = 0
+        self._path = backing_path
+        self._fd: Optional[int] = None
+        self._pending = bytearray()
+        self._active = False
+        self._finalized = False
+
+    @property
+    def path(self) -> Optional[Path]:
+        return self._path if self._active else None
+
+    def append(self, data: bytes) -> None:
+        if not data:
+            return
+        if self._finalized:
+            raise RuntimeError("Cannot append to finalized terminal output")
+        self.total_bytes += len(data)
+
+        # Detached sessions write directly to ``backing_path`` so their child
+        # can continue appending after the Kolega process exits. We only decide
+        # whether to expose that path here.
+        if self.backing_path is not None:
+            if self.total_bytes > SPILL_THRESHOLD_BYTES:
+                self._active = True
+            return
+
+        if self._fd is not None:
+            _write_all(self._fd, data)
+            return
+
+        if self.store is None:
+            # Non-model internal managers may intentionally omit spill storage.
+            # Keep only the threshold prefix so memory remains bounded.
+            remaining = max(0, SPILL_THRESHOLD_BYTES + 1 - len(self._pending))
+            self._pending.extend(data[:remaining])
+            return
+
+        if self.total_bytes <= SPILL_THRESHOLD_BYTES:
+            self._pending.extend(data)
+            return
+
+        self._path = self.store.allocate_path(self.tool_name)
+        self._fd = os.open(self._path, os.O_WRONLY | os.O_APPEND)
+        _write_all(self._fd, bytes(self._pending))
+        self._pending.clear()
+        _write_all(self._fd, data)
+        self._active = True
+
+    def finalize(self) -> None:
+        if self._finalized:
+            return
+        self._finalized = True
+        if self._fd is not None:
+            os.fsync(self._fd)
+            os.close(self._fd)
+            self._fd = None
+        if self._active and self._path is not None:
+            try:
+                os.chmod(self._path, 0o400)
+            except OSError:
+                pass
+        if self.backing_path is not None and not self._active:
+            try:
+                self.backing_path.unlink()
+            except OSError:
+                pass
+            self._path = None
+        self._pending.clear()
+
+
+class _StreamingLineCap:
+    """Cap logical lines across arbitrary streaming chunk/read boundaries."""
+
+    def __init__(self, cap_bytes: int = LINE_CAP_BYTES):
+        marker_bytes = len(LINE_TRUNCATION_MARKER.encode("utf-8"))
+        self.cap_bytes = max(marker_bytes, cap_bytes)
+        self._payload_bytes = max(
+            0,
+            self.cap_bytes - marker_bytes,
+        )
+        self._visible_bytes = 0
+        self._line_truncated = False
+        self._delta_line_counted = False
+        self._delta_lines = 0
+        self._delta_bytes = 0
+
+    def append(self, text: str) -> bytes:
+        rendered: list[str] = []
+        for char in text:
+            if char == "\n":
+                rendered.append(char)
+                self._visible_bytes = 0
+                self._line_truncated = False
+                self._delta_line_counted = False
+                continue
+
+            encoded_size = len(char.encode("utf-8"))
+            if not self._line_truncated and self._visible_bytes + encoded_size <= self._payload_bytes:
+                rendered.append(char)
+                self._visible_bytes += encoded_size
+                continue
+
+            if not self._line_truncated:
+                rendered.append(LINE_TRUNCATION_MARKER)
+                self._line_truncated = True
+            if not self._delta_line_counted:
+                self._delta_lines += 1
+                self._delta_line_counted = True
+            self._delta_bytes += encoded_size
+        return "".join(rendered).encode("utf-8")
+
+    def take_delta_stats(self) -> tuple[int, int]:
+        result = (self._delta_lines, self._delta_bytes)
+        self._delta_lines = 0
+        self._delta_bytes = 0
+        # A continued logical line should count once again if a later read also
+        # drops bytes, even though its inline marker remains one-per-line.
+        self._delta_line_counted = False
+        return result
+
+
+def _allocate_preview_chars(head_length: int, tail_length: int, available: int) -> tuple[int, int]:
+    """Allocate a bounded preview with the configured 20/30 head-tail ratio."""
+    available = max(0, available)
+    head = min(head_length, available * PREVIEW_HEAD_BYTES // (PREVIEW_HEAD_BYTES + PREVIEW_TAIL_BYTES))
+    tail = min(tail_length, available - head)
+    remaining = available - head - tail
+    if remaining:
+        extra_head = min(remaining, head_length - head)
+        head += extra_head
+        remaining -= extra_head
+    if remaining:
+        tail += min(remaining, tail_length - tail)
+    return head, tail
+
+
+def _render_preview(view: HeadTailView, budget_chars: int) -> tuple[str, int, int]:
+    """Render a bounded head/tail preview whose marker accounts for all omissions."""
+    budget = max(0, budget_chars)
+    if view.omitted_bytes == 0:
+        full = view.head
+        if len(full) <= budget:
+            return full, 0, 0
+        split = len(full) * PREVIEW_HEAD_BYTES // (PREVIEW_HEAD_BYTES + PREVIEW_TAIL_BYTES)
+        source_head = full[:split]
+        source_tail = full[split:]
+    else:
+        source_head = view.head
+        source_tail = view.tail
+
+    marker = _omitted_marker(max(1, view.omitted_bytes), max(1, view.omitted_lines))
+    head_keep = tail_keep = -1
+    omitted_bytes = view.omitted_bytes
+    omitted_lines = view.omitted_lines
+
+    for _ in range(6):
+        available = max(0, budget - len(marker))
+        next_head_keep, next_tail_keep = _allocate_preview_chars(
+            len(source_head),
+            len(source_tail),
+            available,
+        )
+        removed_head = source_head[next_head_keep:]
+        removed_tail = source_tail[: len(source_tail) - next_tail_keep] if next_tail_keep else source_tail
+        omitted_bytes = view.omitted_bytes + len(removed_head.encode("utf-8")) + len(removed_tail.encode("utf-8"))
+        omitted_newlines = view.omitted_newlines + removed_head.count("\n") + removed_tail.count("\n")
+        if removed_tail:
+            omitted_ends_newline = removed_tail.endswith("\n")
+        elif view.omitted_bytes:
+            omitted_ends_newline = view.omitted_ends_newline
+        else:
+            omitted_ends_newline = removed_head.endswith("\n")
+        omitted_lines = max(1, omitted_newlines + (0 if omitted_ends_newline else 1))
+        next_marker = _omitted_marker(omitted_bytes, omitted_lines)
+        if next_head_keep == head_keep and next_tail_keep == tail_keep and next_marker == marker:
+            break
+        head_keep, tail_keep, marker = next_head_keep, next_tail_keep, next_marker
+
+    if len(marker) > budget:
+        capped = cap_chars(
+            source_head + source_tail,
+            budget,
+            marker=_truncation_marker(max(1, budget // 4)),
+        )
+        return capped.text, omitted_bytes, omitted_lines
+
+    head_text = source_head[: max(0, head_keep)]
+    tail_text = source_tail[-tail_keep:] if tail_keep > 0 else ""
+    return head_text + marker + tail_text, omitted_bytes, omitted_lines
+
+
+class TerminalOutputAccumulator:
+    """Persist a complete stream and expose bounded model-facing deltas."""
+
+    def __init__(
+        self,
+        spill_store: Optional[TerminalSpillStore],
+        *,
+        tool_name: str = "exec_command",
+        backing_path: Optional[Path] = None,
+        line_cap_bytes: int = LINE_CAP_BYTES,
+        retain_full_delta: bool = False,
+    ) -> None:
+        self._spill = _SpillWriter(spill_store, tool_name=tool_name, backing_path=backing_path)
+        self._preview = HeadTailBuffer(PREVIEW_HEAD_BYTES, PREVIEW_TAIL_BYTES)
+        self._line_cap = _StreamingLineCap(line_cap_bytes)
+        self._decoder = codecs.getincrementaldecoder("utf-8")("replace")
+        self._full_delta = bytearray() if retain_full_delta else None
+        self._delta_chars = 0
+        self._finalized = False
+
+    @property
+    def spill_path(self) -> Optional[str]:
+        path = self._spill.path
+        return str(path) if path is not None else None
+
+    @property
+    def total_bytes(self) -> int:
+        return self._spill.total_bytes
+
+    def append_bytes(self, data: bytes) -> None:
+        if not data:
+            return
+        text = self._decoder.decode(data, final=False)
+        self._append_normalized(text)
+
+    def append_text(self, text: str) -> None:
+        if text:
+            self._append_normalized(text)
+
+    def _append_normalized(self, text: str) -> None:
+        if not text:
+            return
+        normalized = text.encode("utf-8")
+        self._spill.append(normalized)
+        if self._full_delta is not None:
+            self._full_delta.extend(normalized)
+        self._preview.append(self._line_cap.append(text))
+        self._delta_chars += len(text)
+
+    def finalize(self) -> None:
+        if self._finalized:
+            return
+        self._finalized = True
+        self._append_normalized(self._decoder.decode(b"", final=True))
+        self._spill.finalize()
+
+    def read_delta(self, max_output_tokens: int, *, hard_limit: bool = True) -> CappedOutput:
+        if not hard_limit and self._full_delta is not None:
+            text = bytes(self._full_delta).decode("utf-8")
+            self._line_cap.take_delta_stats()
+            result = CappedOutput(
+                text=text,
+                truncated=False,
+                original_token_count=_estimated_tokens(len(text)),
+                spill_path=self.spill_path,
+                spill_bytes=self.total_bytes if self.spill_path else 0,
+            )
+            self._preview.reset()
+            self._full_delta.clear()
+            self._delta_chars = 0
+            return result
+
+        effective_tokens = clamp_output_tokens(max_output_tokens) if hard_limit else max(1, int(max_output_tokens))
+        text, omitted_bytes, omitted_lines = _render_preview(
+            self._preview.view(),
+            effective_tokens * 4,
+        )
+        line_count, line_bytes = self._line_cap.take_delta_stats()
+        spill_path = self.spill_path
+        original_tokens = _estimated_tokens(self._delta_chars)
+        result = CappedOutput(
+            text=text,
+            truncated=omitted_bytes > 0 or line_bytes > 0,
+            original_token_count=original_tokens,
+            spill_path=spill_path,
+            spill_bytes=self.total_bytes if spill_path else 0,
+            line_truncated_count=line_count,
+            line_truncated_bytes=line_bytes,
+            preview_omitted_bytes=omitted_bytes,
+            preview_omitted_lines=omitted_lines,
+        )
+        self._preview.reset()
+        if self._full_delta is not None:
+            self._full_delta.clear()
+        self._delta_chars = 0
+        return result

--- a/tests/agent/_terminal_manager_stub.py
+++ b/tests/agent/_terminal_manager_stub.py
@@ -1,0 +1,59 @@
+from typing import Any
+
+from kolega_code.services.base import ExecResult, TerminalManager
+
+
+class _StubSandbox:
+    def get_host(self, port: int) -> str:
+        return f"stub-sandbox:{port}"
+
+
+class SandboxCarryingTerminalManager(TerminalManager):
+    """ABC-based terminal-manager stand-in carrying a sandbox host provider."""
+
+    def __init__(self) -> None:
+        self.sandbox = _StubSandbox()
+
+    async def exec_command(
+        self,
+        command: str,
+        *,
+        workdir: str | None = None,
+        yield_time_ms: int = 10000,
+        max_output_tokens: int = 10000,
+        login: bool = False,
+        env: dict[str, str] | None = None,
+        background: bool = False,
+    ) -> ExecResult:
+        _ = (command, workdir, yield_time_ms, max_output_tokens, login, env, background)
+        raise AssertionError("exec_command is not used by tool inventory tests")
+
+    async def write_stdin(
+        self,
+        session_id: str,
+        chars: str = "",
+        *,
+        yield_time_ms: int = 10000,
+        max_output_tokens: int = 10000,
+    ) -> ExecResult:
+        _ = (session_id, chars, yield_time_ms, max_output_tokens)
+        raise AssertionError("write_stdin is not used by tool inventory tests")
+
+    async def kill_session(self, session_id: str, signal: str = "TERM") -> ExecResult:
+        _ = (session_id, signal)
+        raise AssertionError("kill_session is not used by tool inventory tests")
+
+    async def list_sessions(self) -> dict[str, Any]:
+        raise AssertionError("list_sessions is not used by tool inventory tests")
+
+    async def close_all(self) -> None:
+        raise AssertionError("close_all is not used by tool inventory tests")
+
+    async def run_command(
+        self,
+        command: str,
+        cwd: str | None = None,
+        timeout: int | None = None,
+    ) -> str:
+        _ = (command, cwd, timeout)
+        raise AssertionError("run_command is not used by tool inventory tests")

--- a/tests/agent/services/test_sandbox_terminal_input.py
+++ b/tests/agent/services/test_sandbox_terminal_input.py
@@ -1,9 +1,12 @@
 import asyncio
+import base64
+import shlex
 from types import SimpleNamespace
 
 import pytest
 
-from kolega_code.sandbox.terminal import SandboxTerminalManager
+from kolega_code.sandbox.terminal import BoundedTerminalOutputs, SandboxTerminalManager
+from kolega_code.services.base import TerminalCommandCancelled
 
 
 class FakeCommandHandle:
@@ -27,21 +30,39 @@ class FakeCommandHandle:
 
 
 class FakeCommands:
-    def __init__(self):
+    def __init__(self, stdout: str = "line1\n"):
         self.handle = FakeCommandHandle()
         self.run_calls = []
         self.send_stdin_calls = []
         self.started = asyncio.Event()
+        self.stdout = stdout
+        self.remote_files = {}
 
     async def run(self, command: str, **kwargs):
         if command.startswith("test -d") or command.startswith("mkdir"):
+            if "&& : >" in command:
+                remote_path = shlex.split(command.split("&& : >", 1)[1].strip())[0]
+                self.remote_files[remote_path] = bytearray()
+            return SimpleNamespace(exit_code=0)
+        if command.startswith("printf %s ") and " | base64 -d >> " in command:
+            encoded_part, path_part = command.removeprefix("printf %s ").split(
+                " | base64 -d >> ",
+                1,
+            )
+            encoded = shlex.split(encoded_part)[0]
+            remote_path = shlex.split(path_part)[0]
+            self.remote_files.setdefault(remote_path, bytearray()).extend(
+                base64.b64decode(encoded),
+            )
+            return SimpleNamespace(exit_code=0)
+        if command.startswith("chmod 0400 "):
             return SimpleNamespace(exit_code=0)
 
         self.run_calls.append((command, kwargs))
         self.started.set()
         on_stdout = kwargs.get("on_stdout")
         if on_stdout:
-            await on_stdout("line1\n")
+            await on_stdout(self.stdout)
         return self.handle
 
     async def send_stdin(self, pid: int, data: str):
@@ -49,8 +70,8 @@ class FakeCommands:
 
 
 class FakeSandbox:
-    def __init__(self):
-        self.commands = FakeCommands()
+    def __init__(self, stdout: str = "line1\n"):
+        self.commands = FakeCommands(stdout)
 
 
 @pytest.mark.asyncio
@@ -142,3 +163,67 @@ async def test_write_stdin_unknown_session_raises():
     manager = SandboxTerminalManager(FakeSandbox(), "workspace", "thread")
     with pytest.raises(KeyError):
         await manager.write_stdin("nope", "x")
+
+
+@pytest.mark.asyncio
+async def test_sandbox_spill_is_mirrored_to_recoverable_sandbox_path(tmp_path):
+    complete = "BEGIN\n" + ("line-" + "x" * 90 + "\n") * 700 + "END\n"
+    sandbox = FakeSandbox(complete)
+    manager = SandboxTerminalManager(sandbox, "workspace", "thread")
+    manager.configure_output_spill(tmp_path / "terminal-output")
+
+    result = await manager.exec_command(
+        "produce lots of output",
+        yield_time_ms=300,
+        max_output_tokens=1_000_000,
+    )
+
+    assert result.status == "running"
+    assert result.spill_path is not None
+    assert result.spill_path.startswith("/home/user/.kolega/terminal-output/")
+    assert bytes(sandbox.commands.remote_files[result.spill_path]).decode("utf-8") == complete
+    assert result.spill_bytes == len(complete.encode("utf-8"))
+    assert "BEGIN" in result.output
+    assert "END" in result.output
+    assert len(result.output) <= 40_000
+
+    sandbox.commands.handle.complete()
+    assert result.session_id is not None
+    final = await manager.write_stdin(result.session_id, "", yield_time_ms=5000)
+    assert final.status == "exited"
+
+
+@pytest.mark.asyncio
+async def test_cancelled_sandbox_exec_returns_recoverable_spill_result(tmp_path):
+    complete = "BEGIN\n" + ("line-" + "x" * 90 + "\n") * 700 + "END\n"
+    sandbox = FakeSandbox(complete)
+    manager = SandboxTerminalManager(sandbox, "workspace", "thread")
+    manager.configure_output_spill(tmp_path / "terminal-output")
+
+    task = asyncio.create_task(
+        manager.exec_command("produce forever", yield_time_ms=30_000),
+    )
+    await sandbox.commands.started.wait()
+    await asyncio.sleep(0)
+    task.cancel()
+
+    with pytest.raises(TerminalCommandCancelled) as cancelled:
+        await task
+
+    result = cancelled.value.result
+    assert result.status == "cancelled"
+    assert result.exit_code == 137
+    assert result.spill_path is not None
+    assert bytes(sandbox.commands.remote_files[result.spill_path]).decode("utf-8") == complete
+    assert result.spill_bytes == len(complete.encode("utf-8"))
+    assert sandbox.commands.handle.killed is True
+    assert await manager.list_sessions() == {}
+
+
+def test_sandbox_terminal_history_is_bounded():
+    outputs = BoundedTerminalOutputs()
+    outputs.append({"type": "stdout", "data": "a" * 600_000})
+    outputs.append({"type": "stdout", "data": "b" * 600_000})
+
+    assert sum(len(item["data"].encode("utf-8")) for item in outputs) <= outputs.MAX_BYTES
+    assert outputs[-1]["data"].startswith("b")

--- a/tests/agent/services/test_terminal.py
+++ b/tests/agent/services/test_terminal.py
@@ -1,13 +1,16 @@
 import asyncio
 import contextlib
 import os
+import shlex
 import signal
 import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from kolega_code.events import AgentConnectionManager
+from kolega_code.services.base import TerminalCommandCancelled
 from kolega_code.services.terminal import (
     DetachedSession,
     LocalTerminalManager,
@@ -155,6 +158,85 @@ async def test_kill_unknown_session_raises(manager):
 async def test_run_command_convenience_accumulates_output(manager):
     output = await manager.run_command("echo a; echo b; echo c")
     assert "a" in output and "b" in output and "c" in output
+
+
+@pytest.mark.asyncio
+async def test_run_command_timeout_keeps_uncapped_final_delta(manager):
+    script = "import sys,time;sys.stdout.write('BEGIN-' + 'x' * 60000 + '-END');sys.stdout.flush();time.sleep(30)"
+    command = f"{shlex.quote(sys.executable)} -c {shlex.quote(script)}"
+
+    output = await manager.run_command(command, timeout=1)
+
+    assert output.startswith("BEGIN-")
+    assert "-END" in output
+    assert len(output) > 60_000
+
+
+@pytest.mark.asyncio
+async def test_exec_command_spills_complete_output_to_session_path(manager, tmp_path):
+    spill_root = tmp_path / "terminal-output"
+    manager.configure_output_spill(spill_root)
+    script = (
+        "import sys;"
+        "sys.stdout.write('BEGIN\\n' + ''.join(f'line-{i:04d}-' + 'x' * 90 + '\\n' "
+        "for i in range(900)) + 'END\\n')"
+    )
+    command = f"{shlex.quote(sys.executable)} -c {shlex.quote(script)}"
+
+    result = await manager.exec_command(
+        command,
+        yield_time_ms=10_000,
+        max_output_tokens=1_000_000,
+    )
+
+    assert result.status == "exited"
+    assert result.spill_path is not None
+    spill_path = os.path.realpath(result.spill_path)
+    assert os.path.commonpath([spill_path, str(spill_root.resolve())]) == str(spill_root.resolve())
+    complete_bytes = Path(spill_path).read_bytes()
+    complete = complete_bytes.decode("utf-8")
+    assert complete.startswith("BEGIN")
+    assert "line-0450-" in complete
+    assert complete.rstrip().endswith("END")
+    assert "line-0450-" not in result.output
+    assert len(result.output) <= 40_000
+    assert result.spill_bytes == len(complete_bytes)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_exec_returns_recoverable_spill_result(manager, tmp_path):
+    spill_root = tmp_path / "terminal-output"
+    manager.configure_output_spill(spill_root)
+    script = (
+        "import sys,time;sys.stdout.write('BEGIN\\n' + 'x' * 70000 + '\\nEND\\n');sys.stdout.flush();time.sleep(30)"
+    )
+    command = f"{shlex.quote(sys.executable)} -c {shlex.quote(script)}"
+
+    task = asyncio.create_task(
+        manager.exec_command(command, yield_time_ms=30_000),
+    )
+    for _ in range(200):
+        if list(spill_root.glob("*.log")):
+            break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("terminal output did not spill before cancellation")
+
+    task.cancel()
+    with pytest.raises(TerminalCommandCancelled) as cancelled:
+        await task
+
+    result = cancelled.value.result
+    assert result.status == "cancelled"
+    assert result.exit_code in (143, 137)
+    assert result.spill_path is not None
+    complete_bytes = Path(result.spill_path).read_bytes()
+    complete = complete_bytes.decode("utf-8")
+    lines = complete.splitlines()
+    assert lines[0] == "BEGIN"
+    assert "END" in lines
+    assert result.spill_bytes == len(complete_bytes)
+    assert await manager.list_sessions() == {}
 
 
 @pytest.mark.asyncio
@@ -390,6 +472,35 @@ async def test_background_poll_captures_incremental_output(manager):
     assert poll.status == "running"
     assert "second" in poll.output
     await manager.kill_session(result.session_id, "TERM")
+
+
+@pytest.mark.asyncio
+async def test_background_spill_is_normalized_and_raw_spool_is_internal(manager, tmp_path):
+    spill_root = tmp_path / "terminal-output"
+    manager.configure_output_spill(spill_root)
+    script = (
+        "import sys,time;sys.stdout.write('BEGIN\\n' + 'x' * 60000 + '\\nEND\\n');sys.stdout.flush();time.sleep(30)"
+    )
+    command = f"{shlex.quote(sys.executable)} -c {shlex.quote(script)}"
+
+    result = await manager.exec_command(command, yield_time_ms=1000, background=True)
+
+    assert result.status == "running"
+    assert result.session_id is not None
+    session = manager.sessions[result.session_id]
+    raw_spool = session.log_path
+    assert raw_spool is not None
+    assert result.spill_path is not None
+    assert os.path.realpath(raw_spool) != os.path.realpath(result.spill_path)
+    spill = Path(result.spill_path).read_bytes()
+    assert spill.startswith(b"BEGIN\n")
+    assert spill.endswith(b"\nEND\n")
+    assert result.spill_bytes == len(spill)
+
+    await manager.kill_session(result.session_id, "TERM")
+
+    assert not os.path.exists(raw_spool)
+    assert os.path.exists(result.spill_path)
 
 
 @pytest.mark.asyncio

--- a/tests/agent/services/test_terminal_buffer.py
+++ b/tests/agent/services/test_terminal_buffer.py
@@ -1,10 +1,18 @@
+import os
+
 from kolega_code.services.terminal_buffer import (
+    GLOBAL_MAX_TOOL_OUTPUT_TOKENS,
+    LINE_CAP_BYTES,
+    LINE_TRUNCATION_MARKER,
     MAX_POLL_MS,
     MAX_YIELD_MS,
     MIN_POLL_MS,
     MIN_YIELD_MS,
     HeadTailBuffer,
+    TerminalOutputAccumulator,
+    TerminalSpillStore,
     cap_tokens,
+    clamp_output_tokens,
     clamp_yield,
 )
 
@@ -58,6 +66,84 @@ def test_cap_tokens_over_budget_truncates_middle():
     assert out.original_token_count > 50
     assert "truncated to fit" in out.text
     assert len(out.text) < len(text)
+
+
+def test_output_token_request_is_globally_clamped():
+    assert clamp_output_tokens(1_000_000) == GLOBAL_MAX_TOOL_OUTPUT_TOKENS
+    out = cap_tokens("x" * 100_000, 1_000_000)
+    assert len(out.text) <= GLOBAL_MAX_TOOL_OUTPUT_TOKENS * 4
+
+
+def test_accumulator_spills_complete_stream_before_preview_truncation(tmp_path):
+    store = TerminalSpillStore(tmp_path / "terminal-output")
+    accumulator = TerminalOutputAccumulator(store)
+    head = "BEGIN\n" + ("head-" + "h" * 90 + "\n") * 250
+    middle = "RECOVERABLE-MIDDLE\n" + ("middle-" + "m" * 88 + "\n") * 300
+    tail = ("tail-" + "t" * 90 + "\n") * 350 + "END\n"
+    complete = head + middle + tail
+
+    for start in range(0, len(complete), 997):
+        accumulator.append_text(complete[start : start + 997])
+    accumulator.finalize()
+    result = accumulator.read_delta(1_000_000)
+
+    assert result.spill_path is not None
+    spill_path = tmp_path / "terminal-output" / os.path.basename(result.spill_path)
+    assert spill_path.read_text(encoding="utf-8") == complete
+    assert result.spill_bytes == len(complete.encode("utf-8"))
+    assert "BEGIN" in result.text
+    assert "END" in result.text
+    assert "RECOVERABLE-MIDDLE" not in result.text
+    assert result.preview_omitted_bytes > 0
+    assert len(result.text) <= GLOBAL_MAX_TOOL_OUTPUT_TOKENS * 4
+    assert spill_path.stat().st_mode & 0o777 == 0o400
+
+
+def test_spill_ids_continue_after_existing_files(tmp_path):
+    root = tmp_path / "terminal-output"
+    root.mkdir()
+    (root / "000007.exec_command.log").write_text("old", encoding="utf-8")
+    store = TerminalSpillStore(root)
+
+    path = store.allocate_path("exec_command")
+
+    assert path.name == "000008.exec_command.log"
+    assert (root / "000007.exec_command.log").read_text(encoding="utf-8") == "old"
+
+
+def test_streaming_line_cap_cannot_be_bypassed_across_reads():
+    accumulator = TerminalOutputAccumulator(None)
+    accumulator.append_text("a" * 800)
+    first = accumulator.read_delta(10_000)
+    accumulator.append_text("b" * 800)
+    second = accumulator.read_delta(10_000)
+    accumulator.append_text("c" * 100)
+    third = accumulator.read_delta(10_000)
+    accumulator.append_text("\nnext\n")
+    fourth = accumulator.read_delta(10_000)
+
+    combined_line = first.text + second.text + third.text
+    assert len(combined_line.encode("utf-8")) <= LINE_CAP_BYTES
+    assert combined_line.count(LINE_TRUNCATION_MARKER) == 1
+    assert second.line_truncated_count == 1
+    assert second.line_truncated_bytes > 0
+    assert third.line_truncated_count == 1
+    assert third.line_truncated_bytes == 100
+    assert fourth.text == "\nnext\n"
+
+
+def test_split_utf8_is_normalized_before_spill_and_preview(tmp_path):
+    accumulator = TerminalOutputAccumulator(TerminalSpillStore(tmp_path / "terminal-output"))
+    euro = "€".encode("utf-8")
+    accumulator.append_bytes(euro[:1])
+    accumulator.append_bytes(euro[1:])
+    accumulator.finalize()
+
+    result = accumulator.read_delta(100)
+
+    assert result.text == "€"
+    assert "�" not in result.text
+    assert result.original_token_count == 1
 
 
 def test_clamp_yield_write():

--- a/tests/agent/test_agent_tools_inventory.py
+++ b/tests/agent/test_agent_tools_inventory.py
@@ -17,6 +17,7 @@ from kolega_code.agent.planningagent import PlanningAgent
 from kolega_code.agent.prompt_provider import AgentMode, PromptProvider
 from kolega_code.agent.tools import ToolCollection, ToolExtension
 from kolega_code.llm.specs import MODEL_SPECS
+from tests.agent._terminal_manager_stub import SandboxCarryingTerminalManager
 
 
 INTERNAL_TOOL_NAMES = {"registry", "has_tool", "call", "cleanup", "initialize"}
@@ -780,24 +781,6 @@ def test_shared_tool_names_are_well_formed(project_path, mock_connection_manager
             assert tool.description
 
 
-class _StubSandbox:
-    def get_host(self, port: int) -> str:
-        return f"stub-sandbox:{port}"
-
-
-class _SandboxCarryingTerminalManager:
-    """Terminal-manager stand-in that carries a ``sandbox`` host provider.
-
-    Deliberately not an instance of ``SandboxTerminalManager``: the gate must
-    duck-type on the attribute (getattr), not isinstance, so kolega-code-e2b's
-    injected manager — possibly subclassed from a pinned older version — keeps
-    qualifying when they bump.
-    """
-
-    def __init__(self) -> None:
-        self.sandbox = _StubSandbox()
-
-
 def test_get_host_absent_without_sandbox_terminal_manager(project_path, mock_connection_manager, agent_config):
     """get_host is a sandbox-only tool: the default local CLI coder does not get it."""
     agent = _coder(project_path, mock_connection_manager, agent_config)
@@ -815,7 +798,7 @@ def test_get_host_present_with_sandbox_terminal_manager(project_path, mock_conne
         connection_manager=mock_connection_manager,
         config=agent_config,
         agent_mode=AgentMode.CLI,
-        terminal_manager=_SandboxCarryingTerminalManager(),
+        terminal_manager=SandboxCarryingTerminalManager(),
     )
 
     tool_names = {tool.name for tool in agent.tool_collection.get_tool_list()}

--- a/tests/agent/test_tool_collection_config.py
+++ b/tests/agent/test_tool_collection_config.py
@@ -10,6 +10,7 @@ from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimi
 from kolega_code.events import AgentConnectionManager
 from kolega_code.agent.tool_backend.memory_tool import MemoryTool
 from kolega_code.agent.tools import ToolCollection, ToolDefinition, ToolCollectionConfig, ToolExtension
+from tests.agent._terminal_manager_stub import SandboxCarryingTerminalManager
 
 
 INTERNAL_TOOL_NAMES = {
@@ -23,24 +24,6 @@ INTERNAL_TOOL_NAMES = {
     "log_warning",
     "log_info",
 }
-
-
-class _StubSandbox:
-    def get_host(self, port: int) -> str:
-        return f"stub-sandbox:{port}"
-
-
-class _SandboxCarryingTerminalManager:
-    """Terminal-manager stand-in that carries a ``sandbox`` host provider.
-
-    Deliberately not an instance of ``SandboxTerminalManager``: the gate must
-    duck-type on the attribute (getattr), not isinstance, so kolega-code-e2b's
-    injected manager — possibly subclassed from a pinned older version — keeps
-    qualifying when they bump.
-    """
-
-    def __init__(self) -> None:
-        self.sandbox = _StubSandbox()
 
 
 @pytest.fixture
@@ -174,9 +157,9 @@ class TestToolCollection:
             mock_connection_manager,
             agent_config,
             mock_base_agent,
-            # The stub is deliberately not a TerminalManager subclass: the gate
-            # duck-types on the `sandbox` attribute, so pyright can't see it.
-            terminal_manager=_SandboxCarryingTerminalManager(),  # pyright: ignore[reportArgumentType]
+            # The stand-in implements TerminalManager but is deliberately not a
+            # SandboxTerminalManager: the gate duck-types on `sandbox`.
+            terminal_manager=SandboxCarryingTerminalManager(),
         )
 
         definitions = {tool.name: tool for tool in tool_collection.get_tool_list()}

--- a/tests/agent/tool_backend/test_terminal_tool.py
+++ b/tests/agent/tool_backend/test_terminal_tool.py
@@ -1,6 +1,5 @@
 import os
 import asyncio
-import json
 import sys
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -9,11 +8,16 @@ import uuid
 
 from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
 from kolega_code.events import AgentEvent
-from kolega_code.services.base import ExecResult
+from kolega_code.services.base import ExecResult, TerminalCommandCancelled
 from kolega_code.agent.tool_backend.terminal_tool import BACKGROUND_SETTLE_MS, TerminalTool
 
 # Check if running in CI environment
 SKIP_IN_CI = bool(os.getenv("CI")) or bool(os.getenv("GITLAB_CI"))
+
+
+def _result_field(result: str, name: str) -> str:
+    prefix = f"{name}: "
+    return next(line.removeprefix(prefix) for line in result.splitlines() if line.startswith(prefix))
 
 
 @pytest.fixture
@@ -178,17 +182,16 @@ class TestUnifiedExecTools:
     """Tests for the codex-style exec_command / write_stdin / kill_command tools."""
 
     @pytest.mark.asyncio
-    async def test_exec_command_returns_json_and_defaults_workdir(self, terminal_tool):
+    async def test_exec_command_returns_structured_text_and_defaults_workdir(self, terminal_tool):
         terminal_tool.terminal_manager = Mock()
         terminal_tool.terminal_manager.exec_command = AsyncMock(
             return_value=ExecResult(status="exited", exit_code=0, output="hi", duration_ms=12)
         )
 
         out = await terminal_tool.exec_command("echo hi")
-        data = json.loads(out)
-        assert data["status"] == "exited"
-        assert data["exit_code"] == 0
-        assert data["output"] == "hi"
+        assert _result_field(out, "Status") == "exited"
+        assert _result_field(out, "Exit code") == "0"
+        assert "Output:\nhi" in out
 
         kwargs = terminal_tool.terminal_manager.exec_command.call_args.kwargs
         assert kwargs["workdir"] == str(terminal_tool.project_path)
@@ -214,9 +217,9 @@ class TestUnifiedExecTools:
     async def test_exec_command_end_to_end_runs_in_project_root(self, terminal_tool):
         # Real PTY through the default manager: even when the CLI process runs
         # elsewhere, workdir="." must land in the project root.
-        data = json.loads(await terminal_tool.exec_command("pwd", workdir=".", yield_time_ms=5000))
-        assert data["status"] == "exited"
-        assert data["output"].strip().endswith(terminal_tool.project_path.name)
+        result = await terminal_tool.exec_command("pwd", workdir=".", yield_time_ms=5000)
+        assert _result_field(result, "Status") == "exited"
+        assert f"Output:\n{terminal_tool.project_path}" in result
 
     @pytest.mark.asyncio
     async def test_exec_command_injects_scratchpad_env(self, terminal_tool, mock_base_agent, tmp_path):
@@ -245,22 +248,24 @@ class TestUnifiedExecTools:
     async def test_exec_command_end_to_end_scratchpad_env(self, terminal_tool, mock_base_agent, tmp_path):
         # Real PTY: the model-facing session sees $KOLEGA_SCRATCHPAD.
         mock_base_agent.scratchpad_dir = tmp_path / "scratchpad"
-        data = json.loads(await terminal_tool.exec_command('echo "SP=$KOLEGA_SCRATCHPAD"', yield_time_ms=5000))
-        assert data["status"] == "exited"
-        assert f"SP={tmp_path / 'scratchpad'}" in data["output"]
+        result = await terminal_tool.exec_command('echo "SP=$KOLEGA_SCRATCHPAD"', yield_time_ms=5000)
+        assert _result_field(result, "Status") == "exited"
+        assert f"SP={tmp_path / 'scratchpad'}" in result
 
     @pytest.mark.asyncio
     async def test_write_stdin_session_keeps_scratchpad_env(self, terminal_tool, mock_base_agent, tmp_path):
         # A session created by exec_command and driven with write_stdin keeps
         # the env it was spawned with.
         mock_base_agent.scratchpad_dir = tmp_path / "scratchpad"
-        data = json.loads(
-            await terminal_tool.exec_command('read line; echo "GOT=$KOLEGA_SCRATCHPAD"', yield_time_ms=300)
+        result = await terminal_tool.exec_command(
+            'read line; echo "GOT=$KOLEGA_SCRATCHPAD"',
+            yield_time_ms=300,
         )
-        assert data["status"] == "running"
-        data = json.loads(await terminal_tool.write_stdin(data["session_id"], "go\n", yield_time_ms=5000))
-        assert data["status"] == "exited"
-        assert f"GOT={tmp_path / 'scratchpad'}" in data["output"]
+        assert _result_field(result, "Status") == "running"
+        session_id = _result_field(result, "Session")
+        result = await terminal_tool.write_stdin(session_id, "go\n", yield_time_ms=5000)
+        assert _result_field(result, "Status") == "exited"
+        assert f"GOT={tmp_path / 'scratchpad'}" in result
 
     @pytest.mark.asyncio
     async def test_exec_command_passes_absolute_workdir_through(self, terminal_tool):
@@ -280,38 +285,122 @@ class TestUnifiedExecTools:
             return_value=ExecResult(status="running", session_id="s_1", output="partial")
         )
 
-        data = json.loads(await terminal_tool.exec_command("sleep 5"))
-        assert data["status"] == "running"
-        assert data["session_id"] == "s_1"
+        result = await terminal_tool.exec_command("sleep 5")
+        assert _result_field(result, "Status") == "running"
+        assert _result_field(result, "Session") == "s_1"
 
     @pytest.mark.asyncio
-    async def test_write_stdin_returns_json(self, terminal_tool):
+    async def test_cancelled_exec_command_returns_structured_recovery_result(self, terminal_tool, tmp_path):
+        spill_path = tmp_path / "terminal-output" / "000001.exec_command.log"
+        terminal_tool.terminal_manager = Mock()
+        terminal_tool.terminal_manager.exec_command = AsyncMock(
+            side_effect=TerminalCommandCancelled(
+                ExecResult(
+                    status="cancelled",
+                    exit_code=143,
+                    output="partial",
+                    truncated=True,
+                    original_token_count=20_000,
+                    spill_path=str(spill_path),
+                    spill_bytes=80_000,
+                )
+            )
+        )
+
+        result = await terminal_tool.exec_command("produce forever")
+
+        assert _result_field(result, "Status") == "cancelled"
+        assert _result_field(result, "Exit code") == "143"
+        assert f"Full output: {spill_path}" in result
+        assert "Output:\npartial" in result
+
+    @pytest.mark.asyncio
+    async def test_structured_result_hard_caps_complete_text_and_preserves_spill_path(
+        self,
+        terminal_tool,
+        tmp_path,
+    ):
+        spill_path = tmp_path / "terminal-output" / "000001.exec_command.log"
+        terminal_tool.terminal_manager = Mock()
+        terminal_tool.terminal_manager.exec_command = AsyncMock(
+            return_value=ExecResult(
+                status="exited",
+                exit_code=0,
+                output="x" * 100_000,
+                truncated=True,
+                original_token_count=25_000,
+                spill_path=str(spill_path),
+                spill_bytes=100_000,
+                line_truncated_count=2,
+                line_truncated_bytes=500,
+                preview_omitted_bytes=60_000,
+                preview_omitted_lines=600,
+            )
+        )
+
+        result = await terminal_tool.exec_command(
+            "produce output",
+            max_output_tokens=1_000_000,
+        )
+
+        assert len(result) <= 40_000
+        assert f"Full output: {spill_path}" in result
+        assert "Output truncated: yes" in result
+        assert "Original output: ~25,000 tokens" in result
+        assert "Long lines shortened: 2 lines, 500 bytes omitted" in result
+        assert "Preview middle omitted: 60,000 bytes across 600 lines" in result
+
+    @pytest.mark.asyncio
+    async def test_write_stdin_returns_structured_text(self, terminal_tool):
         terminal_tool.terminal_manager = Mock()
         terminal_tool.terminal_manager.write_stdin = AsyncMock(
             return_value=ExecResult(status="exited", exit_code=0, output="done")
         )
 
-        data = json.loads(await terminal_tool.write_stdin("s_1", "y\n"))
-        assert data["status"] == "exited"
-        assert data["output"] == "done"
+        result = await terminal_tool.write_stdin("s_1", "y\n")
+        assert _result_field(result, "Status") == "exited"
+        assert "Output:\ndone" in result
         terminal_tool.terminal_manager.write_stdin.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_write_stdin_returns_structured_recovery_result(self, terminal_tool, tmp_path):
+        spill_path = tmp_path / "terminal-output" / "000001.exec_command.log"
+        terminal_tool.terminal_manager = Mock()
+        terminal_tool.terminal_manager.write_stdin = AsyncMock(
+            side_effect=TerminalCommandCancelled(
+                ExecResult(
+                    status="cancelled",
+                    exit_code=137,
+                    output="latest",
+                    spill_path=str(spill_path),
+                    spill_bytes=70_000,
+                )
+            )
+        )
+
+        result = await terminal_tool.write_stdin("s_1")
+
+        assert _result_field(result, "Status") == "cancelled"
+        assert _result_field(result, "Exit code") == "137"
+        assert f"Full output: {spill_path}" in result
+        assert "Output:\nlatest" in result
 
     @pytest.mark.asyncio
     async def test_write_stdin_unknown_session_returns_error(self, terminal_tool):
         terminal_tool.terminal_manager = Mock()
         terminal_tool.terminal_manager.write_stdin = AsyncMock(side_effect=KeyError("No such session: s_9"))
 
-        data = json.loads(await terminal_tool.write_stdin("s_9"))
-        assert data["status"] == "error"
+        result = await terminal_tool.write_stdin("s_9")
+        assert _result_field(result, "Status") == "error"
 
     @pytest.mark.asyncio
-    async def test_kill_command_returns_json(self, terminal_tool):
+    async def test_kill_command_returns_structured_text(self, terminal_tool):
         terminal_tool.terminal_manager = Mock()
         terminal_tool.terminal_manager.kill_session = AsyncMock(return_value=ExecResult(status="exited", exit_code=143))
 
-        data = json.loads(await terminal_tool.kill_command("s_1", "TERM"))
-        assert data["status"] == "exited"
-        assert data["exit_code"] == 143
+        result = await terminal_tool.kill_command("s_1", "TERM")
+        assert _result_field(result, "Status") == "exited"
+        assert _result_field(result, "Exit code") == "143"
         terminal_tool.terminal_manager.kill_session.assert_awaited_once_with("s_1", "TERM")
 
     @pytest.mark.asyncio
@@ -319,18 +408,26 @@ class TestUnifiedExecTools:
         terminal_tool.terminal_manager = Mock()
         terminal_tool.terminal_manager.kill_session = AsyncMock(side_effect=KeyError("No such session"))
 
-        data = json.loads(await terminal_tool.kill_command("s_9"))
-        assert data["status"] == "error"
+        result = await terminal_tool.kill_command("s_9")
+        assert _result_field(result, "Status") == "error"
 
     @pytest.mark.asyncio
-    async def test_list_sessions_returns_json(self, terminal_tool):
+    async def test_list_sessions_returns_structured_text(self, terminal_tool):
         terminal_tool.terminal_manager = Mock()
         terminal_tool.terminal_manager.list_sessions = AsyncMock(
             return_value={"s_1": {"command": "sleep 5", "running": True}}
         )
 
-        data = json.loads(await terminal_tool.list_sessions())
-        assert "s_1" in data["sessions"]
+        result = await terminal_tool.list_sessions()
+        assert "Session: s_1" in result
+        assert "Command: sleep 5" in result
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_empty_is_plain_text(self, terminal_tool):
+        terminal_tool.terminal_manager = Mock()
+        terminal_tool.terminal_manager.list_sessions = AsyncMock(return_value={})
+
+        assert await terminal_tool.list_sessions() == "No running sessions."
 
     @pytest.mark.asyncio
     async def test_exec_command_blocked_by_security_check(self, terminal_tool):
@@ -354,12 +451,12 @@ class TestBackgroundExec:
             return_value=ExecResult(status="running", session_id="s_1", output="ready", duration_ms=2000)
         )
 
-        data = json.loads(await terminal_tool.exec_command("npm run dev", background=True, yield_time_ms=30000))
+        result = await terminal_tool.exec_command("npm run dev", background=True, yield_time_ms=30000)
 
-        assert data["status"] == "running"
-        assert data["session_id"] == "s_1"
-        assert data["background"] is True
-        assert "kill_command" in data["note"]
+        assert _result_field(result, "Status") == "running"
+        assert _result_field(result, "Session") == "s_1"
+        assert _result_field(result, "Background") == "true"
+        assert "kill_command" in result
         kwargs = terminal_tool.terminal_manager.exec_command.call_args.kwargs
         assert kwargs["yield_time_ms"] == BACKGROUND_SETTLE_MS
         assert "s_1" in terminal_tool._background_sessions
@@ -371,11 +468,11 @@ class TestBackgroundExec:
             return_value=ExecResult(status="exited", exit_code=1, output="EADDRINUSE", duration_ms=300)
         )
 
-        data = json.loads(await terminal_tool.exec_command("npm run dev", background=True))
+        result = await terminal_tool.exec_command("npm run dev", background=True)
 
-        assert data["status"] == "exited"
-        assert data["exit_code"] == 1
-        assert "background" not in data
+        assert _result_field(result, "Status") == "exited"
+        assert _result_field(result, "Exit code") == "1"
+        assert "Background:" not in result
         assert terminal_tool._background_sessions == set()
 
     @pytest.mark.asyncio
@@ -385,10 +482,10 @@ class TestBackgroundExec:
             return_value=ExecResult(status="running", session_id="s_2", output="", duration_ms=10000)
         )
 
-        data = json.loads(await terminal_tool.exec_command("sleep 5", yield_time_ms=30000))
+        result = await terminal_tool.exec_command("sleep 5", yield_time_ms=30000)
 
-        assert data["status"] == "running"
-        assert "background" not in data
+        assert _result_field(result, "Status") == "running"
+        assert "Background:" not in result
         kwargs = terminal_tool.terminal_manager.exec_command.call_args.kwargs
         assert kwargs["yield_time_ms"] == 30000
         assert terminal_tool._background_sessions == set()
@@ -405,9 +502,10 @@ class TestBackgroundExec:
         terminal_tool.terminal_manager.list_sessions = AsyncMock(
             return_value={"s_1": {"command": "npm run dev", "running": True}}
         )
-        data = json.loads(await terminal_tool.list_sessions())
+        result = await terminal_tool.list_sessions()
 
-        assert data["sessions"]["s_1"]["background"] is True
+        assert "Session: s_1" in result
+        assert "Background: true" in result
         # Ids no longer running are pruned from the tracking set.
         assert terminal_tool._background_sessions == {"s_1"}
 
@@ -426,15 +524,15 @@ class TestBackgroundExec:
         # Real PTY through the default manager: a backgrounded server process
         # stays alive across later tool calls, appears in list_sessions, and
         # dies via kill_command — the dev-server flow the browser agent needs.
-        data = json.loads(await terminal_tool.exec_command("sleep 30", background=True))
-        assert data["status"] == "running"
-        assert data["background"] is True
-        session_id = data["session_id"]
+        result = await terminal_tool.exec_command("sleep 30", background=True)
+        assert _result_field(result, "Status") == "running"
+        assert _result_field(result, "Background") == "true"
+        session_id = _result_field(result, "Session")
 
-        sessions = json.loads(await terminal_tool.list_sessions())["sessions"]
-        assert session_id in sessions
-        assert sessions[session_id]["background"] is True
+        sessions = await terminal_tool.list_sessions()
+        assert f"Session: {session_id}" in sessions
+        assert "Background: true" in sessions
 
-        killed = json.loads(await terminal_tool.kill_command(session_id))
-        assert killed["status"] == "exited"
-        assert session_id not in json.loads(await terminal_tool.list_sessions())["sessions"]
+        killed = await terminal_tool.kill_command(session_id)
+        assert _result_field(killed, "Status") == "exited"
+        assert f"Session: {session_id}" not in await terminal_tool.list_sessions()

--- a/tests/cli/test_session_store.py
+++ b/tests/cli/test_session_store.py
@@ -46,12 +46,14 @@ def test_session_store_writes_private_directory_layout(tmp_path: Path) -> None:
     assert store.path_for(record.session_id).name == "metadata.json"
     assert store.events_path_for(record.session_id).name == "events.jsonl"
     assert (store.session_dir_for(record.session_id) / "artifacts").is_dir()
+    assert store.terminal_output_dir_for(record.session_id).is_dir()
     if os.name != "nt":
         assert stat.S_IMODE(store.root.stat().st_mode) == 0o700
         assert stat.S_IMODE(store.sessions_dir.stat().st_mode) == 0o700
         assert stat.S_IMODE(store.session_dir_for(record.session_id).stat().st_mode) == 0o700
         assert stat.S_IMODE(store.path_for(record.session_id).stat().st_mode) == 0o600
         assert stat.S_IMODE(store.events_path_for(record.session_id).stat().st_mode) == 0o600
+        assert stat.S_IMODE(store.terminal_output_dir_for(record.session_id).stat().st_mode) == 0o700
 
 
 def test_session_store_create_load_list_export_delete(tmp_path: Path) -> None:
@@ -92,8 +94,11 @@ def test_session_store_create_load_list_export_delete(tmp_path: Path) -> None:
     assert "latest_plan_markdown" in exported
     assert "interaction_mode" in exported
 
+    spill = store.terminal_output_dir_for(record.session_id) / "000001.exec_command.log"
+    spill.write_text("complete terminal output", encoding="utf-8")
     store.delete(record.session_id)
     assert not store.session_dir_for(record.session_id).exists()
+    assert not spill.exists()
     with pytest.raises(SessionStoreError):
         store.load(record.session_id)
 
@@ -332,6 +337,43 @@ def test_large_tool_result_uses_artifact_and_bounded_preview(tmp_path: Path) -> 
     assert full not in bug_export.session_json
     assert full not in bug_export.events_jsonl
     assert ref["sha256"] in bug_export.artifact_manifest_json
+
+
+def test_terminal_spill_path_round_trips_without_resume_rewriting(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    store = SessionStore(tmp_path / "state")
+    record = store.create(project, "code", {})
+    spill_path = store.terminal_output_dir_for(record.session_id) / "000001.exec_command.log"
+    spill_path.write_text("complete output", encoding="utf-8")
+    structured = (
+        "Status: exited\n"
+        "Session: none\n"
+        "Exit code: 0\n"
+        "Duration: 1 ms\n"
+        "Output:\npreview\n"
+        f"Full output: {spill_path}\n"
+        "Output truncated: yes"
+    )
+    recorder = store.recorder(record.session_id)
+    recorder.start_turn(Message(role="user", content=[TextBlock("run it")]))
+    recorder.record_assistant(
+        Message(
+            role="assistant",
+            content=[ToolCall(id="call-1", name="exec_command", input={"command": "run"})],
+            stop_reason="tool_use",
+        )
+    )
+    recorder.record_tool_results(
+        [ToolResult(tool_use_id="call-1", content=structured, name="exec_command", is_error=False)]
+    )
+    recorder.finish_turn("completed")
+
+    loaded_result = Message.from_dict(store.load(record.session_id).history[2]).content[0]
+
+    assert isinstance(loaded_result, ToolResult)
+    assert loaded_result.content == structured
+    assert spill_path.exists()
 
 
 def test_images_and_provider_opaque_fields_are_hydrated_from_artifacts(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- hard-clamp model-visible `exec_command` and `write_stdin` output to 10,000 requested tokens while preserving truncation accounting
- persist terminal streams above 50 KiB to private, session-owned spill files with bounded head/tail previews and UTF-8-aware logical-line caps
- return structured text from `exec_command`, `write_stdin`, `kill_command`, and `list_sessions`, including stable recovery paths and cancellation results
- integrate spill handling across local PTY, detached background, and sandbox sessions without resume-time sanitization or shared export/redaction changes

## Verification
- `PYTHONDONTWRITEBYTECODE=1 uv run pytest -q tests/agent/services/test_terminal_buffer.py tests/agent/services/test_terminal.py tests/agent/services/test_sandbox_terminal_input.py tests/agent/tool_backend/test_terminal_tool.py tests/agent/services/test_terminal_state_serializer.py tests/cli/test_session_store.py` — 148 passed
- `uv run ruff check` on changed implementation and test files — passed
- `uv run pyright` on changed implementation files — 0 errors, 0 warnings
- pre-commit hooks — passed
- broader suite reached 603 passed and 4 skipped before being stopped; three unrelated live Tinker cases failed because the optional native Tinker stack is not installed