### PR TITLE
feat: journal schema v2 with agent lineage + public semantic event protocol

### DIFF
--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -340,6 +340,8 @@ class BaseAgent(LogMixin):
         self.sub_agent_recorder = context.telemetry.sub_agent_recorder
         self.usage_ledger = context.telemetry.usage_ledger
         self.llm_trace_sink = context.telemetry.llm_trace_sink
+        # Subagents start unrecorded; AgentTool assigns a scoped child recorder
+        # post-construction when the parent session is being recorded.
         self.session_recorder = None if sub_agent else session_recorder
         self.custom_agent_catalog = custom_agent_catalog
         self.memory_manager = context.services.memory_manager
@@ -579,6 +581,15 @@ class BaseAgent(LogMixin):
                 Message(role="user", content=[TextBlock(text=text)]),
             )
         self.append_user_message([TextBlock(text=text)])
+
+    async def _record_synthetic_notice(self, text: str, notice_code: str) -> None:
+        """Journal a deterministic assistant notice that never enters history."""
+        if self.session_recorder is not None:
+            await asyncio.to_thread(
+                self.session_recorder.record_synthetic_assistant,
+                text,
+                notice_code=notice_code,
+            )
 
     def extend_history(self, messages: List[Message]) -> None:
         """
@@ -1126,12 +1137,16 @@ class BaseAgent(LogMixin):
             message=message,
         )
 
-    async def compress_history(self) -> CompactionResult:
+    async def compress_history(
+        self, *, trigger: str = "manual", tokens_before: Optional[int] = None
+    ) -> CompactionResult:
         """
         Non-destructively summarize the current history, keeping recent turns
         verbatim. Emits a compaction_status event around the work so the UI can
         show progress, then recounts + emits a context_update so the gauge
         refreshes. Returns the structured outcome.
+
+        ``trigger``/``tokens_before`` are journaled as compaction provenance.
         """
         # Compacted-away web_search_call blocks stop being replayed, so the
         # server stops restoring their content. Reset the hosted-search residual
@@ -1180,7 +1195,16 @@ class BaseAgent(LogMixin):
                 # the manual /compact command gets the same re-injection as auto-compaction.
                 self._volatile_context.forget()
                 if self.session_recorder is not None:
-                    await asyncio.to_thread(self.session_recorder.record_compaction, self.dump_compaction_state())
+                    await asyncio.to_thread(
+                        self.session_recorder.record_compaction,
+                        self.dump_compaction_state(),
+                        info={
+                            "trigger": trigger,
+                            "reason": result.reason,
+                            "summarized_messages": result.summarized_messages,
+                            "input_tokens_before": tokens_before,
+                        },
+                    )
         finally:
             # Recount + emit so the context gauge reflects post-compaction reality
             # (even on a no-op the UI may have been stale).
@@ -1611,6 +1635,18 @@ class BaseAgent(LogMixin):
         them and no response is ever journaled twice.
         """
         if self.session_recorder is not None:
+            if self.sub_agent:
+                # Scoped subagent recording journals these responses too; keep
+                # the history dedup rule but preserve the agent lineage for
+                # failure attribution and usage breakdowns.
+                stamp = self.session_recorder.agent_stamp
+                return LlmCallOrigin(
+                    kind="history",
+                    agent_name=stamp.agent_name,
+                    agent_id=stamp.agent_id,
+                    parent_tool_call_id=stamp.parent_tool_call_id,
+                    depth=stamp.depth,
+                )
             return HISTORY_ORIGIN
         if self.sub_agent:
             context = getattr(self, "sub_agent_context", None) or {}
@@ -2145,6 +2181,7 @@ class BaseAgent(LogMixin):
 
         unsupported_attachment_message = self._unsupported_attachment_message(attachments)
         if unsupported_attachment_message:
+            await self._record_synthetic_notice(unsupported_attachment_message, "unsupported_attachment")
             yield {
                 "type": "response",
                 "content": unsupported_attachment_message,
@@ -2161,6 +2198,7 @@ class BaseAgent(LogMixin):
             submit = await self.fire_hook(HookEvent.USER_PROMPT_SUBMIT, {"user_message": message})
             if submit.blocked or submit.end_turn:
                 reason = submit.reason or "A hook blocked this prompt."
+                await self._record_synthetic_notice(reason, "hook_blocked")
                 yield {"type": "response", "content": reason, "complete": True, "uuid": str(uuid.uuid4())}
                 return
             if submit.additional_context:
@@ -2170,6 +2208,12 @@ class BaseAgent(LogMixin):
             await asyncio.to_thread(
                 self.session_recorder.start_turn,
                 Message(role="user", content=content_blocks),
+            )
+            # Journal the rendered provider-facing system context; deduplicated
+            # by fingerprint inside the recorder so only changes are recorded.
+            await asyncio.to_thread(
+                self.session_recorder.record_system_context,
+                self.system_prompt.get_text_content(),
             )
 
         self.append_user_message(content_blocks)
@@ -2229,7 +2273,7 @@ class BaseAgent(LogMixin):
                             "model_context_length": self.model_context_length,
                         },
                     )
-                    result = await self.compress_history()
+                    result = await self.compress_history(trigger="auto", tokens_before=before_tokens)
                     # compress_history forgets the volatile-context sent-state on success,
                     # so the next turn re-sends memory, guidance, and any host sections
                     # (plan handle, task list) the summary may have folded away.
@@ -2409,7 +2453,11 @@ class BaseAgent(LogMixin):
                     )
 
                 if self.session_recorder is not None:
-                    await asyncio.to_thread(self.session_recorder.record_assistant, assistant_message)
+                    await asyncio.to_thread(
+                        self.session_recorder.record_assistant,
+                        assistant_message,
+                        reasoning_effort=self.primary_model_config.thinking_effort,
+                    )
                 self.append_assistant_message(assistant_message)
                 # A clean stream resets the transient-failure budget, so the cap measures
                 # only consecutive failures, not lifetime failures across the turn.
@@ -2449,6 +2497,7 @@ class BaseAgent(LogMixin):
                                 content=f"Failed to process tool calls: {str(ex)}",
                                 name=tool_call.name,
                                 is_error=True,
+                                execution_id=tool_call.execution_id,
                                 input_kind=tool_call.input_kind,
                             )
                             for tool_call in assistant_message.tool_calls
@@ -2507,13 +2556,15 @@ class BaseAgent(LogMixin):
                             "Model returned no output after repeated reminders — ending the turn with no result.",
                         )
                         await self._record_context_user_message(SILENT_TURN_EXHAUSTED_NOTICE)
+                        silent_exhausted_text = (
+                            "[no output] The model ended its turn with no tool call and no visible "
+                            f"message {self.MAX_SILENT_TURN_NUDGES + 1} times in a row despite "
+                            "reminders. The turn was terminated without a result."
+                        )
+                        await self._record_synthetic_notice(silent_exhausted_text, "silent_turn_exhausted")
                         yield {
                             "type": "response",
-                            "content": (
-                                "[no output] The model ended its turn with no tool call and no visible "
-                                f"message {self.MAX_SILENT_TURN_NUDGES + 1} times in a row despite "
-                                "reminders. The turn was terminated without a result."
-                            ),
+                            "content": silent_exhausted_text,
                             "complete": True,
                             "uuid": str(uuid.uuid4()),
                         }

--- a/kolega_code/agent/tool_backend/agent_tool.py
+++ b/kolega_code/agent/tool_backend/agent_tool.py
@@ -1,3 +1,4 @@
+import asyncio
 import uuid
 import inspect
 import json
@@ -319,6 +320,8 @@ class AgentTool(BaseTool):
         await self._send_status_event("GENERATING", f"Starting {agent_name} task", sub_agent_info=sub_agent_info)
         conversation_finished = False
         agent = None
+        scoped_recorder = None
+        agent_terminal_recorded = False
 
         try:
             # Create the agent instance
@@ -381,6 +384,19 @@ class AgentTool(BaseTool):
             if workflow_accounting is not None:
                 agent._workflow_accounting = workflow_accounting
                 agent._accounting_reservation = reservation
+
+            scoped_recorder = await asyncio.to_thread(
+                self._scoped_session_recorder,
+                agent_id=agent_id,
+                agent_name=agent_name,
+                class_name=class_name,
+                task=task,
+                tool_call_id=tool_call_id,
+                conversation_id=conversation_id,
+                sub_agent_info=sub_agent_info,
+            )
+            if scoped_recorder is not None:
+                agent.session_recorder = scoped_recorder
 
             # Track messages and their sequence
             last_saved_index = -1  # Track what we've already saved
@@ -469,6 +485,20 @@ class AgentTool(BaseTool):
             # SubagentStop is deferred; the per-agent Stop hook covers keep-working.)
             result = await self._apply_subagent_stop_hooks(agent_name, result, sub_agent_info)
 
+            if scoped_recorder is not None:
+                completed_tokens = getattr(agent, "total_tokens_used", None)
+                await asyncio.to_thread(
+                    scoped_recorder.record_agent_terminal,
+                    "completed",
+                    {
+                        "summary": str(result)[:2000],
+                        "message_count": len(final_history),
+                        "execution_time_seconds": time.time() - start_time,
+                        "total_tokens": completed_tokens if isinstance(completed_tokens, int) else None,
+                    },
+                )
+                agent_terminal_recorded = True
+
             # Update conversation with completion status
             if conversation_id:
                 execution_time = time.time() - start_time
@@ -499,6 +529,15 @@ class AgentTool(BaseTool):
             return result
 
         except Exception as e:
+            if scoped_recorder is not None and not agent_terminal_recorded:
+                try:
+                    scoped_recorder.record_agent_terminal(
+                        "failed",
+                        {"error": str(e)[:2000], "execution_time_seconds": time.time() - start_time},
+                    )
+                    agent_terminal_recorded = True
+                except Exception:  # noqa: BLE001 - journaling must not mask the dispatch failure
+                    pass
             # Update conversation with error status
             if conversation_id:
                 execution_time = time.time() - start_time
@@ -519,6 +558,16 @@ class AgentTool(BaseTool):
             raise
 
         finally:
+            if scoped_recorder is not None and not agent_terminal_recorded:
+                try:
+                    # Synchronous on purpose: an await here can be re-cancelled
+                    # while the CancelledError is already propagating.
+                    scoped_recorder.record_agent_terminal(
+                        "failed",
+                        {"error_code": "interrupted", "execution_time_seconds": time.time() - start_time},
+                    )
+                except Exception:  # noqa: BLE001 - never mask the primary outcome
+                    pass
             if reservation is not None:
                 total_tokens = getattr(agent, "total_tokens_used", None)
                 reservation.report_total(total_tokens if type(total_tokens) is int else None)
@@ -934,6 +983,44 @@ class AgentTool(BaseTool):
                 lines.append(self._render_workflow_message(message))
         path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
 
+    def _scoped_session_recorder(
+        self,
+        *,
+        agent_id: str,
+        agent_name: str,
+        class_name: str,
+        task: str,
+        tool_call_id: Optional[str],
+        conversation_id: Optional[str],
+        sub_agent_info: dict,
+    ):
+        """Create the subagent's scoped session recorder and journal ``agent.started``.
+
+        Returns None when the parent session is not being recorded. Synchronous
+        (one journal append) — call via ``asyncio.to_thread``.
+        """
+        parent_recorder = getattr(self.caller, "session_recorder", None) if self.caller else None
+        if parent_recorder is None:
+            return None
+        scoped = parent_recorder.scoped_child(
+            agent_id=agent_id,
+            agent_name=agent_name,
+            parent_tool_call_id=tool_call_id,
+            depth=sub_agent_info["depth"],
+        )
+        scoped.record_agent_started(
+            {
+                "agent_name": agent_name,
+                "class_name": class_name,
+                "task": task,
+                "requested_routing": sub_agent_info.get("requested_routing"),
+                "effective_routing": sub_agent_info.get("effective_routing"),
+                "conversation_id": conversation_id,
+            },
+            turn_id=parent_recorder.current_turn_id,
+        )
+        return scoped
+
     async def dispatch_workflow_agent(
         self,
         agent_class,
@@ -1009,6 +1096,8 @@ class AgentTool(BaseTool):
         await self._send_status_event("GENERATING", f"Starting {agent_name} task", sub_agent_info=sub_agent_info)
         conversation_finished = False
         agent = None
+        scoped_recorder = None
+        agent_terminal_recorded = False
 
         try:
             agent = self._construct_workflow_sub_agent(
@@ -1053,6 +1142,17 @@ class AgentTool(BaseTool):
             result = await self._apply_subagent_stop_hooks(agent_name, result, sub_agent_info)
 
             total_tokens = getattr(agent, "total_tokens_used", None)
+            if scoped_recorder is not None:
+                await asyncio.to_thread(
+                    scoped_recorder.record_agent_terminal,
+                    "completed",
+                    {
+                        "summary": str(result)[:2000],
+                        "execution_time_seconds": time.time() - start_time,
+                        "total_tokens": total_tokens if isinstance(total_tokens, int) else None,
+                    },
+                )
+                agent_terminal_recorded = True
             if conversation_id:
                 await self._complete_conversation(
                     conversation_id,
@@ -1090,6 +1190,15 @@ class AgentTool(BaseTool):
             return result, (total_tokens if isinstance(total_tokens, int) else 0), structured
 
         except Exception as e:
+            if scoped_recorder is not None and not agent_terminal_recorded:
+                try:
+                    scoped_recorder.record_agent_terminal(
+                        "failed",
+                        {"error": str(e)[:2000], "execution_time_seconds": time.time() - start_time},
+                    )
+                    agent_terminal_recorded = True
+                except Exception:  # noqa: BLE001 - journaling must not mask the dispatch failure
+                    pass
             failed_tokens = getattr(agent, "total_tokens_used", None)
             reservation.report_total(failed_tokens if type(failed_tokens) is int else None)
             if conversation_id:
@@ -1123,6 +1232,16 @@ class AgentTool(BaseTool):
             raise
 
         finally:
+            if scoped_recorder is not None and not agent_terminal_recorded:
+                try:
+                    # Synchronous on purpose: an await here can be re-cancelled
+                    # while the CancelledError is already propagating.
+                    scoped_recorder.record_agent_terminal(
+                        "failed",
+                        {"error_code": "interrupted", "execution_time_seconds": time.time() - start_time},
+                    )
+                except Exception:  # noqa: BLE001 - never mask the primary outcome
+                    pass
             total_tokens = getattr(agent, "total_tokens_used", None)
             reservation.report_total(total_tokens if type(total_tokens) is int else None)
             if conversation_id and not conversation_finished:

--- a/kolega_code/cli/session_event_protocol.py
+++ b/kolega_code/cli/session_event_protocol.py
@@ -1,0 +1,295 @@
+"""Public semantic session-event protocol (v2).
+
+One projection serves every public surface: the live ``ask --json`` stream, the
+``sessions export --format events-jsonl`` output, and the ATIF converter all
+consume ``to_public_event``. The journal remains the single assigner of event
+identity (id/seq/timestamp); this module only removes replay-private state and
+serializes.
+
+The public/private split is allowlist-shaped where it matters: artifact
+references leave this module only for the shareable purposes (tool results,
+images) and never carry local filesystem paths. Opaque provider fields
+(signatures, encrypted reasoning) are structurally removed from message
+payloads, matching what the TUI shows users. Configured secret values and the
+machine's home directory are scrubbed from every string leaf.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import threading
+from pathlib import Path
+from typing import IO, Any, Iterable, Optional, Sequence
+
+from kolega_code.cli.session_journal import (
+    DEFAULT_ROOT_AGENT_NAME,
+    PUBLIC_EVENT_SCHEMA,
+    SessionEvent,
+    SessionJournal,
+    SessionJournalError,
+    derive_root_agent_id,
+)
+from kolega_code.security import redact_secrets_in_obj
+from kolega_code.web.redaction import scrub_home_paths
+
+PUBLIC_EVENT_VERSION = 2
+UI_EVENT_PREFIX = "ui."
+
+#: The only artifact purposes permitted in public output (kolega_code.events.ArtifactPurpose.SHAREABLE).
+SHAREABLE_ARTIFACT_PURPOSES = frozenset({"tool_result", "image"})
+
+#: Public artifact-reference keys; local ``path`` is deliberately absent.
+_PUBLIC_ARTIFACT_KEYS = ("sha256", "bytes", "media_type", "purpose", "encoding", "chars")
+
+# Content-block state that exists purely to be replayed to the provider.
+OPAQUE_BLOCK_TYPES = {"redacted_thinking"}
+OPAQUE_BLOCK_FIELDS = {
+    "thinking": ("signature",),
+    "tool_call": ("thought_signature",),
+    "responses_reasoning": ("encrypted_content", "item_id"),
+}
+
+SYNTHETIC_ORIGIN = "synthetic"
+LLM_ORIGIN = "llm"
+
+#: Event payload keys whose value is a prepared Message dict.
+_MESSAGE_BEARING_TYPES = {
+    "turn.started",
+    "assistant.message",
+    "tool.results",
+    "context.message",
+    "context.system",
+    "llm.message",
+}
+
+
+def public_artifact_ref(ref: dict[str, Any]) -> dict[str, Any]:
+    """Portable artifact reference: content address and metadata, no local path."""
+    return {key: ref[key] for key in _PUBLIC_ARTIFACT_KEYS if key in ref}
+
+
+def public_tool_call(block: dict[str, Any]) -> dict[str, Any]:
+    """Public shape for one tool call: canonical id first, provider id retained.
+
+    ``arguments`` is always a JSON object usable for ATIF conversion; the
+    original ``input``/``input_kind`` are kept so free-form input is lossless.
+    """
+    input_kind = str(block.get("input_kind") or "json")
+    original = block.get("input")
+    if input_kind == "freeform" or not isinstance(original, dict):
+        arguments: dict[str, Any] = {"input": original if isinstance(original, str) else str(original)}
+    else:
+        arguments = original
+    return {
+        "type": "tool_call",
+        "tool_call_id": block.get("execution_id") or block.get("id"),
+        "provider_call_id": block.get("id"),
+        "name": block.get("name"),
+        "input_kind": input_kind,
+        "input": original,
+        "arguments": arguments,
+    }
+
+
+def public_tool_result(block: dict[str, Any]) -> dict[str, Any]:
+    """Public shape for one tool result, correlated by the same canonical id.
+
+    v1 records may lack ``execution_id``; the provider ``tool_use_id`` is the
+    documented fallback so a result always pairs with its call.
+    """
+    result: dict[str, Any] = {
+        "type": "tool_result",
+        "tool_call_id": block.get("execution_id") or block.get("tool_use_id"),
+        "provider_call_id": block.get("tool_use_id"),
+        "name": block.get("name"),
+        "is_error": bool(block.get("is_error")),
+        "input_kind": block.get("input_kind", "json"),
+        "content": block.get("content"),
+    }
+    artifact = block.get("content_artifact")
+    if isinstance(artifact, dict):
+        result["content_artifact"] = public_artifact_ref(artifact)
+    return result
+
+
+def _public_blocks(blocks: list[Any]) -> list[Any]:
+    cleaned: list[Any] = []
+    for block in blocks:
+        if not isinstance(block, dict):
+            cleaned.append(block)
+            continue
+        block_type = block.get("type")
+        if block_type in OPAQUE_BLOCK_TYPES:
+            continue
+        if block_type == "responses_reasoning" and not block.get("content"):
+            # Encrypted-only reasoning (OpenAI/ChatGPT backends): nothing
+            # readable remains once the opaque blob is stripped. DeepSeek
+            # flash blocks carry readable text in `content` and are kept.
+            continue
+        if block_type == "tool_call":
+            cleaned.append(public_tool_call(block))
+            continue
+        if block_type == "tool_result":
+            public = public_tool_result(block)
+            if isinstance(public.get("content"), list):
+                public["content"] = _public_blocks(public["content"])
+            cleaned.append(public)
+            continue
+        block = dict(block)
+        for field in OPAQUE_BLOCK_FIELDS.get(block_type or "", ()):
+            block.pop(field, None)
+        artifact_fields = block.pop("artifact_fields", None)
+        if isinstance(artifact_fields, dict):
+            for field, ref in artifact_fields.items():
+                if isinstance(ref, dict) and ref.get("purpose") in SHAREABLE_ARTIFACT_PURPOSES:
+                    block[f"{field}_artifact"] = public_artifact_ref(ref)
+        cleaned.append(block)
+    return cleaned
+
+
+def _public_message(message: dict[str, Any]) -> dict[str, Any]:
+    public = dict(message)
+    public.pop("usage_metadata", None)  # internal provider-shaped dict; `usage` is the contract
+    content = public.get("content")
+    if isinstance(content, list):
+        public["content"] = _public_blocks(content)
+    return public
+
+
+def _scrub_home_in_obj(obj: Any) -> Any:
+    if isinstance(obj, str):
+        return scrub_home_paths(obj)
+    if isinstance(obj, list):
+        return [_scrub_home_in_obj(item) for item in obj]
+    if isinstance(obj, dict):
+        return {key: _scrub_home_in_obj(value) for key, value in obj.items()}
+    return obj
+
+
+def to_public_event(event: SessionEvent, *, secret_values: Sequence[str] = ()) -> Optional[dict[str, Any]]:
+    """Project one journal event to its public form, or None for `ui.*` events."""
+    if event.event_type.startswith(UI_EVENT_PREFIX):
+        return None
+    payload = dict(event.payload)
+    if event.event_type in _MESSAGE_BEARING_TYPES and isinstance(payload.get("message"), dict):
+        payload["message"] = _public_message(payload["message"])
+    payload = redact_secrets_in_obj(payload, list(secret_values), include_environment=True)
+    payload = _scrub_home_in_obj(payload)
+    return {
+        "schema": PUBLIC_EVENT_SCHEMA,
+        "version": PUBLIC_EVENT_VERSION,
+        "id": event.event_id,
+        "session_id": event.session_id,
+        "seq": event.seq,
+        "epoch_id": event.epoch_id,
+        "turn_id": event.turn_id,
+        "timestamp": event.timestamp,
+        "actor": event.actor,
+        "agent_id": event.agent_id or derive_root_agent_id(event.session_id),
+        "agent_name": event.agent_name or DEFAULT_ROOT_AGENT_NAME,
+        "parent_agent_id": event.parent_agent_id,
+        "parent_tool_call_id": event.parent_tool_call_id,
+        "depth": event.depth if event.depth is not None else 0,
+        "type": event.event_type,
+        "payload": payload,
+        "artifacts": [
+            public_artifact_ref(ref)
+            for ref in event.artifacts
+            if isinstance(ref, dict) and ref.get("purpose") in SHAREABLE_ARTIFACT_PURPOSES
+        ],
+    }
+
+
+class SemanticStdoutPrinter:
+    """Journal listener that streams public events as JSON lines.
+
+    Registered via ``SessionJournal.add_listener``, so it receives the exact
+    persisted event objects: a live line and the saved record share id, seq,
+    and timestamp by construction. The only writer of protocol lines.
+    """
+
+    def __init__(self, *, secret_values: Sequence[str] = (), stream: Optional[IO[str]] = None) -> None:
+        self._secret_values = list(secret_values)
+        self._stream = stream if stream is not None else sys.stdout
+        self._lock = threading.Lock()
+        self._emitted_ids: set[str] = set()
+        self.emitted_total = 0
+
+    def __call__(self, event: SessionEvent) -> None:
+        record = to_public_event(event, secret_values=self._secret_values)
+        if record is None:
+            return
+        line = json.dumps(record, separators=(",", ":"), ensure_ascii=False, default=str)
+        with self._lock:
+            if event.event_id in self._emitted_ids:
+                return
+            self._emitted_ids.add(event.event_id)
+            self._stream.write(line + "\n")
+            self._stream.flush()
+            self.emitted_total += 1
+
+    def emit_backlog(self, events: Iterable[SessionEvent]) -> None:
+        """Print events persisted before this printer was registered (e.g. the
+        session bootstrap records of a session created by this invocation)."""
+        for event in events:
+            self(event)
+
+
+class InMemorySessionJournal(SessionJournal):
+    """Journal for unsaved runs: same id/seq/schema rules, nothing on disk.
+
+    Creates no directories and never appears in ``sessions list``. Artifacts
+    live in memory keyed by content hash; their references carry no ``path``.
+    """
+
+    def __init__(self, session_id: str) -> None:
+        super().__init__(session_id, Path("<in-memory>") / session_id)
+        self._records: list[SessionEvent] = []
+        self._artifact_data: dict[str, bytes] = {}
+
+    def _write_event_locked(self, event: SessionEvent) -> None:
+        self._records.append(event)
+
+    def _read_events_locked(self, *, repair_tail: bool) -> list[SessionEvent]:
+        return list(self._records)
+
+    def raw_events(self) -> str:
+        with self._lock:
+            return "".join(
+                json.dumps(event.to_dict(), separators=(",", ":"), ensure_ascii=False) + "\n" for event in self._records
+            )
+
+    def put_artifact(
+        self,
+        data: bytes,
+        *,
+        media_type: str,
+        purpose: str,
+        encoding: str,
+        chars: Optional[int] = None,
+    ) -> dict[str, Any]:
+        digest = hashlib.sha256(data).hexdigest()
+        with self._lock:
+            self._artifact_data[digest] = data
+        ref: dict[str, Any] = {
+            "sha256": digest,
+            "bytes": len(data),
+            "media_type": media_type,
+            "purpose": purpose,
+            "encoding": encoding,
+        }
+        if chars is not None:
+            ref["chars"] = chars
+        return ref
+
+    def read_artifact(self, ref: dict[str, Any]) -> bytes:
+        digest = str(ref.get("sha256") or "")
+        with self._lock:
+            data = self._artifact_data.get(digest)
+        if data is None:
+            raise SessionJournalError(f"Missing session artifact: {digest}")
+        if hashlib.sha256(data).hexdigest() != digest:
+            raise SessionJournalError(f"Session artifact failed integrity check: {digest}")
+        return data

--- a/kolega_code/cli/session_journal.py
+++ b/kolega_code/cli/session_journal.py
@@ -6,20 +6,44 @@ import base64
 import copy
 import hashlib
 import json
+import logging
 import os
 import threading
 import uuid
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable, Optional, cast
+from typing import Any, Callable, Iterable, Optional, cast
 
 from kolega_code.llm.models import ContentBlock, Message, ToolResult
 from kolega_code.local_state import ensure_private_dir, ensure_private_file, write_private_bytes
 
-EVENT_SCHEMA_VERSION = 1
+logger = logging.getLogger(__name__)
+
+EVENT_SCHEMA_VERSION = 2
+SUPPORTED_EVENT_VERSIONS = frozenset({1, 2})
+PUBLIC_EVENT_SCHEMA = "kolega.session.event"
+DEFAULT_ROOT_AGENT_NAME = "main"
 TOOL_RESULT_PREVIEW_CHARS = 100_000
 TERMINAL_TURN_EVENTS = {"turn.completed", "turn.failed", "turn.cancelled"}
+
+_AGENT_ID_NAMESPACE = uuid.UUID("6f9c4d47-1a52-4ef1-9c11-7f1b8f7a3a9e")
+
+
+def derive_root_agent_id(session_id: str) -> str:
+    """Stable root-agent identity, shared with v1 export fallbacks."""
+    return str(uuid.uuid5(_AGENT_ID_NAMESPACE, f"{session_id}:root"))
+
+
+@dataclass(frozen=True)
+class AgentStamp:
+    """Agent lineage stamped on every v2 session event."""
+
+    agent_id: str
+    agent_name: str
+    parent_agent_id: Optional[str]
+    parent_tool_call_id: Optional[str]
+    depth: int
 
 
 class SessionJournalError(RuntimeError):
@@ -45,9 +69,14 @@ class SessionEvent:
     event_type: str
     payload: dict[str, Any]
     artifacts: list[dict[str, Any]]
+    agent_id: Optional[str] = None
+    agent_name: Optional[str] = None
+    parent_agent_id: Optional[str] = None
+    parent_tool_call_id: Optional[str] = None
+    depth: Optional[int] = None
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        data: dict[str, Any] = {
             "version": self.version,
             "id": self.event_id,
             "session_id": self.session_id,
@@ -60,6 +89,14 @@ class SessionEvent:
             "payload": self.payload,
             "artifacts": self.artifacts,
         }
+        if self.version >= 2:
+            data["schema"] = PUBLIC_EVENT_SCHEMA
+            data["agent_id"] = self.agent_id
+            data["agent_name"] = self.agent_name
+            data["parent_agent_id"] = self.parent_agent_id
+            data["parent_tool_call_id"] = self.parent_tool_call_id
+            data["depth"] = self.depth
+        return data
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "SessionEvent":
@@ -77,8 +114,9 @@ class SessionEvent:
         missing = required.difference(data)
         if missing:
             raise SessionJournalError(f"Session event is missing fields: {', '.join(sorted(missing))}")
-        if data["version"] != EVENT_SCHEMA_VERSION:
-            raise SessionJournalError(f"Unsupported session event version: {data['version']}")
+        version = data["version"]
+        if version not in SUPPORTED_EVENT_VERSIONS:
+            raise SessionJournalError(f"Unsupported session event version: {version}")
         if not isinstance(data["seq"], int) or data["seq"] < 1:
             raise SessionJournalError("Session event sequence must be a positive integer")
         if not isinstance(data["payload"], dict):
@@ -89,8 +127,28 @@ class SessionEvent:
         for field in ("id", "session_id", "epoch_id", "timestamp", "actor", "type"):
             if not isinstance(data[field], str) or not data[field]:
                 raise SessionJournalError(f"Session event field {field} must be a non-empty string")
+        agent_id: Optional[str] = None
+        agent_name: Optional[str] = None
+        parent_agent_id: Optional[str] = None
+        parent_tool_call_id: Optional[str] = None
+        depth: Optional[int] = None
+        if version >= 2:
+            for field in ("agent_id", "agent_name"):
+                if not isinstance(data.get(field), str) or not data[field]:
+                    raise SessionJournalError(f"Session event field {field} must be a non-empty string")
+            depth = data.get("depth")
+            if not isinstance(depth, int) or depth < 0:
+                raise SessionJournalError("Session event depth must be a non-negative integer")
+            for field in ("parent_agent_id", "parent_tool_call_id"):
+                value = data.get(field)
+                if value is not None and (not isinstance(value, str) or not value):
+                    raise SessionJournalError(f"Session event field {field} must be null or a non-empty string")
+            agent_id = str(data["agent_id"])
+            agent_name = str(data["agent_name"])
+            parent_agent_id = data.get("parent_agent_id")
+            parent_tool_call_id = data.get("parent_tool_call_id")
         return cls(
-            version=data["version"],
+            version=version,
             event_id=str(data["id"]),
             session_id=str(data["session_id"]),
             seq=data["seq"],
@@ -101,6 +159,11 @@ class SessionEvent:
             event_type=str(data["type"]),
             payload=data["payload"],
             artifacts=artifacts,
+            agent_id=agent_id,
+            agent_name=agent_name,
+            parent_agent_id=parent_agent_id,
+            parent_tool_call_id=parent_tool_call_id,
+            depth=depth,
         )
 
 
@@ -128,6 +191,10 @@ def collect_epoch_turns(events: Iterable[SessionEvent], epoch_id: str) -> list[T
     turns: list[TurnSummary] = []
     for event in events:
         if event.epoch_id != epoch_id:
+            continue
+        if event.depth:
+            # Subagent turns live in the same journal but are never part of the
+            # root agent's rewindable history.
             continue
         if event.event_type == "turn.started":
             turns.append(
@@ -185,6 +252,28 @@ class SessionJournal:
         self._loaded = False
         self._next_seq = 1
         self._epoch_id: Optional[str] = None
+        self._root_stamp = AgentStamp(
+            agent_id=derive_root_agent_id(session_id),
+            agent_name=DEFAULT_ROOT_AGENT_NAME,
+            parent_agent_id=None,
+            parent_tool_call_id=None,
+            depth=0,
+        )
+        self._listeners: list[Callable[[SessionEvent], None]] = []
+
+    @property
+    def root_stamp(self) -> AgentStamp:
+        return self._root_stamp
+
+    def add_listener(self, listener: Callable[[SessionEvent], None]) -> None:
+        """Tee every successfully appended event to ``listener``.
+
+        Listeners receive the exact persisted ``SessionEvent`` object, so a live
+        consumer and the saved record share id, seq, and timestamp. Listener
+        failures are logged and never fail the append.
+        """
+        with self._lock:
+            self._listeners.append(listener)
 
     @property
     def epoch_id(self) -> str:
@@ -216,12 +305,14 @@ class SessionJournal:
         turn_id: Optional[str] = None,
         epoch_id: Optional[str] = None,
         artifacts: Optional[list[dict[str, Any]]] = None,
+        agent: Optional[AgentStamp] = None,
     ) -> SessionEvent:
         with self._lock:
             self._ensure_loaded_locked()
             resolved_epoch = epoch_id or self._epoch_id
             if not resolved_epoch:
                 raise SessionJournalError("An epoch id is required for every session event")
+            stamp = agent or self._root_stamp
             event = SessionEvent(
                 version=EVENT_SCHEMA_VERSION,
                 event_id=str(uuid.uuid4()),
@@ -234,11 +325,21 @@ class SessionJournal:
                 event_type=event_type,
                 payload=payload or {},
                 artifacts=artifacts or [],
+                agent_id=stamp.agent_id,
+                agent_name=stamp.agent_name,
+                parent_agent_id=stamp.parent_agent_id,
+                parent_tool_call_id=stamp.parent_tool_call_id,
+                depth=stamp.depth,
             )
             self._write_event_locked(event)
             self._next_seq += 1
             if event_type == "context.epoch_started":
                 self._epoch_id = resolved_epoch
+            for listener in self._listeners:
+                try:
+                    listener(event)
+                except Exception:
+                    logger.exception("Session event listener failed for %s", event_type)
             return event
 
     def _write_event_locked(self, event: SessionEvent) -> None:
@@ -495,14 +596,78 @@ class SessionJournal:
 
 
 class SessionRecorder:
-    """Semantic turn recorder used by the top-level agent."""
+    """Semantic recorder for one agent's events in a shared session journal.
 
-    def __init__(self, journal: SessionJournal, *, recover: bool = True) -> None:
+    The top-level agent uses a recorder carrying the journal's root stamp;
+    subagents record through ``scoped_child`` recorders whose stamp carries
+    their lineage. All recorders append to the same journal and share its
+    session-wide sequence.
+    """
+
+    def __init__(
+        self,
+        journal: SessionJournal,
+        *,
+        recover: bool = True,
+        agent_stamp: Optional[AgentStamp] = None,
+    ) -> None:
         self.journal = journal
         self._lock = threading.RLock()
         self.current_turn_id: Optional[str] = None
+        self._agent_stamp = agent_stamp
+        self._last_system_fingerprint: Optional[str] = None
+        self._turn_started_at: Optional[str] = None
+        self._assistant_count = 0
+        self._tool_batches = 0
+        self._run_terminal_recorded = False
         if recover:
             self.recover_interrupted_turn()
+
+    @property
+    def agent_stamp(self) -> AgentStamp:
+        return self._agent_stamp or self.journal.root_stamp
+
+    def scoped_child(
+        self,
+        *,
+        agent_id: str,
+        agent_name: str,
+        parent_tool_call_id: Optional[str],
+        depth: int,
+    ) -> "SessionRecorder":
+        """A recorder for one subagent, stamping its lineage on every event."""
+        stamp = AgentStamp(
+            agent_id=agent_id,
+            agent_name=agent_name,
+            parent_agent_id=self.agent_stamp.agent_id,
+            parent_tool_call_id=parent_tool_call_id,
+            depth=depth,
+        )
+        return SessionRecorder(self.journal, recover=False, agent_stamp=stamp)
+
+    def _append(
+        self,
+        event_type: str,
+        *,
+        actor: str,
+        payload: Optional[dict[str, Any]] = None,
+        turn_id: Optional[str] = None,
+        epoch_id: Optional[str] = None,
+        artifacts: Optional[list[dict[str, Any]]] = None,
+    ) -> SessionEvent:
+        return self.journal.append(
+            event_type,
+            actor=actor,
+            payload=payload,
+            turn_id=turn_id,
+            epoch_id=epoch_id,
+            artifacts=artifacts,
+            agent=self.agent_stamp,
+        )
+
+    def _require_root(self, operation: str) -> None:
+        if self.agent_stamp.depth:
+            raise SessionJournalError(f"{operation} is only valid for the root agent recorder")
 
     def start_turn(self, message: Message) -> str:
         with self._lock:
@@ -510,7 +675,7 @@ class SessionRecorder:
                 raise SessionJournalError("Cannot start a session turn while another turn is open")
             turn_id = str(uuid.uuid4())
             stored, artifacts = self.journal.prepare_message(message.to_dict())
-            self.journal.append(
+            event = self._append(
                 "turn.started",
                 actor="user",
                 payload={"message": stored},
@@ -518,32 +683,98 @@ class SessionRecorder:
                 artifacts=artifacts,
             )
             self.current_turn_id = turn_id
+            self._turn_started_at = event.timestamp
+            self._assistant_count = 0
+            self._tool_batches = 0
             return turn_id
 
-    def record_assistant(self, message: Message) -> None:
+    def record_assistant(self, message: Message, *, reasoning_effort: Optional[str] = None) -> None:
         with self._lock:
             turn_id = self._require_turn()
             stored, artifacts = self.journal.prepare_message(message.to_dict())
-            self.journal.append(
+            llm_call = None
+            metadata = stored.get("usage_metadata")
+            if isinstance(metadata, dict):
+                llm_call = metadata.pop("llm_call", None)
+                if not metadata:
+                    stored.pop("usage_metadata", None)
+            payload: dict[str, Any] = {
+                "message": stored,
+                "origin_type": "llm",
+                "llm_call_id": None,
+                "provider": None,
+                "model": None,
+                "reasoning_effort": reasoning_effort,
+                "llm_call_count": 1,
+            }
+            if isinstance(llm_call, dict):
+                payload["llm_call_id"] = llm_call.get("llm_call_id")
+                payload["run_id"] = llm_call.get("run_id")
+                payload["provider"] = llm_call.get("provider")
+                payload["model"] = llm_call.get("model")
+            self._append(
                 "assistant.message",
                 actor="assistant",
-                payload={"message": stored},
+                payload=payload,
                 turn_id=turn_id,
                 artifacts=artifacts,
             )
+            self._assistant_count += 1
+
+    def record_synthetic_assistant(self, text: str, *, notice_code: str) -> None:
+        """A deterministic assistant notice that did not come from an LLM call."""
+        with self._lock:
+            payload = {
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": text}],
+                    "stop_reason": "end_turn",
+                },
+                "origin_type": "synthetic",
+                "llm_call_id": None,
+                "llm_call_count": 0,
+                "notice_code": notice_code,
+            }
+            self._append(
+                "assistant.message",
+                actor="assistant",
+                payload=payload,
+                turn_id=self.current_turn_id,
+            )
+            if self.current_turn_id is not None:
+                self._assistant_count += 1
+
+    def record_system_context(self, text: str) -> bool:
+        """Record the rendered provider-facing system context when it changes."""
+        fingerprint = hashlib.sha256(text.encode("utf-8")).hexdigest()
+        with self._lock:
+            if fingerprint == self._last_system_fingerprint:
+                return False
+            message = {"role": "system", "content": [{"type": "text", "text": text}]}
+            stored, artifacts = self.journal.prepare_message(message)
+            self._append(
+                "context.system",
+                actor="system",
+                payload={"message": stored, "sha256": fingerprint},
+                turn_id=self.current_turn_id,
+                artifacts=artifacts,
+            )
+            self._last_system_fingerprint = fingerprint
+            return True
 
     def record_tool_results(self, results: list[ToolResult]) -> list[ToolResult]:
         with self._lock:
             turn_id = self._require_turn()
             message = Message(role="user", content=cast(list[ContentBlock], results))
             stored, artifacts = self.journal.prepare_message(message.to_dict())
-            self.journal.append(
+            self._append(
                 "tool.results",
                 actor="tool",
                 payload={"message": stored},
                 turn_id=turn_id,
                 artifacts=artifacts,
             )
+            self._tool_batches += 1
             replayed = Message.from_dict(self.journal.hydrate_message(stored))
             if not isinstance(replayed.content, list) or not all(
                 isinstance(item, ToolResult) for item in replayed.content
@@ -554,7 +785,7 @@ class SessionRecorder:
     def record_context_message(self, message: Message, *, actor: Optional[str] = None) -> None:
         with self._lock:
             stored, artifacts = self.journal.prepare_message(message.to_dict())
-            self.journal.append(
+            self._append(
                 "context.message",
                 actor=actor or message.role,
                 payload={"message": stored},
@@ -574,7 +805,7 @@ class SessionRecorder:
     ) -> None:
         """Record a durable, additive active-workspace boundary."""
         with self._lock:
-            self.journal.append(
+            self._append(
                 "session.workspace_switched",
                 actor="system",
                 payload={
@@ -588,35 +819,104 @@ class SessionRecorder:
                 turn_id=self.current_turn_id,
             )
 
-    def record_compaction(self, compaction: dict[str, Any]) -> None:
+    def record_compaction(self, compaction: dict[str, Any], *, info: Optional[dict[str, Any]] = None) -> None:
         with self._lock:
-            self.journal.append(
+            payload: dict[str, Any] = {"compaction": copy.deepcopy(compaction)}
+            if info:
+                payload.update(copy.deepcopy(info))
+            self._append(
                 "context.compacted",
                 actor="system",
-                payload={"compaction": copy.deepcopy(compaction)},
+                payload=payload,
                 turn_id=self.current_turn_id,
             )
 
-    def finish_turn(self, status: str, *, error: Optional[str] = None) -> None:
+    def finish_turn(self, status: str, *, error: Optional[str] = None, reason: Optional[str] = None) -> None:
         if status not in {"completed", "failed", "cancelled"}:
             raise ValueError(f"Unknown terminal turn status: {status}")
         with self._lock:
             turn_id = self._require_turn()
-            payload: dict[str, Any] = {}
+            payload: dict[str, Any] = {
+                "assistant_messages": self._assistant_count,
+                "tool_result_batches": self._tool_batches,
+            }
+            if self._turn_started_at is not None:
+                payload["started_at"] = self._turn_started_at
+                try:
+                    started = datetime.fromisoformat(self._turn_started_at)
+                    payload["duration_ms"] = max(0, int((datetime.now(timezone.utc) - started).total_seconds() * 1000))
+                except ValueError:
+                    pass
             if error:
                 payload["error"] = error[:2000]
-            self.journal.append(
+            if reason:
+                payload["reason"] = reason
+            self._append(
                 f"turn.{status}",
                 actor="system",
                 payload=payload,
                 turn_id=turn_id,
             )
             self.current_turn_id = None
+            self._turn_started_at = None
+
+    def record_run_terminal(self, status: str, payload: dict[str, Any]) -> None:
+        """Record the run's terminal state; at most one per recorder, root only."""
+        if status not in {"completed", "failed", "cancelled"}:
+            raise ValueError(f"Unknown terminal run status: {status}")
+        self._require_root("A run terminal record")
+        with self._lock:
+            if self._run_terminal_recorded:
+                return
+            self._append(f"run.{status}", actor="system", payload=copy.deepcopy(payload))
+            self._run_terminal_recorded = True
+
+    def record_skill_activated(self, *, name: str, source: str, already_active: bool = False) -> None:
+        with self._lock:
+            self._append(
+                "skill.activated",
+                actor="system",
+                payload={"name": name, "source": source, "already_active": already_active},
+                turn_id=self.current_turn_id,
+            )
+
+    def record_goal_evaluated(self, payload: dict[str, Any]) -> None:
+        with self._lock:
+            self._append("goal.evaluated", actor="system", payload=copy.deepcopy(payload))
+
+    def record_goal_completed(self, payload: dict[str, Any]) -> None:
+        with self._lock:
+            self._append("goal.completed", actor="system", payload=copy.deepcopy(payload))
+
+    def record_loop_iteration_started(self, payload: dict[str, Any]) -> None:
+        with self._lock:
+            self._append("loop.iteration_started", actor="system", payload=copy.deepcopy(payload))
+
+    def record_loop_sleeping(self, payload: dict[str, Any]) -> None:
+        with self._lock:
+            self._append("loop.sleeping", actor="system", payload=copy.deepcopy(payload))
+
+    def record_loop_completed(self, payload: dict[str, Any]) -> None:
+        with self._lock:
+            self._append("loop.completed", actor="system", payload=copy.deepcopy(payload))
+
+    def record_agent_started(self, payload: dict[str, Any], *, turn_id: Optional[str] = None) -> None:
+        """Record a subagent's start under its own stamp, tied to the parent turn."""
+        with self._lock:
+            self._append("agent.started", actor="system", payload=copy.deepcopy(payload), turn_id=turn_id)
+
+    def record_agent_terminal(self, status: str, payload: dict[str, Any]) -> None:
+        if status not in {"completed", "failed"}:
+            raise ValueError(f"Unknown terminal agent status: {status}")
+        with self._lock:
+            self._append(f"agent.{status}", actor="system", payload=copy.deepcopy(payload))
 
     def start_epoch(self, reason: str) -> str:
+        self._require_root("A context epoch reset")
         with self._lock:
             if self.current_turn_id is not None:
                 raise SessionJournalError("Cannot reset context while a session turn is open")
+            self._last_system_fingerprint = None
             return self.journal.start_epoch(reason)
 
     def list_rewindable_turns(self) -> list[TurnSummary]:
@@ -626,6 +926,7 @@ class SessionRecorder:
 
     def record_rewind(self, target_turn_id: str) -> RewindOutcome:
         """Append the rewind event truncating the target turn and everything after it."""
+        self._require_root("A context rewind")
         with self._lock:
             if self.current_turn_id is not None:
                 raise SessionJournalError("Cannot rewind while a session turn is open")
@@ -635,7 +936,7 @@ class SessionRecorder:
             if target is None:
                 raise SessionJournalError(f"Turn {target_turn_id} is not rewindable in the current context epoch")
             rewound = [turn.turn_id for turn in turns if turn.boundary_seq >= target.boundary_seq]
-            self.journal.append(
+            self._append(
                 "context.rewound",
                 actor="user",
                 payload={
@@ -662,6 +963,10 @@ class SessionRecorder:
             turn_events: list[SessionEvent] = []
             for event in events:
                 if event.epoch_id != current_epoch:
+                    continue
+                if event.depth:
+                    # Recovery closes root turns only; a subagent's interrupted
+                    # turn is surfaced by export, not auto-closed here.
                     continue
                 if event.event_type == "turn.started":
                     open_turn = event.turn_id
@@ -731,9 +1036,10 @@ def _message_blocks(message: Any) -> list[dict[str, Any]]:
 
 
 def _tool_result_preview(content: str, ref: dict[str, Any]) -> str:
+    location = ref.get("path") or "the session artifact store"
     marker = (
         "\n\n[Middle of tool result omitted from model history. "
-        f"Full output: {ref['path']} (sha256 {ref['sha256']}, {ref['chars']:,} characters).]\n\n"
+        f"Full output: {location} (sha256 {ref['sha256']}, {ref['chars']:,} characters).]\n\n"
     )
     available = max(0, TOOL_RESULT_PREVIEW_CHARS - len(marker))
     head = available // 2

--- a/kolega_code/cli/session_store.py
+++ b/kolega_code/cli/session_store.py
@@ -238,10 +238,12 @@ class SessionStore:
         journal = self.journal(record.session_id)
         epoch_id = str(uuid.uuid4())
         try:
+            from kolega_code import __version__ as kolega_version
+
             journal.append(
                 "session.created",
                 actor="system",
-                payload={"metadata": record.to_metadata_dict()},
+                payload={"metadata": record.to_metadata_dict(), "kolega_version": kolega_version},
                 epoch_id=epoch_id,
             )
             journal.append(
@@ -546,6 +548,10 @@ class SessionStore:
         epoch_start_seq = 0
         message_events = {"turn.started", "assistant.message", "tool.results", "context.message"}
         for event in events:
+            if event.depth:
+                # Subagent semantic events share the journal but must never
+                # replay into the root agent's resumable history.
+                continue
             if event.event_type == "context.epoch_started":
                 current_epoch = event.epoch_id
                 epoch_start_seq = event.seq

--- a/kolega_code/cli/session_usage.py
+++ b/kolega_code/cli/session_usage.py
@@ -183,6 +183,12 @@ class SessionUsageSink:
             refs: list[dict[str, Any]] = []
             if item.message_dict is not None:
                 prepared, refs = self._journal.prepare_message(item.message_dict)
+            if prepared is not None:
+                # The ledger's call-identity stamp duplicates this event's own
+                # top-level request_id; keep the journaled message clean.
+                metadata = prepared.get("usage_metadata")
+                if isinstance(metadata, dict):
+                    metadata.pop("llm_call", None)
             self._journal.append(
                 LLM_MESSAGE_EVENT,
                 actor="assistant",

--- a/kolega_code/llm/ledger.py
+++ b/kolega_code/llm/ledger.py
@@ -270,6 +270,24 @@ class UsageLedger:
                 return
             record.state = _RequestState.RESPONDED
             record.usage = usage if isinstance(usage, NormalizedUsage) else None
+            if message is not None:
+                # Stamp the settled call identity onto the message so downstream
+                # recorders can expose it as `llm_call_id` without an observer.
+                # First-settle-wins above guarantees exactly one stamp. A message
+                # that cannot hold the stamp must still notify and settle.
+                try:
+                    metadata = getattr(message, "usage_metadata", None)
+                    if not isinstance(metadata, dict):
+                        metadata = {}
+                        message.usage_metadata = metadata
+                    metadata["llm_call"] = {
+                        "llm_call_id": request_id,
+                        "run_id": self.run_id,
+                        "provider": record.provider,
+                        "model": record.model,
+                    }
+                except Exception:
+                    logger.debug("UsageLedger: could not stamp llm_call onto the message", exc_info=True)
             self._notify(lambda observer: observer.on_response(self._settled(request_id, record), message))
         except Exception:
             logger.exception("UsageLedger.record_response failed for request %s", request_id)

--- a/tests/agent/test_base_agent_queued_injection.py
+++ b/tests/agent/test_base_agent_queued_injection.py
@@ -134,8 +134,9 @@ async def test_injection_journal_ordering_and_replay(base_agent, tmp_path) -> No
     event_types = [event.event_type for event in store.journal(session.session_id).read_events()]
     # Two context messages now: the volatile-context update at the start of the turn, and the
     # queued user input delivered mid-turn.
-    assert event_types[-7:] == [
+    assert event_types[-8:] == [
         "turn.started",
+        "context.system",
         "context.message",
         "assistant.message",
         "tool.results",

--- a/tests/agent/test_base_agent_runtime.py
+++ b/tests/agent/test_base_agent_runtime.py
@@ -205,8 +205,9 @@ class TestBaseAgent:
         assert chunks[-1]["complete"] is True
         # The volatile-context update is journalled inside the turn, after turn.started, so it is
         # attributed to the turn rather than dangling outside one. See agent/volatile_context.py.
-        assert [event.event_type for event in store.journal(session.session_id).read_events()][-4:] == [
+        assert [event.event_type for event in store.journal(session.session_id).read_events()][-5:] == [
             "turn.started",
+            "context.system",
             "context.message",
             "assistant.message",
             "turn.completed",
@@ -248,10 +249,13 @@ class TestBaseAgent:
             def start_turn(self, message):
                 self.current_turn_id = "turn"
 
+            def record_system_context(self, text):
+                return False
+
             def record_context_message(self, message, *, actor=None):
                 pass
 
-            def record_assistant(self, message):
+            def record_assistant(self, message, *, reasoning_effort=None):
                 raise OSError("assistant event failed")
 
             def finish_turn(self, status, *, error=None):
@@ -290,10 +294,13 @@ class TestBaseAgent:
             def start_turn(self, message):
                 self.current_turn_id = "turn"
 
+            def record_system_context(self, text):
+                return False
+
             def record_context_message(self, message, *, actor=None):
                 pass
 
-            def record_assistant(self, message):
+            def record_assistant(self, message, *, reasoning_effort=None):
                 return None
 
             def record_tool_results(self, results):

--- a/tests/agent/test_silent_turn_guard.py
+++ b/tests/agent/test_silent_turn_guard.py
@@ -285,8 +285,9 @@ async def test_nudge_journal_ordering_and_replay(base_agent, tmp_path) -> None:
     event_types = [event.event_type for event in store.journal(session.session_id).read_events()]
     # Context messages: the volatile-context update at the start of the turn,
     # then the nudge injected after the silent assistant response.
-    assert event_types[-6:] == [
+    assert event_types[-7:] == [
         "turn.started",
+        "context.system",
         "context.message",
         "assistant.message",
         "context.message",

--- a/tests/cli/test_event_protocol.py
+++ b/tests/cli/test_event_protocol.py
@@ -1,0 +1,533 @@
+"""Semantic event protocol v2: envelope, public projection, sinks, lineage."""
+
+import json
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+from kolega_code.cli.session_event_protocol import (
+    InMemorySessionJournal,
+    SemanticStdoutPrinter,
+    to_public_event,
+)
+from kolega_code.cli.session_journal import (
+    DEFAULT_ROOT_AGENT_NAME,
+    EVENT_SCHEMA_VERSION,
+    SessionEvent,
+    SessionJournal,
+    SessionJournalError,
+    SessionRecorder,
+    collect_epoch_turns,
+    derive_root_agent_id,
+)
+from kolega_code.llm.models import (
+    ContentBlock,
+    Message,
+    RedactedThinkingBlock,
+    ResponsesReasoningBlock,
+    TextBlock,
+    ThinkingBlock,
+    ToolCall,
+    ToolResult,
+)
+
+ENVELOPE_KEYS = {
+    "schema",
+    "version",
+    "id",
+    "session_id",
+    "seq",
+    "epoch_id",
+    "turn_id",
+    "timestamp",
+    "actor",
+    "agent_id",
+    "agent_name",
+    "parent_agent_id",
+    "parent_tool_call_id",
+    "depth",
+    "type",
+    "payload",
+    "artifacts",
+}
+
+
+def make_file_journal(tmp_path: Path, session_id: str = "s1") -> SessionJournal:
+    return SessionJournal(session_id, tmp_path / "session")
+
+
+def bootstrap(journal: SessionJournal) -> None:
+    journal.append("session.created", actor="system", payload={"metadata": {}}, epoch_id="e1")
+    journal.append("context.epoch_started", actor="system", payload={"reason": "session_created"}, epoch_id="e1")
+
+
+def drive_turn(recorder: SessionRecorder) -> None:
+    recorder.start_turn(Message(role="user", content=[TextBlock("hello")]))
+    recorder.record_assistant(Message(role="assistant", content=[TextBlock("hi")], stop_reason="end_turn"))
+    recorder.finish_turn("completed")
+
+
+def test_every_public_event_has_the_complete_v2_envelope(tmp_path: Path) -> None:
+    journal = make_file_journal(tmp_path)
+    bootstrap(journal)
+    recorder = SessionRecorder(journal, recover=False)
+    drive_turn(recorder)
+
+    for event in journal.read_events():
+        public = to_public_event(event)
+        assert public is not None
+        assert set(public) == ENVELOPE_KEYS
+        assert public["schema"] == "kolega.session.event"
+        assert public["version"] == 2
+        assert public["seq"] >= 1
+        assert public["agent_id"] == derive_root_agent_id("s1")
+        assert public["agent_name"] == DEFAULT_ROOT_AGENT_NAME
+        assert public["depth"] == 0
+        assert public["parent_agent_id"] is None
+        assert public["parent_tool_call_id"] is None
+
+
+def test_v1_events_project_with_derived_root_identity() -> None:
+    event = SessionEvent(
+        version=1,
+        event_id="ev-1",
+        session_id="legacy",
+        seq=1,
+        epoch_id="e1",
+        turn_id=None,
+        timestamp="2026-01-01T00:00:00+00:00",
+        actor="system",
+        event_type="session.created",
+        payload={"metadata": {}},
+        artifacts=[],
+    )
+    public = to_public_event(event)
+    assert public is not None
+    assert set(public) == ENVELOPE_KEYS
+    assert public["agent_id"] == derive_root_agent_id("legacy")
+    assert public["agent_name"] == DEFAULT_ROOT_AGENT_NAME
+    assert public["depth"] == 0
+
+
+def test_ui_events_are_excluded_from_the_public_projection(tmp_path: Path) -> None:
+    journal = make_file_journal(tmp_path)
+    bootstrap(journal)
+    event = journal.append("ui.chat_message", actor="agent", payload={"event": {"content": "x"}})
+    assert to_public_event(event) is None
+
+
+def test_opaque_provider_state_is_stripped_and_readable_reasoning_kept(tmp_path: Path) -> None:
+    journal = make_file_journal(tmp_path)
+    bootstrap(journal)
+    recorder = SessionRecorder(journal, recover=False)
+    recorder.start_turn(Message(role="user", content=[TextBlock("q")]))
+    blocks_in: list[ContentBlock] = [
+        ThinkingBlock("visible thinking", signature="OPAQUE-SIGNATURE"),
+        RedactedThinkingBlock(data="T1BBUVVF"),
+        ResponsesReasoningBlock(content=["readable"], encrypted_content="ENC", item_id="rs_1"),
+        ResponsesReasoningBlock(content=None, encrypted_content="ENC-ONLY", item_id="rs_2"),
+        TextBlock("answer"),
+    ]
+    recorder.record_assistant(Message(role="assistant", content=blocks_in, stop_reason="end_turn"))
+    recorder.finish_turn("completed")
+
+    event = next(e for e in journal.read_events() if e.event_type == "assistant.message")
+    public = to_public_event(event)
+    assert public is not None
+    rendered = json.dumps(public)
+    blocks = public["payload"]["message"]["content"]
+    types = [b["type"] for b in blocks]
+    assert types == ["thinking", "responses_reasoning", "text"]
+    assert "OPAQUE-SIGNATURE" not in rendered
+    assert "ENC" not in rendered.replace("ENC-ONLY", "")
+    assert "ENC-ONLY" not in rendered
+    assert "signature" not in blocks[0]
+    assert "artifact_fields" not in json.dumps(blocks)
+    assert public["payload"]["origin_type"] == "llm"
+    assert public["payload"]["llm_call_count"] == 1
+    assert "usage_metadata" not in public["payload"]["message"]
+
+
+def test_tool_blocks_use_canonical_execution_ids(tmp_path: Path) -> None:
+    journal = make_file_journal(tmp_path)
+    bootstrap(journal)
+    recorder = SessionRecorder(journal, recover=False)
+    recorder.start_turn(Message(role="user", content=[TextBlock("q")]))
+    recorder.record_assistant(
+        Message(
+            role="assistant",
+            content=[
+                ToolCall(id="prov-1", name="read_file", input={"path": "a.py"}, execution_id="tool_exec_a"),
+                ToolCall(
+                    id="prov-2",
+                    name="apply_patch",
+                    input="*** Begin Patch",
+                    execution_id="tool_exec_b",
+                    input_kind="freeform",
+                ),
+            ],
+            stop_reason="tool_use",
+        )
+    )
+    recorder.record_tool_results(
+        [
+            ToolResult(
+                tool_use_id="prov-2",
+                content="patched",
+                name="apply_patch",
+                is_error=False,
+                execution_id="tool_exec_b",
+                input_kind="freeform",
+            ),
+            ToolResult(
+                tool_use_id="prov-1", content="text", name="read_file", is_error=False, execution_id="tool_exec_a"
+            ),
+        ]
+    )
+    recorder.finish_turn("completed")
+
+    events = journal.read_events()
+    assistant = to_public_event(next(e for e in events if e.event_type == "assistant.message"))
+    assert assistant is not None
+    calls = [b for b in assistant["payload"]["message"]["content"] if b["type"] == "tool_call"]
+    assert [c["tool_call_id"] for c in calls] == ["tool_exec_a", "tool_exec_b"]
+    assert [c["provider_call_id"] for c in calls] == ["prov-1", "prov-2"]
+    assert calls[0]["arguments"] == {"path": "a.py"}
+    assert calls[1]["input_kind"] == "freeform"
+    assert calls[1]["arguments"] == {"input": "*** Begin Patch"}
+    assert calls[1]["input"] == "*** Begin Patch"
+
+    results_event = to_public_event(next(e for e in events if e.event_type == "tool.results"))
+    assert results_event is not None
+    results = results_event["payload"]["message"]["content"]
+    # Results arrived out of order; correlation is by id, never order.
+    assert [r["tool_call_id"] for r in results] == ["tool_exec_b", "tool_exec_a"]
+    assert all(r["provider_call_id"] for r in results)
+
+
+def test_v1_tool_result_without_execution_id_falls_back_to_provider_id() -> None:
+    event = SessionEvent(
+        version=1,
+        event_id="ev-1",
+        session_id="legacy",
+        seq=5,
+        epoch_id="e1",
+        turn_id="t1",
+        timestamp="2026-01-01T00:00:00+00:00",
+        actor="tool",
+        event_type="tool.results",
+        payload={
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "prov-9", "content": "x", "name": "bash", "is_error": False}
+                ],
+            }
+        },
+        artifacts=[],
+    )
+    public = to_public_event(event)
+    assert public is not None
+    result = public["payload"]["message"]["content"][0]
+    assert result["tool_call_id"] == "prov-9"
+    assert result["provider_call_id"] == "prov-9"
+
+
+def test_secrets_and_home_paths_are_scrubbed(tmp_path: Path) -> None:
+    journal = make_file_journal(tmp_path)
+    bootstrap(journal)
+    recorder = SessionRecorder(journal, recover=False)
+    home = str(Path.home())
+    recorder.start_turn(Message(role="user", content=[TextBlock(f"key sk-VERYSECRET123 lives at {home}/creds.txt")]))
+    recorder.finish_turn("completed")
+
+    event = next(e for e in journal.read_events() if e.event_type == "turn.started")
+    public = to_public_event(event, secret_values=["sk-VERYSECRET123"])
+    rendered = json.dumps(public)
+    assert "sk-VERYSECRET123" not in rendered
+    assert home not in rendered
+    assert "~/creds.txt" in rendered
+
+
+def test_artifact_refs_are_filtered_and_path_stripped(tmp_path: Path) -> None:
+    journal = make_file_journal(tmp_path)
+    bootstrap(journal)
+    recorder = SessionRecorder(journal, recover=False)
+    recorder.start_turn(Message(role="user", content=[TextBlock("q")]))
+    recorder.record_assistant(
+        Message(
+            role="assistant",
+            content=[ThinkingBlock("t", signature="SIG-ARTIFACT"), TextBlock("a")],
+            stop_reason="end_turn",
+        )
+    )
+    big = "x" * 200_000
+    recorder.record_tool_results(
+        [ToolResult(tool_use_id="p1", content=big, name="bash", is_error=False, execution_id="tool_exec_1")]
+    )
+    recorder.finish_turn("completed")
+
+    events = journal.read_events()
+    assistant_public = to_public_event(next(e for e in events if e.event_type == "assistant.message"))
+    assert assistant_public is not None
+    # The provider-signature artifact is not shareable: filtered from the envelope.
+    assert assistant_public["artifacts"] == []
+
+    results_public = to_public_event(next(e for e in events if e.event_type == "tool.results"))
+    assert results_public is not None
+    assert len(results_public["artifacts"]) == 1
+    ref = results_public["artifacts"][0]
+    assert ref["purpose"] == "tool_result"
+    assert "path" not in ref
+    block_ref = results_public["payload"]["message"]["content"][0]["content_artifact"]
+    assert "path" not in block_ref
+
+
+def test_mixed_v1_and_v2_journals_read_and_append(tmp_path: Path) -> None:
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    v1_lines = [
+        {
+            "version": 1,
+            "id": "ev-1",
+            "session_id": "mix",
+            "seq": 1,
+            "epoch_id": "e1",
+            "turn_id": None,
+            "timestamp": "2026-01-01T00:00:00+00:00",
+            "actor": "system",
+            "type": "session.created",
+            "payload": {"metadata": {}},
+            "artifacts": [],
+        },
+        {
+            "version": 1,
+            "id": "ev-2",
+            "session_id": "mix",
+            "seq": 2,
+            "epoch_id": "e1",
+            "turn_id": None,
+            "timestamp": "2026-01-01T00:00:01+00:00",
+            "actor": "system",
+            "type": "context.epoch_started",
+            "payload": {"reason": "session_created"},
+            "artifacts": [],
+        },
+    ]
+    (session_dir / "events.jsonl").write_text("".join(json.dumps(line) + "\n" for line in v1_lines), encoding="utf-8")
+    journal = SessionJournal("mix", session_dir)
+    events = journal.read_events()
+    assert [e.version for e in events] == [1, 1]
+
+    appended = journal.append(
+        "turn.started", actor="user", payload={"message": {"role": "user", "content": []}}, turn_id="t1"
+    )
+    assert appended.version == EVENT_SCHEMA_VERSION == 2
+    events = journal.read_events()
+    assert [e.version for e in events] == [1, 1, 2]
+    assert [e.seq for e in events] == [1, 2, 3]
+
+
+def test_listener_receives_persisted_event_and_failures_do_not_break_append(tmp_path: Path) -> None:
+    journal = make_file_journal(tmp_path)
+    seen: list[SessionEvent] = []
+
+    def bad_listener(event: SessionEvent) -> None:
+        raise RuntimeError("listener boom")
+
+    journal.add_listener(bad_listener)
+    journal.add_listener(seen.append)
+    bootstrap(journal)
+
+    assert len(seen) == 2
+    persisted = journal.read_events()
+    assert seen[0].event_id == persisted[0].event_id
+    assert seen[0].seq == persisted[0].seq
+    assert seen[0].timestamp == persisted[0].timestamp
+
+
+def test_printer_streams_the_same_records_as_the_saved_projection(tmp_path: Path) -> None:
+    journal = make_file_journal(tmp_path)
+    buffer = StringIO()
+    printer = SemanticStdoutPrinter(stream=buffer)
+    journal.add_listener(printer)
+    bootstrap(journal)
+    recorder = SessionRecorder(journal, recover=False)
+    drive_turn(recorder)
+
+    live = [json.loads(line) for line in buffer.getvalue().splitlines()]
+    saved = [p for p in (to_public_event(e) for e in journal.read_events()) if p is not None]
+    assert [(r["id"], r["seq"], r["timestamp"]) for r in live] == [(r["id"], r["seq"], r["timestamp"]) for r in saved]
+    assert printer.emitted_total == len(saved)
+
+
+def test_printer_backlog_does_not_duplicate_live_events(tmp_path: Path) -> None:
+    journal = make_file_journal(tmp_path)
+    buffer = StringIO()
+    printer = SemanticStdoutPrinter(stream=buffer)
+    journal.add_listener(printer)
+    bootstrap(journal)
+    printer.emit_backlog(journal.read_events())
+    assert printer.emitted_total == 2
+
+
+def test_in_memory_journal_matches_file_journal_and_touches_no_disk(tmp_path: Path) -> None:
+    def run(journal: SessionJournal) -> list[str]:
+        bootstrap(journal)
+        recorder = SessionRecorder(journal, recover=False)
+        drive_turn(recorder)
+        return [e.event_type for e in journal.read_events()]
+
+    file_types = run(make_file_journal(tmp_path))
+    memory_journal = InMemorySessionJournal("s1")
+    memory_types = run(memory_journal)
+    assert memory_types == file_types
+    assert not Path("<in-memory>").exists()
+
+    big = "y" * 200_000
+    recorder = SessionRecorder(memory_journal, recover=False)
+    recorder.start_turn(Message(role="user", content=[TextBlock("more")]))
+    stored = recorder.record_tool_results(
+        [ToolResult(tool_use_id="p", content=big, name="bash", is_error=False, execution_id="tool_exec_z")]
+    )
+    recorder.finish_turn("completed")
+    assert len(stored) == 1
+    event = next(e for e in memory_journal.read_events() if e.event_type == "tool.results")
+    ref = event.payload["message"]["content"][0]["content_artifact"]
+    assert "path" not in ref
+    assert memory_journal.read_artifact(ref).decode() == big
+
+
+def test_llm_call_stamp_is_lifted_into_the_assistant_payload(tmp_path: Path) -> None:
+    from kolega_code.llm.ledger import UsageLedger
+
+    journal = make_file_journal(tmp_path)
+    bootstrap(journal)
+    recorder = SessionRecorder(journal, recover=False)
+    ledger = UsageLedger()
+    message = Message(role="assistant", content=[TextBlock("hi")], stop_reason="end_turn")
+    request_id = ledger.begin("anthropic", "claude-opus-5")
+    ledger.record_response(request_id, None, message)
+
+    recorder.start_turn(Message(role="user", content=[TextBlock("q")]))
+    recorder.record_assistant(message, reasoning_effort="high")
+    recorder.finish_turn("completed")
+
+    event = next(e for e in journal.read_events() if e.event_type == "assistant.message")
+    assert event.payload["llm_call_id"] == request_id
+    assert event.payload["run_id"] == ledger.run_id
+    assert event.payload["provider"] == "anthropic"
+    assert event.payload["model"] == "claude-opus-5"
+    assert event.payload["reasoning_effort"] == "high"
+    assert event.payload["llm_call_count"] == 1
+    # The stamp is payload metadata, not part of the replayable message.
+    assert "llm_call" not in json.dumps(event.payload["message"])
+
+
+def test_synthetic_assistant_notice_shape(tmp_path: Path) -> None:
+    journal = make_file_journal(tmp_path)
+    bootstrap(journal)
+    recorder = SessionRecorder(journal, recover=False)
+    recorder.record_synthetic_assistant("Prompt blocked by policy.", notice_code="hook_blocked")
+
+    event = next(e for e in journal.read_events() if e.event_type == "assistant.message")
+    assert event.payload["origin_type"] == "synthetic"
+    assert event.payload["llm_call_id"] is None
+    assert event.payload["llm_call_count"] == 0
+    assert event.payload["notice_code"] == "hook_blocked"
+    assert "provider" not in event.payload
+    assert event.turn_id is None
+
+
+def test_system_context_is_fingerprinted_and_reset_by_epoch(tmp_path: Path) -> None:
+    journal = make_file_journal(tmp_path)
+    bootstrap(journal)
+    recorder = SessionRecorder(journal, recover=False)
+    assert recorder.record_system_context("You are a helpful agent.") is True
+    assert recorder.record_system_context("You are a helpful agent.") is False
+    assert recorder.record_system_context("Changed prompt.") is True
+    recorder.start_epoch("agent_clear_command")
+    assert recorder.record_system_context("Changed prompt.") is True
+    assert sum(1 for e in journal.read_events() if e.event_type == "context.system") == 3
+
+
+def test_scoped_child_recorder_stamps_lineage_and_interleaves(tmp_path: Path) -> None:
+    journal = make_file_journal(tmp_path)
+    bootstrap(journal)
+    root = SessionRecorder(journal, recover=False)
+    root.start_turn(Message(role="user", content=[TextBlock("dispatch two agents")]))
+
+    child_a = root.scoped_child(agent_id="agent-a", agent_name="explorer", parent_tool_call_id="tool_exec_a", depth=1)
+    child_b = root.scoped_child(agent_id="agent-b", agent_name="explorer", parent_tool_call_id="tool_exec_b", depth=1)
+    child_a.record_agent_started({"task": "a"}, turn_id=root.current_turn_id)
+    child_b.record_agent_started({"task": "b"}, turn_id=root.current_turn_id)
+    child_a.start_turn(Message(role="user", content=[TextBlock("task a")]))
+    child_b.start_turn(Message(role="user", content=[TextBlock("task b")]))
+    child_a.record_assistant(Message(role="assistant", content=[TextBlock("done a")], stop_reason="end_turn"))
+    child_a.finish_turn("completed")
+    child_b.finish_turn("failed", error="boom")
+    child_a.record_agent_terminal("completed", {"summary": "done a"})
+    child_b.record_agent_terminal("failed", {"error": "boom"})
+    root.finish_turn("completed")
+
+    events = journal.read_events()
+    assert [e.seq for e in events] == list(range(1, len(events) + 1))
+    a_events = [e for e in events if e.agent_id == "agent-a"]
+    assert {e.parent_tool_call_id for e in a_events} == {"tool_exec_a"}
+    assert {e.parent_agent_id for e in a_events} == {derive_root_agent_id("s1")}
+    assert {e.depth for e in a_events} == {1}
+    assert [e.event_type for e in a_events] == [
+        "agent.started",
+        "turn.started",
+        "assistant.message",
+        "turn.completed",
+        "agent.completed",
+    ]
+
+    # Sibling agents may share a name; identity is the id.
+    b_events = [e for e in events if e.agent_id == "agent-b"]
+    assert {e.agent_name for e in a_events} == {e.agent_name for e in b_events} == {"explorer"}
+
+    # Subagent turns never appear in the root's rewindable history.
+    turns = collect_epoch_turns(events, journal.epoch_id)
+    assert [t.user_text for t in turns] == ["dispatch two agents"]
+
+
+def test_scoped_recorders_cannot_reset_rewind_or_terminate_the_run(tmp_path: Path) -> None:
+    journal = make_file_journal(tmp_path)
+    bootstrap(journal)
+    root = SessionRecorder(journal, recover=False)
+    child = root.scoped_child(agent_id="a", agent_name="x", parent_tool_call_id="t", depth=1)
+    with pytest.raises(SessionJournalError):
+        child.start_epoch("agent_clear_command")
+    with pytest.raises(SessionJournalError):
+        child.record_rewind("some-turn")
+    with pytest.raises(SessionJournalError):
+        child.record_run_terminal("completed", {})
+
+
+def test_run_terminal_records_once_and_only_once(tmp_path: Path) -> None:
+    journal = make_file_journal(tmp_path)
+    bootstrap(journal)
+    recorder = SessionRecorder(journal, recover=False)
+    recorder.record_run_terminal("failed", {"error": {"code": "billing_error"}})
+    recorder.record_run_terminal("completed", {})
+    events = [e for e in journal.read_events() if e.event_type.startswith("run.")]
+    assert [e.event_type for e in events] == ["run.failed"]
+
+
+def test_recovery_ignores_open_subagent_turns(tmp_path: Path) -> None:
+    journal = make_file_journal(tmp_path)
+    bootstrap(journal)
+    root = SessionRecorder(journal, recover=False)
+    root.start_turn(Message(role="user", content=[TextBlock("go")]))
+    child = root.scoped_child(agent_id="a", agent_name="x", parent_tool_call_id="t", depth=1)
+    child.start_turn(Message(role="user", content=[TextBlock("subtask")]))
+    root.finish_turn("completed")
+    # The child's turn is left open (interrupted dispatch). Recovery must not
+    # reopen or close it as if it were the root's.
+    recovered = SessionRecorder(journal, recover=True)
+    assert recovered.current_turn_id is None
+    types = [e.event_type for e in journal.read_events()]
+    assert types.count("turn.completed") == 1

--- a/tests/cli/test_session_store.py
+++ b/tests/cli/test_session_store.py
@@ -7,7 +7,13 @@ from unittest.mock import Mock
 import pytest
 
 from kolega_code.cli import session_journal as session_journal_module
-from kolega_code.cli.session_journal import SessionJournalError, SessionRecorder, TOOL_RESULT_PREVIEW_CHARS
+from kolega_code.cli.session_journal import (
+    DEFAULT_ROOT_AGENT_NAME,
+    TOOL_RESULT_PREVIEW_CHARS,
+    SessionJournalError,
+    SessionRecorder,
+    derive_root_agent_id,
+)
 from kolega_code.cli.session_store import SessionRecord, SessionStore, SessionStoreError, default_state_dir
 from kolega_code.llm.models import (
     ImageBlock,
@@ -206,9 +212,19 @@ def test_event_records_are_ordered_and_have_stable_envelope(tmp_path: Path) -> N
         "assistant.message",
         "turn.completed",
     ]
-    assert all(event.version == 1 for event in events)
+    assert all(event.version == 2 for event in events)
     assert all(event.session_id == record.session_id for event in events)
     assert all(event.event_id and event.timestamp and event.epoch_id for event in events)
+    root_id = derive_root_agent_id(record.session_id)
+    assert all(event.agent_id == root_id for event in events)
+    assert all(event.agent_name == DEFAULT_ROOT_AGENT_NAME for event in events)
+    assert all(event.depth == 0 for event in events)
+    assert all(event.parent_agent_id is None and event.parent_tool_call_id is None for event in events)
+    raw_lines = store.events_path_for(record.session_id).read_text(encoding="utf-8").splitlines()
+    for line in raw_lines:
+        data = json.loads(line)
+        assert data["schema"] == "kolega.session.event"
+        assert set(data) >= {"agent_id", "agent_name", "parent_agent_id", "parent_tool_call_id", "depth"}
 
 
 def test_incomplete_final_jsonl_fragment_is_repaired(tmp_path: Path) -> None:


### PR DESCRIPTION
PR 1 of 3 implementing `json-output-atif-spec.md` (semantic JSON output + ATIF v1.7 export). **Additive only** — no change to `ask` output, plain-mode behavior, or any existing CLI contract. PR 2 (breaking `--json` swap + `events-jsonl` export) and PR 3 (ATIF converter) stack on this.

## What this adds

**Journal schema v2** (`session_journal.py`)
- Every appended event now carries `schema`, `agent_id`, `agent_name`, `parent_agent_id`, `parent_tool_call_id`, `depth` (`AgentStamp`). v1 files remain readable; a resumed v1 session appends v2 lines to the same gapless sequence. Old readers fail loudly on v2 instead of silently mis-replaying.

**Public event protocol** (`session_event_protocol.py`, new)
- `to_public_event()` — the single public projection: strips provider-opaque state (signatures, encrypted reasoning), scrubs configured secrets + home paths, drops artifact filesystem paths, allowlists artifact purposes, and rewrites tool blocks around the canonical `execution_id` (`tool_call_id` / `provider_call_id` / normalized `arguments`, lossless freeform).
- `InMemorySessionJournal` — same id/seq/schema rules, zero disk; the sink unsaved `ask` runs will use in PR 2.
- `SemanticStdoutPrinter` — journal listener that will drive live `--json` in PR 2; receives the exact persisted event objects, so live lines and saved records share id/seq/timestamp by construction.

**LLM call identity** — `UsageLedger.record_response` stamps the settled `request_id` onto the message; `record_assistant` lifts it into the event payload (`llm_call_id`, `provider`, `model`, `reasoning_effort`, `llm_call_count: 1`). Synthetic notices record with `origin_type: "synthetic"`, `llm_call_count: 0`, and a stable `notice_code`.

**Scoped subagent recording** — `SessionRecorder.scoped_child()` + AgentTool wiring: dispatched subagents (regular and workflow) now durably record `agent.started`, their turns, assistant messages (with call ids), tool results, and `agent.completed/failed`, all lineage-stamped in the shared sequence. Root replay, rewind listing, and crash recovery filter on `depth`, so subagent events never enter the root agent's resumable history.

**New recording points** — `context.system` (fingerprinted rendered system prompt, re-recorded only on change/epoch), compaction provenance (`trigger`, `reason`, `summarized_messages`, `input_tokens_before`), turn duration/counters, and `run.*`/`skill.activated`/`goal.*`/`loop.*` recorder methods that `main.py` adopts in PR 2.

**Fix** — batch-failure `ToolResult`s now carry `execution_id` (previously the only path producing results without a canonical id).

## Tests

- New `tests/cli/test_event_protocol.py` (20 tests): envelope completeness, v1 fallbacks, `ui.*` exclusion, opaque strip, secret/home scrub, artifact path-strip, canonical tool ids incl. out-of-order correlation and freeform, mixed v1+v2 files, listener identity + failure isolation, in-memory/file journal equivalence, scoped-recorder lineage/interleaving, depth guards, run-terminal once-guard, recovery ignoring open subagent turns.
- Updated suites for the new `context.system` event and enriched payloads.
- Full fast suite: 4427 passed. Ruff + Pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WA3jkDUSkeaBnus47HX5LY