### PR TITLE
fix(terminal): hide naturally exited sessions

### DIFF
--- a/kolega_code/services/terminal.py
+++ b/kolega_code/services/terminal.py
@@ -762,6 +762,9 @@ class LocalTerminalManager(TerminalManager):
         self.workspace_id = workspace_id
         self.thread_id = thread_id
         self.connection_manager = connection_manager
+        # Naturally exited sessions remain here until write_stdin/kill_session
+        # returns their final unread delta. list_sessions hides them and closes
+        # their process resources without discarding that recoverable result.
         self.sessions: Dict[str, Session] = {}
         self._counter = 0
         self.auto_activate_venv = True
@@ -1050,13 +1053,22 @@ class LocalTerminalManager(TerminalManager):
 
     async def list_sessions(self) -> Dict[str, Any]:
         result: Dict[str, Any] = {}
-        for session_id, session in self.sessions.items():
+        completed: list[Session] = []
+        for session_id, session in list(self.sessions.items()):
+            running = session.running
+            if not running:
+                completed.append(session)
+                continue
             result[session_id] = {
                 "command": session.command,
                 "workdir": str(session.workdir),
                 "runtime_s": round(time.monotonic() - session.start_time, 1),
-                "running": session.running,
+                "running": True,
             }
+        if completed:
+            # Release PTY descriptors, detached pumps, raw spools, and FIFOs,
+            # but retain each finalized output accumulator for one final poll.
+            await asyncio.gather(*(session.close() for session in completed), return_exceptions=True)
         return result
 
     async def close_all(self) -> None:

--- a/tests/agent/services/test_terminal.py
+++ b/tests/agent/services/test_terminal.py
@@ -40,6 +40,20 @@ def _process_alive(pid: int) -> bool:
     return True
 
 
+def _marker_command(marker: Path, final_output: str) -> str:
+    script = "\n".join(
+        [
+            "import pathlib, time",
+            f"marker = pathlib.Path({str(marker)!r})",
+            "print('started', flush=True)",
+            "while not marker.exists():",
+            "    time.sleep(0.01)",
+            f"print({final_output!r}, flush=True)",
+        ]
+    )
+    return f"{shlex.quote(sys.executable)} -c {shlex.quote(script)}"
+
+
 class _RecordingConnectionManager(AgentConnectionManager):
     def __init__(self):
         self.events = []
@@ -140,6 +154,102 @@ async def test_list_sessions_tracks_running_and_clears(manager):
 
     await manager.kill_session(result.session_id, "TERM")
     assert result.session_id not in await manager.list_sessions()
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_hides_naturally_exited_pty_until_final_poll(manager, tmp_path):
+    marker = tmp_path / "finish-pty"
+    result = await manager.exec_command(
+        _marker_command(marker, "pty-final"),
+        workdir=str(tmp_path),
+        yield_time_ms=250,
+    )
+    assert result.status == "running"
+    session_id = result.session_id
+    assert session_id is not None
+    session = manager.sessions[session_id]
+    assert isinstance(session, PtySession)
+
+    marker.touch()
+    await asyncio.wait_for(session.exited.wait(), timeout=3)
+
+    assert session_id not in await manager.list_sessions()
+    assert manager.sessions[session_id] is session
+    assert session.master_fd is None
+
+    final = await manager.write_stdin(session_id, "", yield_time_ms=250)
+    assert final.status == "exited"
+    assert final.exit_code == 0
+    assert "pty-final" in final.output
+    assert session_id not in manager.sessions
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_hides_naturally_exited_detached_session_and_closes_raw_resources(manager, tmp_path):
+    marker = tmp_path / "finish-detached"
+    result = await manager.exec_command(
+        _marker_command(marker, "detached-final"),
+        workdir=str(tmp_path),
+        yield_time_ms=250,
+        background=True,
+    )
+    assert result.status == "running"
+    session_id = result.session_id
+    assert session_id is not None
+    session = manager.sessions[session_id]
+    assert isinstance(session, DetachedSession)
+    assert session.log_path is not None
+    assert session.stdin_path is not None
+    log_path = Path(session.log_path)
+    stdin_path = Path(session.stdin_path)
+
+    marker.touch()
+    await asyncio.wait_for(session.exited.wait(), timeout=3)
+    assert log_path.exists()
+    assert stdin_path.exists()
+
+    assert session_id not in await manager.list_sessions()
+    assert manager.sessions[session_id] is session
+    assert session.log_path is None
+    assert session.stdin_path is None
+    assert not log_path.exists()
+    assert not stdin_path.exists()
+
+    final = await manager.kill_session(session_id, "TERM")
+    assert final.status == "exited"
+    assert final.exit_code == 0
+    assert "detached-final" in final.output
+    assert session_id not in manager.sessions
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_reports_only_live_sessions_when_completed_results_are_retained(manager, tmp_path):
+    live = await manager.exec_command("sleep 30", workdir=str(tmp_path), yield_time_ms=250)
+    marker = tmp_path / "finish-mixed"
+    completed = await manager.exec_command(
+        _marker_command(marker, "mixed-final"),
+        workdir=str(tmp_path),
+        yield_time_ms=250,
+    )
+    assert live.session_id is not None
+    assert completed.session_id is not None
+
+    try:
+        completed_session = manager.sessions[completed.session_id]
+        marker.touch()
+        await asyncio.wait_for(completed_session.exited.wait(), timeout=3)
+
+        sessions = await manager.list_sessions()
+        assert set(sessions) == {live.session_id}
+        assert sessions[live.session_id]["running"] is True
+        assert completed.session_id in manager.sessions
+
+        final = await manager.write_stdin(completed.session_id, "", yield_time_ms=250)
+        assert final.status == "exited"
+        assert "mixed-final" in final.output
+    finally:
+        if live.session_id in manager.sessions:
+            await manager.kill_session(live.session_id, "TERM")
 
 
 @pytest.mark.asyncio

--- a/tests/agent/tool_backend/test_terminal_tool.py
+++ b/tests/agent/tool_backend/test_terminal_tool.py
@@ -1,5 +1,6 @@
 import os
 import asyncio
+import shlex
 import sys
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -18,6 +19,20 @@ SKIP_IN_CI = bool(os.getenv("CI")) or bool(os.getenv("GITLAB_CI"))
 def _result_field(result: str, name: str) -> str:
     prefix = f"{name}: "
     return next(line.removeprefix(prefix) for line in result.splitlines() if line.startswith(prefix))
+
+
+def _marker_command(marker, final_output: str) -> str:
+    script = "\n".join(
+        [
+            "import pathlib, time",
+            f"marker = pathlib.Path({str(marker)!r})",
+            "print('started', flush=True)",
+            "while not marker.exists():",
+            "    time.sleep(0.01)",
+            f"print({final_output!r}, flush=True)",
+        ]
+    )
+    return f"{shlex.quote(sys.executable)} -c {shlex.quote(script)}"
 
 
 @pytest.fixture
@@ -508,6 +523,38 @@ class TestBackgroundExec:
         assert "Background: true" in result
         # Ids no longer running are pruned from the tracking set.
         assert terminal_tool._background_sessions == {"s_1"}
+
+    @pytest.mark.asyncio
+    async def test_naturally_exited_background_session_is_hidden_but_final_output_remains(
+        self,
+        terminal_tool,
+        tmp_path,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(
+            "kolega_code.agent.tool_backend.terminal_tool.BACKGROUND_SETTLE_MS",
+            250,
+        )
+        marker = tmp_path / "finish-background-tool"
+        result = await terminal_tool.exec_command(
+            _marker_command(marker, "background-final"),
+            workdir=str(tmp_path),
+            background=True,
+        )
+        assert _result_field(result, "Status") == "running"
+        session_id = _result_field(result, "Session")
+        session = terminal_tool.terminal_manager.sessions[session_id]
+
+        marker.touch()
+        await asyncio.wait_for(session.exited.wait(), timeout=3)
+
+        assert await terminal_tool.list_sessions() == "No running sessions."
+        assert terminal_tool._background_sessions == set()
+
+        final = await terminal_tool.write_stdin(session_id, "", yield_time_ms=250)
+        assert _result_field(final, "Status") == "exited"
+        assert _result_field(final, "Exit code") == "0"
+        assert "background-final" in final
 
     @pytest.mark.asyncio
     async def test_kill_command_forgets_background_session(self, terminal_tool):


### PR DESCRIPTION
## Summary
- make `LocalTerminalManager.list_sessions()` report only actively running sessions
- close completed PTY and detached-process resources without discarding finalized unread output
- retain naturally exited sessions until `write_stdin()` or `kill_session()` returns their final result
- add manager- and tool-level regressions for foreground, detached, and mixed-session lifecycle behavior

## Dependency
Depends on #514 (`feat(terminal): spill oversized command output`). This branch starts from the current #514 head, `8e7da5e30b9b255b4956d0debb6006834dab44b4`, and intentionally targets `main`; merge #514 before this PR.

## Verification
- `uv run pytest -q tests/agent/services/test_terminal.py tests/agent/services/test_sandbox_terminal_input.py tests/agent/tool_backend/test_terminal_tool.py` — 89 passed
- `uv run pre-commit run --all-files`
- `git diff --check`
