### PR TITLE
feat(agent): zero-tail compaction fallback with fail-closed strict context cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,19 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ### Changed
 
+- Automatic compaction now gets one recovery attempt when the ordinary pass —
+  which keeps the six most recent messages verbatim — still leaves a request
+  above the model's resolved input budget: a second pass with no retained tail
+  (`keep_recent=0`, journaled with trigger `auto_tail_fallback`) folds
+  everything before the safe boundary into the summary, still without touching
+  the raw history or splitting a tool call from its result. A pass that failed
+  at the model or hit the minimum-history guard is not retried. When the paired
+  `--context-window-tokens` + `--max-output-tokens` cap is active and the
+  request still does not fit, the run now fails closed with
+  `LLMContextWindowExceededError` before the primary model is called (recorded
+  as the `run.failed` error code) instead of dispatching the oversized request;
+  uncapped runs keep the legacy provider-accept-or-reject behavior.
+
 - **Breaking:** `kolega-code ask --json` now streams the semantic session-event
   protocol — one v2 event envelope per line (`schema: "kolega.session.event"`,
   stable `id`/`seq`/`timestamp`, agent lineage, typed `payload`) — replacing

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -36,6 +36,7 @@ from kolega_code.hooks import (
 )
 from kolega_code.llm.exceptions import (
     LLMConnectionError,
+    LLMContextWindowExceededError,
     LLMError,
     LLMInternalServerError,
     LLMRateLimitError,
@@ -1156,7 +1157,7 @@ class BaseAgent(LogMixin):
         )
 
     async def compress_history(
-        self, *, trigger: str = "manual", tokens_before: Optional[int] = None
+        self, *, trigger: str = "manual", tokens_before: Optional[int] = None, keep_recent: Optional[int] = None
     ) -> CompactionResult:
         """
         Non-destructively summarize the current history, keeping recent turns
@@ -1165,6 +1166,9 @@ class BaseAgent(LogMixin):
         refreshes. Returns the structured outcome.
 
         ``trigger``/``tokens_before`` are journaled as compaction provenance.
+        ``keep_recent`` overrides the compressor's verbatim tail; ``None`` keeps
+        the default six-message tail, ``0`` folds everything before the safe
+        boundary (the automatic zero-tail recovery pass).
         """
         # Compaction changes what the server restores and what the client
         # counts, so any carried residual is stale; the next clean response
@@ -1203,6 +1207,7 @@ class BaseAgent(LogMixin):
                 on_info=on_info,
                 on_error=on_error,
                 system_prompt_text=compaction_system_prompt,
+                keep_recent=keep_recent,
             )
             if result.ok:
                 # Compaction summarizes the injected volatile-context blocks along with
@@ -1231,6 +1236,50 @@ class BaseAgent(LogMixin):
         summary_text = self.conversation.summary.get_text_content() if result.ok and self.conversation.summary else ""
         await self.emitter.compaction_status(phase, result.message, summary=summary_text)
         return result
+
+    async def _auto_compact_once(
+        self, *, trigger: str, before_tokens: int, keep_recent: Optional[int] = None
+    ) -> tuple[CompactionResult, MessageHistory, TokenCount]:
+        """One automatic compaction pass with its hook lifecycle, then a rebuilt + recounted request.
+
+        Fires the advisory PreCompact/PostCompact hooks around ``compress_history``
+        with ``trigger`` provenance, then rebuilds the request history — compaction
+        moved the boundary — and recounts so the caller decides on the
+        post-compaction size. Returns the outcome plus the rebuilt history and
+        count so the agent loop can reuse them for the primary request.
+        """
+        await self.fire_hook(
+            HookEvent.PRE_COMPACT,
+            {
+                "trigger": trigger,
+                "input_tokens": before_tokens,
+                "model_context_length": self.model_context_length,
+            },
+        )
+        result = await self.compress_history(trigger=trigger, tokens_before=before_tokens, keep_recent=keep_recent)
+        # compress_history forgets the volatile-context sent-state on success,
+        # so the next turn re-sends memory, guidance, and any host sections
+        # (plan handle, task list) the summary may have folded away.
+        # Rebuild after compaction (history changed) and re-mark the cache
+        # checkpoint before re-counting so the reused history reflects it.
+        self.mark_cache_checkpoint()
+        self._sanitize_oversized_tool_results()
+        fixed_history = await self._history_for_llm_async()
+        token_count = await self.count_current_context(fixed_history)
+
+        await self.fire_hook(
+            HookEvent.POST_COMPACT,
+            {
+                "trigger": trigger,
+                "ok": result.ok,
+                "reason": result.reason,
+                "summarized_messages": result.summarized_messages,
+                "input_tokens_before": before_tokens,
+                "input_tokens_after": token_count.input_tokens,
+                "model_context_length": self.model_context_length,
+            },
+        )
+        return result, fixed_history, token_count
 
     def clear_history(self) -> None:
         """Drop all history and reset compaction state."""
@@ -2361,43 +2410,38 @@ class BaseAgent(LogMixin):
                 logger.debug("Input token count: %s", token_count)
 
                 if self.compressor.over_budget(token_count.input_tokens, self.model_max_input_tokens):
-                    before_tokens = token_count.input_tokens
-                    # PreCompact hooks (advisory): observe before history is compacted.
-                    await self.fire_hook(
-                        HookEvent.PRE_COMPACT,
-                        {
-                            "trigger": "auto",
-                            "input_tokens": before_tokens,
-                            "model_context_length": self.model_context_length,
-                        },
+                    # Ordinary pass: keep the six most recent messages verbatim.
+                    result, fixed_history, token_count = await self._auto_compact_once(
+                        trigger="auto", before_tokens=token_count.input_tokens
                     )
-                    result = await self.compress_history(trigger="auto", tokens_before=before_tokens)
-                    # compress_history forgets the volatile-context sent-state on success,
-                    # so the next turn re-sends memory, guidance, and any host sections
-                    # (plan handle, task list) the summary may have folded away.
-                    # Rebuild after compaction (history changed) and re-mark the cache
-                    # checkpoint before re-counting so the reused history reflects it.
-                    self.mark_cache_checkpoint()
-                    self._sanitize_oversized_tool_results()
-                    fixed_history = await self._history_for_llm_async()
-                    token_count = await self.count_current_context(fixed_history)
 
-                    # PostCompact hooks (advisory): observe the outcome. There is no
-                    # destructive fallback — a bounded summary plus capped tool results
-                    # and a small verbatim tail keep us under budget; if somehow not, we
-                    # send as-is rather than wipe history.
-                    await self.fire_hook(
-                        HookEvent.POST_COMPACT,
-                        {
-                            "trigger": "auto",
-                            "ok": result.ok,
-                            "reason": result.reason,
-                            "summarized_messages": result.summarized_messages,
-                            "input_tokens_before": before_tokens,
-                            "input_tokens_after": token_count.input_tokens,
-                            "model_context_length": self.model_context_length,
-                        },
-                    )
+                    # Zero-tail recovery: one aggressive pass with no requested
+                    # verbatim tail when the retained tail alone still exceeds the
+                    # resolved maximum input. Skipped when the ordinary pass failed
+                    # at the model (llm_error — the provider client already applied
+                    # its retry policy, so another summarization request buys
+                    # nothing) or hit the minimum-history guard (too_few — a zero
+                    # tail must not weaken it). A nothing_to_summarize result MAY
+                    # proceed: with no retained tail, the safe boundary can advance
+                    # past the previous one even when the six-message tail could not.
+                    if token_count.input_tokens > self.model_max_input_tokens and result.reason not in (
+                        "llm_error",
+                        "too_few",
+                    ):
+                        result, fixed_history, token_count = await self._auto_compact_once(
+                            trigger="auto_tail_fallback", before_tokens=token_count.input_tokens, keep_recent=0
+                        )
+
+                    # Fail closed only under the paired per-run cap
+                    # (--context-window-tokens + --max-output-tokens): never dispatch
+                    # a request whose measured input exceeds the run's resolved
+                    # maximum (equality is allowed). Without the cap, preserve the
+                    # legacy behavior and let the provider accept or reject it.
+                    if token_count.input_tokens > self.model_max_input_tokens and self.strict_context_budget:
+                        raise LLMContextWindowExceededError(
+                            f"Request needs {token_count.input_tokens} input tokens after automatic compaction, "
+                            f"exceeding this run's resolved maximum input of {self.model_max_input_tokens}."
+                        )
 
                 current_response = ""
                 current_thinking = ""

--- a/kolega_code/agent/compression.py
+++ b/kolega_code/agent/compression.py
@@ -65,6 +65,7 @@ class HistoryCompressor:
         on_info: Optional[LogCallback] = None,
         on_error: Optional[LogCallback] = None,
         system_prompt_text: Optional[str] = None,
+        keep_recent: Optional[int] = None,
     ) -> CompactionResult:
         """
         Non-destructively summarize the aged-out prefix while keeping the most
@@ -73,6 +74,12 @@ class HistoryCompressor:
         Incremental: only the messages that have aged out since the previous
         boundary are summarized, with the prior summary folded in for continuity.
         Returns a CompactionResult describing what happened — never a silent no-op.
+
+        ``keep_recent`` overrides KEEP_RECENT_MESSAGES (the verbatim tail). A
+        literal ``0`` is the aggressive fallback: everything before the safe
+        boundary — potentially including recent user content — becomes eligible
+        for lossy summarization. The raw history is never modified, and the
+        safe-boundary snap still keeps tool_use/tool_result pairs together.
         """
         history = conversation.history
         if not history or len(history) < self.MIN_MESSAGES_TO_COMPRESS:
@@ -85,9 +92,9 @@ class HistoryCompressor:
                 ),
             )
 
-        split = conversation.compaction_split_point(
-            keep_recent=self.KEEP_RECENT_MESSAGES, min_prefix=self.MIN_PREFIX_TO_SUMMARIZE
-        )
+        if keep_recent is None:
+            keep_recent = self.KEEP_RECENT_MESSAGES
+        split = conversation.compaction_split_point(keep_recent=keep_recent, min_prefix=self.MIN_PREFIX_TO_SUMMARIZE)
         prior_through = conversation.compacted_through if conversation.summary is not None else 0
         if split is None or split <= prior_through:
             return CompactionResult(

--- a/tests/agent/compaction_helpers.py
+++ b/tests/agent/compaction_helpers.py
@@ -5,6 +5,7 @@ No network and no API keys: every test installs a ``FakeLLM`` on the agent so
 """
 
 import uuid
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 from kolega_code.events import AgentConnectionManager
@@ -131,7 +132,7 @@ def long_history(n_pairs: int = 6) -> MessageHistory:
 # ---------------------------------------------------------------------------
 
 
-def make_agent_config():
+def make_agent_config(strict_budget: tuple[int, int] | None = None):
     from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
 
     def cfg(**extra):
@@ -142,21 +143,41 @@ def make_agent_config():
             **extra,
         )
 
+    # The paired per-run cap (--context-window-tokens + --max-output-tokens):
+    # validated together by AgentConfig and substituted into the effective model
+    # specs at agent construction (window_minus_output budgeting).
+    strict: dict[str, Any] = {}
+    if strict_budget is not None:
+        window, output = strict_budget
+        strict = {"context_window_tokens": window, "max_output_tokens": output}
+
     return AgentConfig(
         anthropic_api_key="test_key",
         openai_api_key="test_key",
         long_context_config=cfg(),
         fast_config=cfg(),
+        **strict,
     )
 
 
 def build_agent(
-    tmp_path, *, connection_manager=None, agent_cls=None, sub_agent=False, llm=None, model_context_length=1000
+    tmp_path,
+    *,
+    connection_manager=None,
+    agent_cls=None,
+    sub_agent=False,
+    llm=None,
+    model_context_length=1000,
+    strict_budget: tuple[int, int] | None = None,
 ):
     """Construct an agent wired for hermetic compaction tests.
 
     Returns ``(agent, connection_manager)``. The agent has a FakeLLM (if provided),
     a stub tool collection + system prompt, and AsyncMock log/chat sinks.
+
+    With ``strict_budget=(window, output)`` the agent derives its own
+    ``model_max_input_tokens`` from the paired cap (``window - output``); the
+    test-side override is then skipped so the derived value is the one under test.
     """
     from kolega_code.agent.baseagent import BaseAgent
 
@@ -167,7 +188,7 @@ def build_agent(
         workspace_id="test_ws",
         thread_id=str(uuid.uuid4()),
         connection_manager=cm,
-        config=make_agent_config(),
+        config=make_agent_config(strict_budget=strict_budget),
         sub_agent=sub_agent,
     )
     agent.send_chat_message = AsyncMock()
@@ -179,7 +200,8 @@ def build_agent(
     if llm is not None:
         agent.llm = llm
     agent.model_context_length = model_context_length
-    agent.model_max_input_tokens = model_context_length
+    if strict_budget is None:
+        agent.model_max_input_tokens = model_context_length
     # Histories in these tests are sized against a fixed 0.8 trigger; the
     # default threshold is asserted separately in test_compression_threshold.
     agent.history_compression_threshold = 0.8

--- a/tests/agent/test_compaction_integration.py
+++ b/tests/agent/test_compaction_integration.py
@@ -1,10 +1,21 @@
-"""Full agent-loop integration for compaction (hermetic, no network)."""
+"""Full agent-loop integration for compaction (hermetic, no network).
+
+FakeLLM token-script accounting: the loop counts once per iteration, and each
+compaction pass counts twice (``compress_history``'s finally recount for the
+gauge, then the loop's own post-pass recount on the rebuilt history). A script
+like ``[900, 1100, 1100, 400]`` therefore reads as: 900 triggers the ordinary
+pass, 1100 is its post-pass size (twice), 400 is the post-fallback size. The
+final scripted value repeats, so trailing reads stay deterministic.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from kolega_code.hooks.events import HookEvent
+from kolega_code.llm.exceptions import LLMContextWindowExceededError
 
-from .compaction_helpers import FakeLLM, build_agent, context_update_events, long_history
+from .compaction_helpers import FakeLLM, FakeStream, build_agent, context_update_events, long_history
 
 
 def _hook_spy(agent):
@@ -17,6 +28,22 @@ def _hook_spy(agent):
 
     agent.fire_hook = spy
     return fired
+
+
+def _hook_payload_spy(agent):
+    fired = []
+    original = agent.fire_hook
+
+    async def spy(name, payload, **kwargs):
+        fired.append((name, payload))
+        return await original(name, payload, **kwargs)
+
+    agent.fire_hook = spy
+    return fired
+
+
+def _compaction_triggers(fired):
+    return [payload["trigger"] for name, payload in fired if name == HookEvent.PRE_COMPACT]
 
 
 @pytest.mark.asyncio
@@ -54,7 +81,8 @@ async def test_full_loop_no_fallback_preserves_summary_when_still_over_budget(tm
 
 @pytest.mark.asyncio
 async def test_full_loop_no_compaction_under_budget(tmp_path):
-    agent, _cm = build_agent(tmp_path, llm=FakeLLM(token_script=[100]))
+    fake = FakeLLM(token_script=[100])
+    agent, _cm = build_agent(tmp_path, llm=fake)
     agent.history = long_history(6)
     fired = _hook_spy(agent)
 
@@ -64,3 +92,179 @@ async def test_full_loop_no_compaction_under_budget(tmp_path):
     assert HookEvent.PRE_COMPACT not in fired
     assert HookEvent.POST_COMPACT not in fired
     assert agent.conversation.summary is None
+    fake.stream.assert_awaited_once()  # the primary generation only
+
+
+@pytest.mark.asyncio
+async def test_full_loop_single_pass_when_normal_compaction_fits(tmp_path):
+    # Post-compaction size is back under the resolved maximum: exactly one
+    # ordinary pass, no zero-tail fallback.
+    fake = FakeLLM(token_script=[900, 300])
+    agent, _cm = build_agent(tmp_path, llm=fake)
+    agent.history = long_history(6)
+    fired = _hook_payload_spy(agent)
+
+    async for _chunk in agent.process_message_stream("hello"):
+        pass
+
+    assert _compaction_triggers(fired) == ["auto"]
+    assert fake.stream.await_count == 2  # one summarization + one primary generation
+    assert agent.conversation.summary is not None
+
+
+@pytest.mark.asyncio
+async def test_full_loop_zero_tail_fallback_when_retained_tail_too_large(tmp_path):
+    # The six-message retained tail alone still exceeds the resolved maximum
+    # (1100 > 1000): one aggressive keep_recent=0 pass folds it and the request
+    # proceeds (400 <= 1000).
+    fake = FakeLLM(token_script=[900, 1100, 1100, 400])
+    agent, _cm = build_agent(tmp_path, llm=fake)
+    agent.session_recorder = MagicMock()
+    agent.history = long_history(6)
+    original = list(agent.history)
+    fired = _hook_payload_spy(agent)
+
+    async for _chunk in agent.process_message_stream("hello"):
+        pass
+
+    # Two passes with distinct provenance, then one primary generation.
+    assert _compaction_triggers(fired) == ["auto", "auto_tail_fallback"]
+    # Each successful pass is journaled through the existing compaction record
+    # with its own trigger.
+    recorded_triggers = [
+        call.kwargs["info"]["trigger"] for call in agent.session_recorder.record_compaction.call_args_list
+    ]
+    assert recorded_triggers == ["auto", "auto_tail_fallback"]
+    assert fake.stream.await_count == 3
+    # The primary request carried the fully folded view: the summary alone.
+    primary_messages = fake.stream.await_args_list[-1].kwargs["messages"]
+    assert [m.get_text_content() for m in primary_messages] == ["SUMMARY: condensed older turns."]
+    # The raw conversation is intact — only the effective view and the
+    # compaction boundary changed. Everything present before the turn is still
+    # there, in order, and the boundary covers everything but the reply.
+    assert list(agent.history)[: len(original)] == original
+    assert agent.conversation.summary is not None
+    assert agent.conversation.compacted_through == len(agent.history) - 1
+
+
+@pytest.mark.asyncio
+async def test_full_loop_strict_cap_raises_when_fallback_insufficient(tmp_path):
+    # Paired cap: window 1000 - output 200 → resolved max input 800
+    # (window_minus_output). The zero-tail pass still leaves 900: fail closed
+    # before the primary model is called.
+    fake = FakeLLM(token_script=[700, 900, 900, 900])
+    agent, _cm = build_agent(tmp_path, llm=fake, strict_budget=(1000, 200))
+    assert agent.strict_context_budget is True
+    assert agent.model_max_input_tokens == 800
+    agent.history = long_history(6)
+    fired = _hook_payload_spy(agent)
+
+    with pytest.raises(LLMContextWindowExceededError) as excinfo:
+        async for _chunk in agent.process_message_stream("hello"):
+            pass
+
+    message = str(excinfo.value)
+    assert "900" in message  # measured input tokens
+    assert "800" in message  # resolved maximum input
+    assert _compaction_triggers(fired) == ["auto", "auto_tail_fallback"]
+    assert fake.stream.await_count == 2  # both summarizations; the primary model was never called
+
+
+@pytest.mark.asyncio
+async def test_full_loop_strict_cap_allows_equality_with_max_input(tmp_path):
+    # Equality with the resolved maximum input is allowed.
+    fake = FakeLLM(token_script=[700, 900, 900, 800])
+    agent, _cm = build_agent(tmp_path, llm=fake, strict_budget=(1000, 200))
+    assert agent.model_max_input_tokens == 800
+    agent.history = long_history(6)
+
+    async for _chunk in agent.process_message_stream("hello"):
+        pass
+
+    assert fake.stream.await_count == 3  # two summarizations + the primary generation
+
+
+@pytest.mark.asyncio
+async def test_full_loop_no_aggressive_retry_after_llm_error(tmp_path):
+    # The ordinary pass fails at the model: the provider client already applied
+    # its retry policy, so no second summarization request is issued — the final
+    # size check falls through to ordinary provider dispatch.
+    fake = FakeLLM(token_script=[900, 1100, 1100])
+    fake.stream = AsyncMock(side_effect=[RuntimeError("boom"), FakeStream()])
+    agent, _cm = build_agent(tmp_path, llm=fake)
+    agent.history = long_history(6)
+    fired = _hook_payload_spy(agent)
+
+    async for _chunk in agent.process_message_stream("hello"):
+        pass
+
+    assert _compaction_triggers(fired) == ["auto"]  # no auto_tail_fallback pass
+    assert fake.stream.await_count == 2  # the failed summarization + the primary generation
+    assert agent.conversation.summary is None  # nothing was folded
+
+
+@pytest.mark.asyncio
+async def test_full_loop_strict_cap_raises_after_llm_error_without_retry(tmp_path):
+    # Same llm_error path under the paired cap: still no aggressive retry, and
+    # the size check rejects the request before the primary model is called.
+    fake = FakeLLM(token_script=[700, 900, 900])
+    fake.stream = AsyncMock(side_effect=[RuntimeError("boom")])
+    agent, _cm = build_agent(tmp_path, llm=fake, strict_budget=(1000, 200))
+    agent.history = long_history(6)
+
+    with pytest.raises(LLMContextWindowExceededError):
+        async for _chunk in agent.process_message_stream("hello"):
+            pass
+
+    assert fake.stream.await_count == 1  # the failed summarization; no retry, no primary
+
+
+@pytest.mark.asyncio
+async def test_full_loop_no_aggressive_retry_after_too_few(tmp_path):
+    # Minimum-history guard: the zero-tail pass must not weaken it. Two stored
+    # messages plus the new user turn stay below MIN_MESSAGES_TO_COMPRESS.
+    fake = FakeLLM(token_script=[900, 1100, 1100])
+    agent, _cm = build_agent(tmp_path, llm=fake)
+    agent.history = long_history(1)  # 2 messages
+    fired = _hook_payload_spy(agent)
+
+    async for _chunk in agent.process_message_stream("hello"):
+        pass
+
+    assert _compaction_triggers(fired) == ["auto"]
+    post = [payload for name, payload in fired if name == HookEvent.POST_COMPACT]
+    assert post[0]["reason"] == "too_few"
+    assert fake.stream.await_count == 1  # the primary generation only — no summarization ran
+    assert agent.conversation.summary is None
+
+
+@pytest.mark.asyncio
+async def test_full_loop_strict_cap_raises_after_too_few(tmp_path):
+    # too_few under the paired cap: the guard stays intact and the size check
+    # rejects the request; no LLM call is made at all.
+    fake = FakeLLM(token_script=[700, 900, 900])
+    agent, _cm = build_agent(tmp_path, llm=fake, strict_budget=(1000, 200))
+    agent.history = long_history(1)  # 2 messages
+
+    with pytest.raises(LLMContextWindowExceededError):
+        async for _chunk in agent.process_message_stream("hello"):
+            pass
+
+    fake.stream.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_full_loop_ordinary_run_dispatches_when_fallback_insufficient(tmp_path):
+    # Without the paired cap, the legacy provider-dispatch behavior is preserved
+    # even when the zero-tail pass still leaves the request too large.
+    fake = FakeLLM(token_script=[900, 1100, 1100, 1200])
+    agent, _cm = build_agent(tmp_path, llm=fake)
+    agent.history = long_history(6)
+    original = list(agent.history)
+
+    async for _chunk in agent.process_message_stream("hello"):
+        pass
+
+    assert fake.stream.await_count == 3  # both summarizations + the oversized primary request
+    assert agent.conversation.summary is not None
+    assert list(agent.history)[: len(original)] == original  # raw history intact

--- a/tests/agent/test_compaction_persistence.py
+++ b/tests/agent/test_compaction_persistence.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from kolega_code.llm.models import Message, TextBlock
+
 from .compaction_helpers import FakeLLM, build_agent, long_history
 
 
@@ -43,3 +45,39 @@ async def test_agent_without_compaction_dumps_empty(tmp_path):
     fresh.restore_compaction_state(data)
     assert fresh.conversation.summary is None
     assert fresh.conversation.compacted_through == 0
+
+
+@pytest.mark.asyncio
+async def test_zero_tail_compaction_survives_dump_restore(tmp_path):
+    # A fallback pass (trigger auto_tail_fallback, keep_recent=0) folds the whole
+    # conversation; the boundary + summary round-trip like an ordinary compaction.
+    summary_msg = Message(role="assistant", content=[TextBlock(text="ZERO-TAIL PERSISTED")], stop_reason="end_turn")
+    primary_msg = Message(role="assistant", content=[TextBlock(text="PRIMARY RESPONSE")], stop_reason="end_turn")
+    fake = FakeLLM(
+        token_script=[900, 1100, 1100, 400],
+        message_script=[summary_msg, summary_msg, primary_msg],
+    )
+    agent, _cm = build_agent(tmp_path, llm=fake)
+    agent.history = long_history(6)
+
+    async for _chunk in agent.process_message_stream("hello"):
+        pass
+
+    # Zero tail: everything but the post-compaction primary reply is folded.
+    assert agent.conversation.compacted_through == len(agent.history) - 1
+    history_dump = agent.dump_message_history()
+    compaction_dump = agent.dump_compaction_state()
+    pre_effective = [m.get_text_content() for m in agent.get_effective_history_for_llm()]
+    assert compaction_dump["summary"] == "ZERO-TAIL PERSISTED"
+    assert pre_effective == ["ZERO-TAIL PERSISTED", "PRIMARY RESPONSE"]
+
+    # Resume into a fresh agent: restore messages, then the compaction boundary.
+    fresh, _cm2 = build_agent(tmp_path, llm=FakeLLM())
+    fresh.restore_message_history(history_dump)
+    fresh.restore_compaction_state(compaction_dump)
+
+    assert len(fresh.history) == len(agent.history)  # full history intact after resume
+    assert fresh.conversation.summary is not None
+    assert fresh.conversation.compacted_through == agent.conversation.compacted_through
+    # The effective view the model sees is identical to before saving.
+    assert [m.get_text_content() for m in fresh.get_effective_history_for_llm()] == pre_effective

--- a/tests/agent/test_compression.py
+++ b/tests/agent/test_compression.py
@@ -207,3 +207,62 @@ async def test_summarize_snaps_split_out_of_tool_pair():
     # Whether or not it summarized, the effective view is always valid.
     assert conv.is_valid_for_anthropic(list(conv.effective_history())) is True
     assert isinstance(result, CompactionResult)
+
+
+@pytest.mark.asyncio
+async def test_summarize_default_tail_is_keep_recent_messages():
+    # keep_recent omitted: exactly KEEP_RECENT_MESSAGES stay verbatim.
+    history = long_history(6)  # 12 messages
+    conv = Conversation(list(history))
+    result = await HistoryCompressor().summarize(conv, llm=FakeLLM(), **SUMMARIZE_KW)
+
+    assert result.ok is True
+    assert result.summarized_messages == 12 - HistoryCompressor.KEEP_RECENT_MESSAGES
+    effective = list(conv.effective_history())
+    assert (
+        list(history)[-HistoryCompressor.KEEP_RECENT_MESSAGES :] == effective[-HistoryCompressor.KEEP_RECENT_MESSAGES :]
+    )
+
+
+@pytest.mark.asyncio
+async def test_summarize_keep_recent_zero_folds_everything_before_safe_boundary():
+    # Zero-tail fallback: no verbatim tail is requested, so with a plain
+    # user/assistant history the safe boundary is the end of the conversation.
+    history = long_history(6)  # 12 messages
+    conv = Conversation(list(history))
+    llm = FakeLLM(summary_text="ZERO-TAIL SUMMARY")
+    result = await HistoryCompressor().summarize(conv, llm=llm, keep_recent=0, **SUMMARIZE_KW)
+
+    assert result.ok is True
+    assert result.summarized_messages == 12
+    assert conv.compacted_through == 12
+    # Non-destructive: the raw history is untouched; the effective view is the summary alone.
+    assert list(conv.history) == list(history)
+    effective = list(conv.effective_history())
+    assert [m.get_text_content() for m in effective] == ["ZERO-TAIL SUMMARY"]
+
+
+@pytest.mark.asyncio
+async def test_summarize_keep_recent_zero_recovers_when_default_tail_cannot_advance():
+    # Prior boundary inside the six-message tail: the ordinary pass has nothing
+    # new to fold (its candidate split is behind the boundary), but the zero-tail
+    # pass finds the later boundary and folds the remaining messages — including
+    # the previous summary, which the prompt carries forward.
+    conv = Conversation(list(long_history(6)))  # 12 messages
+    conv.apply_compaction("EARLIER SUMMARY", split_point=8)
+
+    ordinary = await HistoryCompressor().summarize(conv, llm=FakeLLM(), **SUMMARIZE_KW)
+    assert ordinary.ok is False
+    assert ordinary.reason == "nothing_to_summarize"
+
+    llm = FakeLLM(summary_text="FOLDED SUMMARY")
+    fallback = await HistoryCompressor().summarize(conv, llm=llm, keep_recent=0, **SUMMARIZE_KW)
+    assert fallback.ok is True
+    assert fallback.summarized_messages == 4  # messages 8..12 folded into the new summary
+    assert conv.compacted_through == 12
+    assert conv.summary is not None
+    assert conv.summary.get_text_content() == "FOLDED SUMMARY"
+    # The previous summary was handed to the summarizer for folding, not dropped.
+    assert llm.stream.await_args is not None
+    prompt_message = llm.stream.await_args.kwargs["messages"][0]
+    assert "EARLIER SUMMARY" in prompt_message.get_text_content()

--- a/tests/agent/test_conversation_compaction.py
+++ b/tests/agent/test_conversation_compaction.py
@@ -64,7 +64,7 @@ def test_recent_tail_is_verbatim_identity():
         assert original is shown
 
 
-@pytest.mark.parametrize("keep_recent", [1, 2, 3, 4, 5])
+@pytest.mark.parametrize("keep_recent", [0, 1, 2, 3, 4, 5])
 def test_compaction_never_splits_tool_pair(keep_recent):
     a_tc, u_tr = tool_pair("tool_x")
     history = MessageHistory(
@@ -95,6 +95,47 @@ def test_stale_compacted_through_is_clamped():
     # min(compacted_through, len) keeps it safe; no IndexError.
     effective = list(conv.effective_history())
     assert effective[-1].get_text_content() == "S"  # everything folded, tail empty
+
+
+def test_zero_tail_boundary_retains_unmatched_final_tool_call():
+    # keep_recent=0 asks to fold the whole history, but the safe-boundary snap
+    # must still move the cut back before a trailing assistant tool call, so the
+    # pending call survives verbatim instead of being folded into the summary.
+    a_tc, _u_tr = tool_pair("tool_unmatched")
+    history = [
+        text_msg("user", "u0"),
+        text_msg("assistant", "a0"),
+        text_msg("user", "u1"),
+        text_msg("assistant", "a1"),
+        a_tc,  # final message: tool call with no result yet
+    ]
+    conv = _conv(history)
+    split = conv.compaction_split_point(keep_recent=0, min_prefix=1)
+
+    assert split == 4  # snapped back from 5: the unmatched call forces a retained tail
+    conv.apply_compaction("S", split)
+    effective = list(conv.effective_history())
+    assert effective[-1] is a_tc  # same object, verbatim
+    assert len(conv.history) == 5  # raw history untouched
+
+
+def test_zero_tail_boundary_folds_matched_tool_pair_together():
+    # Ending on the tool RESULT: the pair is either both-folded or both-kept —
+    # here both fold (the snap only walks back over assistant tool calls), and
+    # the effective view stays valid.
+    a_tc, u_tr = tool_pair("tool_matched")
+    history = [
+        text_msg("user", "u0"),
+        text_msg("assistant", "a0"),
+        a_tc,
+        u_tr,
+    ]
+    conv = _conv(history)
+    split = conv.compaction_split_point(keep_recent=0, min_prefix=1)
+
+    assert split == 4
+    conv.apply_compaction("S", split)
+    assert conv.is_valid_for_anthropic(list(conv.effective_history())) is True
 
 
 def test_clear_resets_compaction_state():


### PR DESCRIPTION
## Summary

Automatic compaction gets one recovery attempt when the ordinary pass — which keeps the six most recent messages verbatim — still leaves a request above the agent's resolved `model_max_input_tokens`: a second pass with no retained tail (`keep_recent=0`, journaled with trigger `auto_tail_fallback`) folds everything before the safe boundary into the summary. When the paired `--context-window-tokens` + `--max-output-tokens` cap is active and the request still does not fit, the run fails closed with `LLMContextWindowExceededError` before the primary model is called; uncapped runs keep the legacy provider-accept-or-reject behavior.

## Behavior

- **Fallback pass** reuses the existing summarizer, previous summary, and safe-boundary logic: raw history is never deleted or truncated, and a tool call is never split from its result (an unmatched trailing tool call forces a retained tail). Minimum-history and minimum-prefix guards are unchanged; a first pass returning `llm_error` or `too_few` is not retried, while `nothing_to_summarize` may still advance (the zero tail can find a later boundary than the six-message tail).
- **Applies to every automatic parent/child agent-loop request** (single call site in `_agent_loop_stream`). The fallback decision never branches on `strict_context_budget`; only the final raise does. Manual `/compress` remains one ordinary pass.
- **Fail-closed path**: no new exception or event — the existing `LLMContextWindowExceededError` (message carries measured input + resolved maximum) propagates through `handle_llm_error` and is journaled as the `run.failed` error code. No primary-model call, no third compaction, no history clearing.
- **Session restore** needs no format change: the fallback pass journals the same `context.compacted` record (latest record wins on replay; boundary clamps on restore), covered by a new round-trip test. Volatile-context re-injection and residual reset are inherited from `compress_history`.

## Implementation

- `compression.py`: `HistoryCompressor.summarize(..., keep_recent: Optional[int] = None)` — `None` keeps `KEEP_RECENT_MESSAGES`, `0` is the aggressive tail.
- `baseagent.py`: `compress_history(..., keep_recent=None)` passthrough; the loop's per-pass sequence (PreCompact hook → compress → rebuild → recount → PostCompact hook) extracted to `_auto_compact_once` so both passes share identical hook payloads and provenance.

## Tests

- Unit: zero-tail folds everything before the safe boundary; default tail pinned to six; `nothing_to_summarize` → zero-tail recovery folds the previous summary forward.
- Boundary: zero-tail retains an unmatched final tool call verbatim; matched pairs fold together; `keep_recent=0` added to the never-split parametrize.
- Loop: single-pass fits; fallback succeeds (raw history intact, journal triggers `["auto", "auto_tail_fallback"]`); strict cap raises with measured/resolved values and never calls the primary model; strict equality allowed; `llm_error`/`too_few` skip the retry in ordinary and strict modes; ordinary run still dispatches when the fallback is insufficient.
- Persistence: zero-tail boundary + summary survive dump/restore with identical effective history.

Focused suites: 80 passed. Full `tests/agent`: 2298 passed (3 `tinker` live-test failures are the documented fresh-worktree `.env`-leak artifact — they skip in isolation and are unrelated). Full-repo pyright clean; pre-commit hooks passed.