### PR TITLE
fix(cli): drop redundant project path from resume hint

### DIFF
--- a/kolega_code/cli/messages.py
+++ b/kolega_code/cli/messages.py
@@ -294,7 +294,7 @@ CHATGPT_LOGOUT_DONE = "Signed out of ChatGPT. Stored credentials were removed."
 CHATGPT_LOGOUT_NONE = "You are not signed in to ChatGPT."
 
 # Session quit hint
-SESSION_RESUME_HINT = "Session saved. Resume it with: kolega-code . --resume {session_id}"
+SESSION_RESUME_HINT = "Session saved. Resume it with: kolega-code --resume {session_id}"
 
 # Misc
 COPY_MACOS_FAILED = "Copied for supported terminals, but the macOS clipboard failed."

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -702,7 +702,7 @@ def test_print_quit_resume_hint_shows_full_session_id(capsys) -> None:
     _print_quit_resume_hint(session_id)
 
     captured = capsys.readouterr()
-    assert captured.out.strip() == "Session saved. Resume it with: kolega-code . --resume " + session_id
+    assert captured.out.strip() == "Session saved. Resume it with: kolega-code --resume " + session_id
     assert captured.err == ""
 
 


### PR DESCRIPTION
The TUI quit hint prints:

```
Session saved. Resume it with: kolega-code . --resume <session-id>
```

The project path already defaults to `.` (`project_path` nargs=`?` default="."`), so the dot is noise. Print the simpler, equally functional form instead:

```
Session saved. Resume it with: kolega-code --resume <session-id>
```

Changes:
- `kolega_code/cli/messages.py`: updated `SESSION_RESUME_HINT`.
- `tests/cli/test_main.py`: updated the assertion in `test_print_quit_resume_hint_shows_full_session_id`.

Verified: full `tests/cli/test_main.py` (58 passed), ruff check/format clean, pre-commit passed on commit.