### PR TITLE
feat(llm): enforce strict per-run context budget in LLMClient

### DIFF
--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -2484,6 +2484,10 @@ class BaseAgent(LogMixin):
                             tools=self.tool_collection.get_tool_list(),
                             thinking=self.primary_model_config.thinking_effort,
                             hosted_web_search=self.hosted_web_search_active,
+                            # The strict per-run budget rechecks this request inside
+                            # the client; hand it the count already taken for the
+                            # gauge (same history) so it is not counted twice.
+                            _precomputed_input_tokens=token_count.input_tokens,
                         ),
                     )
                     async with stream_cm as stream:

--- a/kolega_code/agent/context.py
+++ b/kolega_code/agent/context.py
@@ -133,6 +133,8 @@ class AgentContext:
                 token_manager=self.config.get_chatgpt_token_manager(),
                 usage_ledger=self.telemetry.usage_ledger,
                 trace_sink=self.telemetry.llm_trace_sink,
+                context_window_tokens=self.config.context_window_tokens,
+                max_output_tokens=self.config.max_output_tokens,
             )
 
         return LLMClient(
@@ -145,4 +147,6 @@ class AgentContext:
             token_manager=self.config.get_chatgpt_token_manager(),
             usage_ledger=self.telemetry.usage_ledger,
             trace_sink=self.telemetry.llm_trace_sink,
+            context_window_tokens=self.config.context_window_tokens,
+            max_output_tokens=self.config.max_output_tokens,
         )

--- a/kolega_code/llm/client.py
+++ b/kolega_code/llm/client.py
@@ -31,9 +31,11 @@ The module also provides supporting classes and types for working with messages,
 tools, and provider-specific parameters in a standardized way.
 """
 
+import dataclasses
+import inspect
 from typing import TYPE_CHECKING, Any, AsyncContextManager, Coroutine, Dict, List, Optional, Union
 
-from .exceptions import map_to_llm_error
+from .exceptions import LLMContextWindowExceededError, map_to_llm_error
 from .ledger import LedgerStreamAdapter, UsageLedger, describe_error
 from .models import Message, MessageHistory, ToolDefinition
 from .providers.models import GenerationParams, TokenCount
@@ -78,11 +80,21 @@ class LLMClient:
         model: Optional[str] = None,
         usage_ledger: Optional[UsageLedger] = None,
         trace_sink: Optional[Any] = None,
+        context_window_tokens: Optional[int] = None,
+        max_output_tokens: Optional[int] = None,
     ):
+        if (context_window_tokens is None) != (max_output_tokens is None):
+            raise ValueError("context_window_tokens and max_output_tokens must be supplied together")
         self.provider_name = provider.lower()
         self._api_key = api_key  # Store API key privately
         # Refreshing OAuth token manager, used only by the ChatGPT-subscription provider.
         self._token_manager = token_manager
+        # Strict per-run context budget (the paired AgentConfig fields, propagated
+        # by AgentContext.create_llm_client). When set, generate()/stream() cap the
+        # output maximum at max_output_tokens and reject, before any provider call,
+        # a request whose counted input exceeds context_window_tokens - output.
+        self._context_window_tokens = context_window_tokens
+        self._max_output_tokens = max_output_tokens
         # Optional structured trace sink for the native Tinker provider (the
         # on-policy RL trajectory record). Ignored by every other provider.
         self._trace_sink = trace_sink
@@ -290,6 +302,61 @@ class LLMClient:
             raise ValueError("A model is required when setting thinking effort.")
         return validate_thinking_effort(self.provider_name, model, thinking)
 
+    @property
+    def _has_run_context_budget(self) -> bool:
+        return self._context_window_tokens is not None and self._max_output_tokens is not None
+
+    async def _enforce_run_context_budget(
+        self,
+        messages: MessageHistory,
+        system: Optional[Message],
+        params: GenerationParams,
+        kwargs: Dict[str, Any],
+        precomputed_input_tokens: Optional[int],
+    ) -> GenerationParams:
+        """Apply the strict per-run context budget to one request.
+
+        Returns the params to send: a copy of ``params`` carrying the effective
+        output maximum (the smaller of the caller's request and the run-wide cap,
+        or the run-wide cap when the caller requested none). The supplied params
+        are never mutated. Raises LLMContextWindowExceededError before any
+        provider generation when the request's input — the fully rendered
+        request, counted with the same messages/system/tools/model and
+        renderer-affecting thinking setting — exceeds
+        ``context_window_tokens - effective_output`` (equality is allowed).
+        ``precomputed_input_tokens`` is the caller's own count of this exact
+        request (BaseAgent already counts its main-loop request for the context
+        gauge); when given, no second count is performed.
+        """
+        assert self._context_window_tokens is not None and self._max_output_tokens is not None
+        requested = params.max_completion_tokens
+        effective_output = self._max_output_tokens if requested is None else min(requested, self._max_output_tokens)
+
+        if precomputed_input_tokens is not None:
+            input_tokens = precomputed_input_tokens
+        else:
+            counted = await self.provider.count_tokens(
+                messages=messages,
+                system=system,
+                model=self._request_model(kwargs),
+                tools=params.tools or [],
+                thinking=params.thinking,
+            )
+            input_tokens = counted.input_tokens
+
+        max_input = self._context_window_tokens - effective_output
+        if input_tokens > max_input:
+            raise LLMContextWindowExceededError(
+                f"Request needs {input_tokens} input tokens, exceeding this run's maximum input of "
+                f"{max_input} (context window {self._context_window_tokens} tokens minus "
+                f"{effective_output} reserved output tokens).",
+                provider=self.provider_name,
+            )
+
+        if effective_output == params.max_completion_tokens:
+            return params
+        return dataclasses.replace(params, max_completion_tokens=effective_output)
+
     async def generate(
         self,
         messages: MessageHistory,
@@ -300,6 +367,8 @@ class LLMClient:
         thinking: Optional[Union[int, str]] = None,
         params: Optional[GenerationParams] = None,
         hosted_web_search: bool = False,
+        *,
+        _precomputed_input_tokens: Optional[int] = None,
         **kwargs: Any,
     ) -> Message:
         """Generate a complete response from the LLM provider.
@@ -314,6 +383,10 @@ class LLMClient:
             params (Optional[GenerationParams]): Override all parameters with a GenerationParams object
             hosted_web_search (bool): Expose the provider's server-side web_search
                 tool (Responses APIs only; ignored elsewhere).
+            _precomputed_input_tokens: Internal. The caller's own input count for
+                this exact request; used by the strict per-run context budget to
+                avoid counting the same request twice. Never forwarded to
+                providers.
             **kwargs: Additional provider-specific parameters
 
         Returns:
@@ -332,6 +405,10 @@ class LLMClient:
                         thinking, str(kwargs.get("model")) if kwargs.get("model") else None
                     ),
                     hosted_web_search=hosted_web_search,
+                )
+            if self._has_run_context_budget:
+                params = await self._enforce_run_context_budget(
+                    messages, system, params, kwargs, _precomputed_input_tokens
                 )
             if self._usage_ledger is None:
                 return await self.provider.generate(messages, system, params, **kwargs)
@@ -359,6 +436,8 @@ class LLMClient:
         thinking: Optional[Union[int, str]] = None,
         params: Optional[GenerationParams] = None,
         hosted_web_search: bool = False,
+        *,
+        _precomputed_input_tokens: Optional[int] = None,
         **kwargs: Any,
     ) -> Union[AsyncContextManager[Any], Coroutine[Any, Any, AsyncContextManager[Any]]]:
         """Generate a streaming response from the LLM provider.
@@ -373,6 +452,10 @@ class LLMClient:
             params (Optional[GenerationParams]): Override all parameters with a GenerationParams object
             hosted_web_search (bool): Expose the provider's server-side web_search
                 tool (Responses APIs only; ignored elsewhere).
+            _precomputed_input_tokens: Internal. The caller's own input count for
+                this exact request; used by the strict per-run context budget to
+                avoid counting the same request twice. Never forwarded to
+                providers.
             **kwargs: Additional provider-specific parameters
 
         Returns:
@@ -393,6 +476,12 @@ class LLMClient:
                     hosted_web_search=hosted_web_search,
                 )
 
+            if self._has_run_context_budget:
+                # The budget check is async (token counting), and stream() is not:
+                # defer both into a coroutine so the over-limit error surfaces when
+                # the caller awaits — still before any provider generation.
+                return self._budgeted_stream(messages, system, params, kwargs, _precomputed_input_tokens)
+
             # Return the appropriate stream type for the provider
             inner = self.provider.stream(messages, system, params, **kwargs)
             if self._usage_ledger is None:
@@ -400,6 +489,27 @@ class LLMClient:
             return self._ledgered_stream(inner, self._request_model(kwargs))
         except Exception as e:
             raise map_to_llm_error(e, self.provider_name) from e
+
+    async def _budgeted_stream(
+        self,
+        messages: MessageHistory,
+        system: Optional[Message],
+        params: GenerationParams,
+        kwargs: Dict[str, Any],
+        precomputed_input_tokens: Optional[int],
+    ) -> AsyncContextManager[Any]:
+        """Enforce the run context budget, then open the provider stream.
+
+        Runs when the caller awaits the stream — the point the request starts —
+        so the over-limit error is raised before any provider generation.
+        """
+        params = await self._enforce_run_context_budget(messages, system, params, kwargs, precomputed_input_tokens)
+        inner = self.provider.stream(messages, system, params, **kwargs)
+        if self._usage_ledger is not None:
+            return await self._ledgered_stream(inner, self._request_model(kwargs))
+        if inspect.iscoroutine(inner):
+            return await inner
+        return inner
 
     def _request_model(self, kwargs: Dict[str, Any]) -> Optional[str]:
         model = kwargs.get("model")

--- a/kolega_code/llm/instrumented_client.py
+++ b/kolega_code/llm/instrumented_client.py
@@ -57,6 +57,8 @@ class InstrumentedLLMClient(LLMClient):
         model: Optional[str] = None,
         usage_ledger: Optional[Any] = None,
         trace_sink: Optional[Any] = None,
+        context_window_tokens: Optional[int] = None,
+        max_output_tokens: Optional[int] = None,
     ):
         super().__init__(
             provider,
@@ -68,6 +70,8 @@ class InstrumentedLLMClient(LLMClient):
             model=model,
             usage_ledger=usage_ledger,
             trace_sink=trace_sink,
+            context_window_tokens=context_window_tokens,
+            max_output_tokens=max_output_tokens,
         )
         self.langfuse = langfuse_client
         self.workspace_id = workspace_id
@@ -190,13 +194,23 @@ class InstrumentedLLMClient(LLMClient):
         tools: Optional[List[ToolDefinition]] = None,
         thinking: Optional[Union[int, str]] = None,
         params: Optional[GenerationParams] = None,
+        *,
+        _precomputed_input_tokens: Optional[int] = None,
         **kwargs: Any,
     ) -> Message:
         """Generate with Langfuse tracing."""
         if not self.langfuse:
             # Fallback to non-instrumented if Langfuse not configured
             return await super().generate(
-                messages, system, temperature, max_completion_tokens, tools, thinking, params, **kwargs
+                messages,
+                system,
+                temperature,
+                max_completion_tokens,
+                tools,
+                thinking,
+                params,
+                _precomputed_input_tokens=_precomputed_input_tokens,
+                **kwargs,
             )
 
         # Extract model from kwargs
@@ -259,7 +273,15 @@ class InstrumentedLLMClient(LLMClient):
         try:
             # Call parent generate method
             response = await super().generate(
-                messages, system, temperature, max_completion_tokens, tools, thinking, params, **kwargs
+                messages,
+                system,
+                temperature,
+                max_completion_tokens,
+                tools,
+                thinking,
+                params,
+                _precomputed_input_tokens=_precomputed_input_tokens,
+                **kwargs,
             )
 
             # Extract token usage from response
@@ -331,13 +353,23 @@ class InstrumentedLLMClient(LLMClient):
         tools: Optional[List[ToolDefinition]] = None,
         thinking: Optional[Union[int, str]] = None,
         params: Optional[GenerationParams] = None,
+        *,
+        _precomputed_input_tokens: Optional[int] = None,
         **kwargs: Any,
     ) -> Union[AsyncContextManager[Any], Coroutine[Any, Any, AsyncContextManager[Any]]]:
         """Stream a response with Langfuse tracing"""
         if not self.langfuse:
             # Fallback to non-instrumented if Langfuse not configured
             return super().stream(
-                messages, system, temperature, max_completion_tokens, tools, thinking, params, **kwargs
+                messages,
+                system,
+                temperature,
+                max_completion_tokens,
+                tools,
+                thinking,
+                params,
+                _precomputed_input_tokens=_precomputed_input_tokens,
+                **kwargs,
             )
 
         # ``self.langfuse`` is guaranteed non-None here (we returned early above).
@@ -408,7 +440,16 @@ class InstrumentedLLMClient(LLMClient):
 
             # Get stream from underlying client
             stream = LLMClient.stream(
-                self, messages, system, temperature, max_completion_tokens, tools, thinking, params, **kwargs
+                self,
+                messages,
+                system,
+                temperature,
+                max_completion_tokens,
+                tools,
+                thinking,
+                params,
+                _precomputed_input_tokens=_precomputed_input_tokens,
+                **kwargs,
             )
 
             # Check if stream is a coroutine (needs to be awaited)

--- a/tests/agent/llm/test_client_context_budget.py
+++ b/tests/agent/llm/test_client_context_budget.py
@@ -1,0 +1,494 @@
+"""Strict per-run context budget enforcement in LLMClient/InstrumentedLLMClient.
+
+When the paired caps (context_window_tokens + max_output_tokens) are propagated
+from AgentConfig through AgentContext.create_llm_client, generate()/stream()
+cap the effective output maximum, count the fully rendered request, and raise
+LLMContextWindowExceededError before any provider generation when the input
+exceeds context_window_tokens - effective_output (equality allowed). Without
+the pair, behavior is byte-for-byte the legacy path (no counting, params
+untouched).
+"""
+
+from typing import Any, AsyncContextManager, Coroutine, Dict, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from kolega_code.llm.client import GenerationParams, LLMClient, TokenCount
+from kolega_code.llm.exceptions import LLMContextWindowExceededError
+from kolega_code.llm.instrumented_client import InstrumentedLLMClient
+from kolega_code.llm.models import Message, MessageHistory, TextBlock, ToolDefinition
+
+WINDOW = 1000
+RUN_OUTPUT = 200
+
+MESSAGES = MessageHistory([Message("user", [TextBlock("Hello")])])
+SYSTEM = Message("system", [TextBlock("You are helpful.")])
+TOOLS = [ToolDefinition(name="echo", description="Echo input", parameters=[])]
+
+
+def _client(**overrides) -> LLMClient:
+    kwargs: Dict[str, Any] = dict(
+        provider="anthropic",
+        api_key="test-key",
+        context_window_tokens=WINDOW,
+        max_output_tokens=RUN_OUTPUT,
+    )
+    kwargs.update(overrides)
+    return LLMClient(**kwargs)
+
+
+def _mock_provider(client: LLMClient, input_tokens: int) -> Dict[str, Any]:
+    """Patch the client's provider with recording mocks; return captured state."""
+    captured: Dict[str, Any] = {"count_calls": 0, "generate_calls": 0, "stream_calls": 0}
+
+    async def _count_tokens(messages=None, system=None, model=None, tools=None, thinking=None, **kwargs):
+        captured["count_calls"] += 1
+        captured["count_args"] = {
+            "messages": messages,
+            "system": system,
+            "model": model,
+            "tools": tools,
+            "thinking": thinking,
+        }
+        return TokenCount(input_tokens=input_tokens)
+
+    async def _generate(messages, system, params, **kwargs):
+        captured["generate_calls"] += 1
+        captured["generate_params"] = params
+        captured["generate_kwargs"] = kwargs
+        return Message("assistant", [TextBlock("ok")])
+
+    async def _stream(messages, system, params, **kwargs):
+        captured["stream_calls"] += 1
+        captured["stream_params"] = params
+        return _FakeStreamCM()
+
+    client.provider.count_tokens = _count_tokens  # type: ignore[assignment]
+    client.provider.generate = _generate  # type: ignore[assignment]
+    client.provider.stream = _stream  # type: ignore[assignment]
+    return captured
+
+
+class _FakeStreamCM:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+    async def get_final_message(self):
+        return Message("assistant", [TextBlock("summary text")])
+
+
+async def _open_stream(client: LLMClient, *args, **kwargs) -> AsyncContextManager[Any]:
+    """Await client.stream()'s union return (every concrete provider is async)."""
+    return await cast(Coroutine[Any, Any, AsyncContextManager[Any]], client.stream(*args, **kwargs))
+
+
+def _mock_langfuse():
+    langfuse = MagicMock()
+    generation = MagicMock()
+    trace = MagicMock()
+    trace.start_generation = MagicMock(return_value=generation)
+    langfuse.start_span = MagicMock(return_value=trace)
+    return langfuse, trace, generation
+
+
+# ---------------------------------------------------------------------------
+# Constructor pairing
+# ---------------------------------------------------------------------------
+
+
+def test_constructor_requires_paired_caps():
+    with pytest.raises(ValueError, match="supplied together"):
+        LLMClient(provider="anthropic", api_key="test-key", context_window_tokens=WINDOW)
+    with pytest.raises(ValueError, match="supplied together"):
+        LLMClient(provider="anthropic", api_key="test-key", max_output_tokens=RUN_OUTPUT)
+
+
+# ---------------------------------------------------------------------------
+# generate(): effective output maximum
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_caps_caller_output_to_run_max():
+    client = _client()
+    captured = _mock_provider(client, input_tokens=100)
+    await client.generate(MESSAGES, SYSTEM, max_completion_tokens=500, model="m")
+    assert captured["generate_params"].max_completion_tokens == RUN_OUTPUT
+
+
+@pytest.mark.asyncio
+async def test_generate_uses_run_max_when_caller_supplies_none():
+    client = _client()
+    captured = _mock_provider(client, input_tokens=100)
+    await client.generate(MESSAGES, SYSTEM, model="m")
+    assert captured["generate_params"].max_completion_tokens == RUN_OUTPUT
+
+
+@pytest.mark.asyncio
+async def test_generate_keeps_smaller_caller_output_limit():
+    client = _client()
+    captured = _mock_provider(client, input_tokens=100)
+    await client.generate(MESSAGES, SYSTEM, max_completion_tokens=50, model="m")
+    assert captured["generate_params"].max_completion_tokens == 50
+
+
+@pytest.mark.asyncio
+async def test_generate_input_ceiling_derives_from_effective_output():
+    # 900 input tokens fit when the caller's smaller output limit (50) raises
+    # the input ceiling to 950...
+    client = _client()
+    captured = _mock_provider(client, input_tokens=900)
+    await client.generate(MESSAGES, SYSTEM, max_completion_tokens=50, model="m")
+    assert captured["generate_calls"] == 1
+
+    # ...but not when the run-wide output reservation (200) lowers it to 800.
+    client = _client()
+    captured = _mock_provider(client, input_tokens=900)
+    with pytest.raises(LLMContextWindowExceededError):
+        await client.generate(MESSAGES, SYSTEM, model="m")
+    assert captured["generate_calls"] == 0
+
+
+# ---------------------------------------------------------------------------
+# generate(): boundary and rejection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_exact_boundary_is_allowed():
+    client = _client()
+    captured = _mock_provider(client, input_tokens=WINDOW - RUN_OUTPUT)
+    await client.generate(MESSAGES, SYSTEM, model="m")
+    assert captured["generate_calls"] == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_over_limit_rejected_before_provider_invocation():
+    client = _client()
+    captured = _mock_provider(client, input_tokens=WINDOW - RUN_OUTPUT + 1)
+    with pytest.raises(LLMContextWindowExceededError):
+        await client.generate(MESSAGES, SYSTEM, model="m")
+    assert captured["generate_calls"] == 0
+    assert captured["count_calls"] == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_counts_fully_rendered_request():
+    client = _client()
+    captured = _mock_provider(client, input_tokens=100)
+    params = GenerationParams(max_completion_tokens=100, tools=TOOLS, thinking="high")
+    await client.generate(MESSAGES, SYSTEM, params=params, model="claude-test")
+    count_args = captured["count_args"]
+    assert count_args["messages"] is MESSAGES
+    assert count_args["system"] is SYSTEM
+    assert count_args["tools"] is TOOLS
+    assert count_args["model"] == "claude-test"
+    assert count_args["thinking"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_generate_does_not_mutate_supplied_params():
+    client = _client()
+    captured = _mock_provider(client, input_tokens=100)
+    params = GenerationParams(temperature=0.3, max_completion_tokens=500, tools=TOOLS)
+    await client.generate(MESSAGES, SYSTEM, params=params, model="m")
+    assert params.max_completion_tokens == 500
+    sent = captured["generate_params"]
+    assert sent is not params
+    assert sent.max_completion_tokens == RUN_OUTPUT
+    assert sent.temperature == 0.3
+    assert sent.tools is TOOLS
+
+
+# ---------------------------------------------------------------------------
+# generate(): precomputed count
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_precomputed_count_skips_recount():
+    client = _client()
+    captured = _mock_provider(client, input_tokens=999_999)
+    await client.generate(MESSAGES, SYSTEM, model="m", _precomputed_input_tokens=WINDOW - RUN_OUTPUT)
+    assert captured["count_calls"] == 0
+    assert captured["generate_calls"] == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_over_limit_precomputed_count_rejected_without_recount():
+    client = _client()
+    captured = _mock_provider(client, input_tokens=0)
+    with pytest.raises(LLMContextWindowExceededError):
+        await client.generate(MESSAGES, SYSTEM, model="m", _precomputed_input_tokens=WINDOW - RUN_OUTPUT + 1)
+    assert captured["count_calls"] == 0
+    assert captured["generate_calls"] == 0
+
+
+# ---------------------------------------------------------------------------
+# stream(): same contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_caps_caller_output_to_run_max():
+    client = _client()
+    captured = _mock_provider(client, input_tokens=100)
+    cm = await _open_stream(client, MESSAGES, SYSTEM, max_completion_tokens=500, model="m")
+    assert captured["stream_params"].max_completion_tokens == RUN_OUTPUT
+    async with cm:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_stream_exact_boundary_is_allowed():
+    client = _client()
+    captured = _mock_provider(client, input_tokens=WINDOW - RUN_OUTPUT)
+    cm = await _open_stream(client, MESSAGES, SYSTEM, model="m")
+    assert captured["stream_calls"] == 1
+    async with cm:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_stream_over_limit_rejected_before_provider_invocation():
+    client = _client()
+    captured = _mock_provider(client, input_tokens=WINDOW - RUN_OUTPUT + 1)
+    with pytest.raises(LLMContextWindowExceededError):
+        await _open_stream(client, MESSAGES, SYSTEM, model="m")
+    assert captured["stream_calls"] == 0
+    assert captured["count_calls"] == 1
+
+
+@pytest.mark.asyncio
+async def test_stream_precomputed_count_skips_recount():
+    client = _client()
+    captured = _mock_provider(client, input_tokens=999_999)
+    cm = await _open_stream(client, MESSAGES, SYSTEM, model="m", _precomputed_input_tokens=WINDOW - RUN_OUTPUT)
+    assert captured["count_calls"] == 0
+    assert captured["stream_calls"] == 1
+    async with cm:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_stream_does_not_mutate_supplied_params():
+    client = _client()
+    captured = _mock_provider(client, input_tokens=100)
+    params = GenerationParams(max_completion_tokens=None)
+    cm = await _open_stream(client, MESSAGES, SYSTEM, params=params, model="m")
+    assert params.max_completion_tokens is None
+    assert captured["stream_params"].max_completion_tokens == RUN_OUTPUT
+    async with cm:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# No caps: unchanged legacy behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_without_caps_does_not_count_and_passes_params_through():
+    client = LLMClient(provider="anthropic", api_key="test-key")
+    captured = _mock_provider(client, input_tokens=999_999)
+    await client.generate(MESSAGES, SYSTEM, model="m")
+    assert captured["count_calls"] == 0
+    assert captured["generate_calls"] == 1
+    assert captured["generate_params"].max_completion_tokens is None
+
+
+@pytest.mark.asyncio
+async def test_generate_without_caps_keeps_caller_output_limit():
+    client = LLMClient(provider="anthropic", api_key="test-key")
+    captured = _mock_provider(client, input_tokens=999_999)
+    await client.generate(MESSAGES, SYSTEM, max_completion_tokens=500, model="m")
+    assert captured["count_calls"] == 0
+    assert captured["generate_params"].max_completion_tokens == 500
+
+
+@pytest.mark.asyncio
+async def test_stream_without_caps_returns_provider_stream_directly():
+    client = LLMClient(provider="anthropic", api_key="test-key")
+    captured = _mock_provider(client, input_tokens=999_999)
+    cm = await _open_stream(client, MESSAGES, SYSTEM, model="m")
+    assert captured["count_calls"] == 0
+    assert captured["stream_calls"] == 1
+    assert captured["stream_params"].max_completion_tokens is None
+    async with cm:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Instrumented client
+# ---------------------------------------------------------------------------
+
+
+def _instrumented_client(**overrides) -> InstrumentedLLMClient:
+    kwargs: Dict[str, Any] = dict(
+        provider="anthropic",
+        api_key="test-key",
+        context_window_tokens=WINDOW,
+        max_output_tokens=RUN_OUTPUT,
+        workspace_id="ws",
+        thread_id="th",
+        agent_type="test-agent",
+    )
+    kwargs.update(overrides)
+    return InstrumentedLLMClient(**kwargs)
+
+
+@pytest.mark.asyncio
+async def test_instrumented_generate_enforces_budget_and_caps_output():
+    langfuse, _trace, _generation = _mock_langfuse()
+    client = _instrumented_client(langfuse_client=langfuse)
+    captured = _mock_provider(client, input_tokens=100)
+    await client.generate(MESSAGES, SYSTEM, max_completion_tokens=500, model="m")
+    assert captured["generate_params"].max_completion_tokens == RUN_OUTPUT
+
+    captured = _mock_provider(client, input_tokens=WINDOW - RUN_OUTPUT + 1)
+    with pytest.raises(LLMContextWindowExceededError):
+        await client.generate(MESSAGES, SYSTEM, model="m")
+    assert captured["generate_calls"] == 0
+
+
+@pytest.mark.asyncio
+async def test_instrumented_stream_enforces_budget_and_caps_output():
+    langfuse, _trace, _generation = _mock_langfuse()
+    client = _instrumented_client(langfuse_client=langfuse)
+    captured = _mock_provider(client, input_tokens=100)
+    cm = await _open_stream(client, MESSAGES, SYSTEM, max_completion_tokens=500, model="m")
+    assert captured["stream_params"].max_completion_tokens == RUN_OUTPUT
+    async with cm:
+        pass
+
+    captured = _mock_provider(client, input_tokens=WINDOW - RUN_OUTPUT + 1)
+    with pytest.raises(LLMContextWindowExceededError):
+        await _open_stream(client, MESSAGES, SYSTEM, model="m")
+    assert captured["stream_calls"] == 0
+
+
+@pytest.mark.asyncio
+async def test_instrumented_precomputed_count_used_and_kept_out_of_trace_metadata():
+    langfuse, trace, _generation = _mock_langfuse()
+    client = _instrumented_client(langfuse_client=langfuse)
+    captured = _mock_provider(client, input_tokens=999_999)
+    await client.generate(MESSAGES, SYSTEM, model="m", _precomputed_input_tokens=WINDOW - RUN_OUTPUT)
+    assert captured["count_calls"] == 0
+    assert captured["generate_calls"] == 1
+    assert "_precomputed_input_tokens" not in captured["generate_kwargs"]
+
+    span_metadata = trace.start_generation.call_args.kwargs["metadata"]
+    assert "_precomputed_input_tokens" not in span_metadata
+
+
+@pytest.mark.asyncio
+async def test_instrumented_without_langfuse_still_enforces_budget():
+    client = _instrumented_client(langfuse_client=None)
+    captured = _mock_provider(client, input_tokens=WINDOW - RUN_OUTPUT + 1)
+    with pytest.raises(LLMContextWindowExceededError):
+        await client.generate(MESSAGES, SYSTEM, model="m")
+    assert captured["generate_calls"] == 0
+
+
+# ---------------------------------------------------------------------------
+# AgentContext propagation
+# ---------------------------------------------------------------------------
+
+
+def _make_agent(tmp_path, *, strict_budget, langfuse_client=None):
+    import uuid
+    from unittest.mock import AsyncMock
+
+    from kolega_code.agent.coder import CoderAgent
+    from kolega_code.agent.prompt_provider import AgentMode
+    from kolega_code.events import AgentConnectionManager
+
+    from ..compaction_helpers import make_agent_config
+
+    return CoderAgent(
+        project_path=tmp_path,
+        workspace_id="test_ws",
+        thread_id=str(uuid.uuid4()),
+        connection_manager=AsyncMock(spec=AgentConnectionManager),
+        config=make_agent_config(strict_budget=strict_budget),
+        agent_mode=AgentMode.CLI,
+        langfuse_client=langfuse_client,
+    )
+
+
+def test_create_llm_client_propagates_caps_to_plain_client(tmp_path):
+    agent = _make_agent(tmp_path, strict_budget=(WINDOW, RUN_OUTPUT))
+    client = agent.context.create_llm_client(agent.agent_name)
+    assert not isinstance(client, InstrumentedLLMClient)
+    assert client._context_window_tokens == WINDOW
+    assert client._max_output_tokens == RUN_OUTPUT
+
+
+def test_create_llm_client_propagates_caps_to_instrumented_client(tmp_path):
+    agent = _make_agent(tmp_path, strict_budget=(WINDOW, RUN_OUTPUT), langfuse_client=MagicMock())
+    client = agent.context.create_llm_client(agent.agent_name)
+    assert isinstance(client, InstrumentedLLMClient)
+    assert client._context_window_tokens == WINDOW
+    assert client._max_output_tokens == RUN_OUTPUT
+
+
+def test_create_llm_client_without_caps_leaves_budget_unset(tmp_path):
+    agent = _make_agent(tmp_path, strict_budget=None)
+    client = agent.context.create_llm_client(agent.agent_name)
+    assert client._context_window_tokens is None
+    assert client._max_output_tokens is None
+    assert not client._has_run_context_budget
+
+
+# ---------------------------------------------------------------------------
+# Ordinary history compactor: covered automatically via the agent's client
+# ---------------------------------------------------------------------------
+
+
+def _compressible_conversation():
+    from kolega_code.agent.conversation import Conversation
+
+    messages = []
+    for i in range(12):
+        role = "user" if i % 2 == 0 else "assistant"
+        messages.append(Message(role, [TextBlock(f"turn {i}")]))
+    return Conversation(messages)
+
+
+@pytest.mark.asyncio
+async def test_history_compactor_output_capped_to_run_max():
+    from kolega_code.agent.compression import HistoryCompressor
+
+    client = _client()
+    captured = _mock_provider(client, input_tokens=100)
+    result = await HistoryCompressor().summarize(
+        _compressible_conversation(), llm=client, model="m", temperature=1.0, thinking=None
+    )
+    assert result.ok, result.message
+    # The compactor asks for SUMMARY_MAX_TOKENS (8192); the run-wide cap wins.
+    assert captured["stream_params"].max_completion_tokens == RUN_OUTPUT
+
+
+@pytest.mark.asyncio
+async def test_history_compactor_over_limit_fails_before_provider_invocation():
+    from kolega_code.agent.compression import HistoryCompressor
+
+    client = _client()
+    captured = _mock_provider(client, input_tokens=WINDOW - RUN_OUTPUT + 1)
+    result = await HistoryCompressor().summarize(
+        _compressible_conversation(), llm=client, model="m", temperature=1.0, thinking=None
+    )
+    assert not result.ok
+    assert result.reason == "llm_error"
+    assert captured["count_calls"] == 1
+    assert captured["stream_calls"] == 0


### PR DESCRIPTION
## Summary

Implements strict per-run context enforcement for every `LLMClient` call, driven by the existing paired `AgentConfig` fields `context_window_tokens` / `max_output_tokens`, now propagated through `AgentContext.create_llm_client()` into both `LLMClient` and `InstrumentedLLMClient`.

When the pair is present, `generate()` and `stream()`:

- set the effective output maximum to the smaller of the caller's request and the run-wide cap (the run-wide cap when the caller supplies none), and pass it to the provider;
- count the fully rendered request — messages, system prompt, tools, model, and renderer-affecting thinking settings;
- derive maximum input as `context_window_tokens - effective_output` and raise the existing `LLMContextWindowExceededError` before any provider generation when the input exceeds it (equality is allowed).

Supplied `GenerationParams` are copied via `dataclasses.replace`, never mutated. BaseAgent hands its existing gauge count through the keyword-only internal `_precomputed_input_tokens` parameter so the main request is not counted twice; the parameter is an explicit named argument on both clients, so it can never reach providers or Langfuse trace metadata. With no paired cap, the code path is unchanged (no counting, params untouched), so the ordinary history compactor and every client created through `AgentContext` are covered automatically. Clients constructed directly outside `AgentContext` (hook prompts, terminal/web helpers) are intentionally out of scope.

No new service, exception type, provider-specific cap, catalog mutation, truncation, or retry behavior.

## Test plan

- New `tests/agent/llm/test_client_context_budget.py` (28 tests): plain and instrumented clients, generate and stream, smaller caller output limits, run-cap fallback, input ceiling derived from effective output, exact-boundary acceptance, over-limit rejection before provider invocation, precomputed-count handling, params non-mutation, trace-metadata hygiene, unchanged no-cap behavior, `create_llm_client` propagation, and compactor-level coverage.
- Full fast suite: 4658 passed (1 pre-existing failure in a kimi_coding live test — provider quota exhausted, environmental).
- `ruff check`, `ruff format --check`, `pyright` clean; pre-commit hooks passed.