### PR TITLE
fix(cli): prevent concurrent session journal corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ### Fixed
 
+- A session could be opened in two kolega-code instances at once, interleaving
+  duplicate event sequence numbers into the session journal until it became
+  unreadable (and `switch_worktree`/`save` failed with "Session event sequence
+  gap"). Resuming a session that is already open in another instance is now
+  refused with a clear error, journal appends allocate sequence numbers under
+  a cross-process lock, and `kolega-code sessions repair <id>` renumbers a
+  corrupted journal back into a contiguous sequence.
+
 - File tools (`read`, `write`, `edit`, `multi_edit`, `read_image`) now expand
   a `$KOLEGA_SCRATCHPAD` (or `${KOLEGA_SCRATCHPAD}`) reference in path
   arguments to the session scratchpad at the tool-dispatch choke point, so

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -569,6 +569,9 @@ def _build_subcommand_parser() -> argparse.ArgumentParser:
     sessions_delete = sessions_sub.add_parser("delete", help="Delete a session.")
     sessions_delete.add_argument("session_id")
     sessions_delete.add_argument("--state-dir", type=Path, help="Directory for CLI session state.")
+    sessions_repair = sessions_sub.add_parser("repair", help="Renumber the events of a corrupted session journal.")
+    sessions_repair.add_argument("session_id")
+    sessions_repair.add_argument("--state-dir", type=Path, help="Directory for CLI session state.")
     sessions_export = sessions_sub.add_parser("export", help="Export a session (replay JSON or semantic events).")
     sessions_export.add_argument("session_id")
     sessions_export.add_argument(
@@ -1922,6 +1925,12 @@ async def _run_ask(args: argparse.Namespace) -> int:
                     # a run that already failed keeps its own exit status.
                     exit_code = 1
 
+        # The command's ownership of the session ends here: release the
+        # cross-process lock so a sequential resume in this process (tests,
+        # embedded hosts) is not refused. A concurrent process cannot run
+        # while this command is alive, so there is no window to exploit.
+        store.release_session_locks()
+
     return exit_code
 
 
@@ -2150,6 +2159,10 @@ def _run_sessions(args: argparse.Namespace) -> int:
     if args.sessions_command == "delete":
         store.delete(args.session_id)
         print(f"Deleted session {args.session_id}")
+        return 0
+    if args.sessions_command == "repair":
+        count = store.repair_sequence(args.session_id)
+        print(f"Repaired session {args.session_id}: {count} events with a contiguous sequence.")
         return 0
     if args.sessions_command == "export":
         export_format = getattr(args, "format", "json")

--- a/kolega_code/cli/session_journal.py
+++ b/kolega_code/cli/session_journal.py
@@ -15,6 +15,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterable, Optional, cast
 
+from filelock import BaseFileLock, Timeout
+
 from kolega_code.llm.models import ContentBlock, Message, ToolResult
 from kolega_code.local_state import ensure_private_dir, ensure_private_file, write_private_bytes
 
@@ -242,6 +244,7 @@ class SessionJournal:
         session_dir: Path,
         lock: Optional[threading.RLock] = None,
         artifact_reference_dir: Optional[Path] = None,
+        cross_process_lock: Optional[BaseFileLock] = None,
     ) -> None:
         self.session_id = session_id
         self.session_dir = session_dir
@@ -249,6 +252,7 @@ class SessionJournal:
         self.artifacts_dir = session_dir / "artifacts"
         self.artifact_reference_dir = artifact_reference_dir or self.artifacts_dir
         self._lock = lock or threading.RLock()
+        self._cross_process_lock: Optional[BaseFileLock] = cross_process_lock
         self._loaded = False
         self._next_seq = 1
         self._epoch_id: Optional[str] = None
@@ -308,39 +312,172 @@ class SessionJournal:
         agent: Optional[AgentStamp] = None,
     ) -> SessionEvent:
         with self._lock:
-            self._ensure_loaded_locked()
-            resolved_epoch = epoch_id or self._epoch_id
-            if not resolved_epoch:
-                raise SessionJournalError("An epoch id is required for every session event")
-            stamp = agent or self._root_stamp
-            event = SessionEvent(
-                version=EVENT_SCHEMA_VERSION,
-                event_id=str(uuid.uuid4()),
-                session_id=self.session_id,
-                seq=self._next_seq,
-                epoch_id=resolved_epoch,
-                turn_id=turn_id,
-                timestamp=_now(),
-                actor=actor,
-                event_type=event_type,
-                payload=payload or {},
-                artifacts=artifacts or [],
-                agent_id=stamp.agent_id,
-                agent_name=stamp.agent_name,
-                parent_agent_id=stamp.parent_agent_id,
-                parent_tool_call_id=stamp.parent_tool_call_id,
-                depth=stamp.depth,
-            )
-            self._write_event_locked(event)
-            self._next_seq += 1
-            if event_type == "context.epoch_started":
-                self._epoch_id = resolved_epoch
-            for listener in self._listeners:
+            if self._cross_process_lock is not None:
                 try:
-                    listener(event)
-                except Exception:
-                    logger.exception("Session event listener failed for %s", event_type)
-            return event
+                    with self._cross_process_lock:
+                        return self._append_locked(
+                            event_type,
+                            actor=actor,
+                            payload=payload,
+                            turn_id=turn_id,
+                            epoch_id=epoch_id,
+                            artifacts=artifacts,
+                            agent=agent,
+                        )
+                except Timeout as exc:
+                    raise SessionJournalError(
+                        f"Session event log is locked by another kolega-code instance: {self.events_path}"
+                    ) from exc
+            return self._append_locked(
+                event_type,
+                actor=actor,
+                payload=payload,
+                turn_id=turn_id,
+                epoch_id=epoch_id,
+                artifacts=artifacts,
+                agent=agent,
+            )
+
+    def _append_locked(
+        self,
+        event_type: str,
+        *,
+        actor: str,
+        payload: Optional[dict[str, Any]] = None,
+        turn_id: Optional[str] = None,
+        epoch_id: Optional[str] = None,
+        artifacts: Optional[list[dict[str, Any]]] = None,
+        agent: Optional[AgentStamp] = None,
+    ) -> SessionEvent:
+        """Allocate and persist one event; callers hold the process lock and, when configured, the cross-process lock."""
+        self._ensure_loaded_locked()
+        if self._cross_process_lock is not None:
+            self._resync_seq_from_tail_locked()
+        resolved_epoch = epoch_id or self._epoch_id
+        if not resolved_epoch:
+            raise SessionJournalError("An epoch id is required for every session event")
+        stamp = agent or self._root_stamp
+        event = SessionEvent(
+            version=EVENT_SCHEMA_VERSION,
+            event_id=str(uuid.uuid4()),
+            session_id=self.session_id,
+            seq=self._next_seq,
+            epoch_id=resolved_epoch,
+            turn_id=turn_id,
+            timestamp=_now(),
+            actor=actor,
+            event_type=event_type,
+            payload=payload or {},
+            artifacts=artifacts or [],
+            agent_id=stamp.agent_id,
+            agent_name=stamp.agent_name,
+            parent_agent_id=stamp.parent_agent_id,
+            parent_tool_call_id=stamp.parent_tool_call_id,
+            depth=stamp.depth,
+        )
+        self._write_event_locked(event)
+        self._next_seq += 1
+        if event_type == "context.epoch_started":
+            self._epoch_id = resolved_epoch
+        for listener in self._listeners:
+            try:
+                listener(event)
+            except Exception:
+                logger.exception("Session event listener failed for %s", event_type)
+        return event
+
+    def _resync_seq_from_tail_locked(self) -> None:
+        """Reconcile ``_next_seq`` with the durable tail after another writer appended.
+
+        Called with the cross-process lock held, so the tail read cannot race
+        with another writer's allocate+write. A missing or unreadable tail
+        (e.g. a crashed partial write) falls back to a full repair-and-reload.
+        """
+        tail_seq = self._read_tail_seq_locked()
+        if tail_seq is None:
+            events = self._read_events_locked(repair_tail=True)
+            self._set_state_from_events_locked(events)
+            return
+        if tail_seq + 1 != self._next_seq:
+            self._next_seq = tail_seq + 1
+
+    def _read_tail_seq_locked(self) -> Optional[int]:
+        """Return the seq of the last complete event line, or None when absent or unreadable."""
+        if not self.events_path.exists():
+            return None
+        try:
+            size = self.events_path.stat().st_size
+        except OSError:
+            return None
+        if size == 0:
+            return None
+        try:
+            with open(self.events_path, "rb") as fh:
+                fh.seek(max(0, size - 65536))
+                chunk = fh.read()
+        except OSError:
+            return None
+        if chunk.endswith(b"\n"):
+            lines = chunk.split(b"\n")
+            last = lines[-2] if len(lines) >= 2 else b""
+        else:
+            last = chunk.split(b"\n")[-1]
+        if not last.strip():
+            return None
+        try:
+            data = json.loads(last)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return None
+        seq = data.get("seq") if isinstance(data, dict) else None
+        return seq if isinstance(seq, int) else None
+
+    def repair_sequence(self) -> int:
+        """Renumber every event 1..N in file order and return the event count.
+
+        Rewrites the journal atomically only when the sequence is broken. The
+        store holds the cross-process lock around calls that may race with
+        another instance; the lock is acquired here too for direct callers.
+        """
+        with self._lock:
+            if self._cross_process_lock is not None:
+                with self._cross_process_lock:
+                    return self._repair_sequence_locked()
+            return self._repair_sequence_locked()
+
+    def _repair_sequence_locked(self) -> int:
+        events = self._read_events_locked(repair_tail=True, strict_seq=False)
+        if not events:
+            self._set_state_from_events_locked(events)
+            return 0
+        needs_rewrite = any(event.seq != index for index, event in enumerate(events, start=1))
+        if needs_rewrite:
+            payload = b"".join(
+                (
+                    json.dumps(replace(event, seq=index).to_dict(), separators=(",", ":"), ensure_ascii=False) + "\n"
+                ).encode("utf-8")
+                for index, event in enumerate(events, start=1)
+            )
+            tmp_path = self.events_path.with_name(f".{self.events_path.name}.repair-{uuid.uuid4().hex}")
+            try:
+                fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+                try:
+                    os.fchmod(fd, 0o600)
+                    with os.fdopen(fd, "wb") as fh:
+                        fh.write(payload)
+                        fh.flush()
+                        os.fsync(fh.fileno())
+                except BaseException:
+                    os.close(fd)
+                    raise
+                os.replace(tmp_path, self.events_path)
+            except BaseException:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
+        self._set_state_from_events_locked(events)
+        return len(events)
 
     def _write_event_locked(self, event: SessionEvent) -> None:
         """Append one complete event, truncating a failed partial write."""
@@ -546,7 +683,7 @@ class SessionJournal:
                 self._epoch_id = event.epoch_id
         self._loaded = True
 
-    def _read_events_locked(self, *, repair_tail: bool) -> list[SessionEvent]:
+    def _read_events_locked(self, *, repair_tail: bool, strict_seq: bool = True) -> list[SessionEvent]:
         if not self.events_path.exists():
             return []
         try:
@@ -586,7 +723,7 @@ class SessionJournal:
                 raise SessionJournalError(
                     f"Session event at line {line_number} belongs to {event.session_id}, expected {self.session_id}"
                 )
-            if event.seq != expected_seq:
+            if strict_seq and event.seq != expected_seq:
                 raise SessionJournalError(
                     f"Session event sequence gap at line {line_number}: expected {expected_seq}, got {event.seq}"
                 )

--- a/kolega_code/cli/session_store.py
+++ b/kolega_code/cli/session_store.py
@@ -14,6 +14,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Iterator, Optional, Sequence
 
+from filelock import BaseFileLock, FileLock, Timeout
+
 from kolega_code.local_state import ensure_private_dir, write_private_text
 
 from .session_journal import (
@@ -195,6 +197,7 @@ class SessionStore:
         self.sessions_dir = self.root / "sessions"
         self._locks_guard = threading.RLock()
         self._locks: dict[str, threading.RLock] = {}
+        self._session_locks: dict[str, BaseFileLock] = {}
         self._journals: dict[str, SessionJournal] = {}
         self._recorders: dict[str, SessionRecorder] = {}
 
@@ -352,6 +355,7 @@ class SessionStore:
         if not self.session_dir_for(session_id).exists():
             raise SessionStoreError(f"Session not found: {session_id}")
         with self._lock_for(session_id):
+            self._acquire_session_lock(session_id)
             with self._locks_guard:
                 recorder = self._recorders.get(session_id)
             if recorder is not None:
@@ -368,9 +372,80 @@ class SessionStore:
         with self._locks_guard:
             journal = self._journals.get(session_id)
             if journal is None:
-                journal = SessionJournal(session_id, self.session_dir_for(session_id), self._lock_for(session_id))
+                journal = SessionJournal(
+                    session_id,
+                    self.session_dir_for(session_id),
+                    self._lock_for(session_id),
+                    cross_process_lock=self._session_lock_for(session_id),
+                )
                 self._journals[session_id] = journal
             return journal
+
+    def _session_lock_for(self, session_id: str) -> BaseFileLock:
+        """Return the shared cross-process lock for a session (one instance per store).
+
+        The lock file is a dot-prefixed sibling of the session directory, so
+        session listing, migration, and export never see it. ``thread_local``
+        is disabled so acquire/release balance across the store's threads
+        (recording, background saves), and ``timeout`` is zero so contention
+        surfaces immediately as a refusal instead of blocking.
+        """
+        with self._locks_guard:
+            lock = self._session_locks.get(session_id)
+            if lock is None:
+                lock = FileLock(
+                    self.sessions_dir / f".{_validate_session_id(session_id)}.lock",
+                    timeout=0,
+                    thread_local=False,
+                )
+                self._session_locks[session_id] = lock
+            return lock
+
+    def _acquire_session_lock(self, session_id: str) -> None:
+        """Take exclusive ownership of a session for this process.
+
+        The lock is held for the process lifetime — ``flock`` releases it
+        automatically on exit, so there is no stale-lock cleanup. A second
+        instance opening the same session is refused here.
+        """
+        lock = self._session_lock_for(session_id)
+        try:
+            lock.acquire(timeout=0)
+        except Timeout as exc:
+            raise SessionStoreError(
+                f"Session {session_id} is already open in another kolega-code instance; close it there before retrying."
+            ) from exc
+
+    def repair_sequence(self, session_id: str) -> int:
+        """Renumber a corrupted journal's events 1..N in file order; returns the event count.
+
+        Refused while another instance holds the session, because repairing a
+        live journal is exactly the corruption scenario.
+        """
+        self._ensure_migrated(session_id)
+        if not self.session_dir_for(session_id).exists():
+            raise SessionStoreError(f"Session not found: {session_id}")
+        with self._lock_for(session_id):
+            self._acquire_session_lock(session_id)
+            try:
+                return self.journal(session_id).repair_sequence()
+            finally:
+                self._session_lock_for(session_id).release()
+
+    def release_session_locks(self) -> None:
+        """Release every cross-process session lock held by this store.
+
+        Ownership is per-invocation for headless commands: a finished command
+        must not keep the session locked for the rest of the process's life,
+        or a sequential resume in the same process (tests, embedded hosts)
+        would be refused. The TUI keeps its locks until process exit, which
+        releases them via ``flock``.
+        """
+        with self._locks_guard:
+            locks = list(self._session_locks.values())
+        for lock in locks:
+            if lock.is_locked:
+                lock.release(force=True)
 
     def start_epoch(self, session_id: str, reason: str) -> str:
         return self.recorder(session_id).start_epoch(reason)

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -977,3 +977,26 @@ def test_ask_prompt_with_unresolved_mention_warns_on_stderr(
     captured = capsys.readouterr()
     assert "@missing.md not found" in captured.err
     assert FakeCoderAgent.instances[0].attachments == [None]
+
+
+def test_sessions_repair_renumbers_corrupted_journal(tmp_path: Path, capsys) -> None:
+    import json
+
+    from kolega_code.cli import main as main_module
+    from kolega_code.cli.session_store import SessionStore
+
+    project = tmp_path / "project"
+    project.mkdir()
+    store = SessionStore(tmp_path / "state")
+    record = store.create(project, "code", {})
+    events_path = store.events_path_for(record.session_id)
+    events = [json.loads(line) for line in events_path.read_text(encoding="utf-8").splitlines()]
+    events[1]["seq"] = events[0]["seq"]
+    events_path.write_text("\n".join(json.dumps(event) for event in events) + "\n", encoding="utf-8")
+
+    exit_code = main_module.main(["sessions", "repair", record.session_id, "--state-dir", str(tmp_path / "state")])
+
+    assert exit_code == 0
+    assert f"Repaired session {record.session_id}" in capsys.readouterr().out
+    loaded = store.load(record.session_id)
+    assert loaded.session_id == record.session_id

--- a/tests/cli/test_session_event_store.py
+++ b/tests/cli/test_session_event_store.py
@@ -199,3 +199,90 @@ async def test_llm_events_are_invisible_to_the_presentation_stream(tmp_path):
     )
     events = await FileSessionEventStore(journal).read(session.session_id)
     assert events == []
+
+
+def test_append_resyncs_from_tail_after_foreign_writer(tmp_path: Path) -> None:
+    """A writer that bypassed this journal object must not cause duplicate seqs."""
+    import json
+
+    from filelock import FileLock
+
+    from kolega_code.cli.session_journal import SessionJournal
+
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    lock = FileLock(tmp_path / "session.lock", timeout=0, thread_local=False)
+    journal = SessionJournal("test-session", session_dir, cross_process_lock=lock)
+    journal.append("context.epoch_started", actor="system", epoch_id="epoch-1")
+    journal.append("test.event", actor="system", epoch_id="epoch-1")
+
+    # A second writer appends directly to the file, advancing the durable tail
+    # past this journal's in-memory counter.
+    events_path = session_dir / "events.jsonl"
+    base = json.loads(events_path.read_text(encoding="utf-8").splitlines()[-1])
+    for seq in (3, 4):
+        foreign = dict(base)
+        foreign["seq"] = seq
+        foreign["event_id"] = f"foreign-{seq}"
+        with events_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(foreign) + "\n")
+
+    event = journal.append("test.event", actor="system", epoch_id="epoch-1")
+    assert event.seq == 5
+    assert [e.seq for e in journal.read_events()] == [1, 2, 3, 4, 5]
+
+
+def test_concurrent_appends_keep_sequence_monotonic(tmp_path: Path) -> None:
+    """Two processes appending to one journal produce one contiguous sequence."""
+    import subprocess
+    import sys
+    import textwrap
+
+    from kolega_code.cli.session_journal import SessionJournal
+
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    child_script = tmp_path / "append_loop.py"
+    child_script.write_text(
+        textwrap.dedent(
+            """\
+            import sys
+            from pathlib import Path
+
+            from filelock import FileLock
+
+            from kolega_code.cli.session_journal import SessionJournal
+
+            session_dir = Path(sys.argv[1])
+            who = sys.argv[2]
+            lock = FileLock(session_dir / ".lock", timeout=30, thread_local=False)
+            journal = SessionJournal("test-session", session_dir, cross_process_lock=lock)
+            for index in range(25):
+                journal.append("test.event", actor=who, payload={"index": index}, epoch_id="epoch-1")
+            """
+        ),
+        encoding="utf-8",
+    )
+    procs = [
+        subprocess.Popen(
+            [sys.executable, str(child_script), str(session_dir), "writer-a"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        ),
+        subprocess.Popen(
+            [sys.executable, str(child_script), str(session_dir), "writer-b"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        ),
+    ]
+    for proc in procs:
+        _, stderr = proc.communicate(timeout=60)
+        assert proc.returncode == 0, stderr
+
+    journal = SessionJournal("test-session", session_dir)
+    events = journal.read_events()
+    assert len(events) == 50
+    assert [event.seq for event in events] == list(range(1, 51))
+    assert len({event.event_id for event in events}) == 50

--- a/tests/cli/test_session_store.py
+++ b/tests/cli/test_session_store.py
@@ -1,6 +1,9 @@
 import json
 import os
 import stat
+import subprocess
+import sys
+import time
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -890,3 +893,109 @@ def test_rewind_of_recovered_crashed_turn(tmp_path: Path) -> None:
     recovered.record_rewind(turns[1].turn_id)
     loaded = store.load(record.session_id)
     assert [message["content"][0]["text"] for message in loaded.history] == ["turn one", "answer one"]
+
+
+def _corrupt_journal_with_duplicate_seq(events_path: Path) -> None:
+    """Rewrite a journal so line 2 duplicates line 1's seq (the two-instance corruption pattern)."""
+    events = [json.loads(line) for line in events_path.read_text(encoding="utf-8").splitlines()]
+    events[1]["seq"] = events[0]["seq"]
+    for index in range(2, len(events)):
+        events[index]["seq"] = events[0]["seq"] + index - 1
+    events_path.write_text("\n".join(json.dumps(event) for event in events) + "\n", encoding="utf-8")
+
+
+def test_recorder_refuses_second_instance(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    first = SessionStore(tmp_path / "state")
+    second = SessionStore(tmp_path / "state")
+    record = first.create(project, "code", {})
+    recorder = first.recorder(record.session_id)
+
+    with pytest.raises(SessionStoreError, match="already open"):
+        second.recorder(record.session_id)
+
+    # The first instance keeps recording normally.
+    journal = first.journal(record.session_id)
+    event = journal.append("test.event", actor="system", epoch_id=journal.epoch_id)
+    assert event.seq == 3
+    assert recorder.journal is journal
+
+
+def test_recorder_same_store_reentrant(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    store = SessionStore(tmp_path / "state")
+    record = store.create(project, "code", {})
+    first = store.recorder(record.session_id)
+    second = store.recorder(record.session_id)
+    assert second is first
+
+
+def test_recorder_lock_released_on_process_exit(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    store = SessionStore(tmp_path / "state")
+    record = store.create(project, "code", {})
+
+    child_script = tmp_path / "hold_lock.py"
+    child_script.write_text(
+        "import sys\n"
+        "import time\n"
+        "from pathlib import Path\n"
+        "from kolega_code.cli.session_store import SessionStore\n"
+        "state_dir, session_id = sys.argv[1], sys.argv[2]\n"
+        "store = SessionStore(Path(state_dir))\n"
+        "store.recorder(session_id)\n"
+        "Path(state_dir, 'locked.marker').write_text('ok')\n"
+        "time.sleep(30)\n",
+        encoding="utf-8",
+    )
+    proc = subprocess.Popen(
+        [sys.executable, str(child_script), str(tmp_path / "state"), record.session_id],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        marker = tmp_path / "state" / "locked.marker"
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            if marker.exists():
+                break
+            if proc.poll() is not None:
+                child_error = proc.stderr.read() if proc.stderr is not None else ""
+                raise AssertionError(f"child exited early: {child_error}")
+            time.sleep(0.05)
+        assert marker.exists(), "child never acquired the session lock"
+
+        with pytest.raises(SessionStoreError, match="already open"):
+            store.recorder(record.session_id)
+    finally:
+        proc.terminate()
+        proc.wait(timeout=10)
+
+    recorder = store.recorder(record.session_id)
+    assert recorder is not None
+
+
+def test_repair_sequence_recovers_gap(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    store = SessionStore(tmp_path / "state")
+    record = store.create(project, "code", {})
+    events_path = store.events_path_for(record.session_id)
+    _corrupt_journal_with_duplicate_seq(events_path)
+
+    with pytest.raises(SessionStoreError, match="sequence gap"):
+        store.load(record.session_id)
+
+    count = store.repair_sequence(record.session_id)
+    assert count == 2
+    loaded = store.load(record.session_id)
+    assert loaded.session_id == record.session_id
+
+    journal = store.journal(record.session_id)
+    event = journal.append("test.event", actor="system", epoch_id=journal.epoch_id)
+    assert event.seq == count + 1
+    assert [e.seq for e in journal.read_events()] == [1, 2, 3]


### PR DESCRIPTION
## What

Opening the same session in two kolega-code instances at once interleaved duplicate event sequence numbers into `events.jsonl`, permanently corrupting the journal (a mid-file gap `repair_tail` cannot fix) and breaking `load`/`save`/`switch_worktree` with "Session event sequence gap" errors. This makes that structurally impossible and adds a repair path for journals that are already broken.

## Changes

- **Exclusive session ownership** — `SessionStore.recorder()` acquires a per-session cross-process lock (`flock` via `filelock`, one instance per store, dot-prefixed sibling lock file so listing/migration/export never see it). A second instance resuming the session is refused with a clear error instead of corrupting the journal; read-only views (list/export) still work. Headless `ask` releases the lock when the command finishes so sequential resumes within one process keep working; the TUI holds it until process exit.
- **Collision-proof seq allocation** — `SessionJournal.append()` allocates `seq` under the same cross-process lock and resyncs its counter from the durable tail, so even a writer that bypasses the ownership guard produces contiguous, gap-free sequences.
- **Repair tooling** — new `kolega-code sessions repair <id>` renumbers a corrupted journal back into a contiguous 1..N sequence in file order (atomic rewrite; refused while another instance holds the session).

## Tests

- Two stores on the same state dir: second `recorder()` refused with "already open"; first keeps recording.
- Subprocess test: lock released on process exit.
- Same-store reentrancy; journal append resyncs from a foreign writer's tail; two processes appending concurrently produce one contiguous 1..50 sequence; `repair_sequence` recovers a duplicate-seq journal and continues at N+1.
- CLI smoke test for `sessions repair`.

## Verification

- Fast suite: 4633 passed; only the 4 pre-existing environmental live-provider failures (tinker needs the optional `[tinker]` extra; kimi key hit its billing quota).
- `ruff check`, `ruff format`, and `pre-commit run --all-files` (incl. pyright) all pass.
