### PR TITLE
chore(skills): sync bundled skills v0.3.2

### DIFF
--- a/docs/src/content/docs/skills.mdx
+++ b/docs/src/content/docs/skills.mdx
@@ -26,7 +26,7 @@ Skills come from three scopes:
 | **Project** | `<project>/.agents/skills/` |
 
 The bundled catalog is pinned to
-[`kolega-skills` v0.3.1](https://github.com/kolega-ai/kolega-skills/tree/v0.3.1)
+[`kolega-skills` v0.3.2](https://github.com/kolega-ai/kolega-skills/tree/v0.3.2)
 and includes `deep-research`, `docx`, `humanizer`, `pdf`, `pptx`, `review`, `skill-authoring`, and `xlsx`.
 It is part of the installed package, so listing and activating these skills does not
 download anything or follow the upstream repository's latest branch.

--- a/kolega_code/_bundled_skills/manifest.json
+++ b/kolega_code/_bundled_skills/manifest.json
@@ -138,7 +138,7 @@
     },
     {
       "path": "skills/pptx/references/operations.md",
-      "sha256": "ef0a0f508b562d65d16624cf126075c33924a156b71efbe4cc0ff995a1be87d1"
+      "sha256": "7e65b53b63b25d6c0a84598946fcbf98c341f2d32ce356801a011ffa408b01bf"
     },
     {
       "path": "skills/pptx/requirements.txt",
@@ -146,11 +146,11 @@
     },
     {
       "path": "skills/pptx/scripts/pptx_tool.py",
-      "sha256": "b67bf31e00ea81904b89b2dc3a48dc346e0a940f99cd86c9c042a81d8b331465"
+      "sha256": "71a90eb26a581e0d7f06e5b1765b4ab26cc494085d2b8ed4a8ec219a3282799e"
     },
     {
       "path": "skills/pptx/scripts/smoke_test.py",
-      "sha256": "200d9d5f1ffdaa8497c589877f0941d8cf79a94743ddb737952e0aeab5179ba0"
+      "sha256": "6b52cc0be763dcf3b7d1ab5e4418f56549d858cc6415fce041b1692d078bc26d"
     },
     {
       "path": "skills/review/SKILL.md",
@@ -217,8 +217,8 @@
     "xlsx"
   ],
   "source": {
-    "commit": "ff2d74cd95523e9173332ef5f2ba6c92d40acf0b",
+    "commit": "2de7491964d92e3dc78f13290d875c800ac6e22d",
     "repository": "https://github.com/kolega-ai/kolega-skills",
-    "tag": "v0.3.1"
+    "tag": "v0.3.2"
   }
 }

--- a/kolega_code/_bundled_skills/skills/pptx/references/operations.md
+++ b/kolega_code/_bundled_skills/skills/pptx/references/operations.md
@@ -149,10 +149,12 @@ A create job has this top-level shape:
 }
 ```
 
-`template` is optional. Without one, `python-pptx`'s default presentation is used. With one, the
-template's masters and layouts are retained. Existing template slides are removed by default;
-set `keep_template_slides` to `true` to retain them. Template removal uses the same
-version-aware, reopen-verified relationship adapter as edit operations.
+`template` is optional. Without one, `python-pptx`'s 10 × 7.5-inch (4:3) default presentation is
+used. The schema does not resize a presentation; use a template with the required slide size
+before authoring absolute-inch geometry for another aspect ratio. With a template, its masters,
+layouts, and slide size are retained. Existing template slides are removed by default; set
+`keep_template_slides` to `true` to retain them. Template removal uses the same version-aware,
+reopen-verified relationship adapter as edit operations.
 
 A slide may select a `layout` with either `{"name": "Exact Layout Name"}` or `{"index": 1}`.
 If `layout` is omitted, layout index 1 is used and must exist. Duplicate layout names are
@@ -198,7 +200,9 @@ Supported actions:
 - `replace_image`: select one picture and provide `path`. The replacement must use the same media
   content type. Geometry/crop and unselected picture relationships remain unchanged; the selected
   picture receives a relationship to the validated replacement image.
-- `set_notes`: select a slide and provide plain `text`.
+- `set_notes`: select a slide and provide plain `text`. Written decks include and verify the
+  presentation-level notes-master owner reference required for PowerPoint and Keynote
+  interoperability.
 - `remove_slide`: select exactly one slide.
 - `reorder_slides`: provide `slide_ids` containing every current slide ID exactly once.
 
@@ -263,10 +267,13 @@ Elements:
 
 Chart types are `column`, `bar`, `line`, `line_markers`, `pie`, `doughnut`, `area`, `scatter`,
 and `scatter_lines`. Add `title` and `has_legend` as needed. Tables and charts remain editable.
-Notes are plain text only. Resource files are bounded and validated before use. Images are limited
-to 50 MiB compressed, 20,000 pixels per dimension, 50 million pixels, one frame, and an estimated
-200 MiB decoded raster. Each image path is read once into a bounded immutable byte snapshot;
-Pillow validation, full decode, and `python-pptx` ingestion all consume that same snapshot.
+Notes are plain text only. The tool repairs and validates the notes-master relationship graph that
+`python-pptx` 1.x can otherwise serialize without its presentation-level owner reference, which
+some consumers including Keynote reject. Resource files are bounded and validated before use.
+Images are limited to 50 MiB compressed, 20,000 pixels per dimension, 50 million pixels, one
+frame, and an estimated 200 MiB decoded raster. Each image path is read once into a bounded
+immutable byte snapshot; Pillow validation, full decode, and `python-pptx` ingestion all consume
+that same snapshot.
 
 ## LibreOffice prerequisite
 

--- a/kolega_code/_bundled_skills/skills/pptx/scripts/pptx_tool.py
+++ b/kolega_code/_bundled_skills/skills/pptx/scripts/pptx_tool.py
@@ -95,6 +95,7 @@ P_NS = "http://schemas.openxmlformats.org/presentationml/2006/main"
 A_NS = "http://schemas.openxmlformats.org/drawingml/2006/main"
 R_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
 NOTES_REL = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesSlide"
+NOTES_MASTER_REL = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesMaster"
 SLIDE_REL = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide"
 OFFICE_DOCUMENT_REL = (
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument"
@@ -815,6 +816,92 @@ class OoxmlAdapter:
             slide_id_list.append(by_id[slide_id])
 
     @classmethod
+    def ensure_notes_master_reference(cls, presentation: Any) -> None:
+        """Repair python-pptx's missing presentation-level notes-master owner reference."""
+
+        cls.require_supported_version()
+        relationships = [
+            (rel_id, relationship)
+            for rel_id, relationship in presentation.part.rels.items()
+            if relationship.reltype == NOTES_MASTER_REL
+        ]
+        root = presentation.part._element
+        master_lists = root.findall(f"{{{P_NS}}}notesMasterIdLst")
+        if not relationships:
+            if master_lists:
+                raise ToolError(
+                    "post_write_validation",
+                    "presentation has a notes-master owner reference without a relationship",
+                )
+            return
+        if len(relationships) != 1 or relationships[0][1].is_external:
+            raise ToolError(
+                "post_write_validation",
+                "presentation must contain exactly one internal notes-master relationship",
+                {"relationships": len(relationships)},
+            )
+        relationship_id = relationships[0][0]
+        if len(master_lists) > 1:
+            raise ToolError(
+                "post_write_validation",
+                "presentation contains duplicate notes-master owner-reference lists",
+            )
+        if master_lists:
+            master_ids = master_lists[0].findall(f"{{{P_NS}}}notesMasterId")
+            if (
+                len(master_ids) != 1
+                or len(master_lists[0]) != 1
+                or master_ids[0].get(f"{{{R_NS}}}id") != relationship_id
+            ):
+                raise ToolError(
+                    "post_write_validation",
+                    "presentation notes-master owner reference conflicts with its relationship",
+                    {"relationship": relationship_id},
+                )
+            return
+
+        master_list = etree.Element(f"{{{P_NS}}}notesMasterIdLst")
+        master_id = etree.SubElement(master_list, f"{{{P_NS}}}notesMasterId")
+        master_id.set(f"{{{R_NS}}}id", relationship_id)
+        children = list(root)
+        slide_master_tag = f"{{{P_NS}}}sldMasterIdLst"
+        successor_tags = {
+            f"{{{P_NS}}}handoutMasterIdLst",
+            f"{{{P_NS}}}sldIdLst",
+            f"{{{P_NS}}}sldSz",
+            f"{{{P_NS}}}notesSz",
+            f"{{{P_NS}}}smartTags",
+            f"{{{P_NS}}}embeddedFontLst",
+            f"{{{P_NS}}}custShowLst",
+            f"{{{P_NS}}}photoAlbum",
+            f"{{{P_NS}}}custDataLst",
+            f"{{{P_NS}}}kinsoku",
+            f"{{{P_NS}}}defaultTextStyle",
+            f"{{{P_NS}}}modifyVerifier",
+            f"{{{P_NS}}}extLst",
+        }
+        slide_master_indexes = [
+            index for index, child in enumerate(children) if child.tag == slide_master_tag
+        ]
+        if len(slide_master_indexes) > 1:
+            raise ToolError(
+                "post_write_validation",
+                "presentation contains duplicate slide-master ID lists",
+            )
+        insert_at = slide_master_indexes[0] + 1 if slide_master_indexes else 0
+        successor_indexes = [
+            index for index, child in enumerate(children) if child.tag in successor_tags
+        ]
+        if successor_indexes and min(successor_indexes) < insert_at:
+            raise ToolError(
+                "post_write_validation",
+                "presentation child order cannot accept a notes-master owner reference",
+            )
+        if not slide_master_indexes and successor_indexes:
+            insert_at = min(successor_indexes)
+        root.insert(insert_at, master_list)
+
+    @classmethod
     def paragraph_has_field(cls, paragraph: Any) -> bool:
         cls.require_supported_version()
         return bool(paragraph._p.xpath("./a:fld"))
@@ -944,9 +1031,84 @@ def _open_presentation(path: Path, category: str = "bad_input") -> Any:
         raise ToolError(category, "python-pptx could not reopen the presentation") from exc
 
 
+def _validate_notes_master_reference(path: Path) -> None:
+    try:
+        with zipfile.ZipFile(path) as archive:
+            presentation = _safe_xml(archive.read(PRESENTATION_PART), PRESENTATION_PART)
+            relationships_root = _safe_xml(
+                archive.read(PRESENTATION_RELS),
+                PRESENTATION_RELS,
+            )
+    except (OSError, RuntimeError, zipfile.BadZipFile, KeyError) as exc:
+        raise ToolError(
+            "post_write_validation",
+            "written PPTX notes-master graph could not be inspected",
+        ) from exc
+
+    relationships = [
+        relationship
+        for relationship in relationships_root.findall(f"{{{REL_NS}}}Relationship")
+        if relationship.get("Type") == NOTES_MASTER_REL
+    ]
+    master_lists = presentation.findall(f"{{{P_NS}}}notesMasterIdLst")
+    if not relationships:
+        if master_lists:
+            raise ToolError(
+                "post_write_validation",
+                "written PPTX has a notes-master owner reference without a relationship",
+            )
+        return
+    if len(relationships) != 1 or relationships[0].get("TargetMode") == "External":
+        raise ToolError(
+            "post_write_validation",
+            "written PPTX must contain exactly one internal notes-master relationship",
+            {"relationships": len(relationships)},
+        )
+    if len(master_lists) != 1:
+        raise ToolError(
+            "post_write_validation",
+            "written PPTX is missing its notes-master owner reference",
+            {"owner_reference_lists": len(master_lists)},
+        )
+    master_ids = master_lists[0].findall(f"{{{P_NS}}}notesMasterId")
+    relationship_id = relationships[0].get("Id")
+    if (
+        len(master_ids) != 1
+        or len(master_lists[0]) != 1
+        or master_ids[0].get(f"{{{R_NS}}}id") != relationship_id
+    ):
+        raise ToolError(
+            "post_write_validation",
+            "written PPTX notes-master owner reference does not match its relationship",
+            {"relationship": relationship_id},
+        )
+
+    children = list(presentation)
+    notes_index = children.index(master_lists[0])
+    slide_master_indexes = [
+        index for index, child in enumerate(children) if child.tag == f"{{{P_NS}}}sldMasterIdLst"
+    ]
+    successor_indexes = [
+        index
+        for index, child in enumerate(children)
+        if child.tag in {f"{{{P_NS}}}handoutMasterIdLst", f"{{{P_NS}}}sldIdLst"}
+    ]
+    if (
+        slide_master_indexes
+        and notes_index <= max(slide_master_indexes)
+        or successor_indexes
+        and notes_index >= min(successor_indexes)
+    ):
+        raise ToolError(
+            "post_write_validation",
+            "written PPTX notes-master owner reference is in an invalid presentation order",
+        )
+
+
 def _validate_pptx_output(path: Path, expected_ids: list[int]) -> PackageReport:
     try:
         report = preflight_pptx(path)
+        _validate_notes_master_reference(path)
         reopened = _open_presentation(path, "post_write_validation")
     except ToolError as exc:
         if exc.category in {"bad_input", "resource_limit", "unsupported_operation"}:
@@ -979,6 +1141,7 @@ def _checkpoint_graph_mutation(
     if set(retained) != set(before_ids) & set(expected_ids):
         raise ToolError("post_write_validation", "retained slide ID calculation failed")
     path = checkpoint_dir / f"graph-{ordinal}.pptx"
+    OoxmlAdapter.ensure_notes_master_reference(presentation)
     try:
         presentation.save(str(path))
     except Exception as exc:
@@ -2341,6 +2504,7 @@ def _save_atomic_presentation(
     temporary = _temporary_sibling(destination, ".pptx")
     try:
         _enforce_presentation_limits(presentation)
+        OoxmlAdapter.ensure_notes_master_reference(presentation)
         try:
             presentation.save(str(temporary))
         except Exception as exc:

--- a/kolega_code/_bundled_skills/skills/pptx/scripts/smoke_test.py
+++ b/kolega_code/_bundled_skills/skills/pptx/scripts/smoke_test.py
@@ -137,6 +137,87 @@ def _rewrite_zip(
             output.writestr(name, data)
 
 
+def _assert_notes_master_graph(path: Path, expected_notes_slides: int) -> None:
+    with zipfile.ZipFile(path) as archive:
+        names = set(archive.namelist())
+        presentation = ElementTree.fromstring(archive.read(PptxTool.PRESENTATION_PART))
+        relationships = ElementTree.fromstring(archive.read(PptxTool.PRESENTATION_RELS))
+    notes_slide_parts = {
+        name
+        for name in names
+        if name.startswith("ppt/notesSlides/notesSlide")
+        and name.endswith(".xml")
+        and "/_rels/" not in name
+    }
+    _assert(
+        len(notes_slide_parts) == expected_notes_slides,
+        f"expected {expected_notes_slides} notes-slide parts, found {len(notes_slide_parts)}",
+    )
+    notes_relationships = [
+        relationship
+        for relationship in relationships.findall(f"{{{PptxTool.REL_NS}}}Relationship")
+        if relationship.get("Type") == PptxTool.NOTES_MASTER_REL
+    ]
+    master_lists = presentation.findall(f"{{{PptxTool.P_NS}}}notesMasterIdLst")
+    if expected_notes_slides == 0:
+        _assert(
+            not notes_relationships,
+            "no-notes deck unexpectedly has a notes-master relationship",
+        )
+        _assert(not master_lists, "no-notes deck unexpectedly has a notes-master owner reference")
+        _assert(
+            not any(name.startswith("ppt/notesMasters/") for name in names),
+            "no-notes deck unexpectedly has a notes-master part",
+        )
+        return
+    _assert(
+        len(notes_relationships) == 1 and notes_relationships[0].get("TargetMode") != "External",
+        "notes deck must have exactly one internal notes-master relationship",
+    )
+    _assert(len(master_lists) == 1, "notes deck must have one notes-master owner-reference list")
+    master_ids = master_lists[0].findall(f"{{{PptxTool.P_NS}}}notesMasterId")
+    _assert(
+        len(master_ids) == 1
+        and len(master_lists[0]) == 1
+        and master_ids[0].get(f"{{{PptxTool.R_NS}}}id") == notes_relationships[0].get("Id"),
+        "notes-master owner reference does not match the presentation relationship",
+    )
+    children = list(presentation)
+    notes_index = children.index(master_lists[0])
+    slide_master_indexes = [
+        index
+        for index, child in enumerate(children)
+        if child.tag == f"{{{PptxTool.P_NS}}}sldMasterIdLst"
+    ]
+    slide_indexes = [
+        index for index, child in enumerate(children) if child.tag == f"{{{PptxTool.P_NS}}}sldIdLst"
+    ]
+    _assert(
+        (not slide_master_indexes or notes_index > max(slide_master_indexes))
+        and (not slide_indexes or notes_index < min(slide_indexes)),
+        "notes-master owner reference is not in schema order",
+    )
+
+
+def _remove_notes_master_owner_reference(source: Path, destination: Path) -> None:
+    with zipfile.ZipFile(source) as archive:
+        presentation = ElementTree.fromstring(archive.read(PptxTool.PRESENTATION_PART))
+    master_lists = presentation.findall(f"{{{PptxTool.P_NS}}}notesMasterIdLst")
+    _assert(len(master_lists) == 1, "notes-master corruption fixture lacks one owner list")
+    presentation.remove(master_lists[0])
+    _rewrite_zip(
+        source,
+        destination,
+        replacements={
+            PptxTool.PRESENTATION_PART: ElementTree.tostring(
+                presentation,
+                encoding="UTF-8",
+                xml_declaration=True,
+            )
+        },
+    )
+
+
 def _rewrite_font_typefaces(
     source: Path,
     destination: Path,
@@ -466,8 +547,9 @@ def _run_smoke(require_libreoffice: bool) -> dict[str, Any]:
             and create_result["verification"]["owner_relationship_references_resolved"],
             "create relationship target/reference verification missing",
         )
+        _assert_notes_master_graph(created, 2)
         Presentation(str(created))
-        checks.append("create/reopen")
+        checks.append("create/reopen-notes-master-reference")
 
         created_hash = _sha256(created)
         first_inspection = _run(["inspect", str(created)])
@@ -475,6 +557,68 @@ def _run_smoke(require_libreoffice: bool) -> dict[str, Any]:
         slides = first_inspection["presentation"]["slides"]
         original_ids = [slide["slide_id"] for slide in slides]
         _assert(len(set(original_ids)) == 3, "slide IDs are not unique")
+        missing_notes_owner = work / "missing-notes-owner.pptx"
+        _remove_notes_master_owner_reference(created, missing_notes_owner)
+        try:
+            PptxTool._validate_pptx_output(missing_notes_owner, original_ids)
+        except PptxTool.ToolError as exc:
+            _assert(
+                exc.category == "post_write_validation"
+                and "notes-master owner reference" in exc.message,
+                "missing notes-master owner reference produced the wrong validation failure",
+            )
+        else:
+            raise SmokeFailure("output validation accepted a missing notes-master owner reference")
+        checks.append("failure/missing-notes-master-owner-reference")
+
+        no_notes_job = work / "no-notes.json"
+        no_notes = work / "no-notes.pptx"
+        _write_json(
+            no_notes_job,
+            {
+                "schema_version": 1,
+                "operation": "create",
+                "slides": [{"layout": {"index": 5}, "title": "No notes"}],
+            },
+        )
+        _run(["create", "--job", str(no_notes_job), "--output", str(no_notes)])
+        _assert_notes_master_graph(no_notes, 0)
+        no_notes_inspection = _run(["inspect", str(no_notes)])
+        no_notes_slide_id = no_notes_inspection["presentation"]["slides"][0]["slide_id"]
+        add_notes_job = work / "add-notes.json"
+        added_notes = work / "added-notes.pptx"
+        _write_json(
+            add_notes_job,
+            {
+                "schema_version": 1,
+                "operation": "edit",
+                "operations": [
+                    {
+                        "action": "set_notes",
+                        "slide": {"slide_id": no_notes_slide_id},
+                        "text": "Added after creation",
+                    }
+                ],
+            },
+        )
+        _run(
+            [
+                "edit",
+                str(no_notes),
+                "--job",
+                str(add_notes_job),
+                "--output",
+                str(added_notes),
+            ]
+        )
+        _assert_notes_master_graph(added_notes, 1)
+        _assert(
+            _run(["inspect", str(added_notes)])["presentation"]["slides"][0]["notes"]
+            == "Added after creation",
+            "notes added during edit did not round-trip",
+        )
+        checks.append("create-edit/notes-master-lifecycle")
+
         _assert(first_inspection["counts"]["images"] == 2, "image inventory mismatch")
         _assert(first_inspection["counts"]["tables"] == 1, "table inventory mismatch")
         _assert(first_inspection["counts"]["charts"] == 1, "chart inventory mismatch")
@@ -916,6 +1060,7 @@ def _run_smoke(require_libreoffice: bool) -> dict[str, Any]:
             len(first_edit_result["verification"]["graph_checkpoints"]) == 1,
             "insert reorder was not checkpointed",
         )
+        _assert_notes_master_graph(first_edit, 3)
         second_inspection = _run(["inspect", str(first_edit)])
         second_slides = second_inspection["presentation"]["slides"]
         second_ids = [slide["slide_id"] for slide in second_slides]


### PR DESCRIPTION
Vendors kolega-skills `v0.3.2` (PR #17: pptx notes-master fix) into the bundled catalog.

- `pptx_tool.py` + `smoke_test.py` updated to repair and validate the notes-master relationship graph python-pptx 1.x can serialize without its presentation-level owner reference (breaks Keynote)
- `references/operations.md` documents the repair and the 4:3 default slide size
- Manifest re-pinned to tag v0.3.2 (`2de7491`)
- Docs catalog pin bumped v0.3.1 -> v0.3.2
- Verified: bundled-skills tests pass; every bundled file byte-matches the tag archive