### PR TITLE
feat(llm): explicit per-model input budgets with billed-true residual accounting

### DIFF
--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -58,6 +58,7 @@ from kolega_code.llm.specs import (
     deepseek_output_token_cap,
     get_model_specs,
     is_deepseek_model,
+    resolve_max_input_tokens,
     supports_vision as model_supports_vision,
 )
 from kolega_code.permissions import (
@@ -140,7 +141,7 @@ class BaseAgent(LogMixin):
     # Tool collection; subclasses initialize this in ``__init__`` with the
     # appropriate tool configuration. ``None`` until then.
     tool_collection: Optional[ToolCollection] = None
-    history_compression_threshold = 0.8
+    history_compression_threshold = 0.95
     # Cap on concurrently executing tool calls within one batch (each dispatched
     # sub-agent runs its own multi-turn LLM loop, so an unbounded fan-out would
     # multiply token spend and shared-resource pressure).
@@ -467,6 +468,10 @@ class BaseAgent(LogMixin):
         model_specs = get_model_specs(self.primary_model_config.provider, self.primary_model_config.model)
         self.model_context_length = model_specs["context_length"]
         self.model_completion_tokens = model_specs["max_completion_tokens"]
+        # Usable input budget per the spec's declared input_budget convention.
+        # Compaction and the context gauge denominate on this so
+        # input + max_output ≤ window holds wherever the window is shared.
+        self.model_max_input_tokens = resolve_max_input_tokens(model_specs)
         self.model_default_temperature = model_specs.get("default_temperature", 1.0)
         # The clamped cap DeepSeek requests carry on the wire (None for other
         # models). Used to flag probable silent server-side truncation — see the
@@ -520,14 +525,12 @@ class BaseAgent(LogMixin):
         self._workflow_accounting: Optional["WorkflowRunAccounting"] = None
         self._accounting_reservation: Optional["AgentReservation"] = None
         self.total_tokens_used: int = 0
-        # Hosted web-search accounting side-channel. Searched/fetched content is
-        # injected into the model's context SERVER-side (restored on replay of
-        # web_search_call items, billed as input) and never reaches the client,
-        # so tiktoken-over-history can't see it. The residual — billed input
-        # minus the client-side count of the request actually sent — measures it
-        # and is added to the gauge in count_current_context. Updated by
-        # _update_hosted_search_residual; zeroed by compress_history.
-        self._hosted_injected_tokens: int = 0
+        # Billed input minus the client-side count of the request actually
+        # sent, measured on clean responses: server-injected content (hosted
+        # web-search restores, re-attachment wrapping of restored reasoning)
+        # is invisible to the local count. Added to the gauge in
+        # count_current_context; zeroed by compress_history.
+        self._context_residual_tokens: int = 0
         self._last_raw_context_count: Optional[int] = None
         # Set by a blocking PostToolUse hook to end the turn after the current tool batch.
         self._hook_end_turn = False
@@ -1063,15 +1066,12 @@ class BaseAgent(LogMixin):
             model=self.primary_model_config.model,
             tools=self.tool_collection.get_tool_list(),
         )
-        # Hosted web-search content lives only in the server's copy of the
-        # context (restored on replay of the web_search_call items, billed as
-        # input) — the client history has nothing to count for it. Add the
-        # residual measured from billed usage so the gauge AND the compaction
-        # check both see the true context size. Nonzero only while un-compacted
-        # web_search_call blocks exist (see _update_hosted_search_residual).
+        # Add the measured billed−counted residual so the gauge and the
+        # compaction check see the billed-true context size (see
+        # _update_context_residual).
         self._last_raw_context_count = token_count.input_tokens
-        if self._hosted_injected_tokens > 0:
-            token_count.input_tokens += self._hosted_injected_tokens
+        if self._context_residual_tokens > 0:
+            token_count.input_tokens += self._context_residual_tokens
 
         # Send context update event
         await self._send_context_update(token_count)
@@ -1088,39 +1088,29 @@ class BaseAgent(LogMixin):
     # 6000 overestimates safely, and overestimating only compacts early.
     HOSTED_SEARCH_PROVISIONAL_TOKENS = 6000
 
-    def _update_hosted_search_residual(self, assistant_message: Message) -> None:
-        """Track server-injected hosted-search content from billed usage.
+    def _update_context_residual(self, assistant_message: Message) -> None:
+        """Track the billed−counted residual from billed usage.
 
-        Search-bearing responses bump the estimate by a provisional per-call
-        constant (their own billing telescopes internal rounds, so the direct
-        residual would overshoot and could trip compaction spuriously). Clean
-        responses — single invocation, so ``billed − counted`` is exact —
-        replace it with the measurement. No-ops for sessions that never
-        searched, keeping the known ±tokenizer-drift band out of the gauge.
+        Search-bearing responses bump a provisional per-call constant (their
+        billing telescopes internal rounds); clean responses — single
+        invocation, so ``billed − counted`` is exact — replace it with the
+        measurement. Positive-only: billing below the local count reads as
+        zero, which errs toward compacting early.
         """
         content = assistant_message.content if isinstance(assistant_message.content, list) else []
         new_calls = sum(1 for block in content if isinstance(block, WebSearchCallBlock))
         if new_calls:
-            self._hosted_injected_tokens += self.HOSTED_SEARCH_PROVISIONAL_TOKENS * new_calls
-            return
-        if self._hosted_injected_tokens <= 0 and not self._history_contains_hosted_search():
+            self._context_residual_tokens += self.HOSTED_SEARCH_PROVISIONAL_TOKENS * new_calls
             return
         billed = (assistant_message.usage_metadata or {}).get("prompt_tokens")
         counted = self._last_raw_context_count
         if not isinstance(billed, int) or counted is None:
             return
-        self._hosted_injected_tokens = max(0, billed - counted)
-
-    def _history_contains_hosted_search(self) -> bool:
-        for message in self.history:
-            content = getattr(message, "content", None)
-            if isinstance(content, list) and any(isinstance(block, WebSearchCallBlock) for block in content):
-                return True
-        return False
+        self._context_residual_tokens = max(0, billed - counted)
 
     async def _send_context_update(self, token_count: TokenCount) -> None:
         """Send an event to update the UI about current context usage."""
-        usage_percentage = (token_count.input_tokens / self.model_context_length) * 100
+        usage_percentage = (token_count.input_tokens / self.model_max_input_tokens) * 100
 
         # Determine alert level based on usage
         alert_level = "normal"
@@ -1132,7 +1122,7 @@ class BaseAgent(LogMixin):
 
         await self.emitter.context_update(
             input_tokens=token_count.input_tokens,
-            model_context_length=self.model_context_length,
+            model_context_length=self.model_max_input_tokens,
             compression_threshold=self.history_compression_threshold,
             alert_level=alert_level,
             message=message,
@@ -1149,11 +1139,10 @@ class BaseAgent(LogMixin):
 
         ``trigger``/``tokens_before`` are journaled as compaction provenance.
         """
-        # Compacted-away web_search_call blocks stop being replayed, so the
-        # server stops restoring their content. Reset the hosted-search residual
-        # rather than carrying a stale figure; if search blocks survive in the
-        # verbatim tail, the next clean response re-measures it.
-        self._hosted_injected_tokens = 0
+        # Compaction changes what the server restores and what the client
+        # counts, so any carried residual is stale; the next clean response
+        # re-measures.
+        self._context_residual_tokens = 0
 
         async def on_info(message: str) -> None:
             await self.log_info(message, sender=self.agent_name)
@@ -2344,7 +2333,7 @@ class BaseAgent(LogMixin):
                 token_count = await self.count_current_context(fixed_history)
                 logger.debug("Input token count: %s", token_count)
 
-                if self.compressor.over_budget(token_count.input_tokens, self.model_context_length):
+                if self.compressor.over_budget(token_count.input_tokens, self.model_max_input_tokens):
                     before_tokens = token_count.input_tokens
                     # PreCompact hooks (advisory): observe before history is compacted.
                     await self.fire_hook(
@@ -2505,7 +2494,7 @@ class BaseAgent(LogMixin):
 
                     assistant_message = await stream.get_final_message()
                 self._normalize_freeform_tool_calls(assistant_message)
-                self._update_hosted_search_residual(assistant_message)
+                self._update_context_residual(assistant_message)
                 assistant_message.usage_metadata["edit_protocol"] = self.edit_protocol.value
                 response_output_tokens = get_output_tokens(
                     assistant_message.usage_metadata,

--- a/kolega_code/agent/compression.py
+++ b/kolega_code/agent/compression.py
@@ -50,8 +50,9 @@ class HistoryCompressor:
         # Fraction of the model context window above which compression kicks in
         self.threshold = threshold
 
-    def over_budget(self, input_tokens: int, model_context_length: int) -> bool:
-        return input_tokens > model_context_length * self.threshold
+    def over_budget(self, input_tokens: int, input_budget_tokens: int) -> bool:
+        """True when input exceeds the threshold fraction of the input budget."""
+        return input_tokens > input_budget_tokens * self.threshold
 
     async def summarize(
         self,

--- a/kolega_code/agent/utils/commands.py
+++ b/kolega_code/agent/utils/commands.py
@@ -48,7 +48,7 @@ class CommandProcessor:
         before = (await agent.count_current_context()).input_tokens if has_history else 0
         result = await agent.compress_history()
         after = (await agent.count_current_context()).input_tokens if has_history else 0
-        ctx = agent.model_context_length
+        ctx = agent.model_max_input_tokens
 
         def pct(tokens: int) -> int:
             return int(tokens * 100 / ctx) if ctx else 0
@@ -56,11 +56,11 @@ class CommandProcessor:
         if result.ok:
             return (
                 f"Compressed history: {result.summarized_messages} older message(s) summarized. "
-                f"Context {pct(before)}% → {pct(after)}% of the window."
+                f"Context {pct(before)}% → {pct(after)}% of the input budget."
             )
         if result.reason == "llm_error":
             return f"Compression failed: {result.message}"
-        return f"Nothing to compress. {result.message} (context {pct(before)}% of the window)."
+        return f"Nothing to compress. {result.message} (context {pct(before)}% of the input budget)."
 
     async def _handle_clear(self) -> str:
         """Handle the /clear command."""

--- a/kolega_code/cli/config.py
+++ b/kolega_code/cli/config.py
@@ -78,7 +78,7 @@ SUBAGENTS_MODE_ENV = "KOLEGA_CODE_SUBAGENTS"
 SKILL_MODES = ("on", "off")
 SKILLS_MODE_ENV = "KOLEGA_CODE_SKILLS"
 # Compression threshold override, in percent (10-100). Absent means defer to
-# settings.compression_threshold, then the agent's built-in default (80%).
+# settings.compression_threshold, then the agent's built-in default (95%).
 COMPRESSION_THRESHOLD_ENV = "KOLEGA_CODE_COMPRESSION_THRESHOLD"
 # Env vars that supply a cloud web-search backend's key, keyed by backend name.
 SEARCH_BACKEND_KEY_ENV = {

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -253,8 +253,8 @@ def _add_common_model_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--compression-threshold",
         metavar="PERCENT",
-        help="Context-window usage percentage that triggers automatic history compression "
-        "(10-100; default 80). Overrides settings.json for this session; not persisted. "
+        help="Input-budget usage percentage that triggers automatic history compression "
+        "(10-100; default 95). Overrides settings.json for this session; not persisted. "
         "100 effectively disables automatic compression.",
     )
     parser.add_argument(

--- a/kolega_code/events.py
+++ b/kolega_code/events.py
@@ -353,7 +353,12 @@ class AgentEventEmitter:
         alert_level: str,
         message: Optional[str],
     ) -> None:
-        """Send an llm_context_update event describing context-window usage."""
+        """Send an llm_context_update event describing context usage.
+
+        ``model_context_length`` is the usable input budget (window minus the
+        output allowance), so percentages and ``will_compress_at`` line up
+        with the compaction trigger. The payload key stays ``max_tokens``.
+        """
         usage_percentage = (input_tokens / model_context_length) * 100
         sub_agent_info = self._sub_agent_info_provider() if self._sub_agent_info_provider else None
 

--- a/kolega_code/llm/specs/__init__.py
+++ b/kolega_code/llm/specs/__init__.py
@@ -1,6 +1,7 @@
 from .accessors import (
     DEEPSEEK_WIRE_OUTPUT_CAP,
     deepseek_output_token_cap,
+    resolve_max_input_tokens,
     default_thinking_effort,
     get_model_specs,
     get_thinking_effort_spec,
@@ -28,6 +29,7 @@ __all__ = [
     "MODEL_SPECS",
     "DEEPSEEK_WIRE_OUTPUT_CAP",
     "deepseek_output_token_cap",
+    "resolve_max_input_tokens",
     "is_deepseek_model",
     "get_model_specs",
     "supports_hosted_web_search",

--- a/kolega_code/llm/specs/accessors.py
+++ b/kolega_code/llm/specs/accessors.py
@@ -3,6 +3,30 @@ from typing import Any, Dict, Optional
 from .catalog import MODEL_SPECS, WILDCARD_MODEL_SPECS
 from .types import ThinkingEffortSpec
 
+# Every spec entry must declare which input-budget calculation applies:
+#   window_minus_output   — usable input = context_length − max_completion_tokens
+#                           (one shared pool; we reserve what we request)
+#   separate_output_limit — usable input = context_length (independent output cap)
+#   output_shares_window  — usable input = context_length (output may consume the
+#                           whole window, bounded only at generation time)
+INPUT_BUDGET_CONVENTIONS = ("window_minus_output", "separate_output_limit", "output_shares_window")
+
+
+def resolve_max_input_tokens(specs: Dict[str, Any]) -> int:
+    """The usable input budget for a spec entry, per its declared convention."""
+    if specs["input_budget"] == "window_minus_output":
+        return max(1, specs["context_length"] - specs["max_completion_tokens"])
+    return specs["context_length"]
+
+
+def _validate_input_budgets() -> None:
+    for key, specs in list(MODEL_SPECS.items()) + list(WILDCARD_MODEL_SPECS.items()):
+        if specs.get("input_budget") not in INPUT_BUDGET_CONVENTIONS:
+            raise ValueError(f"Spec {key} missing or invalid input_budget (got {specs.get('input_budget')!r})")
+
+
+_validate_input_budgets()
+
 
 def _provider_value(provider: Any) -> str:
     return provider.value if hasattr(provider, "value") else provider

--- a/kolega_code/llm/specs/catalog/anthropic.py
+++ b/kolega_code/llm/specs/catalog/anthropic.py
@@ -5,6 +5,7 @@ ANTHROPIC_SPECS = {
     ("anthropic", "claude-fable-5"): {
         "context_length": 1000000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -17,6 +18,7 @@ ANTHROPIC_SPECS = {
     ("anthropic", "claude-opus-5"): {
         "context_length": 1000000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -29,6 +31,7 @@ ANTHROPIC_SPECS = {
     ("anthropic", "claude-opus-4-8"): {
         "context_length": 1000000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -41,6 +44,7 @@ ANTHROPIC_SPECS = {
     ("anthropic", "claude-opus-4-7"): {
         "context_length": 1000000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -53,6 +57,7 @@ ANTHROPIC_SPECS = {
     ("anthropic", "claude-opus-4-6"): {
         "context_length": 1000000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -64,6 +69,7 @@ ANTHROPIC_SPECS = {
     ("anthropic", "claude-sonnet-5"): {
         "context_length": 1000000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -76,6 +82,7 @@ ANTHROPIC_SPECS = {
     ("anthropic", "claude-sonnet-4-6"): {
         "context_length": 1000000,
         "max_completion_tokens": 64000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -87,18 +94,21 @@ ANTHROPIC_SPECS = {
     ("anthropic", "claude-sonnet-4-5-20250929"): {
         "context_length": 200000,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
     },
     ("anthropic", "claude-opus-4-5-20251101"): {
         "context_length": 200000,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
     },
     ("anthropic", "claude-haiku-4-5-20251001"): {
         "context_length": 200000,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
     },

--- a/kolega_code/llm/specs/catalog/dashscope.py
+++ b/kolega_code/llm/specs/catalog/dashscope.py
@@ -3,12 +3,14 @@ DASHSCOPE_SPECS = {
     ("dashscope", "qwen3-coder-plus"): {
         "context_length": 1000000,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 0.7,
         "supports_vision": False,
     },
     ("dashscope", "qwen3-coder-flash"): {
         "context_length": 1000000,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 0.7,
         "supports_vision": False,
     },

--- a/kolega_code/llm/specs/catalog/deepseek.py
+++ b/kolega_code/llm/specs/catalog/deepseek.py
@@ -23,6 +23,7 @@ DEEPSEEK_SPECS = {
     ("deepseek", "deepseek-v4-pro"): {
         "context_length": 1000000,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -48,6 +49,7 @@ DEEPSEEK_SPECS = {
     ("deepseek", "deepseek-v4-flash"): {
         "context_length": 1000000,
         "max_completion_tokens": 384000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         # /responses executes {"type": "web_search"} server-side (search +

--- a/kolega_code/llm/specs/catalog/fireworks.py
+++ b/kolega_code/llm/specs/catalog/fireworks.py
@@ -8,6 +8,7 @@ FIREWORKS_SPECS = {
     ("fireworks", "accounts/fireworks/models/kimi-k3"): {
         "context_length": 1048576,
         "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -19,6 +20,7 @@ FIREWORKS_SPECS = {
     ("fireworks", "accounts/fireworks/models/glm-5p2"): {
         "context_length": 1048576,
         "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(
@@ -30,6 +32,7 @@ FIREWORKS_SPECS = {
     ("fireworks", "accounts/fireworks/models/glm-5p1"): {
         "context_length": 202800,
         "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(
@@ -41,6 +44,7 @@ FIREWORKS_SPECS = {
     ("fireworks", "accounts/fireworks/models/kimi-k2p7-code"): {
         "context_length": 262144,
         "max_completion_tokens": 262144,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -57,6 +61,7 @@ FIREWORKS_SPECS = {
     ("fireworks", "accounts/fireworks/models/deepseek-v4-pro"): {
         "context_length": 1048576,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(
@@ -68,6 +73,7 @@ FIREWORKS_SPECS = {
     ("fireworks", "accounts/fireworks/models/deepseek-v4-flash"): {
         "context_length": 1048576,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(
@@ -79,6 +85,7 @@ FIREWORKS_SPECS = {
     ("fireworks", "accounts/fireworks/models/minimax-m3"): {
         "context_length": 512000,
         "max_completion_tokens": 512000,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -90,6 +97,7 @@ FIREWORKS_SPECS = {
     ("fireworks", "accounts/fireworks/models/qwen3p7-plus"): {
         "context_length": 262144,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(

--- a/kolega_code/llm/specs/catalog/google.py
+++ b/kolega_code/llm/specs/catalog/google.py
@@ -5,6 +5,7 @@ GOOGLE_SPECS = {
     ("google", "gemini-3.6-flash"): {
         "context_length": 1048576,
         "max_completion_tokens": 65536,
+        "input_budget": "separate_output_limit",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -17,6 +18,7 @@ GOOGLE_SPECS = {
     ("google", "gemini-3.5-flash-lite"): {
         "context_length": 1048576,
         "max_completion_tokens": 65536,
+        "input_budget": "separate_output_limit",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -29,6 +31,7 @@ GOOGLE_SPECS = {
     ("google", "gemini-3.1-pro-preview"): {
         "context_length": 1048576,
         "max_completion_tokens": 65536,
+        "input_budget": "separate_output_limit",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -40,6 +43,7 @@ GOOGLE_SPECS = {
     ("google", "gemini-3.5-flash"): {
         "context_length": 1048576,
         "max_completion_tokens": 65536,
+        "input_budget": "separate_output_limit",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(

--- a/kolega_code/llm/specs/catalog/kimi_coding.py
+++ b/kolega_code/llm/specs/catalog/kimi_coding.py
@@ -6,6 +6,7 @@ KIMI_CODING_SPECS = {
     ("kimi_coding", "k3"): {
         "context_length": 262144,
         "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -18,6 +19,7 @@ KIMI_CODING_SPECS = {
     ("kimi_coding", "k3[1m]"): {
         "context_length": 1048576,
         "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -30,6 +32,7 @@ KIMI_CODING_SPECS = {
     ("kimi_coding", "kimi-for-coding"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(

--- a/kolega_code/llm/specs/catalog/moonshot.py
+++ b/kolega_code/llm/specs/catalog/moonshot.py
@@ -5,6 +5,7 @@ MOONSHOT_SPECS = {
     ("moonshot", "kimi-k3"): {
         "context_length": 1048576,
         "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -17,6 +18,7 @@ MOONSHOT_SPECS = {
     ("moonshot", "kimi-k2.7-code"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -28,6 +30,7 @@ MOONSHOT_SPECS = {
     ("moonshot", "kimi-k2.6"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -39,6 +42,7 @@ MOONSHOT_SPECS = {
     ("moonshot", "kimi-k2.7-code-highspeed"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(

--- a/kolega_code/llm/specs/catalog/ollama_cloud.py
+++ b/kolega_code/llm/specs/catalog/ollama_cloud.py
@@ -13,6 +13,7 @@ OLLAMA_CLOUD_SPECS = {
     ("ollama_cloud", "deepseek-v4-flash:0731"): {
         "context_length": 1048576,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(
@@ -24,6 +25,7 @@ OLLAMA_CLOUD_SPECS = {
     ("ollama_cloud", "deepseek-v4-flash:preview"): {
         "context_length": 1048576,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(
@@ -35,6 +37,7 @@ OLLAMA_CLOUD_SPECS = {
     ("ollama_cloud", "deepseek-v4-pro"): {
         "context_length": 524288,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(
@@ -46,6 +49,7 @@ OLLAMA_CLOUD_SPECS = {
     ("ollama_cloud", "gemma4:31b"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -57,6 +61,7 @@ OLLAMA_CLOUD_SPECS = {
     ("ollama_cloud", "glm-5.1"): {
         "context_length": 202752,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(
@@ -68,6 +73,7 @@ OLLAMA_CLOUD_SPECS = {
     ("ollama_cloud", "glm-5.2"): {
         "context_length": 1000000,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(
@@ -79,6 +85,7 @@ OLLAMA_CLOUD_SPECS = {
     ("ollama_cloud", "gpt-oss:120b"): {
         "context_length": 131072,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(
@@ -90,6 +97,7 @@ OLLAMA_CLOUD_SPECS = {
     ("ollama_cloud", "gpt-oss:20b"): {
         "context_length": 131072,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(
@@ -101,6 +109,7 @@ OLLAMA_CLOUD_SPECS = {
     ("ollama_cloud", "kimi-k2.6"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -112,6 +121,7 @@ OLLAMA_CLOUD_SPECS = {
     ("ollama_cloud", "kimi-k2.7-code"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -123,6 +133,7 @@ OLLAMA_CLOUD_SPECS = {
     ("ollama_cloud", "kimi-k3"): {
         "context_length": 1048576,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -134,6 +145,7 @@ OLLAMA_CLOUD_SPECS = {
     ("ollama_cloud", "minimax-m2.7"): {
         "context_length": 196608,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(
@@ -145,6 +157,7 @@ OLLAMA_CLOUD_SPECS = {
     ("ollama_cloud", "minimax-m3"): {
         "context_length": 524288,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -156,12 +169,14 @@ OLLAMA_CLOUD_SPECS = {
     ("ollama_cloud", "mistral-large-3:675b"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
     },
     ("ollama_cloud", "nemotron-3-nano:30b"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(
@@ -173,6 +188,7 @@ OLLAMA_CLOUD_SPECS = {
     ("ollama_cloud", "nemotron-3-super"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(
@@ -184,6 +200,7 @@ OLLAMA_CLOUD_SPECS = {
     ("ollama_cloud", "nemotron-3-ultra"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(
@@ -195,6 +212,7 @@ OLLAMA_CLOUD_SPECS = {
     ("ollama_cloud", "qwen3.5:397b"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(

--- a/kolega_code/llm/specs/catalog/openai.py
+++ b/kolega_code/llm/specs/catalog/openai.py
@@ -14,6 +14,7 @@ OPENAI_SPECS = {
     ("openai", "gpt-5.6-sol"): {
         "context_length": 1050000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -28,6 +29,7 @@ OPENAI_SPECS = {
     ("openai", "gpt-5.6-terra"): {
         "context_length": 1050000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -42,6 +44,7 @@ OPENAI_SPECS = {
     ("openai", "gpt-5.6-luna"): {
         "context_length": 1050000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -56,6 +59,7 @@ OPENAI_SPECS = {
     ("openai", "gpt-5.5"): {
         "context_length": 1050000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -68,8 +72,9 @@ OPENAI_SPECS = {
         ),
     },
     ("openai", "gpt-5.4"): {
-        "context_length": 400000,
+        "context_length": 1050000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -84,6 +89,7 @@ OPENAI_SPECS = {
     ("openai", "gpt-5.4-mini"): {
         "context_length": 400000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,

--- a/kolega_code/llm/specs/catalog/openai_chatgpt.py
+++ b/kolega_code/llm/specs/catalog/openai_chatgpt.py
@@ -14,8 +14,9 @@ from kolega_code.llm.specs.types import ThinkingEffortSpec
 # subscription-specific values here so compression runs before backend limits.
 OPENAI_CHATGPT_SPECS = {
     ("openai_chatgpt", "gpt-5.6-sol"): {
-        "context_length": 272000,
+        "context_length": 400000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -28,8 +29,9 @@ OPENAI_CHATGPT_SPECS = {
         ),
     },
     ("openai_chatgpt", "gpt-5.6-terra"): {
-        "context_length": 272000,
+        "context_length": 400000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -42,8 +44,9 @@ OPENAI_CHATGPT_SPECS = {
         ),
     },
     ("openai_chatgpt", "gpt-5.6-luna"): {
-        "context_length": 272000,
+        "context_length": 400000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -56,8 +59,9 @@ OPENAI_CHATGPT_SPECS = {
         ),
     },
     ("openai_chatgpt", "gpt-5.5"): {
-        "context_length": 272000,
+        "context_length": 400000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -72,6 +76,7 @@ OPENAI_CHATGPT_SPECS = {
     ("openai_chatgpt", "gpt-5.4"): {
         "context_length": 400000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -86,6 +91,7 @@ OPENAI_CHATGPT_SPECS = {
     ("openai_chatgpt", "gpt-5.4-mini"): {
         "context_length": 400000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -98,8 +104,10 @@ OPENAI_CHATGPT_SPECS = {
         ),
     },
     ("openai_chatgpt", "gpt-5.3-codex-spark"): {
-        "context_length": 256000,
+        # Input limit probed live 2026-08-11: accepted 122,473, rejected ~129.6k.
+        "context_length": 128000,
         "max_completion_tokens": 128000,
+        "input_budget": "separate_output_limit",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,

--- a/kolega_code/llm/specs/catalog/openrouter.py
+++ b/kolega_code/llm/specs/catalog/openrouter.py
@@ -16,6 +16,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "deepseek/deepseek-v4-flash-0731"): {
         "context_length": 1048576,
         "max_completion_tokens": 384000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -29,6 +30,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "tencent/hy3"): {
         "context_length": 262144,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -42,6 +44,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "deepseek/deepseek-v4-flash"): {
         "context_length": 1048576,
         "max_completion_tokens": 393216,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -55,6 +58,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "xiaomi/mimo-v2.5"): {
         "context_length": 1050000,
         "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -63,6 +67,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-5.6-luna"): {
         "context_length": 1050000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -77,6 +82,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "z-ai/glm-5.2"): {
         "context_length": 1048576,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -90,6 +96,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "deepseek/deepseek-v4-pro"): {
         "context_length": 1048576,
         "max_completion_tokens": 384000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -103,6 +110,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "nvidia/nemotron-3-ultra-550b-a55b:free"): {
         "context_length": 1000000,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -116,6 +124,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "google/gemini-3.6-flash"): {
         "context_length": 1048576,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -129,6 +138,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "poolside/laguna-s-2.1:free"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -137,6 +147,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "minimax/minimax-m3"): {
         "context_length": 1048576,
         "max_completion_tokens": 512000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -145,6 +156,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "moonshotai/kimi-k3"): {
         "context_length": 1048576,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -158,6 +170,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "stepfun/step-3.7-flash"): {
         "context_length": 262144,
         "max_completion_tokens": 256000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -171,6 +184,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "anthropic/claude-opus-5"): {
         "context_length": 1000000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -185,6 +199,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "anthropic/claude-sonnet-5"): {
         "context_length": 1000000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -200,6 +215,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "google/gemini-3-flash-preview"): {
         "context_length": 1048576,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -213,6 +229,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "anthropic/claude-sonnet-4.6"): {
         "context_length": 1000000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -227,6 +244,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-5.6-terra"): {
         "context_length": 1050000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -241,6 +259,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "google/gemini-2.5-flash-lite"): {
         "context_length": 1048576,
         "max_completion_tokens": 65535,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -249,6 +268,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-5.6-sol"): {
         "context_length": 1050000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -263,6 +283,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-5.6-luna-pro"): {
         "context_length": 1050000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -276,6 +297,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "anthropic/claude-opus-4.8"): {
         "context_length": 1000000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -289,6 +311,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "google/gemini-2.5-flash"): {
         "context_length": 1048576,
         "max_completion_tokens": 65535,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -296,6 +319,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "xiaomi/mimo-v2.5-pro"): {
         "context_length": 1050000,
         "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -303,6 +327,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "google/gemini-3.1-flash-lite"): {
         "context_length": 1048576,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -315,6 +340,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-oss-120b"): {
         "context_length": 131072,
         "max_completion_tokens": 131072,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "codex_apply_patch",
@@ -327,6 +353,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "google/gemma-4-31b-it"): {
         "context_length": 262144,
         "max_completion_tokens": 262144,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -334,6 +361,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "deepseek/deepseek-v3.2"): {
         "context_length": 163840,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -341,6 +369,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "google/gemma-4-26b-a4b-it"): {
         "context_length": 262144,
         "max_completion_tokens": 262144,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -348,6 +377,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "nvidia/nemotron-3-super-120b-a12b:free"): {
         "context_length": 262144,
         "max_completion_tokens": 262144,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -360,6 +390,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "x-ai/grok-4.5"): {
         "context_length": 500000,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -372,6 +403,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "anthropic/claude-opus-4.7"): {
         "context_length": 1000000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -386,6 +418,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "cohere/north-mini-code:free"): {
         "context_length": 256000,
         "max_completion_tokens": 64000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -393,6 +426,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "anthropic/claude-haiku-4.5"): {
         "context_length": 200000,
         "max_completion_tokens": 64000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -401,6 +435,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "anthropic/claude-fable-5"): {
         "context_length": 1000000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -415,6 +450,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "inclusionai/ling-2.6-flash"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -422,6 +458,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-4o-mini"): {
         "context_length": 128000,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "codex_apply_patch",
@@ -429,6 +466,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3.8-max"): {
         "context_length": 1000000,
         "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -441,6 +479,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "moonshotai/kimi-k2.6"): {
         "context_length": 262144,
         "max_completion_tokens": 262144,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -448,6 +487,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "minimax/minimax-m2.7"): {
         "context_length": 204800,
         "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -455,6 +495,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "google/gemini-3.5-flash"): {
         "context_length": 1048576,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -467,6 +508,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "google/gemini-3.5-flash-lite"): {
         "context_length": 1048576,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -479,6 +521,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-5-mini"): {
         "context_length": 400000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -492,6 +535,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "google/gemini-3.1-pro-preview"): {
         "context_length": 1048576,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -504,6 +548,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "poolside/laguna-xs-2.1:free"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -511,6 +556,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-oss-20b"): {
         "context_length": 131072,
         "max_completion_tokens": 131072,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "codex_apply_patch",
@@ -523,6 +569,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-5.4"): {
         "context_length": 1050000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -536,6 +583,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "anthropic/claude-opus-4.6"): {
         "context_length": 1000000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -549,6 +597,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3.7-flash"): {
         "context_length": 1000000,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -556,6 +605,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-5.5"): {
         "context_length": 1050000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -569,6 +619,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-5.4-mini"): {
         "context_length": 400000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -582,6 +633,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "mistralai/mistral-nemo"): {
         "context_length": 131072,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -589,6 +641,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-5.4-nano"): {
         "context_length": 400000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -602,6 +655,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "moonshotai/kimi-k2.5"): {
         "context_length": 262144,
         "max_completion_tokens": 262144,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -609,6 +663,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3.7-plus"): {
         "context_length": 1000000,
         "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -616,6 +671,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "google/gemini-3.1-flash-lite-preview"): {
         "context_length": 1048576,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -628,6 +684,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-4.1-mini"): {
         "context_length": 1047576,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "codex_apply_patch",
@@ -635,6 +692,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "moonshotai/kimi-k2.7-code"): {
         "context_length": 262144,
         "max_completion_tokens": 262144,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -642,6 +700,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3.6-35b-a3b"): {
         "context_length": 262144,
         "max_completion_tokens": 262144,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -649,6 +708,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "anthropic/claude-sonnet-4.5"): {
         "context_length": 1000000,
         "max_completion_tokens": 64000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -657,6 +717,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "z-ai/glm-5.1"): {
         "context_length": 204800,
         "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -664,6 +725,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "z-ai/glm-5"): {
         "context_length": 204800,
         "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -671,6 +733,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "x-ai/grok-4.3"): {
         "context_length": 1000000,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -683,6 +746,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "amazon/nova-micro-v1"): {
         "context_length": 128000,
         "max_completion_tokens": 5120,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -690,6 +754,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "z-ai/glm-4.7"): {
         "context_length": 204800,
         "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -697,6 +762,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-5.6-terra-pro"): {
         "context_length": 1050000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -710,6 +776,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3-235b-a22b-2507"): {
         "context_length": 262144,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -717,6 +784,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "google/gemini-2.5-pro"): {
         "context_length": 1048576,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -724,6 +792,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3.7-max"): {
         "context_length": 1000000,
         "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -731,6 +800,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3.5-flash-02-23"): {
         "context_length": 1000000,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -738,6 +808,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "meta/muse-spark-1.1"): {
         "context_length": 1048576,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -750,6 +821,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-5.6-sol-pro"): {
         "context_length": 1050000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -763,6 +835,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-4.1"): {
         "context_length": 1047576,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "codex_apply_patch",
@@ -770,6 +843,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "nvidia/nemotron-3-ultra-550b-a55b"): {
         "context_length": 512288,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -782,6 +856,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-5.2"): {
         "context_length": 400000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -795,6 +870,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "poolside/laguna-s-2.1"): {
         "context_length": 1048576,
         "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -802,6 +878,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "meta-llama/llama-3.1-8b-instruct"): {
         "context_length": 131072,
         "max_completion_tokens": 131072,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -809,6 +886,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "deepseek/deepseek-chat-v3.1"): {
         "context_length": 163840,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -816,6 +894,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "nvidia/nemotron-3-nano-30b-a3b:free"): {
         "context_length": 256000,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -823,6 +902,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-5-nano"): {
         "context_length": 400000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -836,6 +916,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3.6-plus"): {
         "context_length": 1000000,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -843,6 +924,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "tencent/hy3-preview"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -855,6 +937,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "deepseek/deepseek-chat-v3-0324"): {
         "context_length": 163840,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -862,6 +945,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "meta/muse-spark-1.2"): {
         "context_length": 1048576,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -874,6 +958,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "x-ai/grok-4.20"): {
         "context_length": 2000000,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -881,6 +966,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-5.3-codex"): {
         "context_length": 400000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -894,6 +980,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free"): {
         "context_length": 256000,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -901,6 +988,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "minimax/minimax-m2.5"): {
         "context_length": 204800,
         "max_completion_tokens": 196608,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -908,6 +996,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "deepseek/deepseek-v3.1-terminus"): {
         "context_length": 163840,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -915,6 +1004,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "anthropic/claude-opus-5-fast"): {
         "context_length": 1000000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -929,6 +1019,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "meta-llama/llama-3.3-70b-instruct"): {
         "context_length": 131072,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -936,6 +1027,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "meta-llama/llama-4-maverick"): {
         "context_length": 1048576,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -943,6 +1035,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3-30b-a3b-instruct-2507"): {
         "context_length": 262144,
         "max_completion_tokens": 32000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -950,6 +1043,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3.5-9b"): {
         "context_length": 262144,
         "max_completion_tokens": 262144,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -957,6 +1051,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "deepseek/deepseek-chat"): {
         "context_length": 163840,
         "max_completion_tokens": 16000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -964,6 +1059,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "google/gemma-3-27b-it"): {
         "context_length": 262144,
         "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -971,6 +1067,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3.6-27b"): {
         "context_length": 262144,
         "max_completion_tokens": 262144,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -978,6 +1075,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-4.1-nano"): {
         "context_length": 1047576,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "codex_apply_patch",
@@ -985,6 +1083,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "anthropic/claude-sonnet-4"): {
         "context_length": 1000000,
         "max_completion_tokens": 64000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -993,6 +1092,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "inclusionai/ling-3.0-tiny:free"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1000,6 +1100,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "z-ai/glm-5v-turbo"): {
         "context_length": 202752,
         "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1007,6 +1108,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3-coder-next"): {
         "context_length": 262144,
         "max_completion_tokens": 262144,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1014,6 +1116,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "deepseek/deepseek-v3.2-exp"): {
         "context_length": 163840,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1021,6 +1124,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3.5-35b-a3b"): {
         "context_length": 262144,
         "max_completion_tokens": 262144,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1028,6 +1132,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "nvidia/nemotron-3-super-120b-a12b"): {
         "context_length": 1000000,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1040,6 +1145,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "meta-llama/llama-4-scout"): {
         "context_length": 1310720,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1047,6 +1153,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "mistralai/mistral-small-3.2-24b-instruct"): {
         "context_length": 256000,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1054,6 +1161,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "mistralai/mistral-small-2603"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1066,6 +1174,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "thinkingmachines/inkling"): {
         "context_length": 1048576,
         "max_completion_tokens": 262144,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1078,6 +1187,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "z-ai/glm-4.7-flash"): {
         "context_length": 202752,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1085,6 +1195,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "google/gemma-3-12b-it"): {
         "context_length": 131072,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1092,6 +1203,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-5"): {
         "context_length": 400000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -1105,6 +1217,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-5.1"): {
         "context_length": 400000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -1118,6 +1231,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3-32b"): {
         "context_length": 131072,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1125,6 +1239,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "anthropic/claude-opus-4.5"): {
         "context_length": 200000,
         "max_completion_tokens": 64000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1133,6 +1248,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "nvidia/nemotron-nano-9b-v2:free"): {
         "context_length": 128000,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1140,6 +1256,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "google/gemma-4-26b-a4b-it:free"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1147,6 +1264,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3.5-397b-a17b"): {
         "context_length": 262144,
         "max_completion_tokens": 262144,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1154,6 +1272,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3-coder"): {
         "context_length": 262144,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1161,6 +1280,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "nex-agi/nex-n2-mini"): {
         "context_length": 262144,
         "max_completion_tokens": 262144,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1168,6 +1288,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "nvidia/nemotron-3-nano-30b-a3b"): {
         "context_length": 262144,
         "max_completion_tokens": 228000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1175,6 +1296,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3.5-122b-a10b"): {
         "context_length": 262144,
         "max_completion_tokens": 81920,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1182,6 +1304,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-4o"): {
         "context_length": 128000,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "codex_apply_patch",
@@ -1189,6 +1312,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3.6-flash"): {
         "context_length": 1000000,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1196,6 +1320,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3-next-80b-a3b-instruct"): {
         "context_length": 262144,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1203,6 +1328,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "z-ai/glm-4.6"): {
         "context_length": 204800,
         "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1210,6 +1336,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "anthropic/claude-opus-4.8-fast"): {
         "context_length": 1000000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -1224,6 +1351,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3-vl-235b-a22b-instruct"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1231,6 +1359,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "z-ai/glm-4.5-air"): {
         "context_length": 131072,
         "max_completion_tokens": 98304,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1238,6 +1367,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3-vl-32b-instruct"): {
         "context_length": 131072,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1245,6 +1375,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-4o-mini-2024-07-18"): {
         "context_length": 128000,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "codex_apply_patch",
@@ -1252,6 +1383,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3-vl-8b-instruct"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1259,6 +1391,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "inclusionai/ling-3.0-flash"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1266,6 +1399,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "moonshotai/kimi-k2-0905"): {
         "context_length": 262144,
         "max_completion_tokens": 100352,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1273,6 +1407,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "mistralai/mistral-medium-3-5"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1285,6 +1420,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-oss-20b:free"): {
         "context_length": 131072,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "codex_apply_patch",
@@ -1297,6 +1433,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "deepseek/deepseek-r1-0528"): {
         "context_length": 163840,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1304,6 +1441,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3.5-plus-02-15"): {
         "context_length": 1000000,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1311,6 +1449,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "meta-llama/llama-3.1-70b-instruct"): {
         "context_length": 131072,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1318,6 +1457,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3-vl-30b-a3b-instruct"): {
         "context_length": 262144,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1325,6 +1465,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "thinkingmachines/inkling-small"): {
         "context_length": 524288,
         "max_completion_tokens": 262144,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1337,6 +1478,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "aion-labs/aion-3.0"): {
         "context_length": 131072,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1344,6 +1486,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3-coder-30b-a3b-instruct"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1351,6 +1494,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-5.3-chat"): {
         "context_length": 128000,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -1359,6 +1503,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "mistralai/mistral-large-2512"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1366,6 +1511,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "nvidia/nemotron-nano-12b-v2-vl:free"): {
         "context_length": 128000,
         "max_completion_tokens": 128000,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1373,6 +1519,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen-2.5-7b-instruct"): {
         "context_length": 32768,
         "max_completion_tokens": 32768,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1380,6 +1527,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-oss-safeguard-20b"): {
         "context_length": 131072,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "codex_apply_patch",
@@ -1387,6 +1535,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3.5-27b"): {
         "context_length": 262144,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1394,6 +1543,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "meituan/longcat-2.0"): {
         "context_length": 1048756,
         "max_completion_tokens": 262144,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1401,6 +1551,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3-14b"): {
         "context_length": 131072,
         "max_completion_tokens": 8192,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1408,6 +1559,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "mistralai/ministral-8b-2512"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1415,6 +1567,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "z-ai/glm-5-turbo"): {
         "context_length": 202752,
         "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1422,6 +1575,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "inclusionai/ring-2.6-1t"): {
         "context_length": 262144,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1434,6 +1588,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3-8b"): {
         "context_length": 131072,
         "max_completion_tokens": 8192,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1441,6 +1596,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3-235b-a22b-thinking-2507"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1448,6 +1604,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen-2.5-72b-instruct"): {
         "context_length": 32768,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1455,6 +1612,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "poolside/laguna-xs-2.1"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1462,6 +1620,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3-30b-a3b"): {
         "context_length": 131072,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1469,6 +1628,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "inclusionai/ling-2.6-1t"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1476,6 +1636,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "inception/mercury-2"): {
         "context_length": 128000,
         "max_completion_tokens": 50000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1488,6 +1649,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "x-ai/grok-build-0.1"): {
         "context_length": 256000,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1495,6 +1657,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "bytedance-seed/seed-2.0-mini"): {
         "context_length": 262144,
         "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1507,6 +1670,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "ibm-granite/granite-4.1-8b"): {
         "context_length": 131072,
         "max_completion_tokens": 131072,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1514,6 +1678,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "deepseek/deepseek-r1"): {
         "context_length": 163840,
         "max_completion_tokens": 16000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1521,6 +1686,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "moonshotai/kimi-k2"): {
         "context_length": 131072,
         "max_completion_tokens": 100352,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1528,6 +1694,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3-coder-plus"): {
         "context_length": 1000000,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1535,6 +1702,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "mistralai/mistral-medium-3.1"): {
         "context_length": 131072,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1542,6 +1710,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/o3-mini"): {
         "context_length": 200000,
         "max_completion_tokens": 100000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": False,
@@ -1550,6 +1719,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "aion-labs/aion-2.0"): {
         "context_length": 131072,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1557,6 +1727,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3-max"): {
         "context_length": 262144,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1564,6 +1735,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "stepfun/step-3.5-flash"): {
         "context_length": 262144,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1571,6 +1743,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3-coder-flash"): {
         "context_length": 1000000,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1578,6 +1751,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-4o-2024-11-20"): {
         "context_length": 128000,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "codex_apply_patch",
@@ -1585,6 +1759,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "moonshotai/kimi-k2-thinking"): {
         "context_length": 262144,
         "max_completion_tokens": 100352,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1592,6 +1767,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "amazon/nova-lite-v1"): {
         "context_length": 300000,
         "max_completion_tokens": 5120,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1599,6 +1775,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "mistralai/ministral-14b-2512"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1606,6 +1783,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/o4-mini"): {
         "context_length": 200000,
         "max_completion_tokens": 100000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -1614,6 +1792,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "anthropic/claude-3-haiku"): {
         "context_length": 200000,
         "max_completion_tokens": 4096,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1622,6 +1801,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "upstage/solar-pro-3"): {
         "context_length": 131072,
         "max_completion_tokens": 131072,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1629,6 +1809,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-5.2-chat"): {
         "context_length": 128000,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -1637,6 +1818,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "amazon/nova-2-lite-v1"): {
         "context_length": 1000000,
         "max_completion_tokens": 65535,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1644,6 +1826,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "aion-labs/aion-3.0-mini"): {
         "context_length": 131072,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1651,6 +1834,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-4o-2024-08-06"): {
         "context_length": 128000,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "codex_apply_patch",
@@ -1658,6 +1842,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "bytedance-seed/seed-1.6-flash"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1665,6 +1850,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3.5-plus-20260420"): {
         "context_length": 1000000,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1672,6 +1858,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "kwaipilot/kat-coder-pro-v2"): {
         "context_length": 262144,
         "max_completion_tokens": 80000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1679,6 +1866,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "bytedance-seed/seed-2.0-lite"): {
         "context_length": 262144,
         "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1691,6 +1879,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3-235b-a22b"): {
         "context_length": 131072,
         "max_completion_tokens": 8192,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1698,6 +1887,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "nex-agi/nex-n2-pro"): {
         "context_length": 262144,
         "max_completion_tokens": 262144,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1705,6 +1895,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen-plus"): {
         "context_length": 1000000,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1712,6 +1903,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "mistralai/ministral-3b-2512"): {
         "context_length": 131072,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1719,6 +1911,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "google/gemini-3.1-pro-preview-customtools"): {
         "context_length": 1048576,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1731,6 +1924,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "google/gemma-4-31b-it:free"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1738,6 +1932,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-5.1-codex-mini"): {
         "context_length": 400000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -1751,6 +1946,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "sakana/fugu-ultra"): {
         "context_length": 1000000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -1764,6 +1960,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "anthropic/claude-opus-4.1"): {
         "context_length": 200000,
         "max_completion_tokens": 32000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1772,6 +1969,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "google/gemini-3-pro-image"): {
         "context_length": 131072,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1779,6 +1977,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "minimax/minimax-m2.1"): {
         "context_length": 204800,
         "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1786,6 +1985,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "kwaipilot/kat-coder-air-v2.5"): {
         "context_length": 256000,
         "max_completion_tokens": 80000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1793,6 +1993,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "mistralai/mistral-large"): {
         "context_length": 128000,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1800,6 +2001,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-5.1-codex"): {
         "context_length": 400000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -1813,6 +2015,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/o3"): {
         "context_length": 200000,
         "max_completion_tokens": 100000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -1821,6 +2024,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "z-ai/glm-4.5"): {
         "context_length": 131072,
         "max_completion_tokens": 98304,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1828,6 +2032,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "minimax/minimax-m2"): {
         "context_length": 204800,
         "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1835,6 +2040,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "z-ai/glm-4.6v"): {
         "context_length": 131072,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1842,6 +2048,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-3.5-turbo"): {
         "context_length": 16385,
         "max_completion_tokens": 4096,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "codex_apply_patch",
@@ -1849,6 +2056,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "arcee-ai/trinity-large-thinking"): {
         "context_length": 262144,
         "max_completion_tokens": 262144,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1856,6 +2064,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-5.2-codex"): {
         "context_length": 400000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -1869,6 +2078,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "anthropic/claude-opus-4"): {
         "context_length": 200000,
         "max_completion_tokens": 32000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1877,6 +2087,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "kwaipilot/kat-coder-pro-v2.5"): {
         "context_length": 256000,
         "max_completion_tokens": 80000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1884,6 +2095,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "mistralai/codestral-2508"): {
         "context_length": 256000,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1891,6 +2103,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-chat-latest"): {
         "context_length": 400000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -1899,6 +2112,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-5.5-pro"): {
         "context_length": 1050000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -1912,6 +2126,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3.6-max-preview"): {
         "context_length": 262144,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1919,6 +2134,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "mistralai/mistral-medium-3"): {
         "context_length": 131072,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1926,6 +2142,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "thedrummer/unslopnemo-12b"): {
         "context_length": 1024000,
         "max_completion_tokens": 1024000,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1933,6 +2150,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "z-ai/glm-4.5v"): {
         "context_length": 65536,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1940,6 +2158,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "mistralai/mixtral-8x22b-instruct"): {
         "context_length": 65536,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1947,6 +2166,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3-vl-30b-a3b-thinking"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -1954,6 +2174,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen-plus-2025-07-28"): {
         "context_length": 1000000,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1961,6 +2182,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3-30b-a3b-thinking-2507"): {
         "context_length": 81920,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1968,6 +2190,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-5.1-codex-max"): {
         "context_length": 400000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -1981,6 +2204,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3-max-thinking"): {
         "context_length": 262144,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1988,6 +2212,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "sao10k/l3.1-euryale-70b"): {
         "context_length": 131072,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -1995,6 +2220,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-audio-mini"): {
         "context_length": 128000,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "codex_apply_patch",
@@ -2002,6 +2228,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3-vl-235b-a22b-thinking"): {
         "context_length": 131072,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -2009,6 +2236,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-4o-2024-05-13"): {
         "context_length": 128000,
         "max_completion_tokens": 4096,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "codex_apply_patch",
@@ -2016,6 +2244,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3-vl-8b-thinking"): {
         "context_length": 131072,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -2023,6 +2252,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "ai21/jamba-large-1.7"): {
         "context_length": 256000,
         "max_completion_tokens": 4096,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -2030,6 +2260,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "amazon/nova-pro-v1"): {
         "context_length": 300000,
         "max_completion_tokens": 5120,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -2037,6 +2268,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "cohere/command-r-08-2024"): {
         "context_length": 128000,
         "max_completion_tokens": 4000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -2044,6 +2276,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-3.5-turbo-0613"): {
         "context_length": 4095,
         "max_completion_tokens": 4096,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "codex_apply_patch",
@@ -2051,6 +2284,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen3-next-80b-a3b-thinking"): {
         "context_length": 262144,
         "max_completion_tokens": 262144,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -2058,6 +2292,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-4"): {
         "context_length": 8191,
         "max_completion_tokens": 4096,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "codex_apply_patch",
@@ -2065,6 +2300,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "mistralai/voxtral-small-24b-2507"): {
         "context_length": 32000,
         "max_completion_tokens": 32000,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -2072,6 +2308,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-4-turbo"): {
         "context_length": 128000,
         "max_completion_tokens": 4096,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "codex_apply_patch",
@@ -2079,6 +2316,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "mistralai/mistral-large-2407"): {
         "context_length": 131072,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -2086,6 +2324,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "minimax/minimax-m1"): {
         "context_length": 1000000,
         "max_completion_tokens": 40000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -2093,6 +2332,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "bytedance-seed/seed-1.6"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -2100,6 +2340,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "amazon/nova-premier-v1"): {
         "context_length": 1000000,
         "max_completion_tokens": 32000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -2107,6 +2348,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "mistralai/mistral-saba"): {
         "context_length": 32768,
         "max_completion_tokens": 32768,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -2114,6 +2356,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/o4-mini-high"): {
         "context_length": 200000,
         "max_completion_tokens": 100000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -2127,6 +2370,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-5.4-pro"): {
         "context_length": 1050000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -2140,6 +2384,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-5.2-pro"): {
         "context_length": 400000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -2153,6 +2398,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "rekaai/reka-edge"): {
         "context_length": 16384,
         "max_completion_tokens": 16384,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -2160,6 +2406,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "cohere/command-r-plus-08-2024"): {
         "context_length": 128000,
         "max_completion_tokens": 4000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -2167,6 +2414,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-audio"): {
         "context_length": 128000,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "codex_apply_patch",
@@ -2174,6 +2422,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/o3-pro"): {
         "context_length": 200000,
         "max_completion_tokens": 100000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -2182,6 +2431,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "qwen/qwen-plus-2025-07-28:thinking"): {
         "context_length": 1000000,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -2189,6 +2439,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-5-pro"): {
         "context_length": 400000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -2202,6 +2453,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/o1"): {
         "context_length": 200000,
         "max_completion_tokens": 100000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -2210,6 +2462,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/o3-mini-high"): {
         "context_length": 200000,
         "max_completion_tokens": 100000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": False,
@@ -2223,6 +2476,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "relace/relace-search"): {
         "context_length": 256000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -2230,6 +2484,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-3.5-turbo-16k"): {
         "context_length": 16385,
         "max_completion_tokens": 4096,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "codex_apply_patch",
@@ -2237,6 +2492,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "anthropic/claude-opus-4.7-fast"): {
         "context_length": 1000000,
         "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_temperature": False,
         "supports_vision": True,
@@ -2251,6 +2507,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "arcee-ai/virtuoso-large"): {
         "context_length": 131072,
         "max_completion_tokens": 64000,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "claude_code",
@@ -2258,6 +2515,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "google/gemini-2.5-pro-preview"): {
         "context_length": 1048576,
         "max_completion_tokens": 65536,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -2265,6 +2523,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "google/gemini-2.5-pro-preview-05-06"): {
         "context_length": 1048576,
         "max_completion_tokens": 65535,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "preferred_edit_protocol": "claude_code",
@@ -2272,6 +2531,7 @@ OPENROUTER_SPECS = {
     ("openrouter", "openai/gpt-4-turbo-preview"): {
         "context_length": 128000,
         "max_completion_tokens": 4096,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
         "preferred_edit_protocol": "codex_apply_patch",

--- a/kolega_code/llm/specs/catalog/thinking_machines.py
+++ b/kolega_code/llm/specs/catalog/thinking_machines.py
@@ -12,6 +12,7 @@ THINKING_MACHINES_SPECS = {
     ("thinking_machines", "thinkingmachines/Inkling"): {
         "context_length": 1000000,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -23,6 +24,7 @@ THINKING_MACHINES_SPECS = {
     ("thinking_machines", "thinkingmachines/Inkling-Small"): {
         "context_length": 1000000,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(

--- a/kolega_code/llm/specs/catalog/tinker.py
+++ b/kolega_code/llm/specs/catalog/tinker.py
@@ -13,6 +13,7 @@ TINKER_SPECS = {
     ("tinker", "thinkingmachines/Inkling"): {
         "context_length": 65536,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -24,6 +25,7 @@ TINKER_SPECS = {
     ("tinker", "thinkingmachines/Inkling:peft:262144"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -35,6 +37,7 @@ TINKER_SPECS = {
     ("tinker", "thinkingmachines/Inkling-Small"): {
         "context_length": 65536,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -46,6 +49,7 @@ TINKER_SPECS = {
     ("tinker", "thinkingmachines/Inkling-Small:peft:262144"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -57,36 +61,42 @@ TINKER_SPECS = {
     ("tinker", "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16"): {
         "context_length": 65536,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
     },
     ("tinker", "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16:peft:262144"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
     },
     ("tinker", "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16"): {
         "context_length": 65536,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
     },
     ("tinker", "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16:peft:262144"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
     },
     ("tinker", "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"): {
         "context_length": 65536,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
     },
     ("tinker", "moonshotai/Kimi-K2.6"): {
         "context_length": 32768,
         "max_completion_tokens": 32768,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -98,6 +108,7 @@ TINKER_SPECS = {
     ("tinker", "moonshotai/Kimi-K2.6:peft:131072"): {
         "context_length": 131072,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -109,6 +120,7 @@ TINKER_SPECS = {
     ("tinker", "Qwen/Qwen3.6-35B-A3B"): {
         "context_length": 65536,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -120,6 +132,7 @@ TINKER_SPECS = {
     ("tinker", "Qwen/Qwen3.6-27B"): {
         "context_length": 65536,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -131,6 +144,7 @@ TINKER_SPECS = {
     ("tinker", "Qwen/Qwen3.5-397B-A17B"): {
         "context_length": 65536,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -142,6 +156,7 @@ TINKER_SPECS = {
     ("tinker", "Qwen/Qwen3.5-397B-A17B:peft:262144"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -153,6 +168,7 @@ TINKER_SPECS = {
     ("tinker", "Qwen/Qwen3.5-9B"): {
         "context_length": 65536,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -164,6 +180,7 @@ TINKER_SPECS = {
     ("tinker", "Qwen/Qwen3.5-4B"): {
         "context_length": 65536,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -175,30 +192,35 @@ TINKER_SPECS = {
     ("tinker", "Qwen/Qwen3-8B"): {
         "context_length": 32768,
         "max_completion_tokens": 32768,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": False,
     },
     ("tinker", "openai/gpt-oss-120b"): {
         "context_length": 32768,
         "max_completion_tokens": 32768,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": False,
     },
     ("tinker", "openai/gpt-oss-120b:peft:131072"): {
         "context_length": 131072,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
     },
     ("tinker", "openai/gpt-oss-20b"): {
         "context_length": 32768,
         "max_completion_tokens": 32768,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": False,
     },
     ("tinker", "deepseek-ai/DeepSeek-V3.1"): {
         "context_length": 32768,
         "max_completion_tokens": 32768,
+        "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(
@@ -215,6 +237,7 @@ TINKER_WILDCARD_SPECS = {
     ("tinker", "tinker://*"): {
         "context_length": 65536,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
     },

--- a/kolega_code/llm/specs/catalog/together.py
+++ b/kolega_code/llm/specs/catalog/together.py
@@ -3,12 +3,14 @@ TOGETHER_SPECS = {
     ("together", "moonshotai/Kimi-K2.7-Code"): {
         "context_length": 262144,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
     },
     ("together", "zai-org/GLM-5.1"): {
         "context_length": 202752,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
     },

--- a/kolega_code/llm/specs/catalog/xai.py
+++ b/kolega_code/llm/specs/catalog/xai.py
@@ -5,6 +5,7 @@ XAI_SPECS = {
     ("xai", "grok-4.5"): {
         "context_length": 500000,
         "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
         # 0.7 matches xAI/Vals AI benchmark defaults (temp 0.7 + high reasoning).
         "default_temperature": 0.7,
         "supports_vision": True,
@@ -18,6 +19,7 @@ XAI_SPECS = {
     ("xai", "grok-4.3"): {
         "context_length": 1000000,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 0.6,
         "supports_vision": True,
         "thinking_effort": ThinkingEffortSpec(
@@ -29,6 +31,7 @@ XAI_SPECS = {
     ("xai", "grok-build-0.1"): {
         "context_length": 256000,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 0.6,
         "supports_vision": False,
     },

--- a/kolega_code/llm/specs/catalog/zai.py
+++ b/kolega_code/llm/specs/catalog/zai.py
@@ -5,6 +5,7 @@ ZAI_SPECS = {
     ("zai", "glm-5.2"): {
         "context_length": 1000000,
         "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
         "default_temperature": 0.6,
         "supports_vision": False,
         "thinking_effort": ThinkingEffortSpec(
@@ -16,6 +17,7 @@ ZAI_SPECS = {
     ("zai", "glm-5.1"): {
         "context_length": 202752,
         "max_completion_tokens": 16384,
+        "input_budget": "window_minus_output",
         "default_temperature": 0.6,
         "supports_vision": False,
         # GLM-5.1 predates GLM-5.2's named effort levels, so it's a plain

--- a/kolega_code/llm/specs/ollama_cloud_catalog.py
+++ b/kolega_code/llm/specs/ollama_cloud_catalog.py
@@ -154,6 +154,10 @@ def _model_spec(identifier: str, detail: Mapping[str, Any], capabilities: set[st
         "default_temperature": DEFAULT_TEMPERATURE,
         "supports_vision": "vision" in capabilities,
     }
+    # Upstream declares no budget convention; classify from the pair itself.
+    spec["input_budget"] = (
+        "output_shares_window" if spec["max_completion_tokens"] >= context_length else "window_minus_output"
+    )
     if "thinking" in capabilities:
         spec["thinking_effort"] = THINKING_EFFORT_SPEC
     return spec

--- a/kolega_code/llm/specs/openrouter_catalog.py
+++ b/kolega_code/llm/specs/openrouter_catalog.py
@@ -211,6 +211,9 @@ def model_spec(entry: Mapping[str, Any]) -> dict[str, Any]:
     spec: dict[str, Any] = {
         "context_length": context_length,
         "max_completion_tokens": max_completion_tokens,
+        # Upstream declares no budget convention; mirrors are wire-clamped
+        # budgeting data, so classify from the pair itself.
+        "input_budget": "output_shares_window" if max_completion_tokens >= context_length else "window_minus_output",
         "default_temperature": 1.0,
     }
     # Reasoning models such as openai/gpt-5.6-* reject an explicit temperature.

--- a/kolega_code/llm/specs/tinker_catalog.py
+++ b/kolega_code/llm/specs/tinker_catalog.py
@@ -123,6 +123,9 @@ def catalog_entries(payload: Any) -> list[tuple[str, dict[str, Any]]]:
         spec: dict[str, Any] = {
             "context_length": _context_tokens(item.get("context")),
             "max_completion_tokens": MAX_COMPLETION_TOKENS,
+            # Output shares the window; the sampler clamps to remaining context
+            # at generation time (providers/tinker.py), so nothing is reserved.
+            "input_budget": "output_shares_window",
             "default_temperature": DEFAULT_TEMPERATURE,
             "supports_vision": "Vision" in model_type,
         }
@@ -223,6 +226,7 @@ TINKER_WILDCARD_SPECS = {
     (PROVIDER, "tinker://*"): {
         "context_length": 65536,
         "max_completion_tokens": MAX_COMPLETION_TOKENS,
+        "input_budget": "output_shares_window",
         "default_temperature": DEFAULT_TEMPERATURE,
         "supports_vision": False,
     },

--- a/tests/agent/compaction_helpers.py
+++ b/tests/agent/compaction_helpers.py
@@ -179,6 +179,11 @@ def build_agent(
     if llm is not None:
         agent.llm = llm
     agent.model_context_length = model_context_length
+    agent.model_max_input_tokens = model_context_length
+    # Histories in these tests are sized against a fixed 0.8 trigger; the
+    # default threshold is asserted separately in test_compression_threshold.
+    agent.history_compression_threshold = 0.8
+    agent.compressor.threshold = 0.8
     return agent, cm
 
 

--- a/tests/agent/llm/test_context_residual_live.py
+++ b/tests/agent/llm/test_context_residual_live.py
@@ -1,0 +1,48 @@
+"""Live billed-vs-counted drift on DeepSeek flash (Responses).
+
+The generalized context residual assumes billed input ≥ the client-side count
+on clean single-turn requests (a small constant request-wrapper overhead;
+probed live: +6 at every size, no tokenizer divergence on prose or code).
+This pins the sign of that drift so the positive-only residual keeps reading
+billed-true. Multi-turn tool traffic adds server-side re-attachment overhead
+on top; text-only chats can bill BELOW the count (the server drops resent
+reasoning with no function_call anchor), which the clamp reads as zero.
+Hermetic counterpart: tests/agent/test_context_residual_accounting.py.
+"""
+
+import os
+
+import pytest
+
+from kolega_code.cli.config import API_KEY_ENV
+from kolega_code.config import ModelProvider
+from kolega_code.llm.models import Message, MessageHistory, TextBlock
+from kolega_code.llm.providers.deepseek_responses import DeepSeekResponsesProvider
+from kolega_code.llm.providers.models import GenerationParams
+
+pytestmark = [pytest.mark.slow, pytest.mark.integration]
+
+SKIP_IN_CI = bool(os.getenv("CI")) or bool(os.getenv("GITLAB_CI"))
+
+
+@pytest.mark.asyncio
+async def test_flash_bills_at_least_the_client_count():
+    if SKIP_IN_CI:
+        pytest.skip("Skipping live provider call in CI")
+    api_key = os.getenv(API_KEY_ENV[ModelProvider.DEEPSEEK])
+    if not api_key:
+        pytest.skip(f"{API_KEY_ENV[ModelProvider.DEEPSEEK]} not set")
+    provider = DeepSeekResponsesProvider(api_key=api_key)
+    model = "deepseek-v4-flash"
+    history = MessageHistory(
+        [Message(role="user", content=[TextBlock(text="Reply with the single word: ok")])]
+    )
+    counted = await provider.count_tokens(messages=history, system=None, model=model, tools=[])
+    message = await provider.generate(
+        history, system=None, params=GenerationParams(thinking="high", max_completion_tokens=2000), model=model
+    )
+    billed = (message.usage_metadata or {}).get("prompt_tokens", 0)
+    drift = billed - counted.input_tokens
+    print(f"\nRESIDUAL-LIVE billed={billed} counted={counted.input_tokens} drift={drift}")
+    assert billed > 0
+    assert drift >= 0, "billed below client count — positive-only residual would misread"

--- a/tests/agent/llm/test_context_residual_live.py
+++ b/tests/agent/llm/test_context_residual_live.py
@@ -34,9 +34,7 @@ async def test_flash_bills_at_least_the_client_count():
         pytest.skip(f"{API_KEY_ENV[ModelProvider.DEEPSEEK]} not set")
     provider = DeepSeekResponsesProvider(api_key=api_key)
     model = "deepseek-v4-flash"
-    history = MessageHistory(
-        [Message(role="user", content=[TextBlock(text="Reply with the single word: ok")])]
-    )
+    history = MessageHistory([Message(role="user", content=[TextBlock(text="Reply with the single word: ok")])])
     counted = await provider.count_tokens(messages=history, system=None, model=model, tools=[])
     message = await provider.generate(
         history, system=None, params=GenerationParams(thinking="high", max_completion_tokens=2000), model=model

--- a/tests/agent/llm/test_model_specs.py
+++ b/tests/agent/llm/test_model_specs.py
@@ -1,6 +1,11 @@
 import pytest
 
-from kolega_code.llm.specs import build_thinking_request_params, get_model_specs, thinking_effort_options
+from kolega_code.llm.specs import (
+    build_thinking_request_params,
+    get_model_specs,
+    resolve_max_input_tokens,
+    thinking_effort_options,
+)
 
 
 @pytest.mark.parametrize(
@@ -28,7 +33,7 @@ def test_new_google_model_specs(
 
 
 @pytest.mark.parametrize("model", ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"])
-@pytest.mark.parametrize("provider,context_length", [("openai", 1050000), ("openai_chatgpt", 272000)])
+@pytest.mark.parametrize("provider,context_length", [("openai", 1050000), ("openai_chatgpt", 400000)])
 def test_gpt56_model_specs(provider, context_length, model):
     specs = get_model_specs(provider, model)
 
@@ -47,8 +52,9 @@ def test_openai_chatgpt_gpt55_context_length():
     backend, with 128K reserved for output → effective max input is ~272K."""
     specs = get_model_specs("openai_chatgpt", "gpt-5.5")
 
-    assert specs["context_length"] == 272000
+    assert specs["context_length"] == 400000
     assert specs["max_completion_tokens"] == 128000
+    assert resolve_max_input_tokens(specs) == 272000
     assert specs["thinking_effort"].default == "medium"
 
 

--- a/tests/agent/test_commands.py
+++ b/tests/agent/test_commands.py
@@ -16,6 +16,7 @@ class MockAgent:
         self.compress_history = AsyncMock()
         self.count_current_context = AsyncMock()
         self.model_context_length = 1000
+        self.model_max_input_tokens = 1000
 
     def clear_history(self):
         self.history = MessageHistory()

--- a/tests/agent/test_context_budget.py
+++ b/tests/agent/test_context_budget.py
@@ -1,0 +1,75 @@
+"""The usable input budget is the window minus the requested output allowance."""
+
+import uuid
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from kolega_code.agent.coder import CoderAgent
+from kolega_code.agent.prompt_provider import AgentMode
+from kolega_code.config import AgentConfig
+from kolega_code.events import AgentConnectionManager
+from kolega_code.llm.specs import get_model_specs
+
+
+@pytest.fixture
+def agent(tmp_path):
+    manager = Mock(spec=AgentConnectionManager)
+    manager.workspace_id = "test_workspace"
+    manager.send_message = AsyncMock()
+    config = Mock(spec=AgentConfig)
+    config.long_context_config = Mock()
+    config.long_context_config.provider = "anthropic"
+    config.long_context_config.model = "claude-sonnet-4-5-20250929"
+    config.openai_api_key = "test_key"
+    config.anthropic_api_key = "test_key"
+    config.browser_use_headless = True
+    config.agent_models = {}
+    config.web_search_mode = "auto"
+    config.model_config_for_agent.return_value = config.long_context_config
+    return CoderAgent(
+        project_path=str(tmp_path),
+        workspace_id="test_workspace",
+        thread_id=str(uuid.uuid4()),
+        connection_manager=manager,
+        config=config,
+        agent_mode=AgentMode.CLI,
+    )
+
+
+def test_max_input_budget_is_window_minus_output(agent):
+    specs = get_model_specs("anthropic", "claude-sonnet-4-5-20250929")
+    assert agent.model_max_input_tokens == specs["context_length"] - specs["max_completion_tokens"]
+
+
+@pytest.mark.asyncio
+async def test_gauge_denominates_on_input_budget(agent, monkeypatch):
+    from kolega_code.llm.providers.models import TokenCount
+
+    monkeypatch.setattr(agent.llm, "count_tokens", AsyncMock(return_value=TokenCount(input_tokens=10_000)))
+    emitted = {}
+
+    async def capture(**kwargs):
+        emitted.update(kwargs)
+
+    monkeypatch.setattr(agent.emitter, "context_update", capture)
+    await agent.count_current_context()
+    assert emitted["model_context_length"] == agent.model_max_input_tokens
+
+
+def test_resolver_covers_all_three_conventions():
+    from kolega_code.llm.specs import resolve_max_input_tokens
+
+    shared = {"context_length": 1000, "max_completion_tokens": 400, "input_budget": "window_minus_output"}
+    separate = {"context_length": 1000, "max_completion_tokens": 400, "input_budget": "separate_output_limit"}
+    shares = {"context_length": 1000, "max_completion_tokens": 1000, "input_budget": "output_shares_window"}
+    assert resolve_max_input_tokens(shared) == 600
+    assert resolve_max_input_tokens(separate) == 1000
+    assert resolve_max_input_tokens(shares) == 1000
+
+
+def test_catalog_declares_input_budget_everywhere():
+    from kolega_code.llm.specs.accessors import INPUT_BUDGET_CONVENTIONS, MODEL_SPECS, WILDCARD_MODEL_SPECS
+
+    for key, specs in list(MODEL_SPECS.items()) + list(WILDCARD_MODEL_SPECS.items()):
+        assert specs.get("input_budget") in INPUT_BUDGET_CONVENTIONS, key

--- a/tests/agent/test_context_residual_accounting.py
+++ b/tests/agent/test_context_residual_accounting.py
@@ -100,9 +100,7 @@ class TestResidualUpdates:
     def test_missing_usage_keeps_last_value(self, agent):
         agent._context_residual_tokens = 5_000
         agent._last_raw_context_count = 2_000
-        agent._update_context_residual(
-            Message(role="assistant", content=[TextBlock(text="ok")], usage_metadata={})
-        )
+        agent._update_context_residual(Message(role="assistant", content=[TextBlock(text="ok")], usage_metadata={}))
         assert agent._context_residual_tokens == 5_000
 
 

--- a/tests/agent/test_context_residual_accounting.py
+++ b/tests/agent/test_context_residual_accounting.py
@@ -1,13 +1,14 @@
-"""Hosted web-search residual accounting: the gauge must read billed-true.
+"""Context-residual accounting: the gauge must read billed-true.
 
-Hosted search content is injected into the model context SERVER-side (restored
-on replay of web_search_call items, billed as input) and never reaches the
-client, so tiktoken-over-history undercounts. BaseAgent tracks the residual
-(billed − counted) as a side-channel: search-bearing responses bump a
-provisional per-call constant (their own billing telescopes internal rounds),
-clean responses replace it with the measured residual, compaction resets it.
-Live counterpart: the gauge-invariant test in
-tests/agent/llm/test_hosted_web_search_live.py.
+BaseAgent tracks billed − counted as a side-channel covering everything the
+local count cannot see: hosted web-search content injected SERVER-side
+(restored on replay of web_search_call items, billed as input) and the
+server-side wrapping of restored content in tool-call rounds (+4–5% of
+context measured on deepseek-v4-flash agent sessions).
+Search-bearing responses bump a provisional per-call constant (their own
+billing telescopes internal rounds); every clean response replaces the value
+with the measured residual; compaction resets it. Live counterpart: the
+gauge-invariant test in tests/agent/llm/test_hosted_web_search_live.py.
 """
 
 import uuid
@@ -64,51 +65,52 @@ def _clean_message(billed):
 class TestResidualUpdates:
     def test_search_bearing_response_adds_provisional_per_call(self, agent):
         agent._last_raw_context_count = 1000
-        agent._update_hosted_search_residual(_search_message(n_calls=2, billed=50_000))
-        assert agent._hosted_injected_tokens == 2 * CoderAgent.HOSTED_SEARCH_PROVISIONAL_TOKENS
+        agent._update_context_residual(_search_message(n_calls=2, billed=50_000))
+        assert agent._context_residual_tokens == 2 * CoderAgent.HOSTED_SEARCH_PROVISIONAL_TOKENS
 
     def test_clean_response_replaces_estimate_with_measurement(self, agent):
-        agent._hosted_injected_tokens = 12_000
+        agent._context_residual_tokens = 12_000
         agent._last_raw_context_count = 1_000
-        agent._update_hosted_search_residual(_clean_message(billed=3_800))
-        assert agent._hosted_injected_tokens == 2_800
+        agent._update_context_residual(_clean_message(billed=3_800))
+        assert agent._context_residual_tokens == 2_800
 
-    def test_clean_response_without_any_search_history_is_a_noop(self, agent):
-        # Tokenizer drift (billed > counted) must not leak into the gauge for
+    def test_clean_response_measures_drift_without_any_search_history(self, agent):
+        # Tokenizer drift (billed > counted) is a systematic undercount the
+        # compaction trigger must see, so clean responses measure it even in
         # sessions that never searched.
         agent._last_raw_context_count = 1_000
-        agent._update_hosted_search_residual(_clean_message(billed=1_400))
-        assert agent._hosted_injected_tokens == 0
+        agent._update_context_residual(_clean_message(billed=1_400))
+        assert agent._context_residual_tokens == 400
 
     def test_recovers_after_compaction_when_search_blocks_survive(self, agent):
         # Post-compaction the residual is 0 but surviving web_search_call blocks
         # keep the server restoring content — the next clean response re-measures.
         agent.history.append(_search_message(n_calls=1))
-        agent._hosted_injected_tokens = 0
+        agent._context_residual_tokens = 0
         agent._last_raw_context_count = 1_000
-        agent._update_hosted_search_residual(_clean_message(billed=4_000))
-        assert agent._hosted_injected_tokens == 3_000
+        agent._update_context_residual(_clean_message(billed=4_000))
+        assert agent._context_residual_tokens == 3_000
 
     def test_negative_residual_clamps_to_zero(self, agent):
-        agent._hosted_injected_tokens = 5_000
+        agent._context_residual_tokens = 5_000
         agent._last_raw_context_count = 2_000
-        agent._update_hosted_search_residual(_clean_message(billed=1_500))
-        assert agent._hosted_injected_tokens == 0
+        agent._update_context_residual(_clean_message(billed=1_500))
+        assert agent._context_residual_tokens == 0
 
     def test_missing_usage_keeps_last_value(self, agent):
-        agent._hosted_injected_tokens = 5_000
+        agent._context_residual_tokens = 5_000
         agent._last_raw_context_count = 2_000
-        agent._update_hosted_search_residual(
+        agent._update_context_residual(
             Message(role="assistant", content=[TextBlock(text="ok")], usage_metadata={})
         )
-        assert agent._hosted_injected_tokens == 5_000
+        assert agent._context_residual_tokens == 5_000
 
 
 class TestGaugeApplication:
     @pytest.mark.asyncio
     async def test_count_current_context_adds_positive_residual(self, agent, monkeypatch):
         monkeypatch.setattr(agent.llm, "count_tokens", AsyncMock(return_value=TokenCount(input_tokens=10_000)))
-        agent._hosted_injected_tokens = 2_500
+        agent._context_residual_tokens = 2_500
         token_count = await agent.count_current_context()
         assert token_count.input_tokens == 12_500
         # The raw (pre-residual) count is stashed for the next residual update.
@@ -124,7 +126,7 @@ class TestGaugeApplication:
     async def test_compress_history_resets_the_residual(self, agent, monkeypatch):
         from kolega_code.agent.compression import CompactionResult
 
-        agent._hosted_injected_tokens = 9_999
+        agent._context_residual_tokens = 9_999
         monkeypatch.setattr(agent.llm, "count_tokens", AsyncMock(return_value=TokenCount(input_tokens=100)))
         monkeypatch.setattr(
             agent.compressor,
@@ -132,4 +134,4 @@ class TestGaugeApplication:
             AsyncMock(return_value=CompactionResult(ok=True, reason="ok", summarized_messages=0)),
         )
         await agent.compress_history()
-        assert agent._hosted_injected_tokens == 0
+        assert agent._context_residual_tokens == 0

--- a/tests/agent/test_duplicate_tool_results.py
+++ b/tests/agent/test_duplicate_tool_results.py
@@ -37,7 +37,11 @@ class TestDuplicateToolResultPrevention:
             patch("kolega_code.agent.context.LocalFileSystem") as mock_filesystem_class,
         ):
             # Mock get_model_specs to return reasonable values
-            mock_get_model_specs.return_value = {"context_length": 100000, "max_completion_tokens": 4096}
+            mock_get_model_specs.return_value = {
+                "context_length": 100000,
+                "max_completion_tokens": 4096,
+                "input_budget": "window_minus_output",
+            }
 
             # Create mock filesystem instance
             mock_filesystem = Mock()

--- a/tests/cli/test_compression_threshold.py
+++ b/tests/cli/test_compression_threshold.py
@@ -95,8 +95,8 @@ def test_ask_default_keeps_builtin_threshold(tmp_path, monkeypatch, isolated_cli
 
     assert exit_code == 0
     agent = RecordingCoderAgent.instances[0]
-    assert agent.history_compression_threshold == pytest.approx(0.8)
-    assert agent.compressor.threshold == pytest.approx(0.8)
+    assert agent.history_compression_threshold == pytest.approx(0.95)
+    assert agent.compressor.threshold == pytest.approx(0.95)
 
 
 def test_ask_flag_sets_threshold(tmp_path, monkeypatch, isolated_cli_env):


### PR DESCRIPTION
## Summary

- Adds a required `input_budget` field to every model spec entry, naming the input-budget calculation explicitly: `window_minus_output` (usable input = window − output allowance), `separate_output_limit` (independent caps — Google, ChatGPT codex-spark), or `output_shares_window` (output may consume the whole window — tinker, no-cap mirrors). Catalog load validates the field; `resolve_max_input_tokens` is the single resolution rule; the tinker/openrouter/ollama_cloud generators stamp it so `models refresh` preserves it.
- Compaction, the context gauge, and `/compress` denominate on the usable input budget instead of the raw window, so `input + max_output ≤ window` holds wherever the window is shared, and the gauge reaching the threshold means compaction fires now. Default compression threshold rises to 95% (settings/flag overrides unchanged).
- Generalizes the hosted-search residual into an always-on `billed − counted` correction measured on every clean response, so the gauge and trigger read billed-true (server-injected content and wrapper overhead are invisible to the local count; drift is positive-only, reset on compaction).
- Catalog corrections: `openai` gpt-5.4 → 1,050,000 total; `openai_chatgpt` gpt-5.5 / gpt-5.6-* → 400,000 total (272,000 usable input, matching the Codex backend); `gpt-5.3-codex-spark` → 128,000 input limit, independently validated.

## Live verification

- 25/25 keyed live provider generate tests pass under the new budgets.
- OpenAI: accepted 256,389 input / rejected 287,780 — brackets the derived 272,000 input boundary exactly.
- DeepSeek flash: accepted input 634,718 with max_output 384,000 (sum over the window) — confirms generation-time-only enforcement; the threshold is the protection.
- Anthropic: accepts over-sum requests at the margin (input 193,899 + 16,384 on a 200k window ran normally) — no up-front sum rejection.
- ChatGPT backend (subscription OAuth): spark accepted 122,473 / rejected ~129.6k input → 128,000 input limit, validated independently of output.
- Full suite: 4,557 passed / 2 skipped; the only failures are 3 tinker live tests requiring the optional native stack not installed in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEe1aSEJDsZTYbEtLAunqp