### PR TITLE
feat(cli): show cache hit percentage in status usage panel

### DIFF
--- a/docs/src/content/docs/tui/interface.md
+++ b/docs/src/content/docs/tui/interface.md
@@ -31,7 +31,7 @@ conversation and the Planning tab's task list.
 
 | Tab | What it shows |
 | --- | --- |
-| **Status** | The active provider/model and thinking effort, the current interaction mode (Build/Plan), permission mode, the agent's turn state (idle, generating, thinking, running a tool, running sub-agents, waiting for input, …), token usage, context warnings, the active [goal](../../goal/) status when a goal is set, and the active [scheduled loop](../../loop/) with its schedule, countdown to the next iteration, and iteration count when a loop is running. |
+| **Status** | The active provider/model and thinking effort, the current interaction mode (Build/Plan), permission mode, the agent's turn state (idle, generating, thinking, running a tool, running sub-agents, waiting for input, …), token usage (including cache hit rate), context warnings, the active [goal](../../goal/) status when a goal is set, and the active [scheduled loop](../../loop/) with its schedule, countdown to the next iteration, and iteration count when a loop is running. |
 | **Logs** | Optional. Launch with `--show-logs` to show a timestamped, color-coded diagnostic activity log. New entries preserve manual scrollback and an indicator flags unseen entries when you're on another tab. |
 | **Terminal** | Live output from commands the agent runs. |
 | **Planning** | The current **Plan** (markdown from the planning agent) and the shared **Task List** that both modes can edit. |

--- a/kolega_code/cli/tui/status_dashboard.py
+++ b/kolega_code/cli/tui/status_dashboard.py
@@ -142,6 +142,10 @@ class StatusDashboardMixin(tui_app_base.KolegaAppBase):
         cache_reads = combined("cache_read_input_tokens")
         if cache_reads:
             split_line += f" · Cache reads {self._format_token_count(cache_reads)}"
+            input_total = combined("input_tokens")
+            if input_total:
+                hit_pct = 100.0 * cache_reads / input_total
+                split_line += f" · Cache hit {hit_pct:.2f}%"
 
         requests_line = f"Requests: {combined('requests'):,}"
         failed = combined("failed")

--- a/tests/cli/test_app_status_usage.py
+++ b/tests/cli/test_app_status_usage.py
@@ -53,6 +53,7 @@ async def test_fresh_session_renders_zero_usage_without_markers(tmp_path, monkey
     assert "(partial)" not in card
     assert "failed" not in card
     assert "Cache reads" not in card
+    assert "Cache hit" not in card
     # Usage lives in its own card, not folded into the Status section.
     assert "Session:" not in dashboard
 
@@ -95,6 +96,37 @@ async def test_baseline_and_live_usage_combine(tmp_path, monkeypatch):
     assert "In 8k · Out 2k" in card
     assert "Requests: 11" in card
     assert "(partial)" not in card
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_percentage_renders(tmp_path, monkeypatch):
+    app = _build_app(tmp_path, monkeypatch)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        _settle(app._usage_ledger, inp=200, out=200, cache_read=800)
+        _settle(app._usage_ledger, inp=200, out=200, cache_read=800)
+        card = app._usage_summary_lines()
+
+    # Normalized input_tokens is inclusive of cache reads: 1000 per request,
+    # 800 served from cache → 1600 of 2000 tokens → 80.00%, two decimals.
+    assert "Cache reads 1.6k · Cache hit 80.00%" in card
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_percentage_from_baseline(tmp_path, monkeypatch):
+    app = _build_app(tmp_path, monkeypatch)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.session.usage = {
+            "input_tokens": 10_000,
+            "output_tokens": 1_000,
+            "total_tokens": 11_000,
+            "cache_read_input_tokens": 5_000,
+            "coverage": {"accounted_runs": 1, "pre_accounting_turns": 0, "full": True},
+        }
+        card = app._usage_summary_lines()
+
+    assert "Cache hit 50.00%" in card
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The Usage card on the Status tab of the sidebar now shows a session-level **cache hit percentage** alongside the existing `Cache reads` segment:

```
In 2M · Out 100.2k · Cache reads 1.6k · Cache hit 80.00%
```

The metric is `cache_read_input_tokens / input_tokens` (normalized input is inclusive of cached input), aggregated over the journal-derived baseline plus the live ledger at render time — no persistence, journal, or schema changes.

## Details

- `kolega_code/cli/tui/status_dashboard.py` — `_usage_summary_lines()` appends ` · Cache hit {pct:.2f}%` (2 decimal places) when cache reads are nonzero, with a defensive zero-input guard.
- `tests/cli/test_app_status_usage.py` — new tests for the live-ledger and journal-baseline paths, plus an assertion that a fresh session shows no cache field.
- `docs/src/content/docs/tui/interface.md` — Status tab description now mentions the cache hit rate.

## Verification

- `tests/cli/test_app_status_usage.py`: 8 passed; plus 36 passed across dashboard-adjacent TUI test files.
- `ruff check`, `ruff format --check`, `pyright`, and pre-commit all clean on the changed files.