### PR TITLE
chore: release v0.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.28.1 - 2026-08-12
+
+### Fixed
+
+- Restored native Tinker tool dispatch so generated tool calls execute through
+  the agent loop instead of being returned as plain assistant output.
+
 ## 0.28.0 - 2026-08-11
 
 ### Added

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -173,4 +173,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.28.0"
+__version__ = "0.28.1"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.28.0"
+__version__ = "0.28.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.28.0"
+version = "0.28.1"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -1787,7 +1787,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.28.0"
+version = "0.28.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- bump Kolega Code from 0.28.0 to 0.28.1
- document the restored native Tinker tool dispatch fix
- refresh the lockfile package version

## Why

PR #560 restores Tinker-generated tool calls to the ordinary agent tool loop. This patch release publishes that fix.

## Validation

- `UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" ./run_tests.sh` — 4,605 passed, 74 skipped
- `UV_PROJECT_ENVIRONMENT="$PWD/.venv-release" uv run pre-commit run --all-files --show-diff-on-failure` — passed
