### PR TITLE
feat: ATIF v1.7 trajectory export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+### Added
+
+- ATIF v1.7 trajectory export: `sessions export --format atif` converts any
+  session (including pre-upgrade v1 sessions, with explicit conversion
+  warnings) into a validated [ATIF](https://github.com/harbor-framework/harbor/blob/main/rfcs/0001-trajectory-format.md)
+  document, and `ask --atif-output FILE` writes one directly when a run ends —
+  completed, failed, or cancelled, with or without `--save`. Embedded subagent
+  trajectories, per-step token metrics, hydrated oversized tool results, and
+  atomic file+assets output; image trajectories require `--output`/a file
+  destination for portable relative asset paths.
+
 ### Changed
 
 - **Breaking:** `kolega-code ask --json` now streams the semantic session-event

--- a/docs/src/content/docs/cli/ask.md
+++ b/docs/src/content/docs/cli/ask.md
@@ -189,6 +189,7 @@ Common event types:
 | `session.created` / `context.epoch_started` | Session metadata and context boundaries |
 | `turn.started` | The complete user message |
 | `context.system` | The rendered system context (recorded when it changes) |
+| `context.tools` | Public schemas of the tools available to the agent (recorded when they change) |
 | `assistant.message` | One completed LLM response (`origin_type: "llm"`, `llm_call_id`, `provider`, `model`, `llm_call_count: 1`) or one deterministic notice (`origin_type: "synthetic"`, `llm_call_count: 0`, `notice_code`). The `message` carries content blocks with readable reasoning kept and provider-opaque state removed; tool calls expose the canonical `tool_call_id` plus `provider_call_id`, `input`, `input_kind`, and normalized `arguments` |
 | `tool.results` | Durable results, correlated to calls by the same `tool_call_id`; oversized content carries a `content_artifact` reference |
 | `turn.completed` / `turn.failed` / `turn.cancelled` | Turn outcome with counts and timing |

--- a/docs/src/content/docs/cli/sessions.md
+++ b/docs/src/content/docs/cli/sessions.md
@@ -63,12 +63,13 @@ Export a session to stdout or a file, in one of two formats.
 kolega-code sessions export <session_id>                          # replay JSON (default)
 kolega-code sessions export <session_id> --output run.json
 kolega-code sessions export <session_id> --format events-jsonl    # semantic event log
+kolega-code sessions export <session_id> --format atif --output trajectory.json
 ```
 
 | Argument / option | Description |
 | --- | --- |
 | `session_id` | The Resume ID shown by `sessions list` (required) |
-| `--format <json\|events-jsonl>` | `json` (default): effective-history replay snapshot. `events-jsonl`: the canonical public semantic event log |
+| `--format <json\|events-jsonl\|atif>` | `json` (default): effective-history replay snapshot. `events-jsonl`: the canonical public semantic event log. `atif`: a validated ATIF v1.7 trajectory |
 | `--output <PATH>` | Write the export to a file instead of stdout |
 | `--state-dir <PATH>` | Directory for CLI session state |
 
@@ -85,3 +86,16 @@ recorded by older Kolega versions export with deterministic fallbacks (derived
 root agent identity); facts those sessions never captured are not invented.
 Secrets are scrubbed and provider-opaque replay state is excluded in both
 formats' event output.
+
+`atif` converts the same events into an [ATIF v1.7](https://github.com/harbor-framework/harbor/blob/main/rfcs/0001-trajectory-format.md)
+trajectory document, validated before anything is written. One `source: agent`
+step per LLM inference (with per-step token metrics), tool results attached as
+observations on the step that made the call, compactions and rewinds preserved
+as auditable system steps, and subagents embedded as complete
+`subagent_trajectories` referenced from their dispatch call. Oversized tool
+results are fully hydrated into the document. If the trajectory contains
+images, stdout export refuses and asks for `--output`; file export writes
+assets to `<output-stem>.assets/` with relative paths, atomically. Legacy (v1)
+sessions convert with explicit `conversion_warnings` in the document's
+`extra`. `ask --atif-output FILE` writes the same document directly at the end
+of a run — completed, failed, or cancelled, with or without `--save`.

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -2209,12 +2209,18 @@ class BaseAgent(LogMixin):
                 self.session_recorder.start_turn,
                 Message(role="user", content=content_blocks),
             )
-            # Journal the rendered provider-facing system context; deduplicated
-            # by fingerprint inside the recorder so only changes are recorded.
+            # Journal the rendered provider-facing system context and the
+            # available tool schemas; both are deduplicated by fingerprint
+            # inside the recorder so only changes are recorded.
             await asyncio.to_thread(
                 self.session_recorder.record_system_context,
                 self.system_prompt.get_text_content(),
             )
+            if self.tool_collection is not None:
+                await asyncio.to_thread(
+                    self.session_recorder.record_tool_definitions,
+                    [tool.to_public_dict() for tool in self.tool_collection.get_tool_list()],
+                )
 
         self.append_user_message(content_blocks)
 

--- a/kolega_code/cli/atif_export.py
+++ b/kolega_code/cli/atif_export.py
@@ -1,0 +1,1053 @@
+"""ATIF v1.7 export: a deterministic, validated projection of the semantic journal.
+
+The converter consumes the *public* event projection (``to_public_event``) —
+never raw journal lines — so scrubbing, opaque-state removal, and canonical
+tool identity are identical to every other public surface. Conversion is a
+pure pipeline::
+
+    TrajectorySource -> public events -> grouped trajectory drafts
+        -> ATIF document dicts (+ asset plan) -> validate -> write
+
+Everything up to the write is side-effect-free. The document is built as plain
+dicts and validated with ``atif.Trajectory.model_validate`` before any output
+exists; a failed conversion or validation writes nothing. File export is
+atomic: document and assets are staged as temp siblings and renamed into
+place, so a failure leaves any previous export intact.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Optional, Protocol, Sequence
+
+from kolega_code.cli.session_event_protocol import to_public_event
+from kolega_code.cli.session_journal import SessionEvent
+
+ATIF_SCHEMA_VERSION = "ATIF-v1.7"
+ATIF_AGENT_NAME = "kolega-code"
+STATE_DIR_PLACEHOLDER = "<state-dir>"
+
+_UUID_NS = uuid.uuid5(uuid.NAMESPACE_URL, "kolega-code:atif")
+_IMAGE_EXTENSIONS = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+}
+
+#: Event types that fold into root ``extra.kolega`` rather than steps.
+_EXTRA_ONLY_TYPES = {
+    "session.created",
+    "session.metadata_updated",
+    "turn.completed",
+    "turn.failed",
+    "turn.cancelled",
+    "run.completed",
+    "run.failed",
+    "run.cancelled",
+    "goal.completed",
+    "loop.sleeping",
+    "loop.completed",
+    "llm.run_started",
+    "llm.request_failed",
+    "agent.started",
+    "agent.completed",
+    "agent.failed",
+}
+
+
+class AtifExportError(RuntimeError):
+    """Conversion or validation failed; no partial output was written."""
+
+
+class AtifImagesNeedOutputError(AtifExportError):
+    """Stdout export refused: the trajectory contains images, so assets need a
+    file destination (``--output``) to hold portable relative paths."""
+
+
+class TrajectorySource(Protocol):
+    session_id: str
+
+    def read_events(self, *, repair_tail: bool = True) -> list[SessionEvent]: ...
+
+    def read_artifact(self, ref: dict[str, Any]) -> bytes: ...
+
+
+@dataclass
+class ConversionWarnings:
+    entries: list[dict[str, Any]] = field(default_factory=list)
+    _seen: set[tuple[str, str]] = field(default_factory=set)
+
+    def add(self, code: str, message: str, *, seq: Optional[int] = None) -> None:
+        key = (code, message)
+        if key in self._seen:
+            return
+        self._seen.add(key)
+        entry: dict[str, Any] = {"code": code, "message": message}
+        if seq is not None:
+            entry["seq"] = seq
+        self.entries.append(entry)
+
+    def to_extra(self) -> list[dict[str, Any]]:
+        return list(self.entries)
+
+    def to_notes(self) -> Optional[str]:
+        if not self.entries:
+            return None
+        lines = [f"- {entry['code']}: {entry['message']}" for entry in self.entries]
+        return "kolega-code conversion notes:\n" + "\n".join(lines)
+
+
+class _AssetPlan:
+    """Collects shareable image bytes for the ``<output-stem>.assets/`` dir."""
+
+    def __init__(self, *, assets_dir_name: Optional[str], source: TrajectorySource) -> None:
+        self._assets_dir_name = assets_dir_name
+        self._source = source
+        self._files: dict[str, bytes] = {}
+        self.has_images = False
+
+    def add_image_ref(self, ref: dict[str, Any], *, warnings: ConversionWarnings, seq: int) -> Optional[dict[str, Any]]:
+        if ref.get("purpose") != "image":
+            raise AtifExportError(f"Refusing to materialize a non-image artifact: {ref.get('purpose')}")
+        media_type = str(ref.get("media_type") or "")
+        extension = _IMAGE_EXTENSIONS.get(media_type)
+        if extension is None:
+            warnings.add(
+                "unsupported_image_media_type",
+                f"Image with media type {media_type or 'unknown'} is retained by reference only.",
+                seq=seq,
+            )
+            return None
+        self.has_images = True
+        if self._assets_dir_name is None:
+            # Building for stdout: remember that images exist so the caller can
+            # refuse before emitting anything; bytes are not materialized.
+            return None
+        data = self._source.read_artifact(ref)
+        digest = str(ref["sha256"])
+        filename = f"{digest}{extension}"
+        self._files[filename] = data
+        return {"media_type": media_type, "path": f"{self._assets_dir_name}/{filename}"}
+
+    def files(self) -> list[tuple[str, bytes]]:
+        return sorted(self._files.items())
+
+
+@dataclass
+class _StepDraft:
+    seq: int
+    event_id: str
+    timestamp: Optional[str]
+    source: str  # system | user | agent
+    message: Any = ""
+    model_name: Optional[str] = None
+    reasoning_effort: Optional[Any] = None
+    reasoning_content: Optional[str] = None
+    tool_calls: Optional[list[dict[str, Any]]] = None
+    observation_results: list[dict[str, Any]] = field(default_factory=list)
+    metrics: Optional[dict[str, Any]] = None
+    llm_call_count: Optional[int] = None
+    is_copied_context: Optional[bool] = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class _TrajectoryDraft:
+    agent_id: str
+    agent_name: str
+    depth: int
+    parent_agent_id: Optional[str] = None
+    parent_tool_call_id: Optional[str] = None
+    task: Optional[str] = None
+    status: Optional[str] = None
+    summary: Optional[str] = None
+    model_name: Optional[str] = None
+    steps: list[_StepDraft] = field(default_factory=list)
+    call_owner: dict[str, int] = field(default_factory=dict)  # tool_call_id -> steps index
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+def _derived_id(kind: str, *parts: Any) -> str:
+    return str(uuid.uuid5(_UUID_NS, ":".join([kind, *[str(part) for part in parts]])))
+
+
+def _message_blocks(message: Any) -> list[dict[str, Any]]:
+    if not isinstance(message, dict) or not isinstance(message.get("content"), list):
+        return []
+    return [block for block in message["content"] if isinstance(block, dict)]
+
+
+def _step_message_and_reasoning(
+    message: dict[str, Any],
+    *,
+    event: dict[str, Any],
+    assets: _AssetPlan,
+    warnings: ConversionWarnings,
+) -> tuple[Any, Optional[str], Optional[list[dict[str, Any]]], list[dict[str, Any]]]:
+    """Project one prepared message: (message, reasoning, tool_calls, content_blocks)."""
+    text_parts: list[str] = []
+    content_parts: list[dict[str, Any]] = []
+    reasoning_parts: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+    content_blocks: list[dict[str, Any]] = []
+    has_image = False
+    seq = int(event["seq"])
+
+    for index, block in enumerate(_message_blocks(message)):
+        block_type = block.get("type")
+        record: dict[str, Any] = {"index": index, "type": block_type}
+        if block_type == "text":
+            text = str(block.get("text") or "")
+            text_parts.append(text)
+            content_parts.append({"type": "text", "text": text})
+            record["disposition"] = "message"
+        elif block_type == "thinking":
+            reasoning_parts.append(str(block.get("thinking") or ""))
+            record["disposition"] = "reasoning"
+        elif block_type == "responses_reasoning":
+            texts = [str(item) for item in block.get("content") or []]
+            if texts:
+                reasoning_parts.append("\n".join(texts))
+            record["disposition"] = "reasoning"
+        elif block_type == "tool_call":
+            call_id = block.get("tool_call_id") or _derived_id("tool", event["id"], index)
+            if not block.get("tool_call_id"):
+                warnings.add(
+                    "v1_derived_tool_call_id",
+                    "A tool call without a recorded id was assigned a derived stable id.",
+                    seq=seq,
+                )
+            call = {
+                "tool_call_id": str(call_id),
+                "function_name": str(block.get("name") or "unknown_tool"),
+                "arguments": block.get("arguments") if isinstance(block.get("arguments"), dict) else {},
+                "extra": {
+                    "kolega": {
+                        "provider_call_id": block.get("provider_call_id"),
+                        "input_kind": block.get("input_kind"),
+                    }
+                },
+            }
+            if block.get("input_kind") == "freeform":
+                call["extra"]["kolega"]["input"] = block.get("input")
+            tool_calls.append(call)
+            record["disposition"] = "tool_call"
+            record["tool_call_id"] = call["tool_call_id"]
+        elif block_type == "image_url":
+            ref = block.get("data_artifact")
+            source = None
+            if isinstance(ref, dict):
+                source = assets.add_image_ref(ref, warnings=warnings, seq=seq)
+            if source is not None:
+                has_image = True
+                content_parts.append({"type": "image", "source": source})
+                record["disposition"] = "message"
+            else:
+                record["disposition"] = "retained"
+                record["block"] = {k: v for k, v in block.items() if k != "data"}
+        else:
+            # Unsupported public block (web_search_call, future types): retained
+            # losslessly, never silently discarded.
+            warnings.add(
+                "unsupported_content_block",
+                f"Content blocks of type {block_type} are retained in step extra, not mapped.",
+                seq=seq,
+            )
+            record["disposition"] = "retained"
+            record["block"] = dict(block)
+        content_blocks.append(record)
+
+    step_message: Any
+    if has_image:
+        step_message = content_parts
+    else:
+        step_message = "\n\n".join(part for part in text_parts if part) if text_parts else ""
+    reasoning = "\n\n".join(part for part in reasoning_parts if part) or None
+    return step_message, reasoning, tool_calls or None, content_blocks
+
+
+def _hydrated_result_content(
+    block: dict[str, Any],
+    *,
+    source: TrajectorySource,
+    assets: _AssetPlan,
+    event: dict[str, Any],
+    warnings: ConversionWarnings,
+) -> Any:
+    """Full tool-result content: artifact-backed text is hydrated, images copied."""
+    artifact = block.get("content_artifact")
+    if isinstance(artifact, dict):
+        try:
+            return source.read_artifact(artifact).decode("utf-8")
+        except Exception as exc:
+            raise AtifExportError(f"Could not hydrate an oversized tool result: {exc}") from exc
+    content = block.get("content")
+    if isinstance(content, list):
+        parts: list[dict[str, Any]] = []
+        for nested in content:
+            if not isinstance(nested, dict):
+                continue
+            if nested.get("type") == "text":
+                parts.append({"type": "text", "text": str(nested.get("text") or "")})
+            elif nested.get("type") == "image_url" and isinstance(nested.get("data_artifact"), dict):
+                image = assets.add_image_ref(nested["data_artifact"], warnings=warnings, seq=int(event["seq"]))
+                if image is not None:
+                    parts.append({"type": "image", "source": image})
+            else:
+                warnings.add(
+                    "unsupported_content_block",
+                    f"Tool-result blocks of type {nested.get('type')} are not mapped.",
+                    seq=int(event["seq"]),
+                )
+        return parts
+    return str(content or "")
+
+
+def _metrics_from_usage(usage: Any, *, warnings: ConversionWarnings, seq: int) -> Optional[dict[str, Any]]:
+    if not isinstance(usage, dict) or not usage.get("reported"):
+        warnings.add(
+            "usage_missing_for_llm_step",
+            "One or more LLM steps have no reported usage; totals cover reported steps only.",
+            seq=seq,
+        )
+        return None
+    metrics: dict[str, Any] = {}
+    mapping = {
+        "prompt_tokens": "input_tokens",
+        "completion_tokens": "output_tokens",
+        "cached_tokens": "cache_read_input_tokens",
+    }
+    for target, key in mapping.items():
+        value = usage.get(key)
+        if isinstance(value, int):
+            metrics[target] = value
+    extra: dict[str, Any] = {}
+    for key in ("reasoning_output_tokens", "cache_write_input_tokens"):
+        value = usage.get(key)
+        if isinstance(value, int):
+            extra[key if key != "reasoning_output_tokens" else "reasoning_tokens"] = value
+    if extra:
+        metrics["extra"] = extra
+    return metrics or None
+
+
+def _final_metrics(steps: list[_StepDraft], *, warnings: ConversionWarnings) -> Optional[dict[str, Any]]:
+    llm_steps = [step for step in steps if step.llm_call_count == 1]
+    with_usage = [step for step in llm_steps if step.metrics]
+    if llm_steps and len(with_usage) < len(llm_steps):
+        warnings.add(
+            "usage_totals_partial",
+            f"{len(llm_steps) - len(with_usage)} of {len(llm_steps)} LLM steps carry no usage; "
+            "final metrics sum reported values only.",
+        )
+    totals: dict[str, Any] = {"total_steps": len(steps)}
+    for target, source_key in (
+        ("total_prompt_tokens", "prompt_tokens"),
+        ("total_completion_tokens", "completion_tokens"),
+        ("total_cached_tokens", "cached_tokens"),
+    ):
+        values = [step.metrics[source_key] for step in with_usage if step.metrics and source_key in step.metrics]
+        if values:
+            totals[target] = sum(values)
+    extra: dict[str, Any] = {"llm_steps": len(llm_steps), "llm_steps_with_usage": len(with_usage)}
+    for key in ("reasoning_tokens", "cache_write_input_tokens"):
+        values = [
+            step.metrics["extra"][key]
+            for step in with_usage
+            if step.metrics and isinstance(step.metrics.get("extra"), dict) and key in step.metrics["extra"]
+        ]
+        if values:
+            extra[key] = sum(values)
+    totals["extra"] = extra
+    return totals
+
+
+class _Grouper:
+    """One seq-ordered pass over public events -> trajectory drafts."""
+
+    def __init__(self, session_id: str, *, source: TrajectorySource, assets: _AssetPlan, warnings: ConversionWarnings):
+        self.session_id = session_id
+        self.source = source
+        self.assets = assets
+        self.warnings = warnings
+        self.root: Optional[_TrajectoryDraft] = None
+        self.subagents: dict[str, _TrajectoryDraft] = {}
+        self.root_extra: dict[str, Any] = {
+            "session": {},
+            "turns": [],
+            "epochs": [],
+            "unknown_events": [],
+        }
+        self._saw_v1 = False
+
+    # -- draft resolution ---------------------------------------------------
+
+    def _draft_for(self, event: dict[str, Any]) -> _TrajectoryDraft:
+        depth = int(event.get("depth") or 0)
+        agent_id = str(event["agent_id"])
+        if depth == 0:
+            if self.root is None:
+                self.root = _TrajectoryDraft(agent_id=agent_id, agent_name=str(event["agent_name"]), depth=0)
+            return self.root
+        draft = self.subagents.get(agent_id)
+        if draft is None:
+            draft = _TrajectoryDraft(
+                agent_id=agent_id,
+                agent_name=str(event["agent_name"]),
+                depth=depth,
+                parent_agent_id=event.get("parent_agent_id"),
+                parent_tool_call_id=event.get("parent_tool_call_id"),
+            )
+            self.subagents[agent_id] = draft
+        return draft
+
+    def _append_step(self, draft: _TrajectoryDraft, step: _StepDraft) -> None:
+        step.extra.setdefault("kolega", {}).update({"event_id": step.event_id, "seq": step.seq})
+        draft.steps.append(step)
+
+    def _system_step(self, event: dict[str, Any], text: str, *, extra: Optional[dict[str, Any]] = None) -> _StepDraft:
+        step = _StepDraft(
+            seq=int(event["seq"]),
+            event_id=str(event["id"]),
+            timestamp=event.get("timestamp"),
+            source="system",
+            message=text,
+        )
+        if extra:
+            step.extra.update(extra)
+        return step
+
+    # -- event handlers -----------------------------------------------------
+
+    def feed(self, event: dict[str, Any]) -> None:
+        event_type = str(event["type"])
+        draft = self._draft_for(event)
+        payload = event.get("payload") or {}
+        handler = {
+            "turn.started": self._on_turn_started,
+            "context.system": self._on_context_system,
+            "context.message": self._on_context_message,
+            "assistant.message": self._on_assistant_message,
+            "llm.message": self._on_llm_message,
+            "tool.results": self._on_tool_results,
+            "context.compacted": self._on_compacted,
+            "context.rewound": self._on_rewound,
+            "context.epoch_started": self._on_epoch_started,
+            "session.workspace_switched": self._on_workspace_switched,
+            "goal.evaluated": self._on_goal_evaluated,
+            "loop.iteration_started": self._on_loop_iteration,
+            "skill.activated": self._on_skill_activated,
+        }.get(event_type)
+        if handler is not None:
+            handler(draft, event, payload)
+            return
+        if event_type in _EXTRA_ONLY_TYPES:
+            self._fold_extra(draft, event, payload)
+            return
+        self.root_extra["unknown_events"].append({"type": event_type, "seq": event["seq"]})
+        self.warnings.add("unknown_event_type", f"Unknown event type {event_type} kept in extra only.")
+
+    def _on_turn_started(self, draft: _TrajectoryDraft, event: dict[str, Any], payload: dict[str, Any]) -> None:
+        message, _, _, content_blocks = _step_message_and_reasoning(
+            payload.get("message") or {}, event=event, assets=self.assets, warnings=self.warnings
+        )
+        step = _StepDraft(
+            seq=int(event["seq"]),
+            event_id=str(event["id"]),
+            timestamp=event.get("timestamp"),
+            source="user",
+            message=message,
+        )
+        step.extra["kolega"] = {"turn_id": event.get("turn_id"), "content_blocks": content_blocks}
+        self._append_step(draft, step)
+
+    def _on_context_system(self, draft: _TrajectoryDraft, event: dict[str, Any], payload: dict[str, Any]) -> None:
+        message, _, _, _ = _step_message_and_reasoning(
+            payload.get("message") or {}, event=event, assets=self.assets, warnings=self.warnings
+        )
+        self._append_step(draft, self._system_step(event, message if isinstance(message, str) else ""))
+
+    def _on_context_message(self, draft: _TrajectoryDraft, event: dict[str, Any], payload: dict[str, Any]) -> None:
+        message, _, _, content_blocks = _step_message_and_reasoning(
+            payload.get("message") or {}, event=event, assets=self.assets, warnings=self.warnings
+        )
+        source = "user" if event.get("actor") == "user" else "system"
+        step = _StepDraft(
+            seq=int(event["seq"]),
+            event_id=str(event["id"]),
+            timestamp=event.get("timestamp"),
+            source=source,
+            message=message,
+        )
+        step.extra["kolega"] = {"origin": "context.message", "content_blocks": content_blocks}
+        self._append_step(draft, step)
+
+    def _assistant_step(
+        self, draft: _TrajectoryDraft, event: dict[str, Any], payload: dict[str, Any], *, llm_call_id: Optional[str]
+    ) -> None:
+        message, reasoning, tool_calls, content_blocks = _step_message_and_reasoning(
+            payload.get("message") or {}, event=event, assets=self.assets, warnings=self.warnings
+        )
+        synthetic = payload.get("origin_type") == "synthetic"
+        step = _StepDraft(
+            seq=int(event["seq"]),
+            event_id=str(event["id"]),
+            timestamp=event.get("timestamp"),
+            source="agent",
+            message=message,
+            llm_call_count=0 if synthetic else 1,
+        )
+        if not synthetic:
+            step.model_name = payload.get("model")
+            step.reasoning_effort = payload.get("reasoning_effort")
+            step.reasoning_content = reasoning
+            step.tool_calls = tool_calls
+            usage = (payload.get("message") or {}).get("usage")
+            step.metrics = _metrics_from_usage(usage, warnings=self.warnings, seq=int(event["seq"]))
+            if draft.model_name is None and step.model_name:
+                draft.model_name = step.model_name
+        kolega_extra: dict[str, Any] = {"content_blocks": content_blocks}
+        if llm_call_id:
+            kolega_extra["llm_call_id"] = llm_call_id
+        if synthetic:
+            kolega_extra["origin_type"] = "synthetic"
+            if payload.get("notice_code"):
+                kolega_extra["notice_code"] = payload["notice_code"]
+            if tool_calls:
+                # A synthetic notice never carries tool calls today; retain
+                # defensively rather than violating the ATIF gating.
+                kolega_extra["tool_calls"] = tool_calls
+        step.extra["kolega"] = kolega_extra
+        self._append_step(draft, step)
+        for call in step.tool_calls or []:
+            draft.call_owner[call["tool_call_id"]] = len(draft.steps) - 1
+
+    def _on_assistant_message(self, draft: _TrajectoryDraft, event: dict[str, Any], payload: dict[str, Any]) -> None:
+        llm_call_id = payload.get("llm_call_id")
+        if not llm_call_id and payload.get("origin_type") != "synthetic":
+            llm_call_id = _derived_id("llm", event["id"])
+            self.warnings.add(
+                "v1_derived_llm_call_id",
+                "Assistant messages recorded before call-identity stamping use ids derived from their event ids.",
+                seq=int(event["seq"]),
+            )
+        self._assistant_step(draft, event, payload, llm_call_id=llm_call_id)
+
+    def _on_llm_message(self, draft: _TrajectoryDraft, event: dict[str, Any], payload: dict[str, Any]) -> None:
+        origin = payload.get("origin") or {}
+        kind = origin.get("kind")
+        if kind == "sub_agent" and origin.get("agent_id"):
+            # v1 sessions: the only durable record of subagent inference.
+            sub = self.subagents.get(str(origin["agent_id"]))
+            if sub is None:
+                sub = _TrajectoryDraft(
+                    agent_id=str(origin["agent_id"]),
+                    agent_name=str(origin.get("agent_name") or "subagent"),
+                    depth=int(origin.get("depth") or 1),
+                    parent_agent_id=self.root.agent_id if self.root else None,
+                    parent_tool_call_id=origin.get("parent_tool_call_id"),
+                )
+                self.subagents[sub.agent_id] = sub
+                self.warnings.add(
+                    "v1_subagent_tools_unrecorded",
+                    "Subagent trajectories recovered from llm.message events contain LLM steps only; "
+                    "their tool results and turn boundaries were never durably recorded.",
+                )
+            enriched = dict(payload)
+            enriched.setdefault("llm_call_id", payload.get("request_id"))
+            enriched.setdefault("origin_type", "llm")
+            self._assistant_step(sub, event, enriched, llm_call_id=enriched.get("llm_call_id"))
+            return
+        # Helper calls (compaction summarizer, goal verifier, hooks): real
+        # spend that belongs to no trajectory step.
+        usage = (payload.get("message") or {}).get("usage") or {}
+        bucket = self.root_extra.setdefault(
+            "unattributed_usage", {"requests": 0, "input_tokens": 0, "output_tokens": 0}
+        )
+        bucket["requests"] += 1
+        for key in ("input_tokens", "output_tokens"):
+            value = usage.get(key)
+            if isinstance(value, int):
+                bucket[key] += value
+        self.warnings.add(
+            "unattributed_helper_usage",
+            "Helper LLM calls (compaction, goal verification, hooks) are summed in extra.kolega.unattributed_usage.",
+        )
+
+    def _on_tool_results(self, draft: _TrajectoryDraft, event: dict[str, Any], payload: dict[str, Any]) -> None:
+        for block in _message_blocks(payload.get("message")):
+            if block.get("type") != "tool_result":
+                continue
+            call_id = block.get("tool_call_id")
+            content = _hydrated_result_content(
+                block, source=self.source, assets=self.assets, event=event, warnings=self.warnings
+            )
+            result: dict[str, Any] = {
+                "content": content,
+                "extra": {
+                    "kolega": {
+                        "is_error": bool(block.get("is_error")),
+                        "name": block.get("name"),
+                        "provider_call_id": block.get("provider_call_id"),
+                        "event_id": event["id"],
+                        "seq": event["seq"],
+                    }
+                },
+            }
+            artifact = block.get("content_artifact")
+            if isinstance(artifact, dict):
+                result["extra"]["kolega"]["hydrated_from_artifact"] = {
+                    key: artifact[key] for key in ("sha256", "bytes", "chars") if key in artifact
+                }
+            owner = draft.call_owner.get(str(call_id)) if call_id else None
+            if owner is not None:
+                result["source_call_id"] = str(call_id)
+                draft.steps[owner].observation_results.append(result)
+            else:
+                self.warnings.add(
+                    "unmatched_tool_result",
+                    "A tool result could not be correlated to a recorded call; kept as a system observation.",
+                    seq=int(event["seq"]),
+                )
+                result["extra"]["kolega"]["uncorrelated_call_id"] = call_id
+                step = self._system_step(event, "")
+                step.observation_results.append(result)
+                self._append_step(draft, step)
+
+    def _on_compacted(self, draft: _TrajectoryDraft, event: dict[str, Any], payload: dict[str, Any]) -> None:
+        compaction = payload.get("compaction") or {}
+        summary = ""
+        summary_message = compaction.get("summary")
+        if isinstance(summary_message, dict):
+            summary = "\n".join(
+                str(block.get("text") or "")
+                for block in _message_blocks(summary_message)
+                if block.get("type") == "text"
+            )
+        provenance = {key: payload[key] for key in payload if key not in ("compaction",)}
+        if not provenance:
+            self.warnings.add(
+                "v1_compaction_missing_token_info",
+                "Compactions recorded before provenance enrichment carry no trigger/token information.",
+            )
+        step = self._system_step(
+            event,
+            "",
+            extra={
+                "context_management": {"type": "compaction", "boundary": "replace"},
+                "kolega": {"compaction": provenance or None},
+            },
+        )
+        step.observation_results.append({"content": summary})
+        self._append_step(draft, step)
+
+    def _on_rewound(self, draft: _TrajectoryDraft, event: dict[str, Any], payload: dict[str, Any]) -> None:
+        step = self._system_step(
+            event,
+            f"Context rewound to turn {payload.get('target_turn_id')}",
+            extra={"kolega": {"rewind": dict(payload)}},
+        )
+        self._append_step(draft, step)
+
+    def _on_epoch_started(self, draft: _TrajectoryDraft, event: dict[str, Any], payload: dict[str, Any]) -> None:
+        self.root_extra["epochs"].append(
+            {"epoch_id": event.get("epoch_id"), "reason": payload.get("reason"), "seq": event["seq"]}
+        )
+        if len(self.root_extra["epochs"]) > 1:
+            step = self._system_step(
+                event,
+                f"Context epoch started: {payload.get('reason')}",
+                extra={"kolega": {"epoch": {"epoch_id": event.get("epoch_id"), "reason": payload.get("reason")}}},
+            )
+            self._append_step(draft, step)
+
+    def _on_workspace_switched(self, draft: _TrajectoryDraft, event: dict[str, Any], payload: dict[str, Any]) -> None:
+        old = payload.get("new_label") or payload.get("new_branch") or "workspace"
+        step = self._system_step(
+            event,
+            f"Workspace switched to {old}",
+            extra={
+                "kolega": {
+                    "workspace_switch": {
+                        key: payload.get(key) for key in ("old_label", "new_label", "old_branch", "new_branch")
+                    }
+                }
+            },
+        )
+        self._append_step(draft, step)
+
+    def _on_goal_evaluated(self, draft: _TrajectoryDraft, event: dict[str, Any], payload: dict[str, Any]) -> None:
+        met = payload.get("met")
+        step = self._system_step(
+            event,
+            f"Goal evaluated: {'met' if met else 'not met'} — {payload.get('reason')}",
+            extra={"kolega": {"goal_evaluated": dict(payload)}},
+        )
+        self._append_step(draft, step)
+
+    def _on_loop_iteration(self, draft: _TrajectoryDraft, event: dict[str, Any], payload: dict[str, Any]) -> None:
+        step = self._system_step(
+            event,
+            f"Loop iteration {payload.get('iteration')} started",
+            extra={"kolega": {"loop_iteration": dict(payload)}},
+        )
+        self._append_step(draft, step)
+
+    def _on_skill_activated(self, draft: _TrajectoryDraft, event: dict[str, Any], payload: dict[str, Any]) -> None:
+        step = self._system_step(
+            event,
+            f"Skill activated: {payload.get('name')}",
+            extra={"kolega": {"skill_activated": dict(payload)}},
+        )
+        self._append_step(draft, step)
+
+    def _fold_extra(self, draft: _TrajectoryDraft, event: dict[str, Any], payload: dict[str, Any]) -> None:
+        event_type = str(event["type"])
+        if event_type == "session.created":
+            metadata = payload.get("metadata") or {}
+            config = metadata.get("config") or {}
+            self.root_extra["session"] = {
+                "kolega_version": payload.get("kolega_version"),
+                "mode": metadata.get("mode"),
+                "title": metadata.get("title"),
+                "project": Path(str(metadata.get("project_path") or "")).name or None,
+                "created_at": metadata.get("created_at"),
+                "config": {
+                    key: config.get(key)
+                    for key in ("long_provider", "long_model", "thinking_effort")
+                    if isinstance(config, dict) and key in config
+                },
+            }
+        elif event_type.startswith("turn."):
+            self.root_extra["turns"].append(
+                {
+                    "turn_id": event.get("turn_id"),
+                    "status": event_type.split(".", 1)[1],
+                    "agent_id": event.get("agent_id"),
+                    **{k: payload[k] for k in ("error", "duration_ms") if k in payload},
+                }
+            )
+        elif event_type.startswith("run."):
+            self.root_extra["status"] = {"outcome": event_type.split(".", 1)[1], **payload}
+        elif event_type == "goal.completed":
+            self.root_extra["goal"] = dict(payload)
+        elif event_type in ("loop.sleeping", "loop.completed"):
+            if event_type == "loop.completed":
+                self.root_extra["loop"] = dict(payload)
+        elif event_type == "llm.request_failed":
+            self.root_extra.setdefault("llm_failures", []).append(
+                {key: payload.get(key) for key in ("provider", "model", "error")} | {"seq": event["seq"]}
+            )
+        elif event_type == "agent.started":
+            draft.task = payload.get("task")
+            if payload.get("agent_name"):
+                draft.agent_name = str(payload["agent_name"])
+            draft.extra["started"] = {
+                key: payload.get(key) for key in ("class_name", "requested_routing", "effective_routing")
+            }
+        elif event_type in ("agent.completed", "agent.failed"):
+            draft.status = event_type.split(".", 1)[1]
+            draft.summary = payload.get("summary")
+            draft.extra["terminal"] = dict(payload)
+        # session.metadata_updated and llm.run_started carry nothing ATIF needs.
+
+
+def _project_trajectory(
+    draft: _TrajectoryDraft,
+    *,
+    warnings: ConversionWarnings,
+    agent: dict[str, Any],
+    session_id: Optional[str],
+    extra: Optional[dict[str, Any]],
+    subagent_refs: dict[str, str],
+) -> dict[str, Any]:
+    steps: list[dict[str, Any]] = []
+    for index, step_draft in enumerate(sorted(draft.steps, key=lambda item: item.seq), start=1):
+        step: dict[str, Any] = {
+            "step_id": index,
+            "source": step_draft.source,
+            "message": step_draft.message,
+        }
+        if step_draft.timestamp:
+            step["timestamp"] = step_draft.timestamp
+        if step_draft.model_name:
+            step["model_name"] = step_draft.model_name
+        if step_draft.reasoning_effort is not None:
+            step["reasoning_effort"] = step_draft.reasoning_effort
+        if step_draft.reasoning_content:
+            step["reasoning_content"] = step_draft.reasoning_content
+        if step_draft.tool_calls:
+            step["tool_calls"] = step_draft.tool_calls
+        if step_draft.llm_call_count is not None:
+            step["llm_call_count"] = step_draft.llm_call_count
+        results = list(step_draft.observation_results)
+        # Attach embedded-subagent refs to the dispatch call's observation.
+        for call in step_draft.tool_calls or []:
+            child_id = subagent_refs.get(call["tool_call_id"])
+            if child_id is None:
+                continue
+            ref = {"trajectory_id": child_id}
+            existing = next((r for r in results if r.get("source_call_id") == call["tool_call_id"]), None)
+            if existing is not None:
+                existing.setdefault("subagent_trajectory_ref", []).append(ref)
+            else:
+                results.append({"source_call_id": call["tool_call_id"], "subagent_trajectory_ref": [ref]})
+        if results:
+            step["observation"] = {"results": results}
+        if step_draft.metrics:
+            step["metrics"] = step_draft.metrics
+        if step_draft.is_copied_context is not None:
+            step["is_copied_context"] = step_draft.is_copied_context
+        if step_draft.extra:
+            step["extra"] = step_draft.extra
+        steps.append(step)
+
+    document: dict[str, Any] = {
+        "schema_version": ATIF_SCHEMA_VERSION,
+        "trajectory_id": draft.agent_id,
+        "agent": agent,
+        "steps": steps,
+    }
+    if session_id:
+        document["session_id"] = session_id
+    metrics = _final_metrics(sorted(draft.steps, key=lambda item: item.seq), warnings=warnings)
+    if metrics:
+        document["final_metrics"] = metrics
+    if extra:
+        document["extra"] = extra
+    return document
+
+
+def build_atif_document(
+    source: TrajectorySource,
+    *,
+    session_metadata: Optional[dict[str, Any]] = None,
+    kolega_version: str,
+    secret_values: Sequence[str] = (),
+    state_dirs: Sequence[Path] = (),
+    assets_dir_name: Optional[str] = None,
+) -> tuple[dict[str, Any], _AssetPlan]:
+    """Convert one session's journal into an unvalidated ATIF document dict."""
+    warnings = ConversionWarnings()
+    assets = _AssetPlan(assets_dir_name=assets_dir_name, source=source)
+    grouper = _Grouper(source.session_id, source=source, assets=assets, warnings=warnings)
+
+    raw_events = source.read_events(repair_tail=True)
+    if not raw_events:
+        raise AtifExportError(f"Session {source.session_id} has no recorded events to convert")
+    if any(event.version == 1 for event in raw_events):
+        warnings.add(
+            "v1_source_journal",
+            "This session was recorded with journal schema v1; deterministic fallbacks were applied.",
+        )
+        warnings.add(
+            "v1_derived_agent_id",
+            "The root agent identity is derived from the session id.",
+        )
+    for event in raw_events:
+        public = to_public_event(event, secret_values=secret_values)
+        if public is not None:
+            grouper.feed(public)
+
+    if grouper.root is None:
+        raise AtifExportError(f"Session {source.session_id} contains no root-agent events")
+
+    session_info = grouper.root_extra.get("session") or {}
+    config = session_info.get("config") or {}
+    if session_metadata:
+        metadata_config = session_metadata.get("config") or {}
+        for key in ("long_provider", "long_model", "thinking_effort"):
+            if key in metadata_config and key not in config:
+                config[key] = metadata_config[key]
+    warnings.add(
+        "tool_definitions_unavailable",
+        "Tool definitions are not recorded in the session journal; agent.tool_definitions is omitted.",
+    )
+
+    root_agent = {
+        "name": ATIF_AGENT_NAME,
+        "version": kolega_version,
+        "model_name": grouper.root.model_name or config.get("long_model"),
+        "extra": {
+            "provider": config.get("long_provider"),
+            "reasoning_effort": config.get("thinking_effort"),
+            "mode": session_info.get("mode"),
+            "profile": grouper.root.agent_name,
+        },
+    }
+
+    subagent_refs = {
+        draft.parent_tool_call_id: draft.agent_id for draft in grouper.subagents.values() if draft.parent_tool_call_id
+    }
+
+    subagent_documents = []
+    for child in grouper.subagents.values():
+        child_agent = {
+            "name": ATIF_AGENT_NAME,
+            "version": kolega_version,
+            "model_name": child.model_name,
+            "extra": {
+                "agent_name": child.agent_name,
+                "task": child.task,
+                "depth": child.depth,
+                "parent_agent_id": child.parent_agent_id,
+                "parent_tool_call_id": child.parent_tool_call_id,
+                "status": child.status,
+                **({"summary": child.summary} if child.summary else {}),
+            },
+        }
+        subagent_documents.append(
+            _project_trajectory(
+                child,
+                warnings=warnings,
+                agent=child_agent,
+                session_id=None,
+                extra={"kolega": child.extra} if child.extra else None,
+                subagent_refs=subagent_refs,
+            )
+        )
+
+    root_extra_kolega = {key: value for key, value in grouper.root_extra.items() if value}
+    document = _project_trajectory(
+        grouper.root,
+        warnings=warnings,
+        agent=root_agent,
+        session_id=source.session_id,
+        extra=None,
+        subagent_refs=subagent_refs,
+    )
+    if subagent_documents:
+        document["subagent_trajectories"] = subagent_documents
+    notes = warnings.to_notes()
+    if notes:
+        document["notes"] = notes
+    document["extra"] = {"conversion_warnings": warnings.to_extra(), "kolega": root_extra_kolega}
+
+    document = _scrub_state_dirs(document, state_dirs)
+    return document, assets
+
+
+def _scrub_state_dirs(document: dict[str, Any], state_dirs: Sequence[Path]) -> dict[str, Any]:
+    """Replace any state-directory prefix with a placeholder, everywhere.
+
+    Secrets and home paths were already scrubbed by the public projection; the
+    state dir gets its own, more specific placeholder (it usually lives under
+    home, so this runs against both raw and home-rewritten spellings).
+    """
+    prefixes: set[str] = set()
+    home = Path.home()
+    for state_dir in state_dirs:
+        for form in (state_dir, state_dir.expanduser(), state_dir.resolve()):
+            text = str(form).rstrip("/")
+            if len(text) > 1:
+                prefixes.add(text)
+            try:
+                prefixes.add("~/" + str(form.relative_to(home)))
+            except ValueError:
+                pass
+    if not prefixes:
+        return document
+    ordered = sorted(prefixes, key=len, reverse=True)
+
+    def scrub(value: Any) -> Any:
+        if isinstance(value, str):
+            for prefix in ordered:
+                if prefix in value:
+                    value = value.replace(prefix, STATE_DIR_PLACEHOLDER)
+            return value
+        if isinstance(value, list):
+            return [scrub(item) for item in value]
+        if isinstance(value, dict):
+            return {key: scrub(item) for key, item in value.items()}
+        return value
+
+    return scrub(document)
+
+
+def validate_atif_document(document: dict[str, Any]) -> Any:
+    import atif
+
+    try:
+        return atif.Trajectory.model_validate(document)
+    except Exception as exc:
+        raise AtifExportError(f"Generated ATIF document failed validation (kolega-code bug): {exc}") from exc
+
+
+def render_atif_text(document: dict[str, Any]) -> str:
+    validated = validate_atif_document(document)
+    return json.dumps(validated.to_json_dict(exclude_none=True), indent=2, ensure_ascii=False, default=str) + "\n"
+
+
+def export_atif_to_text(source: TrajectorySource, **kwargs: Any) -> str:
+    """Build, validate, and render for stdout. Refuses multimodal output."""
+    kwargs.pop("assets_dir_name", None)
+    document, assets = build_atif_document(source, assets_dir_name=None, **kwargs)
+    if assets.has_images:
+        raise AtifImagesNeedOutputError(
+            "This trajectory contains image content; pass --output FILE so assets "
+            "can be written to FILE-stem.assets/ with portable relative paths."
+        )
+    return render_atif_text(document)
+
+
+def export_atif_to_path(source: TrajectorySource, *, output: Path, **kwargs: Any) -> Path:
+    """Atomic file export: temp siblings, hash-verified assets, rename into place."""
+    output = output.expanduser()
+    assets_dir = output.parent / f"{output.stem}.assets"
+    kwargs.pop("assets_dir_name", None)
+    document, assets = build_atif_document(source, assets_dir_name=assets_dir.name, **kwargs)
+    rendered = render_atif_text(document)
+    files = assets.files()
+
+    token = uuid.uuid4().hex
+    tmp_doc = output.parent / f".{output.name}.tmp-atif-{token}"
+    tmp_assets = output.parent / f".{assets_dir.name}.tmp-atif-{token}"
+    old_aside = output.parent / f".{assets_dir.name}.old-{token}"
+    swapped = False
+    try:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        if files:
+            tmp_assets.mkdir()
+            import hashlib
+
+            for filename, data in files:
+                path = tmp_assets / filename
+                path.write_bytes(data)
+                digest = filename.split(".", 1)[0]
+                if hashlib.sha256(path.read_bytes()).hexdigest() != digest:
+                    raise AtifExportError(f"Asset failed hash verification after write: {filename}")
+        tmp_doc.write_text(rendered, encoding="utf-8")
+
+        if files and assets_dir.exists():
+            assets_dir.rename(old_aside)
+        if files:
+            tmp_assets.rename(assets_dir)
+        tmp_doc.replace(output)
+        swapped = True
+        if old_aside.exists():
+            shutil.rmtree(old_aside, ignore_errors=True)
+        return output
+    finally:
+        if not swapped:
+            for leftover in (tmp_doc, tmp_assets):
+                if leftover.is_dir():
+                    shutil.rmtree(leftover, ignore_errors=True)
+                elif leftover.exists():
+                    leftover.unlink(missing_ok=True)
+            if old_aside.exists() and not assets_dir.exists():
+                old_aside.rename(assets_dir)
+
+
+def iter_public_events_for_source(
+    source: TrajectorySource, *, secret_values: Sequence[str] = ()
+) -> Iterable[dict[str, Any]]:
+    """Public events for an arbitrary source (used by tests and tooling)."""
+    for event in source.read_events(repair_tail=True):
+        public = to_public_event(event, secret_values=secret_values)
+        if public is not None:
+            yield public

--- a/kolega_code/cli/atif_export.py
+++ b/kolega_code/cli/atif_export.py
@@ -167,6 +167,7 @@ class _TrajectoryDraft:
     status: Optional[str] = None
     summary: Optional[str] = None
     model_name: Optional[str] = None
+    tool_definitions: Optional[list[dict[str, Any]]] = None
     steps: list[_StepDraft] = field(default_factory=list)
     call_owner: dict[str, int] = field(default_factory=dict)  # tool_call_id -> steps index
     extra: dict[str, Any] = field(default_factory=dict)
@@ -431,6 +432,7 @@ class _Grouper:
         handler = {
             "turn.started": self._on_turn_started,
             "context.system": self._on_context_system,
+            "context.tools": self._on_context_tools,
             "context.message": self._on_context_message,
             "assistant.message": self._on_assistant_message,
             "llm.message": self._on_llm_message,
@@ -471,6 +473,13 @@ class _Grouper:
             payload.get("message") or {}, event=event, assets=self.assets, warnings=self.warnings
         )
         self._append_step(draft, self._system_step(event, message if isinstance(message, str) else ""))
+
+    def _on_context_tools(self, draft: _TrajectoryDraft, event: dict[str, Any], payload: dict[str, Any]) -> None:
+        # Not a step: the toolset describes the agent, not a context change the
+        # model observed as content. Latest recording wins.
+        tools = payload.get("tools")
+        if isinstance(tools, list) and tools:
+            draft.tool_definitions = tools
 
     def _on_context_message(self, draft: _TrajectoryDraft, event: dict[str, Any], payload: dict[str, Any]) -> None:
         message, _, _, content_blocks = _step_message_and_reasoning(
@@ -864,11 +873,6 @@ def build_atif_document(
         for key in ("long_provider", "long_model", "thinking_effort"):
             if key in metadata_config and key not in config:
                 config[key] = metadata_config[key]
-    warnings.add(
-        "tool_definitions_unavailable",
-        "Tool definitions are not recorded in the session journal; agent.tool_definitions is omitted.",
-    )
-
     root_agent = {
         "name": ATIF_AGENT_NAME,
         "version": kolega_version,
@@ -880,6 +884,13 @@ def build_atif_document(
             "profile": grouper.root.agent_name,
         },
     }
+    if grouper.root.tool_definitions:
+        root_agent["tool_definitions"] = grouper.root.tool_definitions
+    else:
+        warnings.add(
+            "tool_definitions_unavailable",
+            "This session recorded no tool schemas (pre-context.tools journal); agent.tool_definitions is omitted.",
+        )
 
     subagent_refs = {
         draft.parent_tool_call_id: draft.agent_id for draft in grouper.subagents.values() if draft.parent_tool_call_id
@@ -887,7 +898,7 @@ def build_atif_document(
 
     subagent_documents = []
     for child in grouper.subagents.values():
-        child_agent = {
+        child_agent: dict[str, Any] = {
             "name": ATIF_AGENT_NAME,
             "version": kolega_version,
             "model_name": child.model_name,
@@ -901,6 +912,8 @@ def build_atif_document(
                 **({"summary": child.summary} if child.summary else {}),
             },
         }
+        if child.tool_definitions:
+            child_agent["tool_definitions"] = child.tool_definitions
         subagent_documents.append(
             _project_trajectory(
                 child,

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -501,7 +501,17 @@ def _build_subcommand_parser() -> argparse.ArgumentParser:
         help="Force Agent Skills on or off for this session (overrides settings.json; not persisted).",
     )
     ask.add_argument("--save", action="store_true", help="Persist the session after the prompt completes.")
-    ask.add_argument("--json", action="store_true", help="Emit complete messages and events as JSON.")
+    ask.add_argument("--json", action="store_true", help="Stream the semantic event protocol as JSON lines.")
+    ask.add_argument(
+        "--atif-output",
+        type=Path,
+        default=None,
+        help=(
+            "After the run ends (completed, failed, or cancelled), write a validated ATIF v1.7 "
+            "trajectory to this file (image assets to <file-stem>.assets/). Works with or "
+            "without --save; stdout is unchanged."
+        ),
+    )
     ask.add_argument("--browser-visible", action="store_true", help="Launch visible Playwright browser windows.")
     ask.add_argument(
         "--permission-mode",
@@ -548,11 +558,13 @@ def _build_subcommand_parser() -> argparse.ArgumentParser:
     sessions_export.add_argument("session_id")
     sessions_export.add_argument(
         "--format",
-        choices=("json", "events-jsonl"),
+        choices=("json", "events-jsonl", "atif"),
         default="json",
         help=(
             "json: effective-history replay snapshot (default, unchanged); "
-            "events-jsonl: the canonical public semantic event log, one v2 envelope per line."
+            "events-jsonl: the canonical public semantic event log, one v2 envelope per line; "
+            "atif: a validated ATIF v1.7 trajectory (image assets require --output and are "
+            "written to <output-stem>.assets/)."
         ),
     )
     sessions_export.add_argument("--output", type=Path, help="Write the export to a file instead of stdout.")
@@ -1884,6 +1896,30 @@ async def _run_ask(args: argparse.Namespace) -> int:
             provider=str(getattr(config.long_context_config, "provider", None) or "") or None,
             model=config.long_context_config.model,
         )
+        if getattr(args, "atif_output", None) is not None:
+            # After the run terminal so the trajectory carries the outcome.
+            # Synchronous and broadly guarded: this runs inside a finally and
+            # must never mask billing errors or a propagating cancellation.
+            try:
+                from kolega_code import __version__ as _kolega_version_atif
+
+                from .atif_export import export_atif_to_path
+
+                path = export_atif_to_path(
+                    journal,
+                    output=args.atif_output,
+                    session_metadata=session.to_metadata_dict(),
+                    kolega_version=_kolega_version_atif,
+                    secret_values=known_secret_values(settings, settings_store, project_path=launch_project_path),
+                    state_dirs=(store.root,),
+                )
+                _print_styled(f"Wrote ATIF trajectory to {path}", style="success", stderr=True)
+            except Exception as exc:  # noqa: BLE001 - reported; run outcome wins
+                _print_styled(f"ATIF export failed: {exc}", style="error", stderr=True)
+                if exit_code == 0:
+                    # A conversion failure on an otherwise-clean run exits 1;
+                    # a run that already failed keeps its own exit status.
+                    exit_code = 1
 
     return exit_code
 
@@ -2031,7 +2067,10 @@ def _run_sessions(args: argparse.Namespace) -> int:
         print(f"Deleted session {args.session_id}")
         return 0
     if args.sessions_command == "export":
-        if getattr(args, "format", "json") == "events-jsonl":
+        export_format = getattr(args, "format", "json")
+        if export_format == "atif":
+            return _run_sessions_export_atif(args, store)
+        if export_format == "events-jsonl":
             settings_store = _settings_store_from_args(args)
             settings = settings_store.load()
             payload = store.export_events(
@@ -2046,6 +2085,38 @@ def _run_sessions(args: argparse.Namespace) -> int:
             print(payload, end="")
         return 0
     raise ValueError(f"Unknown sessions command: {args.sessions_command}")
+
+
+def _run_sessions_export_atif(args: argparse.Namespace, store: SessionStore) -> int:
+    # Local import: the converter (and the pinned atif package) load only when
+    # an ATIF export is actually requested.
+    from kolega_code import __version__ as kolega_version
+
+    from .atif_export import AtifExportError, AtifImagesNeedOutputError, export_atif_to_path, export_atif_to_text
+
+    settings_store = _settings_store_from_args(args)
+    settings = settings_store.load()
+    record = store.load(args.session_id)
+    source = store.journal(record.session_id)
+    common: dict[str, Any] = {
+        "session_metadata": record.to_metadata_dict(),
+        "kolega_version": kolega_version,
+        "secret_values": known_secret_values(settings, settings_store, project_path=Path(record.project_path)),
+        "state_dirs": (store.root,),
+    }
+    try:
+        if args.output:
+            path = export_atif_to_path(source, output=args.output, **common)
+            print(f"Wrote ATIF trajectory to {path}", file=sys.stderr)
+        else:
+            sys.stdout.write(export_atif_to_text(source, **common))
+        return 0
+    except AtifImagesNeedOutputError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+    except AtifExportError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
 
 
 def _run_prompts(args: argparse.Namespace) -> int:

--- a/kolega_code/cli/session_journal.py
+++ b/kolega_code/cli/session_journal.py
@@ -616,6 +616,7 @@ class SessionRecorder:
         self.current_turn_id: Optional[str] = None
         self._agent_stamp = agent_stamp
         self._last_system_fingerprint: Optional[str] = None
+        self._last_tools_fingerprint: Optional[str] = None
         self._turn_started_at: Optional[str] = None
         self._assistant_count = 0
         self._tool_batches = 0
@@ -760,6 +761,28 @@ class SessionRecorder:
                 artifacts=artifacts,
             )
             self._last_system_fingerprint = fingerprint
+            return True
+
+    def record_tool_definitions(self, tools: list[dict[str, Any]]) -> bool:
+        """Record the public schemas of the tools available to this agent.
+
+        Fingerprinted like the system context so only changes are journaled;
+        an empty toolset records nothing.
+        """
+        if not tools:
+            return False
+        canonical = json.dumps(tools, sort_keys=True, separators=(",", ":"), default=str)
+        fingerprint = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+        with self._lock:
+            if fingerprint == self._last_tools_fingerprint:
+                return False
+            self._append(
+                "context.tools",
+                actor="system",
+                payload={"tools": copy.deepcopy(tools), "sha256": fingerprint},
+                turn_id=self.current_turn_id,
+            )
+            self._last_tools_fingerprint = fingerprint
             return True
 
     def record_tool_results(self, results: list[ToolResult]) -> list[ToolResult]:
@@ -917,6 +940,7 @@ class SessionRecorder:
             if self.current_turn_id is not None:
                 raise SessionJournalError("Cannot reset context while a session turn is open")
             self._last_system_fingerprint = None
+            self._last_tools_fingerprint = None
             return self.journal.start_epoch(reason)
 
     def list_rewindable_turns(self) -> list[TurnSummary]:

--- a/kolega_code/llm/models.py
+++ b/kolega_code/llm/models.py
@@ -743,6 +743,19 @@ class ToolDefinition(ContentBlock):
             }
         return self._object_schema()
 
+    def to_public_dict(self) -> Dict[str, Any]:
+        """Provider-neutral public shape for journaling and trajectory export."""
+        public: Dict[str, Any] = {
+            "name": self.name,
+            "description": self.description,
+            "input_schema": self._object_schema(),
+        }
+        if self.input_kind != "json":
+            public["input_kind"] = self.input_kind
+        if self.freeform_format:
+            public["freeform_format"] = dict(self.freeform_format)
+        return public
+
     @classmethod
     def _dict_to_google_schema(cls, schema: Dict[str, Any]) -> genai_types.Schema:
         """Recursively convert a JSON-schema dict to a google.genai Schema."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ classifiers = [
 ]
 dependencies = [
     "anthropic==0.101.0",
+    # ATIF v1.7 trajectory models: every `sessions export --format atif` /
+    # `ask --atif-output` document is validated before it is written.
+    "atif==1.7.0",
     "beautifulsoup4==4.14.3",
     # Not imported directly (google-auth/pdfminer-six pull it in); pinned for
     # security: 48.0.1 is vulnerable to CVE-2026-69247/-69248/-69249 (PKCS#7

--- a/tests/agent/test_base_agent_runtime.py
+++ b/tests/agent/test_base_agent_runtime.py
@@ -252,6 +252,9 @@ class TestBaseAgent:
             def record_system_context(self, text):
                 return False
 
+            def record_tool_definitions(self, tools):
+                return False
+
             def record_context_message(self, message, *, actor=None):
                 pass
 
@@ -295,6 +298,9 @@ class TestBaseAgent:
                 self.current_turn_id = "turn"
 
             def record_system_context(self, text):
+                return False
+
+            def record_tool_definitions(self, tools):
                 return False
 
             def record_context_message(self, message, *, actor=None):

--- a/tests/cli/test_ask_atif_output.py
+++ b/tests/cli/test_ask_atif_output.py
@@ -1,0 +1,173 @@
+"""`ask --atif-output` and `sessions export --format atif` end to end."""
+
+import base64
+import json
+
+import pytest
+
+from kolega_code.cli.session_store import SessionStore
+from kolega_code.llm.exceptions import LLMBillingError
+from kolega_code.llm.models import ImageBlock, Message, TextBlock
+
+from .test_ask_semantic_json import SemanticAskFakeAgent, _setup
+
+
+def _validate(path):
+    import atif
+
+    document = json.loads(path.read_text(encoding="utf-8"))
+    return atif.Trajectory.model_validate(document)
+
+
+def test_saved_run_writes_a_validated_trajectory(tmp_path, capsys, monkeypatch, isolated_cli_env):
+    main_module, project = _setup(tmp_path, monkeypatch, SemanticAskFakeAgent)
+    out = tmp_path / "exports" / "trajectory.json"
+
+    exit_code = main_module.main(
+        ["ask", "run the tests", "--project", str(project), "--save", "--atif-output", str(out)]
+    )
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    # Plain stdout is unchanged; the export notice goes to stderr.
+    assert captured.out == "Checking the tests.All green.\n"
+    assert "Wrote ATIF trajectory" in captured.err
+
+    trajectory = _validate(out)
+    assert trajectory.schema_version == "ATIF-v1.7"
+    sources = [step.source for step in trajectory.steps]
+    assert sources.count("agent") == 2
+    assert trajectory.extra is not None
+    assert trajectory.extra["kolega"]["status"]["outcome"] == "completed"
+
+
+def test_unsaved_run_writes_a_trajectory_and_no_session_state(tmp_path, capsys, monkeypatch, isolated_cli_env):
+    main_module, project = _setup(tmp_path, monkeypatch, SemanticAskFakeAgent)
+    out = tmp_path / "trajectory.json"
+
+    exit_code = main_module.main(["ask", "run the tests", "--project", str(project), "--atif-output", str(out)])
+    assert exit_code == 0
+    trajectory = _validate(out)
+    assert [step.source for step in trajectory.steps].count("agent") == 2
+    store = SessionStore()
+    assert store.list() == []
+
+
+def test_failed_run_still_produces_a_trajectory_and_keeps_exit_one(tmp_path, capsys, monkeypatch, isolated_cli_env):
+    class BillingFailureAgent(SemanticAskFakeAgent):
+        async def process_message_stream(self, message, attachments=None):
+            self.messages.append(message)
+            raise LLMBillingError("Insufficient Balance", provider="anthropic")
+            yield {}
+
+    main_module, project = _setup(tmp_path, monkeypatch, BillingFailureAgent)
+    out = tmp_path / "trajectory.json"
+
+    exit_code = main_module.main(["ask", "go", "--project", str(project), "--atif-output", str(out)])
+    assert exit_code == 1
+    trajectory = _validate(out)
+    assert trajectory.extra is not None
+    status = trajectory.extra["kolega"]["status"]
+    assert status["outcome"] == "failed"
+    assert status["error"]["code"] == "billing_error"
+
+
+def test_conversion_failure_on_a_clean_run_exits_one(tmp_path, capsys, monkeypatch, isolated_cli_env):
+    main_module, project = _setup(tmp_path, monkeypatch, SemanticAskFakeAgent)
+    out = tmp_path / "trajectory.json"
+
+    from kolega_code.cli import atif_export as atif_module
+
+    def boom(document):
+        raise atif_module.AtifExportError("forced failure")
+
+    monkeypatch.setattr(atif_module, "validate_atif_document", boom)
+    exit_code = main_module.main(["ask", "go", "--project", str(project), "--atif-output", str(out)])
+    assert exit_code == 1
+    assert not out.exists()
+    assert "ATIF export failed" in capsys.readouterr().err
+
+
+def test_sessions_export_atif_stdout_and_json_parity(tmp_path, capsys, monkeypatch, isolated_cli_env):
+    import atif
+
+    main_module, project = _setup(tmp_path, monkeypatch, SemanticAskFakeAgent)
+    exit_code = main_module.main(["ask", "run the tests", "--project", str(project), "--save", "--json"])
+    assert exit_code == 0
+    session_id = json.loads(capsys.readouterr().out.splitlines()[0])["session_id"]
+
+    exit_code = main_module.main(["sessions", "export", session_id, "--format", "atif"])
+    assert exit_code == 0
+    document = json.loads(capsys.readouterr().out)
+    atif.Trajectory.model_validate(document)
+    assert document["session_id"] == session_id
+
+    # The default replay snapshot is untouched by the new formats.
+    exit_code = main_module.main(["sessions", "export", session_id])
+    assert exit_code == 0
+    assert capsys.readouterr().out == SessionStore().export(session_id)
+
+
+def test_sessions_export_atif_with_images_needs_output(tmp_path, capsys, monkeypatch, isolated_cli_env):
+    png = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFAAH/q842iQAAAABJRU5ErkJggg=="
+    )
+
+    class ImageTurnAgent(SemanticAskFakeAgent):
+        async def process_message_stream(self, message, attachments=None):
+            self.messages.append(message)
+            recorder = self.session_recorder
+            assert recorder is not None
+            recorder.start_turn(
+                Message(
+                    role="user",
+                    content=[TextBlock("look"), ImageBlock("base64", "image/png", base64.b64encode(png).decode())],
+                )
+            )
+            recorder.finish_turn("completed")
+            yield {"type": "response", "content": "seen", "complete": True, "uuid": "r1"}
+
+    main_module, project = _setup(tmp_path, monkeypatch, ImageTurnAgent)
+    exit_code = main_module.main(["ask", "look", "--project", str(project), "--save", "--json"])
+    assert exit_code == 0
+    session_id = json.loads(capsys.readouterr().out.splitlines()[0])["session_id"]
+
+    # Stdout export refuses before writing anything.
+    exit_code = main_module.main(["sessions", "export", session_id, "--format", "atif"])
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert captured.out == ""
+    assert "--output" in captured.err
+
+    out = tmp_path / "img" / "trajectory.json"
+    exit_code = main_module.main(["sessions", "export", session_id, "--format", "atif", "--output", str(out)])
+    assert exit_code == 0
+    trajectory = _validate(out)
+    assert trajectory.has_multimodal_content()
+    assets = sorted((out.parent / "trajectory.assets").iterdir())
+    assert len(assets) == 1 and assets[0].read_bytes() == png
+
+
+def test_sessions_export_events_jsonl_round_trip(tmp_path, capsys, monkeypatch, isolated_cli_env):
+    main_module, project = _setup(tmp_path, monkeypatch, SemanticAskFakeAgent)
+    exit_code = main_module.main(["ask", "run the tests", "--project", str(project), "--save", "--json"])
+    assert exit_code == 0
+    live = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+
+    exit_code = main_module.main(["sessions", "export", live[0]["session_id"], "--format", "events-jsonl"])
+    assert exit_code == 0
+    exported = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    assert exported == live
+
+
+def test_unknown_session_exits_two(tmp_path, capsys, monkeypatch, isolated_cli_env):
+    main_module, _ = _setup(tmp_path, monkeypatch, SemanticAskFakeAgent)
+    exit_code = main_module.main(["sessions", "export", "does-not-exist", "--format", "atif"])
+    assert exit_code == 2
+
+
+@pytest.mark.parametrize("bad_format", ["yaml", "atiff"])
+def test_invalid_format_is_rejected_by_argparse(tmp_path, capsys, monkeypatch, isolated_cli_env, bad_format):
+    main_module, _ = _setup(tmp_path, monkeypatch, SemanticAskFakeAgent)
+    with pytest.raises(SystemExit) as excinfo:
+        main_module.main(["sessions", "export", "x", "--format", bad_format])
+    assert excinfo.value.code == 2

--- a/tests/cli/test_atif_export.py
+++ b/tests/cli/test_atif_export.py
@@ -1,0 +1,560 @@
+"""ATIF v1.7 export: projection, v1 fallbacks, assets, security, atomicity."""
+
+import base64
+import json
+
+import pytest
+
+from kolega_code.cli.atif_export import (
+    AtifExportError,
+    AtifImagesNeedOutputError,
+    export_atif_to_path,
+    export_atif_to_text,
+)
+from kolega_code.cli.session_event_protocol import InMemorySessionJournal
+from kolega_code.cli.session_journal import (
+    TOOL_RESULT_PREVIEW_CHARS,
+    SessionJournal,
+    SessionRecorder,
+    derive_root_agent_id,
+)
+from kolega_code.llm.ledger import HISTORY_ORIGIN, UsageLedger, llm_call_origin
+from kolega_code.llm.models import (
+    ImageBlock,
+    Message,
+    TextBlock,
+    ThinkingBlock,
+    ToolCall,
+    ToolResult,
+)
+from kolega_code.llm.usage import normalize_usage
+
+# A 1x1 red PNG.
+_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFAAH/q842iQAAAABJRU5ErkJggg=="
+)
+
+EXPORT_KW = dict(kolega_version="0.0.0-test", secret_values=(), state_dirs=())
+
+
+def _usage(inp, out):
+    return normalize_usage({"input_tokens": inp, "output_tokens": out}, "anthropic", "claude-opus-5")
+
+
+def make_journal(tmp_path=None, session_id="atif-s1"):
+    if tmp_path is None:
+        return InMemorySessionJournal(session_id)
+    return SessionJournal(session_id, tmp_path / "session")
+
+
+def bootstrap(journal, *, project="/Users/evandempsey/git/x"):
+    journal.append(
+        "session.created",
+        actor="system",
+        payload={
+            "metadata": {
+                "mode": "code",
+                "title": "t",
+                "project_path": project,
+                "config": {"long_provider": "anthropic", "long_model": "claude-opus-5", "thinking_effort": "high"},
+            },
+            "kolega_version": "0.27.1",
+        },
+        epoch_id="e1",
+    )
+    journal.append("context.epoch_started", actor="system", payload={"reason": "session_created"}, epoch_id="e1")
+    return SessionRecorder(journal, recover=False)
+
+
+def settled(ledger, message):
+    with llm_call_origin(HISTORY_ORIGIN):
+        request_id = ledger.begin("anthropic", "claude-opus-5")
+        ledger.record_response(request_id, message.usage, message)
+    return message
+
+
+def convert(journal, **overrides):
+    kwargs = {**EXPORT_KW, **overrides}
+    return json.loads(export_atif_to_text(journal, **kwargs))
+
+
+def drive_rich_turn(recorder, ledger):
+    recorder.start_turn(Message(role="user", content=[TextBlock("run the tests")]))
+    recorder.record_system_context("You are kolega.")
+    first = settled(
+        ledger,
+        Message(
+            role="assistant",
+            content=[
+                ThinkingBlock("let me think", signature="OPAQUE-SIG"),
+                TextBlock("Checking."),
+                ToolCall(id="p1", name="exec_command", input={"command": "pytest"}, execution_id="tool_exec_1"),
+                ToolCall(
+                    id="p2",
+                    name="apply_patch",
+                    input="*** Begin Patch",
+                    execution_id="tool_exec_2",
+                    input_kind="freeform",
+                ),
+            ],
+            stop_reason="tool_use",
+            usage=_usage(100, 20),
+        ),
+    )
+    recorder.record_assistant(first, reasoning_effort="high")
+    # Results recorded out of call order: correlation is by id, never order.
+    recorder.record_tool_results(
+        [
+            ToolResult(
+                tool_use_id="p2",
+                content="patched",
+                name="apply_patch",
+                is_error=False,
+                execution_id="tool_exec_2",
+                input_kind="freeform",
+            ),
+            ToolResult(
+                tool_use_id="p1", content="1 passed", name="exec_command", is_error=False, execution_id="tool_exec_1"
+            ),
+        ]
+    )
+    second = settled(
+        ledger,
+        Message(role="assistant", content=[TextBlock("All green.")], stop_reason="end_turn", usage=_usage(150, 10)),
+    )
+    recorder.record_assistant(second)
+    recorder.finish_turn("completed")
+
+
+def test_rich_turn_projects_and_validates():
+    journal = make_journal()
+    recorder = bootstrap(journal)
+    ledger = UsageLedger()
+    drive_rich_turn(recorder, ledger)
+    recorder.record_run_terminal("completed", {"status": "completed", "exit_code": 0})
+
+    doc = convert(journal)
+    assert doc["schema_version"] == "ATIF-v1.7"
+    assert doc["session_id"] == "atif-s1"
+    assert doc["trajectory_id"] == derive_root_agent_id("atif-s1")
+    assert doc["agent"]["name"] == "kolega-code"
+    assert doc["agent"]["model_name"] == "claude-opus-5"
+
+    steps = doc["steps"]
+    assert [step["step_id"] for step in steps] == list(range(1, len(steps) + 1))
+    sources = [step["source"] for step in steps]
+    assert sources == ["user", "system", "agent", "agent"]
+
+    agent_step = steps[2]
+    assert agent_step["llm_call_count"] == 1
+    assert agent_step["model_name"] == "claude-opus-5"
+    assert agent_step["reasoning_effort"] == "high"
+    assert agent_step["reasoning_content"] == "let me think"
+    calls = agent_step["tool_calls"]
+    assert [call["tool_call_id"] for call in calls] == ["tool_exec_1", "tool_exec_2"]
+    assert calls[0]["function_name"] == "exec_command"
+    assert calls[0]["arguments"] == {"command": "pytest"}
+    # Free-form input becomes an object without losing the original text.
+    assert calls[1]["arguments"] == {"input": "*** Begin Patch"}
+    assert calls[1]["extra"]["kolega"]["input"] == "*** Begin Patch"
+
+    results = agent_step["observation"]["results"]
+    assert {result["source_call_id"] for result in results} == {"tool_exec_1", "tool_exec_2"}
+    by_call = {result["source_call_id"]: result for result in results}
+    assert by_call["tool_exec_1"]["content"] == "1 passed"
+
+    assert agent_step["metrics"] == {"prompt_tokens": 100, "completion_tokens": 20}
+    assert doc["final_metrics"]["total_prompt_tokens"] == 250
+    assert doc["final_metrics"]["total_completion_tokens"] == 30
+    assert doc["final_metrics"]["extra"]["llm_steps"] == 2
+
+    # llm_call_id provenance retained per step; opaque state absent everywhere.
+    assert agent_step["extra"]["kolega"]["llm_call_id"]
+    assert "OPAQUE-SIG" not in json.dumps(doc)
+    assert doc["extra"]["kolega"]["status"]["outcome"] == "completed"
+    # Original identity is preserved on every step.
+    assert all("seq" in step["extra"]["kolega"] for step in steps)
+
+
+def test_synthetic_notice_step_has_no_llm_fields():
+    journal = make_journal()
+    recorder = bootstrap(journal)
+    recorder.start_turn(Message(role="user", content=[TextBlock("hi")]))
+    recorder.record_synthetic_assistant("Prompt blocked.", notice_code="hook_blocked")
+    recorder.finish_turn("completed")
+
+    doc = convert(journal)
+    step = next(step for step in doc["steps"] if step["source"] == "agent")
+    assert step["llm_call_count"] == 0
+    assert "metrics" not in step
+    assert "reasoning_content" not in step
+    assert "model_name" not in step
+    assert step["extra"]["kolega"]["notice_code"] == "hook_blocked"
+
+
+def test_oversized_tool_result_is_fully_hydrated(tmp_path):
+    journal = make_journal(tmp_path)
+    recorder = bootstrap(journal)
+    ledger = UsageLedger()
+    big = "x" * (TOOL_RESULT_PREVIEW_CHARS + 500)
+    recorder.start_turn(Message(role="user", content=[TextBlock("go")]))
+    first = settled(
+        ledger,
+        Message(
+            role="assistant",
+            content=[ToolCall(id="p1", name="bash", input={}, execution_id="tool_exec_big")],
+            stop_reason="tool_use",
+            usage=_usage(10, 5),
+        ),
+    )
+    recorder.record_assistant(first)
+    recorder.record_tool_results(
+        [ToolResult(tool_use_id="p1", content=big, name="bash", is_error=False, execution_id="tool_exec_big")]
+    )
+    recorder.finish_turn("completed")
+
+    doc = convert(journal, state_dirs=(tmp_path,))
+    step = next(step for step in doc["steps"] if step.get("tool_calls"))
+    content = step["observation"]["results"][0]["content"]
+    assert len(content) == len(big)
+    assert "[Middle of tool result omitted" not in content
+    assert str(tmp_path) not in json.dumps(doc)
+    assert step["observation"]["results"][0]["extra"]["kolega"]["hydrated_from_artifact"]["chars"] == len(big)
+
+
+def test_compaction_and_rewind_are_auditable_system_steps():
+    journal = make_journal()
+    recorder = bootstrap(journal)
+    recorder.start_turn(Message(role="user", content=[TextBlock("first")]))
+    recorder.record_assistant(Message(role="assistant", content=[TextBlock("one")], stop_reason="end_turn"))
+    recorder.finish_turn("completed")
+    recorder.record_compaction({"compacted_through": 2}, info={"trigger": "auto", "input_tokens_before": 90000})
+    recorder.record_rewind(recorder.list_rewindable_turns()[0].turn_id)
+
+    doc = convert(journal)
+    compaction = next(s for s in doc["steps"] if s.get("extra", {}).get("context_management"))
+    assert compaction["source"] == "system"
+    assert compaction["extra"]["context_management"] == {"type": "compaction", "boundary": "replace"}
+    assert compaction["extra"]["kolega"]["compaction"]["trigger"] == "auto"
+    rewind = next(s for s in doc["steps"] if "rewind" in s.get("extra", {}).get("kolega", {}))
+    assert rewind["source"] == "system"
+    # Pre-boundary steps stay: the trajectory is an audit record.
+    assert [s["source"] for s in doc["steps"]].count("user") == 1
+    assert any(s["source"] == "agent" for s in doc["steps"])
+
+
+def test_unmatched_tool_result_is_kept_with_a_warning():
+    journal = make_journal()
+    recorder = bootstrap(journal)
+    recorder.start_turn(Message(role="user", content=[TextBlock("go")]))
+    recorder.record_tool_results(
+        [
+            ToolResult(
+                tool_use_id="ghost", content="orphaned", name="bash", is_error=True, execution_id="tool_exec_ghost"
+            )
+        ]
+    )
+    recorder.finish_turn("completed")
+
+    doc = convert(journal)
+    orphan = next(s for s in doc["steps"] if s.get("observation") and s["source"] == "system")
+    result = orphan["observation"]["results"][0]
+    assert result["content"] == "orphaned"
+    assert "source_call_id" not in result
+    assert result["extra"]["kolega"]["uncorrelated_call_id"] == "tool_exec_ghost"
+    assert any(w["code"] == "unmatched_tool_result" for w in doc["extra"]["conversion_warnings"])
+
+
+def test_subagent_trajectories_embed_with_refs():
+    journal = make_journal()
+    recorder = bootstrap(journal)
+    ledger = UsageLedger()
+    recorder.start_turn(Message(role="user", content=[TextBlock("dispatch")]))
+    dispatch = settled(
+        ledger,
+        Message(
+            role="assistant",
+            content=[ToolCall(id="p1", name="dispatch_agent", input={"task": "explore"}, execution_id="tool_exec_d")],
+            stop_reason="tool_use",
+            usage=_usage(10, 5),
+        ),
+    )
+    recorder.record_assistant(dispatch)
+
+    child = recorder.scoped_child(agent_id="child-1", agent_name="explorer", parent_tool_call_id="tool_exec_d", depth=1)
+    child.record_agent_started({"agent_name": "explorer", "task": "explore"}, turn_id=recorder.current_turn_id)
+    child.start_turn(Message(role="user", content=[TextBlock("explore")]))
+    child.record_assistant(
+        settled(
+            ledger, Message(role="assistant", content=[TextBlock("found")], stop_reason="end_turn", usage=_usage(5, 2))
+        )
+    )
+    child.finish_turn("completed")
+    child.record_agent_terminal("completed", {"summary": "found"})
+
+    recorder.record_tool_results(
+        [
+            ToolResult(
+                tool_use_id="p1", content="found", name="dispatch_agent", is_error=False, execution_id="tool_exec_d"
+            )
+        ]
+    )
+    recorder.finish_turn("completed")
+
+    doc = convert(journal)
+    subs = doc["subagent_trajectories"]
+    assert [t["trajectory_id"] for t in subs] == ["child-1"]
+    assert subs[0]["agent"]["extra"]["agent_name"] == "explorer"
+    assert subs[0]["agent"]["extra"]["status"] == "completed"
+    assert [s["step_id"] for s in subs[0]["steps"]] == [1, 2]
+    # Every subagent trajectory starts its own step_id sequence and the parent
+    # observation for the dispatch call references it.
+    dispatch_step = next(s for s in doc["steps"] if s.get("tool_calls"))
+    refs = [r for r in dispatch_step["observation"]["results"] if r.get("subagent_trajectory_ref")]
+    assert refs and refs[0]["subagent_trajectory_ref"] == [{"trajectory_id": "child-1"}]
+    assert refs[0]["source_call_id"] == "tool_exec_d"
+    # Subagent LLM usage is counted in the subagent's own final metrics.
+    assert subs[0]["final_metrics"]["total_prompt_tokens"] == 5
+
+
+def test_v1_legacy_journal_exports_with_derived_identities(tmp_path):
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    base = {
+        "version": 1,
+        "session_id": "legacy1",
+        "epoch_id": "e1",
+        "turn_id": "t1",
+        "artifacts": [],
+    }
+    lines = [
+        {
+            **base,
+            "id": "ev1",
+            "seq": 1,
+            "turn_id": None,
+            "timestamp": "2026-01-01T00:00:00+00:00",
+            "actor": "system",
+            "type": "session.created",
+            "payload": {"metadata": {"mode": "code", "project_path": "/p", "config": {}}},
+        },
+        {
+            **base,
+            "id": "ev2",
+            "seq": 2,
+            "turn_id": None,
+            "timestamp": "2026-01-01T00:00:01+00:00",
+            "actor": "system",
+            "type": "context.epoch_started",
+            "payload": {"reason": "session_created"},
+        },
+        {
+            **base,
+            "id": "ev3",
+            "seq": 3,
+            "timestamp": "2026-01-01T00:00:02+00:00",
+            "actor": "user",
+            "type": "turn.started",
+            "payload": {"message": {"role": "user", "content": [{"type": "text", "text": "hello"}]}},
+        },
+        {
+            **base,
+            "id": "ev4",
+            "seq": 4,
+            "timestamp": "2026-01-01T00:00:03+00:00",
+            "actor": "assistant",
+            "type": "assistant.message",
+            "payload": {
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "hi"}],
+                    "stop_reason": "end_turn",
+                    "usage": {
+                        "provider": "anthropic",
+                        "model": "m",
+                        "reported": True,
+                        "input_tokens": 7,
+                        "output_tokens": 3,
+                        "total_tokens": 10,
+                        "cache_read_input_tokens": None,
+                        "cache_write_input_tokens": None,
+                        "reasoning_output_tokens": None,
+                        "unavailable_reason": None,
+                    },
+                }
+            },
+        },
+        {
+            **base,
+            "id": "ev5",
+            "seq": 5,
+            "timestamp": "2026-01-01T00:00:04+00:00",
+            "actor": "assistant",
+            "type": "llm.message",
+            "payload": {
+                "request_id": "req-sub-1",
+                "run_id": "r1",
+                "provider": "anthropic",
+                "model": "m",
+                "origin": {
+                    "kind": "sub_agent",
+                    "agent_name": "investigator",
+                    "agent_id": "sub-legacy",
+                    "parent_tool_call_id": "tool_exec_v1",
+                    "depth": 1,
+                },
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "sub answer"}],
+                    "stop_reason": "end_turn",
+                    "usage": {
+                        "provider": "anthropic",
+                        "model": "m",
+                        "reported": True,
+                        "input_tokens": 4,
+                        "output_tokens": 2,
+                        "total_tokens": 6,
+                        "cache_read_input_tokens": None,
+                        "cache_write_input_tokens": None,
+                        "reasoning_output_tokens": None,
+                        "unavailable_reason": None,
+                    },
+                },
+            },
+        },
+        {
+            **base,
+            "id": "ev6",
+            "seq": 6,
+            "timestamp": "2026-01-01T00:00:05+00:00",
+            "actor": "system",
+            "type": "turn.completed",
+            "payload": {},
+        },
+    ]
+    (session_dir / "events.jsonl").write_text("".join(json.dumps(line) + "\n" for line in lines), encoding="utf-8")
+    journal = SessionJournal("legacy1", session_dir)
+
+    doc = convert(journal)
+    doc_again = convert(journal)
+    # Derived identities are deterministic across conversions.
+    assert doc["trajectory_id"] == doc_again["trajectory_id"] == derive_root_agent_id("legacy1")
+    root_agent_step = next(s for s in doc["steps"] if s["source"] == "agent")
+    again_agent_step = next(s for s in doc_again["steps"] if s["source"] == "agent")
+    assert root_agent_step["extra"]["kolega"]["llm_call_id"] == again_agent_step["extra"]["kolega"]["llm_call_id"]
+    assert root_agent_step["metrics"] == {"prompt_tokens": 7, "completion_tokens": 3}
+
+    subs = doc["subagent_trajectories"]
+    assert [t["trajectory_id"] for t in subs] == ["sub-legacy"]
+    assert subs[0]["steps"][0]["extra"]["kolega"]["llm_call_id"] == "req-sub-1"
+
+    codes = {w["code"] for w in doc["extra"]["conversion_warnings"]}
+    assert {
+        "v1_source_journal",
+        "v1_derived_agent_id",
+        "v1_derived_llm_call_id",
+        "v1_subagent_tools_unrecorded",
+    } <= codes
+    assert "v1_source_journal" in doc["notes"]
+
+
+def test_secrets_and_state_dir_are_scrubbed(tmp_path):
+    journal = make_journal(tmp_path)
+    recorder = bootstrap(journal)
+    recorder.start_turn(
+        Message(role="user", content=[TextBlock(f"key sk-TOPSECRET at {tmp_path}/session/artifacts/x")])
+    )
+    recorder.finish_turn("completed")
+
+    doc = convert(journal, secret_values=("sk-TOPSECRET",), state_dirs=(tmp_path,))
+    rendered = json.dumps(doc)
+    assert "sk-TOPSECRET" not in rendered
+    assert str(tmp_path) not in rendered
+    assert "<state-dir>" in rendered
+
+
+def test_image_assets_are_copied_hash_verified_and_relative(tmp_path):
+    journal = make_journal(tmp_path / "j")
+    recorder = bootstrap(journal)
+    recorder.start_turn(
+        Message(
+            role="user",
+            content=[TextBlock("look"), ImageBlock("base64", "image/png", base64.b64encode(_PNG).decode())],
+        )
+    )
+    recorder.finish_turn("completed")
+
+    out = tmp_path / "export" / "trajectory.json"
+    export_atif_to_path(journal, output=out, **EXPORT_KW)
+    doc = json.loads(out.read_text())
+    parts = doc["steps"][0]["message"]
+    image = next(part for part in parts if part["type"] == "image")
+    assert image["source"]["media_type"] == "image/png"
+    assert image["source"]["path"].startswith("trajectory.assets/")
+    asset = out.parent / image["source"]["path"]
+    assert asset.read_bytes() == _PNG
+    import hashlib
+
+    assert asset.name.split(".")[0] == hashlib.sha256(_PNG).hexdigest()
+    # Provider-opaque artifact purposes are structurally unreachable.
+    assert [p.name for p in sorted((out.parent / "trajectory.assets").iterdir())] == [asset.name]
+
+
+def test_stdout_export_with_images_refuses_before_writing(tmp_path):
+    journal = make_journal(tmp_path)
+    recorder = bootstrap(journal)
+    recorder.start_turn(
+        Message(role="user", content=[ImageBlock("base64", "image/png", base64.b64encode(_PNG).decode())])
+    )
+    recorder.finish_turn("completed")
+
+    with pytest.raises(AtifImagesNeedOutputError):
+        export_atif_to_text(journal, **EXPORT_KW)
+
+
+def test_failed_export_leaves_previous_output_intact(tmp_path, monkeypatch):
+    journal = make_journal(tmp_path / "j")
+    recorder = bootstrap(journal)
+    recorder.start_turn(Message(role="user", content=[TextBlock("one")]))
+    recorder.finish_turn("completed")
+
+    out = tmp_path / "trajectory.json"
+    export_atif_to_path(journal, output=out, **EXPORT_KW)
+    original = out.read_text()
+
+    from kolega_code.cli import atif_export as module
+
+    def boom(document):
+        raise AtifExportError("validation forced to fail")
+
+    monkeypatch.setattr(module, "validate_atif_document", boom)
+    with pytest.raises(AtifExportError):
+        export_atif_to_path(journal, output=out, **EXPORT_KW)
+    assert out.read_text() == original
+    leftovers = [p.name for p in out.parent.iterdir() if p.name.startswith(".")]
+    assert not [name for name in leftovers if "tmp-atif" in name or ".old-" in name]
+
+
+def test_unknown_event_types_are_recorded_not_fatal():
+    journal = make_journal()
+    bootstrap(journal)
+    journal.append("kolega.future_event", actor="system", payload={"x": 1})
+
+    doc = convert(journal)
+    assert doc["extra"]["kolega"]["unknown_events"] == [{"type": "kolega.future_event", "seq": 3}]
+    assert any(w["code"] == "unknown_event_type" for w in doc["extra"]["conversion_warnings"])
+
+
+def test_usage_is_never_fabricated():
+    journal = make_journal()
+    recorder = bootstrap(journal)
+    recorder.start_turn(Message(role="user", content=[TextBlock("go")]))
+    recorder.record_assistant(Message(role="assistant", content=[TextBlock("no usage")], stop_reason="end_turn"))
+    recorder.finish_turn("completed")
+
+    doc = convert(journal)
+    step = next(s for s in doc["steps"] if s["source"] == "agent")
+    assert "metrics" not in step
+    assert "total_prompt_tokens" not in (doc.get("final_metrics") or {})
+    codes = {w["code"] for w in doc["extra"]["conversion_warnings"]}
+    assert "usage_missing_for_llm_step" in codes and "usage_totals_partial" in codes

--- a/tests/cli/test_atif_export.py
+++ b/tests/cli/test_atif_export.py
@@ -78,9 +78,21 @@ def convert(journal, **overrides):
     return json.loads(export_atif_to_text(journal, **kwargs))
 
 
+RICH_TURN_TOOLS = [
+    {"name": "exec_command", "description": "Run a command.", "input_schema": {"type": "object"}},
+    {
+        "name": "apply_patch",
+        "description": "Apply a patch.",
+        "input_schema": {"type": "object"},
+        "input_kind": "freeform",
+    },
+]
+
+
 def drive_rich_turn(recorder, ledger):
     recorder.start_turn(Message(role="user", content=[TextBlock("run the tests")]))
     recorder.record_system_context("You are kolega.")
+    recorder.record_tool_definitions(RICH_TURN_TOOLS)
     first = settled(
         ledger,
         Message(
@@ -139,6 +151,8 @@ def test_rich_turn_projects_and_validates():
     assert doc["trajectory_id"] == derive_root_agent_id("atif-s1")
     assert doc["agent"]["name"] == "kolega-code"
     assert doc["agent"]["model_name"] == "claude-opus-5"
+    assert doc["agent"]["tool_definitions"] == RICH_TURN_TOOLS
+    assert not any(w["code"] == "tool_definitions_unavailable" for w in doc["extra"]["conversion_warnings"])
 
     steps = doc["steps"]
     assert [step["step_id"] for step in steps] == list(range(1, len(steps) + 1))
@@ -456,6 +470,9 @@ def test_v1_legacy_journal_exports_with_derived_identities(tmp_path):
         "v1_subagent_tools_unrecorded",
     } <= codes
     assert "v1_source_journal" in doc["notes"]
+    # v1 sessions never recorded tool schemas: omitted with a warning.
+    assert "tool_definitions" not in doc["agent"]
+    assert "tool_definitions_unavailable" in codes
 
 
 def test_secrets_and_state_dir_are_scrubbed(tmp_path):

--- a/tests/cli/test_atif_reference_validator.py
+++ b/tests/cli/test_atif_reference_validator.py
@@ -1,0 +1,111 @@
+"""Representative ATIF exports validate against the reference implementation
+in a clean, isolated environment.
+
+The `atif` PyPI package is the ATIF RFC's reference implementation; validating
+in a throwaway `uvx` environment proves our documents stand on their own,
+independent of this repo's installed dependency tree. Harbor itself (0.21.0)
+ships no separate importable/CLI trajectory validator and does not depend on
+`atif`; if a future Harbor version grows a validator surface, extend this test
+to invoke it as well.
+
+Slow-marked: provisions an environment at test time and skips cleanly when
+that is unavailable (offline CI).
+"""
+
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from kolega_code.cli.atif_export import export_atif_to_text
+from kolega_code.llm.models import Message, TextBlock, ToolCall, ToolResult
+from kolega_code.llm.usage import normalize_usage
+
+from .test_atif_export import bootstrap, make_journal, settled
+
+ATIF_REFERENCE_PIN = "atif==1.7.0"
+
+pytestmark = [pytest.mark.slow, pytest.mark.integration]
+
+
+def _reference_validate(document_text: str) -> subprocess.CompletedProcess:
+    uvx = shutil.which("uvx")
+    if uvx is None:
+        pytest.skip("uvx is not available to provision the reference validator")
+    return subprocess.run(
+        [
+            uvx,
+            "--with",
+            ATIF_REFERENCE_PIN,
+            "python",
+            "-c",
+            "import atif, json, sys; atif.Trajectory.model_validate(json.load(sys.stdin)); print('VALID')",
+        ],
+        input=document_text,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+
+
+def test_representative_exports_pass_the_reference_validator():
+    from kolega_code.llm.ledger import UsageLedger
+
+    journal = make_journal(session_id="ref-validate")
+    recorder = bootstrap(journal)
+    ledger = UsageLedger()
+    recorder.start_turn(Message(role="user", content=[TextBlock("multi tool")]))
+    first = settled(
+        ledger,
+        Message(
+            role="assistant",
+            content=[
+                TextBlock("working"),
+                ToolCall(id="a", name="read_file", input={"path": "x"}, execution_id="tool_exec_a"),
+                ToolCall(id="b", name="bash", input={"cmd": "ls"}, execution_id="tool_exec_b"),
+            ],
+            stop_reason="tool_use",
+            usage=normalize_usage({"input_tokens": 10, "output_tokens": 4}, "anthropic", "m"),
+        ),
+    )
+    recorder.record_assistant(first)
+    recorder.record_tool_results(
+        [
+            ToolResult(tool_use_id="b", content="dir", name="bash", is_error=False, execution_id="tool_exec_b"),
+            ToolResult(tool_use_id="a", content="text", name="read_file", is_error=False, execution_id="tool_exec_a"),
+        ]
+    )
+    child = recorder.scoped_child(agent_id="sub-ref", agent_name="worker", parent_tool_call_id="tool_exec_b", depth=1)
+    child.record_agent_started({"agent_name": "worker", "task": "t"}, turn_id=recorder.current_turn_id)
+    child.start_turn(Message(role="user", content=[TextBlock("t")]))
+    child.record_assistant(
+        settled(
+            ledger,
+            Message(
+                role="assistant",
+                content=[TextBlock("done")],
+                stop_reason="end_turn",
+                usage=normalize_usage({"input_tokens": 3, "output_tokens": 1}, "anthropic", "m"),
+            ),
+        )
+    )
+    child.finish_turn("completed")
+    child.record_agent_terminal("completed", {"summary": "done"})
+    recorder.record_synthetic_assistant("notice", notice_code="skill_activation")
+    recorder.finish_turn("completed")
+    recorder.record_run_terminal("completed", {"status": "completed", "exit_code": 0})
+
+    text = export_atif_to_text(journal, kolega_version="0.0.0-test", secret_values=(), state_dirs=())
+    try:
+        result = _reference_validate(text)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        pytest.skip(f"Could not provision the reference validator: {exc}")
+    if result.returncode != 0 and "VALID" not in result.stdout:
+        if "No solution found" in result.stderr or "network" in result.stderr.lower():
+            pytest.skip(f"Reference environment unavailable: {result.stderr[-200:]}")
+        pytest.fail(f"Reference validator rejected the document: {result.stderr[-2000:]}")
+    assert "VALID" in result.stdout
+    # Sanity: the document round-trips as JSON with embedded subagents.
+    document = json.loads(text)
+    assert document["subagent_trajectories"][0]["trajectory_id"] == "sub-ref"

--- a/tests/cli/test_event_protocol.py
+++ b/tests/cli/test_event_protocol.py
@@ -452,6 +452,25 @@ def test_system_context_is_fingerprinted_and_reset_by_epoch(tmp_path: Path) -> N
     assert sum(1 for e in journal.read_events() if e.event_type == "context.system") == 3
 
 
+def test_tool_definitions_are_fingerprinted_and_reset_by_epoch(tmp_path: Path) -> None:
+    journal = make_file_journal(tmp_path)
+    bootstrap(journal)
+    recorder = SessionRecorder(journal, recover=False)
+    tools = [{"name": "read_file", "description": "Read a file.", "input_schema": {"type": "object"}}]
+    assert recorder.record_tool_definitions([]) is False
+    assert recorder.record_tool_definitions(tools) is True
+    assert recorder.record_tool_definitions(tools) is False
+    assert recorder.record_tool_definitions(tools + [{"name": "bash", "description": "", "input_schema": {}}]) is True
+    recorder.start_epoch("agent_clear_command")
+    assert recorder.record_tool_definitions(tools) is True
+    events = [e for e in journal.read_events() if e.event_type == "context.tools"]
+    assert len(events) == 3
+    assert events[0].payload["tools"][0]["name"] == "read_file"
+    public = to_public_event(events[0])
+    assert public is not None
+    assert public["payload"]["tools"] == tools
+
+
 def test_scoped_child_recorder_stamps_lineage_and_interleaves(tmp_path: Path) -> None:
     journal = make_file_journal(tmp_path)
     bootstrap(journal)

--- a/uv.lock
+++ b/uv.lock
@@ -215,6 +215,18 @@ wheels = [
 ]
 
 [[package]]
+name = "atif"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/14/b0629cab0a86470c31d530498fc39c65a8385eaf95f4f39dbcde695284c5/atif-1.7.0.tar.gz", hash = "sha256:668cf3d4592a2147e62a4c2fc3663faacb3217a1627b395a1e0f354076f79d3f", size = 9613, upload-time = "2026-05-16T05:23:02.163Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/97/cddb7c5cebe218534563533600eacc57beaace90ee85c435126214f5b18b/atif-1.7.0-py3-none-any.whl", hash = "sha256:7bb0c09a6d94ff5a73f6253a2aeb101d41d0724cfd0cdb8d96541ac4f2b7ab6c", size = 12346, upload-time = "2026-05-16T05:23:00.825Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1777,6 +1789,7 @@ version = "0.27.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "atif" },
     { name = "beautifulsoup4" },
     { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
     { name = "cryptography", version = "50.0.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
@@ -1840,6 +1853,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = "==0.101.0" },
+    { name = "atif", specifier = "==1.7.0" },
     { name = "beautifulsoup4", specifier = "==4.14.3" },
     { name = "cryptography", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'", specifier = "==50.0.0" },
     { name = "cryptography", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'", specifier = "==48.0.1" },


### PR DESCRIPTION
PR 3 of 3 implementing `json-output-atif-spec.md`, stacked on #523 (which stacks on #522). Adds `sessions export --format atif` and `ask --atif-output`, backed by a new pure-projection converter.

## What this adds

**`kolega_code/cli/atif_export.py`** — a five-stage pipeline: `TrajectorySource` (file or in-memory journal) → public events (`to_public_event`, so scrubbing/opaque-removal/canonical tool ids are identical to every other public surface) → grouped trajectory drafts → ATIF document dicts + asset plan → `atif.Trajectory.model_validate` → write. Highlights:

- **One agent step per LLM inference** (`llm_call_count: 1`; synthetic notices `0` with no metrics/reasoning, per the RFC's gating). Per-step metrics map Kolega's normalized usage (input→prompt, output→completion, cache_read→cached, reasoning/cache_write→`metrics.extra`); missing usage is never fabricated and coverage warnings land in `extra.conversion_warnings`.
- **Tool results correlate by canonical id to the step that made the call**, out-of-order safe; unmatched results become system observations with a warning, never dropped. Free-form (`apply_patch`) arguments are objects with the original text preserved.
- **Subagents embed as complete `subagent_trajectories`** (own `step_id` sequence from 1, unique trajectory ids = agent ids), referenced from the dispatch call's observation via `subagent_trajectory_ref`.
- **Audit-record semantics:** compactions (`extra.context_management`), rewinds, and epoch resets are system steps; pre-boundary steps are never deleted. Run/turn terminals and goal/loop outcomes fold into `extra.kolega`.
- **v1 legacy sessions convert** with deterministic fallbacks — derived root agent identity, event-derived `llm_call_id`s, subagent LLM steps recovered from `llm.message` origin lineage — all declared in `extra.conversion_warnings` + `notes`.
- **Assets & hygiene:** oversized tool results are fully hydrated from artifacts; only image-purpose artifacts are ever materialized (opaque purposes are structurally unreachable), copied hash-verified to `<output-stem>.assets/` with relative refs. Stdout export refuses image trajectories before writing anything (exit 2). Atomic file export via temp siblings + ordered rename — failure leaves a previous export intact, no litter. State-dir prefixes become `<state-dir>`; secrets/home/opaque state are already gone via the public projection.

**CLI** — `sessions export --format atif` (stdout or `--output`; conversion failure exits 1); `ask --atif-output FILE` finalizes in the run's `finally` *after* the run-terminal record, so the trajectory carries the outcome — completed, failed, or cancelled, with or without `--save` (unsaved runs convert from the in-memory journal). The run's own exit status always wins; a conversion failure elevates only 0 → 1.

**Tool definitions (follow-up commit)** — the initially-declared gap is closed: `ToolDefinition.to_public_dict()` + `SessionRecorder.record_tool_definitions()` journal the agent's toolset as a fingerprinted `context.tools` event (root and subagents, only on change, epoch-reset aware), and the converter maps it onto `agent.tool_definitions` for the root and embedded trajectories. The `tool_definitions_unavailable` warning now fires only for sessions recorded before the event existed.

**Packaging** — `atif==1.7.0` pinned in base `[project.dependencies]` (deliberate deviation from the spec's "CLI dependency set": the `cli` extra is empty/vestigial, end users install with no extras, and CI/wheel-coverage walk base deps). Pure Python, sole dep `pydantic>=2.9`; resolved without an `exclude-newer` exception.

## Spec deviation worth review

The spec's "Harbor's reference validator" integration test: **harbor 0.21.0 ships no ATIF validator surface** (no importable trajectory module, no CLI command, and no dependency on `atif`). The `atif` package *is* the RFC's reference implementation, so the slow-marked test (`test_atif_reference_validator.py`) validates representative multi-tool/subagent/synthetic exports in an isolated `uvx --with atif==1.7.0` environment instead, skipping cleanly offline. If a future harbor version grows a validator, the test is the place to extend.

## Tests

- `tests/cli/test_atif_export.py` (13): rich-turn projection, synthetic gating, oversized hydration, compaction/rewind audit steps, unmatched results, subagent embedding + refs, v1 legacy fixtures with deterministic derived ids, secret/state-dir scrub, image asset copy + hash + relative paths, stdout image refusal, atomic-failure preservation, unknown event types, never-fabricated usage.
- `tests/cli/test_ask_atif_output.py` (10): saved/unsaved/billing-failed runs, conversion-failure exit codes, `sessions export` format parity + image `--output` flow + `events-jsonl` live≡export round-trip, unknown-session and invalid-format errors.
- Full fast suite: 4446 passed (one unrelated pre-existing flake in `tests/agent/services/test_terminal.py::test_cancelled_exec_returns_recoverable_spill_result` — fails ~1 in 4 runs in isolation on untouched code). Ruff + Pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WA3jkDUSkeaBnus47HX5LY
