### PR TITLE
feat(agent): public continue_from_history_stream for restored conversations

### DIFF
--- a/docs/src/content/docs/concepts/extensions.md
+++ b/docs/src/content/docs/concepts/extensions.md
@@ -126,6 +126,36 @@ assistant message with that tool call. A tool that depends on the top-level
 binding should set `propagate_to_sub_agents=False`, since sub-agents are not
 the bound agent.
 
+### Continuing from restored history
+
+`BaseAgent.continue_from_history_stream()` runs the ordinary agent loop without
+inserting a user message — for resuming a restored conversation that already
+ends at a point from which the assistant should act, commonly an assistant tool
+call followed by its matching tool result. The preparation surface is public:
+
+```python
+agent.restore_message_history(serialized_history)
+agent.restore_compaction_state(compaction)          # after restore, if saved
+agent.append_user_message([ToolResult(tool_use_id=..., name=..., content=...)])
+async for chunk in agent.continue_from_history_stream():
+    ...
+```
+
+The continuation runs the same compaction checks, request construction, model
+streaming, tool execution, iteration limits, stop handling, retries, session
+recording, and usage accounting as a normal turn, and yields the same chunk
+format as `process_message_stream`. It adds no user text, attachment,
+volatile-context turn, or prompt-submit hook. Preconditions and caveats:
+
+- The conversation must be non-empty (`ValueError` otherwise) and valid for the
+  provider; validity is the caller's responsibility.
+- Append the real `ToolResult` **before** continuing. A restored history ending
+  in an unanswered tool call is repaired with a placeholder "interrupted"
+  result — exactly as a normal turn would — not rejected.
+- In a recorded session the turn journals as a `turn.started` event with
+  `{"continuation": true}` and no message; replay skips it, and older Kolega
+  Code versions cannot load sessions that contain one.
+
 ### LLM trace sink
 
 `llm_trace_sink` is an optional callable forwarded to every LLM client created

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -2045,6 +2045,52 @@ class BaseAgent(LogMixin):
             async for chunk in turn:
                 yield chunk
 
+    async def continue_from_history_stream(self) -> AsyncGenerator[Dict[str, Any], None]:
+        """Continue the ordinary agent loop without inserting a user message.
+
+        Requires an already valid conversation ending at a point from which the
+        assistant should act — commonly an assistant tool call followed by its
+        appended matching tool result. ``restore_message_history``,
+        ``restore_compaction_state``, and ``append_user_message`` (with a
+        ``ToolResult`` matched to the restored ``ToolCall``) are the public
+        preparation surface.
+
+        Runs the same compaction checks, request construction, model streaming,
+        tool execution, iteration limits, stop handling, retries, session
+        recording, usage accounting, and cancellation/terminal bookkeeping as a
+        normal turn, and yields the same chunk format as
+        ``process_message_stream``. Adds no user text, attachment,
+        volatile-context turn, or prompt-submit hook.
+        """
+        if not self.get_effective_history_for_llm():
+            raise ValueError(
+                "continue_from_history_stream requires a non-empty conversation; "
+                "restore message history (and any compaction state) first"
+            )
+        turn = self._run_recorded_turn(self._continue_from_history_impl(), user_text=None)
+        async with contextlib.aclosing(turn):
+            async for chunk in turn:
+                yield chunk
+
+    async def _continue_from_history_impl(self) -> AsyncGenerator[Dict[str, Any], None]:
+        # No memory refresh: its only model-visible effect is volatile-context
+        # injection, which a continuation deliberately never performs.
+        if self.session_recorder is not None:
+            await asyncio.to_thread(self.session_recorder.start_continuation_turn)
+            await asyncio.to_thread(
+                self.session_recorder.record_system_context,
+                self.system_prompt.get_text_content(),
+            )
+            if self.tool_collection is not None:
+                await asyncio.to_thread(
+                    self.session_recorder.record_tool_definitions,
+                    [tool.to_public_dict() for tool in self.tool_collection.get_tool_list()],
+                )
+        loop_stream = self._agent_loop_stream()
+        async with contextlib.aclosing(loop_stream):
+            async for chunk in loop_stream:
+                yield chunk
+
     async def _run_recorded_turn(
         self, impl: AsyncGenerator[Dict[str, Any], None], *, user_text: Optional[str]
     ) -> AsyncGenerator[Dict[str, Any], None]:

--- a/kolega_code/cli/atif_export.py
+++ b/kolega_code/cli/atif_export.py
@@ -455,6 +455,16 @@ class _Grouper:
         self.warnings.add("unknown_event_type", f"Unknown event type {event_type} kept in extra only.")
 
     def _on_turn_started(self, draft: _TrajectoryDraft, event: dict[str, Any], payload: dict[str, Any]) -> None:
+        if payload.get("continuation"):
+            # A continuation turn carries no user utterance; keep the boundary
+            # in extra instead of fabricating an empty user step. Root drafts
+            # surface extra via root_extra; subagent drafts via their own extra.
+            record = {"turn_id": event.get("turn_id"), "seq": int(event["seq"])}
+            if draft is self.root:
+                self.root_extra.setdefault("continuation_turns", []).append(record)
+            else:
+                draft.extra.setdefault("continuation_turns", []).append(record)
+            return
         message, _, _, content_blocks = _step_message_and_reasoning(
             payload.get("message") or {}, event=event, assets=self.assets, warnings=self.warnings
         )

--- a/kolega_code/cli/session_journal.py
+++ b/kolega_code/cli/session_journal.py
@@ -674,20 +674,37 @@ class SessionRecorder:
         with self._lock:
             if self.current_turn_id is not None:
                 raise SessionJournalError("Cannot start a session turn while another turn is open")
-            turn_id = str(uuid.uuid4())
             stored, artifacts = self.journal.prepare_message(message.to_dict())
-            event = self._append(
-                "turn.started",
-                actor="user",
-                payload={"message": stored},
-                turn_id=turn_id,
-                artifacts=artifacts,
-            )
-            self.current_turn_id = turn_id
-            self._turn_started_at = event.timestamp
-            self._assistant_count = 0
-            self._tool_batches = 0
-            return turn_id
+            return self._open_turn_locked(actor="user", payload={"message": stored}, artifacts=artifacts)
+
+    def start_continuation_turn(self) -> str:
+        """Open a turn that continues from restored history with no user message.
+
+        The ``turn.started`` payload carries ``{"continuation": True}`` and no
+        ``message`` key: it contributes no history message on replay, and export
+        consumers must not synthesize a user step for it.
+        """
+        with self._lock:
+            if self.current_turn_id is not None:
+                raise SessionJournalError("Cannot start a session turn while another turn is open")
+            return self._open_turn_locked(actor="system", payload={"continuation": True}, artifacts=None)
+
+    def _open_turn_locked(
+        self, *, actor: str, payload: dict[str, Any], artifacts: Optional[list[dict[str, Any]]]
+    ) -> str:
+        turn_id = str(uuid.uuid4())
+        event = self._append(
+            "turn.started",
+            actor=actor,
+            payload=payload,
+            turn_id=turn_id,
+            artifacts=artifacts,
+        )
+        self.current_turn_id = turn_id
+        self._turn_started_at = event.timestamp
+        self._assistant_count = 0
+        self._tool_batches = 0
+        return turn_id
 
     def record_assistant(self, message: Message, *, reasoning_effort: Optional[str] = None) -> None:
         with self._lock:

--- a/kolega_code/cli/session_store.py
+++ b/kolega_code/cli/session_store.py
@@ -586,6 +586,10 @@ class SessionStore:
             if current_epoch is None or event.epoch_id != current_epoch:
                 continue
             if event.event_type in message_events:
+                if event.event_type == "turn.started" and event.payload.get("continuation"):
+                    # A continuation turn opens with no user message; the
+                    # boundary contributes nothing to resumable history.
+                    continue
                 message = event.payload.get("message")
                 if not isinstance(message, dict):
                     raise SessionStoreError(f"Session event {event.seq} is missing a message")

--- a/tests/agent/test_continue_from_history.py
+++ b/tests/agent/test_continue_from_history.py
@@ -1,0 +1,320 @@
+"""continue_from_history_stream: the ordinary agent loop entered from restored
+history with no user message — same recording, compaction, tool execution,
+chunk format, and failure bookkeeping as a normal turn."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kolega_code.agent.errors import MaxAgentIterationsExceeded
+from kolega_code.cli.session_store import SessionStore
+from kolega_code.hooks.events import HookEvent
+from kolega_code.llm.models import Message, TextBlock, ToolCall, ToolResult
+
+from .compaction_helpers import FakeLLM, build_agent, long_history
+from .test_llm_call_origin import OriginProbeLLM
+
+
+def _restored_pending_tool_history(agent, call_id="t1"):
+    """Restore ``[user P, assistant ToolCall]`` via the public dump/restore API,
+    then append the matching ToolResult the way an external caller would."""
+    tool_call = ToolCall(id=call_id, name="probe", input={})
+    history = [
+        Message(role="user", content=[TextBlock(text="P")]).to_dict(),
+        Message(role="assistant", content=[tool_call], tool_calls=[tool_call], stop_reason="tool_use").to_dict(),
+    ]
+    agent.restore_message_history(history)
+    agent.restore_compaction_state(None)
+    agent.append_user_message([ToolResult(tool_use_id=call_id, name="probe", content="probe-output", is_error=False)])
+
+
+def _child_response(text="child answer"):
+    return Message(role="assistant", content=[TextBlock(text=text)], stop_reason="end_turn")
+
+
+@pytest.mark.asyncio
+async def test_continuation_streams_child_response_without_new_user_message(tmp_path):
+    agent, _ = build_agent(tmp_path, llm=FakeLLM(token_script=[100], final_message=_child_response()))
+    _restored_pending_tool_history(agent)
+    before = [message.to_dict() for message in agent.history]
+
+    chunks = [chunk async for chunk in agent.continue_from_history_stream()]
+
+    # History grew by exactly the child assistant message; nothing user-authored
+    # was inserted.
+    after = [message.to_dict() for message in agent.history]
+    assert after[: len(before)] == before
+    assert len(after) == len(before) + 1
+    assert agent.history[-1].role == "assistant"
+    assert agent.history[-1].get_text_content() == "child answer"
+    # Chunk shape matches process_message_stream.
+    final = [chunk for chunk in chunks if chunk.get("complete")]
+    assert final and set(final[-1]) == {"type", "content", "complete", "uuid"}
+    assert final[-1]["type"] == "response"
+    # Tool pairing stays provider-valid.
+    assert agent._is_history_valid_for_anthropic()
+
+
+@pytest.mark.asyncio
+async def test_continuation_journal_and_replay_roundtrip(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", {})
+    agent, _ = build_agent(tmp_path, llm=FakeLLM(token_script=[100], final_message=_child_response()))
+    agent.session_recorder = store.recorder(session.session_id)
+    _restored_pending_tool_history(agent)
+
+    async for _chunk in agent.continue_from_history_stream():
+        pass
+
+    events = store.journal(session.session_id).read_events()
+    # No context.message: a continuation never injects a volatile-context turn.
+    assert [event.event_type for event in events][-4:] == [
+        "turn.started",
+        "context.system",
+        "assistant.message",
+        "turn.completed",
+    ]
+    started = next(event for event in events if event.event_type == "turn.started")
+    assert started.actor == "system"
+    assert started.payload == {"continuation": True}
+    assert "message" not in started.payload
+    # The session stays loadable and replay contributes no message for the
+    # continuation boundary: the replayed history is exactly the recorded
+    # assistant message (restored history predates this journal).
+    replayed = store.load(session.session_id).history
+    assert [Message.from_dict(item).get_text_content() for item in replayed] == ["child answer"]
+
+
+@pytest.mark.asyncio
+async def test_continuation_auto_compaction_matches_normal_turn(tmp_path):
+    agent, _ = build_agent(tmp_path, llm=FakeLLM(token_script=[900, 300]))
+    agent.history = long_history(6)
+    fired = []
+    original = agent.fire_hook
+
+    async def spy(name, payload, **kwargs):
+        fired.append(name)
+        return await original(name, payload, **kwargs)
+
+    agent.fire_hook = spy
+
+    async for _chunk in agent.continue_from_history_stream():
+        pass
+
+    assert HookEvent.PRE_COMPACT in fired
+    assert HookEvent.POST_COMPACT in fired
+    assert agent.conversation.summary is not None
+
+
+@pytest.mark.asyncio
+async def test_continuation_executes_tools_like_normal_turn(tmp_path):
+    next_call = ToolCall(id="t2", name="probe", input={})
+    script = [
+        Message(role="assistant", content=[next_call], tool_calls=[next_call], stop_reason="tool_use"),
+        _child_response("after tools"),
+    ]
+    agent, _ = build_agent(tmp_path, llm=FakeLLM(token_script=[100], message_script=script))
+    _restored_pending_tool_history(agent)
+    agent.process_tool_calls = AsyncMock(
+        return_value=[ToolResult(tool_use_id="t2", name="probe", content="ok", is_error=False)]
+    )
+
+    async for _chunk in agent.continue_from_history_stream():
+        pass
+
+    agent.process_tool_calls.assert_awaited_once()
+    assert agent.history[-1].get_text_content() == "after tools"
+    assert agent._is_history_valid_for_anthropic()
+
+
+@pytest.mark.asyncio
+async def test_continuation_empty_history_raises_before_any_event(tmp_path):
+    agent, cm = build_agent(tmp_path, llm=FakeLLM(token_script=[100]))
+    recorder = MagicMock()
+    recorder.current_turn_id = None
+    agent.session_recorder = recorder
+
+    with pytest.raises(ValueError, match="non-empty conversation"):
+        async for _chunk in agent.continue_from_history_stream():
+            pass
+
+    recorder.start_continuation_turn.assert_not_called()
+    recorder.finish_turn.assert_not_called()
+    assert not any(
+        getattr(call.args[0] if call.args else call.kwargs.get("event"), "event_type", None) == "turn_started"
+        for call in cm.broadcast_event.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_continuation_cancellation_bookkeeping(tmp_path):
+    class BlockingLLM(FakeLLM):
+        async def _stream(self, *args, **kwargs):
+            await asyncio.Event().wait()
+
+    agent, _ = build_agent(tmp_path, llm=BlockingLLM(token_script=[100]))
+    _restored_pending_tool_history(agent)
+
+    class Recorder:
+        current_turn_id = None
+        terminal_status = None
+
+        def start_continuation_turn(self):
+            self.current_turn_id = "turn"
+
+        def record_system_context(self, text):
+            return False
+
+        def record_tool_definitions(self, tools):
+            return False
+
+        def finish_turn(self, status, *, error=None):
+            self.terminal_status = status
+            self.current_turn_id = None
+
+    agent.session_recorder = Recorder()
+
+    async def consume():
+        async for _chunk in agent.continue_from_history_stream():
+            pass
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert agent.session_recorder.terminal_status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_continuation_provider_failure_records_failed_turn(tmp_path):
+    from kolega_code.llm.exceptions import LLMAuthenticationError
+
+    failing = FakeLLM(token_script=[100])
+    failing.stream = AsyncMock(side_effect=LLMAuthenticationError("bad key"))
+    agent, _ = build_agent(tmp_path, llm=failing)
+    _restored_pending_tool_history(agent)
+
+    class Recorder:
+        current_turn_id = None
+        terminal_status = None
+
+        def start_continuation_turn(self):
+            self.current_turn_id = "turn"
+
+        def record_system_context(self, text):
+            return False
+
+        def record_tool_definitions(self, tools):
+            return False
+
+        def finish_turn(self, status, *, error=None):
+            self.terminal_status = status
+            self.current_turn_id = None
+
+    agent.session_recorder = Recorder()
+
+    with pytest.raises(LLMAuthenticationError):
+        async for _chunk in agent.continue_from_history_stream():
+            pass
+
+    assert agent.session_recorder.terminal_status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_continuation_max_iterations_parity(tmp_path):
+    tool_call = ToolCall(id="loop-1", name="probe", input={})
+    looping = Message(role="assistant", content=[tool_call], tool_calls=[tool_call], stop_reason="tool_use")
+    agent, _ = build_agent(tmp_path, llm=FakeLLM(token_script=[100], final_message=looping))
+    agent.max_iterations = 2
+    _restored_pending_tool_history(agent)
+    agent.process_tool_calls = AsyncMock(
+        return_value=[ToolResult(tool_use_id="loop-1", name="probe", content="ok", is_error=False)]
+    )
+
+    with pytest.raises(MaxAgentIterationsExceeded, match="max_iterations=2"):
+        async for _chunk in agent.continue_from_history_stream():
+            pass
+
+
+@pytest.mark.asyncio
+async def test_continuation_tool_error_produces_error_results(tmp_path):
+    next_call = ToolCall(id="t3", name="probe", input={})
+    script = [
+        Message(role="assistant", content=[next_call], tool_calls=[next_call], stop_reason="tool_use"),
+        _child_response("recovered"),
+    ]
+    agent, _ = build_agent(tmp_path, llm=FakeLLM(token_script=[100], message_script=script))
+    _restored_pending_tool_history(agent)
+    agent.process_tool_calls = AsyncMock(side_effect=RuntimeError("tool backend down"))
+
+    async for _chunk in agent.continue_from_history_stream():
+        pass
+
+    # The loop synthesized per-call error results and kept going, same as a
+    # normal turn.
+    error_results = [
+        block
+        for message in agent.history
+        for block in message.content
+        if isinstance(block, ToolResult) and block.tool_use_id == "t3"
+    ]
+    assert error_results and error_results[0].is_error
+    assert agent.history[-1].get_text_content() == "recovered"
+
+
+@pytest.mark.asyncio
+async def test_continuation_stop_sequence_terminal(tmp_path):
+    final = Message(role="assistant", content=[TextBlock(text="cut")], stop_reason="stop_sequence")
+    agent, _ = build_agent(tmp_path, llm=FakeLLM(token_script=[100], final_message=final))
+    _restored_pending_tool_history(agent)
+
+    chunks = [chunk async for chunk in agent.continue_from_history_stream()]
+
+    assert chunks[-1]["complete"] is True
+    assert agent.history[-1].stop_reason == "stop_sequence"
+
+
+@pytest.mark.asyncio
+async def test_continuation_delivers_queued_inputs(tmp_path):
+    next_call = ToolCall(id="t4", name="probe", input={})
+    script = [
+        Message(role="assistant", content=[next_call], tool_calls=[next_call], stop_reason="tool_use"),
+        _child_response("done"),
+    ]
+    agent, _ = build_agent(tmp_path, llm=FakeLLM(token_script=[100], message_script=script))
+    _restored_pending_tool_history(agent)
+    agent.process_tool_calls = AsyncMock(
+        return_value=[ToolResult(tool_use_id="t4", name="probe", content="ok", is_error=False)]
+    )
+    from kolega_code.agent.baseagent import QueuedUserInput
+
+    queued = [QueuedUserInput(text="queued user note", attachments=None)]
+
+    async def provider():
+        return [queued.pop()] if queued else []
+
+    agent.set_queued_input_provider(provider)
+
+    async for _chunk in agent.continue_from_history_stream():
+        pass
+
+    texts = [message.get_text_content() for message in agent.history]
+    assert any("queued user note" in text for text in texts)
+
+
+@pytest.mark.asyncio
+async def test_continuation_origin_matches_main_loop(tmp_path):
+    llm = OriginProbeLLM()
+    agent, _ = build_agent(tmp_path, llm=llm)
+    _restored_pending_tool_history(agent)
+
+    async for _chunk in agent.continue_from_history_stream():
+        pass
+
+    assert {phase for phase, _ in llm.probes} == {"stream", "aenter", "anext", "final"}
+    for phase, origin in llm.probes:
+        assert origin is not None and origin.kind == "primary", phase

--- a/tests/cli/test_app_mention_dropdown.py
+++ b/tests/cli/test_app_mention_dropdown.py
@@ -116,7 +116,13 @@ async def test_mention_dropdown_uses_cached_search_not_blocking_walk(
         dropdown = app.query_one("#completion_dropdown", CompletionDropdown)
         composer.focus()
         composer.insert("@alp")
-        await pilot.pause()
+        # The TextArea.Changed message can land a pump cycle later on a slow
+        # runner; settle until the completion handler has run. The blocking
+        # search() trap stays armed for the whole window.
+        for _ in range(20):
+            await pilot.pause()
+            if calls["cached"]:
+                break
 
         assert calls["cached"] >= 1  # keystroke used the non-blocking cached search
         assert dropdown.is_open

--- a/tests/cli/test_atif_export.py
+++ b/tests/cli/test_atif_export.py
@@ -575,3 +575,26 @@ def test_usage_is_never_fabricated():
     assert "total_prompt_tokens" not in (doc.get("final_metrics") or {})
     codes = {w["code"] for w in doc["extra"]["conversion_warnings"]}
     assert "usage_missing_for_llm_step" in codes and "usage_totals_partial" in codes
+
+
+def test_continuation_turn_produces_no_user_step():
+    journal = make_journal()
+    recorder = bootstrap(journal)
+    ledger = UsageLedger()
+    recorder.start_continuation_turn()
+    recorder.record_system_context("You are kolega.")
+    message = settled(
+        ledger,
+        Message(role="assistant", content=[TextBlock("resumed")], stop_reason="end_turn", usage=_usage(10, 5)),
+    )
+    recorder.record_assistant(message, reasoning_effort="high")
+    recorder.finish_turn("completed")
+
+    doc = convert(journal)
+
+    # No fabricated empty user utterance; the boundary survives in extra.
+    assert [step["source"] for step in doc["steps"]].count("user") == 0
+    continuations = doc["extra"]["kolega"]["continuation_turns"]
+    assert len(continuations) == 1 and continuations[0]["turn_id"]
+    agent_steps = [step for step in doc["steps"] if step["source"] == "agent"]
+    assert len(agent_steps) == 1 and agent_steps[0]["message"] == "resumed"

--- a/tests/cli/test_event_protocol.py
+++ b/tests/cli/test_event_protocol.py
@@ -550,3 +550,18 @@ def test_recovery_ignores_open_subagent_turns(tmp_path: Path) -> None:
     assert recovered.current_turn_id is None
     types = [e.event_type for e in journal.read_events()]
     assert types.count("turn.completed") == 1
+
+
+def test_continuation_turn_started_passes_through_without_message() -> None:
+    journal = InMemorySessionJournal("proto-continuation")
+    bootstrap(journal)
+    recorder = SessionRecorder(journal, recover=False)
+    recorder.start_continuation_turn()
+    recorder.finish_turn("completed")
+
+    started = next(event for event in journal.read_events() if event.event_type == "turn.started")
+    public = to_public_event(started)
+    assert public is not None
+    assert public["type"] == "turn.started"
+    assert public["actor"] == "system"
+    assert public["payload"] == {"continuation": True}


### PR DESCRIPTION
## Summary

Stacked on #529 (it builds on the extracted `_agent_loop_stream` / `_run_recorded_turn`).

Adds the one missing piece for continuing a restored conversation without private APIs: `BaseAgent.continue_from_history_stream()` runs the ordinary agent loop **without inserting a user message**. Every resume path today synthesizes a user prompt; when a restored history ends at an assistant tool call whose result you've just appended, that changes conversation semantics (`process_message_stream("")` is not a substitute). The preparation surface was already public — `restore_message_history` → `restore_compaction_state` → `append_user_message([ToolResult(...)])` — and everything involved is importable from the package root.

**Behavior parity by construction:** the method delegates to the same shared loop as `process_message_stream`, so compaction (incl. PRE/POST_COMPACT hooks), request construction, streaming, tool execution, iteration limits, stop-hook handling, retries, silent/truncated-turn guards, queued-input delivery, session recording, usage accounting, and cancellation/terminal bookkeeping are identical, and it yields the same chunk format. It adds no user text, attachment, volatile-context turn, or prompt-submit hook (memory refresh is skipped too — its only model-visible effect is volatile-context injection). Precondition checking is deliberately minimal: an empty conversation raises `ValueError` before anything is journaled or emitted; anything subtler goes through the exact repair machinery a normal turn uses.

**Journal shape and its ripple** (all in this PR — they must ship together):
- `SessionRecorder.start_continuation_turn()` opens the turn with `actor="system"`, payload `{"continuation": true}`, and **no `message` key** (shared `_open_turn_locked` tail with `start_turn`, whose strict contract is unchanged).
- `SessionStore._replay` skips continuation `turn.started` events — without this every continued session would fail to load (`Session event N is missing a message`).
- The ATIF converter records the boundary in `extra` (`continuation_turns`) instead of fabricating an empty user step; `to_public_event` needed no change (message-less payloads already pass through).
- Compatibility note: older kolega-code versions cannot load a session containing a continuation turn.

Docs: `concepts/extensions.md` gains a "Continuing from restored history" section with the workflow, preconditions, and the placeholder-repair caveat.

## Tests

New `tests/agent/test_continue_from_history.py` (12 cases): restore `[P, assistant ToolCall]` → append `ToolResult` → continue asserts no new user message, the child assistant response first, and provider-valid pairing; journal order `turn.started{continuation}` → `context.system` → `assistant.message` → `turn.completed` with **no** `context.message`, plus a `store.load()` replay round-trip (the `_replay` regression); auto-compaction parity (PRE/POST_COMPACT fire); tool execution; empty history raises before any event; cancellation → `finish_turn("cancelled")`; provider failure → `finish_turn("failed")`; max-iterations; tool-error results; `stop_sequence` terminal; queued-input delivery; and the full-lifecycle origin probe on the continuation path. Plus protocol and ATIF continuation cases in `tests/cli/`.

Full fast suite (4470 passed), ruff, pyright green locally; the continuation workflow is verified reachable from root-level `kolega_code` imports only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WA3jkDUSkeaBnus47HX5LY