### PR TITLE
fix(agent): expand $KOLEGA_SCRATCHPAD references in file-tool paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ### Fixed
 
+- File tools (`read`, `write`, `edit`, `multi_edit`, `read_image`) now expand
+  a `$KOLEGA_SCRATCHPAD` (or `${KOLEGA_SCRATCHPAD}`) reference in path
+  arguments to the session scratchpad at the tool-dispatch choke point, so
+  the shell spelling no longer creates a literal `$KOLEGA_SCRATCHPAD`
+  directory in the workspace.
+
 - Runtime model-catalog caches created before input-budget conventions were
   introduced are now ignored safely instead of injecting incomplete model
   specs that fail later with `KeyError: 'input_budget'`. Refreshing a catalog

--- a/kolega_code/agent/prompt_templates/extensions/cli/scratchpad.md.j2
+++ b/kolega_code/agent/prompt_templates/extensions/cli/scratchpad.md.j2
@@ -4,8 +4,6 @@ You have a private scratchpad working directory for this session at:
 
 This path is also exported as the environment variable `KOLEGA_SCRATCHPAD` in every shell command and eval kernel this session runs (login shells included), so in commands and scripts refer to it as `$KOLEGA_SCRATCHPAD` instead of re-declaring or retyping the literal path.
 
-The file tools (`read`, `write`, `edit`, `multi_edit`, `read_image`) expand the same `$KOLEGA_SCRATCHPAD` reference (or `${KOLEGA_SCRATCHPAD}`) in path arguments, so `$KOLEGA_SCRATCHPAD/notes.md` works there too — use the reference instead of the literal path in tool arguments as well.
-
 Use it for throwaway work that must not touch the user's working tree: one-off scripts, ad-hoc virtual environments, downloaded files, extracted archives, generated intermediates, and log captures. This is the only location outside the working directory where you may create files without asking.
 
 Rules:

--- a/kolega_code/agent/prompt_templates/extensions/cli/scratchpad.md.j2
+++ b/kolega_code/agent/prompt_templates/extensions/cli/scratchpad.md.j2
@@ -4,6 +4,8 @@ You have a private scratchpad working directory for this session at:
 
 This path is also exported as the environment variable `KOLEGA_SCRATCHPAD` in every shell command and eval kernel this session runs (login shells included), so in commands and scripts refer to it as `$KOLEGA_SCRATCHPAD` instead of re-declaring or retyping the literal path.
 
+The file tools (`read`, `write`, `edit`, `multi_edit`, `read_image`) expand the same `$KOLEGA_SCRATCHPAD` reference (or `${KOLEGA_SCRATCHPAD}`) in path arguments, so `$KOLEGA_SCRATCHPAD/notes.md` works there too — use the reference instead of the literal path in tool arguments as well.
+
 Use it for throwaway work that must not touch the user's working tree: one-off scripts, ad-hoc virtual environments, downloaded files, extracted archives, generated intermediates, and log captures. This is the only location outside the working directory where you may create files without asking.
 
 Rules:

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -8,6 +8,7 @@ from kolega_code.config import AgentConfig, EditProtocol
 from kolega_code.llm.models import ImageBlock, ToolDefinition
 from kolega_code.memory import ProjectMemoryManager
 from kolega_code.tools import Tool, ToolRegistry
+from kolega_code.scratchpad import expand_scratchpad_reference
 from kolega_code.services.file_system import FileSystem, LocalFileSystem
 from kolega_code.services.base import TerminalManager, BrowserManager
 from kolega_code.services.terminal import LocalTerminalManager
@@ -35,6 +36,31 @@ from .tool_backend.build_tool import BuildTool
 from .tool_backend.lsp_tool import LspEditTool, LspTool
 from kolega_code.services.lsp import LspManager
 from kolega_code.services.snapshots import SnapshotService
+
+# Canonical path parameters of the built-in file tools. The model-facing names
+# differ across edit protocols (``path`` vs ``file_path``), so expansion covers
+# every spelling the bound handler can accept; alias resolution has already
+# collapsed wrong-name arguments onto these by the time they are expanded.
+FILE_TOOL_PATH_PARAMS = frozenset({"path", "file_path", "rename"})
+
+# Built-in tools whose path arguments may reference the session scratchpad as
+# ``$KOLEGA_SCRATCHPAD``. The dispatch choke point (``Tool.call``) expands
+# those references to the caller's real scratchpad directory before the
+# handler runs, so a literal ``$KOLEGA_SCRATCHPAD`` directory can never appear
+# in the workspace when the model passes the shell spelling to a file tool.
+FILE_TOOLS_WITH_PATH_PARAMS = frozenset(
+    {
+        "write",
+        "edit",
+        "multi_edit",
+        "read",
+        "read_image",
+        "claude_edit",
+        "claude_write",
+        "hashline_edit",
+        "hashline_write",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -1246,6 +1272,7 @@ class ToolCollection(LogMixin):
         ordinary_parallel_dispatch = (
             method_name in self.agent_dispatch_tools and method_name not in self._legacy_only_extension_dispatch_tools
         )
+        path_params = FILE_TOOL_PATH_PARAMS if method_name in FILE_TOOLS_WITH_PATH_PARAMS else frozenset()
         return Tool(
             name=method_name,
             definition=definition,
@@ -1256,7 +1283,23 @@ class ToolCollection(LogMixin):
             parallel_safe=(method_name in (self.read_only_tools or []) or ordinary_parallel_dispatch)
             and not workflow_dispatch,
             log_debug=self._log_alias_hit,
+            path_params=path_params,
+            path_expander=self._expand_scratchpad_path if path_params else None,
         )
+
+    def _expand_scratchpad_path(self, path: str) -> str:
+        """Expand a ``$KOLEGA_SCRATCHPAD`` reference to the caller's scratchpad.
+
+        Applied at the dispatch choke point to file-tool path arguments, so a
+        literal ``$KOLEGA_SCRATCHPAD`` directory is never created in the
+        workspace when the model passes the shell spelling to a file tool.
+        Callers without a real scratchpad directory (including plain Mocks in
+        tests) leave the path untouched.
+        """
+        scratchpad = getattr(self.caller, "scratchpad_dir", None)
+        if not isinstance(scratchpad, (str, Path)):
+            return path
+        return expand_scratchpad_reference(path, scratchpad)
 
     async def _log_alias_hit(self, message: str) -> None:
         """Debug log_message sink for Tool param-alias hits (trajectory mining)."""

--- a/kolega_code/scratchpad.py
+++ b/kolega_code/scratchpad.py
@@ -79,3 +79,24 @@ def ensure_scratchpad_dir(project_path: Path | str, session_id: str) -> Path:
     path = scratchpad_dir_for(project_path, session_id)
     ensure_private_dir(path)
     return path
+
+
+_SCRATCHPAD_TOKEN_PATTERN = re.compile(r"(^|[/\\])\$(?:\{KOLEGA_SCRATCHPAD\}|KOLEGA_SCRATCHPAD)(?=$|[/\\])")
+
+
+def expand_scratchpad_reference(path: str, scratchpad_dir: str | os.PathLike[str] | None) -> str:
+    """Expand ``$KOLEGA_SCRATCHPAD`` references in a model-provided path.
+
+    The scratchpad prompt tells agents to refer to the session scratchpad as
+    ``$KOLEGA_SCRATCHPAD`` (the spelling shells expand). File tools accept the
+    same spelling at the tool-dispatch choke point so a literal
+    ``$KOLEGA_SCRATCHPAD`` directory can never appear in the workspace: every
+    whole-segment occurrence of the token (``$KOLEGA_SCRATCHPAD`` or
+    ``${KOLEGA_SCRATCHPAD}``, at the start of the path or after a separator) is
+    replaced with ``scratchpad_dir``. Paths without the token, or callers
+    without a scratchpad, are returned unchanged.
+    """
+    if not path or not isinstance(scratchpad_dir, (str, os.PathLike)):
+        return path
+    value = str(scratchpad_dir)
+    return _SCRATCHPAD_TOKEN_PATTERN.sub(lambda match: match.group(1) + value, path)

--- a/kolega_code/tools/core.py
+++ b/kolega_code/tools/core.py
@@ -36,6 +36,14 @@ class Tool:
     # Debug-level log_message sink for param-alias hits, so trajectory mining
     # sees which aliases fire. None falls back to stdlib logging.
     log_debug: Optional[Callable[[str], Awaitable[None]]] = None
+    # Expands filesystem-path arguments (scratchpad references such as
+    # ``$KOLEGA_SCRATCHPAD/foo.py``) before the handler runs. Supplied at
+    # construction for the built-in file tools; None leaves paths untouched.
+    path_expander: Optional[Callable[[str], str]] = None
+    # Canonical parameter names of ``handler`` that hold filesystem paths.
+    # Only these receive expansion; a value is expanded only when it is a
+    # plain string. Defaults to empty, so expansion is opt-in per tool.
+    path_params: FrozenSet[str] = field(default_factory=frozenset)
     # Parameter names the bound handler accepts, computed once at construction
     # via ``inspect``. Alias resolution treats a registered alias as real only
     # when the binding does NOT accept the name: a name the handler itself
@@ -53,8 +61,26 @@ class Tool:
 
     async def call(self, **inputs: Any) -> Any:
         inputs = await self._resolve_param_aliases(inputs)
+        inputs = self._expand_path_params(inputs)
         self._reject_malformed_call(inputs)
         return await self.handler(**inputs)
+
+    def _expand_path_params(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
+        """Expand scratchpad references in the tool's path arguments.
+
+        Runs after alias resolution so the canonical parameter names are
+        already in place, and before argument validation so the expanded path
+        is what the handler (and its result strings) sees. A no-op unless the
+        tool was constructed with a ``path_expander``.
+        """
+        expander = self.path_expander
+        if expander is None or not self.path_params:
+            return inputs
+        for name in self.path_params:
+            value = inputs.get(name)
+            if isinstance(value, str):
+                inputs[name] = expander(value)
+        return inputs
 
     async def _resolve_param_aliases(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Map registered wrong-name arguments onto canonical parameters.

--- a/tests/agent/test_scratchpad.py
+++ b/tests/agent/test_scratchpad.py
@@ -16,6 +16,7 @@ from kolega_code.scratchpad import (
     SCRATCHPAD_PROMPT_EXTENSION_ID,
     _user_suffix,
     ensure_scratchpad_dir,
+    expand_scratchpad_reference,
     scratchpad_dir_for,
     scratchpad_root,
 )
@@ -93,6 +94,55 @@ class TestScratchpadPaths:
 
     def test_session_id_is_stripped(self, tmp_path: Path) -> None:
         assert scratchpad_dir_for(tmp_path, "  s1  ") == scratchpad_dir_for(tmp_path, "s1")
+
+
+class TestExpandScratchpadReference:
+    """$KOLEGA_SCRATCHPAD references in model-provided paths expand to the real dir."""
+
+    def test_expands_dollar_form_at_start(self) -> None:
+        assert expand_scratchpad_reference("$KOLEGA_SCRATCHPAD/notes.md", "/sp") == "/sp/notes.md"
+
+    def test_expands_braced_form_at_start(self) -> None:
+        assert expand_scratchpad_reference("${KOLEGA_SCRATCHPAD}/notes.md", "/sp") == "/sp/notes.md"
+
+    def test_expands_bare_reference(self) -> None:
+        assert expand_scratchpad_reference("$KOLEGA_SCRATCHPAD", "/sp") == "/sp"
+
+    def test_expands_after_separator(self) -> None:
+        assert expand_scratchpad_reference("sub/$KOLEGA_SCRATCHPAD/x.py", "/sp") == "sub//sp/x.py"
+        assert expand_scratchpad_reference(r"sub\$KOLEGA_SCRATCHPAD\x.py", "/sp") == "sub\\/sp\\x.py"
+
+    def test_expands_dot_slash_prefix(self) -> None:
+        assert expand_scratchpad_reference("./$KOLEGA_SCRATCHPAD/x.py", "/sp") == ".//sp/x.py"
+
+    def test_expands_multiple_occurrences(self) -> None:
+        path = expand_scratchpad_reference("$KOLEGA_SCRATCHPAD/a/$KOLEGA_SCRATCHPAD/b", "/sp")
+        assert path == "/sp/a//sp/b"
+
+    def test_accepts_pathlike_scratchpad(self, tmp_path: Path) -> None:
+        assert expand_scratchpad_reference("$KOLEGA_SCRATCHPAD/x", tmp_path) == str(tmp_path / "x")
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "plain.txt",
+            "sub/plain.txt",
+            "$KOLEGA_SCRATCHPADISH/file.py",  # longer token: not a reference
+            "x$KOLEGA_SCRATCHPAD/file.py",  # token mid-segment: not a reference
+            "a-$KOLEGA_SCRATCHPAD-b/file.py",
+        ],
+    )
+    def test_without_whole_segment_reference_is_unchanged(self, path: str) -> None:
+        assert expand_scratchpad_reference(path, "/sp") == path
+
+    def test_without_scratchpad_is_unchanged(self) -> None:
+        assert expand_scratchpad_reference("$KOLEGA_SCRATCHPAD/x.py", None) == "$KOLEGA_SCRATCHPAD/x.py"
+
+    def test_non_pathlike_scratchpad_is_unchanged(self) -> None:
+        assert expand_scratchpad_reference("$KOLEGA_SCRATCHPAD/x.py", 42) == "$KOLEGA_SCRATCHPAD/x.py"  # pyright: ignore[reportArgumentType]
+
+    def test_empty_path_is_unchanged(self) -> None:
+        assert expand_scratchpad_reference("", "/sp") == ""
 
 
 class TestEnsureScratchpadDir:

--- a/tests/agent/test_tool_collection_builtin_dispatch.py
+++ b/tests/agent/test_tool_collection_builtin_dispatch.py
@@ -161,3 +161,81 @@ class TestToolCollection:
         """read_image is in read_only_tools and has a ToolCollection wrapper."""
         assert "read_image" in ToolCollection.read_only_tools
         assert hasattr(ToolCollection, "read_image")
+
+
+@pytest.mark.asyncio
+class TestScratchpadPathExpansion:
+    """File-tool path arguments expand $KOLEGA_SCRATCHPAD at the dispatch choke point."""
+
+    @pytest.fixture
+    def real_collection(
+        self, project_path: Path, mock_connection_manager: AsyncMock, agent_config: AgentConfig, mock_base_agent: Mock
+    ) -> ToolCollection:
+        # Real (unmocked) handlers: the expansion must reach the actual tools.
+        # A real tool-call id keeps the snapshot-service records serializable.
+        mock_base_agent.current_tool_execution_id = "test-call-id"
+        return ToolCollection(
+            project_path, "test_workspace", str(uuid.uuid4()), mock_connection_manager, agent_config, mock_base_agent
+        )
+
+    async def test_write_expands_reference_and_never_creates_literal_dir(
+        self, real_collection: ToolCollection, project_path: Path, mock_base_agent: Mock, tmp_path: Path
+    ) -> None:
+        scratchpad = tmp_path / "scratchpad"
+        scratchpad.mkdir()
+        mock_base_agent.scratchpad_dir = scratchpad
+
+        result = await real_collection.call("write", path="$KOLEGA_SCRATCHPAD/notes.txt", content="hello")
+
+        assert str(scratchpad / "notes.txt") in result
+        assert (scratchpad / "notes.txt").read_text() == "hello"
+        # The literal $KOLEGA_SCRATCHPAD directory must never appear in the workspace.
+        assert not (project_path / "$KOLEGA_SCRATCHPAD").exists()
+
+    async def test_write_expands_braced_reference(
+        self, real_collection: ToolCollection, mock_base_agent: Mock, tmp_path: Path
+    ) -> None:
+        scratchpad = tmp_path / "scratchpad"
+        scratchpad.mkdir()
+        mock_base_agent.scratchpad_dir = scratchpad
+
+        result = await real_collection.call("write", path="${KOLEGA_SCRATCHPAD}/notes.txt", content="hi")
+
+        assert str(scratchpad / "notes.txt") in result
+        assert (scratchpad / "notes.txt").read_text() == "hi"
+
+    async def test_read_after_write_round_trips_through_reference(
+        self, real_collection: ToolCollection, mock_base_agent: Mock, tmp_path: Path
+    ) -> None:
+        scratchpad = tmp_path / "scratchpad"
+        scratchpad.mkdir()
+        mock_base_agent.scratchpad_dir = scratchpad
+
+        await real_collection.call("write", path="$KOLEGA_SCRATCHPAD/code.py", content="value = 1\n")
+        read_result = await real_collection.call("read", file_path="$KOLEGA_SCRATCHPAD/code.py")
+
+        assert str(scratchpad / "code.py") in read_result
+        assert "value = 1" in read_result
+
+    async def test_edit_expands_reference(
+        self, real_collection: ToolCollection, mock_base_agent: Mock, tmp_path: Path
+    ) -> None:
+        scratchpad = tmp_path / "scratchpad"
+        scratchpad.mkdir()
+        mock_base_agent.scratchpad_dir = scratchpad
+        (scratchpad / "code.py").write_text("value = 1\n")
+
+        block = "<<<<<<< SEARCH\nvalue = 1\n=======\nvalue = 2\n>>>>>>> REPLACE"
+        result = await real_collection.call("edit", path="$KOLEGA_SCRATCHPAD/code.py", block=block)
+
+        assert str(scratchpad / "code.py") in result
+        assert (scratchpad / "code.py").read_text() == "value = 2\n"
+
+    async def test_without_scratchpad_leaves_path_unchanged(self, tool_collection: AsyncMock) -> None:
+        tool_collection.caller.scratchpad_dir = None
+        tool_collection.edit_tool.write.return_value = "Wrote $KOLEGA_SCRATCHPAD/x.txt"
+
+        result = await tool_collection.call("write", path="$KOLEGA_SCRATCHPAD/x.txt", content="hi")
+
+        assert result == "Wrote $KOLEGA_SCRATCHPAD/x.txt"
+        tool_collection.edit_tool.write.assert_called_once_with("$KOLEGA_SCRATCHPAD/x.txt", "hi")


### PR DESCRIPTION
## Problem

Agents are told to refer to the session scratchpad as `$KOLEGA_SCRATCHPAD` (the spelling shells expand), but the file tools did not expand it — a `write` call with `file_path: "$KOLEGA_SCRATCHPAD/probe.py"` created a real directory literally named `$KOLEGA_SCRATCHPAD` in the workspace root. This happened repeatedly in recent sessions (journals show `?? $KOLEGA_SCRATCHPAD/` in `git status`, and files like `$KOLEGA_SCRATCHPAD/probe_tinker.py`), polluting the user's working tree.

## Fix

Expand the reference at the single tool-dispatch choke point — `Tool.call` in `kolega_code/tools/core.py` — after param-alias resolution and before argument validation, so every file tool gets it with no per-tool changes:

- `Tool` gains `path_expander` + `path_params`; path arguments are expanded right before the handler runs.
- `ToolCollection` wires the expander for the built-in file tools (`write`, `edit`, `multi_edit`, `read`, `read_image`, `claude_edit`, `claude_write`, `hashline_edit`, `hashline_write`) via `FILE_TOOLS_WITH_PATH_PARAMS` in `kolega_code/agent/tools.py`; `apply_patch` is excluded (patch text, not a path argument).
- `expand_scratchpad_reference` in `kolega_code/scratchpad.py` replaces whole-segment `$KOLEGA_SCRATCHPAD` / `${KOLEGA_SCRATCHPAD}` with the caller's real scratchpad directory. Callers without a scratchpad are untouched (path passes through unchanged).

No prompt changes: the expansion just works when a model tries the shell spelling, and the tool set differs per model so names are kept out of the agent's context.

## Tests

- 9 unit tests for `expand_scratchpad_reference` (both spellings, bare token, mid-path, no-op cases).
- 5 dispatch-level tests through the real `ToolCollection`: `write`/`read`/`edit` with `$KOLEGA_SCRATCHPAD/...` land in the scratchpad, and no literal `$KOLEGA_SCRATCHPAD` directory appears in the workspace.

## Verification

- Full fast suite: 4610 passed. The 3 failures are the pre-existing tinker live-provider tests that fail (instead of skipping) in a worktree venv without the optional `[tinker]` extra once the main checkout's `.env` is picked up — reproduced independently of this change; they skip cleanly in isolation.
- `ruff`, `pyright`, and the tracked pre-commit hooks all pass.
