### PR TITLE
fix(llm): full-lifecycle call-origin attribution + trace sinks for helper clients

### DIFF
--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import contextvars
 from dataclasses import dataclass
 import logging
@@ -1683,6 +1684,7 @@ class BaseAgent(LogMixin):
             tokens_per_minute=model_config.rate_limits.tokens_per_minute,
             token_manager=self.config.get_chatgpt_token_manager(),
             usage_ledger=self.usage_ledger,
+            trace_sink=self.llm_trace_sink,
         )
         with llm_call_origin(helper_origin("hook_prompt")):
             response = await client.generate(
@@ -2038,21 +2040,28 @@ class BaseAgent(LogMixin):
         no actual conversation. Mirroring here rather than at each ``yield`` keeps
         one choke point that cannot drift out of sync with the yields.
         """
-        async for chunk in self._run_recorded_turn(
-            self._process_message_stream_impl(message, attachments), user_text=message
-        ):
-            yield chunk
+        turn = self._run_recorded_turn(self._process_message_stream_impl(message, attachments), user_text=message)
+        async with contextlib.aclosing(turn):
+            async for chunk in turn:
+                yield chunk
 
     async def _run_recorded_turn(
         self, impl: AsyncGenerator[Dict[str, Any], None], *, user_text: Optional[str]
     ) -> AsyncGenerator[Dict[str, Any], None]:
-        """Drive one recorded turn: boundaries, chunk mirroring, terminal bookkeeping."""
+        """Drive one recorded turn: boundaries, chunk mirroring, terminal bookkeeping.
+
+        ``aclosing`` propagates an early close of this generator into ``impl``
+        synchronously — an abandoned turn must not leave the inner loop (and the
+        provider stream context it holds) waiting for garbage-collection
+        finalization.
+        """
         turn_id = str(uuid.uuid4())
         await self._emit_turn_boundary("started", turn_id=turn_id, user_text=user_text)
         try:
-            async for chunk in impl:
-                await self._mirror_stream_chunk(chunk)
-                yield chunk
+            async with contextlib.aclosing(impl):
+                async for chunk in impl:
+                    await self._mirror_stream_chunk(chunk)
+                    yield chunk
         except asyncio.CancelledError:
             await self._finish_recorded_turn("cancelled")
             await self._emit_turn_boundary("ended", turn_id=turn_id, status="cancelled")
@@ -2253,8 +2262,10 @@ class BaseAgent(LogMixin):
                 )
             self.append_user_message([volatile_context])
 
-        async for chunk in self._agent_loop_stream():
-            yield chunk
+        loop_stream = self._agent_loop_stream()
+        async with contextlib.aclosing(loop_stream):
+            async for chunk in loop_stream:
+                yield chunk
 
     async def _agent_loop_stream(self) -> AsyncGenerator[Dict[str, Any], None]:
         """The shared agent loop: compaction, model streaming, tool execution.
@@ -2349,6 +2360,12 @@ class BaseAgent(LogMixin):
                 # provider is ``async def``, so the call is always a coroutine that we
                 # await into the context manager. Cast to the coroutine form for the type
                 # checker rather than awaiting the union directly.
+                #
+                # The origin must stay active for the whole request — entry into
+                # the stream context manager, event iteration, and
+                # get_final_message() — because providers may sample and emit
+                # their trace record at any of those points (the native Tinker
+                # provider does all of it in __aenter__), not at stream().
                 with llm_call_origin(self._main_loop_origin()):
                     stream_cm = await cast(
                         Coroutine[Any, Any, AbstractAsyncContextManager[Any]],
@@ -2363,84 +2380,84 @@ class BaseAgent(LogMixin):
                             hosted_web_search=self.hosted_web_search_active,
                         ),
                     )
-                async with stream_cm as stream:
-                    async for event in stream:
-                        if event.type == "text":
-                            current_response += event.text
+                    async with stream_cm as stream:
+                        async for event in stream:
+                            if event.type == "text":
+                                current_response += event.text
 
-                            # Send periodic updates as the response grows
-                            if len(current_response) >= 50:
+                                # Send periodic updates as the response grows
+                                if len(current_response) >= 50:
+                                    yield {
+                                        "type": "response",
+                                        "content": current_response,
+                                        "complete": False,
+                                        "uuid": response_uuid,
+                                    }
+                                    current_response = ""
+
+                            elif event.type == "thinking" and event.thinking:
+                                current_thinking += event.thinking
+
+                                if len(current_thinking) >= 50:
+                                    thinking_started = True
+                                    yield {
+                                        "type": "thinking",
+                                        "content": current_thinking,
+                                        "complete": False,
+                                        "uuid": thinking_uuid,
+                                    }
+                                    current_thinking = ""
+
+                            elif event.type == "tool_use_start" and event.tool_call_delta:
+                                # Flush accumulated text first so the user doesn't have to wait for it.
                                 yield {
                                     "type": "response",
                                     "content": current_response,
-                                    "complete": False,
+                                    "complete": True,
                                     "uuid": response_uuid,
                                 }
                                 current_response = ""
 
-                        elif event.type == "thinking" and event.thinking:
-                            current_thinking += event.thinking
+                                await self.on_tool_use_start(event.tool_call_delta)
 
-                            if len(current_thinking) >= 50:
-                                thinking_started = True
+                            elif event.type == "hosted_tool_call" and event.tool_call_delta:
+                                # A server-side web_search call completed on the
+                                # provider's infrastructure — no local execution.
+                                # Surface it as a normal tool_call/tool_result pair
+                                # so every transcript view renders it.
+                                #
+                                # Close the current thinking/response segment first
+                                # and rotate both uuids: transcript consumers key
+                                # streamed entries by uuid, so without rotation the
+                                # post-search reasoning folds into the bubble above
+                                # these rows instead of opening a new one below
+                                # them. Guards mirror the end-of-stream flushes: an
+                                # unopened thinking segment yields nothing, while
+                                # the response flush is unconditional (an empty
+                                # complete response chunk is a documented no-op for
+                                # every consumer) so a partially streamed response
+                                # entry is never stranded incomplete by rotation.
+                                if thinking_started or current_thinking:
+                                    yield {
+                                        "type": "thinking",
+                                        "content": current_thinking,
+                                        "complete": True,
+                                        "uuid": thinking_uuid,
+                                    }
+                                    current_thinking = ""
+                                    thinking_started = False
+                                    thinking_uuid = str(uuid.uuid4())
                                 yield {
-                                    "type": "thinking",
-                                    "content": current_thinking,
-                                    "complete": False,
-                                    "uuid": thinking_uuid,
-                                }
-                                current_thinking = ""
-
-                        elif event.type == "tool_use_start" and event.tool_call_delta:
-                            # Flush accumulated text first so the user doesn't have to wait for it.
-                            yield {
-                                "type": "response",
-                                "content": current_response,
-                                "complete": True,
-                                "uuid": response_uuid,
-                            }
-                            current_response = ""
-
-                            await self.on_tool_use_start(event.tool_call_delta)
-
-                        elif event.type == "hosted_tool_call" and event.tool_call_delta:
-                            # A server-side web_search call completed on the
-                            # provider's infrastructure — no local execution.
-                            # Surface it as a normal tool_call/tool_result pair
-                            # so every transcript view renders it.
-                            #
-                            # Close the current thinking/response segment first
-                            # and rotate both uuids: transcript consumers key
-                            # streamed entries by uuid, so without rotation the
-                            # post-search reasoning folds into the bubble above
-                            # these rows instead of opening a new one below
-                            # them. Guards mirror the end-of-stream flushes: an
-                            # unopened thinking segment yields nothing, while
-                            # the response flush is unconditional (an empty
-                            # complete response chunk is a documented no-op for
-                            # every consumer) so a partially streamed response
-                            # entry is never stranded incomplete by rotation.
-                            if thinking_started or current_thinking:
-                                yield {
-                                    "type": "thinking",
-                                    "content": current_thinking,
+                                    "type": "response",
+                                    "content": current_response,
                                     "complete": True,
-                                    "uuid": thinking_uuid,
+                                    "uuid": response_uuid,
                                 }
-                                current_thinking = ""
-                                thinking_started = False
-                                thinking_uuid = str(uuid.uuid4())
-                            yield {
-                                "type": "response",
-                                "content": current_response,
-                                "complete": True,
-                                "uuid": response_uuid,
-                            }
-                            current_response = ""
-                            response_uuid = str(uuid.uuid4())
-                            await self._emit_hosted_tool_call(event.tool_call_delta)
+                                current_response = ""
+                                response_uuid = str(uuid.uuid4())
+                                await self._emit_hosted_tool_call(event.tool_call_delta)
 
-                assistant_message = await stream.get_final_message()
+                    assistant_message = await stream.get_final_message()
                 self._normalize_freeform_tool_calls(assistant_message)
                 self._update_hosted_search_residual(assistant_message)
                 assistant_message.usage_metadata["edit_protocol"] = self.edit_protocol.value

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -2038,10 +2038,19 @@ class BaseAgent(LogMixin):
         no actual conversation. Mirroring here rather than at each ``yield`` keeps
         one choke point that cannot drift out of sync with the yields.
         """
+        async for chunk in self._run_recorded_turn(
+            self._process_message_stream_impl(message, attachments), user_text=message
+        ):
+            yield chunk
+
+    async def _run_recorded_turn(
+        self, impl: AsyncGenerator[Dict[str, Any], None], *, user_text: Optional[str]
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        """Drive one recorded turn: boundaries, chunk mirroring, terminal bookkeeping."""
         turn_id = str(uuid.uuid4())
-        await self._emit_turn_boundary("started", turn_id=turn_id, user_text=message)
+        await self._emit_turn_boundary("started", turn_id=turn_id, user_text=user_text)
         try:
-            async for chunk in self._process_message_stream_impl(message, attachments):
+            async for chunk in impl:
                 await self._mirror_stream_chunk(chunk)
                 yield chunk
         except asyncio.CancelledError:
@@ -2244,6 +2253,16 @@ class BaseAgent(LogMixin):
                 )
             self.append_user_message([volatile_context])
 
+        async for chunk in self._agent_loop_stream():
+            yield chunk
+
+    async def _agent_loop_stream(self) -> AsyncGenerator[Dict[str, Any], None]:
+        """The shared agent loop: compaction, model streaming, tool execution.
+
+        Message-independent by construction: user-content handling (attachment
+        guards, prompt-submit hooks, user-message insertion, volatile context)
+        happens before this generator is entered.
+        """
         stop_reason = None
         stop_overrides = 0
         silent_turn_nudges = 0

--- a/kolega_code/agent/compression.py
+++ b/kolega_code/agent/compression.py
@@ -113,6 +113,10 @@ class HistoryCompressor:
             # Stream and drain rather than calling generate(): the Anthropic SDK
             # rejects non-streaming requests whose max_tokens is large enough to risk
             # a >10-minute response, which the model's full completion budget triggers.
+            #
+            # The helper origin spans the whole request: providers may sample and
+            # emit their trace record at context entry or final-message time, not
+            # at stream().
             with llm_call_origin(helper_origin("compression")):
                 stream_cm = await llm.stream(
                     messages=messages,
@@ -122,10 +126,10 @@ class HistoryCompressor:
                     max_completion_tokens=self.SUMMARY_MAX_TOKENS,
                     thinking=thinking,
                 )
-            async with stream_cm as stream:
-                async for _event in stream:
-                    pass
-            response = await stream.get_final_message()
+                async with stream_cm as stream:
+                    async for _event in stream:
+                        pass
+                response = await stream.get_final_message()
 
             summary_text = response.get_text_content()
             if not summary_text or not summary_text.strip():

--- a/kolega_code/agent/tool_backend/terminal_tool.py
+++ b/kolega_code/agent/tool_backend/terminal_tool.py
@@ -107,6 +107,7 @@ class TerminalTool(BaseTool):
             tokens_per_minute=rate_limits.tokens_per_minute,
             token_manager=self.config.get_chatgpt_token_manager(),
             usage_ledger=getattr(self.caller, "usage_ledger", None),
+            trace_sink=getattr(self.caller, "llm_trace_sink", None),
         )
 
         try:

--- a/kolega_code/agent/tool_backend/web_fetch_tool.py
+++ b/kolega_code/agent/tool_backend/web_fetch_tool.py
@@ -155,6 +155,7 @@ class WebFetchTool(StreamingTool):
             "tokens_per_minute": rate_limits.tokens_per_minute,
             "token_manager": self.config.get_chatgpt_token_manager(),
             "usage_ledger": getattr(self.caller, "usage_ledger", None),
+            "trace_sink": getattr(self.caller, "llm_trace_sink", None),
         }
         caller_llm = getattr(self.caller, "llm", None)
         if isinstance(caller_llm, InstrumentedLLMClient):

--- a/kolega_code/llm/ledger.py
+++ b/kolega_code/llm/ledger.py
@@ -105,12 +105,25 @@ def current_llm_call_origin() -> Optional[LlmCallOrigin]:
 
 @contextmanager
 def llm_call_origin(origin: LlmCallOrigin) -> Generator[None]:
-    """Attribute LLM calls begun within this scope (and child tasks) to ``origin``."""
+    """Attribute LLM calls begun within this scope (and child tasks) to ``origin``.
+
+    The scope may span the yields of an async generator (the main agent loop
+    holds it across streaming). Two consequences: consumers observe the origin
+    between chunks (any code that makes its own LLM calls mid-stream must set
+    its own shadowing origin, as every current helper does), and teardown can
+    run in a different Context than entry — ``aclose()`` driven by another task
+    or the loop's ``shutdown_asyncgens`` — where ``reset(token)`` raises, so the
+    reset falls back to restoring the previously observed value.
+    """
+    previous = _llm_call_origin.get()
     token = _llm_call_origin.set(origin)
     try:
         yield
     finally:
-        _llm_call_origin.reset(token)
+        try:
+            _llm_call_origin.reset(token)
+        except ValueError:
+            _llm_call_origin.set(previous)
 
 
 class _RequestState(Enum):

--- a/tests/agent/llm/test_tinker_provider.py
+++ b/tests/agent/llm/test_tinker_provider.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List, Optional, Sequence
 import pytest
 
 from kolega_code.llm.exceptions import LLMInvalidRequestError, map_tinker_errors as _map_errors
-from kolega_code.llm.ledger import helper_origin, llm_call_origin
+from kolega_code.llm.ledger import HISTORY_ORIGIN, helper_origin, llm_call_origin
 from kolega_code.llm.models import (
     Message,
     MessageChunk,
@@ -392,6 +392,28 @@ async def test_trace_sink_receives_full_record(monkeypatch: pytest.MonkeyPatch) 
     assert record.termination == "STOP_SEQUENCE"
     assert record.cache_hit_tokens == 3
     assert record.temperature == 0.5
+
+
+@pytest.mark.asyncio
+async def test_streaming_trace_record_carries_origin_active_at_context_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sampling and trace emission happen in __aenter__, so the origin that
+    matters is the one active when the stream context is entered — not the one
+    active at the stream() call."""
+    records: List[TinkerTraceRecord] = []
+    client = FakeSamplingClient(MODEL, FakeSampleResponse([FakeSequence([7, 8], [-0.4, -0.5])]))
+    _patch_provider(monkeypatch, client, FakeRenderer({"role": "assistant", "content": "ok"}))
+    provider = _make_provider(trace_sink=records.append)
+
+    stream_cm = await provider.stream(MESSAGES, SYSTEM, GenerationParams(), model=MODEL)
+    with llm_call_origin(HISTORY_ORIGIN):
+        async with stream_cm as stream:
+            async for _chunk in stream:
+                pass
+
+    assert len(records) == 1
+    assert records[0].request_role == {"kind": "history"}
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_llm_call_origin.py
+++ b/tests/agent/test_llm_call_origin.py
@@ -16,7 +16,50 @@ from kolega_code.llm.ledger import (
     llm_call_origin,
 )
 
-from .compaction_helpers import build_agent
+from .compaction_helpers import FakeLLM, FakeStream, build_agent
+
+
+class OriginProbeStream(FakeStream):
+    """A stream that records the active origin at every lifecycle phase.
+
+    Models providers that sample (and emit their trace record) inside
+    ``__aenter__`` rather than at ``stream()``-call time — the shape that makes
+    a too-narrow ``llm_call_origin`` scope observable.
+    """
+
+    def __init__(self, final_message=None, probes=None, text_events=()):
+        super().__init__(final_message)
+        self.probes = probes if probes is not None else []
+        self._events = list(text_events)
+
+    async def __aenter__(self):
+        self.probes.append(("aenter", current_llm_call_origin()))
+        return self
+
+    async def __anext__(self):
+        self.probes.append(("anext", current_llm_call_origin()))
+        if self._events:
+            return SimpleNamespace(type="text", text=self._events.pop(0), thinking=None, tool_call_delta=None)
+        raise StopAsyncIteration
+
+    async def get_final_message(self):
+        self.probes.append(("final", current_llm_call_origin()))
+        return self._final
+
+
+class OriginProbeLLM(FakeLLM):
+    """FakeLLM whose streams are OriginProbeStreams sharing one probe list."""
+
+    def __init__(self, *args, text_events=(), **kwargs):
+        super().__init__(*args, **kwargs)
+        self.probes: list = []
+        self._text_events = list(text_events)
+        self.stream = AsyncMock(side_effect=self._probe_stream)
+
+    async def _probe_stream(self, *args, **kwargs):
+        self.probes.append(("stream", current_llm_call_origin()))
+        inner = await self._stream(*args, **kwargs)
+        return OriginProbeStream(inner._final, self.probes, text_events=self._text_events)
 
 
 def test_main_loop_origin_history_iff_recorder_present(tmp_path):
@@ -119,21 +162,67 @@ async def test_terminal_security_check_runs_under_helper_origin(monkeypatch, tmp
 
 
 @pytest.mark.asyncio
-async def test_compression_summarizer_runs_under_helper_origin(tmp_path):
-    from tests.agent.compaction_helpers import FakeLLM, long_history
+async def test_compression_summarizer_origin_live_for_full_stream_lifecycle(tmp_path):
+    from tests.agent.compaction_helpers import long_history
 
-    seen: list = []
-    llm = FakeLLM(summary_text="SUMMARY")
-    original_stream = llm._stream
-
-    async def capturing_stream(*args, **kwargs):
-        seen.append(current_llm_call_origin())
-        return await original_stream(*args, **kwargs)
-
-    llm.stream = AsyncMock(side_effect=capturing_stream)
-
+    llm = OriginProbeLLM(summary_text="SUMMARY: condensed older turns.")
     agent, _ = build_agent(tmp_path, llm=llm)
     agent.history = long_history(6)
     result = await agent.compress_history()
     assert result.ok
-    assert seen and seen[0] is not None and seen[0].helper == "compression"
+    assert {phase for phase, _ in llm.probes} == {"stream", "aenter", "anext", "final"}
+    for phase, origin in llm.probes:
+        assert origin is not None and origin.helper == "compression", phase
+
+
+def _assert_phases_carry_origin(probes, expected_kind):
+    assert {phase for phase, _ in probes} == {"stream", "aenter", "anext", "final"}
+    for phase, origin in probes:
+        assert origin is not None, f"no origin at {phase}"
+        assert origin.kind == expected_kind, f"{phase}: {origin.kind}"
+
+
+@pytest.mark.asyncio
+async def test_main_loop_origin_live_for_full_stream_lifecycle(tmp_path):
+    llm = OriginProbeLLM()
+    agent, _ = build_agent(tmp_path, llm=llm)
+    async for _chunk in agent.process_message_stream("hi"):
+        pass
+    _assert_phases_carry_origin(llm.probes, "primary")
+
+
+@pytest.mark.asyncio
+async def test_sub_agent_origin_live_for_full_stream_lifecycle(tmp_path):
+    llm = OriginProbeLLM()
+    agent, _ = build_agent(tmp_path, sub_agent=True, llm=llm)
+    cast(Any, agent).sub_agent_context = {"agent_id": "a1", "parent_tool_call_id": "tc1", "depth": 1}
+    async for _chunk in agent.process_message_stream("task"):
+        pass
+    _assert_phases_carry_origin(llm.probes, "sub_agent")
+
+
+@pytest.mark.asyncio
+async def test_origin_visible_between_chunks_and_cleared_by_same_task_close(tmp_path):
+    # A mid-stream text event forces a yield while the origin scope is open.
+    llm = OriginProbeLLM(text_events=["x" * 60])
+    agent, _ = build_agent(tmp_path, llm=llm)
+    gen = agent.process_message_stream("hi")
+    chunk = await gen.__anext__()
+    assert chunk["type"] == "response"
+    # Documented property: the consumer observes the origin between chunks.
+    origin = current_llm_call_origin()
+    assert origin is not None and origin.kind == "primary"
+    await gen.aclose()
+    assert current_llm_call_origin() is None
+
+
+@pytest.mark.asyncio
+async def test_cross_task_generator_close_does_not_raise(tmp_path):
+    llm = OriginProbeLLM(text_events=["x" * 60])
+    agent, _ = build_agent(tmp_path, llm=llm)
+    gen = agent.process_message_stream("hi")
+    await gen.__anext__()
+    # Closing from another task runs the origin scope's finally in a foreign
+    # Context, where ContextVar.reset(token) raises; the resilient reset must
+    # swallow it so teardown never surfaces a spurious ValueError.
+    await asyncio.create_task(gen.aclose())

--- a/tests/agent/test_llm_trace_sink_propagation.py
+++ b/tests/agent/test_llm_trace_sink_propagation.py
@@ -82,3 +82,66 @@ def test_create_llm_client_forwards_trace_sink_to_instrumented_client(tmp_path):
     client = agent.context.create_llm_client(agent.agent_name)
     assert isinstance(client, InstrumentedLLMClient)
     assert client._trace_sink is _sink
+
+
+# --- helper clients ---------------------------------------------------------------
+# Every LLM client a helper derives from an agent must carry the agent's sink.
+
+
+@pytest.mark.asyncio
+async def test_hook_prompt_client_receives_trace_sink(tmp_path, monkeypatch):
+    from types import SimpleNamespace
+
+    from .compaction_helpers import build_agent
+
+    agent, _ = build_agent(tmp_path)
+    agent.llm_trace_sink = _sink
+    seen_kwargs = {}
+
+    class _Capturing:
+        def __init__(self, **kwargs):
+            seen_kwargs.update(kwargs)
+
+        async def generate(self, **kwargs):
+            return SimpleNamespace(get_text_content=lambda: "ok")
+
+    monkeypatch.setattr("kolega_code.llm.client.LLMClient", _Capturing)
+    await agent._run_hook_prompt("check", None)
+    assert seen_kwargs["trace_sink"] is _sink
+
+
+@pytest.mark.asyncio
+async def test_terminal_security_client_receives_trace_sink(tmp_path, monkeypatch):
+    from types import SimpleNamespace
+
+    from kolega_code.agent.tool_backend import terminal_tool as terminal_tool_module
+    from kolega_code.agent.tool_backend.terminal_tool import TerminalTool
+
+    seen_kwargs = {}
+
+    class _Capturing:
+        def __init__(self, **kwargs):
+            seen_kwargs.update(kwargs)
+
+        async def generate(self, **kwargs):
+            return SimpleNamespace(get_text_content=lambda: "safe")
+
+    tool = object.__new__(TerminalTool)
+    tool.config = make_agent_config()
+    tool.caller = SimpleNamespace(usage_ledger=None, llm_trace_sink=_sink, scratchpad_dir=None, project_path=tmp_path)
+    monkeypatch.setattr(terminal_tool_module, "LLMClient", _Capturing)
+
+    await tool._run_command_security_check("ls")
+    assert seen_kwargs["trace_sink"] is _sink
+
+
+def test_web_fetch_client_receives_trace_sink():
+    from types import SimpleNamespace
+
+    from kolega_code.agent.tool_backend.web_fetch_tool import WebFetchTool
+
+    tool = object.__new__(WebFetchTool)
+    tool.config = make_agent_config()
+    tool.caller = SimpleNamespace(llm=None, usage_ledger=None, llm_trace_sink=_sink)
+    client = tool._build_client()
+    assert client._trace_sink is _sink


### PR DESCRIPTION
## Summary

Two attribution fixes, plus the refactor that enables them.

**Commit 1 — pure extraction.** `process_message_stream`'s ~460-line body splits into `_run_recorded_turn` (turn boundaries, chunk mirroring, terminal bookkeeping) and `_agent_loop_stream` (the message-independent loop: compaction, streaming, tool execution, silent/truncated-turn guards, stop hooks, queued-input delivery). Verbatim move; name, signature, and behavior unchanged.

**Commit 2 — origin lifetime + helper sinks.**

*Origin lifetime:* `with llm_call_origin(...)` closed immediately after `await llm.stream(...)` in both the main loop and `HistoryCompressor`, but providers may start sampling — and emit their trace record — only when the returned context manager is entered; the native Tinker provider does all of it in `__aenter__`. Result: every streaming trace record carried `request_role=None` (ledger attribution was unaffected — `begin()` already ran inside the scope). The scope now spans context entry, the full event iteration, and `get_final_message()` in both places.

Consequences handled explicitly, since the widened scope now spans the agent loop's yields:
- Early close of a turn generator propagates synchronously through the nested generators (`contextlib.aclosing` at each delegation level) — the origin reset and the provider's stream context no longer wait for GC finalization.
- `llm_call_origin`'s reset is generator-safe: teardown driven from another task (or `shutdown_asyncgens`) runs the `finally` in a foreign `Context`, where `ContextVar.reset(token)` raises `ValueError`; it now falls back to restoring the prior value.
- The consumer observes the origin between chunks — documented on the context manager; every internal LLM-calling helper already shadows with its own origin.

*Helper trace sinks:* the three helper clients built from an agent — hook prompt generation, terminal-command security checks, web-fetch summarization — passed `usage_ledger` but silently dropped the agent's `llm_trace_sink`, despite the extensions doc promising helpers are covered. All three now forward it (explicit parameter; they deliberately select different models than `AgentContext.create_llm_client` would). Helper origin names unchanged (`hook_prompt`, `terminal_security`, `web_fetch`).

## Tests

- New `OriginProbeStream`/`OriginProbeLLM` fakes record the active origin at `stream()`-call, `__aenter__`, iteration, and `get_final_message`. Main loop asserts `primary`/`history` at **all four phases** (fails on main), sub-agent asserts `sub_agent` at all phases, and the compression test is upgraded from probing only `stream()`-call time.
- Between-chunks visibility + same-task close clears the origin; cross-task `aclose()` completes without a spurious `ValueError`.
- Tinker provider: a streaming request's emitted trace record carries the origin active at context entry (the provider-side half of the contract).
- Each helper client asserts `trace_sink` is the agent's sink.

Full fast suite (4456 passed), ruff, pyright green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WA3jkDUSkeaBnus47HX5LY