### PR TITLE
fix(cli): validate strict context caps before run start

### DIFF
--- a/kolega_code/cli/config.py
+++ b/kolega_code/cli/config.py
@@ -91,6 +91,10 @@ class CliConfigError(ValueError):
     """Raised when CLI configuration is incomplete or invalid."""
 
 
+class StrictContextBudgetError(CliConfigError):
+    """Raised when the paired strict context-budget flags are invalid."""
+
+
 @dataclass(frozen=True)
 class CliConfigOverrides:
     """Model and provider overrides supplied by CLI flags."""
@@ -398,15 +402,15 @@ def _strict_context_budget(
     """Parse and validate the paired strict context-budget flags.
 
     Process-local by design: no env or settings layer. Validated against the
-    resolved active model here for an early error; BaseAgent re-validates
-    against its actual primary model (a saved role override can supersede the
-    global selection).
+    resolved active model here for an early error; build_agent_config then
+    re-validates against the resolved coder route after applying saved role
+    overrides. BaseAgent keeps the same check as defense in depth.
     """
     raw_window, raw_output = overrides.context_window_tokens, overrides.max_output_tokens
     if raw_window is None and raw_output is None:
         return None, None
     if raw_window is None or raw_output is None:
-        raise CliConfigError("--context-window-tokens and --max-output-tokens must be supplied together.")
+        raise StrictContextBudgetError("--context-window-tokens and --max-output-tokens must be supplied together.")
 
     def _positive_int(raw: str, flag: str) -> int:
         try:
@@ -414,27 +418,37 @@ def _strict_context_budget(
         except ValueError:
             value = 0
         if value <= 0 or str(value) != raw.strip():
-            raise CliConfigError(f"{flag} must be a positive integer, got '{raw}'.")
+            raise StrictContextBudgetError(f"{flag} must be a positive integer, got '{raw}'.")
         return value
 
     window = _positive_int(raw_window, "--context-window-tokens")
     output = _positive_int(raw_output, "--max-output-tokens")
     if output >= window:
-        raise CliConfigError(
+        raise StrictContextBudgetError(
             f"--max-output-tokens ({output}) must be strictly smaller than --context-window-tokens ({window})."
         )
+    _validate_strict_context_budget_limits(window, output, provider, model)
+    return window, output
+
+
+def _validate_strict_context_budget_limits(
+    window: int,
+    output: int,
+    provider: ModelProvider,
+    model: str,
+) -> None:
+    """Validate a strict context-budget pair against one resolved model."""
     specs = get_model_specs(provider.value, model)
     if window > specs["context_length"]:
-        raise CliConfigError(
+        raise StrictContextBudgetError(
             f"--context-window-tokens ({window}) exceeds the catalogued context length "
             f"({specs['context_length']}) for {provider.value}/{model}."
         )
     if output > specs["max_completion_tokens"]:
-        raise CliConfigError(
+        raise StrictContextBudgetError(
             f"--max-output-tokens ({output}) exceeds the catalogued completion maximum "
             f"({specs['max_completion_tokens']}) for {provider.value}/{model}."
         )
-    return window, output
 
 
 def _coerce_known_model(provider: ModelProvider, model: Optional[str]) -> str:
@@ -758,6 +772,19 @@ def build_agent_config(
         )
     except ValueError as exc:
         raise CliConfigError(str(exc)) from exc
+
+    # The active model was checked while parsing the flags above, but the coder
+    # route may be replaced by a saved "building" role override. Validate that
+    # resolved route before any session run marker or agent construction.
+    if config.context_window_tokens is not None:
+        assert config.max_output_tokens is not None
+        coder = config.model_config_for_agent("coder")
+        _validate_strict_context_budget_limits(
+            config.context_window_tokens,
+            config.max_output_tokens,
+            coder.provider,
+            coder.model,
+        )
 
     # Attach a persisting token manager so mid-session refreshes are written back
     # to settings.json (only possible when a store is supplied by the caller).

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -90,12 +90,13 @@ from .config import (
     WEB_SEARCH_MODES,
     CliConfigError,
     CliConfigOverrides,
+    StrictContextBudgetError,
+    _skills_enabled,
     active_model_override_message,
     build_agent_config,
     config_summary,
-    strict_context_budget_marker,
     load_cli_env,
-    _skills_enabled,
+    strict_context_budget_marker,
 )
 from .connection import CliConnectionManager
 from .mentions import build_file_attachments
@@ -1071,6 +1072,10 @@ def _run_tui(args: argparse.Namespace) -> int:
             project_path, _overrides_from_args(args), settings=settings, settings_store=settings_store
         )
         summary = config_summary(config)
+    except StrictContextBudgetError:
+        # Strict caps are explicit per-run constraints, not recoverable missing
+        # setup. Fail before creating a TUI session or emitting llm.run_started.
+        raise
     except CliConfigError as exc:
         if str(exc) == DEPRECATED_THINKING_TOKENS_MESSAGE:
             raise

--- a/tests/cli/test_strict_context_budget.py
+++ b/tests/cli/test_strict_context_budget.py
@@ -8,6 +8,10 @@ reservation forced. The run evidence is the `context_budget` marker
 `config_summary` expose; the experiment side audits billed usage against it.
 """
 
+import json
+from pathlib import Path
+from typing import Any
+
 import pytest
 
 from kolega_code.agent.coder import CoderAgent
@@ -18,17 +22,22 @@ from kolega_code.cli.config import (
     config_summary,
     strict_context_budget_marker,
 )
+from kolega_code.cli.settings import SettingsStore
 from kolega_code.config import ModelProvider
 
 
 class RecordingCoderAgent(CoderAgent):
     instances: list["RecordingCoderAgent"] = []
+    construction_attempts: int = 0
+    process_calls: int = 0
 
     def __init__(self, **kwargs):
+        RecordingCoderAgent.construction_attempts += 1
         super().__init__(**kwargs)
         RecordingCoderAgent.instances.append(self)
 
     async def process_message_stream(self, message, attachments=None):
+        RecordingCoderAgent.process_calls += 1
         yield {"type": "response", "content": "done", "complete": True, "uuid": "response-1"}
 
 
@@ -36,6 +45,8 @@ def _setup(tmp_path, monkeypatch):
     from kolega_code.cli import main as main_module
 
     RecordingCoderAgent.instances = []
+    RecordingCoderAgent.construction_attempts = 0
+    RecordingCoderAgent.process_calls = 0
     monkeypatch.setattr(main_module, "CoderAgent", RecordingCoderAgent)
     project = tmp_path / "project"
     project.mkdir()
@@ -47,6 +58,23 @@ def _setup(tmp_path, monkeypatch):
 
 def _overrides(window, output):
     return CliConfigOverrides(context_window_tokens=window, max_output_tokens=output)
+
+
+def _persist_building_override(tmp_path: Path) -> None:
+    store = SettingsStore(tmp_path / "state")
+    settings = store.load()
+    settings.set_agent_model("building", "anthropic", "claude-haiku-4-5-20251001")
+    store.save(settings)
+
+
+def _saved_events(tmp_path: Path) -> list[dict[str, Any]]:
+    sessions_dir = tmp_path / "state" / "sessions"
+    if not sessions_dir.exists():
+        return []
+    event_paths = sorted(sessions_dir.glob("*/events.jsonl"))
+    return [
+        json.loads(line) for event_path in event_paths for line in event_path.read_text(encoding="utf-8").splitlines()
+    ]
 
 
 # --- resolution and validation ---------------------------------------------------
@@ -126,6 +154,127 @@ def test_ask_with_flags_budgets_from_effective_spec(tmp_path, monkeypatch, isola
     assert agent.model_context_length == 65536
     assert agent.model_completion_tokens == 8192
     assert agent.model_max_input_tokens == 65536 - 8192
+
+
+def test_ask_validates_compatible_saved_building_override_before_run_start(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_cli_env: None,
+) -> None:
+    main_module, project = _setup(tmp_path, monkeypatch)
+    _persist_building_override(tmp_path)
+
+    exit_code = main_module.main(
+        [
+            "ask",
+            "do the thing",
+            "--project",
+            str(project),
+            "--save",
+            "--context-window-tokens",
+            "180000",
+            "--max-output-tokens",
+            "8192",
+        ]
+    )
+
+    assert exit_code == 0
+    assert RecordingCoderAgent.construction_attempts == 1
+    assert RecordingCoderAgent.process_calls == 1
+    agent = RecordingCoderAgent.instances[0]
+    assert agent.primary_model_config.model == "claude-haiku-4-5-20251001"
+    run_started = next(event for event in _saved_events(tmp_path) if event["type"] == "llm.run_started")
+    assert run_started["payload"]["context_budget"]["model"] == "claude-haiku-4-5-20251001"
+
+
+@pytest.mark.parametrize(
+    "window,output,error_text",
+    [
+        ("300000", "8192", "catalogued context length"),
+        ("180000", "20000", "catalogued completion maximum"),
+    ],
+)
+def test_ask_rejects_incompatible_saved_building_override_before_run_start(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_cli_env: None,
+    capsys: pytest.CaptureFixture[str],
+    window: str,
+    output: str,
+    error_text: str,
+) -> None:
+    main_module, project = _setup(tmp_path, monkeypatch)
+    _persist_building_override(tmp_path)
+
+    exit_code = main_module.main(
+        [
+            "ask",
+            "do the thing",
+            "--project",
+            str(project),
+            "--save",
+            "--context-window-tokens",
+            window,
+            "--max-output-tokens",
+            output,
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert error_text in captured.err
+    assert "anthropic/claude-haiku-4-5-20251001" in captured.err
+    assert RecordingCoderAgent.construction_attempts == 0
+    assert RecordingCoderAgent.process_calls == 0
+    assert "llm.run_started" not in {event["type"] for event in _saved_events(tmp_path)}
+
+
+@pytest.mark.parametrize(
+    "window,output,error_text",
+    [
+        ("300000", "8192", "catalogued context length"),
+        ("180000", "20000", "catalogued completion maximum"),
+    ],
+)
+def test_tui_rejects_incompatible_saved_building_override_before_run_start(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_cli_env: None,
+    capsys: pytest.CaptureFixture[str],
+    window: str,
+    output: str,
+    error_text: str,
+) -> None:
+    main_module, project = _setup(tmp_path, monkeypatch)
+    _persist_building_override(tmp_path)
+    from kolega_code.cli import app as app_module
+
+    app_construction_attempts: list[None] = []
+
+    class UnexpectedTuiApp:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            app_construction_attempts.append(None)
+            raise AssertionError("TUI app constructed before strict context-budget validation")
+
+    monkeypatch.setattr(app_module, "KolegaCodeApp", UnexpectedTuiApp)
+
+    exit_code = main_module.main(
+        [
+            "tui",
+            str(project),
+            "--context-window-tokens",
+            window,
+            "--max-output-tokens",
+            output,
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert error_text in captured.err
+    assert "anthropic/claude-haiku-4-5-20251001" in captured.err
+    assert app_construction_attempts == []
+    assert "llm.run_started" not in {event["type"] for event in _saved_events(tmp_path)}
 
 
 def test_ask_single_flag_fails_before_inference(tmp_path, monkeypatch, isolated_cli_env, capsys):


### PR DESCRIPTION
## Summary
- validate paired strict context caps against the resolved coder route after saved `building` overrides are applied
- propagate strict-cap failures through TUI startup before the usage sink, app, agent construction, or inference can begin
- add saved-override regressions for compatible caps and invalid context-window/output limits while preserving marker schema and routing

## Testing
- `PYTHONDONTWRITEBYTECODE=1 uv run pytest -q tests/cli/test_strict_context_budget.py tests/cli/test_session_usage_sink.py tests/cli/test_cli_config.py -ra` — 94 passed
- `./run_tests.sh tests --ignore=tests/agent/llm/test_live_providers.py --ignore=tests/agent/llm/test_normalized_usage_live.py -ra` — 4,616 passed, 2 skipped
- Ruff formatting/checks, Pyright, `git diff --check`, and commit hooks passed

Provider-dependent unfiltered attempts only encountered unrelated environment failures: the optional Tinker stack was unavailable, Kimi quota was exhausted, and a credential-masked run exposed an ambient fixture conflict.
