### PR TITLE
fix(terminal): drain the PTY before detaching so killed commands keep their tail

### DIFF
--- a/kolega_code/services/terminal.py
+++ b/kolega_code/services/terminal.py
@@ -372,13 +372,30 @@ class PtySession:
     def _detach_pty(self) -> None:
         """Release the PTY after the shell exited without EOF.
 
-        The non-EOF analogue of :meth:`_handle_eof`: drop the reader, close
-        the master (hanging up the slave, which SIGHUPs any surviving
-        background process), finalize the output, and flush the display
-        decoder.
+        The non-EOF analogue of :meth:`_handle_eof`: drop the reader, drain
+        and close the master (hanging up the slave, which SIGHUPs any
+        surviving background process), finalize the output, and flush the
+        display decoder.
         """
         self._remove_reader()
         if self.master_fd is not None:
+            # The shell has exited, so everything still sitting in the PTY
+            # buffer is final output. Drain it synchronously before closing:
+            # the reap path's settle sleep gives the reader callback *a*
+            # chance to run, not a guarantee it consumed every byte — under
+            # load, closing here used to drop the tail of large bursts.
+            # The master is O_NONBLOCK, so this loop cannot stall.
+            while True:
+                try:
+                    data = os.read(self.master_fd, 65536)
+                except (BlockingIOError, InterruptedError):
+                    break
+                except OSError:
+                    break  # EIO: the PTY has nothing further to give
+                if not data:
+                    break
+                self._output.append_bytes(data)
+                self._broadcast(data)
             try:
                 os.close(self.master_fd)
             except OSError:


### PR DESCRIPTION
Fixes the pre-existing ~1-in-4 flake in `tests/agent/services/test_terminal.py::test_cancelled_exec_returns_recoverable_spill_result` — which turned out to be a real output-loss bug, not a test problem.

## The race

On a non-EOF exit, `_poll_for_exit` reaps the shell, sleeps a fixed 20ms settle "so the reader drains", then `_detach_pty` closes the master. The settle gives the `add_reader` callback *a chance* to run — not a guarantee it consumed every byte. Under load, output the child had already flushed (the tail of a 70KB burst in the repro) was still sitting in the PTY buffer when the master closed, and was silently dropped from both the accumulator and the spill file.

## The fix

`_detach_pty` drains the master synchronously until `EAGAIN`/EOF/`EIO` before closing, feeding the same `append_bytes`/broadcast path as the reader callback. The fd is `O_NONBLOCK`, so the loop cannot stall; the child has already exited, so everything read is final output. Deterministic by construction rather than timing-dependent.

## Verification

- Before: ~1 failure in 4 isolated runs of the repro test.
- After: 0 failures in 20 isolated runs; the full `test_terminal.py` suite (46 tests) passes.

Independent of the semantic-JSON/ATIF stack (#522–#524); based on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WA3jkDUSkeaBnus47HX5LY