### PR TITLE
feat(llm): custom endpoints — OpenAI/Responses/Anthropic-compatible servers (core)

### DIFF
--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -22,7 +22,7 @@ from .agent.errors import AgentError, MaxAgentIterationsExceeded
 from .events import AgentEventEmitter
 
 # Configuration
-from .config import AgentConfig, ModelConfig, ModelProvider, RateLimitConfig
+from .config import AgentConfig, CustomEndpointConfig, ModelConfig, ModelProvider, RateLimitConfig
 
 # Events and connection management
 from .events import AgentConnectionManager
@@ -108,6 +108,7 @@ __all__ = [
     "AgentEventEmitter",
     # Configuration
     "AgentConfig",
+    "CustomEndpointConfig",
     "ModelConfig",
     "ModelProvider",
     "RateLimitConfig",

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -1741,6 +1741,7 @@ class BaseAgent(LogMixin):
 
         from kolega_code.llm.client import LLMClient
 
+        endpoint = self.config.custom_endpoint_for(model_config)
         client = LLMClient(
             provider=model_config.provider.value,
             api_key=self.config.get_api_key(model_config.provider) or "",
@@ -1751,6 +1752,8 @@ class BaseAgent(LogMixin):
             token_manager=self.config.get_chatgpt_token_manager(),
             usage_ledger=self.usage_ledger,
             trace_sink=self.llm_trace_sink,
+            base_url=endpoint.base_url if endpoint else None,
+            api_style=endpoint.api_style if endpoint else None,
         )
         with llm_call_origin(helper_origin("hook_prompt")):
             response = await client.generate(

--- a/kolega_code/agent/context.py
+++ b/kolega_code/agent/context.py
@@ -113,6 +113,7 @@ class AgentContext:
         itself is still passed per call.
         """
         model_config = self.config.model_config_for_agent(agent_name)
+        endpoint = self.config.custom_endpoint_for(model_config)
 
         if self.telemetry.langfuse_client:
             return InstrumentedLLMClient(
@@ -135,6 +136,8 @@ class AgentContext:
                 trace_sink=self.telemetry.llm_trace_sink,
                 context_window_tokens=self.config.context_window_tokens,
                 max_output_tokens=self.config.max_output_tokens,
+                base_url=endpoint.base_url if endpoint else None,
+                api_style=endpoint.api_style if endpoint else None,
             )
 
         return LLMClient(
@@ -149,4 +152,6 @@ class AgentContext:
             trace_sink=self.telemetry.llm_trace_sink,
             context_window_tokens=self.config.context_window_tokens,
             max_output_tokens=self.config.max_output_tokens,
+            base_url=endpoint.base_url if endpoint else None,
+            api_style=endpoint.api_style if endpoint else None,
         )

--- a/kolega_code/agent/tool_backend/terminal_tool.py
+++ b/kolega_code/agent/tool_backend/terminal_tool.py
@@ -97,6 +97,7 @@ class TerminalTool(BaseTool):
         provider = self.config.fast_config.provider
         api_key = self.config.get_api_key(provider)
         rate_limits = self.config.fast_config.rate_limits
+        endpoint = self.config.custom_endpoint_for(self.config.fast_config)
 
         client = LLMClient(
             provider=provider.value,
@@ -108,6 +109,8 @@ class TerminalTool(BaseTool):
             token_manager=self.config.get_chatgpt_token_manager(),
             usage_ledger=getattr(self.caller, "usage_ledger", None),
             trace_sink=getattr(self.caller, "llm_trace_sink", None),
+            base_url=endpoint.base_url if endpoint else None,
+            api_style=endpoint.api_style if endpoint else None,
         )
 
         try:

--- a/kolega_code/agent/tool_backend/web_fetch_tool.py
+++ b/kolega_code/agent/tool_backend/web_fetch_tool.py
@@ -146,6 +146,7 @@ class WebFetchTool(StreamingTool):
     def _build_client(self) -> LLMClient:
         provider = self.config.fast_config.provider
         rate_limits = self.config.fast_config.rate_limits
+        endpoint = self.config.custom_endpoint_for(self.config.fast_config)
         client_kwargs = {
             "provider": provider.value,
             "api_key": self.config.get_api_key(provider),
@@ -156,6 +157,8 @@ class WebFetchTool(StreamingTool):
             "token_manager": self.config.get_chatgpt_token_manager(),
             "usage_ledger": getattr(self.caller, "usage_ledger", None),
             "trace_sink": getattr(self.caller, "llm_trace_sink", None),
+            "base_url": endpoint.base_url if endpoint else None,
+            "api_style": endpoint.api_style if endpoint else None,
         }
         caller_llm = getattr(self.caller, "llm", None)
         if isinstance(caller_llm, InstrumentedLLMClient):

--- a/kolega_code/cli/model_connection.py
+++ b/kolega_code/cli/model_connection.py
@@ -47,6 +47,8 @@ async def test_model_connection(
     client_factory: Callable[..., Any] = LLMClient,
     timeout: float = CONNECTION_TEST_TIMEOUT_SECONDS,
     usage_ledger: Any = None,
+    base_url: Optional[str] = None,
+    api_style: Optional[str] = None,
 ) -> ModelConnectionResult:
     """Send a tiny no-tool prompt through one provider/model pair.
 
@@ -72,6 +74,10 @@ async def test_model_connection(
         # ledger. Omitted when None so injected fake factories keep their shape.
         if usage_ledger is not None:
             factory_kwargs["usage_ledger"] = usage_ledger
+        if base_url:
+            factory_kwargs["base_url"] = base_url
+        if api_style:
+            factory_kwargs["api_style"] = api_style
         client = client_factory(**factory_kwargs)
         messages = MessageHistory([Message(role="user", content=[TextBlock(text="Reply with OK.")])])
         await asyncio.wait_for(

--- a/kolega_code/config.py
+++ b/kolega_code/config.py
@@ -1,9 +1,19 @@
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional, cast
 
-from pydantic import BaseModel, Field, PrivateAttr, model_validator
+from pydantic import BaseModel, Field, PrivateAttr, field_validator, model_validator
 
 from kolega_code.auth.tokens import OAuthTokens
+from kolega_code.llm.specs.custom_endpoints import (
+    CUSTOM_PROVIDER_PREFIX,
+    DEFAULT_CONTEXT_LENGTH,
+    DEFAULT_MAX_OUTPUT_TOKENS,
+    REASONING_REPLAY_VALUES,
+    custom_endpoint_id,
+    is_custom_provider,
+    sync_custom_endpoint_specs,
+    valid_custom_endpoint_id,
+)
 from kolega_code.services.lsp.config import LspConfig
 
 
@@ -28,6 +38,19 @@ class ModelProvider(str, Enum):
     OPENROUTER = "openrouter"  # Gateway in front of many vendors' models
     THINKING_MACHINES = "thinking_machines"  # Thinking Machines Lab (Tinker API)
     TINKER = "tinker"  # Native Tinker SamplingClient (agentic-RL trajectory source)
+
+    @classmethod
+    def _missing_(cls, value: object) -> Optional["ModelProvider"]:
+        # Dynamic members for user-defined endpoints; __members__ iteration stays built-ins only.
+        if isinstance(value, str) and value.startswith(CUSTOM_PROVIDER_PREFIX):
+            endpoint = value[len(CUSTOM_PROVIDER_PREFIX) :]
+            if valid_custom_endpoint_id(endpoint):
+                member = cast("ModelProvider", str.__new__(cls, value))
+                member._name_ = value  # type: ignore[attr-defined]
+                member._value_ = value  # type: ignore[attr-defined]
+                cls._value2member_map_[value] = member  # type: ignore[attr-defined]
+                return member
+        return None
 
 
 class EditProtocol(str, Enum):
@@ -97,6 +120,46 @@ class ModelConfig(BaseModel):
         default=None,
         description="Model-specific thinking or reasoning effort level",
     )
+
+
+class CustomEndpointConfig(BaseModel):
+    """A user-defined OpenAI/Responses/Anthropic-compatible server endpoint.
+
+    Referenced by provider value ``custom:<id>`` where ``id`` is the key in
+    ``AgentConfig.custom_endpoints``. Any model id is accepted; the endpoint's
+    defaults (and optional per-model ``models`` overrides) supply context specs.
+    """
+
+    api_style: Literal["openai_chat", "openai_responses", "anthropic"] = Field(
+        description="Wire dialect: Chat Completions, Responses API, or Anthropic Messages"
+    )
+    base_url: str = Field(description="Base URL; OpenAI styles include /v1, Anthropic style is the API root")
+    api_key: Optional[str] = Field(default=None, description="Optional Bearer credential")
+    label: Optional[str] = Field(default=None, description="Display name in pickers")
+    default_model: Optional[str] = Field(default=None, description="Model used by connection probes")
+    context_length: int = Field(default=DEFAULT_CONTEXT_LENGTH, gt=0)
+    max_output_tokens: int = Field(default=DEFAULT_MAX_OUTPUT_TOKENS, gt=0)
+    supports_vision: bool = Field(default=False)
+    models: Dict[str, Dict[str, Any]] = Field(default_factory=dict, description="Per-model spec overrides")
+    thinking: Optional[Dict[str, Any]] = Field(default=None, description="Thinking-effort spec for this endpoint")
+    reasoning_replay: str = Field(
+        default="auto", description="Reasoning replay field: auto|reasoning_content|reasoning|off"
+    )
+
+    @field_validator("base_url")
+    @classmethod
+    def _validate_base_url(cls, value: str) -> str:
+        value = value.strip().rstrip("/")
+        if not value.startswith(("http://", "https://")):
+            raise ValueError("base_url must be an http(s) URL")
+        return value
+
+    @field_validator("reasoning_replay")
+    @classmethod
+    def _validate_reasoning_replay(cls, value: str) -> str:
+        if value not in REASONING_REPLAY_VALUES:
+            raise ValueError(f"reasoning_replay must be one of {', '.join(REASONING_REPLAY_VALUES)}")
+        return value
 
 
 class AgentConfig(BaseModel):
@@ -282,6 +345,12 @@ class AgentConfig(BaseModel):
     # the skill catalog prompt and model-facing activation tool.
     skills_enabled: bool = Field(default=True, exclude=True, description="Enable CLI Agent Skills")
 
+    # Custom model endpoints keyed by endpoint id (provider value "custom:<id>").
+    # Excluded from serialization like mcp_config: entries can carry API keys.
+    custom_endpoints: Dict[str, CustomEndpointConfig] = Field(
+        default_factory=dict, exclude=True, description="User-defined OpenAI/Responses/Anthropic-compatible endpoints"
+    )
+
     def model_config_for_agent(self, agent_name: Optional[str]) -> ModelConfig:
         """Return the model configuration an agent should use for its main loop.
 
@@ -295,6 +364,13 @@ class AgentConfig(BaseModel):
             if override is not None:
                 return override
         return self.long_context_config
+
+    def custom_endpoint_for(self, model_config: ModelConfig) -> Optional[CustomEndpointConfig]:
+        """Return the endpoint definition backing a model config, if it is a custom endpoint."""
+        endpoint_id = custom_endpoint_id(model_config.provider)
+        if endpoint_id is None:
+            return None
+        return self.custom_endpoints.get(endpoint_id)
 
     def resolve_edit_protocol(self, model_config: Optional[ModelConfig] = None) -> EditProtocol:
         """Resolve the model-facing edit protocol for one effective model."""
@@ -317,6 +393,10 @@ class AgentConfig(BaseModel):
 
     def get_api_key(self, provider: ModelProvider) -> Optional[str]:
         """Get the API key for a specific provider."""
+        if is_custom_provider(provider):
+            endpoint_id = custom_endpoint_id(provider)
+            endpoint = self.custom_endpoints.get(endpoint_id) if endpoint_id else None
+            return endpoint.api_key if endpoint and endpoint.api_key else None
         api_key_map = {
             ModelProvider.ANTHROPIC: self.anthropic_api_key,
             ModelProvider.OPENAI: self.openai_api_key,
@@ -357,6 +437,9 @@ class AgentConfig(BaseModel):
             provider = config.provider
             if provider == ModelProvider.LLAMA:
                 continue
+            if is_custom_provider(provider):
+                # Endpoint keys are optional (local servers are usually keyless).
+                continue
             if provider == ModelProvider.OPENAI_CHATGPT:
                 # OAuth provider: satisfied by stored ChatGPT tokens, not an api key.
                 if self.openai_chatgpt_tokens is None:
@@ -365,6 +448,17 @@ class AgentConfig(BaseModel):
             if self.get_api_key(provider) is None:
                 raise ValueError(f"Missing API key for {config_name} provider '{provider.value}'")
 
+        return self
+
+    @model_validator(mode="after")
+    def _sync_custom_endpoint_specs(self) -> "AgentConfig":
+        """Register runtime model specs so library hosts don't need a separate sync call."""
+        sync_custom_endpoint_specs(
+            {
+                endpoint_id: endpoint.model_dump(mode="python", exclude_none=True)
+                for endpoint_id, endpoint in self.custom_endpoints.items()
+            }
+        )
         return self
 
     def attach_chatgpt_token_manager(self, manager: Any) -> None:

--- a/kolega_code/llm/client.py
+++ b/kolega_code/llm/client.py
@@ -82,6 +82,8 @@ class LLMClient:
         trace_sink: Optional[Any] = None,
         context_window_tokens: Optional[int] = None,
         max_output_tokens: Optional[int] = None,
+        base_url: Optional[str] = None,
+        api_style: Optional[str] = None,
     ):
         if (context_window_tokens is None) != (max_output_tokens is None):
             raise ValueError("context_window_tokens and max_output_tokens must be supplied together")
@@ -112,6 +114,8 @@ class LLMClient:
             max_retries=max_retries,
             requests_per_minute=requests_per_minute,
             tokens_per_minute=tokens_per_minute,
+            base_url=base_url,
+            api_style=api_style,
         )
 
     @staticmethod
@@ -164,6 +168,8 @@ class LLMClient:
         max_retries: int = 3,
         requests_per_minute: Optional[int] = None,
         tokens_per_minute: Optional[int] = None,
+        base_url: Optional[str] = None,
+        api_style: Optional[str] = None,
     ) -> "Union[AnthropicProvider, OpenAIProvider, GoogleProvider, TinkerProvider]":
         """Initialize the appropriate LLM provider based on the provider name.
 
@@ -180,6 +186,30 @@ class LLMClient:
             LLMError: If an unsupported provider name is specified or initialization fails
         """
         try:
+            # Custom endpoints: the provider value is "custom:<id>" and the wire
+            # dialect comes from api_style, resolved by the config layer.
+            if provider.lower().startswith("custom:"):
+                if not base_url or not api_style:
+                    raise ValueError(f"Custom endpoint provider {provider} requires base_url and api_style.")
+                if api_style == "openai_chat":
+                    from .providers.openai import OpenAIProvider as CustomProviderClass
+                elif api_style == "openai_responses":
+                    from .providers.openai_responses import OpenAIResponsesProvider as CustomProviderClass
+                elif api_style == "anthropic":
+                    from .providers.anthropic import AnthropicProvider as CustomProviderClass
+                else:
+                    raise ValueError(f"Unsupported api_style {api_style!r} for custom endpoint {provider}.")
+                return CustomProviderClass(
+                    # Keyless local servers still require a non-empty credential at
+                    # SDK construction; a dummy satisfies them (servers ignore it).
+                    api_key=self._api_key or "local",
+                    max_retries=max_retries,
+                    requests_per_minute=requests_per_minute,
+                    tokens_per_minute=tokens_per_minute,
+                    base_url=base_url,
+                    provider_name=provider.lower(),
+                )
+
             # ChatGPT-subscription OAuth provider: distinct base URL + Responses API,
             # authenticated by a refreshing token manager rather than an api key.
             if provider.lower() == chatgpt_constants.PROVIDER_KEY:

--- a/kolega_code/llm/instrumented_client.py
+++ b/kolega_code/llm/instrumented_client.py
@@ -59,6 +59,8 @@ class InstrumentedLLMClient(LLMClient):
         trace_sink: Optional[Any] = None,
         context_window_tokens: Optional[int] = None,
         max_output_tokens: Optional[int] = None,
+        base_url: Optional[str] = None,
+        api_style: Optional[str] = None,
     ):
         super().__init__(
             provider,
@@ -72,6 +74,8 @@ class InstrumentedLLMClient(LLMClient):
             trace_sink=trace_sink,
             context_window_tokens=context_window_tokens,
             max_output_tokens=max_output_tokens,
+            base_url=base_url,
+            api_style=api_style,
         )
         self.langfuse = langfuse_client
         self.workspace_id = workspace_id

--- a/kolega_code/llm/models.py
+++ b/kolega_code/llm/models.py
@@ -1446,6 +1446,10 @@ class Message:
             and _provider_value(source_provider) == _provider_value(provider)
         ):
             reasoning_field = reasoning_replay_field(provider, model)
+        if reasoning_field == "auto":
+            # Custom endpoints default to "auto": echo reasoning back in the field
+            # the source server emitted it in, falling back to "reasoning".
+            reasoning_field = (self.usage_metadata or {}).get("reasoning_field") or "reasoning"
 
         reasoning_text: Optional[str] = None
         if isinstance(self.content, str):

--- a/kolega_code/llm/providers/anthropic.py
+++ b/kolega_code/llm/providers/anthropic.py
@@ -122,6 +122,7 @@ class AnthropicProvider(BaseLLMProvider):
         # Billing/accounting must use provider response usage metadata instead.
         self.use_local_token_counting = (
             provider_name in {"moonshot", "kimi_coding"}
+            or provider_name.startswith("custom:")
             or os.getenv("ANTHROPIC_USE_LOCAL_TOKEN_COUNTING", "false").lower() == "true"
         )
 

--- a/kolega_code/llm/providers/openai.py
+++ b/kolega_code/llm/providers/openai.py
@@ -127,6 +127,9 @@ class OpenAIStreamWrapper:
         # buffers over thousands of tiny chunks. Lists make accumulation O(n).
         self._content_parts: List[str] = []
         self._reasoning_parts: List[str] = []
+        # Which delta field carried reasoning ("reasoning_content" | "reasoning"),
+        # recorded for auto replay on custom endpoints.
+        self._reasoning_field: Optional[str] = None
         # Per-index tool-call: the first delta's object (kept for id/name/index) plus
         # its argument fragments collected separately so the JSON arg string (which can
         # be large, e.g. a file-writing tool) is also joined once instead of grown.
@@ -177,11 +180,14 @@ class OpenAIStreamWrapper:
                     if content:
                         self._content_parts.append(content)
 
-                    reasoning_content = (
-                        getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None) or ""
-                    )
+                    reasoning_content = getattr(delta, "reasoning_content", None)
+                    reasoning = getattr(delta, "reasoning", None)
                     if reasoning_content:
+                        self._reasoning_field = "reasoning_content"
                         self._reasoning_parts.append(reasoning_content)
+                    elif reasoning:
+                        self._reasoning_field = "reasoning"
+                        self._reasoning_parts.append(reasoning)
 
                     for tool_call in getattr(delta, "tool_calls", []) or []:
                         index = tool_call.index
@@ -236,6 +242,9 @@ class OpenAIStreamWrapper:
             stop_reason=self.stop_reason,
             tool_execution_ids=self.tool_execution_ids,
         )
+
+        if self._reasoning_field is not None:
+            message.usage_metadata["reasoning_field"] = self._reasoning_field
 
         # Add usage data if available
         if self.usage_data:

--- a/kolega_code/llm/providers/responses_common.py
+++ b/kolega_code/llm/providers/responses_common.py
@@ -125,6 +125,9 @@ def _role_message_item(role: str, parts: List[tuple]) -> Optional[Dict[str, Any]
 # #6913); the persisted transcript keeps the byte-for-byte original.
 _HARMONY_CONTROL_TOKEN_RE = re.compile(r"<\|(start|end|message|channel|constrain|return|call)\|>")
 _HARMONY_CONTROL_TOKEN_BACKENDS = frozenset({"openai", "openai_chatgpt"})
+# Backends whose Responses API returns reasoning as an opaque encrypted item for
+# continuity passback; compatible servers don't implement it.
+_ENCRYPTED_REASONING_BACKENDS = frozenset({"openai", "openai_chatgpt", "deepseek"})
 
 
 def escape_harmony_control_tokens(text: str) -> str:
@@ -997,11 +1000,12 @@ class ResponsesProviderBase(OpenAIProvider):
             reasoning = thinking_params.get("reasoning")
             if reasoning:
                 request["reasoning"] = reasoning
-                # Ask the backend to return the model's reasoning as an opaque
-                # encrypted item so we can resend it next turn for continuity
-                # (mirrors Codex). Without it the model re-reasons from scratch on
-                # every tool-call round and "thinks" far longer at high effort.
-                request["include"] = ["reasoning.encrypted_content"]
+                if self.provider_name in _ENCRYPTED_REASONING_BACKENDS:
+                    # Ask the backend to return the model's reasoning as an opaque
+                    # encrypted item so we can resend it next turn for continuity
+                    # (mirrors Codex). Without it the model re-reasons from scratch on
+                    # every tool-call round and "thinks" far longer at high effort.
+                    request["include"] = ["reasoning.encrypted_content"]
         return request
 
     async def stream(

--- a/kolega_code/llm/specs/__init__.py
+++ b/kolega_code/llm/specs/__init__.py
@@ -17,7 +17,16 @@ from .accessors import (
     thinking_effort_options,
 )
 from .catalog import MODEL_SPECS
+from .custom_endpoints import (
+    CUSTOM_PROVIDER_PREFIX,
+    CUSTOM_THINKING_MODES,
+    CUSTOM_THINKING_PRESETS,
+    custom_endpoint_id,
+    is_custom_provider,
+    sync_custom_endpoint_specs,
+)
 from .thinking import (
+    REASONING_REPLAY_VALUES,
     build_thinking_request_params,
     normalize_thinking_effort,
     validate_thinking_effort,
@@ -47,4 +56,11 @@ __all__ = [
     "validate_thinking_effort",
     "normalize_thinking_effort",
     "build_thinking_request_params",
+    "CUSTOM_PROVIDER_PREFIX",
+    "CUSTOM_THINKING_MODES",
+    "CUSTOM_THINKING_PRESETS",
+    "REASONING_REPLAY_VALUES",
+    "is_custom_provider",
+    "custom_endpoint_id",
+    "sync_custom_endpoint_specs",
 ]

--- a/kolega_code/llm/specs/custom_endpoints.py
+++ b/kolega_code/llm/specs/custom_endpoints.py
@@ -1,0 +1,146 @@
+"""Custom endpoint provider identity and runtime model-spec registration."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping, Optional
+
+from .catalog import MODEL_SPECS, WILDCARD_MODEL_SPECS
+from .thinking import REASONING_REPLAY_VALUES
+from .types import ThinkingEffortSpec
+from .validation import validate_model_spec
+
+CUSTOM_PROVIDER_PREFIX = "custom:"
+DEFAULT_CONTEXT_LENGTH = 32768
+DEFAULT_MAX_OUTPUT_TOKENS = 8192
+
+_CUSTOM_ID_RE = re.compile(r"[a-z0-9][a-z0-9_-]*\Z")
+
+# Wire-safe thinking modes custom endpoints may declare.
+CUSTOM_THINKING_PRESETS: dict[str, dict[str, Any]] = {
+    "openai_reasoning_effort": {
+        "options": ("none", "low", "medium", "high", "xhigh", "max"),
+        "default": "high",
+        "budgets_required": False,
+    },
+    "openai_responses_reasoning": {
+        "options": ("none", "low", "medium", "high", "xhigh"),
+        "default": "medium",
+        "budgets_required": False,
+    },
+    "thinking_toggle": {
+        "options": ("none", "enabled"),
+        "default": "enabled",
+        "budgets_required": False,
+    },
+    "anthropic_budget": {
+        "options": ("none", "low", "medium", "high", "xhigh", "max"),
+        "default": "medium",
+        "budgets_required": True,
+    },
+}
+
+CUSTOM_THINKING_MODES = frozenset(CUSTOM_THINKING_PRESETS)
+
+
+def is_custom_provider(provider: Any) -> bool:
+    value = provider.value if hasattr(provider, "value") else provider
+    return isinstance(value, str) and value.startswith(CUSTOM_PROVIDER_PREFIX)
+
+
+def custom_endpoint_id(provider: Any) -> Optional[str]:
+    value = provider.value if hasattr(provider, "value") else provider
+    if not isinstance(value, str) or not value.startswith(CUSTOM_PROVIDER_PREFIX):
+        return None
+    return value[len(CUSTOM_PROVIDER_PREFIX) :]
+
+
+def valid_custom_endpoint_id(endpoint_id: str) -> bool:
+    return bool(_CUSTOM_ID_RE.match(endpoint_id))
+
+
+def _positive_int(value: Any, default: Optional[int] = None) -> Optional[int]:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return default
+    return value
+
+
+def _thinking_spec(raw: Any) -> Optional[ThinkingEffortSpec]:
+    if not isinstance(raw, dict):
+        return None
+    mode = raw.get("mode")
+    if mode not in CUSTOM_THINKING_MODES:
+        return None
+    preset = CUSTOM_THINKING_PRESETS[mode]
+    if isinstance(raw.get("options"), (list, tuple)):
+        options = tuple(str(option) for option in raw["options"])
+    else:
+        options = preset["options"]
+    if not options:
+        return None
+    default = str(raw.get("default") or preset["default"])
+    if default not in options:
+        default = options[0]
+    budgets: dict[str, int] = {}
+    if preset["budgets_required"]:
+        raw_budgets = raw.get("budgets")
+        if not isinstance(raw_budgets, dict):
+            return None
+        for option in options:
+            if option == "none":
+                continue
+            budget = _positive_int(raw_budgets.get(option))
+            if budget is None:
+                return None
+            budgets[option] = budget
+    return ThinkingEffortSpec(options=options, default=default, mode=mode, budgets=budgets)
+
+
+def _endpoint_spec(entry: Mapping[str, Any], model_override: Optional[Mapping[str, Any]] = None) -> dict[str, Any]:
+    merged: Mapping[str, Any] = {**entry, **model_override} if model_override else entry
+    spec: dict[str, Any] = {
+        "context_length": _positive_int(merged.get("context_length"), DEFAULT_CONTEXT_LENGTH),
+        "max_completion_tokens": _positive_int(merged.get("max_output_tokens"), DEFAULT_MAX_OUTPUT_TOKENS),
+        "input_budget": "window_minus_output",
+        "supports_vision": bool(merged.get("supports_vision", False)),
+        "supports_temperature": True,
+        "default_temperature": 0.7,
+    }
+    thinking = _thinking_spec(merged.get("thinking"))
+    if thinking is not None:
+        spec["thinking_effort"] = thinking
+    if merged.get("api_style") == "openai_chat":
+        replay = merged.get("reasoning_replay", "auto")
+        spec["reasoning_replay"] = str(replay) if replay in REASONING_REPLAY_VALUES else "auto"
+    return spec
+
+
+def sync_custom_endpoint_specs(endpoints: Mapping[str, Any]) -> None:
+    """Rebuild MODEL_SPECS/WILDCARD_MODEL_SPECS entries for custom endpoints. Idempotent."""
+    for registry in (MODEL_SPECS, WILDCARD_MODEL_SPECS):
+        for key in [key for key in registry if key[0].startswith(CUSTOM_PROVIDER_PREFIX)]:
+            del registry[key]
+    for endpoint_id, entry in endpoints.items():
+        if not isinstance(endpoint_id, str) or not valid_custom_endpoint_id(endpoint_id):
+            continue
+        if not isinstance(entry, Mapping):
+            continue
+        provider = f"{CUSTOM_PROVIDER_PREFIX}{endpoint_id}"
+        base = _endpoint_spec(entry)
+        try:
+            validate_model_spec(base)
+        except ValueError:
+            continue
+        WILDCARD_MODEL_SPECS[(provider, "*")] = base
+        models = entry.get("models")
+        if not isinstance(models, dict):
+            continue
+        for model_name, override in models.items():
+            if not isinstance(model_name, str) or not model_name or not isinstance(override, dict):
+                continue
+            spec = _endpoint_spec(entry, override)
+            try:
+                validate_model_spec(spec)
+            except ValueError:
+                continue
+            MODEL_SPECS[(provider, model_name)] = spec

--- a/kolega_code/llm/specs/thinking.py
+++ b/kolega_code/llm/specs/thinking.py
@@ -3,10 +3,14 @@ from typing import Any, Dict, Optional
 from .accessors import (
     _provider_value,
     default_thinking_effort,
+    get_model_specs,
     get_thinking_effort_spec,
     prior_reasoning_is_replayable,
     thinking_effort_options,
 )
+
+# "auto" resolves at serialization time to the field the server emitted reasoning in.
+REASONING_REPLAY_VALUES = ("auto", "reasoning_content", "reasoning", "off")
 
 
 def validate_thinking_effort(provider: str, model_name: str, effort: Optional[Any]) -> Optional[str]:
@@ -138,6 +142,15 @@ def build_thinking_request_params(provider: str, model_name: str, effort: Option
         # reasoning.encrypted_content (see the ChatGPT provider), not the summary.
         return {"reasoning": {"effort": normalized, "summary": "auto"}}
 
+    if spec.mode == "thinking_toggle":
+        # Qwen3-style servers: "thinking" object via extra_body.
+        return {"extra_body": {"thinking": {"type": "enabled" if normalized != "none" else "disabled"}}}
+
+    if spec.mode == "anthropic_budget":
+        if normalized == "none":
+            return {"thinking": {"type": "disabled"}}
+        return {"thinking": {"type": "enabled", "budget_tokens": spec.budgets[normalized]}}
+
     raise ValueError(f"Unknown thinking effort mode '{spec.mode}' for {_provider_value(provider)}/{model_name}.")
 
 
@@ -179,6 +192,17 @@ def reasoning_replay_field(provider: str, model_name: str) -> Optional[str]:
     non-reasoning models, unknown provider/model pairs, and providers whose
     reasoning is not replayable via a flat field.
     """
+    # Spec-declared replay (custom endpoints) takes precedence over the provider map.
+    try:
+        specs = get_model_specs(provider, model_name)
+    except ValueError:
+        specs = None
+    if specs and specs.get("reasoning_replay") is not None:
+        if not prior_reasoning_is_replayable(provider, model_name):
+            return None
+        value = str(specs["reasoning_replay"])
+        return None if value == "off" else value
+
     field = _REASONING_REPLAY_FIELDS.get(_provider_value(provider))
     if field is None:
         return None
@@ -191,9 +215,7 @@ def reasoning_replay_field(provider: str, model_name: str) -> Optional[str]:
     except ValueError:
         # get_model_specs raises for unknown provider/model; treat as non-reasoning.
         return None
-    # A declared spec gates on its mode (flat-field replay only). Models without a
-    # spec may still reason by default; their reasoning arrives in the provider's
-    # own field, so replay is allowed.
+    # A declared spec gates on its mode; spec-less models may reason by default.
     if spec is not None and spec.mode not in _REASONING_REPLAY_MODES:
         return None
     return field

--- a/tests/agent/llm/test_custom_endpoints.py
+++ b/tests/agent/llm/test_custom_endpoints.py
@@ -1,0 +1,374 @@
+"""Custom endpoints: identity, spec sync, client routing, thinking, and reasoning replay."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from kolega_code.config import AgentConfig, CustomEndpointConfig, ModelConfig, ModelProvider
+from kolega_code.llm.client import LLMClient
+from kolega_code.llm.models import Message, MessageHistory, TextBlock, ThinkingBlock
+from kolega_code.llm.providers.models import GenerationParams
+from kolega_code.llm.specs import (
+    MODEL_SPECS,
+    get_model_specs,
+    model_is_known,
+    resolve_max_input_tokens,
+    supports_vision,
+    sync_custom_endpoint_specs,
+    thinking_effort_options,
+)
+from kolega_code.llm.specs.catalog import WILDCARD_MODEL_SPECS
+from kolega_code.llm.specs.custom_endpoints import CUSTOM_PROVIDER_PREFIX, custom_endpoint_id, is_custom_provider
+from kolega_code.llm.specs.thinking import (
+    build_thinking_request_params,
+    default_thinking_effort,
+    reasoning_replay_field,
+)
+
+CHAT_ENDPOINT = {
+    "api_style": "openai_chat",
+    "base_url": "http://localhost:1234/v1",
+    "context_length": 32768,
+    "max_output_tokens": 8192,
+    "thinking": {"mode": "thinking_toggle"},
+    "models": {"big-model": {"context_length": 65536, "supports_vision": True}},
+}
+
+ANTHROPIC_ENDPOINT = {
+    "api_style": "anthropic",
+    "base_url": "http://localhost:8080",
+    "max_output_tokens": 16384,
+    "thinking": {
+        "mode": "anthropic_budget",
+        "options": ["none", "low", "medium", "high"],
+        "default": "medium",
+        "budgets": {"low": 2048, "medium": 8192, "high": 12288},
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def _clean_custom_specs():
+    yield
+    sync_custom_endpoint_specs({})
+
+
+def _config(endpoints, *, provider: str, model: str) -> AgentConfig:
+    return AgentConfig(
+        anthropic_api_key="sk-test",
+        long_context_config=ModelConfig(provider=ModelProvider(provider), model=model),
+        custom_endpoints={
+            endpoint_id: CustomEndpointConfig.model_validate(entry) for endpoint_id, entry in endpoints.items()
+        },
+    )
+
+
+# --- provider identity ----------------------------------------------------
+
+
+def test_model_provider_missing_creates_dynamic_members():
+    first = ModelProvider("custom:lmstudio")
+    second = ModelProvider("custom:lmstudio")
+    assert first is second
+    assert first.value == "custom:lmstudio"
+    assert str(first) == "ModelProvider.custom:lmstudio"
+    assert "custom:lmstudio" not in ModelProvider.__members__
+    with pytest.raises(ValueError):
+        ModelProvider("custom:Bad Slug")
+    with pytest.raises(ValueError):
+        ModelProvider("bogus")
+
+
+def test_model_config_round_trips_custom_provider():
+    config = ModelConfig(provider=ModelProvider("custom:lmstudio"), model="qwen2.5")
+    assert config.provider.value == "custom:lmstudio"
+    dumped = config.model_dump()
+    assert dumped["provider"].value == "custom:lmstudio"
+    reloaded = ModelConfig.model_validate(config.model_dump(mode="json"))
+    assert reloaded.provider.value == "custom:lmstudio"
+    assert ModelConfig(provider=ModelProvider("custom:lmstudio"), model="x").provider.value == "custom:lmstudio"
+
+
+def test_custom_endpoint_helpers():
+    assert is_custom_provider(ModelProvider("custom:lmstudio"))
+    assert not is_custom_provider(ModelProvider.OPENAI)
+    assert custom_endpoint_id(ModelProvider("custom:lmstudio")) == "lmstudio"
+    assert custom_endpoint_id(ModelProvider.OPENAI) is None
+
+
+# --- spec sync ------------------------------------------------------------
+
+
+def test_sync_registers_wildcard_and_exact_specs():
+    sync_custom_endpoint_specs({"lmstudio": CHAT_ENDPOINT})
+    provider = f"{CUSTOM_PROVIDER_PREFIX}lmstudio"
+
+    wildcard = get_model_specs(provider, "any-model")
+    assert wildcard["context_length"] == 32768
+    assert wildcard["max_completion_tokens"] == 8192
+    assert wildcard["input_budget"] == "window_minus_output"
+    assert wildcard["supports_vision"] is False
+    assert wildcard["reasoning_replay"] == "auto"
+    assert wildcard["thinking_effort"].mode == "thinking_toggle"
+
+    exact = get_model_specs(provider, "big-model")
+    assert exact["context_length"] == 65536
+    assert exact["supports_vision"] is True
+    assert exact["reasoning_replay"] == "auto"
+
+    assert model_is_known(provider, "anything-else")
+    assert supports_vision(provider, "big-model")
+    assert not supports_vision(provider, "plain-model")
+    assert resolve_max_input_tokens(wildcard) == 32768 - 8192
+
+
+def test_sync_is_idempotent_and_removes_stale_entries():
+    sync_custom_endpoint_specs({"a": CHAT_ENDPOINT, "b": CHAT_ENDPOINT})
+    assert ("custom:a", "*") in WILDCARD_MODEL_SPECS
+    assert ("custom:b", "*") in WILDCARD_MODEL_SPECS
+
+    sync_custom_endpoint_specs({"a": CHAT_ENDPOINT})
+    assert ("custom:a", "*") in WILDCARD_MODEL_SPECS
+    assert ("custom:b", "*") not in WILDCARD_MODEL_SPECS
+
+    sync_custom_endpoint_specs({"a": CHAT_ENDPOINT})
+    assert ("custom:a", "*") in WILDCARD_MODEL_SPECS
+
+    sync_custom_endpoint_specs({})
+    assert not any(key[0].startswith(CUSTOM_PROVIDER_PREFIX) for key in WILDCARD_MODEL_SPECS)
+    assert not any(key[0].startswith(CUSTOM_PROVIDER_PREFIX) for key in MODEL_SPECS)
+
+
+def test_sync_skips_invalid_ids_and_drops_invalid_thinking_blocks():
+    sync_custom_endpoint_specs(
+        {
+            "bad-id!": CHAT_ENDPOINT,
+            "bad-thinking": {**CHAT_ENDPOINT, "thinking": {"mode": "nope"}},
+            "bad-budgets": {**ANTHROPIC_ENDPOINT, "thinking": {"mode": "anthropic_budget", "budgets": {}}},
+            "good": CHAT_ENDPOINT,
+        }
+    )
+    assert ("custom:bad-id!", "*") not in WILDCARD_MODEL_SPECS
+    assert get_model_specs("custom:bad-thinking", "m").get("thinking_effort") is None
+    assert get_model_specs("custom:bad-budgets", "m").get("thinking_effort") is None
+    assert get_model_specs("custom:good", "m")["thinking_effort"].mode == "thinking_toggle"
+
+
+def test_reasoning_replay_only_declared_for_chat_style():
+    sync_custom_endpoint_specs(
+        {
+            "chat": CHAT_ENDPOINT,
+            "anthropic": ANTHROPIC_ENDPOINT,
+            "responses": {"api_style": "openai_responses", "base_url": "http://localhost:8000/v1"},
+        }
+    )
+    assert "reasoning_replay" in get_model_specs("custom:chat", "m")
+    assert "reasoning_replay" not in get_model_specs("custom:anthropic", "m")
+    assert "reasoning_replay" not in get_model_specs("custom:responses", "m")
+
+
+# --- thinking -------------------------------------------------------------
+
+
+def test_thinking_toggle_and_anthropic_budget_params():
+    sync_custom_endpoint_specs({"chat": CHAT_ENDPOINT, "anthropic": ANTHROPIC_ENDPOINT})
+    assert build_thinking_request_params("custom:chat", "m", "enabled") == {
+        "extra_body": {"thinking": {"type": "enabled"}}
+    }
+    assert build_thinking_request_params("custom:chat", "m", "none") == {
+        "extra_body": {"thinking": {"type": "disabled"}}
+    }
+    assert build_thinking_request_params("custom:anthropic", "m", "low") == {
+        "thinking": {"type": "enabled", "budget_tokens": 2048}
+    }
+    assert build_thinking_request_params("custom:anthropic", "m", "none") == {"thinking": {"type": "disabled"}}
+    assert thinking_effort_options("custom:chat", "m") == ("none", "enabled")
+    assert default_thinking_effort("custom:chat", "m") == "enabled"
+    assert thinking_effort_options("custom:anthropic", "m") == ("none", "low", "medium", "high")
+    assert default_thinking_effort("custom:anthropic", "m") == "medium"
+    assert build_thinking_request_params("custom:chat", "m", None) == {}
+
+
+# --- reasoning replay -----------------------------------------------------
+
+
+def test_reasoning_replay_field_spec_declared_values():
+    sync_custom_endpoint_specs(
+        {
+            "auto": CHAT_ENDPOINT,
+            "content": {**CHAT_ENDPOINT, "reasoning_replay": "reasoning_content"},
+            "field": {**CHAT_ENDPOINT, "reasoning_replay": "reasoning"},
+            "off": {**CHAT_ENDPOINT, "reasoning_replay": "off"},
+            "anthropic": ANTHROPIC_ENDPOINT,
+        }
+    )
+    assert reasoning_replay_field("custom:auto", "m") == "auto"
+    assert reasoning_replay_field("custom:content", "m") == "reasoning_content"
+    assert reasoning_replay_field("custom:field", "m") == "reasoning"
+    assert reasoning_replay_field("custom:off", "m") is None
+    assert reasoning_replay_field("custom:anthropic", "m") is None
+    assert reasoning_replay_field("custom:missing", "m") is None
+
+
+def _assistant(provider: str, *, reasoning_field: str | None = "reasoning"):
+    metadata = {"provider": provider}
+    if reasoning_field:
+        metadata["reasoning_field"] = reasoning_field
+    return Message(role="assistant", content=[ThinkingBlock(thinking="cot"), TextBlock("ans")], usage_metadata=metadata)
+
+
+def test_to_openai_auto_replay_uses_sniffed_field():
+    sync_custom_endpoint_specs({"chat": CHAT_ENDPOINT})
+    out = MessageHistory([_assistant("custom:chat", reasoning_field="reasoning")]).to_openai(
+        provider="custom:chat", model="m"
+    )[0]
+    assert out["reasoning"] == "cot"
+    assert out["content"] == [{"type": "text", "text": "ans"}]
+
+    out = MessageHistory([_assistant("custom:chat", reasoning_field="reasoning_content")]).to_openai(
+        provider="custom:chat", model="m"
+    )[0]
+    assert out["reasoning_content"] == "cot"
+    assert "reasoning" not in out
+
+
+def test_to_openai_auto_replay_falls_back_to_reasoning():
+    sync_custom_endpoint_specs({"chat": CHAT_ENDPOINT})
+    out = MessageHistory([_assistant("custom:chat", reasoning_field=None)]).to_openai(
+        provider="custom:chat", model="m"
+    )[0]
+    assert out["reasoning"] == "cot"
+    assert out["content"] == [{"type": "text", "text": "ans"}]
+
+
+def test_to_openai_replay_override_and_off():
+    sync_custom_endpoint_specs(
+        {
+            "content": {**CHAT_ENDPOINT, "reasoning_replay": "reasoning_content"},
+            "off": {**CHAT_ENDPOINT, "reasoning_replay": "off"},
+        }
+    )
+    out = MessageHistory([_assistant("custom:content", reasoning_field="reasoning")]).to_openai(
+        provider="custom:content", model="m"
+    )[0]
+    assert out["reasoning_content"] == "cot"
+
+    out = MessageHistory([_assistant("custom:off")]).to_openai(provider="custom:off", model="m")[0]
+    assert "reasoning" not in out
+    assert out["content"] == [{"type": "text", "text": "*Thinking:*\ncot"}, {"type": "text", "text": "ans"}]
+
+
+def test_to_openai_replay_never_crosses_endpoints():
+    sync_custom_endpoint_specs({"chat": CHAT_ENDPOINT, "other": CHAT_ENDPOINT})
+    out = MessageHistory([_assistant("custom:chat")]).to_openai(provider="custom:other", model="m")[0]
+    assert "reasoning" not in out
+    assert {"type": "text", "text": "*Thinking:*\ncot"} in out["content"]
+
+
+# --- client routing -------------------------------------------------------
+
+
+def test_llm_client_routes_custom_endpoints():
+    llm = LLMClient(provider="custom:chat", api_key="", base_url="http://localhost:1234/v1", api_style="openai_chat")
+    from kolega_code.llm.providers.openai import OpenAIProvider
+
+    assert isinstance(llm.provider, OpenAIProvider)
+    assert llm.provider.base_url == "http://localhost:1234/v1"
+    assert llm.provider_name == "custom:chat"
+
+    llm = LLMClient(provider="custom:local", api_key="", base_url="http://localhost:8080", api_style="anthropic")
+    from kolega_code.llm.providers.anthropic import AnthropicProvider
+
+    assert isinstance(llm.provider, AnthropicProvider)
+    assert llm.provider.use_local_token_counting
+
+    llm = LLMClient(
+        provider="custom:vllm", api_key="", base_url="http://localhost:8000/v1", api_style="openai_responses"
+    )
+    from kolega_code.llm.providers.openai_responses import OpenAIResponsesProvider
+
+    assert isinstance(llm.provider, OpenAIResponsesProvider)
+    assert llm.provider.base_url == "http://localhost:8000/v1"
+
+
+def test_llm_client_custom_endpoint_requires_base_url_and_style():
+    from kolega_code.llm.exceptions import LLMError
+
+    with pytest.raises(LLMError, match="base_url and api_style"):
+        LLMClient(provider="custom:chat", api_key="", api_style="openai_chat")
+    with pytest.raises(LLMError, match="base_url and api_style"):
+        LLMClient(provider="custom:chat", api_key="", base_url="http://localhost:1/v1")
+    with pytest.raises(LLMError, match="api_style"):
+        LLMClient(provider="custom:chat", api_key="", base_url="http://localhost:1/v1", api_style="grpc")
+
+
+def test_responses_include_gated_to_builtin_backends():
+    sync_custom_endpoint_specs(
+        {
+            "vllm": {
+                "api_style": "openai_responses",
+                "base_url": "http://localhost:8000/v1",
+                "thinking": {"mode": "openai_responses_reasoning"},
+            }
+        }
+    )
+    custom = LLMClient(
+        provider="custom:vllm", api_key="", base_url="http://localhost:8000/v1", api_style="openai_responses"
+    )
+    req = cast(Any, custom.provider)._build_request(
+        MessageHistory([Message(role="user", content=[TextBlock(text="hi")])]),
+        None,
+        GenerationParams(thinking="low", temperature=1.0),
+        {"model": "gpt-oss"},
+    )
+    assert req.get("reasoning") == {"effort": "low", "summary": "auto"}
+    assert "include" not in req
+
+    builtin = LLMClient(provider="openai", api_key="sk-x")
+    req = cast(Any, builtin.provider)._build_request(
+        MessageHistory([Message(role="user", content=[TextBlock(text="hi")])]),
+        None,
+        GenerationParams(thinking="medium", temperature=1.0),
+        {"model": "gpt-5.6-sol"},
+    )
+    assert req.get("include") == ["reasoning.encrypted_content"]
+
+
+# --- AgentConfig ----------------------------------------------------------
+
+
+def test_agent_config_custom_endpoint_plumbing():
+    config = _config({"lmstudio": CHAT_ENDPOINT}, provider="custom:lmstudio", model="m")
+    endpoint = config.custom_endpoint_for(config.long_context_config)
+    assert endpoint is not None
+    assert endpoint.api_style == "openai_chat"
+    assert endpoint.base_url == "http://localhost:1234/v1"
+    assert config.get_api_key(ModelProvider("custom:lmstudio")) is None
+    assert ("custom:lmstudio", "*") in WILDCARD_MODEL_SPECS
+
+
+def test_agent_config_endpoint_api_key_resolves():
+    config = _config(
+        {"lmstudio": {**CHAT_ENDPOINT, "api_key": "secret"}},
+        provider="custom:lmstudio",
+        model="m",
+    )
+    assert config.get_api_key(ModelProvider("custom:lmstudio")) == "secret"
+    assert config.get_api_key(ModelProvider.OPENAI) is None
+
+
+def test_agent_config_keyless_custom_provider_passes_validation():
+    _config({"lmstudio": CHAT_ENDPOINT}, provider="custom:lmstudio", model="m")
+
+
+def test_custom_endpoint_config_validation():
+    config = CustomEndpointConfig(api_style="openai_chat", base_url="http://localhost:1234/v1/")
+    assert config.base_url == "http://localhost:1234/v1"
+    with pytest.raises(ValueError):
+        CustomEndpointConfig(api_style="openai_chat", base_url="localhost:1234/v1")
+    with pytest.raises(ValueError):
+        CustomEndpointConfig(api_style="openai_chat", base_url="http://x/v1", reasoning_replay="sideways")
+    with pytest.raises(ValueError):
+        CustomEndpointConfig.model_validate({"api_style": "grpc", "base_url": "http://x/v1"})

--- a/tests/agent/llm/test_provider_usage_mapping.py
+++ b/tests/agent/llm/test_provider_usage_mapping.py
@@ -190,6 +190,7 @@ async def test_fireworks_stream_final_message_maps_openai_usage():
         "total_tokens": 33,
         "cache_read_input_tokens": 33,
         "provider": "fireworks",
+        "reasoning_field": "reasoning_content",
     }
 
 


### PR DESCRIPTION
## Summary

Library core for pointing kolega-code at arbitrary OpenAI Chat Completions, OpenAI Responses, or Anthropic Messages servers (LM Studio, Ollama, vLLM, ...). Providers are addressed as `custom:<id>` and resolved against `AgentConfig.custom_endpoints`. The CLI/TUI surfaces land in follow-up PRs.

## Changes

- `ModelProvider._missing_`: dynamic `custom:<id>` members (identity-stable, `__members__` unpolluted).
- `CustomEndpointConfig` + `AgentConfig.custom_endpoints`, `custom_endpoint_for`, endpoint-aware `get_api_key`; keyless endpoints pass API-key validation.
- `sync_custom_endpoint_specs`: registers a wildcard spec per endpoint (context window, output cap, vision, optional thinking-effort) plus per-model overrides into `MODEL_SPECS`, so custom models resolve budgets/compression/effort like catalogued ones. Idempotent; invalid entries skipped.
- `LLMClient` gains `base_url`/`api_style` and routes custom providers to the matching SDK shape; keyless local servers get a dummy credential. Wired through agent construction sites (context, hook prompts, web-fetch, terminal security checks) and the connection probe.
- Two generic thinking modes: `thinking_toggle` (Qwen3-style `thinking` object via extra_body) and `anthropic_budget` (Anthropic budget tokens).
- Reasoning replay: custom `openai_chat` endpoints echo emitted reasoning back in the field the server emitted it in (sniffed from the stream), falling back to `reasoning`; per-endpoint override `auto | reasoning_content | reasoning | off`. Responses/Anthropic styles stay no-replay; custom Responses requests skip OpenAI-only `reasoning.encrypted_content` includes.

## Tests

New `tests/agent/llm/test_custom_endpoints.py` (identity, sync, thinking params, replay serialization, client routing, include gating, AgentConfig plumbing). Full fast suite: 4708 passed; pyright clean.