### PR TITLE
fix(agent): warn that ripgrep -r is --replace in system prompt

### DIFF
--- a/kolega_code/agent/prompt_templates/system/includes/terminal_tools.md
+++ b/kolega_code/agent/prompt_templates/system/includes/terminal_tools.md
@@ -6,6 +6,6 @@ Do not run destructive commands automatically — deleting files, rewriting hist
 
 ## Searching and Reading Files
 
-When searching for text or files, prefer `rg` / `rg --files` over grep/find — it is much faster. If `rg` is not found, use alternatives.
+When searching for text or files, prefer `rg` / `rg --files` over grep/find — it is much faster. If `rg` is not found, use alternatives. In ripgrep, `-r` means `--replace`, not recursive — `rg -rn "foo"` prints every match replaced with the literal `n`; recursion is the default, so use `rg -n` for line numbers.
 
 Do not use python scripts (or `eval`) to print chunks of a file — use the file-reading tools instead.

--- a/tests/agent/test_prompt_provider.py
+++ b/tests/agent/test_prompt_provider.py
@@ -215,6 +215,11 @@ class TestPromptProvider:
 
         assert "## Running Commands" in prompt
         assert "prefer `rg` / `rg --files` over grep/find" in prompt
+        # ripgrep's -r is --replace, not recursive; a stray -r silently turns
+        # matches into the literal replacement text and reads as a redaction
+        # layer, so the guidance must call it out explicitly.
+        assert "`-r` means `--replace`, not recursive" in prompt
+        assert "use `rg -n` for line numbers" in prompt
         assert "Do not use python scripts (or `eval`) to print chunks of a file" in prompt
         # One wording serves both interactive and autonomous runs: destructive
         # commands need explicit authorization — by the user or by the task.


### PR DESCRIPTION
## What

One-line addition to the shared terminal-tools system prompt (`system/includes/terminal_tools.md`, included in every terminal-capable agent): ripgrep's `-r` is `--replace`, not recursive.

`rg -rn "foo"` parses as `--replace n`, so every match prints replaced with the literal string `n` (`-rln` → `ln`). A session spent its entire run believing shell tool output was being passed through a secret-redaction layer because of exactly this — `resume`→`n`, `quit`→`ln`, `resumed`→`nd` — and the masked words were always its own search terms. The guidance now says recursion is the default and `rg -n` alone is line numbers.

## Test

`test_prompt_provider.py` asserts the new wording renders for terminal-capable agents (38 tests pass); browser-agent negative test unaffected.