### PR TITLE
fix(llm): repair reused Tinker tool-call IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+### Fixed
+
+- Native Tinker sessions now keep repeated provider tool-call IDs paired with
+  their distinct executions after persistence, avoiding false interrupted-tool
+  placeholders and preserving every result in subsequent model history.
+
 ## 0.28.1 - 2026-08-12
 
 ### Fixed

--- a/kolega_code/agent/conversation.py
+++ b/kolega_code/agent/conversation.py
@@ -9,8 +9,9 @@ holding their own reference.
 
 import logging
 import re
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, cast
 
+from kolega_code.agent.tool_backend.hashline_v2 import strip_hashline_read_output
 from kolega_code.llm.models import (
     ContentBlock,
     ImageBlock,
@@ -23,10 +24,10 @@ from kolega_code.llm.models import (
     ToolCall,
     ToolResult,
     WebSearchCallBlock,
+    same_tool_execution,
 )
 from kolega_code.llm.specs import prior_reasoning_is_replayable
 from kolega_code.utils import images as image_utils
-from kolega_code.agent.tool_backend.hashline_v2 import strip_hashline_read_output
 
 logger = logging.getLogger(__name__)
 
@@ -630,25 +631,48 @@ class Conversation:
             content_blocks = [content]
 
         if isinstance(content_blocks, list):
-            new_tool_results = {}
+            new_tool_results: List[ToolResult] = []
             other_blocks = []
 
             for block in content_blocks:
                 if isinstance(block, ToolResult):
-                    new_tool_results[block.tool_use_id] = block
+                    duplicate_index = next(
+                        (
+                            index
+                            for index, existing in enumerate(new_tool_results)
+                            if same_tool_execution(existing, block)
+                        ),
+                        None,
+                    )
+                    if duplicate_index is None:
+                        new_tool_results.append(block)
+                    else:
+                        new_tool_results[duplicate_index] = block
                 else:
                     other_blocks.append(block)
 
             if new_tool_results:
-                # Find and update any existing tool results with the same IDs
+                # Find and update any existing result for the same execution.
                 for i, msg in enumerate(self.history):
                     if msg.role == "user" and isinstance(msg.content, list):
                         updated_content = []
                         replaced_any = False
 
                         for block in msg.content:
-                            if isinstance(block, ToolResult) and block.tool_use_id in new_tool_results:
-                                new_result = new_tool_results[block.tool_use_id]
+                            matching_index = (
+                                next(
+                                    (
+                                        index
+                                        for index, candidate in enumerate(new_tool_results)
+                                        if same_tool_execution(block, candidate)
+                                    ),
+                                    None,
+                                )
+                                if isinstance(block, ToolResult)
+                                else None
+                            )
+                            if isinstance(block, ToolResult) and matching_index is not None:
+                                new_result = new_tool_results[matching_index]
                                 # Replace if: old is dummy error OR new is success and old is error
                                 should_replace = (block.is_error and "Operation was interrupted" in block.content) or (
                                     not new_result.is_error and block.is_error
@@ -658,14 +682,13 @@ class Conversation:
                                     updated_content.append(new_result)
                                     replaced_any = True
                                     logger.debug("Replaced tool result for tool_use_id: %s", block.tool_use_id)
-                                    del new_tool_results[block.tool_use_id]
+                                    del new_tool_results[matching_index]
                                 else:
                                     updated_content.append(block)
-                                    if block.tool_use_id in new_tool_results:
-                                        logger.debug(
-                                            "Skipping duplicate tool result for tool_use_id: %s", block.tool_use_id
-                                        )
-                                        del new_tool_results[block.tool_use_id]
+                                    logger.debug(
+                                        "Skipping duplicate tool result for tool_use_id: %s", block.tool_use_id
+                                    )
+                                    del new_tool_results[matching_index]
                             else:
                                 updated_content.append(block)
 
@@ -679,7 +702,7 @@ class Conversation:
                             )
 
                 # Add any remaining new tool results along with other blocks
-                content_blocks = list(new_tool_results.values()) + other_blocks
+                content_blocks = cast(List[ContentBlock], list(new_tool_results)) + other_blocks
 
                 # If all blocks were handled (replaced or skipped), don't add empty message
                 if not content_blocks:
@@ -826,10 +849,22 @@ class Conversation:
                     fixed_messages.append(current_message)
                     processed_indices.add(i)
 
-                    # Collect all tool results from the entire remaining conversation
-                    tool_call_ids = {call.id for call in tool_calls}
-                    all_tool_results = {}
+                    # Collect all tool results from the entire remaining conversation.
+                    # Provider IDs may repeat across responses, so correlate modern
+                    # records by their durable execution IDs and fall back to provider
+                    # IDs only when either side is legacy.
+                    all_tool_results: Dict[int, ToolResult] = {}
                     other_content_blocks = []  # Non-tool-result content from the next user message
+
+                    def unmatched_call_index(block: ToolResult) -> Optional[int]:
+                        return next(
+                            (
+                                index
+                                for index, call in enumerate(tool_calls)
+                                if index not in all_tool_results and same_tool_execution(call, block)
+                            ),
+                            None,
+                        )
 
                     # First, check the immediately following message (expected position)
                     next_user_message = None
@@ -837,8 +872,9 @@ class Conversation:
                         next_user_message = messages[i + 1]
                         if isinstance(next_user_message.content, list):
                             for block in next_user_message.content:
-                                if isinstance(block, ToolResult) and block.tool_use_id in tool_call_ids:
-                                    all_tool_results[block.tool_use_id] = block
+                                call_index = unmatched_call_index(block) if isinstance(block, ToolResult) else None
+                                if isinstance(block, ToolResult) and call_index is not None:
+                                    all_tool_results[call_index] = block
                                 else:
                                     other_content_blocks.append(block)
 
@@ -848,8 +884,7 @@ class Conversation:
                             processed_indices.add(i + 1)
 
                     # Search the entire remaining conversation for any missing tool results
-                    missing_ids = tool_call_ids - set(all_tool_results.keys())
-                    if missing_ids:
+                    if len(all_tool_results) < len(tool_calls):
                         for j in range(i + 1, len(messages)):
                             if j in processed_indices:
                                 continue
@@ -860,15 +895,15 @@ class Conversation:
                                 found_any = False
 
                                 for block in msg.content:
-                                    if isinstance(block, ToolResult) and block.tool_use_id in missing_ids:
+                                    call_index = unmatched_call_index(block) if isinstance(block, ToolResult) else None
+                                    if isinstance(block, ToolResult) and call_index is not None:
                                         logger.warning(
                                             "Found tool result %s at position %s instead of expected position %s",
                                             block.tool_use_id,
                                             j,
                                             i + 1,
                                         )
-                                        all_tool_results[block.tool_use_id] = block
-                                        missing_ids.remove(block.tool_use_id)
+                                        all_tool_results[call_index] = block
                                         found_any = True
                                     else:
                                         remaining_content.append(block)
@@ -890,9 +925,9 @@ class Conversation:
 
                     # Create the complete tool results list in the correct order
                     complete_tool_results = []
-                    for tool_call in tool_calls:
-                        if tool_call.id in all_tool_results:
-                            complete_tool_results.append(all_tool_results[tool_call.id])
+                    for call_index, tool_call in enumerate(tool_calls):
+                        if call_index in all_tool_results:
+                            complete_tool_results.append(all_tool_results[call_index])
                         else:
                             logger.warning("Adding placeholder result for missing tool call: %s", tool_call.id)
                             complete_tool_results.append(
@@ -901,6 +936,7 @@ class Conversation:
                                     content="Operation was interrupted. Please retry if needed.",
                                     name=tool_call.name,
                                     is_error=True,
+                                    execution_id=tool_call.execution_id,
                                     input_kind=tool_call.input_kind,
                                 )
                             )

--- a/kolega_code/llm/models.py
+++ b/kolega_code/llm/models.py
@@ -1119,6 +1119,34 @@ class ToolResult(ContentBlock):
         return f"{status} from tool call (ID: {self.tool_use_id}):\n\n```\n{markdown_content}\n```"
 
 
+ToolExecutionBlock = Union[ToolCall, ToolResult]
+
+
+def provider_tool_call_id(block: ToolExecutionBlock) -> str:
+    """Return the provider-owned identifier used on the model wire."""
+    return block.id if isinstance(block, ToolCall) else block.tool_use_id
+
+
+def same_tool_execution(left: ToolExecutionBlock, right: ToolExecutionBlock) -> bool:
+    """Whether two call/result blocks describe one app-level execution.
+
+    Modern records carry the globally unique app ``execution_id`` on both
+    sides. Legacy records may lack it on the result (while restoring the call
+    generates one), so provider-ID matching remains the compatibility fallback
+    whenever either side has no durable execution ID.
+    """
+    if left.execution_id is not None and right.execution_id is not None:
+        return left.execution_id == right.execution_id
+    return provider_tool_call_id(left) == provider_tool_call_id(right)
+
+
+def tool_result_identity(result: ToolResult) -> tuple[str, str]:
+    """Stable de-duplication key for one result, with legacy fallback."""
+    if result.execution_id is not None:
+        return ("execution", result.execution_id)
+    return ("provider", result.tool_use_id)
+
+
 def _tool_result_blocks(tool_result: "ToolResult") -> List[ContentBlock]:
     if isinstance(tool_result.content, list):
         return tool_result.content
@@ -1905,31 +1933,46 @@ class MessageHistory(list):
 
     def to_openai(self, provider: Optional[str] = None, model: Optional[str] = None) -> list:
         processed_messages = []
-        consumed_tool_result_ids = set()
+        # A provider tool-call ID need not be globally unique (native Tinker
+        # emits call_0 in each response). Track their execution identities
+        # instead of treating wire IDs as conversation-global IDs.
+        consumed_tool_results: set[tuple[str, str]] = set()
         messages = list(self)
 
         def payload_has_content(payload: Dict[str, Any]) -> bool:
             content = payload.get("content")
             return (isinstance(content, str) and bool(content)) or (isinstance(content, list) and bool(content))
 
-        def collect_lookahead_tool_results(start_index: int, needed_ids: set) -> List[ToolResult]:
+        def unmatched_tool_calls(calls: List[ToolCall], results: List[ToolResult]) -> List[ToolCall]:
+            unmatched = list(calls)
+            for result in results:
+                matching_index = next(
+                    (index for index, call in enumerate(unmatched) if same_tool_execution(call, result)),
+                    None,
+                )
+                if matching_index is not None:
+                    unmatched.pop(matching_index)
+            return unmatched
+
+        def collect_lookahead_tool_results(start_index: int, needed_calls: List[ToolCall]) -> List[ToolResult]:
             found: List[ToolResult] = []
-            if not needed_ids:
+            unmatched = list(needed_calls)
+            if not unmatched:
                 return found
-            found_ids = set()
             for look_ahead in messages[start_index + 1 :]:
                 if not isinstance(look_ahead.content, list):
                     continue
                 for item in look_ahead.content:
-                    if (
-                        isinstance(item, ToolResult)
-                        and item.tool_use_id in needed_ids
-                        and item.tool_use_id not in consumed_tool_result_ids
-                        and item.tool_use_id not in found_ids
-                    ):
+                    if not isinstance(item, ToolResult) or tool_result_identity(item) in consumed_tool_results:
+                        continue
+                    matching_index = next(
+                        (index for index, call in enumerate(unmatched) if same_tool_execution(call, item)),
+                        None,
+                    )
+                    if matching_index is not None:
                         found.append(item)
-                        found_ids.add(item.tool_use_id)
-                if needed_ids.issubset(found_ids):
+                        unmatched.pop(matching_index)
+                if not unmatched:
                     break
             return found
 
@@ -1944,7 +1987,7 @@ class MessageHistory(list):
             tool_result_blocks = [
                 item
                 for item in message.content
-                if isinstance(item, ToolResult) and item.tool_use_id not in consumed_tool_result_ids
+                if isinstance(item, ToolResult) and tool_result_identity(item) not in consumed_tool_results
             ]
 
             if tool_result_blocks:
@@ -1964,22 +2007,21 @@ class MessageHistory(list):
 
                 # If this same message included tool_calls, pull any missing tool
                 # results forward so all role=tool messages stay contiguous.
-                tool_call_ids = [item.id for item in message.content if isinstance(item, ToolCall)]
-                found_ids = {tr.tool_use_id for tr in tool_result_blocks}
-                lookahead_results = collect_lookahead_tool_results(index, set(tool_call_ids) - found_ids)
+                tool_calls = [item for item in message.content if isinstance(item, ToolCall)]
+                missing_calls = unmatched_tool_calls(tool_calls, tool_result_blocks)
+                lookahead_results = collect_lookahead_tool_results(index, missing_calls)
                 batch_tool_results = tool_result_blocks + lookahead_results
 
                 processed_messages.extend(_openai_tool_result_message(tr) for tr in batch_tool_results)
                 for tr in batch_tool_results:
-                    consumed_tool_result_ids.add(tr.tool_use_id)
+                    consumed_tool_results.add(tool_result_identity(tr))
 
                 # If still missing, emit placeholder tool messages to satisfy API requirements.
                 # These must come before any image follow-up user messages so all required
                 # role=tool responses stay contiguous after the assistant tool calls.
-                added_ids = {tr.tool_use_id for tr in lookahead_results}
-                remaining = set(tool_call_ids) - (found_ids | added_ids)
-                for missing_id in remaining:
-                    processed_messages.append({"role": "tool", "content": "", "tool_call_id": missing_id})
+                remaining_calls = unmatched_tool_calls(missing_calls, lookahead_results)
+                for missing_call in remaining_calls:
+                    processed_messages.append({"role": "tool", "content": "", "tool_call_id": missing_call.id})
                 for tr in batch_tool_results:
                     followup = _openai_tool_result_image_followup(tr)
                     if followup is not None:
@@ -1997,20 +2039,19 @@ class MessageHistory(list):
 
                 tool_calls = temp_payload.get("tool_calls") or []
                 if tool_calls:
-                    tool_call_ids = [tc.get("id") for tc in tool_calls if tc.get("id")]
-                    lookahead_results = collect_lookahead_tool_results(index, set(tool_call_ids))
+                    content_tool_calls = [item for item in message.content if isinstance(item, ToolCall)]
+                    lookahead_results = collect_lookahead_tool_results(index, content_tool_calls)
 
                     processed_messages.extend(_openai_tool_result_message(tr) for tr in lookahead_results)
                     for tr in lookahead_results:
-                        consumed_tool_result_ids.add(tr.tool_use_id)
+                        consumed_tool_results.add(tool_result_identity(tr))
 
                     # If any are still missing, emit placeholder tool messages to satisfy API ordering.
                     # Placeholders also come before image follow-up user messages to keep all role=tool
                     # responses contiguous after the assistant tool-call message.
-                    added_ids = {tr.tool_use_id for tr in lookahead_results}
-                    remaining = [tc_id for tc_id in tool_call_ids if tc_id not in added_ids]
-                    for missing_id in remaining:
-                        processed_messages.append({"role": "tool", "content": "", "tool_call_id": missing_id})
+                    remaining_calls = unmatched_tool_calls(content_tool_calls, lookahead_results)
+                    for missing_call in remaining_calls:
+                        processed_messages.append({"role": "tool", "content": "", "tool_call_id": missing_call.id})
                     for tr in lookahead_results:
                         followup = _openai_tool_result_image_followup(tr)
                         if followup is not None:

--- a/kolega_code/llm/providers/tinker.py
+++ b/kolega_code/llm/providers/tinker.py
@@ -581,7 +581,12 @@ def _message_to_chunks(message: Message) -> List[MessageChunk]:
             chunks.append(
                 MessageChunk(
                     type="tool_use_start",
-                    tool_call_delta={"id": block.id, "name": block.name, "input": ""},
+                    tool_call_delta={
+                        "id": block.id,
+                        "name": block.name,
+                        "input": "",
+                        "execution_id": block.execution_id,
+                    },
                 )
             )
             chunks.append(

--- a/tests/agent/llm/test_openai_message_conversion.py
+++ b/tests/agent/llm/test_openai_message_conversion.py
@@ -40,6 +40,38 @@ def test_mixed_content_splits_tool_result_to_separate_tool_messages():
     assert messages[1]["content"] == "3"
 
 
+def test_reused_provider_tool_call_id_emits_each_execution_result() -> None:
+    history = MessageHistory()
+    for suffix in ("first", "second"):
+        execution_id = f"tool_exec_{suffix}"
+        call = ToolCall(id="call_0", name="lookup", input={}, execution_id=execution_id)
+        history.extend(
+            [
+                Message(role="assistant", content=[call], tool_calls=[call]),
+                Message(
+                    role="user",
+                    content=[
+                        ToolResult(
+                            tool_use_id="call_0",
+                            content=f"{suffix} result",
+                            name="lookup",
+                            is_error=False,
+                            execution_id=execution_id,
+                        )
+                    ],
+                ),
+            ]
+        )
+
+    payload = history.to_openai()
+
+    tool_messages = [message for message in payload if message["role"] == "tool"]
+    assert [(message["tool_call_id"], message["content"]) for message in tool_messages] == [
+        ("call_0", "first result"),
+        ("call_0", "second result"),
+    ]
+
+
 def test_image_tool_result_serializes_as_tool_text_plus_user_image():
     tool_call = ToolCall(id="call_img", name="read_image", input={"path": "shot.png"})
     assistant = Message(role="assistant", content=[tool_call])

--- a/tests/agent/llm/test_tinker_provider.py
+++ b/tests/agent/llm/test_tinker_provider.py
@@ -406,7 +406,12 @@ async def test_stream_final_message_exposes_tool_calls_and_fabricates_missing_id
     ]
     assert final.stop_reason == "tool_use"
     assert [chunk.type for chunk in chunks] == ["tool_use_start", "tool_use_delta"]
-    assert chunks[0].tool_call_delta == {"id": "call_0", "name": "get_weather", "input": ""}
+    assert chunks[0].tool_call_delta == {
+        "id": "call_0",
+        "name": "get_weather",
+        "input": "",
+        "execution_id": final.tool_calls[0].execution_id,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_duplicate_tool_results.py
+++ b/tests/agent/test_duplicate_tool_results.py
@@ -381,6 +381,77 @@ class TestDuplicateToolResultPrevention:
         assert tool_results[0].content == "First successful execution"
         assert tool_results[0].is_error is False
 
+    def test_reused_provider_id_with_distinct_execution_ids_is_not_a_duplicate(self, base_agent):
+        """Provider IDs may repeat across responses; execution IDs identify the actual run."""
+        first_call = ToolCall(id="call_0", name="test_tool", input={}, execution_id="tool_exec_first")
+        second_call = ToolCall(id="call_0", name="test_tool", input={}, execution_id="tool_exec_second")
+        base_agent.history.append(Message(role="assistant", content=[first_call], tool_calls=[first_call]))
+        base_agent.append_user_message(
+            [
+                ToolResult(
+                    tool_use_id="call_0",
+                    name="test_tool",
+                    content="first result",
+                    is_error=False,
+                    execution_id="tool_exec_first",
+                )
+            ]
+        )
+        base_agent.history.append(Message(role="assistant", content=[second_call], tool_calls=[second_call]))
+
+        # SessionRecorder.record_tool_results returns a freshly hydrated object.
+        second_result = ToolResult.from_dict(
+            ToolResult(
+                tool_use_id="call_0",
+                name="test_tool",
+                content="second result",
+                is_error=False,
+                execution_id="tool_exec_second",
+            ).to_dict()
+        )
+        base_agent.append_user_message([second_result])
+
+        results = [
+            block
+            for message in base_agent.history
+            if isinstance(message.content, list)
+            for block in message.content
+            if isinstance(block, ToolResult)
+        ]
+        assert [(result.content, result.execution_id) for result in results] == [
+            ("first result", "tool_exec_first"),
+            ("second result", "tool_exec_second"),
+        ]
+
+    def test_repair_does_not_steal_reused_provider_id_from_another_execution(self, base_agent):
+        first_call = ToolCall(id="call_0", name="test_tool", input={}, execution_id="tool_exec_first")
+        second_call = ToolCall(id="call_0", name="test_tool", input={}, execution_id="tool_exec_second")
+        second_result = ToolResult(
+            tool_use_id="call_0",
+            name="test_tool",
+            content="second result",
+            is_error=False,
+            execution_id="tool_exec_second",
+        )
+
+        repaired = base_agent.fix_incomplete_tool_calls(
+            [
+                Message(role="assistant", content=[first_call], tool_calls=[first_call]),
+                Message(role="assistant", content=[second_call], tool_calls=[second_call]),
+                Message(role="user", content=[second_result]),
+            ]
+        )
+
+        result_messages = [message for message in repaired if message.role == "user"]
+        first_repaired = result_messages[0].content[0]
+        second_repaired = result_messages[1].content[0]
+        assert isinstance(first_repaired, ToolResult)
+        assert isinstance(second_repaired, ToolResult)
+        assert first_repaired.is_error is True
+        assert "Operation was interrupted" in first_repaired.content
+        assert first_repaired.execution_id == "tool_exec_first"
+        assert second_repaired is second_result
+
     def test_cross_message_tool_results_during_restoration(self, base_agent):
         """Test that tool results found in non-adjacent messages are handled correctly during restoration."""
         # Create a scenario where tool result is not in the immediately following message

--- a/tests/cli/test_session_store.py
+++ b/tests/cli/test_session_store.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from kolega_code.agent.conversation import Conversation
 from kolega_code.cli import session_journal as session_journal_module
 from kolega_code.cli.session_journal import (
     DEFAULT_ROOT_AGENT_NAME,
@@ -356,6 +357,58 @@ def test_large_tool_result_uses_artifact_and_bounded_preview(tmp_path: Path) -> 
     assert full not in bug_export.session_json
     assert full not in bug_export.events_jsonl
     assert ref["sha256"] in bug_export.artifact_manifest_json
+
+
+def test_reused_provider_tool_call_id_preserves_execution_pairs_through_session_replay(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    store = SessionStore(tmp_path / "state")
+    record = store.create(project, "code", {})
+    recorder = store.recorder(record.session_id)
+    recorder.start_turn(Message(role="user", content=[TextBlock("repeat")]))
+
+    for suffix in ("first", "second"):
+        execution_id = f"tool_exec_{suffix}"
+        call = ToolCall(id="call_0", name="read_file", input={}, execution_id=execution_id)
+        recorder.record_assistant(Message(role="assistant", content=[call], tool_calls=[call]))
+        replayed = recorder.record_tool_results(
+            [
+                ToolResult(
+                    tool_use_id="call_0",
+                    content=f"{suffix} result",
+                    name="read_file",
+                    is_error=False,
+                    execution_id=execution_id,
+                )
+            ]
+        )
+        assert replayed[0].execution_id == execution_id
+
+    recorder.finish_turn("completed")
+    messages = [Message.from_dict(item) for item in store.load(record.session_id).history]
+    repaired = Conversation(messages).repaired()
+    calls = [
+        block
+        for message in repaired
+        if isinstance(message.content, list)
+        for block in message.content
+        if isinstance(block, ToolCall)
+    ]
+    results = [
+        block
+        for message in repaired
+        if isinstance(message.content, list)
+        for block in message.content
+        if isinstance(block, ToolResult)
+    ]
+    assert [(call.id, call.execution_id) for call in calls] == [
+        ("call_0", "tool_exec_first"),
+        ("call_0", "tool_exec_second"),
+    ]
+    assert [(result.content, result.execution_id) for result in results] == [
+        ("first result", "tool_exec_first"),
+        ("second result", "tool_exec_second"),
+    ]
 
 
 def test_terminal_spill_path_round_trips_without_resume_rewriting(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- correlate tool calls and results by Kolega's unique execution IDs while retaining provider IDs on provider-facing messages
- preserve provider-ID fallback for legacy persisted sessions that predate execution IDs
- propagate execution IDs through native Tinker stream chunks and synthetic interruption placeholders
- add focused regressions for append de-duplication, history repair, OpenAI serialization, session rehydration, and Tinker streaming

## Root cause

Native Tinker can reuse a provider tool-call ID such as `call_0` on every response. Kolega correctly assigns a unique `tool_exec_*` execution ID, but persisted-history append, repair, and serialization paths still treated the provider ID as conversation-global. After hydration, later real results were mistaken for earlier calls, which caused false `Operation was interrupted` placeholders and quadratic warnings. A 92-call reproduction produced 4,186 warnings before this fix.

## Compatibility

Provider IDs remain unchanged on the wire. Providers whose IDs are globally unique or conversation-unique continue to behave as before. New records pair by execution ID; legacy records without execution IDs retain the existing provider-ID fallback.

## Validation

- `uv run pre-commit run --all-files --show-diff-on-failure` — passed
- focused regression suite — 90 passed
- `./run_tests.sh --all` — 4,753 passed, 69 skipped (documented opt-in/unavailable external tests)
- explicit live provider/tool matrix — 35 passed across Anthropic, OpenAI, Google, DeepSeek, Together, xAI, Moonshot/Kimi, Fireworks, DashScope, Z.AI, OpenRouter, Ollama Cloud, Thinking Machines, and Tinker
- native Tinker 0.25.0 repeated-`call_0` hidden-value probe — passed
- exact 92-call persistence/repair reproduction — 92 results retained, 0 warnings, 0 placeholders

## Dependency note

The repository and lockfile already pin Tinker 0.25.0. The development environment had still been using 0.24.0; a frozen sync updated the local environment without changing dependency files.