### PR TITLE
fix(cli): clarify --compression-threshold 100 semantics

### DIFF
--- a/docs/src/content/docs/cli/ask.md
+++ b/docs/src/content/docs/cli/ask.md
@@ -27,7 +27,7 @@ kolega-code ask "<prompt>" [options]
 | `--lsp <on\|off>` | Force LSP tools on or off for this session (overrides settings; not persisted) |
 | `--subagents <on\|off>` | Force sub-agent dispatch (`dispatch_agent`) on or off for this session (overrides settings; not persisted; default on) |
 | `--skills <on\|off>` | Force [Agent Skills](../../skills/) on or off for this session (overrides settings; not persisted; default on). When off, skills are not discovered and the `skill` tool is not exposed |
-| `--compression-threshold PERCENT` | Context-window usage that triggers automatic history compression (`10`–`100`, default `80`; `100` disables proactive compression; over-limit recovery and explicit context caps remain enforced). Overrides settings for the session; not persisted |
+| `--compression-threshold PERCENT` | Context-window usage that triggers automatic history compression (`10`–`100`, default `95`; `100` disables proactive compression; over-limit recovery and explicit context caps remain enforced). Overrides settings for the session; not persisted |
 | `--session <ID>` | Resume or create a specific session |
 | `--state-dir <PATH>` | Directory for CLI session state |
 | `--extension <MODULE:FACTORY>` | Load one installed Python extension for this run (see [Extensions](../../concepts/extensions/)) |

--- a/docs/src/content/docs/cli/ask.md
+++ b/docs/src/content/docs/cli/ask.md
@@ -27,7 +27,7 @@ kolega-code ask "<prompt>" [options]
 | `--lsp <on\|off>` | Force LSP tools on or off for this session (overrides settings; not persisted) |
 | `--subagents <on\|off>` | Force sub-agent dispatch (`dispatch_agent`) on or off for this session (overrides settings; not persisted; default on) |
 | `--skills <on\|off>` | Force [Agent Skills](../../skills/) on or off for this session (overrides settings; not persisted; default on). When off, skills are not discovered and the `skill` tool is not exposed |
-| `--compression-threshold PERCENT` | Context-window usage that triggers automatic history compression (`10`–`100`, default `80`; `100` effectively disables it). Overrides settings for the session; not persisted |
+| `--compression-threshold PERCENT` | Context-window usage that triggers automatic history compression (`10`–`100`, default `80`; `100` disables proactive compression; over-limit recovery and explicit context caps remain enforced). Overrides settings for the session; not persisted |
 | `--session <ID>` | Resume or create a specific session |
 | `--state-dir <PATH>` | Directory for CLI session state |
 | `--extension <MODULE:FACTORY>` | Load one installed Python extension for this run (see [Extensions](../../concepts/extensions/)) |

--- a/docs/src/content/docs/cli/overview.md
+++ b/docs/src/content/docs/cli/overview.md
@@ -122,7 +122,7 @@ for the run.
 | `--thinking-effort` | Model-specific thinking effort, such as `auto`, `medium`, `high`, or `max` |
 | `--edit-protocol` | Override the model-facing edit language with `search_replace`, `codex_apply_patch`, or `claude_code` |
 | `--environment` | Environment label for tracing/metadata |
-| `--compression-threshold PERCENT` | Context-window usage that triggers automatic history compression (`10`–`100`, default `80`; `100` disables proactive compression; over-limit recovery and explicit context caps remain enforced). Overrides settings for the session; not persisted |
+| `--compression-threshold PERCENT` | Context-window usage that triggers automatic history compression (`10`–`100`, default `95`; `100` disables proactive compression; over-limit recovery and explicit context caps remain enforced). Overrides settings for the session; not persisted |
 
 ## Session-state options
 

--- a/docs/src/content/docs/cli/overview.md
+++ b/docs/src/content/docs/cli/overview.md
@@ -122,7 +122,7 @@ for the run.
 | `--thinking-effort` | Model-specific thinking effort, such as `auto`, `medium`, `high`, or `max` |
 | `--edit-protocol` | Override the model-facing edit language with `search_replace`, `codex_apply_patch`, or `claude_code` |
 | `--environment` | Environment label for tracing/metadata |
-| `--compression-threshold PERCENT` | Context-window usage that triggers automatic history compression (`10`–`100`, default `80`; `100` effectively disables it). Overrides settings for the session; not persisted |
+| `--compression-threshold PERCENT` | Context-window usage that triggers automatic history compression (`10`–`100`, default `80`; `100` disables proactive compression; over-limit recovery and explicit context caps remain enforced). Overrides settings for the session; not persisted |
 
 ## Session-state options
 

--- a/docs/src/content/docs/concepts/how-it-works.md
+++ b/docs/src/content/docs/concepts/how-it-works.md
@@ -22,7 +22,7 @@ The agent owns three things worth knowing about:
 - **Conversation** — the running message history.
 - **History compression** — when the conversation grows large, older context is
   compressed to stay within the model's budget. Automatic compression kicks in
-  once context usage crosses a threshold (80% by default — configurable in
+  once context usage crosses a threshold (95% by default — configurable in
   Settings → Tools or with `--compression-threshold`). You can also trigger it
   manually with [`/compress`](../../tui/slash-commands/) and inspect the current
   size with `/context`.

--- a/docs/src/content/docs/configuration/environment-variables.md
+++ b/docs/src/content/docs/configuration/environment-variables.md
@@ -125,7 +125,7 @@ with vision support.
 | `KOLEGA_CODE_STATE_DIR` | Override where settings and sessions are stored |
 | `KOLEGA_CODE_ENVIRONMENT` | Environment label attached to tracing/metadata (default `development`) |
 | `KOLEGA_CODE_NO_DIAGNOSTICS` | Set to any value to disable the local [diagnostics](../../troubleshooting/diagnostics/) log and responsiveness watchdog |
-| `KOLEGA_CODE_COMPRESSION_THRESHOLD` | Context-window usage percent that triggers automatic history compression (`10`–`100`, default `80`; `100` effectively disables automatic compression) |
+| `KOLEGA_CODE_COMPRESSION_THRESHOLD` | Context-window usage percent that triggers automatic history compression (`10`–`100`, default `80`; `100` disables proactive compression; over-limit recovery and explicit context caps remain enforced) |
 | `KOLEGA_CODE_SUBAGENTS` | Sub-agent dispatch (`dispatch_agent`) master switch: `on` or `off` (default `on`). Useful for headless or CI runs; the `--subagents` flag takes precedence |
 | `KOLEGA_CODE_SKILLS` | [Agent Skills](../../skills/) master switch: `on` or `off` (default `on`). When `off`, skills are not discovered, the `skill` tool is not exposed, and `/skills` reports that Agent Skills are disabled; the `--skills` flag takes precedence |
 

--- a/docs/src/content/docs/configuration/environment-variables.md
+++ b/docs/src/content/docs/configuration/environment-variables.md
@@ -125,7 +125,7 @@ with vision support.
 | `KOLEGA_CODE_STATE_DIR` | Override where settings and sessions are stored |
 | `KOLEGA_CODE_ENVIRONMENT` | Environment label attached to tracing/metadata (default `development`) |
 | `KOLEGA_CODE_NO_DIAGNOSTICS` | Set to any value to disable the local [diagnostics](../../troubleshooting/diagnostics/) log and responsiveness watchdog |
-| `KOLEGA_CODE_COMPRESSION_THRESHOLD` | Context-window usage percent that triggers automatic history compression (`10`–`100`, default `80`; `100` disables proactive compression; over-limit recovery and explicit context caps remain enforced) |
+| `KOLEGA_CODE_COMPRESSION_THRESHOLD` | Context-window usage percent that triggers automatic history compression (`10`–`100`, default `95`; `100` disables proactive compression; over-limit recovery and explicit context caps remain enforced) |
 | `KOLEGA_CODE_SUBAGENTS` | Sub-agent dispatch (`dispatch_agent`) master switch: `on` or `off` (default `on`). Useful for headless or CI runs; the `--subagents` flag takes precedence |
 | `KOLEGA_CODE_SKILLS` | [Agent Skills](../../skills/) master switch: `on` or `off` (default `on`). When `off`, skills are not discovered, the `skill` tool is not exposed, and `/skills` reports that Agent Skills are disabled; the `--skills` flag takes precedence |
 

--- a/docs/src/content/docs/configuration/settings-and-api-keys.mdx
+++ b/docs/src/content/docs/configuration/settings-and-api-keys.mdx
@@ -99,8 +99,9 @@ your self-hosted instance. The same settings can be supplied with
 
 The **Tools** category also holds the **history-compression threshold**: the
 context-window usage percent at which older conversation history is summarized
-automatically (default `80%`). Choose `100%` to effectively disable automatic
-compression — `/compress` always works manually. For one session only, override
+automatically (default `95%`). Choose `100%` to disable proactive
+compression; over-limit recovery and explicit context caps remain enforced
+— `/compress` always works manually. For one session only, override
 it with `--compression-threshold PERCENT` or `KOLEGA_CODE_COMPRESSION_THRESHOLD`;
 the editor notes when a launch flag or environment variable has pinned the value.
 

--- a/kolega_code/cli/config.py
+++ b/kolega_code/cli/config.py
@@ -356,7 +356,7 @@ def _compression_threshold(
     """Resolve the compression threshold with flag-over-env-over-settings precedence.
 
     User-facing surfaces carry a percent (10-100); the returned value is the
-    fraction the agent compares against, or None for the built-in default (80%).
+    fraction the agent compares against, or None for the built-in default (95%).
     Explicit flag/env values are validated strictly (a typo must fail loudly);
     settings values were already range-coerced at load."""
     # Resolve presence per layer instead of via _explicit_value, whose truthiness

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -256,7 +256,7 @@ def _add_common_model_args(parser: argparse.ArgumentParser) -> None:
         metavar="PERCENT",
         help="Input-budget usage percentage that triggers automatic history compression "
         "(10-100; default 95). Overrides settings.json for this session; not persisted. "
-        "100 effectively disables automatic compression.",
+        "100 disables proactive compression; over-limit recovery and explicit context caps remain enforced.",
     )
     parser.add_argument(
         "--context-window-tokens",

--- a/kolega_code/cli/settings.py
+++ b/kolega_code/cli/settings.py
@@ -147,7 +147,7 @@ class CliSettings:
     skills_enabled: Optional[bool] = None
     # Context-window usage percent that triggers automatic history compression.
     # Additive optional field — absent in older files -> None -> the agent's
-    # built-in default (80%).
+    # built-in default (95%).
     compression_threshold: Optional[float] = None
     schema_version: int = SETTINGS_SCHEMA_VERSION
 
@@ -197,7 +197,7 @@ class CliSettings:
             subagents_enabled=data.get("subagents_enabled"),
             # Additive optional field; absent in older files -> None (enabled).
             skills_enabled=data.get("skills_enabled"),
-            # Additive optional field; absent in older files -> None (default 80%).
+            # Additive optional field; absent in older files -> None (default 95%).
             compression_threshold=_coerce_compression_threshold(data.get("compression_threshold")),
         )
 

--- a/kolega_code/cli/tui/settings_panel.py
+++ b/kolega_code/cli/tui/settings_panel.py
@@ -82,7 +82,7 @@ MCP_TRANSPORT_OPTIONS = [
 MCP_ENABLED_OPTIONS = [("Enabled", "true"), ("Disabled", "false")]
 MCP_STATUS_MESSAGE_MAX = 96
 MCP_STATUS_NAME_MAX = 34
-# Compression threshold select: "default" maps to None (the agent's built-in 80%).
+# Compression threshold select: "default" maps to None (the agent's built-in 95%).
 COMPRESSION_THRESHOLD_DEFAULT_VALUE = "default"
 COMPRESSION_THRESHOLD_PRESET_PERCENTS = (50, 60, 70, 80, 90, 95, 100)
 MCP_ATTENTION_STATUSES = {"failed", "stale", "unverified"}
@@ -159,7 +159,7 @@ def _compression_threshold_option_value(percent: float) -> str:
 
 def compression_threshold_options(saved: Optional[float] = None) -> list[tuple[str, str]]:
     """Select options for the compression threshold, presets plus any saved off-list value."""
-    options: list[tuple[str, str]] = [("Default (80%)", COMPRESSION_THRESHOLD_DEFAULT_VALUE)]
+    options: list[tuple[str, str]] = [("Default (95%)", COMPRESSION_THRESHOLD_DEFAULT_VALUE)]
     options.extend((f"{percent}%", str(percent)) for percent in COMPRESSION_THRESHOLD_PRESET_PERCENTS)
     if saved is not None:
         saved_value = _compression_threshold_option_value(saved)

--- a/kolega_code/cli/tui/settings_screen.py
+++ b/kolega_code/cli/tui/settings_screen.py
@@ -411,7 +411,8 @@ class SettingsScreen(ModalScreen[None]):
                 compression_section.border_title = "Context Compression"
                 yield Static(
                     "Summarize older conversation history once context-window usage crosses this "
-                    "threshold. 100% effectively disables automatic compression; /compress stays manual.",
+                    "threshold. 100% disables proactive compression; over-limit recovery and explicit "
+                    "context caps remain enforced; /compress stays manual.",
                     classes="settings-hint",
                 )
                 yield Static("", id="compression_status")

--- a/tests/cli/test_compression_threshold.py
+++ b/tests/cli/test_compression_threshold.py
@@ -57,7 +57,7 @@ def _persist_threshold(tmp_path, percent: float):
 def test_compression_resolution_precedence():
     settings = CliSettings(compression_threshold=65.0)
     env = {"KOLEGA_CODE_COMPRESSION_THRESHOLD": "70"}
-    # flag > env > settings > default (None -> the agent's built-in 0.8)
+    # flag > env > settings > default (None -> the agent's built-in 0.95)
     assert _compression_threshold(env, settings, "90") == pytest.approx(0.9)
     assert _compression_threshold(env, settings, None) == pytest.approx(0.7)
     assert _compression_threshold({}, settings, None) == pytest.approx(0.65)

--- a/tests/cli/test_settings.py
+++ b/tests/cli/test_settings.py
@@ -399,7 +399,7 @@ def test_settings_store_round_trips_compression_threshold(tmp_path: Path) -> Non
     assert loaded.compression_threshold == 85.0
     assert loaded.to_dict()["compression_threshold"] == 85.0
 
-    # Absent in older files -> None -> the agent's built-in default (80%) applies.
+    # Absent in older files -> None -> the agent's built-in default (95%) applies.
     store.save(CliSettings())
     assert SettingsStore(tmp_path).load().compression_threshold is None
 


### PR DESCRIPTION
## What

The `--compression-threshold` help text said `100` "effectively disables automatic compression", which is misleading: over-limit recovery and explicit context caps are still enforced at `100`.

Replaced the wording with: **`100 disables proactive compression; over-limit recovery and explicit context caps remain enforced.`**

Also corrected the documented default from `80` to `95` (the built-in default is `BaseAgent.history_compression_threshold = 0.95`) in docs, the TUI settings label, and code comments.

## Changes

- `kolega_code/cli/main.py` — `--compression-threshold` argparse help
- `kolega_code/cli/tui/settings_screen.py` — Context Compression settings hint
- `kolega_code/cli/tui/settings_panel.py` — "Default (95%)" select label + comment
- `kolega_code/cli/settings.py`, `kolega_code/cli/config.py` — stale default comments
- Docs: `cli/ask.md`, `cli/overview.md`, `concepts/how-it-works.md`, `configuration/environment-variables.md`, `configuration/settings-and-api-keys.mdx`

Wording/comment-only change; no behavior changes.

## Verification

- `uv run kolega-code ask --help` renders the new wording
- `tests/cli/test_compression_threshold.py`, `tests/cli/test_app_compression_settings.py`, `tests/cli/test_settings.py`, `tests/cli/test_app_status_modes.py`, `tests/agent/test_compression.py`: 101 passed
- Pre-commit hooks (ruff, pyright, etc.) pass
