### PR TITLE
fix(extensions): transactional extension-generation cleanup on every exit path

### DIFF
--- a/docs/src/content/docs/concepts/extensions.md
+++ b/docs/src/content/docs/concepts/extensions.md
@@ -36,7 +36,9 @@ kolega-code ask "Inspect the repository" \
   error.
 
 Load and validation failures terminate before the first model request with a
-concise error and a nonzero exit status. A tool name contributed by the
+concise error and a nonzero exit status. Any ordinary exception raised while
+importing the module — not just an `ImportError` — is reported the same way,
+naming the module and the original exception. A tool name contributed by the
 extension that conflicts with a built-in or already-provisioned tool also
 refuses to start.
 
@@ -141,8 +143,14 @@ helper calls without extra plumbing.
 
 `cleanup` runs exactly once per bundle (awaited when awaitable), after the
 corresponding agent's own cleanup, on every exit path: completion, interactive
-agent rebuild, failure, or interrupt. A cleanup failure is reported without
-masking the primary error.
+agent rebuild, failure, or interrupt. Once a bundle exists, the rest of the
+generation is one transaction — a failure during agent construction, LSP
+initialization, binding, session-start hooks, inference, or output
+serialization, and cancellation at any of those points, all still release the
+bundle. A partially constructed generation is cleaned to the extent it exists:
+agent cleanup runs only when the agent was built, and bundle cleanup runs even
+when agent cleanup fails. A cleanup failure is reported without masking the
+primary error.
 
 ## Minimal example
 

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -2021,15 +2021,18 @@ class KolegaCodeApp(
                     except Exception:
                         pass
                 await self._save_session_history_async()
-                await self.agent.cleanup()
-            await self._cleanup_extension_bundle()
-            # After cleanup: cancelled streams settle their failures into the
-            # ledger first, so the drain below captures them.
-            if self._usage_sink is not None:
-                await self._usage_sink.aclose()
         finally:
-            self._close_memory_manager()
-            self.exit()
+            # Generation teardown and the sink drain run even when an earlier
+            # step raised; the original failure still propagates.
+            try:
+                await self._cleanup_agent_generation()
+                # After cleanup: cancelled streams settle their failures into
+                # the ledger first, so the drain below captures them.
+                if self._usage_sink is not None:
+                    await self._usage_sink.aclose()
+            finally:
+                self._close_memory_manager()
+                self.exit()
 
     def _set_sidebar_visible(self, visible: bool) -> None:
         self.sidebar_visible = visible

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -1096,8 +1096,23 @@ def _run_tui(args: argparse.Namespace) -> int:
         startup_config_error=startup_config_error,
         extension_selection=extension_selection,
     )
+
+    async def _run_app() -> None:
+        try:
+            await app.run_async()
+        finally:
+            # Awaited teardown for exits that bypass action_quit (startup
+            # errors, crashes); a no-op after a normal quit.
+            await app._cleanup_agent_generation()
+            usage_sink = getattr(app, "_usage_sink", None)
+            if usage_sink is not None:
+                try:
+                    await usage_sink.aclose()
+                except Exception as exc:  # noqa: BLE001 — reported, never masks the primary exception
+                    print(f"Warning: usage sink close failed: {exc}", file=sys.stderr)
+
     try:
-        app.run()
+        asyncio.run(_run_app())
     except Exception as exc:  # noqa: BLE001 — last-resort crash capture before re-raising
         _secrets = known_secret_values(
             settings, settings_store, project_path=project_path, mcp_config=getattr(config, "mcp_config", None)
@@ -1522,215 +1537,208 @@ async def _run_ask(args: argparse.Namespace) -> int:
             return 2
         prompt_extensions.extend(extension_bundle.prompt_extensions)
         tool_extensions.extend(extension_bundle.tool_extensions)
-    permission_mode = normalize_permission_mode(
-        getattr(args, "permission_mode", ASK_DEFAULT_PERMISSION_MODE),
-        default=PermissionMode.AUTO,
-    )
-    usage_ledger = UsageLedger()
-    # Journal every settled non-history response and failure (in-memory journal
-    # for unsaved runs). Attached before the SESSION_START hook below: hook
-    # prompts are paid LLM calls and must be covered from the first request.
+
+    # An extension bundle may exist from here on: every exit path below must
+    # flow through the finally, which tears down agent/bundle/sink exactly once
+    # and records the run terminal.
     usage_sink: Optional[SessionUsageSink] = None
-    sink = SessionUsageSink(journal, session_recorder, usage_ledger, mode="ask")
-    usage_sink = sink
-    usage_ledger.observer = sink
-    await sink.start()
-    try:
-        agent = CoderAgent(
-            project_path=project_path,
-            workspace_id=session.workspace_id,
-            thread_id=session.thread_id,
-            connection_manager=manager,
-            config=config,
-            browser_manager=browser_manager,
-            agent_mode=AgentMode.ASK,
-            prompt_extensions=prompt_extensions,
-            tool_extensions=tool_extensions,
-            permission_mode=permission_mode,
-            permission_callback=_permission_callback_for_ask(launch_project_path)
-            if permission_mode == PermissionMode.ASK
-            else None,
-            session_recorder=session_recorder,
-            hook_dispatcher=hook_dispatcher,
-            custom_agent_catalog=custom_agent_catalog,
-            memory_project_path=launch_project_path,
-            memory_enabled=not getattr(args, "no_memory_tools", False),
-            usage_ledger=usage_ledger,
-            llm_trace_sink=extension_bundle.llm_trace_sink if extension_bundle else None,
-        )
-    except ValueError as exc:
-        if extension_bundle is not None:
-            # With an extension loaded, a tool-name conflict at construction
-            # refuses to start rather than running without the extension.
-            print(f"Error: {exc}", file=sys.stderr)
-            _record_ask_run_terminal(
-                session_recorder,
-                status="failed",
-                exit_code=2,
-                started_at=run_started_at,
-                error={"code": "extension_error", "message": str(exc)[:500]},
-                usage_ledger=usage_ledger,
-                provider=str(getattr(config.long_context_config, "provider", None) or "") or None,
-                model=config.long_context_config.model,
-            )
-            return 2
-        raise
-    agent_ref["agent"] = agent
-    # --gigacode turns orchestration on for this run; a resumed session that had
-    # it on keeps it on, exactly as the TUI's /gigacode toggle persists.
-    gigacode_enabled = bool(getattr(args, "gigacode", False)) or bool(session.gigacode_enabled)
-    if gigacode_enabled:
-        agent.apply_gigacode(True, gigacode_prompt_extension())
-    session.gigacode_enabled = gigacode_enabled
-    # Web tool mode: an explicit --web-search flag already reached the agent via
-    # AgentConfig; otherwise a resumed session keeps its persisted mode, exactly
-    # as the TUI's /web-search toggle persists.
-    flag_web_search = getattr(args, "web_search", None)
-    if not flag_web_search and session.web_search_mode:
-        agent.apply_web_search_mode(session.web_search_mode)
-    session.web_search_mode = flag_web_search or session.web_search_mode
-    lsp_messages = await agent.tool_collection.initialize()
-    if not args.json:
-        for msg in lsp_messages:
-            print(msg, file=sys.stderr)
-    if session.history:
-        agent.restore_message_history(session.history)
-        agent.restore_compaction_state(session.compaction)
-
-    if extension_bundle is not None:
-        try:
-            await bind_extension_agent(extension_bundle, agent)
-        except KolegaExtensionLoadError as exc:
-            print(f"Error: {exc}", file=sys.stderr)
-            await agent.cleanup()
-            await cleanup_extension_bundle(extension_bundle)
-            if usage_sink is not None:
-                await usage_sink.aclose()
-            _record_ask_run_terminal(
-                session_recorder,
-                status="failed",
-                exit_code=2,
-                started_at=run_started_at,
-                error={"code": "extension_error", "message": str(exc)[:500]},
-                usage_ledger=usage_ledger,
-                provider=str(getattr(config.long_context_config, "provider", None) or "") or None,
-                model=config.long_context_config.model,
-            )
-            return 2
-
-    fire_hook = getattr(agent, "fire_hook", None)
-    if fire_hook is not None:
-        session_start = await fire_hook(HookEvent.SESSION_START, {"source": "startup"})
-        if session_start.additional_context:
-            if session_recorder is not None:
-                session_recorder.record_context_message(
-                    Message(role="user", content=[TextBlock(text=session_start.additional_context)])
-                )
-            agent.append_user_message([TextBlock(text=session_start.additional_context)])
-
-    prompt = raw_prompt
-    if skill_command:
-        skill_name, skill_prompt = skill_command
-        active_names = activated_skill_names(agent.history)
-        activation_content = skill_catalog.activation_content(skill_name, active_names=active_names)
-        if skill_name not in active_names:
-            session_recorder.record_context_message(Message(role="user", content=[TextBlock(text=activation_content)]))
-            agent.append_user_message([TextBlock(text=activation_content)])
-        session_recorder.record_skill_activated(
-            name=skill_name,
-            source="prompt_command",
-            already_active=skill_name in active_names,
-        )
-        prompt = skill_prompt
-        if not prompt:
-            session_recorder.record_synthetic_assistant(activation_content, notice_code="skill_activation")
-            if not args.json:
-                print(activation_content)
-            if args.save or args.session:
-                session.config = summary
-                store.save(session)
-            await agent.cleanup()
-            if extension_bundle is not None:
-                await cleanup_extension_bundle(extension_bundle)
-            if usage_sink is not None:
-                await usage_sink.aclose()
-            _record_ask_run_terminal(
-                session_recorder,
-                status="completed",
-                exit_code=0,
-                started_at=run_started_at,
-                error=None,
-                usage_ledger=usage_ledger,
-                provider=str(getattr(config.long_context_config, "provider", None) or "") or None,
-                model=config.long_context_config.model,
-            )
-            return 0
-
-    # --goal: apply the goal-aware prompt extension and synthesise the first
-    # work-turn message when no explicit prompt was given.
-    goal_state: Optional[GoalState] = None
-    if goal_condition:
-        max_turns = getattr(args, "goal_max_turns", None) or DEFAULT_GOAL_MAX_TURNS
-        goal_state = GoalState.create(goal_condition, max_turns=max_turns, run_to_completion=True)
-        agent.apply_goal(
-            goal_condition,
-            PromptExtension(
-                id="cli-active-goal",
-                title="Active goal",
-                markdown=build_goal_prompt_extension_markdown(goal_condition),
-                modes=None,
-                propagate_to_sub_agents=True,
-            ),
-        )
-        if not prompt:
-            prompt = build_goal_task_prompt(goal_condition)
-
-    # --loop / --loop-cron: arm the schedule and apply the loop-aware prompt
-    # extension. The prompt itself is sent verbatim on every iteration.
-    loop_state: Optional[LoopState] = None
-    if loop_schedule is not None:
-        loop_prompt = loop_md_prompt if loop_md_prompt is not None else (prompt or "")
-        loop_state = LoopState.create(
-            loop_schedule,
-            loop_prompt,
-            prompt_source=PROMPT_SOURCE_LOOP_MD if loop_md_prompt is not None else PROMPT_SOURCE_INLINE,
-            fresh=bool(getattr(args, "loop_fresh", False)),
-            max_iterations=getattr(args, "loop_max_iterations", None) or DEFAULT_LOOP_MAX_ITERATIONS,
-            expires_seconds=loop_expires_seconds,
-        )
-        prompt = loop_prompt
-        agent.apply_loop(
-            True,
-            PromptExtension(
-                id="cli-active-loop",
-                title="Scheduled loop",
-                markdown=build_loop_prompt_extension_markdown(loop_state),
-                modes=None,
-                propagate_to_sub_agents=True,
-            ),
-        )
-
-    attachments, unresolved_mentions = build_file_attachments(prompt or "", project_path)
-    for mention in unresolved_mentions:
-        print(f"Note: @{mention} not found, sent as plain text", file=sys.stderr)
-    for image_path in getattr(args, "image", None) or []:
-        encoded = encode_image_file(image_path)
-        if encoded is not None:
-            attachments.append(encoded)
-        else:
-            print(
-                f"Warning: --image {image_path} could not be attached (not a supported image, missing, or too large)",
-                file=sys.stderr,
-            )
-
+    pump_task: Optional[asyncio.Task] = None
+    usage_ledger = UsageLedger()
     response_chunks: list[dict] = []
     exit_code = 0
     run_status = "completed"
     run_error: Optional[dict[str, Any]] = None
-    # Pump connection-manager events concurrently so sub-agent activity is
-    # reported in real time instead of all at once after streaming finishes.
-    pump_task = asyncio.create_task(_pump_ask_events(manager, args.json))
+    # Exit code stamped on the run terminal; stays None on paths that leave by
+    # a propagating exception (the caller owns the process exit code there).
+    terminal_exit_code: Optional[int] = None
+    generation_closed = False
+
+    async def _close_generation() -> None:
+        # At most once; agent before bundle; each step guarded so a cleanup
+        # failure never replaces the run's primary outcome.
+        nonlocal generation_closed
+        if generation_closed:
+            return
+        generation_closed = True
+        built_agent = agent_ref.get("agent")
+        if built_agent is not None:
+            try:
+                await built_agent.cleanup()
+            except Exception as exc:  # noqa: BLE001 — reported, never masks the primary exception
+                print(f"Warning: agent cleanup failed: {exc}", file=sys.stderr)
+        if extension_bundle is not None:
+            try:
+                await cleanup_extension_bundle(extension_bundle)
+            except Exception as exc:  # noqa: BLE001 — reported, never masks the primary exception
+                print(f"Warning: extension cleanup failed: {exc}", file=sys.stderr)
+
     try:
+        permission_mode = normalize_permission_mode(
+            getattr(args, "permission_mode", ASK_DEFAULT_PERMISSION_MODE),
+            default=PermissionMode.AUTO,
+        )
+        # Journal every settled non-history response and failure (in-memory journal
+        # for unsaved runs). Attached before the SESSION_START hook below: hook
+        # prompts are paid LLM calls and must be covered from the first request.
+        sink = SessionUsageSink(journal, session_recorder, usage_ledger, mode="ask")
+        usage_sink = sink
+        usage_ledger.observer = sink
+        await sink.start()
+        try:
+            agent = CoderAgent(
+                project_path=project_path,
+                workspace_id=session.workspace_id,
+                thread_id=session.thread_id,
+                connection_manager=manager,
+                config=config,
+                browser_manager=browser_manager,
+                agent_mode=AgentMode.ASK,
+                prompt_extensions=prompt_extensions,
+                tool_extensions=tool_extensions,
+                permission_mode=permission_mode,
+                permission_callback=_permission_callback_for_ask(launch_project_path)
+                if permission_mode == PermissionMode.ASK
+                else None,
+                session_recorder=session_recorder,
+                hook_dispatcher=hook_dispatcher,
+                custom_agent_catalog=custom_agent_catalog,
+                memory_project_path=launch_project_path,
+                memory_enabled=not getattr(args, "no_memory_tools", False),
+                usage_ledger=usage_ledger,
+                llm_trace_sink=extension_bundle.llm_trace_sink if extension_bundle else None,
+            )
+        except ValueError as exc:
+            if extension_bundle is None:
+                raise
+            # With an extension loaded, a tool-name conflict at construction
+            # refuses to start rather than running without the extension.
+            print(f"Error: {exc}", file=sys.stderr)
+            run_status = "failed"
+            run_error = {"code": "extension_error", "message": str(exc)[:500]}
+            exit_code = 2
+            terminal_exit_code = 2
+            return exit_code
+        agent_ref["agent"] = agent
+        # --gigacode turns orchestration on for this run; a resumed session that had
+        # it on keeps it on, exactly as the TUI's /gigacode toggle persists.
+        gigacode_enabled = bool(getattr(args, "gigacode", False)) or bool(session.gigacode_enabled)
+        if gigacode_enabled:
+            agent.apply_gigacode(True, gigacode_prompt_extension())
+        session.gigacode_enabled = gigacode_enabled
+        # Web tool mode: an explicit --web-search flag already reached the agent via
+        # AgentConfig; otherwise a resumed session keeps its persisted mode, exactly
+        # as the TUI's /web-search toggle persists.
+        flag_web_search = getattr(args, "web_search", None)
+        if not flag_web_search and session.web_search_mode:
+            agent.apply_web_search_mode(session.web_search_mode)
+        session.web_search_mode = flag_web_search or session.web_search_mode
+        lsp_messages = await agent.tool_collection.initialize()
+        if not args.json:
+            for msg in lsp_messages:
+                print(msg, file=sys.stderr)
+        if session.history:
+            agent.restore_message_history(session.history)
+            agent.restore_compaction_state(session.compaction)
+
+        if extension_bundle is not None:
+            await bind_extension_agent(extension_bundle, agent)
+
+        fire_hook = getattr(agent, "fire_hook", None)
+        if fire_hook is not None:
+            session_start = await fire_hook(HookEvent.SESSION_START, {"source": "startup"})
+            if session_start.additional_context:
+                if session_recorder is not None:
+                    session_recorder.record_context_message(
+                        Message(role="user", content=[TextBlock(text=session_start.additional_context)])
+                    )
+                agent.append_user_message([TextBlock(text=session_start.additional_context)])
+
+        prompt = raw_prompt
+        if skill_command:
+            skill_name, skill_prompt = skill_command
+            active_names = activated_skill_names(agent.history)
+            activation_content = skill_catalog.activation_content(skill_name, active_names=active_names)
+            if skill_name not in active_names:
+                session_recorder.record_context_message(
+                    Message(role="user", content=[TextBlock(text=activation_content)])
+                )
+                agent.append_user_message([TextBlock(text=activation_content)])
+            session_recorder.record_skill_activated(
+                name=skill_name,
+                source="prompt_command",
+                already_active=skill_name in active_names,
+            )
+            prompt = skill_prompt
+            if not prompt:
+                session_recorder.record_synthetic_assistant(activation_content, notice_code="skill_activation")
+                if not args.json:
+                    print(activation_content)
+                if args.save or args.session:
+                    session.config = summary
+                    store.save(session)
+                terminal_exit_code = 0
+                return exit_code
+
+        # --goal: apply the goal-aware prompt extension and synthesise the first
+        # work-turn message when no explicit prompt was given.
+        goal_state: Optional[GoalState] = None
+        if goal_condition:
+            max_turns = getattr(args, "goal_max_turns", None) or DEFAULT_GOAL_MAX_TURNS
+            goal_state = GoalState.create(goal_condition, max_turns=max_turns, run_to_completion=True)
+            agent.apply_goal(
+                goal_condition,
+                PromptExtension(
+                    id="cli-active-goal",
+                    title="Active goal",
+                    markdown=build_goal_prompt_extension_markdown(goal_condition),
+                    modes=None,
+                    propagate_to_sub_agents=True,
+                ),
+            )
+            if not prompt:
+                prompt = build_goal_task_prompt(goal_condition)
+
+        # --loop / --loop-cron: arm the schedule and apply the loop-aware prompt
+        # extension. The prompt itself is sent verbatim on every iteration.
+        loop_state: Optional[LoopState] = None
+        if loop_schedule is not None:
+            loop_prompt = loop_md_prompt if loop_md_prompt is not None else (prompt or "")
+            loop_state = LoopState.create(
+                loop_schedule,
+                loop_prompt,
+                prompt_source=PROMPT_SOURCE_LOOP_MD if loop_md_prompt is not None else PROMPT_SOURCE_INLINE,
+                fresh=bool(getattr(args, "loop_fresh", False)),
+                max_iterations=getattr(args, "loop_max_iterations", None) or DEFAULT_LOOP_MAX_ITERATIONS,
+                expires_seconds=loop_expires_seconds,
+            )
+            prompt = loop_prompt
+            agent.apply_loop(
+                True,
+                PromptExtension(
+                    id="cli-active-loop",
+                    title="Scheduled loop",
+                    markdown=build_loop_prompt_extension_markdown(loop_state),
+                    modes=None,
+                    propagate_to_sub_agents=True,
+                ),
+            )
+
+        attachments, unresolved_mentions = build_file_attachments(prompt or "", project_path)
+        for mention in unresolved_mentions:
+            print(f"Note: @{mention} not found, sent as plain text", file=sys.stderr)
+        for image_path in getattr(args, "image", None) or []:
+            encoded = encode_image_file(image_path)
+            if encoded is not None:
+                attachments.append(encoded)
+            else:
+                print(
+                    f"Warning: --image {image_path} could not be attached (not a supported image, missing, or too large)",
+                    file=sys.stderr,
+                )
+
+        # Pump connection-manager events concurrently so sub-agent activity is
+        # reported in real time instead of all at once after streaming finishes.
+        pump_task = asyncio.create_task(_pump_ask_events(manager, args.json))
         turn_prompt = prompt
         if loop_state is not None:
             # Interval schedules fire immediately; cron schedules wait for the
@@ -1778,74 +1786,46 @@ async def _run_ask(args: argparse.Namespace) -> int:
 
         # --loop: keep re-running the prompt until the cap or the expiry is hit.
         if loop_state is not None:
-            _drain_tokens(loop_state)
-            loop_state.advance_after_completion()
-            while loop_state.is_active:
-                await _sleep_until_loop_fire(loop_state, session_recorder, args.json)
-                if not loop_state.is_active:
-                    break
-                loop_state.mark_fired()
-                if loop_state.fresh:
-                    agent.clear_history()
-                _emit_loop_iteration(loop_state, session_recorder, args.json)
-                turn_prompt = build_loop_iteration_prompt(
-                    prompt or "",
-                    iteration=loop_state.iterations,
-                    max_iterations=loop_state.max_iterations,
-                    fresh=loop_state.fresh,
-                )
-                stream = (
-                    agent.process_message_stream(turn_prompt, attachments)
-                    if attachments
-                    else agent.process_message_stream(turn_prompt)
-                )
-                await _consume_turn(stream)
-                _drain_tokens(loop_state)
-                loop_state.advance_after_completion()
-            _emit_loop_finished(loop_state, session_recorder, args.json)
+            await _run_ask_loop_iterations(
+                agent=agent,
+                loop_state=loop_state,
+                prompt=prompt,
+                attachments=attachments,
+                session_recorder=session_recorder,
+                json_mode=args.json,
+                consume_turn=_consume_turn,
+                drain_tokens=_drain_tokens,
+            )
 
         # --goal: evaluate and auto-continue until the goal is met or the cap is hit.
         if goal_state is not None:
-            _drain_tokens(goal_state)
-            while not goal_state.met and goal_state.turns_evaluated < goal_state.max_turns:
-                verdict = await agent.evaluate_goal_condition(goal_state.condition)
-                goal_state.turns_evaluated += 1
-                goal_state.last_reason = verdict.reason
-                goal_state.last_evaluated_at = now_iso()
-                session_recorder.record_goal_evaluated(
-                    {"met": verdict.met, "turns": goal_state.turns_evaluated, "reason": verdict.reason}
-                )
-                if not args.json:
-                    tag = "MET" if verdict.met else f"not met — {verdict.reason}"
-                    print(f"[goal] turn {goal_state.turns_evaluated}: {tag}", file=sys.stderr)
-                if verdict.met:
-                    goal_state.met = True
-                    break
-                turns_remaining = goal_state.max_turns - goal_state.turns_evaluated
-                nudge = build_goal_nudge(goal_state.condition, verdict, turns_remaining)
-                await _consume_turn(agent.process_message_stream(nudge))
-                _drain_tokens(goal_state)
-            # The loop above can exit on a met verdict or the turn cap; count the
-            # final verifier either way.
-            _drain_tokens(goal_state)
-            # Record the final goal outcome. An unmet goal exits 1 but the run
-            # itself completed: the process finished; the goal did not.
-            session_recorder.record_goal_completed(
-                {"met": goal_state.met, "turns": goal_state.turns_evaluated, "reason": goal_state.last_reason}
+            exit_code = await _run_ask_goal_iterations(
+                agent=agent,
+                goal_state=goal_state,
+                session_recorder=session_recorder,
+                json_mode=args.json,
+                consume_turn=_consume_turn,
+                drain_tokens=_drain_tokens,
             )
-            if not args.json:
-                status = "met" if goal_state.met else "not met (turn cap reached)"
-                print(f"[goal] {status} after {goal_state.turns_evaluated} turn(s)", file=sys.stderr)
-            if not goal_state.met:
-                exit_code = 1
 
         if args.save or args.session:
             session.config = summary
             store.save(session)
+        terminal_exit_code = exit_code
+    except KolegaExtensionLoadError as exc:
+        # Only bind_extension_agent raises this here: refuse the run rather
+        # than continue with the extension unbound.
+        print(f"Error: {exc}", file=sys.stderr)
+        run_status = "failed"
+        run_error = {"code": "extension_error", "message": str(exc)[:500]}
+        exit_code = 2
+        terminal_exit_code = 2
+        return exit_code
     except LLMBillingError as exc:
         exit_code = 1
         run_status = "failed"
         run_error = {"code": "billing_error", "message": CLI_BILLING_ERROR_MESSAGE}
+        terminal_exit_code = 1
         message = billing_error_message(exc, model=config.long_context_config.model)
         _print_styled(message, style="error", stderr=True)
     except asyncio.CancelledError:
@@ -1858,38 +1838,34 @@ async def _run_ask(args: argparse.Namespace) -> int:
         run_error = {"code": type(exc).__name__, "message": str(exc)[:500]}
         raise
     finally:
-        pump_task.cancel()
-        try:
-            await pump_task
-        except asyncio.CancelledError:
-            pass
+        if pump_task is not None:
+            pump_task.cancel()
+            try:
+                await pump_task
+            except asyncio.CancelledError:
+                pass
         while not manager.events.empty():
             event = manager.events.get_nowait()
             _print_ask_event(event, args.json)
-        end_fire_hook = getattr(agent, "fire_hook", None)
+        end_fire_hook = getattr(agent_ref.get("agent"), "fire_hook", None)
         if end_fire_hook is not None:
             try:
                 await end_fire_hook(HookEvent.SESSION_END, {"reason": "ask_complete"})
             except Exception:
                 pass
-        await agent.cleanup()
-        if extension_bundle is not None:
-            try:
-                await cleanup_extension_bundle(extension_bundle)
-            except Exception as exc:  # noqa: BLE001 — reported, never masks the primary exception
-                print(f"Warning: extension cleanup failed: {exc}", file=sys.stderr)
+        await _close_generation()
         if usage_sink is not None:
-            await usage_sink.aclose()
+            try:
+                await usage_sink.aclose()
+            except Exception as exc:  # noqa: BLE001 — reported, never masks the primary exception
+                print(f"Warning: usage sink close failed: {exc}", file=sys.stderr)
         # The run terminal is recorded synchronously after the usage sink has
         # drained, on every exit path — an await here could be re-cancelled
         # while a CancelledError is already propagating.
-        raising = run_status == "cancelled" or (
-            run_status == "failed" and (run_error or {}).get("code") != "billing_error"
-        )
         _record_ask_run_terminal(
             session_recorder,
             status=run_status,
-            exit_code=None if raising else exit_code,
+            exit_code=terminal_exit_code,
             started_at=run_started_at,
             error=run_error,
             usage_ledger=usage_ledger,
@@ -1922,6 +1898,90 @@ async def _run_ask(args: argparse.Namespace) -> int:
                     exit_code = 1
 
     return exit_code
+
+
+async def _run_ask_loop_iterations(
+    *,
+    agent: "CoderAgent",
+    loop_state: LoopState,
+    prompt: Optional[str],
+    attachments: list,
+    session_recorder,
+    json_mode: bool,
+    consume_turn,
+    drain_tokens,
+) -> None:
+    """Re-run the loop prompt until the iteration cap or the expiry is hit."""
+    drain_tokens(loop_state)
+    loop_state.advance_after_completion()
+    while loop_state.is_active:
+        await _sleep_until_loop_fire(loop_state, session_recorder, json_mode)
+        if not loop_state.is_active:
+            break
+        loop_state.mark_fired()
+        if loop_state.fresh:
+            agent.clear_history()
+        _emit_loop_iteration(loop_state, session_recorder, json_mode)
+        turn_prompt = build_loop_iteration_prompt(
+            prompt or "",
+            iteration=loop_state.iterations,
+            max_iterations=loop_state.max_iterations,
+            fresh=loop_state.fresh,
+        )
+        stream = (
+            agent.process_message_stream(turn_prompt, attachments)
+            if attachments
+            else agent.process_message_stream(turn_prompt)
+        )
+        await consume_turn(stream)
+        drain_tokens(loop_state)
+        loop_state.advance_after_completion()
+    _emit_loop_finished(loop_state, session_recorder, json_mode)
+
+
+async def _run_ask_goal_iterations(
+    *,
+    agent: "CoderAgent",
+    goal_state: GoalState,
+    session_recorder,
+    json_mode: bool,
+    consume_turn,
+    drain_tokens,
+) -> int:
+    """Evaluate and auto-continue until the goal is met or the turn cap is hit.
+
+    Returns the process exit code. An unmet goal exits 1 but the run itself
+    completed: the process finished; the goal did not.
+    """
+    drain_tokens(goal_state)
+    while not goal_state.met and goal_state.turns_evaluated < goal_state.max_turns:
+        verdict = await agent.evaluate_goal_condition(goal_state.condition)
+        goal_state.turns_evaluated += 1
+        goal_state.last_reason = verdict.reason
+        goal_state.last_evaluated_at = now_iso()
+        session_recorder.record_goal_evaluated(
+            {"met": verdict.met, "turns": goal_state.turns_evaluated, "reason": verdict.reason}
+        )
+        if not json_mode:
+            tag = "MET" if verdict.met else f"not met — {verdict.reason}"
+            print(f"[goal] turn {goal_state.turns_evaluated}: {tag}", file=sys.stderr)
+        if verdict.met:
+            goal_state.met = True
+            break
+        turns_remaining = goal_state.max_turns - goal_state.turns_evaluated
+        nudge = build_goal_nudge(goal_state.condition, verdict, turns_remaining)
+        await consume_turn(agent.process_message_stream(nudge))
+        drain_tokens(goal_state)
+    # The loop above can exit on a met verdict or the turn cap; count the
+    # final verifier either way.
+    drain_tokens(goal_state)
+    session_recorder.record_goal_completed(
+        {"met": goal_state.met, "turns": goal_state.turns_evaluated, "reason": goal_state.last_reason}
+    )
+    if not json_mode:
+        status = "met" if goal_state.met else "not met (turn cap reached)"
+        print(f"[goal] {status} after {goal_state.turns_evaluated} turn(s)", file=sys.stderr)
+    return 0 if goal_state.met else 1
 
 
 async def _pump_ask_events(manager: CliConnectionManager, json_mode: bool) -> None:

--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -982,7 +982,17 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
         self.config = config
         self.session.config = config_summary(config)
         await self._save_session_async()
-        await self._build_agent(config, rebuild=rebuild)
+        try:
+            await self._build_agent(config, rebuild=rebuild)
+        except KolegaExtensionLoadError as exc:
+            # The failed generation was already reclaimed by _build_agent; there
+            # is no live agent, so surface the error instead of crashing the
+            # worker that requested the rebuild.
+            self._set_chat_enabled(False)
+            self._refresh_status_dashboard()
+            self._log_status(f"extension error: {exc}", level="error")
+            self._ensure_startup_entry()
+            return
         self._set_chat_enabled(True)
         self._update_settings_status()
         self._ensure_startup_entry()
@@ -1095,8 +1105,7 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
             history = self.session.history
             compaction = self.session.compaction
             if rebuild:
-                await self.agent.cleanup()
-                await self._cleanup_extension_bundle()
+                await self._cleanup_agent_generation()
 
         browser_manager = build_browser_manager(
             self.store.root,
@@ -1190,97 +1199,119 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
         if self._goal is not None and self._goal.condition:
             prompt_extensions.append(self._goal_prompt_extension())
 
-        # Launch-selected extension: a fresh bundle for every agent generation,
-        # from the same factory. Assigned to self immediately so every exit path
-        # cleans up exactly this generation's bundle.
-        extension_bundle = None
-        if self.extension_selection is not None:
-            extension_host = KolegaExtensionHost(
-                project_path=self.active_project_path,
-                workspace_id=self.session.workspace_id,
-                thread_id=self.session.thread_id,
-                config=config,
-                agent_mode=AgentMode(self.mode),
-            )
-            extension_bundle = create_extension_bundle(self.extension_selection, extension_host)
-            self._extension_bundle = extension_bundle
-            prompt_extensions.extend(extension_bundle.prompt_extensions)
-            tool_extensions.extend(extension_bundle.tool_extensions)
-
         try:
-            self.agent = agent_class(
-                project_path=self.active_project_path,
-                workspace_id=self.session.workspace_id,
-                thread_id=self.session.thread_id,
-                connection_manager=self.recording_connection_manager,
-                config=config,
-                browser_manager=browser_manager,
-                agent_mode=AgentMode(self.mode),
-                prompt_extensions=prompt_extensions,
-                tool_extensions=tool_extensions,
-                memory_manager=self.memory_manager,
-                permission_mode=self.permission_mode,
-                # Permission policy lives in the session runtime, not the UI: mode
-                # checks and saved-rule matching are decisions about the session, so
-                # every frontend gets them and only real questions reach a person.
-                permission_callback=self.session_runtime.permission_callback,
-                session_recorder=self._session_recorder,
-                hook_dispatcher=self._session_hook_dispatcher(),
-                custom_agent_catalog=self.custom_agent_catalog,
-                usage_ledger=self._usage_ledger,
-                llm_trace_sink=extension_bundle.llm_trace_sink if extension_bundle else None,
-            )
-        except ValueError as exc:
+            # Launch-selected extension: a fresh bundle for every agent generation,
+            # from the same factory. Assigned to self immediately so every exit path
+            # cleans up exactly this generation's bundle.
+            extension_bundle = None
+            if self.extension_selection is not None:
+                extension_host = KolegaExtensionHost(
+                    project_path=self.active_project_path,
+                    workspace_id=self.session.workspace_id,
+                    thread_id=self.session.thread_id,
+                    config=config,
+                    agent_mode=AgentMode(self.mode),
+                )
+                extension_bundle = create_extension_bundle(self.extension_selection, extension_host)
+                self._extension_bundle = extension_bundle
+                prompt_extensions.extend(extension_bundle.prompt_extensions)
+                tool_extensions.extend(extension_bundle.tool_extensions)
+
+            try:
+                self.agent = agent_class(
+                    project_path=self.active_project_path,
+                    workspace_id=self.session.workspace_id,
+                    thread_id=self.session.thread_id,
+                    connection_manager=self.recording_connection_manager,
+                    config=config,
+                    browser_manager=browser_manager,
+                    agent_mode=AgentMode(self.mode),
+                    prompt_extensions=prompt_extensions,
+                    tool_extensions=tool_extensions,
+                    memory_manager=self.memory_manager,
+                    permission_mode=self.permission_mode,
+                    # Permission policy lives in the session runtime, not the UI: mode
+                    # checks and saved-rule matching are decisions about the session, so
+                    # every frontend gets them and only real questions reach a person.
+                    permission_callback=self.session_runtime.permission_callback,
+                    session_recorder=self._session_recorder,
+                    hook_dispatcher=self._session_hook_dispatcher(),
+                    custom_agent_catalog=self.custom_agent_catalog,
+                    usage_ledger=self._usage_ledger,
+                    llm_trace_sink=extension_bundle.llm_trace_sink if extension_bundle else None,
+                )
+            except ValueError as exc:
+                if extension_bundle is not None:
+                    # With an extension loaded, a tool-name conflict at construction
+                    # refuses the generation rather than continuing without the
+                    # requested extension.
+                    raise KolegaExtensionLoadError(str(exc)) from exc
+                raise
+            assert self.agent is not None
+            # The runtime owns the agent for control purposes while the CLI keeps
+            # composing it from settings, skills, hooks, and MCP configuration.
+            self.session_runtime.adopt(self.agent)
+            # The plan handle and shared task list are conversation-injected context (system
+            # reminders), so a compaction that summarizes them away is followed by re-injection
+            # on the next turn — see agent/volatile_context.py. Registered in both interaction
+            # modes: the planner sees the plan artifact while re-planning mid-build, and both
+            # modes keep the task list (read-only for the planner) in view. Each rebuild
+            # constructs a fresh agent, so providers never accumulate across rebuilds.
+            self.agent.add_volatile_section(self._plan_volatile_section)
+            self.agent.add_volatile_section(self._task_list_volatile_section)
+            if scratchpad_extension is not None:
+                # Expose the resolved directory for the KOLEGA_SCRATCHPAD session env
+                # and the terminal safety checker; the prompt extension above is what
+                # the model sees.
+                self.agent.scratchpad_dir = scratchpad_dir_for(self.project_path, self.session.session_id)
+            # Mid-turn queue delivery: the running turn drains composer messages
+            # queued while it works (main agent only; sub-agents never get this).
+            self.agent.set_queued_input_provider(self._provide_queued_user_inputs)
+            # Initialize LSP (language detection + server resolution)
+            agent = self.agent
+            assert agent.tool_collection is not None
+            await agent.tool_collection.initialize()
+            agent.gigacode_enabled = gigacode_active
+            # A session-level /web-search override outlives agent rebuilds (model
+            # switches); without one the config-resolved mode stands.
+            if self._web_search_mode:
+                agent.apply_web_search_mode(self._web_search_mode)
+            self._initialize_ledger_diff_tracker()
+            if history:
+                self.agent.restore_message_history(history)
+                self.agent.restore_compaction_state(compaction)
+                if restore_transcript:
+                    self._restore_conversation_history(history)
             if extension_bundle is not None:
-                # With an extension loaded, a tool-name conflict at construction
-                # refuses the generation rather than continuing without the
-                # requested extension.
-                raise KolegaExtensionLoadError(str(exc)) from exc
+                await bind_extension_agent(extension_bundle, self.agent)
+            self._update_mode_chrome()
+            self._ensure_startup_entry()
+            await self._fire_session_start_once()
+            # Refresh the Settings-tab LSP status now that the agent (and its
+            # initialized lsp_manager) exists. Without this the status is stale
+            # from startup, when it was computed before the agent was built.
+            self._update_lsp_settings_status()
+        except BaseException:
+            # Reclaim the partial generation (bundle is already installed on
+            # self; the agent may or may not be) before surfacing the failure.
+            await self._cleanup_agent_generation()
             raise
-        assert self.agent is not None
-        # The runtime owns the agent for control purposes while the CLI keeps
-        # composing it from settings, skills, hooks, and MCP configuration.
-        self.session_runtime.adopt(self.agent)
-        # The plan handle and shared task list are conversation-injected context (system
-        # reminders), so a compaction that summarizes them away is followed by re-injection
-        # on the next turn — see agent/volatile_context.py. Registered in both interaction
-        # modes: the planner sees the plan artifact while re-planning mid-build, and both
-        # modes keep the task list (read-only for the planner) in view. Each rebuild
-        # constructs a fresh agent, so providers never accumulate across rebuilds.
-        self.agent.add_volatile_section(self._plan_volatile_section)
-        self.agent.add_volatile_section(self._task_list_volatile_section)
-        if scratchpad_extension is not None:
-            # Expose the resolved directory for the KOLEGA_SCRATCHPAD session env
-            # and the terminal safety checker; the prompt extension above is what
-            # the model sees.
-            self.agent.scratchpad_dir = scratchpad_dir_for(self.project_path, self.session.session_id)
-        # Mid-turn queue delivery: the running turn drains composer messages
-        # queued while it works (main agent only; sub-agents never get this).
-        self.agent.set_queued_input_provider(self._provide_queued_user_inputs)
-        # Initialize LSP (language detection + server resolution)
+
+    async def _cleanup_agent_generation(self) -> None:
+        """Tear down the current agent generation (agent, then bundle) exactly once.
+
+        Both references are detached before anything is awaited, so repeated or
+        concurrent callers cannot clean the same generation twice. Each step is
+        guarded: a cleanup failure is reported, never raised.
+        """
         agent = self.agent
-        assert agent.tool_collection is not None
-        await agent.tool_collection.initialize()
-        agent.gigacode_enabled = gigacode_active
-        # A session-level /web-search override outlives agent rebuilds (model
-        # switches); without one the config-resolved mode stands.
-        if self._web_search_mode:
-            agent.apply_web_search_mode(self._web_search_mode)
-        self._initialize_ledger_diff_tracker()
-        if history:
-            self.agent.restore_message_history(history)
-            self.agent.restore_compaction_state(compaction)
-            if restore_transcript:
-                self._restore_conversation_history(history)
-        if extension_bundle is not None:
-            await bind_extension_agent(extension_bundle, self.agent)
-        self._update_mode_chrome()
-        self._ensure_startup_entry()
-        await self._fire_session_start_once()
-        # Refresh the Settings-tab LSP status now that the agent (and its
-        # initialized lsp_manager) exists. Without this the status is stale
-        # from startup, when it was computed before the agent was built.
-        self._update_lsp_settings_status()
+        self.agent = None
+        if agent is not None:
+            try:
+                await agent.cleanup()
+            except Exception as exc:  # noqa: BLE001 — reported, never masks the primary failure
+                self._log_status(f"agent cleanup failed: {exc}", level="warn")
+        await self._cleanup_extension_bundle()
 
     async def _cleanup_extension_bundle(self) -> None:
         """Release the current extension bundle exactly once (rebuild or app exit)."""

--- a/kolega_code/extensions.py
+++ b/kolega_code/extensions.py
@@ -92,6 +92,13 @@ def resolve_extension_selection(spec: str, config_path: str | Path | None) -> Ex
         module = importlib.import_module(module_name)
     except ImportError as exc:
         raise KolegaExtensionLoadError(f"--extension: cannot import module {module_name!r}: {exc}") from exc
+    except Exception as exc:
+        # Module-level code can raise anything during import; keep every
+        # ordinary failure on the same concise CLI error path. BaseException
+        # (KeyboardInterrupt, SystemExit) propagates untouched.
+        raise KolegaExtensionLoadError(
+            f"--extension: importing module {module_name!r} raised {type(exc).__name__}: {exc}"
+        ) from exc
     factory = getattr(module, factory_name, None)
     if factory is None:
         raise KolegaExtensionLoadError(f"--extension: module {module_name!r} has no attribute {factory_name!r}")

--- a/tests/agent/services/test_terminal.py
+++ b/tests/agent/services/test_terminal.py
@@ -325,8 +325,13 @@ async def test_cancelled_exec_returns_recoverable_spill_result(manager, tmp_path
     task = asyncio.create_task(
         manager.exec_command(command, yield_time_ms=30_000),
     )
-    for _ in range(200):
-        if list(spill_root.glob("*.log")):
+    # Wait for the full payload to be durably spilled, not merely for the spill
+    # file to exist: cancelling while the child is still flushing through the
+    # PTY kills it before END was ever written, which is not the recovery path
+    # this test exercises.
+    for _ in range(500):
+        spilled = list(spill_root.glob("*.log"))
+        if spilled and b"END" in spilled[0].read_bytes():
             break
         await asyncio.sleep(0.01)
     else:

--- a/tests/cli/_app_test_utils.py
+++ b/tests/cli/_app_test_utils.py
@@ -48,6 +48,7 @@ class FakeCoderAgent:
         self.gigacode_enabled = False
         self.gigacode_prompt_extension = None
         self.clear_history_calls = 0
+        self.cleanup_calls = 0
         self.session_recorder = kwargs.get("session_recorder")
         self.queued_input_provider = None
         # Volatile-context providers registered by _build_agent (plan handle, task list).
@@ -96,6 +97,7 @@ class FakeCoderAgent:
         pass
 
     async def cleanup(self):
+        self.cleanup_calls += 1
         return None
 
     async def process_message_stream(self, message, attachments=None):

--- a/tests/cli/test_app_extensions.py
+++ b/tests/cli/test_app_extensions.py
@@ -31,6 +31,7 @@ class _Recorder:
         self.factory_calls: list = []
         self.binds: list = []
         self.cleanups: int = 0
+        self.fail_bind: bool = False
 
 
 def _sink(record):
@@ -38,6 +39,11 @@ def _sink(record):
 
 
 def _install_extension(monkeypatch, recorder):
+    def _bind(agent):
+        if recorder.fail_bind:
+            raise RuntimeError("bind boom")
+        recorder.binds.append(agent)
+
     def create_extension(host, config_path):
         recorder.factory_calls.append((host, config_path))
         return KolegaExtensionBundle(
@@ -51,7 +57,7 @@ def _install_extension(monkeypatch, recorder):
                 )
             ],
             llm_trace_sink=_sink,
-            bind_agent=recorder.binds.append,
+            bind_agent=_bind,
             cleanup=lambda: setattr(recorder, "cleanups", recorder.cleanups + 1),
         )
 
@@ -121,6 +127,81 @@ async def test_extension_bundle_injected_and_bound_per_generation(tmp_path, monk
         assert recorder.cleanups == 2
         await app._cleanup_extension_bundle()
         assert recorder.cleanups == 2
+
+
+@pytest.mark.asyncio
+async def test_cleanup_agent_generation_is_idempotent_and_detaches_agent(tmp_path, monkeypatch):
+    pytest.importorskip("textual")
+    recorder = _Recorder()
+    selection = _install_extension(monkeypatch, recorder)
+    app, _config = _build_app(tmp_path, monkeypatch, selection)
+
+    async with app.run_test():
+        agent = app.agent
+        assert isinstance(agent, FakeCoderAgent)
+        await app._cleanup_agent_generation()
+        assert app.agent is None
+        assert app._extension_bundle is None
+        assert agent.cleanup_calls == 1
+        assert recorder.cleanups == 1
+        # Repeated calls find nothing to clean.
+        await app._cleanup_agent_generation()
+        assert agent.cleanup_calls == 1
+        assert recorder.cleanups == 1
+
+
+@pytest.mark.asyncio
+async def test_failed_rebuild_reclaims_partial_generation_exactly_once(tmp_path, monkeypatch):
+    pytest.importorskip("textual")
+    from kolega_code.extensions import KolegaExtensionLoadError
+
+    recorder = _Recorder()
+    selection = _install_extension(monkeypatch, recorder)
+    app, config = _build_app(tmp_path, monkeypatch, selection)
+
+    async with app.run_test():
+        first_agent = app.agent
+        assert isinstance(first_agent, FakeCoderAgent)
+
+        # Make the second generation fail at bind time, after its bundle and
+        # agent already exist.
+        recorder.fail_bind = True
+
+        with pytest.raises(KolegaExtensionLoadError, match="bind_agent failed"):
+            await app._build_agent(config, rebuild=True)
+
+        # Old generation cleaned on rebuild entry, failed new generation
+        # reclaimed by the transaction guard: two bundle cleanups total, the
+        # partially built agent cleaned, and no live generation installed.
+        assert recorder.cleanups == 2
+        assert first_agent.cleanup_calls == 1
+        assert app.agent is None
+        assert app._extension_bundle is None
+
+
+@pytest.mark.asyncio
+async def test_action_quit_cleans_generation_even_when_save_fails(tmp_path, monkeypatch):
+    pytest.importorskip("textual")
+    from unittest.mock import AsyncMock, MagicMock
+
+    recorder = _Recorder()
+    selection = _install_extension(monkeypatch, recorder)
+    app, _config = _build_app(tmp_path, monkeypatch, selection)
+
+    async with app.run_test():
+        agent = app.agent
+        assert isinstance(agent, FakeCoderAgent)
+        app._save_session_history_async = AsyncMock(side_effect=RuntimeError("session save failed"))
+        app.exit = MagicMock()
+
+        with pytest.raises(RuntimeError, match="session save failed"):
+            await app.action_quit()
+
+        assert agent.cleanup_calls == 1
+        assert recorder.cleanups == 1
+        assert app.agent is None
+        assert app._extension_bundle is None
+        app.exit.assert_called_once_with()
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_extensions.py
+++ b/tests/cli/test_extensions.py
@@ -50,6 +50,23 @@ def test_resolve_reports_import_failure():
         resolve_extension_selection("kolega_no_such_module:factory", None)
 
 
+def test_resolve_wraps_import_time_exception(tmp_path, monkeypatch):
+    mod = tmp_path / "raising_ext_mod.py"
+    mod.write_text('raise ValueError("bad module state")\n')
+    monkeypatch.syspath_prepend(str(tmp_path))
+    with pytest.raises(KolegaExtensionLoadError, match="ValueError: bad module state") as excinfo:
+        resolve_extension_selection("raising_ext_mod:factory", None)
+    assert isinstance(excinfo.value.__cause__, ValueError)
+
+
+def test_resolve_does_not_wrap_base_exceptions(tmp_path, monkeypatch):
+    mod = tmp_path / "exiting_ext_mod.py"
+    mod.write_text("raise SystemExit(3)\n")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    with pytest.raises(SystemExit):
+        resolve_extension_selection("exiting_ext_mod:factory", None)
+
+
 def test_resolve_reports_missing_factory(monkeypatch):
     _install_module(monkeypatch)
     with pytest.raises(KolegaExtensionLoadError, match="has no attribute"):
@@ -391,6 +408,8 @@ def test_ask_tool_conflict_refuses_to_start(tmp_path, monkeypatch, isolated_cli_
     assert exit_code == 2
     assert "conflicts" in capsys.readouterr().err
     assert RecordingCoderAgent.events.count("stream") == 0
+    # The refused generation still releases its bundle.
+    assert RecordingCoderAgent.events.count("cleanup") == 1
 
 
 def test_ask_factory_exception_fails_with_concise_error(tmp_path, monkeypatch, isolated_cli_env, capsys):
@@ -408,3 +427,218 @@ def test_ask_factory_exception_fails_with_concise_error(tmp_path, monkeypatch, i
     assert exit_code == 2
     assert "manifest invalid" in capsys.readouterr().err
     assert RecordingCoderAgent.instances == []
+
+
+# --- ask-mode transactional cleanup ------------------------------------------------
+
+
+class LspInitFailsAgent(RecordingCoderAgent):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        assert self.tool_collection is not None
+
+        async def _fail():
+            raise RuntimeError("lsp init failed")
+
+        self.tool_collection.initialize = _fail  # type: ignore[method-assign]
+
+
+class SessionStartHookFailsAgent(RecordingCoderAgent):
+    async def fire_hook(self, name, payload, *, target=""):
+        from kolega_code.hooks import HookEvent
+
+        if name == HookEvent.SESSION_START:
+            raise RuntimeError("session-start hook failed")
+        return await super().fire_hook(name, payload, target=target)
+
+
+class StreamFailsAgent(RecordingCoderAgent):
+    async def process_message_stream(self, message, attachments=None):
+        RecordingCoderAgent.events.append("stream")
+        raise RuntimeError("inference exploded")
+        yield {}  # pragma: no cover — makes this an async generator
+
+
+class StreamCancelledAgent(RecordingCoderAgent):
+    async def process_message_stream(self, message, attachments=None):
+        RecordingCoderAgent.events.append("stream")
+        raise __import__("asyncio").CancelledError()
+        yield {}  # pragma: no cover
+
+
+class AgentCleanupFailsAgent(RecordingCoderAgent):
+    async def cleanup(self):
+        RecordingCoderAgent.events.append("agent-cleanup-attempted")
+        raise RuntimeError("agent cleanup exploded")
+
+
+class StreamAndAgentCleanupFailAgent(StreamFailsAgent, AgentCleanupFailsAgent):
+    pass
+
+
+def _run_ask_with_extension(main_module, project):
+    return main_module.main(
+        ["ask", "do the thing", "--project", str(project), "--extension", "fake_ext_mod:create_extension"]
+    )
+
+
+def _saved_run_terminal(tmp_path):
+    """Last run.* event of the single saved session in the isolated state dir."""
+    import json
+
+    (events_file,) = (tmp_path / "state").glob("sessions/*/events.jsonl")
+    events = [json.loads(line) for line in events_file.read_text().splitlines()]
+    terminals = [event for event in events if event["type"].startswith("run.")]
+    assert len(terminals) == 1
+    return terminals[0]
+
+
+@pytest.mark.parametrize(
+    ("agent_cls", "error"),
+    [
+        (LspInitFailsAgent, "lsp init failed"),
+        (SessionStartHookFailsAgent, "session-start hook failed"),
+        (StreamFailsAgent, "inference exploded"),
+    ],
+)
+def test_ask_failure_paths_clean_up_bundle_and_keep_primary_error(
+    tmp_path, monkeypatch, isolated_cli_env, capsys, agent_cls, error
+):
+    from kolega_code.cli import main as main_module
+
+    _setup_ask(tmp_path, monkeypatch)
+    monkeypatch.setattr(main_module, "CoderAgent", agent_cls)
+    project = tmp_path / "p2"
+    project.mkdir()
+    _lifecycle_factory(monkeypatch)
+
+    with pytest.raises(RuntimeError, match=error):
+        _run_ask_with_extension(main_module, project)
+
+    assert RecordingCoderAgent.events.count("cleanup") == 1
+
+
+def test_ask_pre_run_failure_records_failed_terminal(tmp_path, monkeypatch, isolated_cli_env, capsys):
+    from kolega_code.cli import main as main_module
+
+    _setup_ask(tmp_path, monkeypatch)
+    monkeypatch.setattr(main_module, "CoderAgent", LspInitFailsAgent)
+    project = tmp_path / "p2"
+    project.mkdir()
+    _lifecycle_factory(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="lsp init failed"):
+        main_module.main(
+            [
+                "ask",
+                "do the thing",
+                "--project",
+                str(project),
+                "--save",
+                "--extension",
+                "fake_ext_mod:create_extension",
+            ]
+        )
+
+    terminal = _saved_run_terminal(tmp_path)
+    assert terminal["type"] == "run.failed"
+    assert terminal["payload"]["error"]["code"] == "RuntimeError"
+    assert RecordingCoderAgent.events.count("cleanup") == 1
+
+
+def test_ask_cancellation_cleans_up_bundle(tmp_path, monkeypatch, isolated_cli_env, capsys):
+    import asyncio
+
+    from kolega_code.cli import main as main_module
+
+    _setup_ask(tmp_path, monkeypatch)
+    monkeypatch.setattr(main_module, "CoderAgent", StreamCancelledAgent)
+    project = tmp_path / "p2"
+    project.mkdir()
+    _lifecycle_factory(monkeypatch)
+
+    with pytest.raises(asyncio.CancelledError):
+        _run_ask_with_extension(main_module, project)
+
+    assert RecordingCoderAgent.events.count("cleanup") == 1
+
+
+def test_ask_bind_failure_cleans_up_and_exits_2(tmp_path, monkeypatch, isolated_cli_env, capsys):
+    main_module, project = _setup_ask(tmp_path, monkeypatch)
+
+    def create_extension(host, config_path):
+        def bad_bind(agent):
+            raise RuntimeError("bind boom")
+
+        return KolegaExtensionBundle(
+            bind_agent=bad_bind,
+            cleanup=lambda: RecordingCoderAgent.events.append("cleanup"),
+        )
+
+    _install_module(monkeypatch, create_extension=create_extension)
+
+    exit_code = _run_ask_with_extension(main_module, project)
+
+    assert exit_code == 2
+    assert "bind_agent failed" in capsys.readouterr().err
+    assert RecordingCoderAgent.events.count("stream") == 0
+    assert RecordingCoderAgent.events.count("cleanup") == 1
+
+
+def test_ask_agent_cleanup_failure_still_cleans_bundle(tmp_path, monkeypatch, isolated_cli_env, capsys):
+    from kolega_code.cli import main as main_module
+
+    _setup_ask(tmp_path, monkeypatch)
+    monkeypatch.setattr(main_module, "CoderAgent", AgentCleanupFailsAgent)
+    project = tmp_path / "p2"
+    project.mkdir()
+    _lifecycle_factory(monkeypatch)
+
+    exit_code = _run_ask_with_extension(main_module, project)
+
+    assert exit_code == 0
+    assert RecordingCoderAgent.events.count("agent-cleanup-attempted") == 1
+    assert RecordingCoderAgent.events.count("cleanup") == 1
+    assert "agent cleanup failed" in capsys.readouterr().err
+
+
+def test_ask_agent_cleanup_failure_never_masks_run_failure(tmp_path, monkeypatch, isolated_cli_env, capsys):
+    from kolega_code.cli import main as main_module
+
+    _setup_ask(tmp_path, monkeypatch)
+    monkeypatch.setattr(main_module, "CoderAgent", StreamAndAgentCleanupFailAgent)
+    project = tmp_path / "p2"
+    project.mkdir()
+    _lifecycle_factory(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="inference exploded"):
+        _run_ask_with_extension(main_module, project)
+
+    assert RecordingCoderAgent.events.count("agent-cleanup-attempted") == 1
+    assert RecordingCoderAgent.events.count("cleanup") == 1
+
+
+def test_ask_bundle_cleanup_failure_never_masks_run_failure(tmp_path, monkeypatch, isolated_cli_env, capsys):
+    from kolega_code.cli import main as main_module
+
+    _setup_ask(tmp_path, monkeypatch)
+    monkeypatch.setattr(main_module, "CoderAgent", StreamFailsAgent)
+    project = tmp_path / "p2"
+    project.mkdir()
+
+    cleanups = []
+
+    def create_extension(host, config_path):
+        def bad_cleanup():
+            cleanups.append("attempted")
+            raise RuntimeError("bundle cleanup exploded")
+
+        return KolegaExtensionBundle(cleanup=bad_cleanup)
+
+    _install_module(monkeypatch, create_extension=create_extension)
+
+    with pytest.raises(RuntimeError, match="inference exploded"):
+        _run_ask_with_extension(main_module, project)
+
+    assert cleanups == ["attempted"]
+    assert "extension cleanup failed" in capsys.readouterr().err

--- a/tests/cli/test_main_worktree_startup.py
+++ b/tests/cli/test_main_worktree_startup.py
@@ -162,8 +162,11 @@ def test_tui_selected_worktree_is_effective_before_project_services(
             calls.append(("app", kwargs["project_path"]))
             assert kwargs["session"] is session
 
-        def run(self) -> None:
+        async def run_async(self) -> None:
             calls.append(("run", None))
+
+        async def _cleanup_agent_generation(self) -> None:
+            calls.append(("cleanup_generation", None))
 
     monkeypatch.setattr(main_module, "resolve_worktree", fake_resolve)
     monkeypatch.setattr(main_module, "_store_from_args", lambda _args: FakeStore())


### PR DESCRIPTION
## Summary

Hardens the extension host lifecycle so an installed extension can safely own per-agent-generation resources. Three areas:

**Loader (`extensions.py`)** — any ordinary exception raised while importing the `--extension` module is now wrapped as `KolegaExtensionLoadError` (module name + exception class, cause chained), keeping every load failure on the concise CLI error path. Previously only `ImportError` was wrapped; a module raising `ValueError` at import escaped as a raw traceback. `KeyboardInterrupt`/`SystemExit` still propagate untouched.

**`ask` (`cli/main.py`)** — once a bundle is created, the rest of the run is one transaction. A single guarded `finally` now tears down agent → bundle → usage sink exactly once and records the run terminal on every exit path. Previously ~10 paths between bundle creation and the run region skipped cleanup entirely — most visibly the agent-constructor `ValueError` path (`return 2` leaked both the bundle and the started usage sink; the existing tool-conflict test pinned only the exit code), plus LSP init, history restore, bind, SESSION_START hook, attachment failures, and any cancellation landing before the run region. The two hand-rolled early-return cleanup sites are deleted; cleanup failures are reported to stderr without replacing the run's primary outcome. Construction failures with a live recorder now also record a `run.failed` terminal. The goal/loop iteration blocks moved to module-level helpers (`_run_ask_goal_iterations` / `_run_ask_loop_iterations`).

**TUI** — new idempotent `AgentRuntimeMixin._cleanup_agent_generation()` detaches `self.agent` and the bundle *before* awaiting, so repeated/concurrent callers can't double-clean. It's used:
- on rebuild entry (replacing the hand-paired `agent.cleanup()` + bundle cleanup),
- by a transaction guard around new-generation construction (bundle create → ctor → LSP init → bind → session-start), so a failed rebuild reclaims the partial generation instead of leaking it,
- in `action_quit`, now restructured try/finally — a failing history save no longer skips bundle/sink teardown (the save error still propagates),
- and by an awaited launcher backstop (`asyncio.run(app.run_async())` + `finally`) covering exits that bypass `action_quit` (startup `self.exit`, crashes). Textual's `App.run()` is a thin wrapper over exactly this.

`/model`, `/effort`, and settings-panel rebuild failures now surface as a logged error with chat disabled instead of crashing the worker.

Also includes a test-only de-flake: the terminal spill-recovery test now waits for the payload to be durably spilled before cancelling (under parallel load it previously killed the child mid-flush, so `END` was never written — not the recovery path the test is about).

## Tests

- Loader: import-time `ValueError` → wrapped + chained; `SystemExit` propagates.
- `ask`: parametrized failure injection (LSP init, SESSION_START hook, mid-stream failure, cancellation) each assert the bundle was cleaned exactly once with the primary error preserved; bind failure exits 2 with cleanup; agent-cleanup-raises still cleans the bundle (and never masks a run failure — inverse covered too); pre-run failures record `run.failed`; the tool-conflict test now asserts cleanup ran.
- TUI: `_cleanup_agent_generation` idempotency + detach; failed rebuild reclaims exactly once; `action_quit` with a raising save still cleans generation + sink.

Full fast suite, ruff, and pyright green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WA3jkDUSkeaBnus47HX5LY