### PR TITLE
chore: release v0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.29.0 - 2026-08-13
+
 ### Added
 
 - Custom endpoints: use models from any OpenAI Chat Completions, OpenAI

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -174,4 +174,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.28.4"
+__version__ = "0.29.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.28.4"
+__version__ = "0.29.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.28.4"
+version = "0.29.0"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -1787,7 +1787,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.28.4"
+version = "0.29.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Release v0.29.0

Bumps the version to 0.29.0 in `pyproject.toml`, `uv.lock`, and both `__version__` values; moves the changelog entry from Unreleased.

### Highlights

- **Custom endpoints** — use models from any OpenAI Chat Completions, Responses, or Anthropic Messages-compatible server, selected as `custom:<id>` anywhere a provider is chosen (CLI flags, env vars, TUI settings page).
- **Custom endpoint temperature** — per-endpoint or per-model `temperature` field with TUI editor and `--endpoint-temperature` support.
- **Together reasoning replay fix** — Kimi K2.7-Code and similar models replay prior reasoning via the native `reasoning` field instead of visible `*Thinking:*` text.

Verified locally: fast test suite (4740 passed) and pre-commit hooks green in a disposable `.venv-release` environment.