### PR TITLE
test(web): de-flake player live-state assertions

### DIFF
--- a/tests/web/test_player_live.py
+++ b/tests/web/test_player_live.py
@@ -93,9 +93,13 @@ async def test_a_share_link_follows_the_session_as_it_runs(tmp_path: Path) -> No
             await page.goto(url)
             await page.wait_for_selector(".kc-entry")
 
-            opened = await page.evaluate(_SNAPSHOT_JS)
+            # Entries render from the initial HTTP fetch while the live socket is
+            # still CONNECTING, so the first rendered state is "detached"; the
+            # badge only flips to "following" when the socket opens. Asserting
+            # right after the entries appeared raced on loaded CI runners.
+            opened = await _wait_for(page, lambda snap: snap["liveState"] == "following")
+            assert opened["liveState"] == "following", "the player never attached its live stream"
             assert not opened["liveHidden"], "a live session must advertise itself"
-            assert opened["liveState"] == "following"
 
             # Appended only now, with the page already open.
             await _append(
@@ -282,7 +286,8 @@ async def test_losing_the_network_stops_the_badge_claiming_to_be_live(tmp_path: 
             page = await context.new_page()
             await page.goto(url)
             await page.wait_for_selector(".kc-entry")
-            assert (await page.evaluate(_SNAPSHOT_JS))["liveState"] == "following"
+            attached = await _wait_for(page, lambda snap: snap["liveState"] == "following")
+            assert attached["liveState"] == "following", "the player never attached its live stream"
 
             await context.set_offline(True)
             dropped = await _wait_for(page, lambda snapshot: snapshot["liveState"] != "following")


### PR DESCRIPTION
## What

Fixes the flaky `tests/web/test_player_live.py::test_a_share_link_follows_the_session_as_it_runs` CI failure (`assert 'detached' == 'following'`, seen on #548).

The player's first rendered live badge state is **always** `detached` ("reconnecting…"): `main()` in `kolega_code/web/assets/player.js` calls `renderLive()` synchronously right after `attachStream()` creates the WebSocket — which is still `CONNECTING` — and only the socket's async `open` event flips it to `following`. The tests asserted `liveState == "following"` immediately after `page.wait_for_selector(".kc-entry")`, but the `.kc-entry` elements render from the initial HTTP fetch, before the socket can open, so a loaded CI runner could sample `detached`.

This is a test-sequencing race, not a product bug: reproduced 2/30 loads under simulated 400ms connection latency (CDP `Network.emulateNetworkConditions`) vs 0/200 on an idle machine.

## Fix

Poll for the attach with the file's own `_wait_for(page, predicate)` helper (10s deadline, returns the matching snapshot) and keep an explicit assert for a loud timeout — the same poll-with-timeout pattern already used for the TUI geometry flakes. Applied to both sites that had the pattern:

- `test_a_share_link_follows_the_session_as_it_runs` — the failing first assertion
- `test_losing_the_network_stops_the_badge_claiming_to_be_live` — same latent race on its initial attach check

## Tests

- Fixed logic reaches `following` 30/30 under the same 400ms latency that flaked 2/30
- `tests/web/test_player_live.py` passes 4/4 locally, plus three extra looped runs
- `ruff check` clean; all pre-commit hooks pass
