### PR TITLE
chore(skills): sync bundled skills v0.3.1

### DIFF
--- a/docs/src/content/docs/skills.mdx
+++ b/docs/src/content/docs/skills.mdx
@@ -26,8 +26,8 @@ Skills come from three scopes:
 | **Project** | `<project>/.agents/skills/` |
 
 The bundled catalog is pinned to
-[`kolega-skills` v0.2.1](https://github.com/kolega-ai/kolega-skills/tree/v0.2.1)
-and includes `docx`, `pdf`, `pptx`, `review`, `skill-authoring`, and `xlsx`.
+[`kolega-skills` v0.3.1](https://github.com/kolega-ai/kolega-skills/tree/v0.3.1)
+and includes `deep-research`, `docx`, `humanizer`, `pdf`, `pptx`, `review`, `skill-authoring`, and `xlsx`.
 It is part of the installed package, so listing and activating these skills does not
 download anything or follow the upstream repository's latest branch.
 

--- a/kolega_code/_bundled_skills/manifest.json
+++ b/kolega_code/_bundled_skills/manifest.json
@@ -14,11 +14,11 @@
     },
     {
       "path": "skills/deep-research/references/gigacode-workflow.md",
-      "sha256": "097807156d55a29d12b16a3a5d496a41fb07f152476e95e390699dec1842bc6a"
+      "sha256": "dbbe41f577bd96e2d6658f353b2cffd1e7971fbba255b803f781e86c3a6d5f1b"
     },
     {
       "path": "skills/deep-research/scripts/deep-research.workflow",
-      "sha256": "5207a175f1f1b4144d1c1e53c66e351c20006444e9d31abc7ce3f9be9204df3c"
+      "sha256": "3928a54b360fbee4a942f2b0172ad7607a7350500f9ea5ad413a9c2dcbce2ed7"
     },
     {
       "path": "skills/deep-research/scripts/materialize_report.py",
@@ -217,8 +217,8 @@
     "xlsx"
   ],
   "source": {
-    "commit": "c0ba68e7aee0994318913aa9fcaad4f57cbc11d7",
+    "commit": "ff2d74cd95523e9173332ef5f2ba6c92d40acf0b",
     "repository": "https://github.com/kolega-ai/kolega-skills",
-    "tag": "v0.3.0"
+    "tag": "v0.3.1"
   }
 }

--- a/kolega_code/_bundled_skills/skills/deep-research/references/gigacode-workflow.md
+++ b/kolega_code/_bundled_skills/skills/deep-research/references/gigacode-workflow.md
@@ -192,7 +192,7 @@ The workflow derives every path deterministically:
 
 Scouts write their dossier with `exec_command` and return only a compact record
 plus `dossier_path`. Verification, coverage, drafting, and audit receive paths and
-read the depth they need with `read_file_section`. This is what keeps the
+read the depth they need with `read` (offset/limit for sections). This is what keeps the
 handoffs compact without starving later stages of evidence.
 
 The scratchpad is additive and best-effort. When `workspace` is omitted, a worker

--- a/kolega_code/_bundled_skills/skills/deep-research/scripts/deep-research.workflow
+++ b/kolega_code/_bundled_skills/skills/deep-research/scripts/deep-research.workflow
@@ -1335,9 +1335,10 @@ WRITE_INSTRUCTIONS = (
 )
 
 READ_INSTRUCTIONS = (
-    "Read the referenced files with read_file_section (preferred) or read_entire_file "
-    "using the absolute paths given. If a file is missing or unreadable, continue from "
-    "the inline records below and note the degradation in your gaps."
+    "Read the referenced files with the read tool (using offset/limit for "
+    "sections) using the absolute paths given. If a file is missing or "
+    "unreadable, continue from the inline records below and note the "
+    "degradation in your gaps."
 )
 
 


### PR DESCRIPTION
Vendors kolega-skills `v0.3.1` (PR #16: deep-research read-tool reference fix) into the bundled catalog.

- Deep-research `gigacode-workflow.md` + `deep-research.workflow` updated to reference the merged `read` tool
- Manifest re-pinned to tag v0.3.1 (`ff2d74c`)
- Verified: bundled-skills tests pass; every bundled file byte-matches the tag archive