### PR TITLE
perf(tui): fix long-session UI stalls (window, filter, pacing, torch)

### DIFF
--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -40,7 +40,10 @@ from .extensions import (
 from .llm.client import LLMClient
 from .llm.instrumented_client import InstrumentedLLMClient
 from .llm.ledger import LlmCallOrigin, current_llm_call_origin, helper_origin, llm_call_origin
-from .llm.providers.tinker import TinkerTraceRecord
+
+# From the dependency-free leaf module: importing .llm.providers.tinker itself
+# loads the optional native stack (tinker-cookbook -> torch) when installed.
+from .llm.providers.tinker_trace import TinkerTraceRecord
 from .llm.models import (
     ImageBlock,
     Message,

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -97,6 +97,7 @@ from .tui import prompt_flows as tui_prompt_flows
 from .tui import onboarding_screen as tui_onboarding
 from .tui import settings_panel as tui_settings_panel
 from .tui import settings_screen as tui_settings_screen
+from .tui import pacing as tui_pacing
 from .tui import session_diff as tui_session_diff
 from .tui import status_dashboard as tui_status_dashboard
 from .tui import state as tui_state
@@ -109,10 +110,10 @@ CLI_AGENT_MODE = AgentMode.CLI.value
 LOG_MAX_LINES = 2_000
 TERMINAL_MAX_LINES = 2_000
 ScreenResultT = TypeVar("ScreenResultT")
-TERMINAL_FLUSH_INTERVAL = 0.04
 SESSION_DIFF_REFRESH_INTERVAL = 1.0
+# Immediate-flush triggers are memory bounds, not cadence: they intentionally
+# bypass flush pacing so buffered output can never grow without limit.
 TERMINAL_IMMEDIATE_FLUSH_CHARS = 64 * 1024
-LOG_FLUSH_INTERVAL = 0.05
 LOG_IMMEDIATE_FLUSH_ITEMS = 100
 
 
@@ -353,6 +354,7 @@ class KolegaCodeApp(
         self._terminal_display_normalizer = tui_terminal_display.TerminalDisplayNormalizer()
         self._log_output_buffer: list[Any] = []
         self._log_flush_timer: Optional[Timer] = None
+        self._flush_pacer = tui_pacing.FlushPacer()
 
     def get_line_filters(self) -> Sequence[LineFilter]:
         """Apply the terminal-control boundary after Textual's style filters."""
@@ -510,6 +512,7 @@ class KolegaCodeApp(
             # second: chop below the stack-capture threshold is only visible if a beat
             # lands inside the stalled window. The callback is O(1).
             self.set_interval(self._watchdog.beat_interval, self._watchdog.beat)
+            self._flush_pacer.attach(self._watchdog.recent_excess)
         except Exception:
             self._diag, self._watchdog = None, None
         # Register all themes and apply the persisted one before the first paint,
@@ -605,7 +608,7 @@ class KolegaCodeApp(
 
         if self._terminal_flush_timer is None:
             self._terminal_flush_timer = self.set_timer(
-                TERMINAL_FLUSH_INTERVAL,
+                self._flush_pacer.interval(),
                 self._flush_terminal_output,
                 name="terminal-output-flush",
             )
@@ -699,7 +702,7 @@ class KolegaCodeApp(
 
         if self._log_flush_timer is None:
             self._log_flush_timer = self.set_timer(
-                LOG_FLUSH_INTERVAL,
+                self._flush_pacer.interval(),
                 self._flush_log_output,
                 name="log-output-flush",
             )

--- a/kolega_code/cli/diagnostics.py
+++ b/kolega_code/cli/diagnostics.py
@@ -220,6 +220,9 @@ class ResponsivenessWatchdog:
       stalls well under the stack-capture threshold, which would otherwise leave no
       trace at all; the aggregate ``loop_gap_histogram`` line costs a few bytes and no
       stacks, and says immediately whether the chop is real and how big it is.
+    * **Load signal.** :meth:`recent_excess` exposes a decaying peak of the same
+      lateness for the TUI's flush pacing — when the loop runs late, flush timers
+      stretch so the UI degrades to a lower frame rate instead of freezing.
 
     Thresholds are constructor parameters for tests only — there is no user decision here.
     """
@@ -227,6 +230,11 @@ class ResponsivenessWatchdog:
     # Excess-over-nominal beat lateness, in seconds. The first edge is the floor of
     # human-visible chop; the last is the stack-capture threshold.
     _BUCKET_EDGES: tuple[float, ...] = (0.1, 0.25, 1.0, 5.0)
+
+    # Per-beat decay of the recent-lateness peak. At the healthy 0.2s beat cadence a
+    # 1s stall's influence falls below the 0.1s pacing deadband in ~15 beats (~3s):
+    # backoff outlives the trouble by a few seconds, then full cadence returns.
+    _RECENT_DECAY = 0.85
 
     def __init__(
         self,
@@ -253,6 +261,7 @@ class ResponsivenessWatchdog:
         self._sig_file = None
         self._beats = 0
         self._max_excess = 0.0
+        self._recent_excess = 0.0
         self._labels = self._bucket_labels()
         self._buckets: dict[str, int] = {label: 0 for label in self._labels}
         self._window_start = time.monotonic()
@@ -276,6 +285,9 @@ class ResponsivenessWatchdog:
             excess = (now - self._last_beat) - self.beat_interval
             self._last_beat = now
             self._beats += 1
+            # Peak-hold with decay, updated on quiet beats too so backoff releases.
+            # The 0.0 floor guards early-firing timers (negative excess).
+            self._recent_excess = max(excess, self._recent_excess * self._RECENT_DECAY, 0.0)
             if excess < self._BUCKET_EDGES[0]:
                 return
             self._max_excess = max(self._max_excess, excess)
@@ -283,6 +295,15 @@ class ResponsivenessWatchdog:
                 if excess >= self._BUCKET_EDGES[index]:
                     self._buckets[self._labels[index]] += 1
                     return
+
+    def recent_excess(self) -> float:
+        """Decaying peak of recent beat lateness, in seconds — the TUI's load signal.
+
+        Independent of the histogram: :meth:`flush_histogram` never resets it; it
+        only decays, one ``_RECENT_DECAY`` step per beat.
+        """
+        with self._beat_lock:
+            return self._recent_excess
 
     def start(self) -> None:
         if not self._diag.enabled or self._thread is not None:

--- a/kolega_code/cli/theme.py
+++ b/kolega_code/cli/theme.py
@@ -101,8 +101,8 @@ RENDER_COALESCE_LARGE_CHARS = 200_000
 # sub-agent inspector mount only a trailing window of their entries so Textual's
 # O(mounted-widgets) reflow stays cheap no matter how long the session runs.
 # Scrolling near the top mounts older chunks; following the bottom trims the oldest.
-TRANSCRIPT_WINDOW_MAX = 300
-TRANSCRIPT_WINDOW_TRIM_CHUNK = 100
+TRANSCRIPT_WINDOW_MAX = 120
+TRANSCRIPT_WINDOW_TRIM_CHUNK = 40
 TRANSCRIPT_WINDOW_EXPAND_CHUNK = 100
 INSPECTOR_WINDOW_MAX = 150
 INSPECTOR_WINDOW_EXPAND_CHUNK = 100

--- a/kolega_code/cli/theme.py
+++ b/kolega_code/cli/theme.py
@@ -87,16 +87,6 @@ SUB_AGENT_TASK_PREVIEW_CHARS = 120
 CONTEXT_BAR_WIDTH = 18
 TRANSCRIPT_INDENT = 2
 MARKDOWN_CODE_THEME = "monokai"
-RENDER_COALESCE_INTERVAL = 0.05
-# Coalesce less aggressively as the live streaming entry grows: each flush still costs
-# Textual an O(height) re-measure of an auto-height widget, so for very large reasoning
-# streams we trade a little update latency for far fewer full re-measures. Sizes are
-# characters of the live entry; see transcript._invalidate_conversation.
-RENDER_COALESCE_INTERVAL_MEDIUM = 0.12
-RENDER_COALESCE_INTERVAL_LARGE = 0.25
-RENDER_COALESCE_MEDIUM_CHARS = 40_000
-RENDER_COALESCE_LARGE_CHARS = 200_000
-
 # Scrollback window bounds (see tui.widgets.ScrollbackWindow). The transcript and the
 # sub-agent inspector mount only a trailing window of their entries so Textual's
 # O(mounted-widgets) reflow stays cheap no matter how long the session runs.

--- a/kolega_code/cli/tui/app_base.py
+++ b/kolega_code/cli/tui/app_base.py
@@ -64,6 +64,7 @@ if TYPE_CHECKING:
     from .onboarding_screen import OnboardingScreen
     from .session_diff import DiffScope, SessionDiffFile, SessionDiffTrackerBase, TurnCheckpoint
     from .settings_screen import SettingsScreen
+    from .pacing import FlushPacer
     from .sub_agent_screen import SubAgentInspectorScreen
     from .terminal_display import TerminalDisplayNormalizer
 
@@ -208,6 +209,7 @@ class KolegaAppBase(App):
         _terminal_display_normalizer: TerminalDisplayNormalizer
         _log_output_buffer: list[object]
         _log_flush_timer: Timer | None
+        _flush_pacer: FlushPacer
 
         # ------------------------------------------------------------------
         # Properties (defined on KolegaCodeApp)

--- a/kolega_code/cli/tui/changes_screen.py
+++ b/kolega_code/cli/tui/changes_screen.py
@@ -110,7 +110,7 @@ class ChangesInspectorScreen(ModalScreen):
             return
         self._flush_pending = True
         try:
-            self.set_timer(theme.RENDER_COALESCE_INTERVAL, self._flush)
+            self.set_timer(self._owner._flush_pacer.interval(), self._flush)
         except Exception:
             self._flush()
 

--- a/kolega_code/cli/tui/changes_screen.py
+++ b/kolega_code/cli/tui/changes_screen.py
@@ -18,6 +18,7 @@ from textual.widgets import Static
 
 from .. import messages, theme
 from ..theme import Color, Glyph
+from . import pacing
 from .session_diff import SessionDiffFile
 from .settings_screen import ConfirmSettingsActionScreen
 from .state import SessionFileChange
@@ -110,7 +111,10 @@ class ChangesInspectorScreen(ModalScreen):
             return
         self._flush_pending = True
         try:
-            self.set_timer(self._owner._flush_pacer.interval(), self._flush)
+            # Base cadence, unpaced: flushes here are already bounded by the 1s
+            # session-diff debounce, and a freshly opened modal must paint
+            # immediately even when the loop is running late.
+            self.set_timer(pacing.FLUSH_BASE_INTERVAL, self._flush)
         except Exception:
             self._flush()
 

--- a/kolega_code/cli/tui/pacing.py
+++ b/kolega_code/cli/tui/pacing.py
@@ -1,0 +1,58 @@
+"""Flush-cadence pacing for the TUI.
+
+Every buffered output surface (terminal pane, log pane, transcript, modal
+inspectors) coalesces writes on one base cadence. :class:`FlushPacer` stretches
+that cadence when the event loop is measurably running late, so sustained load
+degrades to a lower frame rate instead of freezing the loop. Content is never
+dropped or hidden — only batched into fewer, larger flushes.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+# 20 Hz — the healthy-loop cadence for every buffered surface.
+FLUSH_BASE_INTERVAL = 0.05
+# The watchdog's first histogram edge: the floor of human-visible chop. Below it
+# the pacer returns exactly the base interval.
+PACING_DEADBAND = 0.10
+# 2 Hz floor — the UI stays visibly alive in the worst backoff.
+PACING_CEILING = 0.50
+# The watchdog beat interval, so (1 + excess/normalizer) is the loop's measured
+# slowdown factor: stretch flushes by how late the loop actually runs.
+PACING_NORMALIZER = 0.20
+
+# Coalesce less aggressively as the live streaming entry grows: each flush still costs
+# Textual an O(height) re-measure of an auto-height widget, so for very large reasoning
+# streams we trade a little update latency for far fewer full re-measures. Sizes are
+# characters of the live entry; see transcript._invalidate_conversation.
+RENDER_COALESCE_INTERVAL_MEDIUM = 0.12
+RENDER_COALESCE_INTERVAL_LARGE = 0.25
+RENDER_COALESCE_MEDIUM_CHARS = 40_000
+RENDER_COALESCE_LARGE_CHARS = 200_000
+
+
+class FlushPacer:
+    """Maps recent event-loop lateness to a flush-timer interval.
+
+    Deliberately stateless: the step-up/decay dynamics live in the signal itself
+    (``ResponsivenessWatchdog.recent_excess``, a decaying peak-hold), so this is
+    a pure mapping, every arming site sees the same value at the same instant,
+    and tests only need a fake lateness callable.
+    """
+
+    def __init__(self, lateness: Optional[Callable[[], float]] = None) -> None:
+        self._lateness = lateness
+
+    def attach(self, lateness: Callable[[], float]) -> None:
+        self._lateness = lateness
+
+    def interval(self) -> float:
+        # Diagnostics init can fail (the app nulls the watchdog); unattached
+        # means "assume healthy" and the TUI runs at the fixed base cadence.
+        if self._lateness is None:
+            return FLUSH_BASE_INTERVAL
+        excess = self._lateness()
+        if excess < PACING_DEADBAND:
+            return FLUSH_BASE_INTERVAL
+        return min(PACING_CEILING, FLUSH_BASE_INTERVAL * (1.0 + excess / PACING_NORMALIZER))

--- a/kolega_code/cli/tui/sub_agent_screen.py
+++ b/kolega_code/cli/tui/sub_agent_screen.py
@@ -16,6 +16,7 @@ from textual.widgets import Static
 
 from .. import messages, theme
 from ..theme import Color, Glyph
+from . import pacing
 from .state import ConversationEntry, SubAgentActivity
 from .widgets import ConversationEntryWidget, ScrollbackWindow, ToolEntryWidget, TrajectoryScrollView
 
@@ -122,7 +123,10 @@ class SubAgentInspectorScreen(ModalScreen):
             return
         self._flush_pending = True
         try:
-            self.set_timer(self._owner._flush_pacer.interval(), self._flush)
+            # Base cadence, unpaced: trajectory updates are already coalesced per
+            # flush, and a freshly opened inspector must paint immediately even
+            # when the loop is running late.
+            self.set_timer(pacing.FLUSH_BASE_INTERVAL, self._flush)
         except Exception:
             self._flush()
 

--- a/kolega_code/cli/tui/sub_agent_screen.py
+++ b/kolega_code/cli/tui/sub_agent_screen.py
@@ -122,7 +122,7 @@ class SubAgentInspectorScreen(ModalScreen):
             return
         self._flush_pending = True
         try:
-            self.set_timer(theme.RENDER_COALESCE_INTERVAL, self._flush)
+            self.set_timer(self._owner._flush_pacer.interval(), self._flush)
         except Exception:
             self._flush()
 

--- a/kolega_code/cli/tui/terminal_display.py
+++ b/kolega_code/cli/tui/terminal_display.py
@@ -9,6 +9,7 @@ model, tool, and persisted values remain untouched.
 
 from __future__ import annotations
 
+import re
 from enum import Enum, auto
 
 from rich.cells import cell_len
@@ -16,6 +17,10 @@ from rich.segment import Segment
 from rich.style import Style
 from textual.color import Color
 from textual.filter import LineFilter
+
+# Mirrors _TerminalControlParser._is_c0_or_c1_control: any hit means the line
+# needs the full parser; no hit means the parser would return it byte-identical.
+_CONTROL_CHARS_RE = re.compile("[\x00-\x1f\x7f-\x9f]")
 
 
 class _State(Enum):
@@ -259,9 +264,26 @@ class TerminalControlFilter(LineFilter):
                 return style.update_link(None)
         return style
 
+    @staticmethod
+    def _is_clean(segment: Segment) -> bool:
+        if _CONTROL_CHARS_RE.search(segment.text):
+            return False
+        style = segment.style
+        if style is not None:
+            link = style.link
+            if link is not None and _CONTROL_CHARS_RE.search(link):
+                return False
+        return True
+
     def apply(self, segments: list[Segment], background: Color) -> list[Segment]:
         """Sanitize one independently rendered line while preserving Rich styles."""
         del background
+        # Fast path: this filter runs on every freshly rendered strip in the app,
+        # and virtually every line carries no control bytes at all. The whole line
+        # must be clean before skipping the parser — escape sequences can span
+        # segment boundaries, so a dirty line is parsed as one stream.
+        if all(self._is_clean(segment) for segment in segments):
+            return segments
         parser = _TerminalControlParser(
             preserve_width=True,
             terminal_transcript=False,

--- a/kolega_code/cli/tui/transcript.py
+++ b/kolega_code/cli/tui/transcript.py
@@ -42,6 +42,7 @@ from .state import (
     tool_state_presentation,
 )
 from . import app_base as tui_app_base
+from . import pacing as tui_pacing
 from . import widgets as tui_widgets
 from .sub_agent_screen import SubAgentEntryWidget
 from .widgets import ConversationEntryWidget, JumpToBottomBar, ToolEntryWidget
@@ -1325,21 +1326,24 @@ class TranscriptRenderingMixin(tui_app_base.KolegaAppBase):
             self._flush_conversation_render()
 
     def _render_coalesce_interval(self, entry: Optional[ConversationEntry]) -> float:
-        """Back off the flush cadence for very large live entries.
+        """Back off the flush cadence for very large live entries and for a late loop.
 
         Each flush makes Textual re-measure the auto-height streaming widget (O(height)),
         so for big reasoning streams fewer, larger flushes beat ~20/sec full re-measures.
         Length lags one flush (deltas materialize at flush time), which is fine: the entry
         only grows, so the cadence steps up within one interval of crossing a threshold.
+        The load-paced interval is a floor under both size tiers: whichever backoff is
+        larger wins.
         """
+        paced = self._flush_pacer.interval()
         if entry is None:
-            return theme.RENDER_COALESCE_INTERVAL
+            return paced
         size = len(entry.content)
-        if size >= theme.RENDER_COALESCE_LARGE_CHARS:
-            return theme.RENDER_COALESCE_INTERVAL_LARGE
-        if size >= theme.RENDER_COALESCE_MEDIUM_CHARS:
-            return theme.RENDER_COALESCE_INTERVAL_MEDIUM
-        return theme.RENDER_COALESCE_INTERVAL
+        if size >= tui_pacing.RENDER_COALESCE_LARGE_CHARS:
+            return max(paced, tui_pacing.RENDER_COALESCE_INTERVAL_LARGE)
+        if size >= tui_pacing.RENDER_COALESCE_MEDIUM_CHARS:
+            return max(paced, tui_pacing.RENDER_COALESCE_INTERVAL_MEDIUM)
+        return paced
 
     def _get_transcript_window(self) -> tui_widgets.ScrollbackWindow:
         """The lazily-created scrollback window bounding mounted transcript widgets."""

--- a/kolega_code/llm/providers/tinker.py
+++ b/kolega_code/llm/providers/tinker.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from dataclasses import dataclass
 from typing import Any, AsyncContextManager, Callable, Dict, List, Optional, Sequence
 
 from ..exceptions import LLMInvalidRequestError
@@ -41,6 +40,7 @@ from ..specs import MODEL_SPECS, get_model_specs
 from ..usage import attach_normalized_usage
 from .base import BaseLLMProvider
 from .models import GenerationParams, TokenCount
+from .tinker_trace import TinkerTraceRecord
 
 logger = logging.getLogger(__name__)
 
@@ -76,30 +76,6 @@ _EFFORT_FLOATS = {
 
 # Conservative context fallback for checkpoints whose base is not catalogued.
 _FALLBACK_CONTEXT_LENGTH = 65536
-
-
-@dataclass(frozen=True)
-class TinkerTraceRecord:
-    """Structured record of one native Tinker sample, for on-policy RL.
-
-    Emitted only when a trace sink is attached; the record carries everything
-    the Anthropic-compatible endpoint cannot provide: the exact rendered
-    prompt tokens, the sampled token ids, per-token behavior logprobs, the stop
-    reason, prefix-cache usage, and the model/checkpoint identity.
-    """
-
-    model: str
-    base_model: str
-    request_role: Optional[Dict[str, Any]]
-    prompt_tokens: List[int]
-    sampled_tokens: List[int]
-    sampled_text: str
-    logprobs: List[Optional[float]]
-    stop_reason: str
-    termination: str
-    cache_hit_tokens: int
-    temperature: Optional[float]
-    max_tokens: Optional[int]
 
 
 def _require_native_stack() -> None:

--- a/kolega_code/llm/providers/tinker_trace.py
+++ b/kolega_code/llm/providers/tinker_trace.py
@@ -1,0 +1,37 @@
+"""Trace record for native Tinker sampling.
+
+A deliberately dependency-free leaf module: the record is part of the package's
+public export surface (extension authors type their trace sinks against it), so
+it must be importable without pulling in the optional native Tinker stack —
+``providers/tinker.py`` imports tinker-cookbook (and therefore torch) at module
+load whenever the ``[tinker]`` extra is installed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class TinkerTraceRecord:
+    """Structured record of one native Tinker sample, for on-policy RL.
+
+    Emitted only when a trace sink is attached; the record carries everything
+    the Anthropic-compatible endpoint cannot provide: the exact rendered
+    prompt tokens, the sampled token ids, per-token behavior logprobs, the stop
+    reason, prefix-cache usage, and the model/checkpoint identity.
+    """
+
+    model: str
+    base_model: str
+    request_role: Optional[Dict[str, Any]]
+    prompt_tokens: List[int]
+    sampled_tokens: List[int]
+    sampled_text: str
+    logprobs: List[Optional[float]]
+    stop_reason: str
+    termination: str
+    cache_hit_tokens: int
+    temperature: Optional[float]
+    max_tokens: Optional[int]

--- a/tests/cli/test_app_rendering_terminal_logs.py
+++ b/tests/cli/test_app_rendering_terminal_logs.py
@@ -856,3 +856,49 @@ async def test_logs_output_supports_mouse_drag_selection(tmp_path: Path, monkeyp
         selected_text = app.screen.get_selected_text()
         assert selected_text is not None
         assert selected_text.strip() == "select this log text"
+
+
+@pytest.mark.asyncio
+async def test_flush_pacing_stretches_terminal_flush_under_loop_load(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui import pacing
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._flush_pacer.attach(lambda: 60.0)  # saturated loop: pacer sits at the ceiling
+
+        app._queue_terminal_output("paced output\n")
+        assert app._terminal_flush_timer is not None
+        assert app._terminal_flush_timer._interval == pacing.PACING_CEILING
+        await pilot.pause(0.1)
+        # At the healthy cadence this would already have flushed.
+        assert app._terminal_output_buffer == ["paced output\n"]
+
+        app._flush_terminal_output()  # forced drains bypass pacing
+        assert app._terminal_output_buffer == []
+
+
+@pytest.mark.asyncio
+async def test_render_coalesce_interval_composes_paced_and_size_backoff(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui import pacing
+    from kolega_code.cli.tui.state import ConversationEntry
+
+    app = _build_sub_agent_test_app(tmp_path, monkeypatch)
+    async with app.run_test():
+        big_entry = ConversationEntry(kind="assistant", content="x" * (pacing.RENDER_COALESCE_LARGE_CHARS + 1))
+
+        app._flush_pacer.attach(lambda: 0.0)  # healthy loop: the size backoff wins
+        assert app._render_coalesce_interval(big_entry) == pacing.RENDER_COALESCE_INTERVAL_LARGE
+        assert app._render_coalesce_interval(None) == pacing.FLUSH_BASE_INTERVAL
+
+        app._flush_pacer.attach(lambda: 60.0)  # saturated loop: the paced floor wins
+        assert app._render_coalesce_interval(big_entry) == pacing.PACING_CEILING
+        assert app._render_coalesce_interval(None) == pacing.PACING_CEILING

--- a/tests/cli/test_app_rendering_window.py
+++ b/tests/cli/test_app_rendering_window.py
@@ -63,23 +63,26 @@ async def test_transcript_trims_oldest_entries_while_following_bottom(tmp_path: 
 
     async with app.run_test() as pilot:
         await _settle(pilot)
-        # Stage 1: below the cap, everything mounts.
-        _add_entries(app, 250)
+        # Stage 1: at the cap (counting the startup entry), everything mounts.
+        stage_one = WINDOW_MAX - 1
+        _add_entries(app, stage_one)
         app._flush_conversation_render()
         await _settle(pilot)
-        assert len(app._entry_widgets) == 251  # 250 + startup entry
+        assert len(app._entry_widgets) == stage_one + 1
 
         # Stage 2: crossing max + trim chunk trims the oldest back to the cap.
-        _add_entries(app, 200, start=250)
+        stage_two = TRIM_CHUNK + 10
+        total = stage_one + stage_two + 1
+        _add_entries(app, stage_two, start=stage_one)
         app._flush_conversation_render()
         await _settle(pilot)
 
         entries = app.conversation_entries
-        assert len(entries) == 451  # data model keeps everything
+        assert len(entries) == total  # data model keeps everything
         assert len(app._entry_widgets) == WINDOW_MAX
-        assert _window(app).mounted_start == 451 - WINDOW_MAX
+        assert _window(app).mounted_start == total - WINDOW_MAX
         first_mounted = next(iter(app._entry_widgets))
-        assert first_mounted == entries[451 - WINDOW_MAX].entry_id
+        assert first_mounted == entries[total - WINDOW_MAX].entry_id
         assert entries[0].entry_id not in app._entry_widgets
 
 
@@ -89,7 +92,8 @@ async def test_transcript_does_not_trim_while_scrolled_up(tmp_path: Path, monkey
 
     async with app.run_test() as pilot:
         await _settle(pilot)
-        _add_entries(app, 250)
+        stage_one = WINDOW_MAX - 1
+        _add_entries(app, stage_one)
         app._flush_conversation_render()
         await _settle(pilot)
 
@@ -98,12 +102,14 @@ async def test_transcript_does_not_trim_while_scrolled_up(tmp_path: Path, monkey
         await _settle(pilot)
         assert view.auto_follow_bottom is False
 
-        _add_entries(app, 200, start=250)
+        # Append within the burst guard (≤ max_mounted) so sync mounts incrementally.
+        stage_two = WINDOW_MAX - 20
+        _add_entries(app, stage_two, start=stage_one)
         app._flush_conversation_render()
         await _settle(pilot)
 
         # Nothing trimmed: the user is reading history, so the window only grows.
-        assert len(app._entry_widgets) == 451
+        assert len(app._entry_widgets) == stage_one + stage_two + 1
         assert _window(app).mounted_start == 0
 
 

--- a/tests/cli/test_diagnostics.py
+++ b/tests/cli/test_diagnostics.py
@@ -7,6 +7,8 @@ import zipfile
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from kolega_code.cli.diagnostics import (
     SECRET_PLACEHOLDER,
     DiagnosticsLog,
@@ -329,3 +331,38 @@ def test_bundle_preserves_readable_json_formatting(tmp_path: Path):
     assert session.startswith("{\n")
     assert '\n  "a": {' in session  # indented and key-sorted
     assert session.endswith("\n")
+
+
+def test_watchdog_recent_excess_peaks_and_decays(tmp_path: Path):
+    diag = DiagnosticsLog(tmp_path, "sess5b")
+    watchdog = ResponsivenessWatchdog(diag, beat_interval=0.0, histogram_interval=3600.0)
+
+    now = [1000.0]
+    with patch("kolega_code.cli.diagnostics.time.monotonic", lambda: now[0]):
+        watchdog._last_beat = now[0]
+        now[0] += 1.0
+        watchdog.beat()
+        # A single late beat registers at full strength immediately.
+        assert watchdog.recent_excess() == pytest.approx(1.0)
+
+        # The histogram window reset leaves the pacing signal alone.
+        watchdog.flush_histogram("test")
+        assert watchdog.recent_excess() == pytest.approx(1.0)
+
+        # On-time beats decay the peak below the pacing deadband in ~15 beats.
+        for _ in range(15):
+            watchdog.beat()
+        assert watchdog.recent_excess() == pytest.approx(0.85**15)
+        assert watchdog.recent_excess() < 0.1
+
+
+def test_watchdog_recent_excess_never_negative(tmp_path: Path):
+    diag = DiagnosticsLog(tmp_path, "sess5c")
+    watchdog = ResponsivenessWatchdog(diag, beat_interval=0.2, histogram_interval=3600.0)
+
+    now = [1000.0]
+    with patch("kolega_code.cli.diagnostics.time.monotonic", lambda: now[0]):
+        watchdog._last_beat = now[0]
+        now[0] += 0.05  # early-firing timer: excess is negative
+        watchdog.beat()
+        assert watchdog.recent_excess() == 0.0

--- a/tests/cli/test_pacing.py
+++ b/tests/cli/test_pacing.py
@@ -1,0 +1,39 @@
+import pytest
+
+from kolega_code.cli.tui.pacing import (
+    FLUSH_BASE_INTERVAL,
+    PACING_CEILING,
+    PACING_DEADBAND,
+    FlushPacer,
+)
+
+
+def test_unattached_pacer_returns_base_interval() -> None:
+    assert FlushPacer().interval() == FLUSH_BASE_INTERVAL
+
+
+def test_healthy_loop_returns_exactly_base_interval() -> None:
+    assert FlushPacer(lambda: 0.0).interval() == FLUSH_BASE_INTERVAL
+    assert FlushPacer(lambda: PACING_DEADBAND - 0.01).interval() == FLUSH_BASE_INTERVAL
+
+
+def test_interval_scales_with_loop_lateness() -> None:
+    # (1 + excess/normalizer) is the loop's measured slowdown factor.
+    assert FlushPacer(lambda: 0.2).interval() == pytest.approx(0.10)
+    assert FlushPacer(lambda: 1.0).interval() == pytest.approx(0.30)
+
+
+def test_interval_is_capped_at_ceiling() -> None:
+    assert FlushPacer(lambda: 60.0).interval() == PACING_CEILING
+
+
+def test_interval_is_monotonic_in_lateness() -> None:
+    samples = [0.0, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0]
+    intervals = [FlushPacer(lambda value=value: value).interval() for value in samples]
+    assert intervals == sorted(intervals)
+
+
+def test_attach_switches_the_lateness_source() -> None:
+    pacer = FlushPacer()
+    pacer.attach(lambda: 1.0)
+    assert pacer.interval() == pytest.approx(0.30)

--- a/tests/cli/test_terminal_display.py
+++ b/tests/cli/test_terminal_display.py
@@ -262,3 +262,35 @@ def test_terminal_control_filter_does_not_share_state_between_rendered_lines() -
     assert second_text == "l suffix"
     assert "1049" not in repaint_text
     assert repaint_text.endswith(" suffix")
+
+
+def test_terminal_control_filter_returns_clean_lines_unchanged() -> None:
+    control_filter = TerminalControlFilter()
+    segments = [
+        Segment("plain text ", Style(bold=True)),
+        Segment("styled", Style(color="red", link="https://example.com/safe")),
+    ]
+
+    filtered = control_filter.apply(segments, Color.parse("#000000"))
+
+    assert filtered is segments
+
+
+def test_terminal_control_filter_sanitizes_every_segment_of_a_dirty_line() -> None:
+    filtered = _filter_segments(Segment("clean prefix "), Segment("dirty\x1b[31m suffix"))
+
+    joined = "".join(segment.text for segment in filtered)
+    assert "\x1b" not in joined
+    # preserve_width pads the suppressed escape with spaces to keep cell width stable.
+    assert joined == "clean prefix dirty     suffix"
+
+
+def test_terminal_control_filter_parses_escapes_split_across_segments() -> None:
+    # The escape introducer and its parameters land in adjacent styled segments;
+    # the whole line must be parsed as one stream so the parameters are consumed.
+    filtered = _filter_segments(Segment("prefix\x1b", Style(bold=True)), Segment("[31m", Style(color="red")))
+
+    joined = "".join(segment.text for segment in filtered)
+    assert "\x1b" not in joined
+    assert "31m" not in joined
+    assert joined.rstrip() == "prefix"

--- a/tests/test_package_imports.py
+++ b/tests/test_package_imports.py
@@ -1,0 +1,36 @@
+"""Guard the package's import-time footprint.
+
+``import kolega_code`` must never load the optional native Tinker stack:
+``providers/tinker.py`` imports tinker-cookbook (and therefore torch) at module
+load whenever the ``[tinker]`` extra is installed, torch takes ~0.6s to import,
+and torch.package monkey-patches ``inspect.getfile`` process-wide — which taxes
+every Textual widget mount in the TUI. Providers are loaded lazily per session;
+only the dependency-free ``tinker_trace`` leaf module is exported eagerly.
+
+Run in a subprocess so the check is independent of what this test process has
+already imported. In environments without the ``[tinker]`` extra the assertion
+is trivially true; with it installed (the dev venv), this catches any eager
+import creeping back into the package root.
+"""
+
+import subprocess
+import sys
+
+_CHECK = """
+import sys
+import kolega_code
+
+heavy = [name for name in ("torch", "tinker", "tinker_cookbook") if name in sys.modules]
+assert not heavy, f"import kolega_code eagerly loaded: {heavy}"
+assert kolega_code.TinkerTraceRecord is not None
+"""
+
+
+def test_importing_the_package_does_not_load_the_native_tinker_stack() -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", _CHECK],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

Watchdog forensics on a 5h40m session (90 event-loop stalls, ~98s frozen, felt as repeated 2-3s freezes during terminal streaming) traced long-session UI hangs to four compounding costs. One commit each:

1. **Shrink the transcript scrollback window** — steady state drops from 300-400 mounted entries (~2k widgets, every layout pass O(mounted)) to 120-160. Scroll-up expansion still reaches the full history.
2. **Fast-path clean lines through `TerminalControlFilter`** — the app-wide line filter ran a fresh per-character parser on every rendered strip (~45µs/line). A compiled C0/C1 regex scan now returns control-free lines untouched (~1.8µs, 25x). Dirty lines take the existing parser path byte-identically.
3. **Unify flush cadences + load-adaptive pacing** — the terminal (25Hz), log (20Hz), and transcript (20Hz) timers collapse into one base cadence in `tui/pacing.py`, armed through a shared `FlushPacer` that stretches the interval by the watchdog's new `recent_excess()` beat-lateness signal (decaying peak-hold). A healthy loop keeps today's cadence exactly; a loop running 1s late drops to ~3Hz with a 0.5s ceiling. Load now degrades to a lower frame rate instead of a frozen loop; content is batched, never dropped.
4. **Stop importing the native Tinker stack at package import** — `kolega_code/__init__.py` held the only eager provider import; with the `[tinker]` extra installed it pulled torch on every launch (1.9s → 0.7s measured) and torch.package's process-wide `inspect.getfile` patch taxed every widget mount. `TinkerTraceRecord` moves to a dependency-free leaf module, with a subprocess regression test.

## Testing

- Full suite: 4476 passed; 3 live-tinker API tests flaked under parallelism and pass in isolation.
- New tests: filter fast-path/split-escape behavior, `FlushPacer` mapping, watchdog `recent_excess` peak/decay/histogram-independence, pacing integration (timer interval + coalesce composition), package import-footprint guard.
- End-to-end tmux drive of the branch build: boot, 300-line exec_command stream, correct answer, clean diagnostics (0 stalls).
- Long-session proof is deferred to real use: the watchdog jsonl of the next multi-hour session should show stall counts far below the 90 baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdErkHaxMf7GjTxnkmmcyS