### PR TITLE
feat(agent): reinject plan handle and task list after compaction

### DIFF
--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -436,6 +436,10 @@ class BaseAgent(LogMixin):
         # change instead of being rendered into the system prompt, which keeps the cached prefix
         # stable for the whole session. See agent/volatile_context.py.
         self._volatile_context = VolatileContextTracker()
+        # Host-registered volatile-context sections (e.g. a plan handle or the shared task
+        # list). Providers run on every turn; an empty text (or None) means the section is
+        # currently absent. See add_volatile_section.
+        self._extra_volatile_sections: List[Callable[[], Optional[VolatileSection]]] = []
 
         self.conversation = Conversation(max_tool_result_chars=self.max_tool_result_chars_in_history)
         self.conversation.skill_content_pattern = self.skill_content_pattern
@@ -1168,8 +1172,15 @@ class BaseAgent(LogMixin):
                 on_error=on_error,
                 system_prompt_text=compaction_system_prompt,
             )
-            if result.ok and self.session_recorder is not None:
-                await asyncio.to_thread(self.session_recorder.record_compaction, self.dump_compaction_state())
+            if result.ok:
+                # Compaction summarizes the injected volatile-context blocks along with
+                # everything else, so memory, guidance, and any host sections (plan handle,
+                # task list) may survive only in lossy summary form. Forget the sent-state
+                # so the next turn re-sends them. Done here — not at the call sites — so
+                # the manual /compact command gets the same re-injection as auto-compaction.
+                self._volatile_context.forget()
+                if self.session_recorder is not None:
+                    await asyncio.to_thread(self.session_recorder.record_compaction, self.dump_compaction_state())
         finally:
             # Recount + emit so the context gauge reflects post-compaction reality
             # (even on a no-op the UI may have been stale).
@@ -1185,6 +1196,9 @@ class BaseAgent(LogMixin):
         if self.session_recorder is not None:
             self.session_recorder.start_epoch("agent_clear_command")
         self.conversation.clear()
+        # The model no longer holds any injected context; re-send the current sections
+        # (memory, guidance, plan handle, task list) on the next turn.
+        self.reset_volatile_context()
 
     # ------------------------------------------------------------------
     # Tool execution
@@ -2073,11 +2087,41 @@ class BaseAgent(LogMixin):
             except Exception:
                 # Disabled/unavailable memory is intentionally invisible to the model.
                 memory_body = ""
-        return [
+        sections = [
             VolatileSection("memory", memory_body),
             VolatileSection("guidance", guidance, guidance_file),
             VolatileSection("date", f"Today's date: {datetime.now().strftime('%Y-%m-%d')}"),
         ]
+        for provider in self._extra_volatile_sections:
+            try:
+                section = provider()
+            except Exception:
+                # A broken host provider must not kill turns; its section is skipped.
+                logger.exception("Volatile-section provider failed; skipping its section")
+                continue
+            if section is not None:
+                sections.append(section)
+        return sections
+
+    def add_volatile_section(self, provider: Callable[[], Optional[VolatileSection]]) -> None:
+        """Register a host-provided volatile-context section.
+
+        ``provider`` is called on every turn and must return the section's current text;
+        ``None`` or an empty-text :class:`VolatileSection` means "not currently present".
+        Sections are injected as ``<system-reminder>`` user messages, deduplicated by
+        fingerprint, and re-sent after compaction or history clears (see
+        ``reset_volatile_context``). The CLI registers the plan handle and the shared task
+        list this way so they survive conversation summarization.
+        """
+        self._extra_volatile_sections.append(provider)
+
+    def reset_volatile_context(self) -> None:
+        """Drop the volatile-context sent-state so the next turn re-sends every section.
+
+        Used after operations that wipe or summarize history (``/clear``, compaction),
+        which otherwise leave the model without context it was already shown.
+        """
+        self._volatile_context.forget()
 
     def pending_volatile_context(self) -> Optional[TextBlock]:
         """Volatile context the model has not been shown yet, or ``None`` if nothing changed."""
@@ -2186,10 +2230,9 @@ class BaseAgent(LogMixin):
                         },
                     )
                     result = await self.compress_history()
-                    # Compaction summarizes the injected volatile-context blocks along with
-                    # everything else, so the memory and guidance the model was given may
-                    # survive only in lossy summary form. Re-send them on the next turn.
-                    self._volatile_context.forget()
+                    # compress_history forgets the volatile-context sent-state on success,
+                    # so the next turn re-sends memory, guidance, and any host sections
+                    # (plan handle, task list) the summary may have folded away.
                     # Rebuild after compaction (history changed) and re-mark the cache
                     # checkpoint before re-counting so the reused history reflects it.
                     self.mark_cache_checkpoint()

--- a/kolega_code/agent/volatile_context.py
+++ b/kolega_code/agent/volatile_context.py
@@ -101,6 +101,8 @@ def _render(section: VolatileSection, body: str) -> str:
 _REMOVAL_LABELS = {
     "memory": "Private project memory",
     "guidance": "Repository guidance",
+    "plan": "The current plan",
+    "task_list": "The shared task list",
 }
 
 

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -2540,6 +2540,9 @@ class KolegaCodeApp(
         if self.agent is not None:
             self.agent.history = MessageHistory()
             self.agent.last_compression_index = None
+            # The wiped history took the injected reminders with it; the next turn must
+            # re-send memory, guidance, the plan handle, and the task list.
+            self.agent.reset_volatile_context()
         self.session.history = []
         self.session.compaction = {}
         self._clear_queued_messages()
@@ -2555,6 +2558,10 @@ class KolegaCodeApp(
         await asyncio.to_thread(self._session_recorder.start_epoch, "thread_reset")
         if self.agent is not None:
             self.agent.history = MessageHistory()
+            # The thread wipe took the injected reminders with it; the next turn re-sends
+            # the current sections. The plan and task list are cleared below, so those
+            # come back absent — memory and guidance are re-sent.
+            self.agent.reset_volatile_context()
         self.session.history = []
         self.session.compaction = {}
         self.session.task_list_markdown = ""

--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -17,6 +17,7 @@ from kolega_code.agent import (
 from kolega_code.agent.baseagent import QueuedUserInput
 from kolega_code.agent.prompt_provider import AgentMode
 from kolega_code.agent.tool_definitions import tool_description_asset
+from kolega_code.agent.volatile_context import VolatileSection
 from kolega_code.extensions import (
     KolegaExtensionHost,
     KolegaExtensionLoadError,
@@ -1021,6 +1022,32 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
             propagate_to_sub_agents=True,
         )
 
+    def _plan_volatile_section(self) -> VolatileSection:
+        """Volatile section carrying a handle to the current plan artifact.
+
+        Registered on the top-level agent so that after compaction (which summarizes the
+        plan away) the model is reminded where the approved plan lives and can re-read it.
+        Empty text when there is no captured plan; best-effort persistence is silent here
+        because the prompt-extension path already surfaces write failures.
+        """
+        plan = getattr(self, "_latest_plan", None)
+        if not plan:
+            return VolatileSection("plan", "")
+        try:
+            path = write_current_plan_artifact(self.store.root, self.session.session_id, plan)
+        except Exception:
+            return VolatileSection("plan", "")
+        return VolatileSection("plan", build_current_plan_artifact_prompt(path))
+
+    def _task_list_volatile_section(self) -> VolatileSection:
+        """Volatile section carrying the current shared task list.
+
+        Injected as a ``<system-reminder>`` so the model always sees the latest todos —
+        including after compaction and after every ``update_task_list`` call — without
+        needing to re-fetch them. Empty text when no task list has been set.
+        """
+        return VolatileSection("task_list", (getattr(self.session, "task_list_markdown", "") or "").strip())
+
     def _scratchpad_prompt_extension(self) -> PromptExtension | None:
         """Return prompt context advertising this session's scratchpad directory.
 
@@ -1214,6 +1241,14 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
         # The runtime owns the agent for control purposes while the CLI keeps
         # composing it from settings, skills, hooks, and MCP configuration.
         self.session_runtime.adopt(self.agent)
+        # The plan handle and shared task list are conversation-injected context (system
+        # reminders), so a compaction that summarizes them away is followed by re-injection
+        # on the next turn — see agent/volatile_context.py. Registered in both interaction
+        # modes: the planner sees the plan artifact while re-planning mid-build, and both
+        # modes keep the task list (read-only for the planner) in view. Each rebuild
+        # constructs a fresh agent, so providers never accumulate across rebuilds.
+        self.agent.add_volatile_section(self._plan_volatile_section)
+        self.agent.add_volatile_section(self._task_list_volatile_section)
         if scratchpad_extension is not None:
             # Expose the resolved directory for the KOLEGA_SCRATCHPAD session env
             # and the terminal safety checker; the prompt extension above is what

--- a/tests/agent/test_volatile_sections.py
+++ b/tests/agent/test_volatile_sections.py
@@ -1,0 +1,156 @@
+"""Host-registered volatile sections (plan handle, task list) and post-compaction re-injection.
+
+The CLI registers the plan artifact handle and the shared task list as volatile-context
+sections on the top-level agent. The tracker contract (dedup, change-driven re-send) is
+covered by ``test_volatile_context.py``; this file exercises the ``BaseAgent`` wiring:
+sections are injected as their own user turn, re-sent when they change, and re-sent after
+compaction (auto and manual) and history clears.
+"""
+
+import pytest
+
+from kolega_code.agent.volatile_context import VolatileSection
+
+from .compaction_helpers import FakeLLM, build_agent, long_history
+
+PLAN_TEXT = "artifact: /plans/current-plan.md"
+
+
+def _plan_provider(text: str = PLAN_TEXT):
+    return lambda: VolatileSection("plan", text)
+
+
+@pytest.mark.asyncio
+async def test_registered_section_is_injected_as_its_own_user_turn(tmp_path):
+    agent, _cm = build_agent(tmp_path, llm=FakeLLM())
+    agent.add_volatile_section(_plan_provider())
+
+    _ = [chunk async for chunk in agent.process_message_stream("do the thing")]
+
+    # history = [user message, injected volatile block, assistant response]
+    assert [message.role for message in agent.history] == ["user", "user", "assistant"]
+    injected = agent.history[1]
+    text = injected.get_text_content()
+    assert 'source="plan"' in text
+    assert PLAN_TEXT in text
+    # The date section is injected alongside on the first turn.
+    assert 'source="date"' in text
+
+
+@pytest.mark.asyncio
+async def test_empty_section_is_absent(tmp_path):
+    agent, _cm = build_agent(tmp_path, llm=FakeLLM())
+    agent.add_volatile_section(lambda: VolatileSection("plan", ""))
+
+    _ = [chunk async for chunk in agent.process_message_stream("do the thing")]
+
+    text = agent.history[1].get_text_content()
+    assert 'source="plan"' not in text
+    assert 'source="date"' in text
+
+
+@pytest.mark.asyncio
+async def test_changed_section_is_reinjected_alone(tmp_path):
+    agent, _cm = build_agent(tmp_path, llm=FakeLLM())
+    state = {"plan": "plan v1"}
+    agent.add_volatile_section(lambda: VolatileSection("plan", state["plan"]))
+
+    _ = [chunk async for chunk in agent.process_message_stream("turn one")]
+    assert "plan v1" in agent.history[1].get_text_content()
+
+    state["plan"] = "plan v2"
+    _ = [chunk async for chunk in agent.process_message_stream("turn two")]
+
+    # The second turn's injected block carries only the changed section.
+    injected = agent.history[-2]
+    text = injected.get_text_content()
+    assert 'source="plan"' in text
+    assert "plan v2" in text
+    assert "plan v1" not in text
+    assert text.count("<system-reminder") == 1
+
+
+@pytest.mark.asyncio
+async def test_auto_compaction_reinjects_sections(tmp_path):
+    """The core ask: after in-turn compaction, the next turn re-sends the sections."""
+    fake = FakeLLM(token_script=[900, 300, 300, 100])
+    agent, _cm = build_agent(tmp_path, llm=fake, model_context_length=1000)
+    agent.history = long_history(6)  # 12 messages: comfortably above the compaction floor
+    agent.add_volatile_section(_plan_provider())
+
+    # Turn 1: first count (900) is over the 80% budget, so the turn compacts mid-flight.
+    _ = [chunk async for chunk in agent.process_message_stream("continue")]
+    assert agent.conversation.summary is not None
+
+    # Turn 2: the volatile sent-state was forgotten by compress_history, so the plan
+    # handle (and the date) are injected again at the start of the turn.
+    _ = [chunk async for chunk in agent.process_message_stream("continue again")]
+    injected = agent.history[-2]
+    text = injected.get_text_content()
+    assert 'source="plan"' in text
+    assert PLAN_TEXT in text
+
+
+@pytest.mark.asyncio
+async def test_manual_compress_reinjects_sections(tmp_path):
+    """/compact previously never re-sent context; the forget now lives in compress_history."""
+    fake = FakeLLM(token_script=[900, 300, 300])
+    agent, _cm = build_agent(tmp_path, llm=fake)
+    agent.history = long_history(6)
+    agent.add_volatile_section(_plan_provider())
+
+    # First injection records sent-state; nothing pending while unchanged.
+    assert agent.pending_volatile_context() is not None
+    assert agent.pending_volatile_context() is None
+
+    result = await agent.command_processor._handle_compress()
+    assert "Compressed history" in result
+
+    # A successful manual compaction forgets the sent-state: the next turn re-sends.
+    pending = agent.pending_volatile_context()
+    assert pending is not None
+    assert 'source="plan"' in pending.text
+
+
+@pytest.mark.asyncio
+async def test_clear_history_resets_sections(tmp_path):
+    agent, _cm = build_agent(tmp_path, llm=FakeLLM())
+    agent.add_volatile_section(_plan_provider())
+
+    assert agent.pending_volatile_context() is not None
+    assert agent.pending_volatile_context() is None
+
+    agent.clear_history()
+
+    assert agent.pending_volatile_context() is not None
+
+
+@pytest.mark.asyncio
+async def test_provider_error_is_skipped(tmp_path, caplog):
+    agent, _cm = build_agent(tmp_path, llm=FakeLLM())
+
+    def broken():
+        raise RuntimeError("boom")
+
+    agent.add_volatile_section(broken)
+    agent.add_volatile_section(_plan_provider())
+
+    _ = [chunk async for chunk in agent.process_message_stream("do the thing")]
+
+    # The turn still ran and the healthy section was injected.
+    assert len(agent.history) == 3
+    assert 'source="plan"' in agent.history[1].get_text_content()
+    assert "Volatile-section provider failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_reset_volatile_context_public_wrapper(tmp_path):
+    agent, _cm = build_agent(tmp_path, llm=FakeLLM())
+    agent.add_volatile_section(_plan_provider())
+
+    assert agent.pending_volatile_context() is not None
+    assert agent.pending_volatile_context() is None
+
+    agent.reset_volatile_context()
+
+    assert agent.pending_volatile_context() is not None

--- a/tests/cli/_app_test_utils.py
+++ b/tests/cli/_app_test_utils.py
@@ -50,6 +50,8 @@ class FakeCoderAgent:
         self.clear_history_calls = 0
         self.session_recorder = kwargs.get("session_recorder")
         self.queued_input_provider = None
+        # Volatile-context providers registered by _build_agent (plan handle, task list).
+        self.volatile_section_providers: list = []
         # Set by _build_agent when the scratchpad prompt extension is active.
         self.scratchpad_dir = None
 
@@ -63,6 +65,13 @@ class FakeCoderAgent:
     def apply_gigacode(self, enabled, prompt_extension=None):
         self.gigacode_enabled = enabled
         self.gigacode_prompt_extension = prompt_extension if enabled else None
+
+    def add_volatile_section(self, provider):
+        self.volatile_section_providers.append(provider)
+
+    def reset_volatile_context(self):
+        # The fake carries no volatile-context sent-state; nothing to clear.
+        pass
 
     def clear_history(self):
         self.clear_history_calls += 1

--- a/tests/cli/test_app_volatile_context.py
+++ b/tests/cli/test_app_volatile_context.py
@@ -1,0 +1,90 @@
+"""The CLI registers the plan handle and shared task list as volatile-context sections.
+
+Agent-level injection behavior is covered by ``tests/agent/test_volatile_sections.py``.
+These tests verify the CLI wiring: ``_build_agent`` registers exactly the plan and
+task-list providers on the top-level agent, and the providers render the session state
+(artifact path / task-list markdown) — or empty text when unset.
+"""
+
+from typing import Any, cast
+
+import pytest
+
+from tests.cli._app_test_utils import build_test_config, install_fake_agents
+
+from kolega_code.cli.config import config_summary
+from kolega_code.cli.session_store import SessionStore
+
+
+def _make_app(tmp_path, monkeypatch):
+    from kolega_code.cli.app import KolegaCodeApp
+
+    install_fake_agents(monkeypatch)
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    return KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+
+@pytest.mark.asyncio
+async def test_build_agent_registers_plan_and_task_list_providers(tmp_path, monkeypatch):
+    pytest.importorskip("textual")
+    app = _make_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert app.agent is not None
+        fake_agent = cast(Any, app.agent)
+        providers = fake_agent.volatile_section_providers
+        assert len(providers) == 2
+        # Bound-method equality: same function + same instance.
+        assert providers[0] == app._plan_volatile_section
+        assert providers[1] == app._task_list_volatile_section
+
+
+@pytest.mark.asyncio
+async def test_plan_section_carries_artifact_path_and_persists_artifact(tmp_path, monkeypatch):
+    pytest.importorskip("textual")
+    app = _make_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._latest_plan = "# Build the feature\n\n- [ ] step one"
+
+        section = app._plan_volatile_section()
+
+        assert section.key == "plan"
+        assert "current-plan.md" in section.text
+        assert app.session.session_id in section.text
+        artifact = app.store.root / "plans" / app.session.session_id / "current-plan.md"
+        assert artifact.exists()
+        assert "Build the feature" in artifact.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_task_list_section_mirrors_session(tmp_path, monkeypatch):
+    pytest.importorskip("textual")
+    app = _make_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.session.task_list_markdown = "- [x] one\n- [ ] two"
+
+        section = app._task_list_volatile_section()
+
+        assert section.key == "task_list"
+        assert section.text == "- [x] one\n- [ ] two"
+
+
+@pytest.mark.asyncio
+async def test_sections_empty_when_unset(tmp_path, monkeypatch):
+    pytest.importorskip("textual")
+    app = _make_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        assert app._plan_volatile_section().text == ""
+        assert app._task_list_volatile_section().text == ""


### PR DESCRIPTION
## What

After conversation compaction (auto or `/compact`) the model loses sight of the approved plan and the shared task list. This change re-injects both as `<system-reminder>` blocks on the turn after any compaction, using the existing volatile-context channel — so reminders are deduplicated, journalled for resume, and automatically refreshed whenever the task list or plan changes.

## How

- `BaseAgent` gains `add_volatile_section(provider)` and `reset_volatile_context()`; registered providers are evaluated every turn and injected as system-reminder user messages alongside memory/guidance/date.
- `compress_history()` now forgets the volatile sent-state on success, covering the **manual `/compact` path** (previously only auto-compaction re-sent context); `clear_history()` resets it too.
- The CLI (`agent_runtime.py`) registers two providers on the top-level agent in `_build_agent` (both interaction modes):
  - plan handle: points at the persisted `plans/<session-id>/current-plan.md` artifact (reuses the existing `current_plan_artifact` template text; absent when no plan is captured),
  - task list: the current `session.task_list_markdown`, so the model always sees the latest todos after `update_task_list` without re-fetching.
- TUI history wipes (`_clear_agent_context` — "implement plan with cleared context" — and thread reset) re-arm the next turn's injection.
- Sub-agents are unaffected by design: the task list is top-level-only, and the plan artifact path already reaches them via the propagated system-prompt extension.

## Verification

- New tests: `tests/agent/test_volatile_sections.py` (8: injection, absence, change-driven re-send, auto-compaction re-injection, manual `/compact`, `/clear`, provider-error tolerance, reset wrapper) and `tests/cli/test_app_volatile_context.py` (4: registration, artifact path + persistence, task-list mirror, empty-when-unset); shared `FakeCoderAgent` updated.
- Focused suites: agent compaction/volatile suites (37 passed), CLI wiring (4), affected TUI suites (166) — all green.
- Full fast suite: **4454 passed, 3 failed**. The 3 failures are `tinker` live-provider tests failing only because the dev worktree lacks the optional `[tinker]` extra while a leaked developer `.env` sets `TINKER_API_KEY` — environmental, unrelated to this change; in CI those tests skip (no keys).
- `ruff`, `pyright`, and all pre-commit hooks pass on the changed files.
