### PR TITLE
test(cli): poll agent-view signal to a deadline in memory screen test

### DIFF
--- a/tests/cli/test_app_memory.py
+++ b/tests/cli/test_app_memory.py
@@ -1,4 +1,5 @@
 # ruff: noqa: F401,F811,E402
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -11,6 +12,23 @@ from ._app_test_utils import (
     install_fake_agents,
     open_settings_screen,
 )
+
+
+async def _wait_for_agent_view(screen, pilot, *, timeout: float = 6.0) -> None:
+    """Poll until the memory screen enters agent view or time out.
+
+    ``_enter_agent_view`` flips the flag and writes the preview in one
+    synchronous step, but the view is rendered by an exclusive worker that
+    queues behind any in-flight entry load, so a fixed pause budget races the
+    worker on a loaded CI runner. Poll the completion signal to a deadline
+    before asserting preview content.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        await pilot.pause(0.02)
+        if screen._agent_view:
+            return
+    raise AssertionError(f"memory screen did not enter agent view within {timeout}s")
 
 
 async def _wait_for_entry(screen, pilot, reference: str) -> None:
@@ -538,10 +556,7 @@ async def test_memory_screen_agent_view_matches_prompt_context(
         await _wait_for_entry(screen, pilot, "MEMORY.md")
 
         screen.action_agent_view()
-        for _ in range(40):
-            await pilot.pause(0.025)
-            if screen._agent_view:
-                break
+        await _wait_for_agent_view(screen, pilot)
         assert screen._agent_view is True
 
         expected = app.memory_manager.prompt_context()
@@ -558,10 +573,7 @@ async def test_memory_screen_agent_view_matches_prompt_context(
 
         app.memory_manager.set_enabled(False)
         screen.action_agent_view()
-        for _ in range(40):
-            await pilot.pause(0.025)
-            if screen._agent_view:
-                break
+        await _wait_for_agent_view(screen, pilot)
         assert "receives no memory context" in screen.query_one("#memory_preview", Markdown).source
 
 


### PR DESCRIPTION
Follow-up to #537 (merged): the flake fix missed that merge, so `main` still has the bounded-poll version of `test_memory_screen_agent_view_matches_prompt_context`.

## Problem

The test waited for the memory screen's agent view with a fixed 40 × 25 ms pause budget. The agent view is rendered by an exclusive worker (`group="memory-screen-read"`) that queues behind any in-flight entry load, so on a loaded CI runner the preview could still show the loaded entry when the budget expired. This failed the Python 3.11 job of #537 (`assert 'receives no memory context' in '# Index...'`) while 3.12–3.14 passed with identical code — a loaded-runner timing flake, not a regression.

## Fix

`_enter_agent_view` flips the `_agent_view` flag and writes the preview in one synchronous step, so the flag is the operation's completion signal. Poll it with the repo's deadline-poll pattern (same as `_wait_for_layout` in `test_app_permission_prompts.py`) instead of a fixed budget, then assert the preview.

## Verification

- `tests/cli/test_app_memory.py` passes repeatedly on Python 3.11; full `tests/cli` tree: 1590 passed on Python 3.11.
- `ruff`, `pyright`, and the tracked pre-commit hooks pass.
