### PR TITLE
fix(cli): prevent concurrent generation cleanup race

### DIFF
--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -1305,13 +1305,21 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
         guarded: a cleanup failure is reported, never raised.
         """
         agent = self.agent
+        bundle = self._extension_bundle
         self.agent = None
-        if agent is not None:
-            try:
-                await agent.cleanup()
-            except Exception as exc:  # noqa: BLE001 — reported, never masks the primary failure
-                self._log_status(f"agent cleanup failed: {exc}", level="warn")
-        await self._cleanup_extension_bundle()
+        self._extension_bundle = None
+        try:
+            if agent is not None:
+                try:
+                    await agent.cleanup()
+                except Exception as exc:  # noqa: BLE001 — reported, never masks the primary failure
+                    self._log_status(f"agent cleanup failed: {exc}", level="warn")
+        finally:
+            if bundle is not None:
+                try:
+                    await cleanup_extension_bundle(bundle)
+                except Exception as exc:  # noqa: BLE001 — reported, never masks the primary failure
+                    self._log_status(f"extension cleanup failed: {exc}", level="warn")
 
     async def _cleanup_extension_bundle(self) -> None:
         """Release the current extension bundle exactly once (rebuild or app exit)."""

--- a/tests/cli/test_app_extensions.py
+++ b/tests/cli/test_app_extensions.py
@@ -4,6 +4,7 @@ with the prior generation's bundle cleaned up exactly once on rebuild and the
 last one on app exit."""
 
 # ruff: noqa: F401,F811,E402
+import asyncio
 import sys
 import types
 
@@ -148,6 +149,90 @@ async def test_cleanup_agent_generation_is_idempotent_and_detaches_agent(tmp_pat
         await app._cleanup_agent_generation()
         assert agent.cleanup_calls == 1
         assert recorder.cleanups == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_generation_cleanup_preserves_agent_before_bundle_order(tmp_path, monkeypatch):
+    pytest.importorskip("textual")
+    recorder = _Recorder()
+    selection = _install_extension(monkeypatch, recorder)
+    app, _config = _build_app(tmp_path, monkeypatch, selection)
+
+    async with app.run_test():
+        agent = app.agent
+        bundle = app._extension_bundle
+        assert isinstance(agent, FakeCoderAgent)
+        assert bundle is not None
+
+        cleanup_started = asyncio.Event()
+        release_cleanup = asyncio.Event()
+        events: list[str] = []
+
+        async def cleanup_agent() -> None:
+            events.append("agent-start")
+            cleanup_started.set()
+            await release_cleanup.wait()
+            events.append("agent-end")
+
+        async def cleanup_bundle() -> None:
+            events.append("bundle")
+
+        agent.cleanup = cleanup_agent
+        bundle.cleanup = cleanup_bundle
+
+        first_cleanup = asyncio.create_task(app._cleanup_agent_generation())
+        await cleanup_started.wait()
+
+        second_cleanup = asyncio.create_task(app._cleanup_agent_generation())
+        await second_cleanup
+
+        assert app.agent is None
+        assert app._extension_bundle is None
+        assert events == ["agent-start"]
+
+        release_cleanup.set()
+        await first_cleanup
+
+        assert events == ["agent-start", "agent-end", "bundle"]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_generation_cleanup_still_releases_claimed_bundle(tmp_path, monkeypatch):
+    pytest.importorskip("textual")
+    recorder = _Recorder()
+    selection = _install_extension(monkeypatch, recorder)
+    app, _config = _build_app(tmp_path, monkeypatch, selection)
+
+    async with app.run_test():
+        agent = app.agent
+        bundle = app._extension_bundle
+        assert isinstance(agent, FakeCoderAgent)
+        assert bundle is not None
+
+        cleanup_started = asyncio.Event()
+        events: list[str] = []
+
+        async def cleanup_agent() -> None:
+            events.append("agent-start")
+            cleanup_started.set()
+            await asyncio.Event().wait()
+
+        async def cleanup_bundle() -> None:
+            events.append("bundle")
+
+        agent.cleanup = cleanup_agent
+        bundle.cleanup = cleanup_bundle
+
+        cleanup_task = asyncio.create_task(app._cleanup_agent_generation())
+        await cleanup_started.wait()
+        cleanup_task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await cleanup_task
+
+        assert app.agent is None
+        assert app._extension_bundle is None
+        assert events == ["agent-start", "bundle"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- claim the agent and extension bundle together before the first cleanup await
- preserve agent-before-bundle teardown ordering across concurrent cleanup callers
- release an already-claimed bundle from `finally` when agent cleanup is cancelled
- add deterministic concurrency and cancellation regression tests

## Verification
- `PYTHONDONTWRITEBYTECODE=1 ./run_tests.sh tests/cli/test_app_extensions.py -q` (7 passed)
- `PYTHONDONTWRITEBYTECODE=1 ./run_tests.sh tests/cli/test_app_worktree_switch.py -q` (20 passed)
- `uv run ruff check kolega_code/cli/tui/agent_runtime.py tests/cli/test_app_extensions.py`
- `uv run ruff format --check kolega_code/cli/tui/agent_runtime.py tests/cli/test_app_extensions.py`
- `uv run pyright`
- `uv run pre-commit run --files kolega_code/cli/tui/agent_runtime.py tests/cli/test_app_extensions.py --show-diff-on-failure`

The full fast suite reached 4,611 passing tests and only failed three Tinker live-provider cases because the worktree had `TINKER_API_KEY` available without the optional `[tinker]` dependency installed.
