### PR TITLE
fix(terminal): report exited when a backgrounded job holds the PTY

### DIFF
--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -2486,7 +2486,13 @@ class KolegaCodeApp(
             self._refresh_queued_messages_panel()
 
     def _set_chat_enabled(self, enabled: bool) -> None:
-        composer = self.query_one("#composer", tui_widgets.ChatComposer)
+        try:
+            composer = self.query_one("#composer", tui_widgets.ChatComposer)
+        except Exception:
+            # The composer may be unmounted while a turn finalizes (e.g. app
+            # teardown); nothing to update then. Guarded like the sibling
+            # composer helpers so a late finalize can't raise WorkerFailed.
+            return
         composer.disabled = not enabled or self._plan_decision_active or self._pending_approval is not None
         if self.config is None and self.agent is None:
             composer.placeholder = messages.DISCONNECTED_COMPOSER_PLACEHOLDER
@@ -2494,7 +2500,11 @@ class KolegaCodeApp(
             composer.placeholder = messages.COMPOSER_PLACEHOLDER
 
     def _set_composer_status(self, status: str) -> None:
-        self.query_one("#composer", tui_widgets.ChatComposer).placeholder = status
+        try:
+            composer = self.query_one("#composer", tui_widgets.ChatComposer)
+        except Exception:
+            return
+        composer.placeholder = status
 
     def _restore_composer_placeholder(self) -> None:
         try:

--- a/kolega_code/services/terminal.py
+++ b/kolega_code/services/terminal.py
@@ -220,6 +220,7 @@ class PtySession:
         self._broadcast_queue: asyncio.Queue[tuple[str, str] | None] = asyncio.Queue()
         self._broadcast_task: Optional[asyncio.Task] = None
         self._reader_added = False
+        self._reap_task: Optional[asyncio.Task] = None
         self._closed = False
 
     # -- lifecycle ---------------------------------------------------------
@@ -267,6 +268,7 @@ class PtySession:
                 self._broadcast_task = asyncio.create_task(self._broadcast_worker())
             asyncio.get_event_loop().add_reader(master_fd, self._on_readable)
             self._reader_added = True
+            self._reap_task = asyncio.create_task(self._poll_for_exit())
 
     def _remove_reader(self) -> None:
         if self._reader_added and self.master_fd is not None:
@@ -324,6 +326,67 @@ class PtySession:
         if pid == self.pid:
             self.exit_code = _normalize_exit_code(status)
             self.exited.set()
+
+    async def _poll_for_exit(self) -> None:
+        """Reap the shell when it exits without PTY EOF.
+
+        PTY EOF is the normal exit signal, but it is withheld while any
+        process still holds the slave open — and a backgrounded (``&``)
+        process does exactly that on Linux, where the kernel does not
+        reliably SIGHUP it when the session leader exits. Reaping the shell
+        itself marks the command finished on every platform; ``_detach_pty``
+        then releases the PTY, and the hangup that release causes kills any
+        surviving background process — which keeps the EXIT trap's warning
+        accurate.
+        """
+        while not self.exited.is_set():
+            await asyncio.sleep(_REAP_POLL_INTERVAL)
+            if not self._poll_reap():
+                continue
+            # The shell's last bytes (e.g. the background-job warning) may
+            # still sit in the PTY buffer; yield once so the reader drains
+            # them before the output is finalized and `exited` wakes waiters.
+            await asyncio.sleep(_REAP_SETTLE_S)
+            self._detach_pty()
+            self.exited.set()
+            return
+
+    def _poll_reap(self) -> bool:
+        """Reap the shell if it exited; True when this call did the reaping.
+
+        Unlike :meth:`_reap` this does not set ``exited``: the poller must
+        finalize the output first so a waiter (``drain``) only wakes once
+        every byte is in the accumulator.
+        """
+        if self.exited.is_set() or self.pid is None:
+            return False
+        try:
+            pid, status = os.waitpid(self.pid, os.WNOHANG)
+        except ChildProcessError:
+            return False  # the EOF path already reaped it
+        if pid != self.pid:
+            return False
+        self.exit_code = _normalize_exit_code(status)
+        return True
+
+    def _detach_pty(self) -> None:
+        """Release the PTY after the shell exited without EOF.
+
+        The non-EOF analogue of :meth:`_handle_eof`: drop the reader, close
+        the master (hanging up the slave, which SIGHUPs any surviving
+        background process), finalize the output, and flush the display
+        decoder.
+        """
+        self._remove_reader()
+        if self.master_fd is not None:
+            try:
+                os.close(self.master_fd)
+            except OSError:
+                pass
+            self.master_fd = None
+        self._output.finalize()
+        self._flush_display_decoder()
+        self._new_output.set()
 
     def _broadcast(self, data: bytes) -> None:
         if not self.connection_manager:
@@ -413,6 +476,11 @@ class PtySession:
         if self._closed:
             return
         self._closed = True
+        if self._reap_task is not None:
+            self._reap_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._reap_task
+            self._reap_task = None
         self._remove_reader()
         if not self.exited.is_set():
             self._signal_group(signal.SIGKILL)
@@ -439,6 +507,20 @@ class PtySession:
 
 # How often the detached-session pump tails its log file and checks liveness.
 _DETACHED_POLL_INTERVAL = 0.05
+
+# How often a PTY session reaps its shell. PTY EOF is the normal exit signal,
+# but it is withheld while any process still holds the slave open — and a
+# backgrounded (`&`) process does exactly that on Linux, where the kernel does
+# not reliably SIGHUP it when the session leader exits. Without this poll,
+# `sleep 30 & echo main-done` would report "running" for the whole 30s even
+# though the shell finished. `waitpid(WNOHANG)` is cheap; 0.05s keeps exit
+# detection invisible to callers.
+_REAP_POLL_INTERVAL = 0.05
+# Grace period after reaping the shell before the output is finalized: the
+# shell's last bytes (e.g. the background-job warning) may still sit in the
+# PTY buffer, and the reader callback needs a loop tick to drain them so the
+# first read after `exited` sees the complete stream.
+_REAP_SETTLE_S = 0.02
 
 
 class DetachedSession:

--- a/tests/cli/test_app_loop_command.py
+++ b/tests/cli/test_app_loop_command.py
@@ -178,6 +178,12 @@ async def _wait_loop_idle(app, pilot, *, timeout: float = 6.0) -> None:
         return app.agent_worker is None and not app._turn_active and not app._loop_iteration_active
 
     await _wait_for(app, pilot, _idle, timeout=timeout)
+    # The turn that just completed scheduled a 10ms queued-message-drain
+    # timer; let it fire before returning. If it fires after a test queues a
+    # message, it would start that message as a real turn which could still be
+    # running at teardown — colliding with widget pruning as a
+    # NoMatches("#composer") WorkerFailed flake in CI.
+    await pilot.pause(0.05)
 
 
 async def _tick(app, pilot) -> None:


### PR DESCRIPTION
## Problem

`PtySession` detected the shell's exit only through PTY EOF. Linux withholds that EOF while a backgrounded (`&`) process still holds the slave open, and SIGHUP delivery to that process when the session leader exits is not reliable — it varies by kernel and runner. So `sleep 30 & echo main-done` reported `running` for the full 30s even though the shell finished in milliseconds.

That nondeterminism failed the Python 3.13 job of #515 (`test_warns_when_command_leaves_background_jobs`: `assert 'running' == 'exited'` after burning the whole 8s yield window) while 3.11/3.12/3.14 passed. The same defect also meant the #515 `list_sessions` hiding behavior could not hide such sessions on Linux.

## Fix

Reap the shell itself with a lightweight `waitpid(WNOHANG)` poll (50ms) instead of relying on PTY EOF:

- shell exit → settle one loop tick so trailing bytes (the background-job warning) drain into the accumulator → release the PTY (the hangup kills surviving background processes, keeping the EXIT trap's warning accurate) → mark the session exited.
- The EOF path is unchanged; the poller only covers the no-EOF case and is cancelled on `close()`.
- Exit detection is now platform-independent; `exec_command` returns `exited` with the complete output and the warning on every OS.

## Verification

- Reproduced the failure mechanism on Linux (Docker, python:3.13): raw PTY read returned EAGAIN for the full `sleep 30` duration — no EOF while the backgrounded process held the slave; the same test on the pre-fix code passes only where the kernel happens to deliver the vhangup EOF.
- `tests/agent/services/test_terminal.py` + `tests/agent/tool_backend/test_terminal_tool.py`: **79 passed** on both macOS and Linux (python:3.13 in a container).
- The previously failing test passes 10/10 on Linux; lint (ruff) and type check (pyright) clean.

## Also in this PR

The first CI run of this PR hit a known TUI flake family on Python 3.12 (`test_no_fire_while_a_prompt_or_queue_is_pending[queued_message]`): every turn completion schedules a one-shot 10ms `queued-message-drain` timer; when a message is queued right after the app goes idle, the timer can win the race and start the message as a real `kolega-turn` worker that is still running at teardown — its unguarded `#composer` query then raises `NoMatches` → `WorkerFailed` at `run_test` exit.

- `_wait_loop_idle` now settles 50ms so the drain timer has fired (empty queue → no-op) before tests queue anything or end.
- `_set_chat_enabled`/`_set_composer_status` are the only unguarded `#composer` mutations reachable from a turn's finalize; they are now guarded like their siblings so a late finalize during teardown cannot raise WorkerFailed.

Verified: full loop test file 52/52 on macOS and Linux (container, python:3.13); the previously failing parametrized test 12×12 green on Linux.
