### PR TITLE
fix(cli): always render cache segment in usage card

### DIFF
--- a/kolega_code/cli/tui/status_dashboard.py
+++ b/kolega_code/cli/tui/status_dashboard.py
@@ -140,19 +140,16 @@ class StatusDashboardMixin(tui_app_base.KolegaAppBase):
             f" · Out {self._format_token_count(combined('output_tokens'))}"
         )
         cache_reads = combined("cache_read_input_tokens")
-        if cache_reads:
-            split_line += f" · Cache reads {self._format_token_count(cache_reads)}"
-            input_total = combined("input_tokens")
-            if input_total:
-                hit_pct = 100.0 * cache_reads / input_total
-                split_line += f" · Cache hit {hit_pct:.2f}%"
+        input_total = combined("input_tokens")
+        hit_pct = 100.0 * cache_reads / input_total if input_total else 0.0
+        cache_line = f"Cache reads {self._format_token_count(cache_reads)} · Cache hit {hit_pct:.2f}%"
 
         requests_line = f"Requests: {combined('requests'):,}"
         failed = combined("failed")
         if failed:
             requests_line += " · " + theme.styled(f"{failed:,} failed", Color.ERROR)
 
-        return f"{session_line}\n{split_line}\n{requests_line}"
+        return f"{session_line}\n{split_line}\n{cache_line}\n{requests_line}"
 
     def _worktree_summary(self) -> str:
         """``name (branch)`` when this session runs in a linked worktree, else "".

--- a/tests/cli/test_app_status_usage.py
+++ b/tests/cli/test_app_status_usage.py
@@ -52,8 +52,7 @@ async def test_fresh_session_renders_zero_usage_without_markers(tmp_path, monkey
     assert "Requests: 0" in card
     assert "(partial)" not in card
     assert "failed" not in card
-    assert "Cache reads" not in card
-    assert "Cache hit" not in card
+    assert "In 0 · Out 0\nCache reads 0 · Cache hit 0.00%" in card
     # Usage lives in its own card, not folded into the Status section.
     assert "Session:" not in dashboard
 


### PR DESCRIPTION
## What

Fixes the Status tab's Usage card so cache information no longer pops in mid-session and shifts the layout.

- **Before:** `Cache reads` / `Cache hit` only rendered once the session had actual cached usage, so the `In · Out` line suddenly grew a segment (and wrapped) the first time the cache was hit.
- **After:** the card always renders a stable four-line structure, with zeros in the empty state:

```
Session: 0 tokens
In 0 · Out 0
Cache reads 0 · Cache hit 0.00%
Requests: 0
```

Cache reads and cache hit moved onto their own line under `In · Out` so neither line can reflow when numbers change. The percentage is division-safe for zero input (`0.00%` shown until there is input to divide).

## Why

Follow-up to #547 (cache hit percentage in the status usage panel): conditional rendering made the card's line structure change the moment cache activity started, which shifted the sidebar layout.

## Tests

- `tests/cli/test_app_status_usage.py` — fresh-session test now asserts `In 0 · Out 0\nCache reads 0 · Cache hit 0.00%`, pinning both the placeholder and the line separation. All 8 tests pass; ruff clean.