### PR TITLE
feat(llm): default to Claude edit tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ### Changed
 
-- Native Tinker and hosted Thinking Machines models now use Claude-style file
-  editing tools by default.
+- Claude-style `edit` and `write` tools are now the default model-facing edit
+  protocol. Explicit overrides and model-catalog preferences still take
+  precedence, and the legacy search/replace protocol remains available.
 
 ## 0.28.2 - 2026-08-12
 

--- a/docs/src/content/docs/configuration/environment-variables.md
+++ b/docs/src/content/docs/configuration/environment-variables.md
@@ -92,7 +92,7 @@ served by different providers on different credentials.
 | `KOLEGA_CODE_PROVIDER` / `KOLEGA_CODE_MODEL` | Main (long-context) coding model |
 | `KOLEGA_CODE_FAST_PROVIDER` / `KOLEGA_CODE_FAST_MODEL` | Fast utility model |
 | `KOLEGA_CODE_THINKING_EFFORT` | Model-specific thinking effort |
-| `KOLEGA_CODE_EDIT_PROTOCOL` | Optional model-facing edit override: `search_replace`, `codex_apply_patch`, or `claude_code`; otherwise the model catalogue preference or `search_replace` fallback is used |
+| `KOLEGA_CODE_EDIT_PROTOCOL` | Optional model-facing edit override: `search_replace`, `codex_apply_patch`, or `claude_code`; otherwise the model catalogue preference or `claude_code` fallback is used |
 
 These outrank the Fast slot saved in Settings. Full precedence per role:
 CLI flag > environment variable > saved slot > the active model.

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -321,7 +321,7 @@ class BaseAgent(LogMixin):
         self.primary_model_config = self.config.model_config_for_agent(self.agent_name)
         resolved_edit_protocol = self.config.resolve_edit_protocol(self.primary_model_config)
         self.edit_protocol = (
-            resolved_edit_protocol if isinstance(resolved_edit_protocol, EditProtocol) else EditProtocol.SEARCH_REPLACE
+            resolved_edit_protocol if isinstance(resolved_edit_protocol, EditProtocol) else EditProtocol.CLAUDE_CODE
         )
         self.filesystem = context.services.filesystem
         self.terminal_manager = context.services.terminal_manager

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -341,9 +341,7 @@ class ToolCollection(LogMixin):
                 model_config = config.long_context_config
             resolved_edit_protocol = config.resolve_edit_protocol(model_config)
             self.edit_protocol = (
-                resolved_edit_protocol
-                if isinstance(resolved_edit_protocol, EditProtocol)
-                else EditProtocol.SEARCH_REPLACE
+                resolved_edit_protocol if isinstance(resolved_edit_protocol, EditProtocol) else EditProtocol.CLAUDE_CODE
             )
         self.langfuse_client = langfuse_client
         self.tool_extensions = tool_extensions or []

--- a/kolega_code/config.py
+++ b/kolega_code/config.py
@@ -313,7 +313,7 @@ class AgentConfig(BaseModel):
         preferred = preferred_edit_protocol(effective_model.provider, effective_model.model)
         if preferred is not None:
             return EditProtocol(preferred), "model_catalog"
-        return EditProtocol.SEARCH_REPLACE, "default"
+        return EditProtocol.CLAUDE_CODE, "default"
 
     def get_api_key(self, provider: ModelProvider) -> Optional[str]:
         """Get the API key for a specific provider."""

--- a/tests/agent/llm/test_edit_protocol_resolution.py
+++ b/tests/agent/llm/test_edit_protocol_resolution.py
@@ -12,11 +12,11 @@ def config(*, edit_protocol: EditProtocol | None = None) -> AgentConfig:
     )
 
 
-def test_protocol_defaults_to_search_replace_without_catalog_preference() -> None:
+def test_protocol_defaults_to_claude_code_without_catalog_preference() -> None:
     value = config()
 
     assert value.edit_protocol is None
-    assert value.resolve_edit_protocol_with_source() == (EditProtocol.SEARCH_REPLACE, "default")
+    assert value.resolve_edit_protocol_with_source() == (EditProtocol.CLAUDE_CODE, "default")
 
 
 def test_catalog_preference_is_provider_and_model_specific(monkeypatch) -> None:

--- a/tests/agent/test_agent_tools_inventory.py
+++ b/tests/agent/test_agent_tools_inventory.py
@@ -369,7 +369,7 @@ def test_general_agent_tool_inventory(project_path, mock_connection_manager, age
     # Full read/write/terminal access
     assert "read" in tool_names
     assert "edit" in tool_names
-    assert "multi_edit" in tool_names
+    assert "multi_edit" not in tool_names
     assert "write" in tool_names
     assert "lsp_edit" in tool_names
     assert "exec_command" in tool_names

--- a/tests/agent/test_edit_protocol_tools.py
+++ b/tests/agent/test_edit_protocol_tools.py
@@ -50,7 +50,7 @@ def collection(
     )
 
 
-def test_default_protocol_keeps_search_replace_tools(tmp_path: Path) -> None:
+def test_search_replace_protocol_keeps_legacy_tools(tmp_path: Path) -> None:
     registry = collection(tmp_path, EditProtocol.SEARCH_REPLACE).registry()
 
     assert {"edit", "multi_edit", "write"}.issubset(registry.names())

--- a/tests/agent/test_tool_collection_builtin_dispatch.py
+++ b/tests/agent/test_tool_collection_builtin_dispatch.py
@@ -6,7 +6,7 @@ import uuid
 import pytest
 
 from kolega_code.agent.baseagent import BaseAgent
-from kolega_code.config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
+from kolega_code.config import AgentConfig, EditProtocol, ModelConfig, ModelProvider, RateLimitConfig
 from kolega_code.events import AgentConnectionManager
 from kolega_code.agent.tool_backend.memory_tool import MemoryTool
 from kolega_code.agent.tools import ToolCollection, ToolDefinition, ToolCollectionConfig
@@ -31,6 +31,7 @@ def agent_config() -> AgentConfig:
             provider=ModelProvider.ANTHROPIC, model="test-model", rate_limits=RateLimitConfig()
         ),
         fast_config=ModelConfig(provider=ModelProvider.ANTHROPIC, model="test-model", rate_limits=RateLimitConfig()),
+        edit_protocol=EditProtocol.SEARCH_REPLACE,
     )
 
 

--- a/tests/agent/test_tool_registry.py
+++ b/tests/agent/test_tool_registry.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from kolega_code.config import EditProtocol
 from kolega_code.llm.models import ToolDefinition
 from kolega_code.tools import Tool, ToolError, ToolPolicy, ToolRegistry
 
@@ -176,7 +177,7 @@ class TestToolCollectionRegistry:
             "thread",
             Mock(),
             Mock(),
-            Mock(agent_name="test"),
+            Mock(agent_name="test", edit_protocol=EditProtocol.SEARCH_REPLACE),
         )
         registry = collection.registry()
 

--- a/tests/cli/test_cli_config.py
+++ b/tests/cli/test_cli_config.py
@@ -170,7 +170,7 @@ def test_build_agent_config_leaves_protocol_unset_for_catalog_resolution(tmp_pat
     summary = config_summary(config)
 
     assert config.edit_protocol is None
-    assert summary["edit_protocol"] == "search_replace"
+    assert summary["edit_protocol"] == "claude_code"
     assert summary["edit_protocol_source"] == "default"
 
 


### PR DESCRIPTION
## Summary

- make the Claude Code `edit`/`write` protocol the fallback for models without a catalog preference
- preserve explicit session overrides and model-catalog preferences, including legacy search/replace and Codex apply-patch behavior
- update CLI reporting, documentation, changelog, and protocol-specific test expectations

## Testing

- `./run_tests.sh` — 4,682 passed, 1 skipped
- scoped pre-commit checks — Ruff, Pyright, and repository policy checks passed
- configured live provider tests passed, including Anthropic, Google, OpenAI/ChatGPT, Tinker, Thinking Machines, ZAI, Kimi, and Fireworks