### PR TITLE
chore: release v0.28.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.28.4 - 2026-08-12
+
+### Fixed
+
+- Conversation compaction now keeps the summarization request within the run's
+  input token budget, so auto-compaction no longer fails on long conversations
+  and lets the run continue instead of aborting.
+
 ## 0.28.3 - 2026-08-12
 
 ### Changed

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -173,4 +173,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.28.3"
+__version__ = "0.28.4"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.28.3"
+__version__ = "0.28.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.28.3"
+version = "0.28.4"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -1787,7 +1787,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.28.3"
+version = "0.28.4"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Release v0.28.4.

### Fixed

- Conversation compaction now keeps the summarization request within the run's input token budget, so auto-compaction no longer fails on long conversations and lets the run continue instead of aborting (PR #572).

Changelog updated; version bumped in `pyproject.toml`, `uv.lock`, `kolega_code/__init__.py`, `kolega_code/agent/__init__.py`.