### PR TITLE
chore: release v0.28.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.28.2 - 2026-08-12
+
 ### Fixed
 
 - Native Tinker sessions now keep repeated provider tool-call IDs paired with

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -173,4 +173,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.28.1"
+__version__ = "0.28.2"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.28.1"
+__version__ = "0.28.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.28.1"
+version = "0.28.2"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -1787,7 +1787,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.28.1"
+version = "0.28.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- bump Kolega Code from 0.28.1 to 0.28.2 in all package version declarations and the lockfile
- move the native Tinker history-repair fix from Unreleased into the 0.28.2 changelog
- retain the existing stable HTTPX 0.28.1 dependency unchanged

## Release impact

This patch release preserves native Tinker tool results when provider tool-call IDs such as `call_0` are reused across turns. Persisted and rehydrated sessions no longer synthesize false interrupted-operation results for completed executions.

## Validation

- isolated release environment: `UV_PROJECT_ENVIRONMENT="$PWD/.venv-release"`
- fast suite with optional native Tinker stack: 4,682 passed, 1 skipped
- native Tinker live generate and streaming usage tests passed
- all pre-commit/CI-parity checks passed, including Ruff, Pyright, secret detection, and package-boundary checks
- release diff contains only the five intended version, lockfile, and changelog files