### PR TITLE
feat(llm): use Claude edit tools for Tinker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+### Changed
+
+- Native Tinker and hosted Thinking Machines models now use Claude-style file
+  editing tools by default.
+
 ## 0.28.2 - 2026-08-12
 
 ### Fixed

--- a/kolega_code/llm/specs/accessors.py
+++ b/kolega_code/llm/specs/accessors.py
@@ -5,6 +5,11 @@ from .types import ThinkingEffortSpec
 from .validation import INPUT_BUDGET_CONVENTIONS as INPUT_BUDGET_CONVENTIONS
 from .validation import validate_model_spec
 
+_PROVIDER_DEFAULT_EDIT_PROTOCOLS = {
+    "thinking_machines": "claude_code",
+    "tinker": "claude_code",
+}
+
 # Every spec entry must declare which input-budget calculation applies:
 #   window_minus_output   — usable input = context_length − max_completion_tokens
 #                           (one shared pool; we reserve what we request)
@@ -171,11 +176,13 @@ def preferred_edit_protocol(provider: str, model_name: str) -> Optional[str]:
     """
 
     provider_str = _provider_value(provider)
-    specs = MODEL_SPECS.get((provider_str, model_name))
+    specs = _resolve_specs(provider_str, model_name)
     if specs is None:
         return None
     value = specs.get("preferred_edit_protocol")
-    return str(value) if value is not None else None
+    if value is not None:
+        return str(value)
+    return _PROVIDER_DEFAULT_EDIT_PROTOCOLS.get(provider_str)
 
 
 # DeepSeek's published max_completion_tokens (384000) is fiction. Probed

--- a/kolega_code/llm/specs/accessors.py
+++ b/kolega_code/llm/specs/accessors.py
@@ -5,11 +5,6 @@ from .types import ThinkingEffortSpec
 from .validation import INPUT_BUDGET_CONVENTIONS as INPUT_BUDGET_CONVENTIONS
 from .validation import validate_model_spec
 
-_PROVIDER_DEFAULT_EDIT_PROTOCOLS = {
-    "thinking_machines": "claude_code",
-    "tinker": "claude_code",
-}
-
 # Every spec entry must declare which input-budget calculation applies:
 #   window_minus_output   — usable input = context_length − max_completion_tokens
 #                           (one shared pool; we reserve what we request)
@@ -176,13 +171,11 @@ def preferred_edit_protocol(provider: str, model_name: str) -> Optional[str]:
     """
 
     provider_str = _provider_value(provider)
-    specs = _resolve_specs(provider_str, model_name)
+    specs = MODEL_SPECS.get((provider_str, model_name))
     if specs is None:
         return None
     value = specs.get("preferred_edit_protocol")
-    if value is not None:
-        return str(value)
-    return _PROVIDER_DEFAULT_EDIT_PROTOCOLS.get(provider_str)
+    return str(value) if value is not None else None
 
 
 # DeepSeek's published max_completion_tokens (384000) is fiction. Probed

--- a/kolega_code/llm/specs/catalog/thinking_machines.py
+++ b/kolega_code/llm/specs/catalog/thinking_machines.py
@@ -15,6 +15,7 @@ THINKING_MACHINES_SPECS = {
         "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
+        "preferred_edit_protocol": "claude_code",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "low", "medium", "high", "xhigh", "max"),
             default="high",
@@ -27,6 +28,7 @@ THINKING_MACHINES_SPECS = {
         "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
+        "preferred_edit_protocol": "claude_code",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "low", "medium", "high", "xhigh", "max"),
             default="high",

--- a/kolega_code/llm/specs/catalog/tinker.py
+++ b/kolega_code/llm/specs/catalog/tinker.py
@@ -16,6 +16,7 @@ TINKER_SPECS = {
         "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
+        "preferred_edit_protocol": "claude_code",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "low", "medium", "high", "xhigh", "max"),
             default="high",
@@ -28,6 +29,7 @@ TINKER_SPECS = {
         "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
+        "preferred_edit_protocol": "claude_code",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "low", "medium", "high", "xhigh", "max"),
             default="high",
@@ -40,6 +42,7 @@ TINKER_SPECS = {
         "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
+        "preferred_edit_protocol": "claude_code",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "low", "medium", "high", "xhigh", "max"),
             default="high",
@@ -52,6 +55,7 @@ TINKER_SPECS = {
         "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
+        "preferred_edit_protocol": "claude_code",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "low", "medium", "high", "xhigh", "max"),
             default="high",
@@ -64,6 +68,7 @@ TINKER_SPECS = {
         "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
+        "preferred_edit_protocol": "claude_code",
     },
     ("tinker", "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16:peft:262144"): {
         "context_length": 262144,
@@ -71,6 +76,7 @@ TINKER_SPECS = {
         "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
+        "preferred_edit_protocol": "claude_code",
     },
     ("tinker", "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16"): {
         "context_length": 65536,
@@ -78,6 +84,7 @@ TINKER_SPECS = {
         "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
+        "preferred_edit_protocol": "claude_code",
     },
     ("tinker", "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16:peft:262144"): {
         "context_length": 262144,
@@ -85,6 +92,7 @@ TINKER_SPECS = {
         "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
+        "preferred_edit_protocol": "claude_code",
     },
     ("tinker", "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"): {
         "context_length": 65536,
@@ -92,6 +100,7 @@ TINKER_SPECS = {
         "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
+        "preferred_edit_protocol": "claude_code",
     },
     ("tinker", "moonshotai/Kimi-K2.6"): {
         "context_length": 32768,
@@ -99,6 +108,7 @@ TINKER_SPECS = {
         "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": True,
+        "preferred_edit_protocol": "claude_code",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "auto"),
             default="auto",
@@ -111,6 +121,7 @@ TINKER_SPECS = {
         "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
+        "preferred_edit_protocol": "claude_code",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "auto"),
             default="auto",
@@ -123,6 +134,7 @@ TINKER_SPECS = {
         "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
+        "preferred_edit_protocol": "claude_code",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "auto"),
             default="auto",
@@ -135,6 +147,7 @@ TINKER_SPECS = {
         "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
+        "preferred_edit_protocol": "claude_code",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "auto"),
             default="auto",
@@ -147,6 +160,7 @@ TINKER_SPECS = {
         "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
+        "preferred_edit_protocol": "claude_code",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "auto"),
             default="auto",
@@ -159,6 +173,7 @@ TINKER_SPECS = {
         "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
+        "preferred_edit_protocol": "claude_code",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "auto"),
             default="auto",
@@ -171,6 +186,7 @@ TINKER_SPECS = {
         "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
+        "preferred_edit_protocol": "claude_code",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "auto"),
             default="auto",
@@ -183,6 +199,7 @@ TINKER_SPECS = {
         "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": True,
+        "preferred_edit_protocol": "claude_code",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "auto"),
             default="auto",
@@ -195,6 +212,7 @@ TINKER_SPECS = {
         "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": False,
+        "preferred_edit_protocol": "claude_code",
     },
     ("tinker", "openai/gpt-oss-120b"): {
         "context_length": 32768,
@@ -202,6 +220,7 @@ TINKER_SPECS = {
         "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": False,
+        "preferred_edit_protocol": "claude_code",
     },
     ("tinker", "openai/gpt-oss-120b:peft:131072"): {
         "context_length": 131072,
@@ -209,6 +228,7 @@ TINKER_SPECS = {
         "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
+        "preferred_edit_protocol": "claude_code",
     },
     ("tinker", "openai/gpt-oss-20b"): {
         "context_length": 32768,
@@ -216,6 +236,7 @@ TINKER_SPECS = {
         "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": False,
+        "preferred_edit_protocol": "claude_code",
     },
     ("tinker", "deepseek-ai/DeepSeek-V3.1"): {
         "context_length": 32768,
@@ -223,6 +244,7 @@ TINKER_SPECS = {
         "input_budget": "output_shares_window",
         "default_temperature": 1.0,
         "supports_vision": False,
+        "preferred_edit_protocol": "claude_code",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "auto"),
             default="auto",
@@ -240,5 +262,6 @@ TINKER_WILDCARD_SPECS = {
         "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
+        "preferred_edit_protocol": "claude_code",
     },
 }

--- a/kolega_code/llm/specs/tinker_catalog.py
+++ b/kolega_code/llm/specs/tinker_catalog.py
@@ -51,6 +51,7 @@ _USER_AGENT = (
 # used across the direct-provider catalogs.
 MAX_COMPLETION_TOKENS = 32768
 DEFAULT_TEMPERATURE = 1.0
+PREFERRED_EDIT_PROTOCOL = "claude_code"
 
 # Named-effort spec for the Inkling family (tml-renderers effort floats).
 INKLING_EFFORT_SPEC = ThinkingEffortSpec(
@@ -131,6 +132,7 @@ def catalog_entries(payload: Any) -> list[tuple[str, dict[str, Any]]]:
             "input_budget": "output_shares_window",
             "default_temperature": DEFAULT_TEMPERATURE,
             "supports_vision": "Vision" in model_type,
+            "preferred_edit_protocol": PREFERRED_EDIT_PROTOCOL,
         }
         spec.update(_family_spec(str(identifier)))
         entries.append((str(identifier), spec))
@@ -160,6 +162,7 @@ def spec_to_jsonable(spec: Mapping[str, Any]) -> dict[str, Any]:
 def spec_from_jsonable(payload: Mapping[str, Any]) -> dict[str, Any]:
     """Rebuild a runtime spec from ``spec_to_jsonable`` output."""
     spec = dict(payload)
+    spec.setdefault("preferred_edit_protocol", PREFERRED_EDIT_PROTOCOL)
     thinking = spec.get("thinking_effort")
     if isinstance(thinking, Mapping) and thinking.get("mode") == "tinker_native_effort":
         spec["thinking_effort"] = ThinkingEffortSpec(
@@ -236,5 +239,6 @@ TINKER_WILDCARD_SPECS = {
         "input_budget": "output_shares_window",
         "default_temperature": DEFAULT_TEMPERATURE,
         "supports_vision": False,
+        "preferred_edit_protocol": PREFERRED_EDIT_PROTOCOL,
     },
 }

--- a/scripts/refresh_tinker_catalog.py
+++ b/scripts/refresh_tinker_catalog.py
@@ -52,6 +52,7 @@ TINKER_WILDCARD_SPECS = {{
         "max_completion_tokens": 32768,
         "default_temperature": 1.0,
         "supports_vision": False,
+        "preferred_edit_protocol": "claude_code",
     }},
 }}
 """

--- a/tests/agent/llm/test_openrouter_catalog.py
+++ b/tests/agent/llm/test_openrouter_catalog.py
@@ -110,4 +110,3 @@ def test_openrouter_entries_do_not_shadow_direct_provider_models() -> None:
             continue
         spec = MODEL_SPECS[(provider, model)]
         assert "featured" not in spec
-        assert "preferred_edit_protocol" not in spec


### PR DESCRIPTION
## Summary

- add `preferred_edit_protocol: "claude_code"` directly to the hosted `thinking_machines` model specs
- add the same preference to every bundled native `tinker` model spec and the wildcard checkpoint spec
- carry the preference through Tinker's catalog generation, runtime refresh, and legacy cache hydration
- leave the shared edit-protocol accessor and every other provider unchanged

## Impact

Tinker and Thinking Machines coding sessions now expose Claude-style file-editing tools by default instead of the legacy search/replace surface.

## Validation

- Ruff check passed
- Ruff format check passed
- commit-time Ruff, Pyright, secret detection, and package-boundary hooks passed
- no tests or coverage added or run, as requested