### PR TITLE
fix(llm): invalidate stale catalog overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+### Fixed
+
+- Runtime model-catalog caches created before input-budget conventions were
+  introduced are now ignored safely instead of injecting incomplete model
+  specs that fail later with `KeyError: 'input_budget'`. Refreshing a catalog
+  rewrites it in the current schema.
+
 ### Added
 
 - ATIF v1.7 trajectory export: `sessions export --format atif` converts any

--- a/kolega_code/cli/model_catalog.py
+++ b/kolega_code/cli/model_catalog.py
@@ -24,6 +24,7 @@ from kolega_code.llm.specs import MODEL_SPECS, is_featured_model
 from kolega_code.llm.specs import ollama_cloud_catalog as ollama_cloud
 from kolega_code.llm.specs import openrouter_catalog as openrouter
 from kolega_code.llm.specs import tinker_catalog as tinker
+from kolega_code.llm.specs.validation import validate_model_spec
 
 from .provider_registry import PROVIDER_LABELS, get_ui_model, rebuild_ui_model_options
 from .session_store import default_state_dir
@@ -114,6 +115,10 @@ def apply_catalog_overlay(
     for identifier, spec in entries:
         key = (module.PROVIDER, identifier)
         if key in MODEL_SPECS:
+            continue
+        try:
+            validate_model_spec(spec)
+        except ValueError:
             continue
         # Overlay models are never featured: the picker keeps showing the
         # release's reviewed most-used set.

--- a/kolega_code/llm/specs/accessors.py
+++ b/kolega_code/llm/specs/accessors.py
@@ -2,6 +2,8 @@ from typing import Any, Dict, Optional
 
 from .catalog import MODEL_SPECS, WILDCARD_MODEL_SPECS
 from .types import ThinkingEffortSpec
+from .validation import INPUT_BUDGET_CONVENTIONS as INPUT_BUDGET_CONVENTIONS
+from .validation import validate_model_spec
 
 # Every spec entry must declare which input-budget calculation applies:
 #   window_minus_output   — usable input = context_length − max_completion_tokens
@@ -9,7 +11,6 @@ from .types import ThinkingEffortSpec
 #   separate_output_limit — usable input = context_length (independent output cap)
 #   output_shares_window  — usable input = context_length (output may consume the
 #                           whole window, bounded only at generation time)
-INPUT_BUDGET_CONVENTIONS = ("window_minus_output", "separate_output_limit", "output_shares_window")
 
 
 def resolve_max_input_tokens(specs: Dict[str, Any]) -> int:
@@ -21,8 +22,10 @@ def resolve_max_input_tokens(specs: Dict[str, Any]) -> int:
 
 def _validate_input_budgets() -> None:
     for key, specs in list(MODEL_SPECS.items()) + list(WILDCARD_MODEL_SPECS.items()):
-        if specs.get("input_budget") not in INPUT_BUDGET_CONVENTIONS:
-            raise ValueError(f"Spec {key} missing or invalid input_budget (got {specs.get('input_budget')!r})")
+        try:
+            validate_model_spec(specs)
+        except ValueError as exc:
+            raise ValueError(f"Invalid spec {key}: {exc}") from exc
 
 
 _validate_input_budgets()

--- a/kolega_code/llm/specs/ollama_cloud_catalog.py
+++ b/kolega_code/llm/specs/ollama_cloud_catalog.py
@@ -27,12 +27,15 @@ from typing import Any, Mapping, Optional, Sequence
 import httpx
 
 from .types import ThinkingEffortSpec
+from .validation import validate_model_spec
 
 PROVIDER = "ollama_cloud"
 MODELS_URL = "https://ollama.com/v1/models"
 SHOW_URL = "https://ollama.com/api/show"
 
-CACHE_SCHEMA_VERSION = 1
+# v2 adds the required input_budget convention. V1 entries are invalidated
+# rather than guessed because the old cache did not encode this semantic.
+CACHE_SCHEMA_VERSION = 2
 CACHE_FILENAME = "ollama_cloud_models.json"
 
 DEFAULT_TEMPERATURE = 1.0
@@ -268,6 +271,7 @@ def spec_from_jsonable(payload: Mapping[str, Any]) -> dict[str, Any]:
         raise ValueError("default_temperature must be numeric")
     if not isinstance(spec.get("supports_vision"), bool):
         raise ValueError("supports_vision must be a boolean")
+    validate_model_spec(spec)
     return spec
 
 

--- a/kolega_code/llm/specs/openrouter_catalog.py
+++ b/kolega_code/llm/specs/openrouter_catalog.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping, Optional, Sequence
 
 from .types import ThinkingEffortSpec
+from .validation import validate_model_spec
 
 PROVIDER = "openrouter"
 BASE_URL = "https://openrouter.ai/api/v1"
@@ -70,7 +71,9 @@ _CODEX_APPLY_PATCH_PREFIXES = ("openai/",)
 # reasoning is dropped for these ids instead (see ``prior_reasoning_is_replayable``).
 _DROP_PRIOR_REASONING_PREFIXES = ("anthropic/",)
 
-CACHE_SCHEMA_VERSION = 1
+# v2 adds the required input_budget convention. V1 entries are invalidated
+# rather than guessed because the provider metadata does not encode it.
+CACHE_SCHEMA_VERSION = 2
 CACHE_FILENAME = "openrouter_models.json"
 
 
@@ -343,6 +346,7 @@ def spec_from_jsonable(payload: Mapping[str, Any]) -> dict[str, Any]:
             default=str(thinking.get("default") or ""),
             mode=str(thinking.get("mode") or "openrouter_reasoning"),
         )
+    validate_model_spec(spec)
     return spec
 
 

--- a/kolega_code/llm/specs/tinker_catalog.py
+++ b/kolega_code/llm/specs/tinker_catalog.py
@@ -30,11 +30,14 @@ from typing import Any, Mapping, Sequence
 import httpx
 
 from .types import ThinkingEffortSpec
+from .validation import validate_model_spec
 
 PROVIDER = "tinker"
 MODELS_URL = "https://tinker-docs.thinkingmachines.ai/tinker/models.json"
 
-CACHE_SCHEMA_VERSION = 1
+# v2 adds the required input_budget convention. V1 entries are invalidated
+# rather than guessed because the old cache did not encode this semantic.
+CACHE_SCHEMA_VERSION = 2
 CACHE_FILENAME = "tinker_models.json"
 
 # Tinker's docs sit behind Cloudflare and return HTTP 403 (error 1010) for
@@ -164,6 +167,7 @@ def spec_from_jsonable(payload: Mapping[str, Any]) -> dict[str, Any]:
             default=str(thinking.get("default") or ""),
             mode="tinker_native_effort",
         )
+    validate_model_spec(spec)
     return spec
 
 
@@ -208,7 +212,10 @@ def load_cache(path: Path) -> list[tuple[str, dict[str, Any]]]:
         spec = item.get("spec")
         if not identifier or not isinstance(spec, Mapping):
             continue
-        entries.append((str(identifier), spec_from_jsonable(spec)))
+        try:
+            entries.append((str(identifier), spec_from_jsonable(spec)))
+        except (TypeError, ValueError):
+            continue
     return entries
 
 

--- a/kolega_code/llm/specs/validation.py
+++ b/kolega_code/llm/specs/validation.py
@@ -1,0 +1,17 @@
+"""Validation shared by bundled and runtime model catalogs."""
+
+from typing import Any, Mapping
+
+INPUT_BUDGET_CONVENTIONS = ("window_minus_output", "separate_output_limit", "output_shares_window")
+
+
+def validate_model_spec(specs: Mapping[str, Any]) -> None:
+    """Raise ``ValueError`` when a model spec cannot support context budgeting."""
+    for key in ("context_length", "max_completion_tokens"):
+        value = specs.get(key)
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError(f"{key} must be a positive integer")
+
+    convention = specs.get("input_budget")
+    if convention not in INPUT_BUDGET_CONVENTIONS:
+        raise ValueError(f"missing or invalid input_budget (got {convention!r})")

--- a/tests/agent/llm/test_ollama_cloud_generator.py
+++ b/tests/agent/llm/test_ollama_cloud_generator.py
@@ -169,10 +169,16 @@ def test_cache_round_trip(entries: list[tuple[str, dict[str, Any]]], tmp_path: P
     "contents",
     [
         "{",
-        '{"schema_version": 999, "provider": "ollama_cloud", "models": []}',
-        '{"schema_version": 1, "provider": "other", "models": []}',
-        '{"schema_version": 1, "provider": "ollama_cloud", "models": "bad"}',
-        '{"schema_version": 1, "provider": "ollama_cloud", "models": [{"id": "x", "spec": {}}]}',
+        json.dumps({"schema_version": 999, "provider": "ollama_cloud", "models": []}),
+        json.dumps({"schema_version": oc.CACHE_SCHEMA_VERSION, "provider": "other", "models": []}),
+        json.dumps({"schema_version": oc.CACHE_SCHEMA_VERSION, "provider": "ollama_cloud", "models": "bad"}),
+        json.dumps(
+            {
+                "schema_version": oc.CACHE_SCHEMA_VERSION,
+                "provider": "ollama_cloud",
+                "models": [{"id": "x", "spec": {}}],
+            }
+        ),
     ],
 )
 def test_invalid_cache_is_ignored(contents: str, tmp_path: Path) -> None:

--- a/tests/cli/test_model_catalog_command.py
+++ b/tests/cli/test_model_catalog_command.py
@@ -10,9 +10,10 @@ from pathlib import Path
 import pytest
 
 from kolega_code.cli import model_catalog
-from kolega_code.llm.specs import MODEL_SPECS
+from kolega_code.llm.specs import MODEL_SPECS, resolve_max_input_tokens
 from kolega_code.llm.specs import ollama_cloud_catalog as ollama_cloud
 from kolega_code.llm.specs import openrouter_catalog as openrouter
+from kolega_code.llm.specs import tinker_catalog as tinker
 from kolega_code.llm.specs.types import ThinkingEffortSpec
 
 PROVIDER = openrouter.PROVIDER
@@ -112,6 +113,7 @@ def _cache_entries() -> list[tuple[str, dict]]:
             {
                 "context_length": 200000,
                 "max_completion_tokens": 8192,
+                "input_budget": "window_minus_output",
                 "default_temperature": 1.0,
                 "supports_vision": False,
                 "preferred_edit_protocol": "claude_code",
@@ -132,6 +134,7 @@ def test_overlay_adds_new_models_without_featuring_them(tmp_path: Path, restore_
     assert added == 1
     spec = MODEL_SPECS[(PROVIDER, "vendor/brand-new")]
     assert spec["context_length"] == 200000
+    assert resolve_max_input_tokens(spec) == 191808
     assert isinstance(spec["thinking_effort"], ThinkingEffortSpec)
     # The picker keeps showing the release's reviewed most-used set.
     assert "featured" not in spec
@@ -148,7 +151,17 @@ def test_overlay_never_overrides_a_bundled_model(tmp_path: Path, restore_catalog
     path = tmp_path / openrouter.CACHE_FILENAME
     openrouter.save_cache(
         path,
-        [(bundled, {"context_length": 1, "max_completion_tokens": 1, "supports_vision": False})],
+        [
+            (
+                bundled,
+                {
+                    "context_length": 1,
+                    "max_completion_tokens": 1,
+                    "input_budget": "output_shares_window",
+                    "supports_vision": False,
+                },
+            )
+        ],
         fetched_at="2026-07-31T00:00:00+00:00",
     )
 
@@ -198,6 +211,78 @@ def test_unusable_cache_files_are_ignored_not_fatal(tmp_path: Path, content: str
 
 def test_missing_cache_is_a_no_op(tmp_path: Path, restore_catalog) -> None:
     assert model_catalog.apply_catalog_overlay(tmp_path, env={}) == 0
+
+
+@pytest.mark.parametrize("module", [openrouter, tinker, ollama_cloud])
+def test_legacy_catalog_cache_without_input_budget_is_ignored(
+    tmp_path: Path,
+    restore_catalog,
+    module,
+) -> None:
+    identifier = f"legacy/{module.PROVIDER}"
+    payload = {
+        "schema_version": 1,
+        "provider": module.PROVIDER,
+        "models": [
+            {
+                "id": identifier,
+                "spec": {
+                    "context_length": 131072,
+                    "max_completion_tokens": 32768,
+                    "default_temperature": 1.0,
+                    "supports_vision": False,
+                },
+            }
+        ],
+    }
+    path = tmp_path / module.CACHE_FILENAME
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert module.load_cache(path) == []
+    assert model_catalog.apply_catalog_overlay(tmp_path, env={}, catalog=module.PROVIDER) == 0
+    assert (module.PROVIDER, identifier) not in MODEL_SPECS
+
+
+@pytest.mark.parametrize("module", [openrouter, tinker, ollama_cloud])
+@pytest.mark.parametrize(
+    ("invalid_field", "invalid_value"),
+    [
+        ("input_budget", None),
+        ("input_budget", "invented_convention"),
+        ("context_length", 0),
+        ("max_completion_tokens", True),
+    ],
+)
+def test_current_catalog_cache_with_invalid_budget_spec_is_ignored(
+    tmp_path: Path,
+    restore_catalog,
+    module,
+    invalid_field: str,
+    invalid_value: object,
+) -> None:
+    identifier = f"invalid/{module.PROVIDER}"
+    spec = {
+        "context_length": 131072,
+        "max_completion_tokens": 32768,
+        "input_budget": "window_minus_output",
+        "default_temperature": 1.0,
+        "supports_vision": False,
+    }
+    if invalid_value is None:
+        spec.pop(invalid_field)
+    else:
+        spec[invalid_field] = invalid_value
+    payload = {
+        "schema_version": module.CACHE_SCHEMA_VERSION,
+        "provider": module.PROVIDER,
+        "models": [{"id": identifier, "spec": spec}],
+    }
+    path = tmp_path / module.CACHE_FILENAME
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert module.load_cache(path) == []
+    assert model_catalog.apply_catalog_overlay(tmp_path, env={}, catalog=module.PROVIDER) == 0
+    assert (module.PROVIDER, identifier) not in MODEL_SPECS
 
 
 # --- models refresh -------------------------------------------------------
@@ -268,6 +353,7 @@ def test_tinker_overlay_adds_new_models_without_featuring_them(tmp_path: Path, r
             {
                 "context_length": 65536,
                 "max_completion_tokens": 32768,
+                "input_budget": "output_shares_window",
                 "default_temperature": 1.0,
                 "supports_vision": False,
             },
@@ -347,6 +433,7 @@ def test_ollama_cloud_overlay_adds_new_ids_without_overwriting_bundled_specs(tmp
             {
                 "context_length": 1,
                 "max_completion_tokens": 1,
+                "input_budget": "output_shares_window",
                 "default_temperature": 1.0,
                 "supports_vision": False,
             },
@@ -356,6 +443,7 @@ def test_ollama_cloud_overlay_adds_new_ids_without_overwriting_bundled_specs(tmp
             {
                 "context_length": 131072,
                 "max_completion_tokens": 32768,
+                "input_budget": "window_minus_output",
                 "default_temperature": 1.0,
                 "supports_vision": True,
             },
@@ -379,6 +467,7 @@ def test_ollama_cloud_overlay_path_and_disable_env_are_provider_specific(tmp_pat
             {
                 "context_length": 131072,
                 "max_completion_tokens": 32768,
+                "input_budget": "window_minus_output",
                 "default_temperature": 1.0,
                 "supports_vision": False,
             },
@@ -432,6 +521,7 @@ def test_ollama_cloud_refresh_preserves_prior_overlay_ids_and_bundled_accounting
             {
                 "context_length": 65536,
                 "max_completion_tokens": 16384,
+                "input_budget": "window_minus_output",
                 "default_temperature": 1.0,
                 "supports_vision": False,
             },
@@ -474,6 +564,7 @@ def test_ollama_cloud_refresh_failure_leaves_existing_cache_untouched(tmp_path: 
                 {
                     "context_length": 131072,
                     "max_completion_tokens": 32768,
+                    "input_budget": "window_minus_output",
                     "default_temperature": 1.0,
                     "supports_vision": False,
                 },


### PR DESCRIPTION
## Summary

- bump OpenRouter, Tinker, and Ollama Cloud runtime catalog caches to schema v2 so pre-input-budget caches are ignored safely
- validate context lengths, completion limits, and input-budget conventions before cached specs can enter the runtime catalog
- retain strict budget resolution instead of guessing a convention for legacy entries
- add regression coverage for schema-v1 caches and malformed schema-v2 entries

## Testing

- `uv run pre-commit run --all-files --show-diff-on-failure`
- 121 catalog/model-spec tests passed
- 58 context/compression tests passed
- 72 focused stale-cache, Ollama generator, and context-budget tests passed
- full fast suite reached 4,502 passed and 74 skipped; its sole failure was caused by deliberately blanking provider keys for hermetic live-test skipping, and that affected test passed when rerun normally