### PR TITLE
feat(cli): configurable temperature for custom endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   them as `custom:<id>` anywhere a provider is chosen. Supports thinking-effort
   modes per wire dialect and native reasoning replay.
 
+- Custom endpoints accept a `temperature` field (per endpoint, or per model in
+  its `models` map; default 1.0), exposed in the TUI endpoint editor, via
+  `--endpoint-temperature`, and via `KOLEGA_CODE_ENDPOINT_TEMPERATURE`. Sent on
+  Chat Completions and Anthropic requests; ignored by Responses-style endpoints.
+
 ### Fixed
 
 - Together models (e.g. Kimi K2.7-Code) now replay prior reasoning through the

--- a/docs/src/content/docs/configuration/custom-endpoints.mdx
+++ b/docs/src/content/docs/configuration/custom-endpoints.mdx
@@ -55,6 +55,7 @@ lowercase slug:
 | `default_model` | Model used by connection probes | none |
 | `context_length` | Context window used for budgeting/compression | 32768 |
 | `max_output_tokens` | Output cap used for budgeting | 8192 |
+| `temperature` | Sampling temperature sent with each request (0–2; keep ≤ 1 for `anthropic`; ignored by `openai_responses`) | 1.0 |
 | `supports_vision` | Whether models accept images | false |
 | `reasoning_replay` | See [Reasoning replay](#reasoning-replay) | `auto` |
 | `thinking` | See [Thinking](#thinking) | none |

--- a/docs/src/content/docs/configuration/environment-variables.md
+++ b/docs/src/content/docs/configuration/environment-variables.md
@@ -98,6 +98,7 @@ served by different providers on different credentials.
 | `KOLEGA_CODE_ENDPOINT_STYLE` | Wire style for that endpoint: `openai_chat`, `openai_responses`, or `anthropic` (default `openai_chat`) |
 | `KOLEGA_CODE_ENDPOINT_API_KEY` | Optional credential for that endpoint |
 | `KOLEGA_CODE_ENDPOINT_CONTEXT` / `KOLEGA_CODE_ENDPOINT_MAX_OUTPUT` | Context window / max output tokens for that endpoint (defaults 32768 / 8192) |
+| `KOLEGA_CODE_ENDPOINT_TEMPERATURE` | Sampling temperature for that endpoint (0–2; default 1.0) |
 | `KOLEGA_CODE_ENDPOINT_VISION` | Non-empty marks that endpoint's models as vision-capable |
 | `KOLEGA_CODE_ENDPOINT_THINKING` | Thinking-effort mode for that endpoint (`thinking_toggle`, `openai_reasoning_effort`, `openai_responses_reasoning`, `anthropic_budget`) |
 | `KOLEGA_CODE_ENDPOINT_REASONING` | Reasoning replay field for that endpoint: `auto`, `reasoning_content`, `reasoning`, or `off` |

--- a/kolega_code/cli/config.py
+++ b/kolega_code/cli/config.py
@@ -115,6 +115,7 @@ ENDPOINT_MAX_OUTPUT_ENV = "KOLEGA_CODE_ENDPOINT_MAX_OUTPUT"
 ENDPOINT_VISION_ENV = "KOLEGA_CODE_ENDPOINT_VISION"
 ENDPOINT_THINKING_ENV = "KOLEGA_CODE_ENDPOINT_THINKING"
 ENDPOINT_REASONING_ENV = "KOLEGA_CODE_ENDPOINT_REASONING"
+ENDPOINT_TEMPERATURE_ENV = "KOLEGA_CODE_ENDPOINT_TEMPERATURE"
 CLI_ENDPOINT_ID = "cli"
 CLI_ENDPOINT_PROVIDER = f"{CUSTOM_PROVIDER_PREFIX}{CLI_ENDPOINT_ID}"
 
@@ -165,6 +166,7 @@ class CliConfigOverrides:
     endpoint_vision: bool = False
     endpoint_thinking: Optional[str] = None
     endpoint_reasoning: Optional[str] = None
+    endpoint_temperature: Optional[str] = None
 
 
 def load_cli_env(project_path: Path, env: Optional[Mapping[str, str]] = None) -> dict[str, str]:
@@ -199,6 +201,7 @@ def _flat_endpoint_fields(env: Mapping[str, str], overrides: CliConfigOverrides)
         ("max_output_tokens", ENDPOINT_MAX_OUTPUT_ENV, overrides.endpoint_max_output),
         ("thinking", ENDPOINT_THINKING_ENV, overrides.endpoint_thinking),
         ("reasoning_replay", ENDPOINT_REASONING_ENV, overrides.endpoint_reasoning),
+        ("temperature", ENDPOINT_TEMPERATURE_ENV, overrides.endpoint_temperature),
     ):
         resolved = value or env.get(env_key)
         if resolved:
@@ -230,6 +233,15 @@ def _cli_endpoint(url: str, env: Mapping[str, str], overrides: CliConfigOverride
         if value <= 0:
             raise CliConfigError(f"--endpoint-{flag} must be a positive integer, got '{raw}'.")
         entry[key] = value
+    raw_temperature = flat.get("temperature")
+    if raw_temperature is not None:
+        try:
+            temperature = float(raw_temperature)
+        except ValueError:
+            temperature = 0.0
+        if not (0 < temperature <= 2):
+            raise CliConfigError(f"--endpoint-temperature must be between 0 and 2, got '{raw_temperature}'.")
+        entry["temperature"] = temperature
     thinking = flat.get("thinking")
     if thinking:
         if thinking not in CUSTOM_THINKING_PRESETS:

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -287,6 +287,11 @@ def _add_common_model_args(parser: argparse.ArgumentParser) -> None:
         choices=list(REASONING_REPLAY_VALUES),
         help="Reasoning replay field for --endpoint-url (auto detects the emitted field).",
     )
+    parser.add_argument(
+        "--endpoint-temperature",
+        metavar="T",
+        help="Sampling temperature for --endpoint-url (0-2; default 1.0).",
+    )
     parser.add_argument("--environment", help="Environment label for tracing/metadata.")
     parser.add_argument(
         "--compression-threshold",
@@ -804,6 +809,7 @@ def _overrides_from_args(args: argparse.Namespace) -> CliConfigOverrides:
         endpoint_vision=bool(getattr(args, "endpoint_vision", False)),
         endpoint_thinking=getattr(args, "endpoint_thinking", None),
         endpoint_reasoning=getattr(args, "endpoint_reasoning", None),
+        endpoint_temperature=getattr(args, "endpoint_temperature", None),
     )
 
 

--- a/kolega_code/cli/settings.py
+++ b/kolega_code/cli/settings.py
@@ -106,6 +106,13 @@ def _coerce_custom_endpoints(raw: object) -> dict[str, dict]:
             value = cleaned.get(key)
             if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
                 cleaned.pop(key, None)
+        temperature = cleaned.get("temperature")
+        if (
+            isinstance(temperature, bool)
+            or not isinstance(temperature, (int, float))
+            or not (0 < float(temperature) <= 2)
+        ):
+            cleaned.pop("temperature", None)
         thinking = cleaned.get("thinking")
         if not isinstance(thinking, dict) or thinking.get("mode") not in CUSTOM_THINKING_MODES:
             cleaned.pop("thinking", None)

--- a/kolega_code/cli/tui/settings_panel.py
+++ b/kolega_code/cli/tui/settings_panel.py
@@ -764,6 +764,10 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             self._settings_query_one("#ep_default_model_input", Input).value = str(entry.get("default_model") or "")
             self._settings_query_one("#ep_context_input", Input).value = str(entry.get("context_length") or "")
             self._settings_query_one("#ep_max_output_input", Input).value = str(entry.get("max_output_tokens") or "")
+            temperature = entry.get("temperature")
+            self._settings_query_one("#ep_temperature_input", Input).value = (
+                str(temperature) if temperature is not None else ""
+            )
             self._settings_query_one("#ep_vision_select", Select).value = (
                 "true" if entry.get("supports_vision") else "false"
             )
@@ -796,6 +800,8 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             ("ep_thinking_budgets_input", budgets),
             ("ep_reasoning_label", style == "openai_chat"),
             ("ep_reasoning_select", style == "openai_chat"),
+            ("ep_temperature_label", style != "openai_responses"),
+            ("ep_temperature_input", style != "openai_responses"),
         ):
             try:
                 self._settings_query_one(f"#{widget_id}").display = visible
@@ -868,6 +874,17 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             entry["context_length"] = context
         if max_output is not None:
             entry["max_output_tokens"] = max_output
+        raw_temperature = input_value("ep_temperature_input")
+        if raw_temperature and style != "openai_responses":
+            try:
+                temperature = float(raw_temperature)
+            except ValueError:
+                temperature = 0.0
+            if not (0 < temperature <= 2):
+                raise ValueError("Temperature must be a number between 0 and 2.")
+            if style == "anthropic" and temperature > 1:
+                raise ValueError("Anthropic-style endpoints accept temperature up to 1.")
+            entry["temperature"] = temperature
         if str(self._settings_query_one("#ep_vision_select", Select).value) == "true":
             entry["supports_vision"] = True
         thinking_mode = str(self._settings_query_one("#ep_thinking_mode_select", Select).value)

--- a/kolega_code/cli/tui/settings_screen.py
+++ b/kolega_code/cli/tui/settings_screen.py
@@ -270,6 +270,8 @@ class SettingsScreen(ModalScreen[None]):
                 yield Input(id="ep_context_input", placeholder="32768")
                 yield Label("Max output tokens")
                 yield Input(id="ep_max_output_input", placeholder="8192")
+                yield Label("Temperature", id="ep_temperature_label")
+                yield Input(id="ep_temperature_input", placeholder="1.0 (leave blank for default)")
                 yield Label("Vision")
                 yield Select(
                     [("No", "false"), ("Yes", "true")],

--- a/kolega_code/config.py
+++ b/kolega_code/config.py
@@ -140,6 +140,12 @@ class CustomEndpointConfig(BaseModel):
     context_length: int = Field(default=DEFAULT_CONTEXT_LENGTH, gt=0)
     max_output_tokens: int = Field(default=DEFAULT_MAX_OUTPUT_TOKENS, gt=0)
     supports_vision: bool = Field(default=False)
+    temperature: Optional[float] = Field(
+        default=None,
+        gt=0,
+        le=2,
+        description="Sampling temperature (keep <= 1 for anthropic style; ignored by openai_responses)",
+    )
     models: Dict[str, Dict[str, Any]] = Field(default_factory=dict, description="Per-model spec overrides")
     thinking: Optional[Dict[str, Any]] = Field(default=None, description="Thinking-effort spec for this endpoint")
     reasoning_replay: str = Field(

--- a/kolega_code/llm/specs/custom_endpoints.py
+++ b/kolega_code/llm/specs/custom_endpoints.py
@@ -13,6 +13,7 @@ from .validation import validate_model_spec
 CUSTOM_PROVIDER_PREFIX = "custom:"
 DEFAULT_CONTEXT_LENGTH = 32768
 DEFAULT_MAX_OUTPUT_TOKENS = 8192
+DEFAULT_TEMPERATURE = 1.0
 API_STYLES = ("openai_chat", "openai_responses", "anthropic")
 
 _CUSTOM_ID_RE = re.compile(r"[a-z0-9][a-z0-9_-]*\Z")
@@ -97,15 +98,23 @@ def _thinking_spec(raw: Any) -> Optional[ThinkingEffortSpec]:
     return ThinkingEffortSpec(options=options, default=default, mode=mode, budgets=budgets)
 
 
+def _valid_temperature(value: Any) -> bool:
+    return not isinstance(value, bool) and isinstance(value, (int, float)) and 0 < float(value) <= 2
+
+
 def _endpoint_spec(entry: Mapping[str, Any], model_override: Optional[Mapping[str, Any]] = None) -> dict[str, Any]:
     merged: Mapping[str, Any] = {**entry, **model_override} if model_override else entry
+    temperature = merged.get("temperature")
+    if not _valid_temperature(temperature):
+        temperature = DEFAULT_TEMPERATURE
+    assert isinstance(temperature, (int, float))
     spec: dict[str, Any] = {
         "context_length": _positive_int(merged.get("context_length"), DEFAULT_CONTEXT_LENGTH),
         "max_completion_tokens": _positive_int(merged.get("max_output_tokens"), DEFAULT_MAX_OUTPUT_TOKENS),
         "input_budget": "window_minus_output",
         "supports_vision": bool(merged.get("supports_vision", False)),
         "supports_temperature": True,
-        "default_temperature": 0.7,
+        "default_temperature": float(temperature),
     }
     thinking = _thinking_spec(merged.get("thinking"))
     if thinking is not None:

--- a/tests/agent/llm/test_custom_endpoints.py
+++ b/tests/agent/llm/test_custom_endpoints.py
@@ -394,3 +394,30 @@ def test_normalize_usage_for_custom_endpoints_by_shape():
     assert usage_token_fields("custom:chat", metadata=openai_shaped) == ("prompt_tokens", "completion_tokens")
     assert usage_token_fields("custom:anthropic", metadata=anthropic_shaped) == ("input_tokens", "output_tokens")
     assert usage_token_fields("custom:chat") == ("prompt_tokens", "completion_tokens")
+
+
+# --- temperature ----------------------------------------------------------
+
+
+def test_sync_maps_endpoint_temperature_into_spec():
+    sync_custom_endpoint_specs(
+        {
+            "hot": {**CHAT_ENDPOINT, "temperature": 0.3},
+            "default": CHAT_ENDPOINT,
+            "bad": {**CHAT_ENDPOINT, "temperature": 7},
+            "override": {**CHAT_ENDPOINT, "temperature": 0.4, "models": {"m": {"temperature": 0.9}}},
+        }
+    )
+    assert get_model_specs("custom:hot", "m")["default_temperature"] == 0.3
+    assert get_model_specs("custom:default", "m")["default_temperature"] == 1.0
+    assert get_model_specs("custom:bad", "m")["default_temperature"] == 1.0
+    assert get_model_specs("custom:override", "m")["default_temperature"] == 0.9
+
+
+def test_custom_endpoint_config_temperature_validation():
+    CustomEndpointConfig(api_style="openai_chat", base_url="http://x/v1", temperature=0.5)
+    CustomEndpointConfig(api_style="openai_chat", base_url="http://x/v1", temperature=2)
+    with pytest.raises(ValueError):
+        CustomEndpointConfig(api_style="openai_chat", base_url="http://x/v1", temperature=0)
+    with pytest.raises(ValueError):
+        CustomEndpointConfig(api_style="openai_chat", base_url="http://x/v1", temperature=2.5)

--- a/tests/cli/test_cli_config.py
+++ b/tests/cli/test_cli_config.py
@@ -1013,3 +1013,30 @@ def test_key_status_reports_custom_endpoint_keys(tmp_path: Path) -> None:
     assert key_status("custom:lmstudio", tmp_path, settings) == "present in local settings"
 
     assert key_status("custom:gone", tmp_path, settings) == "endpoint not defined"
+
+
+def test_build_agent_config_endpoint_temperature_flag(tmp_path: Path) -> None:
+    config = build_agent_config(
+        tmp_path,
+        env={},
+        settings=CliSettings(),
+        overrides=CliConfigOverrides(endpoint_url="http://localhost:11434/v1", endpoint_temperature="0.3", model="m"),
+    )
+    endpoint = config.custom_endpoint_for(config.long_context_config)
+    assert endpoint is not None and endpoint.temperature == 0.3
+    from kolega_code.llm.specs import get_model_specs
+
+    assert get_model_specs("custom:cli", "m")["default_temperature"] == 0.3
+
+
+def test_build_agent_config_endpoint_temperature_validation(tmp_path: Path) -> None:
+    for bad in ("0", "2.5", "hot"):
+        with pytest.raises(CliConfigError, match="endpoint-temperature"):
+            build_agent_config(
+                tmp_path,
+                env={},
+                settings=CliSettings(),
+                overrides=CliConfigOverrides(
+                    endpoint_url="http://localhost:11434/v1", endpoint_temperature=bad, model="m"
+                ),
+            )

--- a/tests/cli/test_settings.py
+++ b/tests/cli/test_settings.py
@@ -598,3 +598,23 @@ def test_custom_endpoints_coercion_tolerates_hand_edits() -> None:
     assert "thinking" not in settings.custom_endpoints["bad-thinking"]
     assert settings.custom_endpoints["bad-replay"]["reasoning_replay"] == "auto"
     assert settings.custom_endpoints["bad-models"]["models"] == {"a": {"context_length": 1}}
+
+
+def test_custom_endpoints_temperature_coercion() -> None:
+    settings = CliSettings.from_dict(
+        {
+            "schema_version": 3,
+            "custom_endpoints": {
+                "good": {"api_style": "openai_chat", "base_url": "http://x/v1", "temperature": 0.5},
+                "int": {"api_style": "openai_chat", "base_url": "http://x/v1", "temperature": 1},
+                "high": {"api_style": "openai_chat", "base_url": "http://x/v1", "temperature": 3},
+                "zero": {"api_style": "openai_chat", "base_url": "http://x/v1", "temperature": 0},
+                "str": {"api_style": "openai_chat", "base_url": "http://x/v1", "temperature": "0.5"},
+            },
+        }
+    )
+    assert settings.custom_endpoints["good"]["temperature"] == 0.5
+    assert settings.custom_endpoints["int"]["temperature"] == 1
+    assert "temperature" not in settings.custom_endpoints["high"]
+    assert "temperature" not in settings.custom_endpoints["zero"]
+    assert "temperature" not in settings.custom_endpoints["str"]

--- a/tests/cli/test_tui_settings_screens.py
+++ b/tests/cli/test_tui_settings_screens.py
@@ -1418,3 +1418,45 @@ async def test_settings_env_defined_endpoints_in_pickers_but_not_the_page(
         endpoint_select = screen.query_one("#endpoint_select", Select)
         option_values = {value for _label, value in endpoint_select._options}  # type: ignore[attr-defined]
         assert option_values == {ENDPOINT_NEW_VALUE}
+
+
+@pytest.mark.asyncio
+async def test_settings_endpoint_temperature_round_trip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+    from textual.widgets import Input
+
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+
+    app, settings_store = _configured_app(tmp_path, monkeypatch)
+
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.action_open_settings()
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+
+        _fill_endpoint_form(screen, endpoint_id="lmstudio")
+        screen.query_one("#ep_temperature_input", Input).value = "0.4"
+        app._handle_endpoint_settings_button("ep_save")
+        await app._save_settings_from_ui()
+
+    assert settings_store.load().custom_endpoints["lmstudio"]["temperature"] == 0.4
+
+    # Anthropic style rejects temperatures above 1.
+    second_dir = tmp_path / "second"
+    second_dir.mkdir()
+    app2, _ = _configured_app(second_dir, monkeypatch)
+    async with app2.run_test(size=(140, 40)) as pilot:
+        app2.action_open_settings()
+        await pilot.pause()
+        screen2 = app2.screen
+        assert isinstance(screen2, SettingsScreen)
+        _fill_endpoint_form(screen2, endpoint_id="ap", style="anthropic")
+        screen2.query_one("#ep_temperature_input", Input).value = "1.5"
+        app2._handle_endpoint_settings_button("ep_save")
+        await pilot.pause()
+        from textual.widgets import Static
+
+        assert "up to 1" in str(screen2.query_one("#endpoint_status", Static).render())


### PR DESCRIPTION
## Summary

Custom endpoints accept a `temperature` field, sent with every request. The agent already reads the catalog's `default_temperature` per model, so this maps the configured value into the endpoint's runtime spec — no agent/provider changes needed.

## Changes

- `settings.json`: `"temperature": 0.6` on an endpoint, or per model in its `models` map. Default 1.0; range 0–2 (Anthropic style documented as ≤ 1; Responses style ignores it and the field is hidden in the TUI).
- `CustomEndpointConfig.temperature` with validation; sync maps it to the spec's `default_temperature`.
- TUI: Temperature input on the Custom Endpoints page (blank = default), style-aware validation.
- CLI/env: `--endpoint-temperature` / `KOLEGA_CODE_ENDPOINT_TEMPERATURE` for the ephemeral `custom:cli` endpoint.
- Docs: schema table row, env-var table row; CHANGELOG entry.

## Tests

New coverage in `test_custom_endpoints.py` (spec mapping, defaults, invalid fallback, per-model override, config validation), `test_settings.py` (coercion), `test_cli_config.py` (flag + env resolution, range errors), and `test_tui_settings_screens.py` (TUI round trip, Anthropic >1 rejection). Full fast suite 4740 passed; ruff/pyright clean; docs build clean.