### PR TITLE
chore: release v0.28.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.28.3 - 2026-08-12
+
 ### Changed
 
 - Claude-style `edit` and `write` tools are now the default model-facing edit

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -173,4 +173,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.28.2"
+__version__ = "0.28.3"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.28.2"
+__version__ = "0.28.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.28.2"
+version = "0.28.3"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -1787,7 +1787,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.28.2"
+version = "0.28.3"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Release v0.28.3. Bumps the version in `pyproject.toml`, `uv.lock`, and both `__version__` values, and moves the changelog entry from Unreleased into the `0.28.3` section.

Changes since v0.28.2:

- **Changed**: Claude-style `edit` and `write` tools are now the default model-facing edit protocol (explicit overrides and model-catalog preferences still win; legacy search/replace protocol remains available).

## Verification

- `UV_PROJECT_ENVIRONMENT=.venv-release uv sync --extra dev --frozen` — clean
- `./run_tests.sh` — 4609 passed, 74 skipped
- `uv run pre-commit run --all-files --show-diff-on-failure` — all hooks passed

## Follow-up

Tag `v0.28.3` after merge (release workflow publishes to PyPI + creates GitHub Release).