### PR TITLE
feat(cli): custom endpoints — settings, flags, and env overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+### Added
+
+- Custom endpoints: use models from any OpenAI Chat Completions, OpenAI
+  Responses, or Anthropic Messages-compatible server (LM Studio, Ollama, vLLM,
+  ...). Define endpoints under `custom_endpoints` in settings.json or via the
+  `--custom-endpoints` / `--endpoint-url` flags and `KOLEGA_CODE_CUSTOM_ENDPOINTS`
+  / `KOLEGA_CODE_ENDPOINT_*` environment variables (never persisted), then select
+  them as `custom:<id>` anywhere a provider is chosen. Supports thinking-effort
+  modes per wire dialect and native reasoning replay.
+
 ### Fixed
 
 - Together models (e.g. Kimi K2.7-Code) now replay prior reasoning through the

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -57,6 +57,10 @@ export default defineConfig({
               slug: "configuration/providers-and-models",
             },
             {
+              label: "Custom Endpoints",
+              slug: "configuration/custom-endpoints",
+            },
+            {
               label: "Sign in with ChatGPT",
               slug: "configuration/sign-in-with-chatgpt",
             },

--- a/docs/src/content/docs/configuration/custom-endpoints.mdx
+++ b/docs/src/content/docs/configuration/custom-endpoints.mdx
@@ -1,0 +1,172 @@
+---
+title: Custom Endpoints
+description: Point Kolega Code at any OpenAI-, Responses-, or Anthropic-compatible server — LM Studio, Ollama, vLLM, or your own gateway.
+---
+
+import { Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+
+Kolega Code can use models served by **any** OpenAI Chat Completions, OpenAI
+Responses, or Anthropic Messages-compatible server — LM Studio, Ollama, vLLM,
+llama.cpp, or a self-hosted gateway. These are **custom endpoints**, addressed as
+providers named `custom:<id>` and usable wherever a built-in provider is: the
+active model, agent-role overrides, model slots, `/model`, CLI flags, and
+environment variables.
+
+## The settings.json schema
+
+Custom endpoints live in `settings.json` under `custom_endpoints`, keyed by a
+lowercase slug:
+
+```json
+"custom_endpoints": {
+  "lmstudio": {
+    "api_style": "openai_chat",
+    "base_url": "http://localhost:1234/v1",
+    "api_key": "",
+    "label": "LM Studio",
+    "default_model": "qwen2.5-coder-7b-instruct",
+    "context_length": 32768,
+    "max_output_tokens": 8192,
+    "supports_vision": false,
+    "reasoning_replay": "auto",
+    "thinking": {
+      "mode": "thinking_toggle",
+      "options": ["none", "enabled"],
+      "default": "enabled"
+    },
+    "models": {
+      "qwen2.5-coder-7b-instruct": { "context_length": 32768, "max_output_tokens": 8192 }
+    }
+  },
+  "vllm": {
+    "api_style": "openai_responses",
+    "base_url": "http://192.168.1.50:8000/v1",
+    "thinking": { "mode": "openai_responses_reasoning" }
+  }
+}
+```
+
+| Field | Meaning | Default |
+| --- | --- | --- |
+| `api_style` | `openai_chat`, `openai_responses`, or `anthropic` | required |
+| `base_url` | See the per-style conventions below | required |
+| `api_key` | Optional Bearer credential (most local servers need none) | none |
+| `label` | Display name in pickers | the id |
+| `default_model` | Model used by connection probes | none |
+| `context_length` | Context window used for budgeting/compression | 32768 |
+| `max_output_tokens` | Output cap used for budgeting | 8192 |
+| `supports_vision` | Whether models accept images | false |
+| `reasoning_replay` | See [Reasoning replay](#reasoning-replay) | `auto` |
+| `thinking` | See [Thinking](#thinking) | none |
+| `models` | Per-model overrides of the fields above (including `thinking`) | none |
+
+The provider is referenced as `"active_provider": "custom:lmstudio"` — the same
+`custom:<id>` value works in `agent_models[].provider`, `model_slots[].provider`,
+`--provider`, and `KOLEGA_CODE_PROVIDER`. Any model id is accepted for a custom
+endpoint; `models` entries add per-model specs, and the endpoint defaults cover
+everything else.
+
+<Aside type="tip">
+Ollama: `http://localhost:11434/v1` · LM Studio: `http://localhost:1234/v1` ·
+vLLM: `http://localhost:8000/v1`.
+</Aside>
+
+### Base-URL conventions per style
+
+- **`openai_chat` / `openai_responses`** — include the `/v1` path (the SDK appends
+  `/chat/completions` or `/responses`): `http://localhost:11434/v1`.
+- **`anthropic`** — the API root (the SDK appends `/v1/messages`):
+  `http://localhost:8080`.
+
+## Thinking
+
+The optional `thinking` block declares an effort control in the wire dialect the
+endpoint speaks:
+
+| Mode | Wire shape | Typical use |
+| --- | --- | --- |
+| `thinking_toggle` | `{"thinking": {"type": "enabled" \| "disabled"}}` | Qwen3 on Ollama/vLLM |
+| `openai_reasoning_effort` | flat `reasoning_effort` | OpenAI-compatible reasoning models |
+| `openai_responses_reasoning` | `{"reasoning": {"effort", "summary"}}` | Responses-API reasoning models |
+| `anthropic_budget` | `{"thinking": {"type": "enabled", "budget_tokens": N}}` | Anthropic-style gateways |
+
+Each mode has preset `options` and a `default`; `thinking_toggle` ships `["none",
+"enabled"]`. For `anthropic_budget` you must supply a `budgets` map with a token
+budget per non-`none` option, and every budget must stay **below**
+`max_output_tokens` (Anthropic requires `max_tokens > budget_tokens`):
+
+```json
+"thinking": {
+  "mode": "anthropic_budget",
+  "options": ["none", "low", "medium", "high"],
+  "default": "medium",
+  "budgets": { "low": 2048, "medium": 8192, "high": 16384 }
+}
+```
+
+The declared options appear in the thinking-effort pickers for that endpoint.
+
+## Reasoning replay
+
+Reasoning the model emits is sent back on the next turn so it does not re-derive
+its chain-of-thought every request. For `openai_chat` endpoints this is **on by
+default**: reasoning is echoed in whichever field the server emitted it in
+(`reasoning_content` or `reasoning`, detected from the stream), falling back to
+`reasoning`.
+
+`reasoning_replay` accepts:
+
+- `auto` (default) — echo in the emitted field, fallback `reasoning`
+- `reasoning_content` — force that field
+- `reasoning` — force that field
+- `off` — keep reasoning as visible `*Thinking:*` text
+
+`openai_responses` and `anthropic` endpoints do not replay reasoning (their
+continuity mechanisms are provider-specific and are not implemented by generic
+servers).
+
+## Configuring
+
+<Steps>
+1. Add the endpoint under `custom_endpoints` in `settings.json`, or use the TUI:
+   **Settings → Custom Endpoints → New endpoint**.
+2. Select the provider (`custom:<id>`) in **Settings → Models**, and type the
+   model id in the **Other…** field.
+3. **Apply Changes**. The endpoint appears in every provider picker and accepts
+   free-text model ids.
+</Steps>
+
+## One-off use without a saved config
+
+Everything above can be supplied per process without touching `settings.json`.
+
+<Tabs>
+<TabItem label="Flat flags">
+
+```bash
+kolega-code --model qwen2.5-coder --endpoint-url http://localhost:11434/v1 \
+  --endpoint-style openai_chat --endpoint-thinking thinking_toggle
+```
+
+`--endpoint-url` defines an ephemeral endpoint named `custom:cli`; when no
+provider is set, it becomes the active provider. Companion flags:
+`--endpoint-style`, `--endpoint-api-key`, `--endpoint-context`,
+`--endpoint-max-output`, `--endpoint-vision`, `--endpoint-thinking`,
+`--endpoint-reasoning` (all mirrored by `KOLEGA_CODE_ENDPOINT_*` environment
+variables).
+
+</TabItem>
+<TabItem label="JSON">
+
+```bash
+kolega-code --provider custom:vllm --model gpt-oss \
+  --custom-endpoints '{"vllm": {"api_style": "openai_responses", "base_url": "http://localhost:8000/v1"}}'
+```
+
+The same JSON object works via `KOLEGA_CODE_CUSTOM_ENDPOINTS`.
+
+</TabItem>
+</Tabs>
+
+Layers merge per endpoint id with **flag > environment > settings.json**; nothing
+from the flag/environment layers is ever persisted.

--- a/docs/src/content/docs/configuration/environment-variables.md
+++ b/docs/src/content/docs/configuration/environment-variables.md
@@ -93,6 +93,14 @@ served by different providers on different credentials.
 | `KOLEGA_CODE_FAST_PROVIDER` / `KOLEGA_CODE_FAST_MODEL` | Fast utility model |
 | `KOLEGA_CODE_THINKING_EFFORT` | Model-specific thinking effort |
 | `KOLEGA_CODE_EDIT_PROTOCOL` | Optional model-facing edit override: `search_replace`, `codex_apply_patch`, or `claude_code`; otherwise the model catalogue preference or `claude_code` fallback is used |
+| `KOLEGA_CODE_CUSTOM_ENDPOINTS` | JSON object of [custom endpoint](../custom-endpoints/) definitions, merged over `settings.json` per endpoint id (never persisted) |
+| `KOLEGA_CODE_ENDPOINT_URL` | Base URL defining the ephemeral `custom:cli` endpoint |
+| `KOLEGA_CODE_ENDPOINT_STYLE` | Wire style for that endpoint: `openai_chat`, `openai_responses`, or `anthropic` (default `openai_chat`) |
+| `KOLEGA_CODE_ENDPOINT_API_KEY` | Optional credential for that endpoint |
+| `KOLEGA_CODE_ENDPOINT_CONTEXT` / `KOLEGA_CODE_ENDPOINT_MAX_OUTPUT` | Context window / max output tokens for that endpoint (defaults 32768 / 8192) |
+| `KOLEGA_CODE_ENDPOINT_VISION` | Non-empty marks that endpoint's models as vision-capable |
+| `KOLEGA_CODE_ENDPOINT_THINKING` | Thinking-effort mode for that endpoint (`thinking_toggle`, `openai_reasoning_effort`, `openai_responses_reasoning`, `anthropic_budget`) |
+| `KOLEGA_CODE_ENDPOINT_REASONING` | Reasoning replay field for that endpoint: `auto`, `reasoning_content`, `reasoning`, or `off` |
 
 These outrank the Fast slot saved in Settings. Full precedence per role:
 CLI flag > environment variable > saved slot > the active model.

--- a/docs/src/content/docs/configuration/providers-and-models.mdx
+++ b/docs/src/content/docs/configuration/providers-and-models.mdx
@@ -14,7 +14,9 @@ stronger models plan, build, or think.
 
 ## Supported providers
 
-The agent runtime recognizes these providers:
+The agent runtime recognizes these providers, plus any server you point it at via
+[Custom Endpoints](../custom-endpoints/) (`custom:<id>`, OpenAI / Responses /
+Anthropic-compatible):
 
 | Provider | Identifier | API key variable |
 | --- | --- | --- |

--- a/kolega_code/cli/config.py
+++ b/kolega_code/cli/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 from dataclasses import dataclass
 from pathlib import Path
@@ -10,12 +11,29 @@ from typing import Any, Mapping, NoReturn, Optional
 from pydantic import ValidationError
 
 from kolega_code.auth.tokens import ChatGPTTokenManager, OAuthTokens
-from kolega_code.config import AgentConfig, AgentRole, EditProtocol, ModelConfig, ModelProvider, RateLimitConfig
+from kolega_code.config import (
+    AgentConfig,
+    AgentRole,
+    CustomEndpointConfig,
+    EditProtocol,
+    ModelConfig,
+    ModelProvider,
+    RateLimitConfig,
+)
 from kolega_code.llm.specs import MODEL_SPECS, get_model_specs, model_is_known, normalize_thinking_effort
+from kolega_code.llm.specs.custom_endpoints import (
+    API_STYLES,
+    CUSTOM_PROVIDER_PREFIX,
+    CUSTOM_THINKING_PRESETS,
+    REASONING_REPLAY_VALUES,
+    custom_endpoint_id,
+    is_custom_provider,
+    sync_custom_endpoint_specs,
+)
 from kolega_code.mcp.config import load_mcp_config
 from kolega_code.services.lsp.config import LspConfig
 
-from .provider_registry import default_model_for_provider
+from .provider_registry import default_model_for_provider, rebuild_ui_model_options, set_custom_provider_labels
 from .settings import (
     COMPRESSION_THRESHOLD_MAX_PERCENT,
     COMPRESSION_THRESHOLD_MIN_PERCENT,
@@ -86,6 +104,20 @@ SEARCH_BACKEND_KEY_ENV = {
     "tavily": "TAVILY_API_KEY",
 }
 
+# Custom-endpoint definition layers: full JSON object, or flat fields describing
+# one ephemeral endpoint under the id below. Never persisted to settings.json.
+CUSTOM_ENDPOINTS_ENV = "KOLEGA_CODE_CUSTOM_ENDPOINTS"
+ENDPOINT_URL_ENV = "KOLEGA_CODE_ENDPOINT_URL"
+ENDPOINT_STYLE_ENV = "KOLEGA_CODE_ENDPOINT_STYLE"
+ENDPOINT_API_KEY_ENV = "KOLEGA_CODE_ENDPOINT_API_KEY"
+ENDPOINT_CONTEXT_ENV = "KOLEGA_CODE_ENDPOINT_CONTEXT"
+ENDPOINT_MAX_OUTPUT_ENV = "KOLEGA_CODE_ENDPOINT_MAX_OUTPUT"
+ENDPOINT_VISION_ENV = "KOLEGA_CODE_ENDPOINT_VISION"
+ENDPOINT_THINKING_ENV = "KOLEGA_CODE_ENDPOINT_THINKING"
+ENDPOINT_REASONING_ENV = "KOLEGA_CODE_ENDPOINT_REASONING"
+CLI_ENDPOINT_ID = "cli"
+CLI_ENDPOINT_PROVIDER = f"{CUSTOM_PROVIDER_PREFIX}{CLI_ENDPOINT_ID}"
+
 
 class CliConfigError(ValueError):
     """Raised when CLI configuration is incomplete or invalid."""
@@ -121,6 +153,18 @@ class CliConfigOverrides:
     # validated as a pair in _strict_context_budget. Never persisted.
     context_window_tokens: Optional[str] = None
     max_output_tokens: Optional[str] = None
+    # Custom endpoint definition layers. --custom-endpoints carries the full JSON
+    # object; the --endpoint-* flags define one ephemeral endpoint "custom:cli".
+    # Neither is ever persisted.
+    custom_endpoints_json: Optional[str] = None
+    endpoint_url: Optional[str] = None
+    endpoint_style: Optional[str] = None
+    endpoint_api_key: Optional[str] = None
+    endpoint_context: Optional[str] = None
+    endpoint_max_output: Optional[str] = None
+    endpoint_vision: bool = False
+    endpoint_thinking: Optional[str] = None
+    endpoint_reasoning: Optional[str] = None
 
 
 def load_cli_env(project_path: Path, env: Optional[Mapping[str, str]] = None) -> dict[str, str]:
@@ -132,6 +176,98 @@ def load_cli_env(project_path: Path, env: Optional[Mapping[str, str]] = None) ->
     """
     _ = project_path
     return dict(env if env is not None else os.environ)
+
+
+def _parse_endpoints_json(raw: str, source: str) -> dict[str, dict]:
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise CliConfigError(f"{source} must be valid JSON: {exc.msg}") from exc
+    if not isinstance(parsed, dict) or not all(
+        isinstance(endpoint_id, str) and isinstance(entry, dict) for endpoint_id, entry in parsed.items()
+    ):
+        raise CliConfigError(f"{source} must be a JSON object of endpoint definitions.")
+    return dict(parsed)
+
+
+def _flat_endpoint_fields(env: Mapping[str, str], overrides: CliConfigOverrides) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    for name, env_key, value in (
+        ("api_style", ENDPOINT_STYLE_ENV, overrides.endpoint_style),
+        ("api_key", ENDPOINT_API_KEY_ENV, overrides.endpoint_api_key),
+        ("context_length", ENDPOINT_CONTEXT_ENV, overrides.endpoint_context),
+        ("max_output_tokens", ENDPOINT_MAX_OUTPUT_ENV, overrides.endpoint_max_output),
+        ("thinking", ENDPOINT_THINKING_ENV, overrides.endpoint_thinking),
+        ("reasoning_replay", ENDPOINT_REASONING_ENV, overrides.endpoint_reasoning),
+    ):
+        resolved = value or env.get(env_key)
+        if resolved:
+            fields[name] = resolved
+    return fields
+
+
+def _cli_endpoint(url: str, env: Mapping[str, str], overrides: CliConfigOverrides) -> dict[str, Any]:
+    """Build the ephemeral `custom:cli` endpoint from --endpoint-url and friends."""
+    if not url.strip():
+        raise CliConfigError("--endpoint-url/KOLEGA_CODE_ENDPOINT_URL must not be empty.")
+    if not url.startswith(("http://", "https://")):
+        raise CliConfigError(f"--endpoint-url must be an http(s) URL, got '{url}'.")
+    flat = _flat_endpoint_fields(env, overrides)
+    api_style = flat.get("api_style", "openai_chat")
+    if api_style not in API_STYLES:
+        raise CliConfigError(f"Unsupported endpoint style '{api_style}'. Valid styles: {', '.join(API_STYLES)}")
+    entry: dict[str, Any] = {"api_style": api_style, "base_url": url.rstrip("/")}
+    if flat.get("api_key"):
+        entry["api_key"] = flat["api_key"]
+    for key, flag in (("context_length", "context"), ("max_output_tokens", "max-output")):
+        raw = flat.get(key)
+        if raw is None:
+            continue
+        try:
+            value = int(raw)
+        except ValueError:
+            value = 0
+        if value <= 0:
+            raise CliConfigError(f"--endpoint-{flag} must be a positive integer, got '{raw}'.")
+        entry[key] = value
+    thinking = flat.get("thinking")
+    if thinking:
+        if thinking not in CUSTOM_THINKING_PRESETS:
+            valid = ", ".join(sorted(CUSTOM_THINKING_PRESETS))
+            raise CliConfigError(f"Unsupported --endpoint-thinking '{thinking}'. Valid modes: {valid}")
+        preset = CUSTOM_THINKING_PRESETS[thinking]
+        if preset["budgets_required"]:
+            raise CliConfigError(
+                f"--endpoint-thinking {thinking} needs per-effort budgets; define it with --custom-endpoints JSON."
+            )
+        entry["thinking"] = {"mode": thinking, "options": list(preset["options"]), "default": preset["default"]}
+    reasoning = flat.get("reasoning_replay")
+    if reasoning:
+        if reasoning not in REASONING_REPLAY_VALUES:
+            valid = ", ".join(REASONING_REPLAY_VALUES)
+            raise CliConfigError(f"Unsupported --endpoint-reasoning '{reasoning}'. Valid values: {valid}")
+        entry["reasoning_replay"] = reasoning
+    if overrides.endpoint_vision or env.get(ENDPOINT_VISION_ENV):
+        entry["supports_vision"] = True
+    return entry
+
+
+def _merged_custom_endpoints(
+    env: Mapping[str, str],
+    overrides: CliConfigOverrides,
+    settings: Optional[CliSettings],
+) -> dict[str, dict]:
+    """Custom endpoints from settings.json overlaid with env JSON then flag JSON (per id)."""
+    merged: dict[str, dict] = dict(settings.custom_endpoints) if settings else {}
+    env_json = env.get(CUSTOM_ENDPOINTS_ENV)
+    if env_json:
+        merged.update(_parse_endpoints_json(env_json, CUSTOM_ENDPOINTS_ENV))
+    if overrides.custom_endpoints_json:
+        merged.update(_parse_endpoints_json(overrides.custom_endpoints_json, "--custom-endpoints"))
+    endpoint_url = overrides.endpoint_url or env.get(ENDPOINT_URL_ENV)
+    if endpoint_url:
+        merged[CLI_ENDPOINT_ID] = _cli_endpoint(endpoint_url, env, overrides)
+    return merged
 
 
 def _provider(value: str) -> ModelProvider:
@@ -197,6 +333,13 @@ def _ensure_explicit_model_supported(
     provider_source: Optional[str],
 ) -> None:
     """Raise a targeted error when an explicit model is paired with the wrong provider."""
+    if is_custom_provider(provider) and not model_is_known(provider, model):
+        # A custom provider resolves any model only through its endpoint's
+        # wildcard; its absence here means the endpoint is not defined.
+        raise CliConfigError(
+            f"Custom endpoint '{custom_endpoint_id(provider)}' is not defined. Add it under custom_endpoints in "
+            "settings.json, or via --custom-endpoints/--endpoint-url for this session."
+        )
     if model_is_known(provider, model):
         return
 
@@ -226,7 +369,13 @@ def _api_key_for_provider(
     provider: ModelProvider,
     env: Mapping[str, str],
     settings: Optional[CliSettings],
+    custom_endpoints: Optional[Mapping[str, Any]] = None,
 ) -> Optional[str]:
+    endpoint_id = custom_endpoint_id(provider)
+    if endpoint_id is not None:
+        merged = custom_endpoints or _merged_custom_endpoints(env, CliConfigOverrides(), settings)
+        entry = merged.get(endpoint_id) or {}
+        return entry.get("api_key") or None
     env_name = API_KEY_ENV.get(provider)
     if env_name and env.get(env_name):
         return env[env_name]
@@ -451,16 +600,20 @@ def _validate_strict_context_budget_limits(
         )
 
 
-def _coerce_known_model(provider: ModelProvider, model: Optional[str]) -> str:
+def _coerce_known_model(provider: ModelProvider, model: Optional[str]) -> Optional[str]:
     """Return ``model`` if it's a known spec for ``provider``, else the default.
 
     Guards against a settings.json that points at a model which has since been
     renamed or removed (e.g. an old ChatGPT slug): without this, config building
     raises and the TUI disables the composer, locking the user out. Wildcard-
-    addressed models (Tinker checkpoint paths) count as known and are kept.
+    addressed models (Tinker checkpoint paths, custom endpoints) count as known
+    and are kept. A custom provider whose endpoint was deleted has no default:
+    return None so the caller degrades to unconfigured.
     """
     if model and model_is_known(provider, model):
         return model
+    if is_custom_provider(provider):
+        return None
     return default_model_for_provider(provider)
 
 
@@ -468,6 +621,7 @@ def _active_provider_model(
     env: Mapping[str, str],
     overrides: CliConfigOverrides,
     settings: Optional[CliSettings],
+    default_custom_provider: Optional[str] = None,
 ) -> tuple[Optional[ModelProvider], Optional[str]]:
     provider_value, provider_source = _explicit_value(overrides.provider, env, "KOLEGA_CODE_PROVIDER", "--provider")
     model_value, model_source = _explicit_value(overrides.model, env, "KOLEGA_CODE_MODEL", "--model")
@@ -475,7 +629,11 @@ def _active_provider_model(
     if provider_value or model_value:
         if not provider_value:
             assert model_value is not None
-            _require_provider_for_model(model_value, model_source, "--provider or KOLEGA_CODE_PROVIDER")
+            if default_custom_provider:
+                provider_value = default_custom_provider
+                provider_source = None
+            else:
+                _require_provider_for_model(model_value, model_source, "--provider or KOLEGA_CODE_PROVIDER")
         if not model_value:
             _require_model_for_provider(provider_value, provider_source, "--model or KOLEGA_CODE_MODEL")
         provider = _provider(provider_value)
@@ -492,7 +650,10 @@ def _active_provider_model(
             provider = _provider(settings.active_provider)
         except CliConfigError:
             return None, None
-        return provider, _coerce_known_model(provider, settings.active_model)
+        model = _coerce_known_model(provider, settings.active_model)
+        if model is None:
+            return None, None
+        return provider, model
 
     return None, None
 
@@ -506,6 +667,7 @@ def _slot_provider_model(
     active_provider: ModelProvider,
     active_model: str,
     saved: Optional[Mapping[str, str]] = None,
+    default_custom_provider: Optional[str] = None,
 ) -> tuple[ModelProvider, str]:
     """Resolve one operational slot: CLI flag > env var > saved slot > active model.
 
@@ -531,7 +693,11 @@ def _slot_provider_model(
     if provider_value and not model_value:
         _require_model_for_provider(provider_value, provider_source, f"{model_flag} or {model_env_key}")
     if model_value and not provider_value:
-        _require_provider_for_model(model_value, model_source, f"{provider_flag} or {provider_env_key}")
+        if default_custom_provider:
+            provider_value = default_custom_provider
+            provider_source = None
+        else:
+            _require_provider_for_model(model_value, model_source, f"{provider_flag} or {provider_env_key}")
 
     if provider_value:
         assert model_value is not None
@@ -549,18 +715,42 @@ def _slot_provider_model(
     if saved_provider and saved_model:
         provider = _provider(saved_provider)
         if not model_is_known(provider, saved_model):
+            if is_custom_provider(provider):
+                # Endpoint deleted from settings: drop the override, inherit the active.
+                return active_provider, active_model
             saved_model = default_model_for_provider(provider)
         return provider, saved_model
 
     return active_provider, active_model
 
 
-def _model_config(provider: ModelProvider, model: str, thinking_effort: Optional[str] = None) -> ModelConfig:
+def _model_config(
+    provider: ModelProvider,
+    model: str,
+    thinking_effort: Optional[str] = None,
+    custom_endpoints: Optional[Mapping[str, Any]] = None,
+) -> ModelConfig:
+    endpoint_id = custom_endpoint_id(provider)
+    if endpoint_id is not None and endpoint_id not in (custom_endpoints or {}):
+        raise CliConfigError(
+            f"Custom endpoint '{endpoint_id}' is not defined. Add it under custom_endpoints in settings.json, "
+            "or via --custom-endpoints/--endpoint-url for this session."
+        )
     try:
-        get_model_specs(provider, model)
+        specs = get_model_specs(provider, model)
         resolved_thinking_effort = normalize_thinking_effort(provider, model, thinking_effort)
     except ValueError as exc:
         raise CliConfigError(str(exc)) from exc
+    if endpoint_id is not None:
+        thinking_spec = specs.get("thinking_effort")
+        if thinking_spec is not None and thinking_spec.mode == "anthropic_budget":
+            cap = specs["max_completion_tokens"]
+            over = [f"{option}={budget}" for option, budget in thinking_spec.budgets.items() if budget >= cap]
+            if over:
+                raise CliConfigError(
+                    f"Custom endpoint '{endpoint_id}': anthropic_budget budgets must stay below max_output_tokens "
+                    f"({cap}); over-limit: {', '.join(over)}."
+                )
 
     return ModelConfig(
         provider=provider,
@@ -602,6 +792,7 @@ def _agent_role_env_keys(role: AgentRole) -> tuple[str, str, str]:
 def _agent_model_overrides(
     env: Mapping[str, str],
     settings: Optional[CliSettings],
+    custom_endpoints: Optional[Mapping[str, Any]] = None,
 ) -> dict[str, ModelConfig]:
     """Resolve per-agent-role model overrides from env vars over saved settings.
 
@@ -640,8 +831,13 @@ def _agent_model_overrides(
                 provider_source=provider_key if provider_env_value else None,
             )
         elif not model_is_known(provider, model_value):
+            if is_custom_provider(provider):
+                # Endpoint deleted from settings: drop the override, role inherits.
+                continue
             model_value = default_model_for_provider(provider)
-        overrides[role.value] = _model_config(provider, model_value, thinking_effort=effort_value)
+        overrides[role.value] = _model_config(
+            provider, model_value, thinking_effort=effort_value, custom_endpoints=custom_endpoints
+        )
     return overrides
 
 
@@ -663,7 +859,18 @@ def build_agent_config(
     if "KOLEGA_CODE_THINKING_TOKENS" in loaded_env:
         raise CliConfigError(DEPRECATED_THINKING_TOKENS_MESSAGE)
 
-    active_provider, active_model = _active_provider_model(loaded_env, overrides, settings)
+    if not (overrides.endpoint_url or loaded_env.get(ENDPOINT_URL_ENV)) and (
+        _flat_endpoint_fields(loaded_env, overrides) or overrides.endpoint_vision
+    ):
+        raise CliConfigError("--endpoint-* flags require --endpoint-url or KOLEGA_CODE_ENDPOINT_URL.")
+
+    merged_endpoints = _merged_custom_endpoints(loaded_env, overrides, settings)
+    sync_custom_endpoint_specs(merged_endpoints)
+    default_custom_provider = CLI_ENDPOINT_PROVIDER if CLI_ENDPOINT_ID in merged_endpoints else None
+
+    active_provider, active_model = _active_provider_model(
+        loaded_env, overrides, settings, default_custom_provider=default_custom_provider
+    )
     if active_provider is None or active_model is None:
         raise CliConfigError(MISSING_MODEL_SELECTION_MESSAGE)
 
@@ -675,6 +882,7 @@ def build_agent_config(
         overrides.model,
         active_provider,
         active_model,
+        default_custom_provider=default_custom_provider,
     )
     fast_provider, fast_model = _slot_provider_model(
         loaded_env,
@@ -694,7 +902,7 @@ def build_agent_config(
         settings,
     )
 
-    agent_model_overrides = _agent_model_overrides(loaded_env, settings)
+    agent_model_overrides = _agent_model_overrides(loaded_env, settings, custom_endpoints=merged_endpoints)
     web_search_backend, web_search_api_key, web_search_base_url = _search_config(loaded_env, settings)
     web_search_mode = _web_search_mode(loaded_env, settings, overrides.web_search_mode)
     compression_threshold = _compression_threshold(loaded_env, settings, overrides.compression_threshold)
@@ -709,12 +917,13 @@ def build_agent_config(
 
     required_providers = {long_provider, fast_provider}
     required_providers.update(override.provider for override in agent_model_overrides.values())
-    # API-key providers: env/settings key required. OAuth and local providers are
-    # exempt (OAuth is checked via stored tokens below; LLAMA is keyless).
+    # API-key providers: env/settings key required. OAuth, local, and custom
+    # endpoint providers are exempt (endpoint keys are optional).
     missing_keys = [
         API_KEY_ENV[provider]
         for provider in sorted(required_providers, key=lambda item: item.value)
         if provider != ModelProvider.LLAMA
+        and not is_custom_provider(provider)
         and provider not in OAUTH_PROVIDERS
         and not _api_key_for_provider(provider, loaded_env, settings)
     ]
@@ -752,9 +961,15 @@ def build_agent_config(
             thinking_machines_api_key=_api_key_for_provider(ModelProvider.THINKING_MACHINES, loaded_env, settings),
             environment=overrides.environment or loaded_env.get("KOLEGA_CODE_ENVIRONMENT", "development"),
             edit_protocol=edit_protocol,
-            long_context_config=_model_config(long_provider, long_model, thinking_effort=active_thinking_effort),
-            fast_config=_model_config(fast_provider, fast_model),
+            long_context_config=_model_config(
+                long_provider, long_model, thinking_effort=active_thinking_effort, custom_endpoints=merged_endpoints
+            ),
+            fast_config=_model_config(fast_provider, fast_model, custom_endpoints=merged_endpoints),
             agent_models=agent_model_overrides,
+            custom_endpoints={
+                endpoint_id: CustomEndpointConfig.model_validate(entry)
+                for endpoint_id, entry in merged_endpoints.items()
+            },
             web_search_mode=web_search_mode,
             web_search_backend=web_search_backend,
             web_search_api_key=web_search_api_key,
@@ -790,6 +1005,13 @@ def build_agent_config(
     # to settings.json (only possible when a store is supplied by the caller).
     if chatgpt_tokens is not None and settings is not None and settings_store is not None:
         config.attach_chatgpt_token_manager(_build_chatgpt_token_manager(chatgpt_tokens, settings, settings_store))
+
+    # Keep the UI picker registry in sync with the endpoints resolved for this
+    # process (includes env/flag-defined ones for the session).
+    set_custom_provider_labels(
+        {endpoint_id: endpoint.label or endpoint_id for endpoint_id, endpoint in config.custom_endpoints.items()}
+    )
+    rebuild_ui_model_options()
     return config
 
 
@@ -798,6 +1020,19 @@ def key_status(provider: str, project_path: Path, settings: Optional[CliSettings
     provider_value = _provider(provider)
     if provider_value == ModelProvider.LLAMA:
         return "not required for the local provider"
+    endpoint_id = custom_endpoint_id(provider_value)
+    if endpoint_id is not None:
+        env = load_cli_env(project_path)
+        merged = _merged_custom_endpoints(env, CliConfigOverrides(), settings)
+        entry = merged.get(endpoint_id) or {}
+        if endpoint_id not in merged:
+            return "endpoint not defined"
+        if entry.get("api_key"):
+            saved_entry = (settings.custom_endpoints if settings else {}).get(endpoint_id) or {}
+            if saved_entry.get("api_key") == entry["api_key"]:
+                return "present in local settings"
+            return "present via environment override"
+        return "key not set (optional)"
     if provider_value in OAUTH_PROVIDERS:
         if settings and settings.has_oauth_token(provider_value.value):
             token = settings.get_oauth_token(provider_value.value) or {}
@@ -842,6 +1077,14 @@ def active_model_override_message(
     """Describe an explicit CLI/process-env active-model override, if one is in effect."""
     overrides = overrides or CliConfigOverrides()
     loaded_env = load_cli_env(project_path, env)
+    endpoint_override = any(
+        (
+            overrides.custom_endpoints_json,
+            overrides.endpoint_url,
+            loaded_env.get(CUSTOM_ENDPOINTS_ENV),
+            loaded_env.get(ENDPOINT_URL_ENV),
+        )
+    )
     explicit_active_override = any(
         (
             overrides.provider,
@@ -850,14 +1093,18 @@ def active_model_override_message(
             loaded_env.get("KOLEGA_CODE_MODEL"),
         )
     )
-    if not explicit_active_override:
+    if not explicit_active_override and not endpoint_override:
         return None
     if not settings or not (settings.active_provider and settings.active_model):
+        if endpoint_override and is_custom_provider(config.long_context_config.provider):
+            return "CLI/environment-defined custom endpoints apply to this session."
         return None
 
     effective_provider = config.long_context_config.provider.value
     effective_model = config.long_context_config.model
     if settings.active_provider == effective_provider and settings.active_model == effective_model:
+        if endpoint_override and is_custom_provider(config.long_context_config.provider):
+            return "CLI/environment-defined custom endpoints apply to this session."
         return None
 
     return (

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -27,6 +27,8 @@ from kolega_code.extensions import (
     resolve_extension_selection,
 )
 from kolega_code.llm.ledger import UsageLedger
+from kolega_code.llm.specs.custom_endpoints import CUSTOM_THINKING_PRESETS
+from kolega_code.llm.specs.thinking import REASONING_REPLAY_VALUES
 
 from .ask_output import InMemorySessionJournal, SemanticStdoutPrinter
 from .session_journal import SessionRecorder
@@ -251,6 +253,40 @@ def _add_common_model_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--fast-model", help="Fast utility model.")
     parser.add_argument("--thinking-effort", help="Model-specific thinking effort for the active model.")
     parser.add_argument("--thinking-tokens", dest="deprecated_thinking_tokens", type=int, help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--custom-endpoints",
+        metavar="JSON",
+        help="Custom endpoint definitions as a JSON object, merged over settings.json per endpoint id. Not persisted.",
+    )
+    parser.add_argument(
+        "--endpoint-url",
+        metavar="URL",
+        help="Base URL of an ephemeral custom endpoint (provider 'custom:cli'). When no --provider is set "
+        "and a model is named, this endpoint becomes the active provider. Not persisted.",
+    )
+    parser.add_argument(
+        "--endpoint-style",
+        choices=["openai_chat", "openai_responses", "anthropic"],
+        help="Wire style for --endpoint-url (default openai_chat).",
+    )
+    parser.add_argument("--endpoint-api-key", help="Optional credential for --endpoint-url.")
+    parser.add_argument(
+        "--endpoint-context", metavar="TOKENS", help="Context length for --endpoint-url (default 32768)."
+    )
+    parser.add_argument(
+        "--endpoint-max-output", metavar="TOKENS", help="Max output tokens for --endpoint-url (default 8192)."
+    )
+    parser.add_argument("--endpoint-vision", action="store_true", help="Mark --endpoint-url models as vision-capable.")
+    parser.add_argument(
+        "--endpoint-thinking",
+        choices=sorted(CUSTOM_THINKING_PRESETS),
+        help="Thinking-effort mode for --endpoint-url.",
+    )
+    parser.add_argument(
+        "--endpoint-reasoning",
+        choices=list(REASONING_REPLAY_VALUES),
+        help="Reasoning replay field for --endpoint-url (auto detects the emitted field).",
+    )
     parser.add_argument("--environment", help="Environment label for tracing/metadata.")
     parser.add_argument(
         "--compression-threshold",
@@ -759,6 +795,15 @@ def _overrides_from_args(args: argparse.Namespace) -> CliConfigOverrides:
         compression_threshold=getattr(args, "compression_threshold", None),
         context_window_tokens=getattr(args, "context_window_tokens", None),
         max_output_tokens=getattr(args, "max_output_tokens", None),
+        custom_endpoints_json=getattr(args, "custom_endpoints", None),
+        endpoint_url=getattr(args, "endpoint_url", None),
+        endpoint_style=getattr(args, "endpoint_style", None),
+        endpoint_api_key=getattr(args, "endpoint_api_key", None),
+        endpoint_context=getattr(args, "endpoint_context", None),
+        endpoint_max_output=getattr(args, "endpoint_max_output", None),
+        endpoint_vision=bool(getattr(args, "endpoint_vision", False)),
+        endpoint_thinking=getattr(args, "endpoint_thinking", None),
+        endpoint_reasoning=getattr(args, "endpoint_reasoning", None),
     )
 
 

--- a/kolega_code/cli/provider_registry.py
+++ b/kolega_code/cli/provider_registry.py
@@ -9,12 +9,15 @@ separate whitelist to maintain.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Mapping
 
 from kolega_code.config import AgentRole, ModelProvider
 from kolega_code.llm.specs import (
     MODEL_SPECS,
+    CUSTOM_PROVIDER_PREFIX,
     default_thinking_effort,
     get_model_specs,
+    is_custom_provider,
     is_featured_model,
     model_is_known,
     provider_has_featured_models,
@@ -192,8 +195,11 @@ def _api_key_env(provider: ModelProvider) -> str:
     """Env var name holding the provider's API key (matches cli/config.API_KEY_ENV).
 
     OAuth providers (ChatGPT subscription) authenticate via sign-in, not an env
-    key, so they have no API-key env var.
+    key, so they have no API-key env var. Custom endpoints carry their optional
+    key on the endpoint definition.
     """
+    if is_custom_provider(provider):
+        return ""
     if provider == ModelProvider.OPENAI_CHATGPT:
         return ""
     if provider == ModelProvider.OLLAMA_CLOUD:
@@ -206,6 +212,23 @@ def _api_key_env(provider: ModelProvider) -> str:
     return f"{provider.value.upper()}_API_KEY"
 
 
+# Display labels for custom endpoint providers, keyed by endpoint id. Refreshed
+# by build_agent_config from the resolved endpoint definitions.
+CUSTOM_PROVIDER_LABELS: dict[str, str] = {}
+
+
+def set_custom_provider_labels(labels: Mapping[str, str]) -> None:
+    CUSTOM_PROVIDER_LABELS.clear()
+    CUSTOM_PROVIDER_LABELS.update(labels)
+
+
+def _provider_label(provider: ModelProvider) -> str:
+    if is_custom_provider(provider):
+        endpoint_id = provider.value[len(CUSTOM_PROVIDER_PREFIX) :]
+        return CUSTOM_PROVIDER_LABELS.get(endpoint_id, endpoint_id)
+    return PROVIDER_LABELS[provider]
+
+
 def _model_label(model: str) -> str:
     return MODEL_LABELS.get(model, model)
 
@@ -214,7 +237,7 @@ def _model_option(provider: ModelProvider, model: str) -> ModelOption:
     specs = get_model_specs(provider, model)
     return ModelOption(
         provider=provider.value,
-        provider_label=PROVIDER_LABELS[provider],
+        provider_label=_provider_label(provider),
         model=model,
         model_label=_model_label(model),
         api_key_env=_api_key_env(provider),
@@ -239,6 +262,9 @@ def _build_ui_model_options() -> list[ModelOption]:
     for provider in PROVIDER_LABELS:
         for model in models_by_provider.get(provider.value, []):
             options.append(_model_option(provider, model))
+    for provider_value in sorted(value for value in models_by_provider if value.startswith(CUSTOM_PROVIDER_PREFIX)):
+        for model in models_by_provider[provider_value]:
+            options.append(_model_option(ModelProvider(provider_value), model))
     return options
 
 
@@ -265,6 +291,12 @@ def ui_provider_options() -> list[tuple[str, str]]:
             continue
         seen.add(option.provider)
         options.append((option.provider_label, option.provider))
+    # Custom endpoints without exact model entries (wildcard-only) still belong
+    # in the provider picker; their models are typed via the "Other…" entry.
+    for endpoint_id in sorted(CUSTOM_PROVIDER_LABELS):
+        provider_value = f"{CUSTOM_PROVIDER_PREFIX}{endpoint_id}"
+        if provider_value not in seen:
+            options.append((CUSTOM_PROVIDER_LABELS[endpoint_id], provider_value))
     return options
 
 
@@ -320,6 +352,7 @@ def _thinking_effort_label(effort: str) -> str:
     return {
         "auto": "Auto",
         "none": "None",
+        "enabled": "Enabled",
         "minimal": "Minimal",
         "low": "Low",
         "medium": "Medium",

--- a/kolega_code/cli/settings.py
+++ b/kolega_code/cli/settings.py
@@ -5,9 +5,15 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from kolega_code.local_state import write_private_text
+from kolega_code.llm.specs.custom_endpoints import (
+    API_STYLES,
+    CUSTOM_THINKING_MODES,
+    REASONING_REPLAY_VALUES,
+    valid_custom_endpoint_id,
+)
 from kolega_code.permissions import PermissionMode
 
 from .session_store import default_state_dir
@@ -73,6 +79,48 @@ def _coerce_permission_mode(raw: object) -> str:
         return PermissionMode(str(raw).lower()).value
     except ValueError:
         return PermissionMode.ASK.value
+
+
+def _coerce_custom_endpoints(raw: object) -> dict[str, dict]:
+    """Normalize a stored endpoint-id -> endpoint-definition mapping.
+
+    Tolerant of hand-edits: entries with an invalid id, api_style, or base_url are
+    dropped; invalid numerics are dropped so defaults apply; an invalid thinking
+    block or reasoning_replay value is dropped/coerced. A malformed file can never
+    crash startup."""
+    if not isinstance(raw, dict):
+        return {}
+    result: dict[str, dict] = {}
+    for endpoint_id, entry in raw.items():
+        if not isinstance(endpoint_id, str) or not valid_custom_endpoint_id(endpoint_id):
+            continue
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("api_style") not in API_STYLES:
+            continue
+        base_url = entry.get("base_url")
+        if not isinstance(base_url, str) or not base_url.strip():
+            continue
+        cleaned: dict[str, Any] = {key: value for key, value in entry.items() if value is not None and key != "models"}
+        for key in ("context_length", "max_output_tokens"):
+            value = cleaned.get(key)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                cleaned.pop(key, None)
+        thinking = cleaned.get("thinking")
+        if not isinstance(thinking, dict) or thinking.get("mode") not in CUSTOM_THINKING_MODES:
+            cleaned.pop("thinking", None)
+        replay = cleaned.get("reasoning_replay")
+        if replay not in REASONING_REPLAY_VALUES:
+            cleaned["reasoning_replay"] = "auto"
+        models = entry.get("models")
+        if isinstance(models, dict):
+            cleaned["models"] = {
+                str(name): dict(spec)
+                for name, spec in models.items()
+                if isinstance(name, str) and isinstance(spec, dict)
+            }
+        result[endpoint_id] = cleaned
+    return result
 
 
 # Valid range (inclusive) for the user-facing compression threshold, in percent.
@@ -149,6 +197,9 @@ class CliSettings:
     # Additive optional field — absent in older files -> None -> the agent's
     # built-in default (95%).
     compression_threshold: Optional[float] = None
+    # Custom model endpoints keyed by endpoint id (provider value "custom:<id>").
+    # Additive optional field — absent in older files -> empty mapping.
+    custom_endpoints: dict[str, dict] = field(default_factory=dict)
     schema_version: int = SETTINGS_SCHEMA_VERSION
 
     @classmethod
@@ -199,6 +250,8 @@ class CliSettings:
             skills_enabled=data.get("skills_enabled"),
             # Additive optional field; absent in older files -> None (default 95%).
             compression_threshold=_coerce_compression_threshold(data.get("compression_threshold")),
+            # Additive optional field; absent in older files -> empty mapping.
+            custom_endpoints=_coerce_custom_endpoints(data.get("custom_endpoints")),
         )
 
     def to_dict(self) -> dict:
@@ -224,6 +277,7 @@ class CliSettings:
             "subagents_enabled": self.subagents_enabled,
             "skills_enabled": self.skills_enabled,
             "compression_threshold": self.compression_threshold,
+            "custom_endpoints": self.custom_endpoints,
         }
 
     def get_api_key(self, provider: str) -> Optional[str]:

--- a/kolega_code/cli/tui/onboarding_screen.py
+++ b/kolega_code/cli/tui/onboarding_screen.py
@@ -24,6 +24,7 @@ from kolega_code.cli.provider_registry import (
     ui_thinking_effort_options,
 )
 from kolega_code.config import ModelProvider
+from kolega_code.llm.specs import CUSTOM_PROVIDER_PREFIX
 
 if TYPE_CHECKING:
     from ..app import KolegaCodeApp
@@ -154,7 +155,12 @@ class OnboardingScreen(ModalScreen[None]):
             self.owner._onboarding_screen = None
 
     def _api_provider_options(self) -> list[tuple[str, str]]:
-        return [(label, value) for label, value in ui_provider_options() if value != chatgpt_constants.PROVIDER_KEY]
+        # Custom endpoints are configured in Settings, not onboarding.
+        return [
+            (label, value)
+            for label, value in ui_provider_options()
+            if value != chatgpt_constants.PROVIDER_KEY and not value.startswith(CUSTOM_PROVIDER_PREFIX)
+        ]
 
     def _initial_auth_method(self) -> str:
         return "chatgpt" if self.draft.active_provider == chatgpt_constants.PROVIDER_KEY else "api"

--- a/kolega_code/llm/specs/custom_endpoints.py
+++ b/kolega_code/llm/specs/custom_endpoints.py
@@ -13,6 +13,7 @@ from .validation import validate_model_spec
 CUSTOM_PROVIDER_PREFIX = "custom:"
 DEFAULT_CONTEXT_LENGTH = 32768
 DEFAULT_MAX_OUTPUT_TOKENS = 8192
+API_STYLES = ("openai_chat", "openai_responses", "anthropic")
 
 _CUSTOM_ID_RE = re.compile(r"[a-z0-9][a-z0-9_-]*\Z")
 

--- a/tests/cli/test_cli_config.py
+++ b/tests/cli/test_cli_config.py
@@ -8,6 +8,7 @@ from kolega_code.cli.config import (
     CliConfigOverrides,
     build_agent_config,
     config_summary,
+    key_status,
 )
 from kolega_code.cli.provider_registry import (
     DEEPSEEK_DEFAULT_MODEL,
@@ -16,7 +17,7 @@ from kolega_code.cli.provider_registry import (
     UI_DEFAULT_PROVIDER,
     default_model_for_provider,
 )
-from kolega_code.cli.settings import CliSettings
+from kolega_code.cli.settings import CliSettings, SettingsStore
 from kolega_code.llm.specs import MODEL_SPECS, default_thinking_effort, is_featured_model
 
 # Anthropic's registry default, used throughout as a convenient known-good model.
@@ -813,3 +814,202 @@ def test_model_slot_override_requires_the_slot_providers_api_key(tmp_path: Path)
 
     with pytest.raises(CliConfigError, match="DEEPSEEK_API_KEY"):
         build_agent_config(tmp_path, settings=settings, env={})
+
+
+# --- custom endpoints -----------------------------------------------------
+
+
+def _saved_endpoint_settings() -> CliSettings:
+    settings = CliSettings(active_provider="custom:lmstudio", active_model="qwen2.5")
+    settings.custom_endpoints = {"lmstudio": {"api_style": "openai_chat", "base_url": "http://localhost:1234/v1"}}
+    return settings
+
+
+def test_build_agent_config_with_custom_endpoint(tmp_path: Path) -> None:
+    config = build_agent_config(tmp_path, env={}, settings=_saved_endpoint_settings())
+
+    assert config.long_context_config.provider.value == "custom:lmstudio"
+    assert config.long_context_config.model == "qwen2.5"
+    endpoint = config.custom_endpoint_for(config.long_context_config)
+    assert endpoint is not None and endpoint.base_url == "http://localhost:1234/v1"
+
+
+def test_build_agent_config_custom_endpoint_keyless_passes_key_check(tmp_path: Path) -> None:
+    config = build_agent_config(tmp_path, env={}, settings=_saved_endpoint_settings())
+    assert config.get_api_key(config.long_context_config.provider) is None
+
+
+def test_build_agent_config_custom_endpoint_api_key_resolves(tmp_path: Path) -> None:
+    settings = _saved_endpoint_settings()
+    settings.custom_endpoints["lmstudio"]["api_key"] = "secret"
+    config = build_agent_config(tmp_path, env={}, settings=settings)
+    assert config.get_api_key(config.long_context_config.provider) == "secret"
+
+
+def test_build_agent_config_custom_endpoint_agent_and_slot_overrides(tmp_path: Path) -> None:
+    settings = _saved_endpoint_settings()
+    settings.set_agent_model("investigation", "custom:lmstudio", "qwen2.5")
+    settings.set_model_slot("fast", "custom:lmstudio", "qwen2.5")
+
+    config = build_agent_config(tmp_path, env={}, settings=settings)
+    assert config.agent_models["investigation"].provider.value == "custom:lmstudio"
+    assert config.fast_config.provider.value == "custom:lmstudio"
+    assert config.fast_config.model == "qwen2.5"
+
+
+def test_build_agent_config_deleted_endpoint_degrades_to_unconfigured(tmp_path: Path) -> None:
+    settings = CliSettings(active_provider="custom:gone", active_model="m")
+    with pytest.raises(CliConfigError, match="No provider/model configured"):
+        build_agent_config(tmp_path, env={}, settings=settings)
+
+
+def test_build_agent_config_deleted_endpoint_slot_inherits(tmp_path: Path) -> None:
+    settings = _saved_endpoint_settings()
+    settings.set_model_slot("fast", "custom:gone", "m")
+    config = build_agent_config(tmp_path, env={}, settings=settings)
+    assert config.fast_config.provider.value == "custom:lmstudio"
+    assert config.fast_config.model == "qwen2.5"
+
+
+def test_build_agent_config_explicit_undefined_endpoint_targeted_error(tmp_path: Path) -> None:
+    with pytest.raises(CliConfigError, match="Custom endpoint 'nope' is not defined"):
+        build_agent_config(
+            tmp_path,
+            env={},
+            settings=CliSettings(),
+            overrides=CliConfigOverrides(provider="custom:nope", model="m"),
+        )
+
+
+def test_build_agent_config_endpoint_flags_define_custom_cli(tmp_path: Path) -> None:
+    config = build_agent_config(
+        tmp_path,
+        env={},
+        settings=CliSettings(),
+        overrides=CliConfigOverrides(
+            endpoint_url="http://localhost:11434/v1",
+            endpoint_style="openai_chat",
+            endpoint_context="32768",
+            endpoint_max_output="8192",
+            endpoint_thinking="thinking_toggle",
+            endpoint_reasoning="auto",
+            model="qwen2.5",
+        ),
+    )
+
+    assert config.long_context_config.provider.value == "custom:cli"
+    assert config.long_context_config.model == "qwen2.5"
+    endpoint = config.custom_endpoint_for(config.long_context_config)
+    assert endpoint is not None
+    assert endpoint.base_url == "http://localhost:11434/v1"
+    assert endpoint.context_length == 32768
+    assert endpoint.max_output_tokens == 8192
+    assert endpoint.thinking == {"mode": "thinking_toggle", "options": ["none", "enabled"], "default": "enabled"}
+
+
+def test_build_agent_config_explicit_provider_wins_over_custom_cli_default(tmp_path: Path) -> None:
+    config = build_agent_config(
+        tmp_path,
+        env={},
+        settings=CliSettings(),
+        overrides=CliConfigOverrides(endpoint_url="http://localhost:11434/v1", provider="custom:cli", model="qwen2.5"),
+    )
+    assert config.long_context_config.provider.value == "custom:cli"
+
+
+def test_build_agent_config_env_json_overrides_saved_endpoint(tmp_path: Path) -> None:
+    settings = _saved_endpoint_settings()
+    config = build_agent_config(
+        tmp_path,
+        env={
+            "KOLEGA_CODE_CUSTOM_ENDPOINTS": '{"lmstudio": {"api_style": "openai_chat", "base_url": "http://new:2/v1"}}'
+        },
+        settings=settings,
+    )
+    endpoint = config.custom_endpoint_for(config.long_context_config)
+    assert endpoint is not None and endpoint.base_url == "http://new:2/v1"
+
+
+def test_build_agent_config_custom_endpoints_never_persisted(tmp_path: Path) -> None:
+    store = SettingsStore(tmp_path)
+    settings = CliSettings(active_provider="custom:lmstudio", active_model="qwen2.5")
+    store.save(settings)
+
+    build_agent_config(
+        tmp_path,
+        env={},
+        settings=store.load(),
+        settings_store=store,
+        overrides=CliConfigOverrides(endpoint_url="http://localhost:11434/v1", model="qwen2.5"),
+    )
+
+    reloaded = store.load()
+    assert reloaded.custom_endpoints == {}
+    assert reloaded.active_provider == "custom:lmstudio"
+
+
+def test_build_agent_config_endpoint_flags_require_url(tmp_path: Path) -> None:
+    with pytest.raises(CliConfigError, match="require --endpoint-url"):
+        build_agent_config(
+            tmp_path,
+            env={},
+            settings=CliSettings(),
+            overrides=CliConfigOverrides(endpoint_context="100"),
+        )
+
+
+def test_build_agent_config_invalid_endpoint_style_and_thinking(tmp_path: Path) -> None:
+    with pytest.raises(CliConfigError, match="endpoint style"):
+        build_agent_config(
+            tmp_path,
+            env={},
+            settings=CliSettings(),
+            overrides=CliConfigOverrides(endpoint_url="http://x/v1", endpoint_style="grpc", model="m"),
+        )
+    with pytest.raises(CliConfigError, match="endpoint-thinking"):
+        build_agent_config(
+            tmp_path,
+            env={},
+            settings=CliSettings(),
+            overrides=CliConfigOverrides(endpoint_url="http://x/v1", endpoint_thinking="nope", model="m"),
+        )
+
+
+def test_build_agent_config_anthropic_budget_cap_validated(tmp_path: Path) -> None:
+    settings = CliSettings(active_provider="custom:ap", active_model="m")
+    settings.custom_endpoints = {
+        "ap": {
+            "api_style": "anthropic",
+            "base_url": "http://x:1",
+            "max_output_tokens": 8192,
+            "thinking": {
+                "mode": "anthropic_budget",
+                "options": ["none", "low"],
+                "default": "low",
+                "budgets": {"low": 9000},
+            },
+        }
+    }
+    with pytest.raises(CliConfigError, match="budgets must stay below max_output_tokens"):
+        build_agent_config(tmp_path, env={}, settings=settings)
+
+
+def test_build_agent_config_custom_endpoint_requires_defined_endpoint_for_saved_active(tmp_path: Path) -> None:
+    settings = CliSettings(active_provider="custom:lmstudio", active_model="qwen2.5")
+    with pytest.raises(CliConfigError, match="Custom endpoint 'lmstudio' is not defined"):
+        build_agent_config(
+            tmp_path,
+            env={},
+            settings=settings,
+            overrides=CliConfigOverrides(provider="custom:lmstudio", model="qwen2.5"),
+        )
+
+
+def test_key_status_reports_custom_endpoint_keys(tmp_path: Path) -> None:
+    settings = _saved_endpoint_settings()
+    assert key_status("custom:lmstudio", tmp_path, settings) == "key not set (optional)"
+
+    settings.custom_endpoints["lmstudio"]["api_key"] = "secret"
+    assert key_status("custom:lmstudio", tmp_path, settings) == "present in local settings"
+
+    assert key_status("custom:gone", tmp_path, settings) == "endpoint not defined"

--- a/tests/cli/test_settings.py
+++ b/tests/cli/test_settings.py
@@ -245,9 +245,13 @@ def test_ui_provider_registry_is_derived_from_model_specs() -> None:
         else:
             assert option.api_key_env == ""
 
-    # Every provider that has specs appears in the provider dropdown.
+    # Every provider that has specs appears in the provider dropdown, plus any
+    # custom endpoints registered for this process (via CUSTOM_PROVIDER_LABELS).
     spec_providers = {provider_value for provider_value, _ in MODEL_SPECS}
-    assert {value for _, value in ui_provider_options()} == spec_providers
+    option_providers = {value for _, value in ui_provider_options()}
+    assert spec_providers <= option_providers
+    for provider_value in option_providers - spec_providers:
+        assert provider_value.startswith("custom:")
 
     # The Moonshot default and its models are present with friendly labels.
     assert ("Moonshot AI", UI_DEFAULT_PROVIDER) in ui_provider_options()
@@ -531,3 +535,66 @@ def test_gateway_providers_list_featured_models_but_resolve_every_catalogued_id(
 def test_non_gateway_providers_still_list_every_model() -> None:
     anthropic_models = [model for provider_value, model in MODEL_SPECS if provider_value == "anthropic"]
     assert [model for _label, model in ui_model_options("anthropic")] == anthropic_models
+
+
+# --- custom endpoints -----------------------------------------------------
+
+
+def test_settings_store_round_trips_custom_endpoints(tmp_path: Path) -> None:
+    store = SettingsStore(tmp_path)
+    settings = CliSettings()
+    settings.custom_endpoints = {
+        "lmstudio": {
+            "api_style": "openai_chat",
+            "base_url": "http://localhost:1234/v1",
+            "api_key": "k",
+            "label": "LM Studio",
+            "context_length": 32768,
+            "max_output_tokens": 8192,
+            "supports_vision": False,
+            "thinking": {"mode": "thinking_toggle", "options": ["none", "enabled"], "default": "enabled"},
+            "reasoning_replay": "auto",
+            "models": {"big": {"context_length": 65536}},
+        }
+    }
+    store.save(settings)
+
+    loaded = store.load()
+    assert loaded.custom_endpoints == settings.custom_endpoints
+    assert loaded.to_dict()["custom_endpoints"] == settings.custom_endpoints
+    store.save(CliSettings())
+    assert SettingsStore(tmp_path).load().custom_endpoints == {}
+
+
+def test_custom_endpoints_coercion_tolerates_hand_edits() -> None:
+    settings = CliSettings.from_dict(
+        {
+            "schema_version": 3,
+            "custom_endpoints": {
+                "good": {"api_style": "openai_chat", "base_url": "http://x/v1"},
+                "Bad Slug!": {"api_style": "openai_chat", "base_url": "http://x/v1"},
+                "no-style": {"base_url": "http://x/v1"},
+                "bad-style": {"api_style": "grpc", "base_url": "http://x/v1"},
+                "no-url": {"api_style": "openai_chat"},
+                "not-dict": "nope",
+                "bad-int": {"api_style": "openai_chat", "base_url": "http://x/v1", "context_length": "huge"},
+                "bad-thinking": {
+                    "api_style": "openai_chat",
+                    "base_url": "http://x/v1",
+                    "thinking": {"mode": "not-a-mode"},
+                },
+                "bad-replay": {"api_style": "openai_chat", "base_url": "http://x/v1", "reasoning_replay": "sideways"},
+                "bad-models": {
+                    "api_style": "openai_chat",
+                    "base_url": "http://x/v1",
+                    "models": {"a": {"context_length": 1}, "b": "not-dict"},
+                },
+            },
+        }
+    )
+
+    assert set(settings.custom_endpoints) == {"good", "bad-int", "bad-thinking", "bad-replay", "bad-models"}
+    assert "context_length" not in settings.custom_endpoints["bad-int"]
+    assert "thinking" not in settings.custom_endpoints["bad-thinking"]
+    assert settings.custom_endpoints["bad-replay"]["reasoning_replay"] == "auto"
+    assert settings.custom_endpoints["bad-models"]["models"] == {"a": {"context_length": 1}}


### PR DESCRIPTION
## Summary

CLI surface for custom endpoints (library core landed in #578): define OpenAI/Responses/Anthropic-compatible servers in settings.json, pick them as `custom:<id>` providers, or run against any endpoint without saving anything.

## Changes

- settings.json gains `custom_endpoints` with tolerant coercion (hand-edits never crash startup).
- `build_agent_config` merges saved endpoints with `--custom-endpoints` JSON and `KOLEGA_CODE_CUSTOM_ENDPOINTS` (flag > env > file per id, never persisted), syncs runtime model specs, and auto-selects the ephemeral `custom:cli` endpoint when a model is named without a provider.
- Flat flags `--endpoint-url/style/api-key/context/max-output/vision/thinking/reasoning` + `KOLEGA_CODE_ENDPOINT_*` mirrors.
- Key handling: endpoint keys are optional; `key_status`/summary report endpoint credentials; strict in-use validation (undefined endpoint → targeted error, anthropic_budget budgets vs max output).
- Deleted endpoints degrade gracefully (active → onboarding, slots/roles → inherit).
- Provider pickers list custom endpoints (wildcard-only included); onboarding stays built-in-only.
- Docs: new Custom Endpoints page (schema, thinking modes, reasoning replay, no-config flow), sidebar entry, env-var table, providers page cross-link.

## Tests

18 new tests across `tests/cli/test_settings.py` (coercion/round trip) and `tests/cli/test_cli_config.py` (resolution, flags, env overrides, degradation, persistence). Full fast suite 4726 passed; pyright clean; docs build clean.