### PR TITLE
fix(cli): seed custom endpoint default model on provider switch

### DIFF
--- a/kolega_code/cli/tui/settings_panel.py
+++ b/kolega_code/cli/tui/settings_panel.py
@@ -1649,6 +1649,7 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             model_select = self._settings_query_one(f"#{model_id}", Select)
         except NoMatches:
             return
+        manual_switch = model_value is None
         if model_value is None:
             current = model_select.value
             model_value = None if current is Select.NULL else str(current)
@@ -1666,6 +1667,13 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
                     # saved non-vision models).
                     model_value = CUSTOM_MODEL_SENTINEL
                     custom_value = stale_option.model
+                    if manual_switch and provider.startswith(CUSTOM_PROVIDER_PREFIX):
+                        # A manual provider switch would carry the previous
+                        # provider's model id into the free-text input; seed the
+                        # endpoint's default model instead.
+                        endpoint_id = provider[len(CUSTOM_PROVIDER_PREFIX) :]
+                        endpoint_default = self._merged_endpoints_for_probe().get(endpoint_id, {}).get("default_model")
+                        custom_value = str(endpoint_default) if endpoint_default else ""
                 elif browser_role:
                     # Non-gateway Browser row: keep the explicit stale option so a
                     # saved non-vision model stays visible and selectable.

--- a/tests/cli/test_tui_settings_screens.py
+++ b/tests/cli/test_tui_settings_screens.py
@@ -1460,3 +1460,41 @@ async def test_settings_endpoint_temperature_round_trip(
         from textual.widgets import Static
 
         assert "up to 1" in str(screen2.query_one("#endpoint_status", Static).render())
+
+
+@pytest.mark.asyncio
+async def test_settings_provider_switch_seeds_custom_endpoint_default_model(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    pytest.importorskip("textual")
+    from textual.widgets import Input, Select
+
+    from kolega_code.cli.tui.custom_model import CUSTOM_MODEL_SENTINEL
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+
+    app, _ = _configured_app(
+        tmp_path,
+        monkeypatch,
+        provider="deepseek",
+        model=DEEPSEEK_DEFAULT_MODEL,
+        custom_endpoints={
+            "lmstudio": {
+                "api_style": "openai_chat",
+                "base_url": "http://localhost:1234/v1",
+                "default_model": "qwen/qwen3.6-35b-a3b",
+            }
+        },
+    )
+
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.action_open_settings()
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+
+        screen.query_one("#provider_select", Select).value = "custom:lmstudio"
+        await _wait_for_select_values(
+            pilot, screen, {"provider_select": "custom:lmstudio", "model_select": CUSTOM_MODEL_SENTINEL}
+        )
+        await pilot.pause()
+        assert screen.query_one("#model_custom_input", Input).value == "qwen/qwen3.6-35b-a3b"


### PR DESCRIPTION
## Problem

Switching a model picker to a custom endpoint left the *previous* provider's model id pre-filled in the free-text `Other…` input (e.g. switching from deepseek showed `deepseek-v4-pro`). Any id resolves against a custom endpoint's wildcard, so the stale-selection carry-over had nothing to reject.

## Fix

On a *manual* provider switch to a custom endpoint, the `Other…` input is seeded from the endpoint's `default_model` instead (blank when the endpoint declares none). Saved selections and settings restores are untouched — the distinction is the explicit `model_value` those paths pass.

## Tests

Regression test `test_settings_provider_switch_seeds_custom_endpoint_default_model` (switch deepseek → custom endpoint with default model → input shows the qwen default). Full fast suite 4741 passed; ruff/pyright clean.