### PR TITLE
feat(cli): print resume command with session ID after quitting

### DIFF
--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -82,11 +82,14 @@ broad enough to benefit from fan-out.
 
 7. **Save and exit.**
 
-   Press `Ctrl+Q` (or run `/quit`) to save the session and exit. Resume later
-   with:
+   Press `Ctrl+Q` (or run `/quit`) to save the session and exit. The terminal
+   then prints the exact command to resume this session, including its session
+   ID. Run that (or `kolega-code . --resume <session-id>`) to come back to this
+   session — bare `--resume` picks the most recently modified session, which may
+   be a different one you have open in another terminal.
 
    ```bash
-   kolega-code . --resume
+   kolega-code . --resume <session-id>
    ```
 
 </Steps>

--- a/docs/src/content/docs/tui/sessions-and-resume.md
+++ b/docs/src/content/docs/tui/sessions-and-resume.md
@@ -30,6 +30,8 @@ kolega-code . --resume <session-id>
 
 A few rules:
 
+- Quitting the TUI prints the exact resume command for the session you just
+  closed, including its ID — copy it to be sure you get this session back.
 - `--resume` with no ID resumes the **latest** session for the project. If there
   are none, the CLI reports that.
 - `sessions list` labels the session ID to copy as **Resume ID**. Previously

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -251,6 +251,9 @@ class KolegaCodeApp(
         self.control_channel.acquire(tui_constants.TUI_CLIENT_ID)
         self._hook_dispatcher: Optional[HookDispatcher] = None
         self._session_started = False
+        #: Set when action_quit saves the session cleanly; main.py prints the
+        #: resume-with-session-ID hint only when this is True.
+        self._quit_cleanly = False
         self.extension_selection = extension_selection
         self._extension_bundle = None
         self.agent = None
@@ -2021,6 +2024,10 @@ class KolegaCodeApp(
                     except Exception:
                         pass
                 await self._save_session_history_async()
+            # The session is durably saved: the post-quit resume hint may point
+            # at it. If any step above raised, the flag stays False and main.py
+            # prints nothing (the finally still exits).
+            self._quit_cleanly = True
         finally:
             # Generation teardown and the sink drain run even when an earlier
             # step raised; the original failure still propagates.

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -1043,6 +1043,11 @@ def _run_browser(args: argparse.Namespace) -> int:
         return 2
 
 
+def _print_quit_resume_hint(session_id: str) -> None:
+    """Print the post-quit resume command for this session."""
+    _print_styled(messages.SESSION_RESUME_HINT.format(session_id=session_id), style="success")
+
+
 def _run_tui(args: argparse.Namespace) -> int:
     if importlib.util.find_spec("textual") is None:
         print("Textual is not installed. Reinstall the CLI with: uv tool install --force kolega-code", file=sys.stderr)
@@ -1130,6 +1135,10 @@ def _run_tui(args: argparse.Namespace) -> int:
                     await usage_sink.aclose()
                 except Exception as exc:  # noqa: BLE001 — reported, never masks the primary exception
                     print(f"Warning: usage sink close failed: {exc}", file=sys.stderr)
+        # Normal quit only: action_quit set _quit_cleanly after saving the
+        # session, so the terminal now shows how to resume exactly this one.
+        if getattr(app, "_quit_cleanly", False):
+            _print_quit_resume_hint(session.session_id)
 
     try:
         asyncio.run(_run_app())

--- a/kolega_code/cli/messages.py
+++ b/kolega_code/cli/messages.py
@@ -293,6 +293,9 @@ CHATGPT_LOGIN_SWITCH_FAILED = "Signed in, but could not switch to the ChatGPT pr
 CHATGPT_LOGOUT_DONE = "Signed out of ChatGPT. Stored credentials were removed."
 CHATGPT_LOGOUT_NONE = "You are not signed in to ChatGPT."
 
+# Session quit hint
+SESSION_RESUME_HINT = "Session saved. Resume it with: kolega-code . --resume {session_id}"
+
 # Misc
 COPY_MACOS_FAILED = "Copied for supported terminals, but the macOS clipboard failed."
 STREAM_TRUNCATED = "[stream truncated to the last {chars} characters]"

--- a/kolega_code/cli/tui/app_base.py
+++ b/kolega_code/cli/tui/app_base.py
@@ -130,6 +130,9 @@ class KolegaAppBase(App):
         control_channel: ControlChannel
         _hook_dispatcher: HookDispatcher | None
         _session_started: bool
+        #: True once action_quit has saved the session; gates the post-quit
+        #: resume hint printed by main.py.
+        _quit_cleanly: bool
         agent: BaseAgent | None
         agent_worker: Worker | None
         conversation_entries: list[tui_state.ConversationEntry]

--- a/tests/cli/test_app_extensions.py
+++ b/tests/cli/test_app_extensions.py
@@ -286,6 +286,8 @@ async def test_action_quit_cleans_generation_even_when_save_fails(tmp_path, monk
         assert recorder.cleanups == 1
         assert app.agent is None
         assert app._extension_bundle is None
+        # The session was not saved, so the post-quit resume hint must not fire.
+        assert app._quit_cleanly is False
         app.exit.assert_called_once_with()
 
 

--- a/tests/cli/test_app_misc_commands.py
+++ b/tests/cli/test_app_misc_commands.py
@@ -158,6 +158,8 @@ async def test_textual_app_quit_slash_command_exits(
 
     assert app.return_value is None
     assert not app.is_running
+    # A clean quit saved the session, so main.py prints the resume hint.
+    assert app._quit_cleanly is True
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -10,6 +10,7 @@ from kolega_code.config import ModelProvider
 from kolega_code.cli.main import (
     CLI_AGENT_MODE,
     RESUME_LATEST,
+    _print_quit_resume_hint,
     _resolve_tui_permission_mode,
     _resolve_tui_session,
     main,
@@ -693,6 +694,16 @@ def test_tui_default_creates_new_session_even_when_latest_exists(tmp_path: Path)
     assert session.session_id != existing.session_id
     assert session.thread_id != existing.thread_id
     assert session.mode == CLI_AGENT_MODE
+
+
+def test_print_quit_resume_hint_shows_full_session_id(capsys) -> None:
+    session_id = "0123456789abcdef0123456789abcdef"
+
+    _print_quit_resume_hint(session_id)
+
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "Session saved. Resume it with: kolega-code . --resume " + session_id
+    assert captured.err == ""
 
 
 def test_tui_resume_without_id_loads_latest_project_session(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

Bare `kolega-code --resume` resumes the **most recently modified** session for the project, which may be a different session you have running in another terminal. Quitting the TUI gave no hint at all about how to get back to the session you just closed, so coming back to the right one was easy to miss.

## Change

When the TUI quits cleanly (Ctrl+Q, `/quit`, `/exit`), the terminal now prints the exact command to resume that session, including its full session ID:

```
Session saved. Resume it with: kolega-code . --resume <session-id>
```

- `kolega_code/cli/messages.py` — new `SESSION_RESUME_HINT` microcopy constant.
- `kolega_code/cli/app.py` — `_quit_cleanly` flag on `KolegaCodeApp`, set in `action_quit` only after the session history is durably saved (declared in `tui/app_base.py`).
- `kolega_code/cli/main.py` — `_print_quit_resume_hint()` runs after `run_async()` returns, gated on the flag, so the hint appears on the restored command line after a normal quit and is suppressed on crash or extension-load failure (where the session was not cleanly saved).
- Docs: quick-start step 7 now recommends `--resume <session-id>` and explains why; the sessions & resuming page notes the quit prints the exact command.

## Tests

- `test_print_quit_resume_hint_shows_full_session_id` — asserts the exact printed line.
- `/quit` and `/exit` TUI tests now assert `_quit_cleanly is True` (clean quit).
- Save-failure test asserts `_quit_cleanly is False` (no hint when the session wasn't saved).
- Full fast suite: 4664 passed; the 4 failures are pre-existing environmental live-provider tests (optional `[tinker]` extra not installed in the fresh worktree venv, and one live kimi quota error). Ruff, pyright, and pre-commit pass.
