### PR TITLE
feat(cli): Custom Endpoints settings page

### DIFF
--- a/docs/src/content/docs/configuration/custom-endpoints.mdx
+++ b/docs/src/content/docs/configuration/custom-endpoints.mdx
@@ -129,11 +129,17 @@ servers).
 
 <Steps>
 1. Add the endpoint under `custom_endpoints` in `settings.json`, or use the TUI:
-   **Settings → Custom Endpoints → New endpoint**.
+   **Settings → Custom Endpoints**. Pick an existing endpoint or **New endpoint**,
+   fill in the id (a lowercase slug), API style, base URL, and the optional key,
+   default model, context/output limits, vision flag, thinking mode (with budgets
+   for the Anthropic budget mode), and reasoning-replay field, then **Save
+   Endpoint**.
 2. Select the provider (`custom:<id>`) in **Settings → Models**, and type the
    model id in the **Other…** field.
 3. **Apply Changes**. The endpoint appears in every provider picker and accepts
-   free-text model ids.
+   free-text model ids. Endpoint edits are staged until Apply; closing without
+   applying discards them. The Providers page's **Test Connection** probes
+   custom endpoints too, using their default model.
 </Steps>
 
 ## One-off use without a saved config

--- a/kolega_code/cli/messages.py
+++ b/kolega_code/cli/messages.py
@@ -270,6 +270,15 @@ MODEL_SLOT_HINT = (
     "Utility slots used outside the main conversation. Default inherits the active model; "
     "a slot may use a different provider, which needs that provider's API key."
 )
+ENDPOINTS_HINT = (
+    "Point Kolega Code at any OpenAI/Responses/Anthropic-compatible server (LM Studio, Ollama, vLLM, ...). "
+    "Each endpoint becomes a provider named custom:<id> and accepts any model id. "
+    "Apply Changes to make new or changed endpoints available in the model pickers."
+)
+ENDPOINT_KEY_EDITED_ON_PAGE = "Endpoint API keys are edited on the Custom Endpoints page."
+ENDPOINT_APPLY_REQUIRED = "Saved to the draft. Apply Changes to make it available in the model pickers."
+ENDPOINT_DELETED = "Endpoint deleted from the draft. Apply Changes to persist."
+ENDPOINT_NONE = "No endpoints yet. Fill in the form and Save Endpoint."
 
 # Status dashboard
 STATUS_TOKENS_UNKNOWN = "Token counts unavailable."

--- a/kolega_code/cli/tui/settings_panel.py
+++ b/kolega_code/cli/tui/settings_panel.py
@@ -8,7 +8,7 @@ import re
 import shlex
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Literal, Optional, TypeVar, cast, overload
+from typing import Any, Literal, Mapping, Optional, TypeVar, cast, overload
 from urllib.parse import urlparse
 
 from textual.css.query import NoMatches
@@ -25,6 +25,13 @@ from kolega_code.agent.tool_backend.search_backends import (
     SearchBackendError,
     available_backends,
     get_backend_class,
+)
+from kolega_code.llm.specs.custom_endpoints import (
+    API_STYLES,
+    CUSTOM_PROVIDER_PREFIX,
+    CUSTOM_THINKING_PRESETS,
+    REASONING_REPLAY_VALUES,
+    valid_custom_endpoint_id,
 )
 from kolega_code.mcp.config import (
     MCPConfigError,
@@ -44,9 +51,12 @@ from ..config import (
     SKILLS_MODE_ENV,
     SUBAGENTS_MODE_ENV,
     CliConfigError,
+    CliConfigOverrides,
+    _merged_custom_endpoints,
     active_model_override_message,
     build_agent_config,
     key_status,
+    load_cli_env,
     probe_token_manager,
     resolved_api_key,
 )
@@ -74,6 +84,14 @@ from ..settings import WEB_SEARCH_KEY_NAMES, CliSettings
 from ..theme import Color, Glyph
 
 MCP_NEW_SERVER_VALUE = "__new_mcp_server__"
+ENDPOINT_NEW_VALUE = "__new_endpoint__"
+ENDPOINT_NEW_VALUE_LABEL = "New endpoint"
+ENDPOINT_THINKING_OPTIONS = [
+    ("Reasoning effort (Chat)", "openai_reasoning_effort"),
+    ("Responses reasoning", "openai_responses_reasoning"),
+    ("Thinking toggle (Qwen3)", "thinking_toggle"),
+    ("Anthropic budget tokens", "anthropic_budget"),
+]
 MCP_TRANSPORT_OPTIONS = [
     ("Streamable HTTP", "streamable_http"),
     ("Server-Sent Events (legacy/deprecated)", "sse"),
@@ -365,6 +383,18 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             self._update_search_backend_fields(str(event.value))
             return
 
+        if select_id == "endpoint_select":
+            if str(event.select.value) != str(event.value):
+                return
+            self._populate_endpoint_form(str(event.value))
+            return
+
+        if select_id in {"ep_style_select", "ep_thinking_mode_select"}:
+            if str(event.select.value) != str(event.value):
+                return
+            self._update_endpoint_field_visibility()
+            return
+
         if select_id == "mcp_server_select":
             self._populate_mcp_server_form(str(event.value))
             return
@@ -506,6 +536,7 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             else theme.DEFAULT_THEME_NAME
         )
         self._populate_provider_rows()
+        self._populate_endpoint_controls()
         self._populate_agent_model_rows()
         self._populate_slot_model_rows()
         self._update_browser_model_hint()
@@ -628,11 +659,19 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             return
         draft = self._draft_credential_settings()
         for label, value in ui_provider_options():
-            provider_list.replace_option_prompt(f"provider_row_{value}", self._provider_row_prompt(label, value, draft))
+            try:
+                provider_list.replace_option_prompt(
+                    f"provider_row_{value}", self._provider_row_prompt(label, value, draft)
+                )
+            except Exception:
+                # The list lags the registry after an apply that adds endpoints;
+                # _populate_provider_rows rebuilds it in that path.
+                continue
 
     def _update_provider_credential_controls(self, provider: str) -> None:
-        """Swap the editor between API-key and ChatGPT sign-in shape, and restate status."""
+        """Swap the editor between API-key, ChatGPT sign-in, and custom-endpoint shape."""
         oauth = provider == chatgpt_constants.PROVIDER_KEY
+        custom = provider.startswith(CUSTOM_PROVIDER_PREFIX)
         for widget_id in ("provider_chatgpt_login", "provider_chatgpt_logout"):
             try:
                 self._settings_query_one(f"#{widget_id}").display = oauth
@@ -640,7 +679,7 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
                 pass
         for widget_id in ("provider_api_key_label", "provider_api_key_input"):
             try:
-                self._settings_query_one(f"#{widget_id}").display = not oauth
+                self._settings_query_one(f"#{widget_id}").display = not oauth and not custom
             except NoMatches:
                 pass
         try:
@@ -650,7 +689,14 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         except NoMatches:
             pass
         try:
-            self._settings_query_one("#provider_api_key_input", Input).placeholder = self._api_key_placeholder(provider)
+            self._settings_query_one("#provider_endpoint_key_hint").display = custom
+        except NoMatches:
+            pass
+        try:
+            if not custom:
+                self._settings_query_one("#provider_api_key_input", Input).placeholder = self._api_key_placeholder(
+                    provider
+                )
             section = self._settings_query_one("#settings_provider_credential")
             # ui_provider_options() is (label, value); index it the other way round.
             labels = {value: label for label, value in ui_provider_options()}
@@ -661,7 +707,7 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             remove_key = self._settings_query_one("#provider_remove_api_key", Button)
         except NoMatches:
             return
-        remove_key.display = not oauth
+        remove_key.display = not oauth and not custom
         screen = getattr(self, "_settings_screen", None)
         pending_removals = getattr(screen, "pending_api_key_removals", set())
         remove_key.disabled = not self.settings.has_api_key(provider) or provider in pending_removals
@@ -678,6 +724,242 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             signed_in = draft.has_oauth_token(chatgpt_constants.PROVIDER_KEY)
             login.label = "Sign in again" if signed_in else "Sign in with ChatGPT"
             logout.disabled = not signed_in
+        except NoMatches:
+            pass
+
+    # --- Custom Endpoints page -------------------------------------------------
+
+    def _populate_endpoint_controls(self) -> None:
+        """Rebuild the endpoint selector from the pending draft and open its form."""
+        screen = getattr(self, "_settings_screen", None)
+        if screen is None:
+            return
+        try:
+            endpoint_select = self._settings_query_one("#endpoint_select", Select)
+        except NoMatches:
+            return
+        pending = getattr(screen, "pending_custom_endpoints", {}) or {}
+        selected = getattr(self, "_ep_selected", None)
+        if selected is None:
+            selected = sorted(pending)[0] if pending else ENDPOINT_NEW_VALUE
+        options = [(ENDPOINT_NEW_VALUE_LABEL, ENDPOINT_NEW_VALUE)]
+        options.extend((endpoint_id, endpoint_id) for endpoint_id in sorted(pending))
+        endpoint_select.set_options(options)
+        endpoint_select.value = selected if selected in {value for _, value in options} else ENDPOINT_NEW_VALUE
+        self._populate_endpoint_form(endpoint_select.value)
+
+    def _populate_endpoint_form(self, endpoint_id: str) -> None:
+        self._ep_selected = endpoint_id
+        screen = getattr(self, "_settings_screen", None)
+        pending = getattr(screen, "pending_custom_endpoints", {}) if screen else {}
+        entry = pending.get(endpoint_id) or {} if endpoint_id != ENDPOINT_NEW_VALUE else {}
+        thinking = entry.get("thinking") or {}
+        try:
+            self._settings_query_one("#ep_id_input", Input).value = endpoint_id if entry else ""
+            self._settings_query_one("#ep_id_input", Input).disabled = bool(entry)
+            self._settings_query_one("#ep_label_input", Input).value = str(entry.get("label") or "")
+            self._settings_query_one("#ep_style_select", Select).value = entry.get("api_style", "openai_chat")
+            self._settings_query_one("#ep_base_url_input", Input).value = str(entry.get("base_url") or "")
+            self._settings_query_one("#ep_api_key_input", Input).value = str(entry.get("api_key") or "")
+            self._settings_query_one("#ep_default_model_input", Input).value = str(entry.get("default_model") or "")
+            self._settings_query_one("#ep_context_input", Input).value = str(entry.get("context_length") or "")
+            self._settings_query_one("#ep_max_output_input", Input).value = str(entry.get("max_output_tokens") or "")
+            self._settings_query_one("#ep_vision_select", Select).value = (
+                "true" if entry.get("supports_vision") else "false"
+            )
+            self._settings_query_one("#ep_thinking_mode_select", Select).value = thinking.get("mode", "")
+            self._settings_query_one("#ep_thinking_budgets_input", Input).value = self._format_thinking_budgets(
+                thinking
+            )
+            self._settings_query_one("#ep_reasoning_select", Select).value = entry.get("reasoning_replay", "auto")
+        except NoMatches:
+            return
+        self._update_endpoint_field_visibility()
+        self._update_endpoint_status()
+
+    @staticmethod
+    def _format_thinking_budgets(thinking: Mapping[str, Any]) -> str:
+        budgets = thinking.get("budgets") if isinstance(thinking, dict) else None
+        if not isinstance(budgets, dict):
+            return ""
+        return ", ".join(f"{option}={budgets[option]}" for option in sorted(budgets))
+
+    def _update_endpoint_field_visibility(self) -> None:
+        try:
+            style = str(self._settings_query_one("#ep_style_select", Select).value)
+            thinking = str(self._settings_query_one("#ep_thinking_mode_select", Select).value)
+        except NoMatches:
+            return
+        budgets = thinking == "anthropic_budget"
+        for widget_id, visible in (
+            ("ep_thinking_budgets_label", budgets),
+            ("ep_thinking_budgets_input", budgets),
+            ("ep_reasoning_label", style == "openai_chat"),
+            ("ep_reasoning_select", style == "openai_chat"),
+        ):
+            try:
+                self._settings_query_one(f"#{widget_id}").display = visible
+            except NoMatches:
+                pass
+
+    @staticmethod
+    def _optional_positive_int(raw: str, label: str) -> Optional[int]:
+        if not raw:
+            return None
+        try:
+            value = int(raw)
+        except ValueError:
+            value = 0
+        if value <= 0:
+            raise ValueError(f"{label} must be a positive integer.")
+        return value
+
+    @staticmethod
+    def _parse_thinking_budgets(raw: str, cap: int) -> dict[str, int]:
+        budgets: dict[str, int] = {}
+        for part in raw.split(","):
+            part = part.strip()
+            if not part:
+                continue
+            if "=" not in part:
+                raise ValueError("Budgets must be effort=tokens pairs, e.g. 'low=2048, medium=8192'.")
+            option, _, value = part.partition("=")
+            option = option.strip()
+            try:
+                budget = int(value.strip())
+            except ValueError:
+                budget = 0
+            if budget <= 0:
+                raise ValueError(f"Budget for '{option}' must be a positive integer.")
+            if budget >= cap:
+                raise ValueError(f"Budget for '{option}' must stay below max output tokens ({cap}).")
+            budgets[option] = budget
+        if not budgets:
+            raise ValueError("anthropic_budget needs budgets, e.g. 'low=2048, medium=8192'.")
+        return budgets
+
+    def _collect_endpoint_from_ui(self) -> tuple[str, dict[str, Any]]:
+        def input_value(widget_id: str) -> str:
+            return self._settings_query_one(f"#{widget_id}", Input).value.strip()
+
+        endpoint_id = input_value("ep_id_input").lower()
+        if not valid_custom_endpoint_id(endpoint_id):
+            raise ValueError("Endpoint id must be a lowercase slug (letters, digits, '-', '_').")
+        base_url = input_value("ep_base_url_input")
+        if not base_url.startswith(("http://", "https://")):
+            raise ValueError("Base URL must be an http(s) URL.")
+        style = str(self._settings_query_one("#ep_style_select", Select).value)
+        if style not in API_STYLES:
+            raise ValueError("API style is required.")
+        context = self._optional_positive_int(input_value("ep_context_input"), "Context length")
+        max_output = self._optional_positive_int(input_value("ep_max_output_input"), "Max output tokens")
+
+        entry: dict[str, Any] = {"api_style": style, "base_url": base_url.rstrip("/")}
+        label = input_value("ep_label_input")
+        if label:
+            entry["label"] = label
+        api_key = self._settings_query_one("#ep_api_key_input", Input).value
+        if api_key:
+            entry["api_key"] = api_key
+        default_model = input_value("ep_default_model_input")
+        if default_model:
+            entry["default_model"] = default_model
+        if context is not None:
+            entry["context_length"] = context
+        if max_output is not None:
+            entry["max_output_tokens"] = max_output
+        if str(self._settings_query_one("#ep_vision_select", Select).value) == "true":
+            entry["supports_vision"] = True
+        thinking_mode = str(self._settings_query_one("#ep_thinking_mode_select", Select).value)
+        if thinking_mode:
+            preset = CUSTOM_THINKING_PRESETS[thinking_mode]
+            thinking: dict[str, Any] = {
+                "mode": thinking_mode,
+                "options": list(preset["options"]),
+                "default": preset["default"],
+            }
+            if preset["budgets_required"]:
+                cap = max_output if max_output is not None else 8192
+                thinking["budgets"] = self._parse_thinking_budgets(input_value("ep_thinking_budgets_input"), cap)
+            entry["thinking"] = thinking
+        if style == "openai_chat":
+            replay = str(self._settings_query_one("#ep_reasoning_select", Select).value)
+            if replay in REASONING_REPLAY_VALUES:
+                entry["reasoning_replay"] = replay
+        screen = getattr(self, "_settings_screen", None)
+        existing = (getattr(screen, "pending_custom_endpoints", {}) or {}).get(endpoint_id) or {}
+        if existing.get("models"):
+            entry["models"] = existing["models"]
+        return endpoint_id, entry
+
+    def _save_endpoint_from_ui(self) -> None:
+        try:
+            endpoint_id, entry = self._collect_endpoint_from_ui()
+        except ValueError as exc:
+            self._set_endpoint_status(str(exc), "warning")
+            return
+        screen = getattr(self, "_settings_screen", None)
+        if screen is None:
+            return
+        previous = deepcopy(screen.pending_custom_endpoints)
+        screen.pending_custom_endpoints[endpoint_id] = entry
+        if screen.pending_custom_endpoints != previous:
+            self._ep_selected = endpoint_id
+            self._populate_endpoint_controls()
+        if self.settings.active_provider == f"{CUSTOM_PROVIDER_PREFIX}{endpoint_id}":
+            self._set_endpoint_status(
+                f"{messages.ENDPOINT_APPLY_REQUIRED} It is the active provider, so this edit applies to it too.",
+                "ok",
+            )
+        else:
+            self._set_endpoint_status(messages.ENDPOINT_APPLY_REQUIRED, "ok")
+        screen.call_after_refresh(screen._refresh_apply_label)
+
+    def _delete_endpoint_from_ui(self) -> None:
+        screen = getattr(self, "_settings_screen", None)
+        if screen is None:
+            return
+        endpoint_id = getattr(self, "_ep_selected", ENDPOINT_NEW_VALUE)
+        if endpoint_id == ENDPOINT_NEW_VALUE:
+            self._set_endpoint_status("Select an endpoint to delete.", "warning")
+            return
+        screen.pending_custom_endpoints.pop(endpoint_id, None)
+        self._ep_selected = ENDPOINT_NEW_VALUE
+        self._populate_endpoint_controls()
+        if self.settings.active_provider == f"{CUSTOM_PROVIDER_PREFIX}{endpoint_id}":
+            self._set_endpoint_status(
+                f"{messages.ENDPOINT_DELETED} It is the active provider; pick another model before applying.", "warning"
+            )
+        else:
+            self._set_endpoint_status(messages.ENDPOINT_DELETED, "ok")
+        screen.call_after_refresh(screen._refresh_apply_label)
+
+    def _handle_endpoint_settings_button(self, button_id: str) -> None:
+        if self._turn_active or self.agent_worker is not None:
+            self._set_endpoint_status("Stop the active turn before changing endpoints.", "warning")
+            return
+        if button_id == "ep_save":
+            self._save_endpoint_from_ui()
+        elif button_id == "ep_delete":
+            self._delete_endpoint_from_ui()
+
+    def _update_endpoint_status(self) -> None:
+        screen = getattr(self, "_settings_screen", None)
+        pending = getattr(screen, "pending_custom_endpoints", {}) if screen else {}
+        if not pending:
+            self._set_endpoint_status(messages.ENDPOINT_NONE)
+
+    def _set_endpoint_status(self, text: str, tone: str = "info") -> None:
+        glyph, style = {
+            "ok": (Glyph.CHECK, Color.SUCCESS),
+            "error": (Glyph.CROSS, Color.ERROR),
+            "warning": (Glyph.STATUS, Color.WARNING),
+        }.get(tone, (Glyph.STATUS, Color.MUTED))
+        content = Text()
+        content.append(theme.g(glyph) + " ", style=style)
+        content.append(text)
+        try:
+            self._settings_query_one("#endpoint_status", Static).update(content)
         except NoMatches:
             pass
 
@@ -1710,6 +1992,7 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         screen = getattr(self, "_settings_screen", None)
         if screen is not None:
             candidate.oauth_tokens = deepcopy(screen.pending_oauth_tokens)
+            candidate.custom_endpoints = deepcopy(screen.pending_custom_endpoints)
             for removed_provider in screen.pending_api_key_removals:
                 candidate.api_keys.pop(removed_provider, None)
             # Removals first, so re-typing a key for a provider you just cleared wins.
@@ -1783,10 +2066,10 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         if screen is not None:
             memory_applied = await screen.apply_memory_draft()
             screen.mark_clean(preserve_memory_draft=not memory_applied)
-            selected = self._selected_credential_provider()
-            if selected is not None:
-                self._update_provider_credential_controls(selected)
-            self._refresh_provider_row_labels()
+            # New/changed endpoints alter the provider set and pickers; rebuild.
+            self._populate_provider_rows()
+            self._populate_endpoint_controls()
+            self._update_provider_credential_controls(self._selected_credential_provider() or "")
             if not memory_applied:
                 self._set_settings_status(
                     "Other settings were saved, but project memory changes failed. Review and retry them.",
@@ -1898,6 +2181,11 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         status.update("ChatGPT sign-out will be saved when you Apply." if removed else "You are not signed in.")
         screen._refresh_apply_label()
 
+    def _merged_endpoints_for_probe(self) -> dict[str, dict]:
+        env = load_cli_env(self.project_path)
+        overrides = getattr(self, "overrides", None) or CliConfigOverrides()
+        return _merged_custom_endpoints(env, overrides, self.settings)
+
     def _credential_probe_model(self, provider: str) -> str:
         """Which model to probe a provider's credential with.
 
@@ -1907,6 +2195,17 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         """
         if self.settings.active_provider == provider and self.settings.active_model:
             return self.settings.active_model
+        if provider.startswith(CUSTOM_PROVIDER_PREFIX):
+            endpoint_id = provider[len(CUSTOM_PROVIDER_PREFIX) :]
+            entry = self._merged_endpoints_for_probe().get(endpoint_id) or {}
+            if entry.get("default_model"):
+                return str(entry["default_model"])
+            models = entry.get("models") or {}
+            if models:
+                return str(next(iter(models)))
+            raise ValueError(
+                f"Custom endpoint '{endpoint_id}' has no default model; add one on the Custom Endpoints page."
+            )
         return default_model_for_provider(ModelProvider(provider))
 
     async def _test_settings_connection(self) -> None:
@@ -1925,6 +2224,13 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         except ValueError as exc:
             status.update(str(exc))
             return
+        base_url = None
+        api_style = None
+        if provider.startswith(CUSTOM_PROVIDER_PREFIX):
+            endpoint_id = provider[len(CUSTOM_PROVIDER_PREFIX) :]
+            entry = self._merged_endpoints_for_probe().get(endpoint_id) or {}
+            base_url = entry.get("base_url")
+            api_style = entry.get("api_style")
         button.disabled = True
         status.update(messages.PROVIDER_TEST_RUNNING.format(provider=provider, model=model))
         result = await test_model_connection(
@@ -1933,6 +2239,8 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             api_key=resolved_api_key(provider, self.project_path, draft) or "",
             token_manager=probe_token_manager(draft),
             usage_ledger=getattr(self, "_usage_ledger", None),
+            base_url=base_url,
+            api_style=api_style,
         )
         status.update(result.message)
         button.disabled = False

--- a/kolega_code/cli/tui/settings_screen.py
+++ b/kolega_code/cli/tui/settings_screen.py
@@ -42,6 +42,7 @@ SETTINGS_CATEGORIES = (
     # (connection, then model). The "model" value is load-bearing: /model and
     # action_open_settings(category=...) both key off it, so only the label changed.
     ("Providers", "providers"),
+    ("Custom Endpoints", "endpoints"),
     ("Models", "model"),
     ("Agent Models", "agents"),
     ("Tools", "tools"),
@@ -148,6 +149,8 @@ class SettingsScreen(ModalScreen[None]):
         self._original_theme = owner.settings.active_theme or theme.DEFAULT_THEME_NAME
         self.pending_oauth_tokens = deepcopy(owner.settings.oauth_tokens)
         self._oauth_baseline = deepcopy(self.pending_oauth_tokens)
+        self.pending_custom_endpoints = deepcopy(owner.settings.custom_endpoints)
+        self._endpoints_baseline = deepcopy(self.pending_custom_endpoints)
         self.pending_api_key_removals: set[str] = set()
         # Keys typed on the Providers page, keyed by provider. The page lets several
         # providers be edited before Apply, so staging cannot live in the Input alone —
@@ -169,6 +172,7 @@ class SettingsScreen(ModalScreen[None]):
             )
             with Vertical(id="settings_screen_detail"):
                 yield from self._compose_providers_page()
+                yield from self._compose_endpoints_page()
                 yield from self._compose_model_page()
                 yield from self._compose_agent_page()
                 yield from self._compose_tools_page()
@@ -221,7 +225,88 @@ class SettingsScreen(ModalScreen[None]):
                     "Connection testing sends a tiny, potentially billable model request.",
                     classes="settings-hint",
                 )
+                endpoint_key_hint = Static(
+                    messages.ENDPOINT_KEY_EDITED_ON_PAGE, id="provider_endpoint_key_hint", classes="settings-hint"
+                )
+                endpoint_key_hint.display = False
+                yield endpoint_key_hint
                 yield Static("", id="provider_credential_status")
+
+    def _compose_endpoints_page(self) -> ComposeResult:
+        with VerticalScroll(id="settings_page_endpoints", classes="settings-page"):
+            with Vertical(classes="settings-section", id="settings_endpoints") as section:
+                section.border_title = "Custom Endpoints"
+                yield Static(messages.ENDPOINTS_HINT, classes="settings-hint")
+                yield Static("", id="endpoint_status", classes="settings-hint")
+                yield Label("Endpoint")
+                yield Select(
+                    [(settings_panel.ENDPOINT_NEW_VALUE_LABEL, settings_panel.ENDPOINT_NEW_VALUE)],
+                    id="endpoint_select",
+                    allow_blank=False,
+                    value=settings_panel.ENDPOINT_NEW_VALUE,
+                )
+                yield Label("Endpoint id")
+                yield Input(id="ep_id_input", placeholder="lmstudio")
+                yield Label("Label")
+                yield Input(id="ep_label_input", placeholder="LM Studio")
+                yield Label("API style")
+                yield Select(
+                    [
+                        ("OpenAI Chat Completions", "openai_chat"),
+                        ("OpenAI Responses", "openai_responses"),
+                        ("Anthropic Messages", "anthropic"),
+                    ],
+                    id="ep_style_select",
+                    allow_blank=False,
+                    value="openai_chat",
+                )
+                yield Label("Base URL")
+                yield Input(id="ep_base_url_input", placeholder="http://localhost:1234/v1")
+                yield Label("API key (optional)")
+                yield Input(password=True, id="ep_api_key_input", placeholder="Leave blank for keyless servers")
+                yield Label("Default model (optional)")
+                yield Input(id="ep_default_model_input", placeholder="qwen2.5-coder-7b-instruct")
+                yield Label("Context length")
+                yield Input(id="ep_context_input", placeholder="32768")
+                yield Label("Max output tokens")
+                yield Input(id="ep_max_output_input", placeholder="8192")
+                yield Label("Vision")
+                yield Select(
+                    [("No", "false"), ("Yes", "true")],
+                    id="ep_vision_select",
+                    allow_blank=False,
+                    value="false",
+                )
+                yield Label("Thinking")
+                yield Select(
+                    [("Off", "")] + [(label, mode) for label, mode in settings_panel.ENDPOINT_THINKING_OPTIONS],
+                    id="ep_thinking_mode_select",
+                    allow_blank=False,
+                    value="",
+                )
+                budgets_label = Label("Thinking budgets (effort=tokens)", id="ep_thinking_budgets_label")
+                budgets_label.display = False
+                yield budgets_label
+                budgets_input = Input(id="ep_thinking_budgets_input", placeholder="low=2048, medium=8192, high=16384")
+                budgets_input.display = False
+                yield budgets_input
+                reasoning_label = Label("Reasoning replay", id="ep_reasoning_label")
+                yield reasoning_label
+                yield Select(
+                    [
+                        ("Auto (detect emitted field)", "auto"),
+                        ("reasoning_content", "reasoning_content"),
+                        ("reasoning", "reasoning"),
+                        ("Off (visible text)", "off"),
+                    ],
+                    id="ep_reasoning_select",
+                    allow_blank=False,
+                    value="auto",
+                )
+                yield Static(messages.ENDPOINT_APPLY_REQUIRED, classes="settings-hint")
+                with Horizontal(classes="settings-button-row"):
+                    yield Button("Save Endpoint", id="ep_save", classes="quiet")
+                    yield Button("Delete", id="ep_delete", classes="quiet danger")
 
     def _compose_model_page(self) -> ComposeResult:
         with VerticalScroll(id="settings_page_model", classes="settings-page"):
@@ -633,6 +718,7 @@ class SettingsScreen(ModalScreen[None]):
         return not self._initializing and (
             self._snapshot() != self._baseline
             or self.pending_oauth_tokens != self._oauth_baseline
+            or self.pending_custom_endpoints != self._endpoints_baseline
             or bool(self.pending_api_key_removals)
             or bool(self.pending_api_keys)
         )
@@ -647,6 +733,7 @@ class SettingsScreen(ModalScreen[None]):
                 baseline[widget_id] = previous.get(widget_id)
         self._baseline = tuple(sorted(baseline.items()))
         self._oauth_baseline = deepcopy(self.pending_oauth_tokens)
+        self._endpoints_baseline = deepcopy(self.pending_custom_endpoints)
         self._original_theme = self.owner.settings.active_theme or theme.DEFAULT_THEME_NAME
         self._refresh_apply_label()
 
@@ -670,6 +757,9 @@ class SettingsScreen(ModalScreen[None]):
         elif event.button.id == "memory_settings_inspect":
             event.stop()
             self.owner.action_open_memory(inspect_disabled=True)
+        elif event.button.id in {"ep_save", "ep_delete"}:
+            event.stop()
+            self.owner._handle_endpoint_settings_button(event.button.id)
         elif event.button.id in {"mcp_delete_server", "mcp_clear_tokens", "mcp_trust_project"}:
             if self._confirm_immediate_action(event.button.id):
                 event.stop()

--- a/kolega_code/llm/instrumented_client.py
+++ b/kolega_code/llm/instrumented_client.py
@@ -28,7 +28,7 @@ def get_output_tokens(usage_metadata: Optional[Mapping[str, Any]], provider: Opt
     """Extract a provider-shaped, non-negative output-token count."""
     if not usage_metadata:
         return 0
-    fields = _usage_token_fields(usage_metadata.get("provider", provider))
+    fields = _usage_token_fields(usage_metadata.get("provider", provider), metadata=usage_metadata)
     if fields is None:
         return 0
     value = usage_metadata.get(fields[1], 0)
@@ -129,7 +129,7 @@ class InstrumentedLLMClient(LLMClient):
 
         provider = usage_metadata.get("provider", self.provider_name)
 
-        fields = _usage_token_fields(provider)
+        fields = _usage_token_fields(provider, metadata=usage_metadata)
         if fields is None:
             logger.warning(f"Unknown provider for usage recording: {provider}")
             return None

--- a/kolega_code/llm/usage.py
+++ b/kolega_code/llm/usage.py
@@ -84,8 +84,14 @@ _TOKEN_FIELDS = (
 )
 
 
-def usage_token_fields(provider: object) -> Optional[tuple[str, str]]:
-    """Return the provider-shaped input/output field names for a known provider."""
+def usage_token_fields(provider: object, *, metadata: Optional[Mapping[str, Any]] = None) -> Optional[tuple[str, str]]:
+    """Return the provider-shaped input/output field names for a known provider.
+
+    Custom endpoints are not registered per id; their wire family is detected
+    from the usage metadata itself (Anthropic-style reports input_tokens/
+    output_tokens, OpenAI-style prompt_tokens/completion_tokens), defaulting to
+    the OpenAI shape.
+    """
     if not isinstance(provider, str):
         return None
     if provider in ANTHROPIC_USAGE_PROVIDERS:
@@ -94,6 +100,11 @@ def usage_token_fields(provider: object) -> Optional[tuple[str, str]]:
         return "prompt_tokens", "completion_tokens"
     if provider in GOOGLE_USAGE_PROVIDERS:
         return "prompt_token_count", "candidates_token_count"
+    if provider.startswith("custom:"):
+        metadata = metadata or {}
+        if "output_tokens" in metadata:
+            return "input_tokens", "output_tokens"
+        return "prompt_tokens", "completion_tokens"
     return None
 
 
@@ -237,11 +248,16 @@ def normalize_usage(
     for family selection; ``usage_metadata["provider"]`` is not consulted (it is
     absent on some no-usage paths). Unknown providers are a programming error —
     the guard test enumerates every ModelProvider value against the family map.
+    Custom endpoints are the exception: their family is detected from the raw
+    metadata shape (Anthropic-style vs OpenAI-style), defaulting to the OpenAI
+    shape when no usage was reported.
     """
     metadata = usage_metadata or {}
-    if provider_name in ANTHROPIC_USAGE_PROVIDERS:
+    if provider_name in ANTHROPIC_USAGE_PROVIDERS or (
+        provider_name.startswith("custom:") and "input_tokens" in metadata
+    ):
         return _normalize_anthropic(metadata, provider_name, model)
-    if provider_name in OPENAI_USAGE_PROVIDERS:
+    if provider_name in OPENAI_USAGE_PROVIDERS or provider_name.startswith("custom:"):
         return _normalize_openai(metadata, provider_name, model)
     if provider_name in GOOGLE_USAGE_PROVIDERS:
         return _normalize_google(metadata, provider_name, model)

--- a/tests/agent/llm/test_custom_endpoints.py
+++ b/tests/agent/llm/test_custom_endpoints.py
@@ -372,3 +372,25 @@ def test_custom_endpoint_config_validation():
         CustomEndpointConfig(api_style="openai_chat", base_url="http://x/v1", reasoning_replay="sideways")
     with pytest.raises(ValueError):
         CustomEndpointConfig.model_validate({"api_style": "grpc", "base_url": "http://x/v1"})
+
+
+# --- usage normalization --------------------------------------------------
+
+
+def test_normalize_usage_for_custom_endpoints_by_shape():
+    from kolega_code.llm.usage import normalize_usage, usage_token_fields
+
+    openai_shaped = {"prompt_tokens": 11, "completion_tokens": 22, "total_tokens": 33}
+    norm = normalize_usage(openai_shaped, "custom:chat", "m")
+    assert (norm.input_tokens, norm.output_tokens, norm.total_tokens) == (11, 22, 33)
+
+    anthropic_shaped = {"input_tokens": 11, "output_tokens": 22}
+    norm = normalize_usage(anthropic_shaped, "custom:anthropic", "m")
+    assert (norm.input_tokens, norm.output_tokens) == (11, 22)
+
+    unreported = normalize_usage({}, "custom:chat", "m")
+    assert unreported.reported is False
+
+    assert usage_token_fields("custom:chat", metadata=openai_shaped) == ("prompt_tokens", "completion_tokens")
+    assert usage_token_fields("custom:anthropic", metadata=anthropic_shaped) == ("input_tokens", "output_tokens")
+    assert usage_token_fields("custom:chat") == ("prompt_tokens", "completion_tokens")

--- a/tests/cli/test_tui_settings_screens.py
+++ b/tests/cli/test_tui_settings_screens.py
@@ -23,6 +23,8 @@ def _configured_app(
     agent_models: dict | None = None,
     model_slots: dict | None = None,
     extra_key_providers: tuple[str, ...] = (),
+    custom_endpoints: dict | None = None,
+    env: dict | None = None,
 ):
     from kolega_code.cli.app import KolegaCodeApp
 
@@ -39,8 +41,10 @@ def _configured_app(
         settings.agent_models = agent_models
     if model_slots:
         settings.model_slots = model_slots
+    if custom_endpoints:
+        settings.custom_endpoints = custom_endpoints
     settings_store.save(settings)
-    config = build_agent_config(project, env={}, settings=settings, settings_store=settings_store)
+    config = build_agent_config(project, env=env or {}, settings=settings, settings_store=settings_store)
     store = SessionStore(state_dir)
     session = store.create(project, "code", config_summary(config))
     return (
@@ -100,7 +104,7 @@ async def test_settings_screen_is_categorized_and_stages_credentials_atomically(
         assert isinstance(screen, SettingsScreen)
         await pilot.pause()
         assert screen.dirty is False
-        assert screen.query_one("#settings_categories", OptionList).option_count == 7
+        assert screen.query_one("#settings_categories", OptionList).option_count == 8
         assert screen.query_one("#settings_page_model").display is True
         assert screen.query_one("#settings_page_tools").display is False
         apply_button = screen.query_one("#save_settings", Button)
@@ -1174,3 +1178,243 @@ async def test_chatgpt_provider_row_offers_sign_in_instead_of_a_key_field(
         assert screen.query_one("#provider_remove_api_key").display is False
         assert screen.query_one("#provider_chatgpt_login").display is True
         assert screen.query_one("#provider_chatgpt_logout").display is True
+
+
+# --- Custom Endpoints page -------------------------------------------------
+
+
+def _fill_endpoint_form(
+    screen, *, endpoint_id: str, base_url: str = "http://localhost:1234/v1", style: str = "openai_chat"
+) -> None:
+    from textual.widgets import Input, Select
+
+    screen.query_one("#ep_id_input", Input).value = endpoint_id
+    screen.query_one("#ep_base_url_input", Input).value = base_url
+    screen.query_one("#ep_style_select", Select).value = style
+
+
+@pytest.mark.asyncio
+async def test_settings_adds_endpoint_and_apply_persists_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+    from textual.widgets import Input, Select
+
+    from kolega_code.cli.provider_registry import ui_provider_options, ui_thinking_effort_options
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+
+    app, settings_store = _configured_app(tmp_path, monkeypatch)
+
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.action_open_settings()
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+
+        _fill_endpoint_form(screen, endpoint_id="lmstudio")
+        screen.query_one("#ep_thinking_mode_select", Select).value = "anthropic_budget"
+        screen.query_one("#ep_max_output_input", Input).value = "8192"
+        screen.query_one(
+            "#ep_thinking_budgets_input", Input
+        ).value = "low=2048, medium=4096, high=7168, xhigh=7168, max=7168"
+        screen.query_one("#ep_reasoning_select", Select).value = "auto"
+        await pilot.pause()
+        app._handle_endpoint_settings_button("ep_save")
+
+        await app._save_settings_from_ui()
+
+    saved = settings_store.load().custom_endpoints["lmstudio"]
+    assert saved["api_style"] == "openai_chat"
+    assert saved["base_url"] == "http://localhost:1234/v1"
+    assert saved["max_output_tokens"] == 8192
+    assert saved["reasoning_replay"] == "auto"
+    assert saved["thinking"]["mode"] == "anthropic_budget"
+    assert saved["thinking"]["budgets"]["low"] == 2048
+    assert "custom:lmstudio" in {value for _, value in ui_provider_options()}
+    assert [value for _label, value in ui_thinking_effort_options("custom:lmstudio", "any-model")] == list(
+        saved["thinking"]["options"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_settings_endpoint_edit_and_delete_round_trip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+    from textual.widgets import Input
+
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+
+    app, settings_store = _configured_app(
+        tmp_path,
+        monkeypatch,
+        custom_endpoints={"lmstudio": {"api_style": "openai_chat", "base_url": "http://localhost:1234/v1"}},
+    )
+
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.action_open_settings()
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+
+        # Editing an existing endpoint: id input is locked, base URL updates.
+        assert screen.query_one("#ep_id_input", Input).disabled is True
+        screen.query_one("#ep_base_url_input", Input).value = "http://localhost:4321/v1"
+        app._handle_endpoint_settings_button("ep_save")
+        await app._save_settings_from_ui()
+
+        assert settings_store.load().custom_endpoints["lmstudio"]["base_url"] == "http://localhost:4321/v1"
+
+        # Delete round trip: staging then apply.
+        app.action_open_settings()
+        await pilot.pause()
+        screen = app.screen
+        app._handle_endpoint_settings_button("ep_delete")
+        await pilot.pause()
+        await app._save_settings_from_ui()
+
+    assert settings_store.load().custom_endpoints == {}
+
+
+@pytest.mark.asyncio
+async def test_settings_endpoint_staging_without_apply_leaves_file_untouched(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+
+    app, settings_store = _configured_app(tmp_path, monkeypatch)
+
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.action_open_settings()
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+
+        _fill_endpoint_form(screen, endpoint_id="lmstudio")
+        app._handle_endpoint_settings_button("ep_save")
+        await pilot.pause()
+        # The draft holds the endpoint but nothing is persisted until Apply.
+        assert screen.pending_custom_endpoints["lmstudio"]["base_url"] == "http://localhost:1234/v1"
+
+    assert settings_store.load().custom_endpoints == {}
+
+
+@pytest.mark.asyncio
+async def test_settings_endpoint_validation_rejects_bad_input(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+    from textual.widgets import Static
+
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+
+    app, settings_store = _configured_app(tmp_path, monkeypatch)
+
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.action_open_settings()
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+
+        _fill_endpoint_form(screen, endpoint_id="Bad Slug!", base_url="localhost:1234")
+        app._handle_endpoint_settings_button("ep_save")
+        await pilot.pause()
+        assert "slug" in str(screen.query_one("#endpoint_status", Static).render())
+
+    assert settings_store.load().custom_endpoints == {}
+
+
+@pytest.mark.asyncio
+async def test_settings_deleting_active_endpoint_blocks_apply(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+    from textual.widgets import Static
+
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+
+    app, settings_store = _configured_app(
+        tmp_path,
+        monkeypatch,
+        provider="custom:lmstudio",
+        model="qwen2.5",
+        custom_endpoints={"lmstudio": {"api_style": "openai_chat", "base_url": "http://localhost:1234/v1"}},
+    )
+
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.action_open_settings()
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+
+        app._handle_endpoint_settings_button("ep_delete")
+        await pilot.pause()
+        await app._save_settings_from_ui()
+
+        status_text = str(screen.query_one("#settings_status", Static).render())
+        assert "No provider/model configured" in status_text
+
+    # The failed apply must not have persisted the deletion.
+    assert "lmstudio" in settings_store.load().custom_endpoints
+
+
+@pytest.mark.asyncio
+async def test_settings_custom_provider_model_uses_other_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+    from textual.widgets import Input, Select
+
+    from kolega_code.cli.tui.custom_model import CUSTOM_MODEL_SENTINEL
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+
+    app, settings_store = _configured_app(
+        tmp_path,
+        monkeypatch,
+        provider="custom:lmstudio",
+        model="qwen2.5",
+        custom_endpoints={"lmstudio": {"api_style": "openai_chat", "base_url": "http://localhost:1234/v1"}},
+    )
+
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.action_open_settings()
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+
+        # The active custom model is restored through the free-text "Other…" entry.
+        assert str(screen.query_one("#model_select", Select).value) == CUSTOM_MODEL_SENTINEL
+        assert screen.query_one("#model_custom_input", Input).value == "qwen2.5"
+
+        screen.query_one("#model_custom_input", Input).value = "qwen3-coder"
+        await pilot.pause()
+        await app._save_settings_from_ui()
+
+    assert settings_store.load().active_model == "qwen3-coder"
+
+
+@pytest.mark.asyncio
+async def test_settings_env_defined_endpoints_in_pickers_but_not_the_page(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+    from textual.widgets import Select
+
+    from kolega_code.cli.provider_registry import ui_provider_options
+    from kolega_code.cli.tui.settings_panel import ENDPOINT_NEW_VALUE
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+
+    env_json = '{"envlocal": {"api_style": "openai_chat", "base_url": "http://localhost:9999/v1"}}'
+    app, _ = _configured_app(tmp_path, monkeypatch, env={"KOLEGA_CODE_CUSTOM_ENDPOINTS": env_json})
+
+    assert "custom:envlocal" in {value for _, value in ui_provider_options()}
+
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.action_open_settings()
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+        endpoint_select = screen.query_one("#endpoint_select", Select)
+        option_values = {value for _label, value in endpoint_select._options}  # type: ignore[attr-defined]
+        assert option_values == {ENDPOINT_NEW_VALUE}


### PR DESCRIPTION
## Summary

TUI editor for custom endpoints, completing the feature (core #578, CLI/settings #580).

## Changes

- New **Custom Endpoints** Settings category: endpoint selector plus a form for id (slug), label, API style, base URL, optional key, default model, context/output limits, vision, thinking mode (with budgets for the Anthropic budget mode), and reasoning-replay field, with per-field validation.
- Edits stage into the settings draft and apply atomically with everything else; closing discards them. Deleting the active endpoint blocks Apply with a clear status and persists nothing.
- Providers page: custom endpoints hide the API-key editor (pointed at the new page), and Test Connection probes them through their base URL/style and default model.
- Provider rows and pickers refresh after Apply so new endpoints appear immediately.
- Docs: TUI walkthrough added to the Custom Endpoints page.

## Tests

7 new tests in `tests/cli/test_tui_settings_screens.py`: add+apply persistence (incl. thinking budgets and reasoning replay), edit/delete round trips, staging without apply, validation errors, deleting the active endpoint blocking Apply, free-text `Other…` model entry for custom providers, and env-defined endpoints appearing in pickers but not the page. Full fast suite 4733 passed; pyright clean; docs build clean.