### PR TITLE
fix(llm): replay Together reasoning via the native field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+### Fixed
+
+- Together models (e.g. Kimi K2.7-Code) now replay prior reasoning through the
+  native `reasoning` field instead of visible `*Thinking:*` text, avoiding a full
+  re-derivation of the chain-of-thought on every turn. Reasoning models without a
+  declared thinking-effort spec now resolve their provider's replay field.
+
 ## 0.28.4 - 2026-08-12
 
 ### Fixed

--- a/kolega_code/llm/specs/thinking.py
+++ b/kolega_code/llm/specs/thinking.py
@@ -156,6 +156,7 @@ _REASONING_REPLAY_FIELDS: Dict[str, str] = {
     # OpenRouter emits reasoning as delta.reasoning and requires it echoed back on
     # assistant tool-call turns whenever reasoning is enabled.
     "openrouter": "reasoning",
+    "together": "reasoning",
     # xAI's Chat Completions endpoint returns and accepts reasoning_content even
     # though its public docs only describe the Responses API (verified live
     # against grok-4.3: streaming emits reasoning_content deltas and replaying it
@@ -190,6 +191,9 @@ def reasoning_replay_field(provider: str, model_name: str) -> Optional[str]:
     except ValueError:
         # get_model_specs raises for unknown provider/model; treat as non-reasoning.
         return None
-    if spec is None or spec.mode not in _REASONING_REPLAY_MODES:
+    # A declared spec gates on its mode (flat-field replay only). Models without a
+    # spec may still reason by default; their reasoning arrives in the provider's
+    # own field, so replay is allowed.
+    if spec is not None and spec.mode not in _REASONING_REPLAY_MODES:
         return None
     return field

--- a/tests/agent/llm/test_openai_reasoning_replay.py
+++ b/tests/agent/llm/test_openai_reasoning_replay.py
@@ -70,12 +70,37 @@ def test_reasoning_replay_field_ollama_uses_reasoning(ollama_reasoning_model: st
 
 def test_reasoning_replay_field_none_for_unmapped_provider_unknown_and_non_reasoning():
     # Provider not in the map at all.
-    assert reasoning_replay_field("together", "anything") is None
     assert reasoning_replay_field("groq", "anything") is None
-    # Mapped provider but a non-reasoning model on it (no thinking_effort spec).
-    assert reasoning_replay_field("xai", "grok-build-0.1") is None
     # Unknown provider/model pair (get_model_specs raises -> None).
     assert reasoning_replay_field("deepseek", "no-such-model") is None
+    assert reasoning_replay_field("together", "no-such-model") is None
+
+
+def test_reasoning_replay_field_without_effort_spec_uses_provider_field():
+    assert reasoning_replay_field("together", "moonshotai/Kimi-K2.7-Code") == "reasoning"
+    assert reasoning_replay_field("xai", "grok-build-0.1") == "reasoning_content"
+    assert reasoning_replay_field("openrouter", "minimax/minimax-m3") == "reasoning"
+
+
+def test_reasoning_replay_field_declared_non_replayable_mode_still_none(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    model = "together/custom-mode-model"
+    monkeypatch.setitem(
+        MODEL_SPECS,
+        ("together", model),
+        {
+            "context_length": 131072,
+            "max_completion_tokens": 32768,
+            "input_budget": "window_minus_output",
+            "thinking_effort": ThinkingEffortSpec(
+                options=("low", "high"),
+                default="low",
+                mode="moonshot_toggle",
+            ),
+        },
+    )
+    assert reasoning_replay_field("together", model) is None
 
 
 # --- native serialization -------------------------------------------------
@@ -116,6 +141,16 @@ def test_fireworks_uses_reasoning_content():
     out = MessageHistory([asst]).to_openai(provider="fireworks", model=FIREWORKS_MODEL)[0]
 
     assert out["reasoning_content"] == "r"
+    assert out["content"] == [{"type": "text", "text": "a"}]
+
+
+def test_together_uses_reasoning():
+    asst = _assistant(ThinkingBlock(thinking="r"), TextBlock("a"), provider="together")
+
+    out = MessageHistory([asst]).to_openai(provider="together", model="moonshotai/Kimi-K2.7-Code")[0]
+
+    assert out["reasoning"] == "r"
+    assert "reasoning_content" not in out
     assert out["content"] == [{"type": "text", "text": "a"}]
 
 
@@ -259,8 +294,10 @@ def test_reasoning_replay_field_openrouter_anthropic_models_opt_out():
 
 
 def test_reasoning_replay_field_openrouter_non_reasoning_model():
-    # minimax/minimax-m3 exposes no effort control, so there is nothing to replay.
-    assert reasoning_replay_field("openrouter", "minimax/minimax-m3") is None
+    # minimax/minimax-m3 exposes no effort control but may still reason by
+    # default (spec-None relaxation): its reasoning, if any, arrives in
+    # OpenRouter's flat `reasoning` field.
+    assert reasoning_replay_field("openrouter", "minimax/minimax-m3") == "reasoning"
     assert reasoning_replay_field("openrouter", "nope/not-a-model") is None
 
 


### PR DESCRIPTION
## Summary

Together serves reasoning models with reasoning in the `reasoning` delta field (Kimi K2.7-Code thinks by default). Kolega currently replays that reasoning as visible `*Thinking:*` text, which makes the model re-derive its chain-of-thought on every turn (live probe: ~2,230 re-reasoning tokens and an empty reply, vs ~138 tokens and a clean answer when echoed natively).

## Changes

- Register `"together": "reasoning"` in `_REASONING_REPLAY_FIELDS`.
- Relax the replay gate: a model with no declared thinking-effort spec may still reason by default, so its provider's flat replay field is used. A declared spec whose mode is not replayable still blocks.

## Tests

- Updated two tests that codified the old gate semantics.
- Added Together resolver + wire-serialization coverage, plus a guard test for declared non-replayable modes.
- `tests/agent/llm/test_openai_reasoning_replay.py` (22), history-adapter/serialization (39), related LLM suites (71) — all pass. Pre-commit (ruff, pyright) clean.