### PR TITLE
fix: bound the compaction summarization request to the run's input budget

### DIFF
--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -1208,6 +1208,7 @@ class BaseAgent(LogMixin):
                 on_error=on_error,
                 system_prompt_text=compaction_system_prompt,
                 keep_recent=keep_recent,
+                max_input_tokens=self.model_max_input_tokens,
             )
             if result.ok:
                 # Compaction summarizes the injected volatile-context blocks along with

--- a/kolega_code/agent/compression.py
+++ b/kolega_code/agent/compression.py
@@ -1,12 +1,14 @@
 """History compression: summarize a conversation when it outgrows the context window."""
 
+import json
 import logging
 from dataclasses import dataclass
-from typing import Awaitable, Callable, Optional
+from typing import Awaitable, Callable, List, Optional
 
-from .conversation import Conversation
+from .conversation import Conversation, replace_image_blocks_with_placeholders
+from kolega_code.llm.exceptions import LLMContextWindowExceededError
 from kolega_code.llm.ledger import helper_origin, llm_call_origin
-from kolega_code.llm.models import Message, MessageHistory, TextBlock
+from kolega_code.llm.models import Message, MessageHistory, TextBlock, ToolCall, ToolResult
 from .prompts import (
     build_compression_summary_user_prompt,
     COMPRESSION_SUMMARY_SYSTEM_PROMPT,
@@ -31,6 +33,90 @@ class CompactionResult:
     message: str = ""
 
 
+def _render_transcript(messages: List[Message]) -> str:
+    """Role-tagged plain text: JSON only for tool arguments, tool results raw.
+
+    JSON-escaping newline-heavy tool output costs ~30% more tokens than
+    leaving it raw.
+    """
+    out: List[str] = []
+    for message in messages:
+        if isinstance(message.content, str):
+            if message.content:
+                out.append(f"[{message.role}]\n{message.content}")
+            continue
+        for block in message.content:
+            if isinstance(block, ToolCall):
+                try:
+                    args = json.dumps(block.input, ensure_ascii=False)
+                except (TypeError, ValueError):
+                    args = str(block.input)
+                out.append(f"[assistant → {block.name}] {args}")
+            elif isinstance(block, ToolResult):
+                if isinstance(block.content, str):
+                    body = block.content
+                else:
+                    body = "\n".join(getattr(item, "text", "") or "" for item in block.content)
+                tag = "error" if block.is_error else "result"
+                out.append(f"[{block.name} {tag}]\n{body}")
+            else:
+                text = getattr(block, "text", None)
+                thinking = getattr(block, "thinking", None)
+                if text:
+                    out.append(f"[{message.role}]\n{text}")
+                elif thinking:
+                    out.append(f"[{message.role} thinking]\n{thinking}")
+    return "\n\n".join(out)
+
+
+def _omission_notice(omitted: int) -> str:
+    return f"[... {omitted} conversation message(s) omitted here so the compaction request fits the context budget ...]"
+
+
+def _approx_message_chars(message: Message) -> int:
+    """Size proxy for picking the omission gap; the request is re-counted before dispatch."""
+    if isinstance(message.content, str):
+        return len(message.content)
+    chars = 0
+    for block in message.content:
+        if isinstance(block, ToolCall):
+            try:
+                chars += len(json.dumps(block.input))
+            except (TypeError, ValueError):
+                chars += len(str(block.input))
+        elif isinstance(block, ToolResult):
+            if isinstance(block.content, str):
+                chars += len(block.content)
+            else:
+                chars += sum(len(getattr(item, "text", "") or "") for item in block.content)
+        else:
+            chars += len(getattr(block, "text", "") or "") + len(getattr(block, "thinking", "") or "")
+    return chars
+
+
+def _middle_gap(weights: List[int], target_chars: float) -> tuple[int, int]:
+    """Pick the (head_end, tail_start) gap keeping ~``target_chars``: half from the
+    oldest messages (task statement), half from the newest (continuity)."""
+    half = target_chars / 2
+    head_end, acc = 0, 0
+    for index, weight in enumerate(weights):
+        if acc + weight > half:
+            break
+        acc += weight
+        head_end = index + 1
+    tail_start, acc = len(weights), 0
+    for index in range(len(weights) - 1, head_end - 1, -1):
+        if acc + weights[index] > half:
+            break
+        acc += weights[index]
+        tail_start = index
+    return head_end, tail_start
+
+
+def _bundles_tool_results(message: Message) -> bool:
+    return isinstance(message.content, list) and any(isinstance(block, ToolResult) for block in message.content)
+
+
 class HistoryCompressor:
     """Summarizes a conversation non-destructively when it crosses the budget threshold."""
 
@@ -45,6 +131,8 @@ class HistoryCompressor:
     # summary. A generous ceiling gives reasoning headroom while still staying
     # well under the model's full completion budget.
     SUMMARY_MAX_TOKENS = 8192
+    # Attempts at widening the omission gap per budget rung.
+    MAX_FIT_ATTEMPTS = 6
 
     def __init__(self, threshold: float = 0.8) -> None:
         # Fraction of the model context window above which compression kicks in
@@ -66,6 +154,7 @@ class HistoryCompressor:
         on_error: Optional[LogCallback] = None,
         system_prompt_text: Optional[str] = None,
         keep_recent: Optional[int] = None,
+        max_input_tokens: Optional[int] = None,
     ) -> CompactionResult:
         """
         Non-destructively summarize the aged-out prefix while keeping the most
@@ -73,6 +162,8 @@ class HistoryCompressor:
 
         Incremental: only the messages that have aged out since the previous
         boundary are summarized, with the prior summary folded in for continuity.
+        The aged-out span is presented to the summarizer as a role-tagged
+        plain-text transcript (tool arguments as JSON, tool results raw).
         Returns a CompactionResult describing what happened — never a silent no-op.
 
         ``keep_recent`` overrides KEEP_RECENT_MESSAGES (the verbatim tail). A
@@ -80,6 +171,16 @@ class HistoryCompressor:
         boundary — potentially including recent user content — becomes eligible
         for lossy summarization. The raw history is never modified, and the
         safe-boundary snap still keeps tool_use/tool_result pairs together.
+
+        ``max_input_tokens`` bounds the summarization request itself: while the
+        rendered request exceeds it, whole messages are dropped from the middle
+        of the span (never splitting a tool exchange) and an omission notice is
+        left in the gap. Dispatch walks a descending budget ladder (100%, 90%,
+        80%, ... of the bound): if the enforcing side rejects a request the
+        counter accepted, the next rung re-widens the gap and retries until a
+        request is accepted. An unbounded request would be rejected before
+        dispatch and read as ``llm_error``, permanently disabling
+        auto-compaction.
         """
         history = conversation.history
         if not history or len(history) < self.MIN_MESSAGES_TO_COMPRESS:
@@ -107,16 +208,51 @@ class HistoryCompressor:
             await on_info("Compressing message history...")
 
         try:
-            prefix = MessageHistory(list(history[prior_through:split]))
-            prefix_markdown = prefix.get_markdown_conversation()
+            # A summary needs no pixels, and base64 must stay out of the transcript.
+            prefix = replace_image_blocks_with_placeholders(list(history[prior_through:split]), model)
             previous_summary = conversation.summary.get_text_content() if conversation.summary is not None else None
-            user_prompt_filled = build_compression_summary_user_prompt(
-                prefix_markdown, previous_summary=previous_summary
-            )
 
-            messages = MessageHistory([Message(role="user", content=[TextBlock(text=user_prompt_filled)])])
+            def build_request(head_end: int, tail_start: int) -> MessageHistory:
+                omitted = tail_start - head_end
+                if omitted:
+                    parts = [
+                        _render_transcript(prefix[:head_end]),
+                        _omission_notice(omitted),
+                        _render_transcript(prefix[tail_start:]),
+                    ]
+                    transcript = "\n\n".join(part for part in parts if part)
+                else:
+                    transcript = _render_transcript(prefix)
+                prompt = build_compression_summary_user_prompt(transcript, previous_summary=previous_summary)
+                return MessageHistory([Message(role="user", content=[TextBlock(text=prompt)])])
+
+            head_end, tail_start = len(prefix), len(prefix)
+            messages = build_request(head_end, tail_start)
             system_text = system_prompt_text or COMPRESSION_SUMMARY_SYSTEM_PROMPT
             system_message = Message(role="system", content=[TextBlock(text=system_text)])
+            weights = [_approx_message_chars(message) for message in prefix]
+
+            async def widen_gap_until_fits(budget: int) -> None:
+                nonlocal head_end, tail_start, messages
+                for _ in range(self.MAX_FIT_ATTEMPTS):
+                    counted = await llm.count_tokens(
+                        messages=messages, system=system_message, model=model, thinking=thinking
+                    )
+                    if counted.input_tokens <= budget:
+                        return
+                    kept_chars = sum(weights[:head_end]) + sum(weights[tail_start:])
+                    target_chars = kept_chars * budget / counted.input_tokens * 0.9
+                    new_head, new_tail = _middle_gap(weights, target_chars)
+                    # Keep tool exchanges whole on both edges of the gap.
+                    new_head = conversation.snap_split_point(prior_through + new_head) - prior_through
+                    while new_head < new_tail < len(prefix) and _bundles_tool_results(prefix[new_tail]):
+                        new_tail += 1
+                    if (new_head, new_tail) == (head_end, tail_start):
+                        # Stalled (fixed prompt parts dominate): let the budget
+                        # check or provider give the definitive answer.
+                        return
+                    head_end, tail_start = new_head, new_tail
+                    messages = build_request(head_end, tail_start)
 
             # Stream and drain rather than calling generate(): the Anthropic SDK
             # rejects non-streaming requests whose max_tokens is large enough to risk
@@ -125,19 +261,41 @@ class HistoryCompressor:
             # The helper origin spans the whole request: providers may sample and
             # emit their trace record at context entry or final-message time, not
             # at stream().
-            with llm_call_origin(helper_origin("compression")):
-                stream_cm = await llm.stream(
-                    messages=messages,
-                    system=system_message,
-                    temperature=temperature,
-                    model=model,
-                    max_completion_tokens=self.SUMMARY_MAX_TOKENS,
-                    thinking=thinking,
-                )
-                async with stream_cm as stream:
-                    async for _event in stream:
-                        pass
-                response = await stream.get_final_message()
+            response = None
+            last_error: Optional[LLMContextWindowExceededError] = None
+            dispatched_gap: Optional[tuple[int, int]] = None
+            rungs = range(10, 0, -1) if max_input_tokens is not None else range(1)
+            for tenths in rungs:
+                if max_input_tokens is not None:
+                    await widen_gap_until_fits(max_input_tokens * tenths // 10)
+                    if dispatched_gap == (head_end, tail_start):
+                        # This rung could not shrink the request any further;
+                        # re-sending it would only be rejected again.
+                        continue
+                try:
+                    with llm_call_origin(helper_origin("compression")):
+                        stream_cm = await llm.stream(
+                            messages=messages,
+                            system=system_message,
+                            temperature=temperature,
+                            model=model,
+                            max_completion_tokens=self.SUMMARY_MAX_TOKENS,
+                            thinking=thinking,
+                        )
+                        async with stream_cm as stream:
+                            async for _event in stream:
+                                pass
+                        response = await stream.get_final_message()
+                    break
+                except LLMContextWindowExceededError as exc:
+                    if max_input_tokens is None:
+                        raise
+                    dispatched_gap = (head_end, tail_start)
+                    last_error = exc
+            if response is None:
+                # Every rung was rejected or would have re-sent an identical request.
+                assert last_error is not None
+                raise last_error
 
             summary_text = response.get_text_content()
             if not summary_text or not summary_text.strip():

--- a/kolega_code/agent/conversation.py
+++ b/kolega_code/agent/conversation.py
@@ -1085,6 +1085,11 @@ class Conversation:
             return None
         return candidate
 
+    def snap_split_point(self, idx: int) -> int:
+        """Clamp ``idx`` to history bounds and snap it backward so a tool_use/
+        tool_result group is never split across a compaction boundary."""
+        return self._snap_to_safe_boundary(max(0, min(idx, len(self._history))))
+
     def _snap_to_safe_boundary(self, idx: int) -> int:
         """Move ``idx`` backward past any assistant tool_use so a tool_use/tool_result
         group is never split across the compaction boundary."""

--- a/kolega_code/agent/prompt_templates/auxiliary/compression/summary.user.md.j2
+++ b/kolega_code/agent/prompt_templates/auxiliary/compression/summary.user.md.j2
@@ -14,4 +14,4 @@ Summarize the following coding session so far:
 {{ history }}
 </conversation_history>
 
-Produce the continuity briefing exactly as specified in your instructions. Summary text only — do not call tools.
+Each transcript entry is tagged with its role; tool calls show their JSON arguments and tool results follow raw. A bracketed line marks messages omitted for length. Produce the continuity briefing exactly as specified in your instructions. Summary text only — do not call tools.

--- a/tests/agent/test_compaction_integration.py
+++ b/tests/agent/test_compaction_integration.py
@@ -1,11 +1,13 @@
 """Full agent-loop integration for compaction (hermetic, no network).
 
 FakeLLM token-script accounting: the loop counts once per iteration, and each
-compaction pass counts twice (``compress_history``'s finally recount for the
-gauge, then the loop's own post-pass recount on the rebuilt history). A script
-like ``[900, 1100, 1100, 400]`` therefore reads as: 900 triggers the ordinary
-pass, 1100 is its post-pass size (twice), 400 is the post-fallback size. The
-final scripted value repeats, so trailing reads stay deterministic.
+compaction pass counts three times (the summarization request's own budget
+check, then ``compress_history``'s finally recount for the gauge, then the
+loop's own post-pass recount on the rebuilt history). A script like
+``[900, 800, 1100, 1100, 800, 400]`` therefore reads as: 900 triggers the
+ordinary pass, 800 is its summarization request (fits), 1100 is its post-pass
+size (twice), 800 the fallback's summarization request, 400 the post-fallback
+size. The final scripted value repeats, so trailing reads stay deterministic.
 """
 
 from unittest.mock import AsyncMock, MagicMock
@@ -117,7 +119,7 @@ async def test_full_loop_zero_tail_fallback_when_retained_tail_too_large(tmp_pat
     # The six-message retained tail alone still exceeds the resolved maximum
     # (1100 > 1000): one aggressive keep_recent=0 pass folds it and the request
     # proceeds (400 <= 1000).
-    fake = FakeLLM(token_script=[900, 1100, 1100, 400])
+    fake = FakeLLM(token_script=[900, 800, 1100, 1100, 800, 400])
     agent, _cm = build_agent(tmp_path, llm=fake)
     agent.session_recorder = MagicMock()
     agent.history = long_history(6)
@@ -173,7 +175,7 @@ async def test_full_loop_strict_cap_raises_when_fallback_insufficient(tmp_path):
 @pytest.mark.asyncio
 async def test_full_loop_strict_cap_allows_equality_with_max_input(tmp_path):
     # Equality with the resolved maximum input is allowed.
-    fake = FakeLLM(token_script=[700, 900, 900, 800])
+    fake = FakeLLM(token_script=[700, 750, 900, 900, 750, 800])
     agent, _cm = build_agent(tmp_path, llm=fake, strict_budget=(1000, 200))
     assert agent.model_max_input_tokens == 800
     agent.history = long_history(6)

--- a/tests/agent/test_compaction_persistence.py
+++ b/tests/agent/test_compaction_persistence.py
@@ -54,7 +54,7 @@ async def test_zero_tail_compaction_survives_dump_restore(tmp_path):
     summary_msg = Message(role="assistant", content=[TextBlock(text="ZERO-TAIL PERSISTED")], stop_reason="end_turn")
     primary_msg = Message(role="assistant", content=[TextBlock(text="PRIMARY RESPONSE")], stop_reason="end_turn")
     fake = FakeLLM(
-        token_script=[900, 1100, 1100, 400],
+        token_script=[900, 800, 1100, 1100, 800, 400],
         message_script=[summary_msg, summary_msg, primary_msg],
     )
     agent, _cm = build_agent(tmp_path, llm=fake)

--- a/tests/agent/test_compaction_request_budget.py
+++ b/tests/agent/test_compaction_request_budget.py
@@ -1,0 +1,206 @@
+"""Regression: the compaction request itself must fit the run's input budget.
+
+The summarization request carries the aged-out span plus the previous summary
+and instructions, so at the compaction trigger it is roughly the size of the
+parent context. If it exceeds max input, the budget check rejects it before
+dispatch, the pass reads as ``llm_error`` (which the agent loop treats as
+final), and compaction stays broken while the conversation grows until the
+run aborts.
+
+One proxy counter (wire-format chars // 4) plays the provider renderer on both
+paths — the context gauge and the stream-side enforcement — as production
+routes both through ``provider.count_tokens``.
+"""
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from kolega_code.agent.compression import HistoryCompressor
+from kolega_code.agent.conversation import Conversation
+from kolega_code.agent.prompts import (
+    COMPRESSION_SUMMARY_SYSTEM_PROMPT,
+    build_compression_summary_user_prompt,
+)
+from kolega_code.hooks.events import HookEvent
+from kolega_code.llm.exceptions import LLMContextWindowExceededError
+from kolega_code.llm.models import Message, MessageHistory, TextBlock, ToolCall, ToolResult
+from kolega_code.llm.providers.models import TokenCount
+
+from .compaction_helpers import FakeLLM, build_agent, text_msg
+
+CONTEXT_WINDOW_TOKENS = 4000
+MAX_OUTPUT_TOKENS = 500
+MAX_INPUT_TOKENS = CONTEXT_WINDOW_TOKENS - MAX_OUTPUT_TOKENS  # 3500
+
+
+def _wire_tokens(messages, system=None) -> int:
+    """Proxy for the provider renderer's count: wire-format chars // 4."""
+    chars = len(system.get_text_content()) if system is not None else 0
+    for message in messages:
+        if isinstance(message.content, str):
+            chars += len(message.content)
+            continue
+        for block in message.content:
+            if isinstance(block, ToolCall):
+                chars += len(json.dumps(block.input))
+            elif isinstance(block, ToolResult):
+                chars += len(block.content) if isinstance(block.content, str) else 0
+            else:
+                chars += len(getattr(block, "text", "") or "")
+    return chars // 4
+
+
+class BudgetEnforcingFakeLLM(FakeLLM):
+    """FakeLLM whose ``stream`` enforces the per-run input cap the way
+    ``LLMClient._enforce_run_context_budget`` does."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.stream_input_counts: list[int] = []
+        self.count_tokens = AsyncMock(side_effect=self._count_tokens_wire)
+        self.stream = AsyncMock(side_effect=self._budgeted_stream)
+
+    async def _count_tokens_wire(self, *args, **kwargs):
+        messages = kwargs.get("messages") or (args[0] if args else [])
+        return TokenCount(input_tokens=_wire_tokens(messages, kwargs.get("system")))
+
+    async def _budgeted_stream(self, *args, **kwargs):
+        input_tokens = _wire_tokens(kwargs.get("messages") or [], kwargs.get("system"))
+        requested = kwargs.get("max_completion_tokens")
+        effective_output = MAX_OUTPUT_TOKENS if requested is None else min(requested, MAX_OUTPUT_TOKENS)
+        max_input = CONTEXT_WINDOW_TOKENS - effective_output
+        self.stream_input_counts.append(input_tokens)
+        if input_tokens > max_input:
+            raise LLMContextWindowExceededError(
+                f"Request needs {input_tokens} input tokens, exceeding this run's maximum input of "
+                f"{max_input} (context window {CONTEXT_WINDOW_TOKENS} tokens minus "
+                f"{effective_output} reserved output tokens).",
+                provider="fake",
+            )
+        return await self._stream(*args, **kwargs)
+
+
+def _tool_pair(i: int) -> list[Message]:
+    call_id = f"call_{i:04d}"
+    args = {"path": f"src/file_{i:03d}.py", "note": f"step {i} " + "x" * 110}
+    output = f"contents of file_{i:03d} " + "y" * 110
+    return [
+        Message(role="assistant", content=[ToolCall(id=call_id, name="read_file", input=args)]),
+        Message(
+            role="user", content=[ToolResult(tool_use_id=call_id, name="read_file", content=output, is_error=False)]
+        ),
+    ]
+
+
+def _hook_payload_spy(agent):
+    fired = []
+    original = agent.fire_hook
+
+    async def spy(name, payload, **kwargs):
+        fired.append((name, payload))
+        return await original(name, payload, **kwargs)
+
+    agent.fire_hook = spy
+    return fired
+
+
+@pytest.mark.asyncio
+async def test_compaction_request_is_bounded_to_run_input_budget(tmp_path):
+    # A session that already compacted once and regrew: prior summary stands in
+    # for the first 8 messages, then 40 tool exchanges of new work.
+    prior_summary = "PRIOR SUMMARY " + "z" * 86
+    old_messages = [m for i in range(4) for m in _tool_pair(i)]
+    regrown = [m for i in range(4, 44) for m in _tool_pair(i)]
+
+    fake = BudgetEnforcingFakeLLM()
+    agent, _cm = build_agent(tmp_path, llm=fake, strict_budget=(CONTEXT_WINDOW_TOKENS, MAX_OUTPUT_TOKENS))
+    assert agent.model_max_input_tokens == MAX_INPUT_TOKENS
+    agent.history = MessageHistory(old_messages + regrown)
+    agent.conversation.apply_compaction(prior_summary, len(old_messages))
+
+    # Preconditions, computed on the exact state the compaction pass will see:
+    probe = Conversation()
+    probe.history = MessageHistory(list(agent.history) + [text_msg("user", "continue")])
+    probe.apply_compaction(prior_summary, len(old_messages))
+    parent_tokens = _wire_tokens(list(probe.effective_history()), agent.system_prompt)
+    # the parent context is over the trigger but under the cap,
+    trigger = MAX_INPUT_TOKENS * agent.history_compression_threshold
+    assert trigger < parent_tokens <= MAX_INPUT_TOKENS
+    # while the whole span rendered into one summarization request exceeds it.
+    split = probe.compaction_split_point(
+        keep_recent=HistoryCompressor.KEEP_RECENT_MESSAGES,
+        min_prefix=HistoryCompressor.MIN_PREFIX_TO_SUMMARIZE,
+    )
+    prefix_markdown = MessageHistory(list(probe.history[len(old_messages) : split])).get_markdown_conversation()
+    unbounded_request = Message(
+        role="user",
+        content=[
+            TextBlock(text=build_compression_summary_user_prompt(prefix_markdown, previous_summary=prior_summary))
+        ],
+    )
+    comp_system = Message(role="system", content=[TextBlock(text=COMPRESSION_SUMMARY_SYSTEM_PROMPT)])
+    assert _wire_tokens([unbounded_request], comp_system) > MAX_INPUT_TOKENS
+
+    fired = _hook_payload_spy(agent)
+    async for _chunk in agent.process_message_stream("continue"):
+        pass
+
+    # Compaction must bound its own request and succeed, not fail llm_error.
+    post = [payload for name, payload in fired if name == HookEvent.POST_COMPACT]
+    assert post and post[0]["trigger"] == "auto"
+    assert post[0]["ok"] is True, f"compaction failed: {post[0]['reason']}"
+    assert agent.conversation.compacted_through > len(old_messages)
+    assert agent.conversation.summary is not None
+    assert agent.conversation.summary.get_text_content() == "SUMMARY: condensed older turns."
+    # Every request this turn dispatched — the summarization included — fit the cap.
+    assert fake.stream_input_counts and all(count <= MAX_INPUT_TOKENS for count in fake.stream_input_counts), (
+        f"stream inputs {fake.stream_input_counts} exceed max input {MAX_INPUT_TOKENS}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_oversized_span_folds_with_middle_omission(tmp_path):
+    # A span that dwarfs the budget folds in one pass: whole messages are
+    # omitted from the middle, with a notice left in the gap.
+    fake = BudgetEnforcingFakeLLM()
+    agent, _cm = build_agent(tmp_path, llm=fake, strict_budget=(CONTEXT_WINDOW_TOKENS, MAX_OUTPUT_TOKENS))
+    agent.history = MessageHistory([m for i in range(120) for m in _tool_pair(i)])
+
+    result = await agent.compress_history(trigger="manual")
+
+    assert result.ok, result.message
+    assert fake.stream_input_counts and all(count <= MAX_INPUT_TOKENS for count in fake.stream_input_counts), (
+        f"stream inputs {fake.stream_input_counts} exceed max input {MAX_INPUT_TOKENS}"
+    )
+    assert fake.stream.await_args is not None
+    sent_prompt = fake.stream.await_args.kwargs["messages"][0].get_text_content()
+    assert "omitted here so the compaction request fits" in sent_prompt
+    assert "file_000" in sent_prompt  # first exchange of the span survives
+    assert "file_116" in sent_prompt  # last exchange of the span survives
+    assert agent.conversation.compacted_through == len(agent.history) - HistoryCompressor.KEEP_RECENT_MESSAGES
+
+
+class UndercountingFakeLLM(BudgetEnforcingFakeLLM):
+    """Counter reads 25% low, the way an estimating tokenizer can."""
+
+    async def _count_tokens_wire(self, *args, **kwargs):
+        messages = kwargs.get("messages") or (args[0] if args else [])
+        return TokenCount(input_tokens=_wire_tokens(messages, kwargs.get("system")) * 3 // 4)
+
+
+@pytest.mark.asyncio
+async def test_rejected_dispatch_steps_down_budget_ladder(tmp_path):
+    # The enforcing side runs hotter than the counter: rejected dispatches must
+    # step down the budget ladder and re-widen the gap until one is accepted.
+    fake = UndercountingFakeLLM()
+    agent, _cm = build_agent(tmp_path, llm=fake, strict_budget=(CONTEXT_WINDOW_TOKENS, MAX_OUTPUT_TOKENS))
+    agent.history = MessageHistory([m for i in range(120) for m in _tool_pair(i)])
+
+    result = await agent.compress_history(trigger="manual")
+
+    assert result.ok, result.message
+    assert any(count > MAX_INPUT_TOKENS for count in fake.stream_input_counts)  # at least one rejection
+    assert fake.stream_input_counts[-1] <= MAX_INPUT_TOKENS  # the accepted request fit
+    assert agent.conversation.summary is not None


### PR DESCRIPTION
## Problem

The compaction summarization request carries the aged-out span plus the previous summary and instructions, so at the compaction trigger it is roughly the size of the parent context. If it exceeds the run's max input tokens, the budget check rejects it before dispatch, the pass reads as `llm_error` (which the agent loop treats as final), and auto-compaction stays broken while the conversation grows until the run aborts.

## Changes

- **Plain-text transcript**: the aged-out span is now rendered as a role-tagged plain-text transcript (tool arguments as JSON, tool results raw) instead of markdown, with image base64 replaced by placeholders.
- **Budget ladder**: dispatch walks a descending budget ladder (100%, 90%, 80%, ... of the bound). While the rendered request exceeds the rung, whole messages are dropped from the middle of the span — never splitting a tool exchange — with an omission notice left in the gap. If the enforcing side rejects a request the counter accepted, the next rung re-widens the gap and retries.
- **`Conversation.snap_split_point`**: public helper to clamp and snap a split point to a safe boundary.
- **Tests**: regression coverage for bounded requests (`test_compaction_request_budget.py`), plus updated token scripts in the existing compaction integration/persistence tests for the new budget-counting pass.

## Verification

- `tests/agent/test_compaction_request_budget.py`, `tests/agent/test_compaction_integration.py`, `tests/agent/test_compaction_persistence.py`: 18 passed.
- Pre-commit (Ruff, Pyright, etc.) passes on all files.
