### PR TITLE
fix(mcp): sanitize MCP tool names and surface provider 400 details

### DIFF
--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -48,17 +48,24 @@ from kolega_code.hooks import HookDispatcher, HookEvent, load_hook_config
 from kolega_code.llm.exceptions import LLMBillingError, billing_error_message
 from kolega_code.llm.models import Message, TextBlock
 from kolega_code.mcp.config import (
+    _SERVER_ID_MAX_LENGTH,
+    LoadedMCPConfig,
     MCPConfigError,
     MCPServerConfig,
     global_mcp_config_path,
     load_mcp_config,
     project_mcp_config_path,
     remove_server_config,
+    sanitize_mcp_server_id,
     server_fingerprint,
     set_server_enabled,
     upsert_server_config,
 )
-from kolega_code.mcp.service import MCP_FAILURE_MESSAGE_GENERIC, MCPService
+from kolega_code.mcp.service import (
+    MCP_FAILURE_MESSAGE_GENERIC,
+    MCPService,
+    mcp_tool_name_adjustment_note,
+)
 from kolega_code.mcp.tools import build_mcp_tool_extension
 from kolega_code.agent.prompt_provider import AgentMode
 from kolega_code.permissions import (
@@ -1606,6 +1613,8 @@ async def _run_ask(args: argparse.Namespace) -> int:
     )
     if mcp_extension is not None:
         tool_extensions.append(mcp_extension)
+        if mcp_config is not None:
+            _print_mcp_tool_name_warnings(mcp_config, settings_store.root, project_path)
     extension_bundle = None
     if extension_selection is not None:
         extension_host = KolegaExtensionHost(
@@ -2335,6 +2344,8 @@ async def _run_mcp(args: argparse.Namespace) -> int:
         return 0
 
     if args.mcp_command == "verify":
+        if getattr(args, "server_id", None):
+            args.server_id = sanitize_mcp_server_id(args.server_id)
         server_ids = _mcp_verify_server_ids(args, config)
         if not server_ids:
             raise ValueError("No MCP servers to verify.")
@@ -2366,33 +2377,41 @@ async def _run_mcp(args: argparse.Namespace) -> int:
         except MCPConfigError as exc:
             raise ValueError(str(exc)) from exc
         print(f"Saved MCP server {server.id} to {path}")
+        if args.server_id.strip() != server.id:
+            print(
+                f"mcp: server id '{args.server_id}' exceeds {_SERVER_ID_MAX_LENGTH} characters; "
+                f"saved as '{server.id}'.",
+                file=sys.stderr,
+            )
         if source == "project" and not settings.is_mcp_project_trusted(project_path):
             print("Project MCP config is not trusted yet. Re-run with --trust-mcp to enable it.", file=sys.stderr)
         return 0
 
     if args.mcp_command == "remove":
         path, source = _mcp_mutation_target(args, project_path, settings_store.root)
+        server_id = sanitize_mcp_server_id(args.server_id)
         try:
-            removed = remove_server_config(path, args.server_id, source=source)
+            removed = remove_server_config(path, server_id, source=source)
         except MCPConfigError as exc:
             raise ValueError(str(exc)) from exc
         if not removed:
-            raise ValueError(f"MCP server not found in {path}: {args.server_id}")
-        service.status_store.clear(args.server_id)
-        service.oauth_store.clear(args.server_id)
-        print(f"Removed MCP server {args.server_id} from {path}")
+            raise ValueError(f"MCP server not found in {path}: {server_id}")
+        service.status_store.clear(server_id)
+        service.oauth_store.clear(server_id)
+        print(f"Removed MCP server {server_id} from {path}")
         return 0
 
     if args.mcp_command in {"enable", "disable"}:
         path, source = _mcp_mutation_target(args, project_path, settings_store.root)
         enabled = args.mcp_command == "enable"
+        server_id = sanitize_mcp_server_id(args.server_id)
         try:
-            changed = set_server_enabled(path, args.server_id, enabled, source=source)
+            changed = set_server_enabled(path, server_id, enabled, source=source)
         except MCPConfigError as exc:
             raise ValueError(str(exc)) from exc
         if not changed:
-            raise ValueError(f"MCP server not found in {path}: {args.server_id}")
-        print(f"{'Enabled' if enabled else 'Disabled'} MCP server {args.server_id} in {path}")
+            raise ValueError(f"MCP server not found in {path}: {server_id}")
+        print(f"{'Enabled' if enabled else 'Disabled'} MCP server {server_id} in {path}")
         return 0
 
     raise ValueError(f"Unknown mcp command: {args.mcp_command}")
@@ -2411,21 +2430,41 @@ def _print_mcp_list(config, service: MCPService) -> None:
         return
     print("ID\tSOURCE\tTRANSPORT\tENABLED\tOAUTH\tSTATUS\tTOOLS\tMESSAGE")
     for server in config.servers.values():
-        status_text, tool_count, message = _mcp_cli_status_parts(server, service)
+        status_text, tool_count, message, _ = _mcp_cli_status_parts(server, service)
         print(
             f"{server.id}\t{server.source}\t{server.transport}\t{server.enabled}\t{server.oauth.enabled}\t"
             f"{status_text}\t{tool_count}\t{message}"
         )
 
 
-def _mcp_cli_status_parts(server: MCPServerConfig, service: MCPService) -> tuple[str, int, str]:
+def _print_mcp_tool_name_warnings(config: LoadedMCPConfig, state_dir: Path, project_path: Path) -> None:
+    """Warn on stderr when verified MCP tools get provider-adjusted wire names.
+
+    Mirrors the ``mcp: {diagnostic}`` startup output: the model-facing names are
+    sanitized, and silently renaming them would be confusing.
+    """
+    service = MCPService(config, state_dir=state_dir, project_path=project_path)
+    for server in config.enabled_servers:
+        status = service.server_status(server)
+        if not status or status.status != "verified":
+            continue
+        if status.fingerprint != server_fingerprint(server):
+            continue
+        note = mcp_tool_name_adjustment_note(server.id, status.tools)
+        if note:
+            print(f"mcp: warning: server '{server.id}': {note}", file=sys.stderr)
+
+
+def _mcp_cli_status_parts(server: MCPServerConfig, service: MCPService) -> tuple[str, int, str, str]:
     status = service.server_status(server)
     current_fingerprint = server_fingerprint(server)
     verified = bool(status and status.status == "verified" and status.fingerprint == current_fingerprint)
     stale = bool(status and status.fingerprint and status.fingerprint != current_fingerprint)
+    note = ""
     if verified and status:
         status_text = "verified"
         tool_count = status.tool_count
+        note = mcp_tool_name_adjustment_note(server.id, status.tools)
     elif stale:
         status_text = "stale"
         tool_count = 0
@@ -2435,12 +2474,13 @@ def _mcp_cli_status_parts(server: MCPServerConfig, service: MCPService) -> tuple
     else:
         status_text = "unverified"
         tool_count = 0
-    return status_text, tool_count, _mcp_cli_list_message(status_text, tool_count)
+    return status_text, tool_count, _mcp_cli_list_message(status_text, tool_count, note), note
 
 
-def _mcp_cli_list_message(status: str, tool_count: int) -> str:
+def _mcp_cli_list_message(status: str, tool_count: int, note: str = "") -> str:
     if status == "verified":
-        return f"Verified {tool_count} tool(s)."
+        message = f"Verified {tool_count} tool(s)."
+        return f"{message} {note}" if note else message
     if status == "stale":
         return "Configuration changed since last verification. Verify again."
     if status == "failed":
@@ -2586,6 +2626,27 @@ def _run_doctor(args: argparse.Namespace) -> int:
     line("Long model", f"{summary['long_provider']}/{summary['long_model']}")
     line("Fast model", f"{summary['fast_provider']}/{summary['fast_model']}")
     line("Thinking effort", summary["thinking_effort"])
+
+    # MCP servers: offline status from config + local verification state (no network).
+    mcp_config = load_mcp_config(
+        project_path, settings_store.root, project_trusted=settings.is_mcp_project_trusted(project_path)
+    )
+    mcp_service = MCPService(mcp_config, state_dir=settings_store.root, project_path=project_path)
+    for diagnostic in mcp_config.diagnostics:
+        print(f"mcp: {diagnostic}", file=sys.stderr)
+    if not mcp_config.servers:
+        line("MCP servers", "none configured", "muted")
+    for server in mcp_config.servers.values():
+        status_text, tool_count, _, note = _mcp_cli_status_parts(server, mcp_service)
+        status_style = "success" if status_text == "verified" else ("error" if status_text == "failed" else "muted")
+        line(
+            f"MCP {server.id}",
+            f"{server.transport} · {'enabled' if server.enabled else 'disabled'} · {status_text} · "
+            f"{tool_count} tool(s)",
+            status_style,
+        )
+        if note:
+            line(f"MCP {server.id} tool names", f"{note} See `kolega-code mcp list` for detail.", "warning")
     return 0
 
 

--- a/kolega_code/cli/tui/agent_runtime.py
+++ b/kolega_code/cli/tui/agent_runtime.py
@@ -34,6 +34,8 @@ from kolega_code.agent.prompts import (
 from kolega_code.hooks import HookDispatcher, HookEvent, load_hook_config, project_hooks_present
 from kolega_code.scratchpad import SCRATCHPAD_PROMPT_EXTENSION_ID, ensure_scratchpad_dir, scratchpad_dir_for
 from kolega_code.llm.exceptions import LLMError, llm_error_message
+from kolega_code.mcp.config import LoadedMCPConfig, server_fingerprint
+from kolega_code.mcp.service import MCPService, mcp_tool_name_adjustment_note
 from kolega_code.mcp.tools import build_mcp_tool_extension
 from kolega_code.permissions import PermissionDecision
 from kolega_code.session.runtime import deserialize_permission_request
@@ -966,6 +968,23 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
         if self._scheduled_loop is not None and self._scheduled_loop.is_active:
             self._request_loop_stop(messages.LOOP_STOPPED_BY_USER.format(iterations=self._scheduled_loop.iterations))
 
+    def _log_mcp_tool_name_warnings(self, mcp_config: LoadedMCPConfig) -> None:
+        """Warn in the log pane when verified MCP tools get provider-adjusted wire names.
+
+        Mirrors the ``mcp: {diagnostic}`` startup warnings: the model-facing names
+        are sanitized, and silently renaming them would be confusing.
+        """
+        service = MCPService(mcp_config, state_dir=self.settings_store.root, project_path=self.active_project_path)
+        for server in mcp_config.enabled_servers:
+            status = service.server_status(server)
+            if not status or status.status != "verified":
+                continue
+            if status.fingerprint != server_fingerprint(server):
+                continue
+            note = mcp_tool_name_adjustment_note(server.id, status.tools)
+            if note:
+                self._log_status(f"mcp: warning: server '{server.id}': {note}", level="warn")
+
     async def _ensure_agent_from_settings(self, rebuild: bool = False) -> None:
         try:
             config = build_agent_config(
@@ -1186,6 +1205,8 @@ class AgentRuntimeMixin(tui_app_base.KolegaAppBase):
         )
         if mcp_extension is not None:
             tool_extensions.append(mcp_extension)
+            if mcp_config is not None and self.active_project_path == self.project_path:
+                self._log_mcp_tool_name_warnings(mcp_config)
 
         # gigacode applies to any top-level agent and is carried across rebuilds.
         # In plan mode the orchestrating agent is read-only, so its workflow

--- a/kolega_code/cli/tui/settings_panel.py
+++ b/kolega_code/cli/tui/settings_panel.py
@@ -42,7 +42,7 @@ from kolega_code.mcp.config import (
     remove_server_config,
     upsert_server_config,
 )
-from kolega_code.mcp.service import MCPService
+from kolega_code.mcp.service import MCPService, mcp_tool_name_adjustment_note
 from kolega_code.mcp.state import MCPStatusStore, MCPOAuthTokenStore
 
 from .. import messages, theme
@@ -1589,7 +1589,12 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         self._populate_mcp_controls()
         await self._ensure_agent_from_settings(rebuild=True)
         if result.ok:
-            self._notify_user(f"Verified MCP server '{selected}' ({result.tool_count} tool(s)).")
+            message = f"Verified MCP server '{selected}' ({result.tool_count} tool(s))."
+            if result.status is not None:
+                note = mcp_tool_name_adjustment_note(selected, result.status.tools)
+                if note:
+                    message = f"{message} {note}"
+            self._notify_user(message)
         else:
             self._notify_user(f"MCP verification failed for '{selected}': {result.message}", severity="warning")
 

--- a/kolega_code/llm/exceptions.py
+++ b/kolega_code/llm/exceptions.py
@@ -217,9 +217,44 @@ def llm_error_message(error: LLMError, model: str | None = None) -> str:
             LLMUnprocessableEntityError,
         ),
     ):
+        detail = _provider_error_detail(error)
+        if detail:
+            return f"{provider_model} could not process this request: {detail}"
         return f"{provider_model} could not process this request. Check the selected provider/model and try again."
 
     return f"{provider_model} returned an error: {error}"
+
+
+_PROVIDER_ERROR_PREFIXES = (
+    "OpenAI APIError: ",
+    "AnthropicError: ",
+    "GoogleAPIError: ",
+    "Google APIError: ",
+    "Tinker request error: ",
+    "Invalid parameter: ",
+    "Missing required parameter: ",
+    "Invalid parameter type: ",
+)
+_MAX_PROVIDER_DETAIL_CHARS = 300
+
+
+def _provider_error_detail(error: LLMError) -> str:
+    """Extract a concise, single-line version of the provider's raw error detail.
+
+    Provider bodies are multiline JSON wrapped in a known prefix (e.g.
+    ``"OpenAI APIError: Error code: 400 - {...}"``); strip the prefix, collapse
+    whitespace, and bound the length so a 400's real cause is visible in the
+    turn error instead of only in the diagnostics JSONL.
+    """
+    detail = str(error)
+    for prefix in _PROVIDER_ERROR_PREFIXES:
+        if detail.startswith(prefix):
+            detail = detail[len(prefix) :]
+            break
+    detail = " ".join(detail.split())
+    if len(detail) > _MAX_PROVIDER_DETAIL_CHARS:
+        detail = detail[:_MAX_PROVIDER_DETAIL_CHARS].rstrip() + "…"
+    return detail
 
 
 def _is_billing_status(error: Exception) -> bool:

--- a/kolega_code/mcp/config.py
+++ b/kolega_code/mcp/config.py
@@ -18,6 +18,29 @@ MCP_GLOBAL_CONFIG_FILENAME = "mcp_servers.json"
 MCP_CONFIG_RELATIVE_PATH = Path(".kolega") / MCP_GLOBAL_CONFIG_FILENAME
 MCP_TRANSPORTS = ("streamable_http", "sse", "stdio")
 _SERVER_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+# Tool wire names are capped at 64 chars total; a 32-char server id leaves at
+# least 25 chars of budget for the tool id after the ``mcp__{server}__`` prefix.
+_SERVER_ID_MAX_LENGTH = 32
+_SERVER_ID_PREFIX_LENGTH = 24
+
+
+def sanitize_mcp_server_id(value: str) -> str:
+    """Validate a server id, rewriting over-long ids so they fit provider budgets.
+
+    Ids longer than ``_SERVER_ID_MAX_LENGTH`` are rewritten deterministically as
+    ``{first 24 chars}_{7-char hash of the original}`` so existing config files
+    keep loading (instead of failing) and distinct long ids stay distinct. Ids
+    within the limit pass through unchanged; invalid characters still raise.
+    """
+    value = str(value).strip()
+    if not value:
+        raise ValueError("server id is required")
+    if not _SERVER_ID_RE.match(value):
+        raise ValueError("server id may contain only letters, numbers, '_' and '-'")
+    if len(value) <= _SERVER_ID_MAX_LENGTH:
+        return value
+    digest = hashlib.sha1(value.encode("utf-8")).hexdigest()[:7]
+    return f"{value[:_SERVER_ID_PREFIX_LENGTH]}_{digest}"
 
 
 class MCPConfigError(ValueError):
@@ -63,12 +86,7 @@ class MCPServerConfig(BaseModel):
     @field_validator("id")
     @classmethod
     def _validate_id(cls, value: str) -> str:
-        value = str(value).strip()
-        if not value:
-            raise ValueError("server id is required")
-        if not _SERVER_ID_RE.match(value):
-            raise ValueError("server id may contain only letters, numbers, '_' and '-'")
-        return value
+        return sanitize_mcp_server_id(value)
 
     @field_validator("headers", "env", mode="before")
     @classmethod
@@ -192,6 +210,24 @@ def load_mcp_config_file(path: Path, *, source: str) -> MCPConfigFile:
     return parse_mcp_config_text(path.read_text(encoding="utf-8"), source=source)
 
 
+def _raw_mcp_server_ids(path: Path) -> list[str]:
+    """Raw server ids from a config file before validation, in file order.
+
+    Used to diagnose ids that ``sanitize_mcp_server_id`` rewrote for length.
+    Returns [] on any read/parse error (the caller reports those separately).
+    """
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return []
+    servers = data.get("servers")
+    if isinstance(servers, list):
+        return [str(entry.get("id")) for entry in servers if isinstance(entry, dict) and entry.get("id") is not None]
+    if isinstance(servers, dict):
+        return [str(key) for key in servers]
+    return []
+
+
 def load_mcp_config(project_path: Path, state_dir: Path, *, project_trusted: bool) -> LoadedMCPConfig:
     """Load global MCP config plus trusted project config.
 
@@ -220,7 +256,13 @@ def load_mcp_config(project_path: Path, state_dir: Path, *, project_trusted: boo
         except (OSError, json.JSONDecodeError, ValidationError, ValueError) as exc:
             diagnostics.append(f"Could not load {source} MCP config {path}: {exc}")
             continue
-        for server in config_file.servers:
+        raw_ids = _raw_mcp_server_ids(path)
+        for position, server in enumerate(config_file.servers):
+            raw_id = raw_ids[position] if position < len(raw_ids) else ""
+            if raw_id and server.id != raw_id:
+                diagnostics.append(
+                    f"MCP server id '{raw_id}' exceeds {_SERVER_ID_MAX_LENGTH} characters; using '{server.id}' instead."
+                )
             if server.id in merged:
                 diagnostics.append(f"MCP server '{server.id}' from {source} overrides earlier configuration.")
             merged[server.id] = server

--- a/kolega_code/mcp/service.py
+++ b/kolega_code/mcp/service.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import json
 import logging
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
@@ -122,6 +124,95 @@ def parse_mcp_tool_name(name: str) -> Optional[tuple[str, str]]:
     if not server_id or not tool_id:
         return None
     return server_id, tool_id
+
+
+# Providers reject tool names that don't match ^[a-zA-Z0-9_-]{1,N}$ — OpenAI and
+# Google cap N at 64, Anthropic at 128. Clamp to the strictest so one bad MCP
+# server can't 400 every provider.
+MCP_TOOL_NAME_MAX_LENGTH = 64
+_INVALID_TOOL_NAME_CHAR_RE = re.compile(r"[^A-Za-z0-9_-]")
+
+
+def sanitize_mcp_tool_name(name: str) -> str:
+    """Return a provider-safe wire name for a composed ``mcp__server__tool`` name.
+
+    Every character outside ``[A-Za-z0-9_-]`` becomes ``_`` and the result is
+    clamped to ``MCP_TOOL_NAME_MAX_LENGTH``. The ``mcp__{server_id}__`` prefix
+    is preserved: only the tool-id segment is truncated unless the server id
+    alone exhausts the budget (then the whole name is truncated).
+    """
+    sanitized = _INVALID_TOOL_NAME_CHAR_RE.sub("_", name)
+    if len(sanitized) <= MCP_TOOL_NAME_MAX_LENGTH:
+        return sanitized
+
+    prefix = ""
+    tool_id = sanitized
+    if sanitized.startswith(MCP_TOOL_PREFIX):
+        rest = sanitized[len(MCP_TOOL_PREFIX) :]
+        if MCP_TOOL_SEPARATOR in rest:
+            server_id, tool_id = rest.split(MCP_TOOL_SEPARATOR, 1)
+            prefix = f"{MCP_TOOL_PREFIX}{server_id}{MCP_TOOL_SEPARATOR}"
+    budget = MCP_TOOL_NAME_MAX_LENGTH - len(prefix)
+    if budget <= 0:
+        return sanitized[:MCP_TOOL_NAME_MAX_LENGTH]
+    return f"{prefix}{tool_id[:budget]}"
+
+
+def exposed_tool_names_for(server_id: str, tools: list[MCPToolStatus]) -> list[tuple[str, str]]:
+    """Return ``(raw_name, final_name)`` pairs for one server's tools.
+
+    Final names are unique and match ``^[a-zA-Z0-9_-]{1,64}$``. Dedupe is
+    content-based (hash of the raw name), so names are stable across
+    re-verifications regardless of the order the server lists its tools.
+    """
+    candidates: list[tuple[str, str]] = []
+    for tool in tools:
+        raw = mcp_tool_name(server_id, tool.id)
+        candidates.append((raw, sanitize_mcp_tool_name(raw)))
+    counts: dict[str, int] = {}
+    for _, sanitized in candidates:
+        counts[sanitized] = counts.get(sanitized, 0) + 1
+
+    pairs: list[tuple[str, str]] = []
+    taken: set[str] = set()
+    for raw, sanitized in candidates:
+        final = sanitized
+        if counts[sanitized] > 1:
+            digest = hashlib.sha1(raw.encode("utf-8")).hexdigest()[:8]
+            suffix = f"_{digest}"
+            final = f"{sanitized[: MCP_TOOL_NAME_MAX_LENGTH - len(suffix)]}{suffix}"
+        # Identical raw names (the server listed a tool twice) would collide
+        # even after hashing; disambiguate by position.
+        counter = 2
+        base = final
+        while final in taken:
+            position_suffix = f"_{counter}"
+            final = f"{base[: MCP_TOOL_NAME_MAX_LENGTH - len(position_suffix)]}{position_suffix}"
+            counter += 1
+        taken.add(final)
+        pairs.append((raw, final))
+    return pairs
+
+
+def mcp_tool_name_adjustments(server_id: str, tools: list[MCPToolStatus]) -> list[tuple[str, str]]:
+    """The subset of a server's tool names that changed, as ``(raw, final)`` pairs."""
+    return [(raw, final) for raw, final in exposed_tool_names_for(server_id, tools) if raw != final]
+
+
+def mcp_tool_name_adjustment_note(server_id: str, tools: list[MCPToolStatus]) -> str:
+    """User-visible sentence describing adjusted tool names, or '' when none.
+
+    Example: ``"2 tool names were adjusted for provider compatibility
+    (mcp__docs__get.file → mcp__docs__get_file)."``
+    """
+    adjustments = mcp_tool_name_adjustments(server_id, tools)
+    if not adjustments:
+        return ""
+    examples = ", ".join(f"{raw} → {final}" for raw, final in adjustments[:3])
+    if len(adjustments) > 3:
+        examples += f", and {len(adjustments) - 3} more"
+    count = "tool name was" if len(adjustments) == 1 else "tool names were"
+    return f"{len(adjustments)} {count} adjusted for provider compatibility ({examples})."
 
 
 @contextlib.contextmanager
@@ -274,13 +365,17 @@ def _dedupe_messages(messages: list[str]) -> list[str]:
     return unique
 
 
-def _status_row_message(status: Optional[MCPServerStatus], *, verified: bool, stale: bool) -> str:
+def _status_row_message(
+    server: MCPServerConfig, status: Optional[MCPServerStatus], *, verified: bool, stale: bool
+) -> str:
     if status is None:
         return "Not verified."
     if stale:
         return "Configuration changed since last verification. Verify again."
     if verified:
-        return f"Verified {status.tool_count} tool(s)."
+        message = f"Verified {status.tool_count} tool(s)."
+        note = mcp_tool_name_adjustment_note(server.id, status.tools)
+        return f"{message} {note}" if note else message
     if status.status == "failed":
         return _safe_failed_status_message(status.message)
     return "Not verified."
@@ -334,7 +429,7 @@ class MCPService:
                     if verified
                     else ("stale" if stale else (status.status if status else "unverified")),
                     "tool_count": status.tool_count if verified and status else 0,
-                    "message": _status_row_message(status, verified=verified, stale=stale),
+                    "message": _status_row_message(server, status, verified=verified, stale=stale),
                 }
             )
         return rows
@@ -364,11 +459,16 @@ class MCPService:
                     ) as session:
                         tools = await self._list_all_tools(session)
             tool_statuses = [_tool_status_from_mcp_tool(tool) for tool in tools]
+            note = mcp_tool_name_adjustment_note(server.id, tool_statuses)
+            message = f"Verified {len(tool_statuses)} tool(s)."
+            if note:
+                message = f"{message} {note}"
             status = MCPServerStatus.verified(
                 fingerprint=fingerprint,
                 transport=server.transport,
                 source=server.source,
                 tools=tool_statuses,
+                message=message,
                 oauth=server.oauth.enabled,
             )
             self.status_store.update(server.id, status)

--- a/kolega_code/mcp/tools.py
+++ b/kolega_code/mcp/tools.py
@@ -9,7 +9,7 @@ from kolega_code.agent.tools import ToolExtension
 from kolega_code.llm.models import ToolDefinition
 
 from .config import LoadedMCPConfig, load_mcp_config
-from .service import MCPService
+from .service import MCPExposedTool, MCPService, exposed_tool_names_for, sanitize_mcp_tool_name
 
 
 def build_mcp_tool_extension(
@@ -35,18 +35,31 @@ def build_mcp_tool_extension(
     schemas = {}
     tool_names = []
 
+    # Wire names are sanitized and deduped per server (names embed the server id,
+    # so cross-server collisions are impossible). Dispatch is unaffected: the
+    # callback closure captures the original server/tool ids, so renaming is
+    # model-facing only.
+    exposed_by_server: dict[str, list[MCPExposedTool]] = {}
     for exposed_tool in exposed:
-        tool_name = exposed_tool.name
-        server_id = exposed_tool.server.id
-        tool_id = exposed_tool.tool.id
+        exposed_by_server.setdefault(exposed_tool.server.id, []).append(exposed_tool)
 
-        async def _call_mcp_tool(_server_id=server_id, _tool_id=tool_id, **inputs):
-            return await service.call_tool(_server_id, _tool_id, inputs)
+    for server_id, server_tools in exposed_by_server.items():
+        name_pairs = exposed_tool_names_for(server_id, [exposed_tool.tool for exposed_tool in server_tools])
+        for exposed_tool, (raw_name, tool_name) in zip(server_tools, name_pairs):
+            tool_id = exposed_tool.tool.id
 
-        callbacks[tool_name] = _call_mcp_tool
-        descriptions[tool_name] = exposed_tool.description
-        schemas[tool_name] = exposed_tool.tool.input_schema
-        tool_names.append(tool_name)
+            async def _call_mcp_tool(_server_id=server_id, _tool_id=tool_id, **inputs):
+                return await service.call_tool(_server_id, _tool_id, inputs)
+
+            callbacks[tool_name] = _call_mcp_tool
+            description = exposed_tool.description
+            if raw_name != tool_name:
+                description = (
+                    f"{description}\n\nThe server-side tool name is `{tool_id}`; it is exposed here as `{tool_name}`."
+                )
+            descriptions[tool_name] = description
+            schemas[tool_name] = exposed_tool.tool.input_schema
+            tool_names.append(tool_name)
 
     return ToolExtension(
         name="mcp",
@@ -60,9 +73,13 @@ def build_mcp_tool_extension(
 
 
 def mcp_tool_definition(exposed_tool) -> ToolDefinition:
-    """Build a ToolDefinition for tests and callers that need explicit definitions."""
+    """Build a ToolDefinition for tests and callers that need explicit definitions.
+
+    Uses the sanitized wire name; ``build_mcp_tool_extension`` additionally
+    dedupes collisions per server.
+    """
     return ToolDefinition(
-        name=exposed_tool.name,
+        name=sanitize_mcp_tool_name(exposed_tool.name),
         description=exposed_tool.description,
         parameters=[],
         input_schema=exposed_tool.tool.input_schema,

--- a/tests/agent/llm/test_exceptions.py
+++ b/tests/agent/llm/test_exceptions.py
@@ -23,6 +23,7 @@ from kolega_code.llm.exceptions import (
     LLMTimeout,
     LLMUnprocessableEntityError,
     LLMUnsupportedParamsError,
+    llm_error_message,
     map_to_llm_error,
     map_anthropic_errors,
     map_google_errors,
@@ -293,3 +294,44 @@ def test_map_deepseek_anthropic_api_status_error_insufficient_balance():
     assert isinstance(mapped, LLMBillingError)
     assert mapped.provider == ModelProvider.DEEPSEEK.value
     assert "AnthropicError:" in str(mapped)
+
+
+def test_llm_error_message_surfaces_provider_400_detail() -> None:
+    error = LLMInvalidRequestError(
+        "OpenAI APIError: Error code: 400 - {'error': {'message': \"Invalid 'tools': tool name "
+        "'mcp__docs__get.file' does not match '^[a-zA-Z0-9_-]{1,64}$'\"}}",
+        provider=ModelProvider.OPENAI.value,
+    )
+    message = llm_error_message(error, model="gpt-x")
+    assert message.startswith("OpenAI/gpt-x could not process this request: ")
+    detail = message.split("could not process this request: ", 1)[1]
+    assert "OpenAI APIError:" not in detail
+    assert "Error code: 400" in detail
+    assert "does not match '^[a-zA-Z0-9_-]{1,64}$'" in detail
+
+
+def test_llm_error_message_collapses_and_truncates_long_provider_detail() -> None:
+    error = LLMInvalidRequestError(
+        "OpenAI APIError: Error code: 400 - " + "word " * 500,
+        provider=ModelProvider.OPENAI.value,
+    )
+    message = llm_error_message(error, model="gpt-x")
+    detail = message.split("could not process this request: ", 1)[1]
+    assert detail.endswith("…")
+    assert len(detail) <= 301
+    assert "\n" not in detail
+
+
+def test_llm_error_message_falls_back_to_generic_copy_without_detail() -> None:
+    error = LLMInvalidRequestError("", provider=ModelProvider.OPENAI.value)
+    message = llm_error_message(error, model="gpt-x")
+    assert message == ("OpenAI/gpt-x could not process this request. Check the selected provider/model and try again.")
+
+
+def test_llm_error_message_other_branches_unchanged() -> None:
+    billing = llm_error_message(LLMBillingError("OpenAI APIError: no credits", provider=ModelProvider.OPENAI.value))
+    assert "insufficient balance" in billing
+    context = llm_error_message(
+        LLMContextWindowExceededError("OpenAI APIError: context", provider=ModelProvider.OPENAI.value)
+    )
+    assert "context became too large" in context

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -641,6 +641,47 @@ def test_doctor_uses_stored_kimi_settings(
     assert "moonshot-key" not in output
 
 
+def test_doctor_reports_mcp_tool_name_adjustments(
+    tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
+) -> None:
+    from kolega_code.cli import main as main_module
+    from kolega_code.mcp.config import MCPServerConfig, global_mcp_config_path, server_fingerprint
+    from kolega_code.mcp.state import MCPServerStatus, MCPStatusStore, MCPToolStatus
+
+    project = tmp_path / "project"
+    project.mkdir()
+    state_dir = tmp_path / "state"
+    settings = CliSettings(active_provider=UI_DEFAULT_PROVIDER, active_model=UI_DEFAULT_MODEL)
+    settings.set_api_key(UI_DEFAULT_PROVIDER, "moonshot-key")
+    SettingsStore(state_dir).save(settings)
+    monkeypatch.setattr(main_module, "check_for_update", no_update_result)
+
+    server = MCPServerConfig(id="docs", transport="streamable_http", url="https://docs.example/mcp")
+    global_mcp_config_path(state_dir).parent.mkdir(parents=True, exist_ok=True)
+    global_mcp_config_path(state_dir).write_text(
+        json.dumps({"schema_version": 1, "servers": [server.model_dump(mode="json")]}),
+        encoding="utf-8",
+    )
+    MCPStatusStore(state_dir).update(
+        server.id,
+        MCPServerStatus.verified(
+            fingerprint=server_fingerprint(server),
+            transport=server.transport,
+            source="global",
+            tools=[MCPToolStatus(id="get.file")],
+        ),
+    )
+
+    exit_code = main_module.main(["doctor", "--project", str(project), "--state-dir", str(state_dir)])
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "MCP docs" in output
+    assert "verified" in output
+    assert "mcp__docs__get.file → mcp__docs__get_file" in output
+    assert "mcp list" in output
+
+
 def test_doctor_requires_model_selection_even_with_api_key(
     tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch, isolated_cli_env: None
 ) -> None:

--- a/tests/cli/test_mcp_cli.py
+++ b/tests/cli/test_mcp_cli.py
@@ -9,7 +9,7 @@ from kolega_code.cli.settings import CliSettings, SettingsStore
 from kolega_code.config import ModelProvider
 from kolega_code.mcp.config import MCPServerConfig, global_mcp_config_path, server_fingerprint
 from kolega_code.mcp.service import MCP_FAILURE_MESSAGE_GENERIC
-from kolega_code.mcp.state import MCPServerStatus, MCPStatusStore
+from kolega_code.mcp.state import MCPServerStatus, MCPStatusStore, MCPToolStatus
 
 
 def test_mcp_subcommands_parse() -> None:
@@ -36,6 +36,44 @@ def test_mcp_subcommands_parse() -> None:
     assert args.transport == "streamable_http"
     assert args.stdio_command is None
     assert args.oauth is True
+
+
+def test_mcp_add_rewrites_over_long_server_id_and_remove_accepts_it(tmp_path: Path, capsys) -> None:
+    project = tmp_path / "project"
+    state = tmp_path / "state"
+    project.mkdir()
+    long_id = "x" * 40
+
+    exit_code = main(
+        [
+            "mcp",
+            "--project",
+            str(project),
+            "--state-dir",
+            str(state),
+            "add",
+            long_id,
+            "--transport",
+            "streamable_http",
+            "--url",
+            "https://docs.example/mcp",
+        ]
+    )
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "exceeds 32 characters" in captured.err
+    payload = json.loads(global_mcp_config_path(state).read_text(encoding="utf-8"))
+    saved_id = payload["servers"][0]["id"]
+    assert saved_id != long_id
+    assert len(saved_id) == 32
+
+    # The original long id still addresses the server for removal.
+    exit_code = main(["mcp", "--project", str(project), "--state-dir", str(state), "remove", long_id])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert f"Removed MCP server {saved_id}" in captured.out
+    payload = json.loads(global_mcp_config_path(state).read_text(encoding="utf-8"))
+    assert payload["servers"] == []
 
 
 def test_mcp_add_and_list_use_state_dir(tmp_path: Path, capsys) -> None:
@@ -115,6 +153,100 @@ def test_mcp_list_does_not_print_legacy_failed_status_message(tmp_path: Path, ca
     assert "legacy-secret" not in captured.out
     assert "docs\tglobal\tstreamable_http\tTrue\tFalse\tfailed\t0" in captured.out
     assert MCP_FAILURE_MESSAGE_GENERIC in captured.out
+
+
+def test_mcp_list_message_column_notes_adjusted_tool_names(tmp_path: Path, capsys) -> None:
+    project = tmp_path / "project"
+    state = tmp_path / "state"
+    project.mkdir()
+    server = MCPServerConfig(id="docs", transport="streamable_http", url="https://docs.example/mcp")
+
+    exit_code = main(
+        [
+            "mcp",
+            "--project",
+            str(project),
+            "--state-dir",
+            str(state),
+            "add",
+            server.id,
+            "--transport",
+            server.transport,
+            "--url",
+            server.url or "",
+        ]
+    )
+    assert exit_code == 0
+    MCPStatusStore(state).update(
+        server.id,
+        MCPServerStatus.verified(
+            fingerprint=server_fingerprint(server),
+            transport=server.transport,
+            source="global",
+            tools=[MCPToolStatus(id="get.file")],
+        ),
+    )
+
+    exit_code = main(["mcp", "--project", str(project), "--state-dir", str(state), "list"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert (
+        "Verified 1 tool(s). 1 tool name was adjusted for provider compatibility "
+        "(mcp__docs__get.file → mcp__docs__get_file)." in captured.out
+    )
+
+
+def test_mcp_verify_cli_prints_adjusted_tool_names(tmp_path: Path, capsys, monkeypatch) -> None:
+    project = tmp_path / "project"
+    state = tmp_path / "state"
+    project.mkdir()
+    server = MCPServerConfig(id="docs", transport="streamable_http", url="https://docs.example/mcp")
+
+    exit_code = main(
+        [
+            "mcp",
+            "--project",
+            str(project),
+            "--state-dir",
+            str(state),
+            "add",
+            server.id,
+            "--transport",
+            server.transport,
+            "--url",
+            server.url or "",
+        ]
+    )
+    assert exit_code == 0
+
+    class FakeTool:
+        name = "get.file"
+        title = None
+        description = "Get a file"
+        input_schema = {"type": "object", "properties": {}}
+
+    class FakeSession:
+        async def list_tools(self, params=None):
+            return type("Result", (), {"tools": [FakeTool()], "next_cursor": None})()
+
+    class FakeSessionContext:
+        async def __aenter__(self):
+            return FakeSession()
+
+        async def __aexit__(self, *args):
+            return False
+
+    monkeypatch.setattr("kolega_code.mcp.service.open_mcp_session", lambda *a, **k: FakeSessionContext())
+
+    exit_code = main(["mcp", "--project", str(project), "--state-dir", str(state), "verify", server.id])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert (
+        "✓ docs: Verified 1 tool(s). 1 tool name was adjusted for provider compatibility "
+        "(mcp__docs__get.file → mcp__docs__get_file)." in captured.out
+    )
 
 
 def test_build_agent_config_loads_trusted_project_mcp(tmp_path: Path, monkeypatch, isolated_cli_env) -> None:

--- a/tests/mcp/test_config_state_tools.py
+++ b/tests/mcp/test_config_state_tools.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from pathlib import Path
 
 import pytest
@@ -12,9 +13,17 @@ from kolega_code.mcp.config import (
     global_mcp_config_path,
     load_mcp_config,
     mcp_secret_values,
+    sanitize_mcp_server_id,
     server_fingerprint,
 )
-from kolega_code.mcp.service import MCPService, mcp_tool_name
+from kolega_code.mcp.service import (
+    MCPService,
+    exposed_tool_names_for,
+    mcp_tool_name,
+    mcp_tool_name_adjustment_note,
+    mcp_tool_name_adjustments,
+    sanitize_mcp_tool_name,
+)
 from kolega_code.mcp.state import MCPServerStatus, MCPStatusStore, MCPToolStatus, MCPOAuthTokenStore
 from kolega_code.mcp.tools import build_mcp_tool_extension
 
@@ -64,6 +73,45 @@ def test_load_mcp_config_merges_global_and_trusted_project(tmp_path: Path) -> No
     assert trusted.servers["shared"].source == "project"
     assert trusted.servers["project"].command == "python"
     assert mcp_secret_values(trusted) == ["Bearer global-secret"]
+
+
+def test_sanitize_mcp_server_id_rewrites_over_long_ids_deterministically() -> None:
+    long_id = "x" * 40
+    rewritten = sanitize_mcp_server_id(long_id)
+    assert len(rewritten) == 32
+    assert rewritten.startswith("x" * 24)
+    assert rewritten != long_id
+    assert sanitize_mcp_server_id(long_id) == rewritten  # deterministic
+    # Distinct long ids sharing a prefix stay distinct.
+    other_long = "x" * 24 + "y" * 16
+    assert sanitize_mcp_server_id(other_long) != rewritten
+    # Within the limit: unchanged, including whitespace trimming.
+    assert sanitize_mcp_server_id("short-id") == "short-id"
+    assert sanitize_mcp_server_id("  short-id  ") == "short-id"
+    # Invalid characters and empty ids still raise.
+    with pytest.raises(ValueError):
+        sanitize_mcp_server_id("bad.id")
+    with pytest.raises(ValueError):
+        sanitize_mcp_server_id("")
+
+
+def test_load_mcp_config_rewrites_over_long_server_ids_with_diagnostic(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    project = tmp_path / "project"
+    project.mkdir()
+    long_id = "x" * 40
+    _write_json(
+        global_mcp_config_path(state_dir),
+        {
+            "schema_version": 1,
+            "servers": [{"id": long_id, "transport": "streamable_http", "url": "https://docs.example/mcp"}],
+        },
+    )
+
+    config = load_mcp_config(project, state_dir, project_trusted=False)
+    rewritten = sanitize_mcp_server_id(long_id)
+    assert set(config.servers) == {rewritten}
+    assert any("exceeds 32 characters" in diagnostic and long_id in diagnostic for diagnostic in config.diagnostics)
 
 
 def test_server_fingerprint_ignores_enabled_and_source_but_not_connection_details() -> None:
@@ -157,3 +205,144 @@ async def test_build_mcp_tool_extension_exposes_verified_tools_and_uses_schema(t
 
     assert await extension.tools[name](query="kolega") == "ok"
     assert calls == [("docs", "search", {"query": "kolega"})]
+
+
+def test_sanitize_mcp_tool_name_maps_invalid_chars_and_preserves_prefix() -> None:
+    assert sanitize_mcp_tool_name("mcp__docs__search") == "mcp__docs__search"
+    assert sanitize_mcp_tool_name("mcp__docs__get.file/path") == "mcp__docs__get_file_path"
+    assert sanitize_mcp_tool_name("mcp__docs__naïve tool") == "mcp__docs__na_ve_tool"
+
+
+def test_sanitize_mcp_tool_name_clamps_to_64_preserving_server_prefix() -> None:
+    name = sanitize_mcp_tool_name(mcp_tool_name("docs", "x" * 200))
+    assert len(name) == 64
+    assert name.startswith("mcp__docs__")
+    assert re.fullmatch(r"[a-zA-Z0-9_-]{1,64}", name) is not None
+
+
+def test_sanitize_mcp_tool_name_truncates_whole_name_when_server_id_exhausts_budget() -> None:
+    name = sanitize_mcp_tool_name(mcp_tool_name("s" * 100, "tool"))
+    assert len(name) == 64
+    assert name.startswith("mcp__")
+    assert re.fullmatch(r"[a-zA-Z0-9_-]{1,64}", name) is not None
+
+
+def test_exposed_tool_names_for_dedupes_collisions_deterministically() -> None:
+    tools = [
+        MCPToolStatus(id="get.file"),
+        MCPToolStatus(id="get_file"),
+        MCPToolStatus(id="get.file"),
+    ]
+    first = exposed_tool_names_for("docs", tools)
+    second = exposed_tool_names_for("docs", tools)
+    assert first == second
+
+    finals = [final for _, final in first]
+    assert len(finals) == len(set(finals)) == 3
+    for final in finals:
+        assert re.fullmatch(r"[a-zA-Z0-9_-]{1,64}", final) is not None
+    # The two distinct raw names hash differently, so their collision suffixes differ.
+    assert finals[0] != finals[1]
+    assert finals[0] != finals[2]  # raw duplicate falls back to the positional suffix
+
+    raws = [raw for raw, _ in first]
+    assert raws[0] == raws[2] == mcp_tool_name("docs", "get.file")
+    assert raws[1] == mcp_tool_name("docs", "get_file")
+
+
+def test_mcp_tool_name_adjustments_and_note() -> None:
+    tools = [MCPToolStatus(id="search"), MCPToolStatus(id="get.file")]
+    assert mcp_tool_name_adjustments("docs", tools) == [
+        (mcp_tool_name("docs", "get.file"), mcp_tool_name("docs", "get_file"))
+    ]
+    note = mcp_tool_name_adjustment_note("docs", tools)
+    assert "1 tool name was adjusted for provider compatibility" in note
+    assert "mcp__docs__get.file → mcp__docs__get_file" in note
+    assert mcp_tool_name_adjustment_note("docs", [MCPToolStatus(id="search")]) == ""
+
+
+@pytest.mark.asyncio
+async def test_build_mcp_tool_extension_sanitizes_and_dedupes_invalid_tool_names(tmp_path: Path, monkeypatch) -> None:
+    state_dir = tmp_path / "state"
+    project = tmp_path / "project"
+    project.mkdir()
+    server = MCPServerConfig(id="docs", transport="streamable_http", url="https://docs.example/mcp")
+    _write_json(global_mcp_config_path(state_dir), MCPConfigFile(servers=[server]).to_file_dict())
+    config = load_mcp_config(project, state_dir, project_trusted=False)
+    tool_statuses = [
+        MCPToolStatus(id="get.file", description="Get a file", input_schema={"type": "object"}),
+        MCPToolStatus(id="get_file", description="Get a file (underscore)", input_schema={"type": "object"}),
+        MCPToolStatus(id="x" * 200, description="Long name", input_schema={"type": "object"}),
+    ]
+    MCPStatusStore(state_dir).update(
+        "docs",
+        MCPServerStatus.verified(
+            fingerprint=server_fingerprint(config.servers["docs"]),
+            transport="streamable_http",
+            source="global",
+            tools=tool_statuses,
+        ),
+    )
+
+    calls = []
+
+    async def fake_call_tool(self, server_id: str, tool_id: str, arguments: dict):
+        calls.append((server_id, tool_id, arguments))
+        return "ok"
+
+    monkeypatch.setattr(MCPService, "call_tool", fake_call_tool)
+
+    extension = build_mcp_tool_extension(project, state_dir, project_trusted=False)
+    assert extension is not None
+    names = list(extension.tools)
+    assert len(names) == len(set(names)) == 3
+    for name in names:
+        assert re.fullmatch(r"[a-zA-Z0-9_-]{1,64}", name) is not None
+    # Every exposed name routes back to its original server/tool ids.
+    for name in names:
+        assert await extension.tools[name]() == "ok"
+    assert {call[1] for call in calls} == {"get.file", "get_file", "x" * 200}
+    # Renamed tools tell the model the server-side name.
+    assert any("The server-side tool name is `get.file`" in desc for desc in extension.tool_descriptions.values())
+    assert any("The server-side tool name is `get_file`" in desc for desc in extension.tool_descriptions.values())
+    assert any(
+        "The server-side tool name is `" + "x" * 200 + "`" in desc for desc in extension.tool_descriptions.values()
+    )
+
+
+@pytest.mark.asyncio
+async def test_verify_server_message_notes_adjusted_tool_names(tmp_path: Path, monkeypatch) -> None:
+    state_dir = tmp_path / "state"
+    project = tmp_path / "project"
+    project.mkdir()
+    server = MCPServerConfig(id="docs", transport="streamable_http", url="https://docs.example/mcp")
+    _write_json(global_mcp_config_path(state_dir), MCPConfigFile(servers=[server]).to_file_dict())
+    config = load_mcp_config(project, state_dir, project_trusted=False)
+    service = MCPService(config, state_dir=state_dir, project_path=project)
+
+    class FakeTool:
+        name = "get.file"
+        title = None
+        description = "Get a file"
+        input_schema = {"type": "object", "properties": {}}
+
+    class FakeSession:
+        async def list_tools(self, params=None):
+            return type("Result", (), {"tools": [FakeTool()], "next_cursor": None})()
+
+    class FakeSessionContext:
+        async def __aenter__(self):
+            return FakeSession()
+
+        async def __aexit__(self, *args):
+            return False
+
+    monkeypatch.setattr("kolega_code.mcp.service.open_mcp_session", lambda *a, **k: FakeSessionContext())
+
+    result = await service.verify_server(server.id, interactive_oauth=False, open_browser=False)
+    assert result.ok
+    assert "Verified 1 tool(s)." in result.message
+    assert (
+        "1 tool name was adjusted for provider compatibility (mcp__docs__get.file → mcp__docs__get_file)."
+        in result.message
+    )


### PR DESCRIPTION
## Problem

MCP tool names passed through verbatim (`mcp__{server}__{tool_id}`), so one server exposing tool ids with invalid characters (dots, slashes, unicode) or names over the provider length limit made **every** provider reject the whole request with a 400. The user only saw the generic "could not process this request" copy; the real cause appeared only in the diagnostics JSONL (`llm_error`). Closes #581.

## Changes

- **Sanitize tool names at collection time** (`kolega_code/mcp/service.py`, `kolega_code/mcp/tools.py`): invalid chars map to `_`, the composed name clamps to 64 chars (OpenAI/Google's strictest limit; Anthropic allows 128), and collisions (e.g. `a.b` vs `a_b`) dedupe deterministically via a content hash of the raw name, so names stay stable across re-verifications. The `mcp__{server}__` prefix is preserved where possible. Dispatch is unaffected — callbacks still capture the original server/tool ids.
- **Rewrite over-long server ids instead of failing** (`kolega_code/mcp/config.py`): ids over 32 chars are deterministically rewritten as `{first 24 chars}_{7-char hash}` so existing config files keep loading, distinct long ids stay distinct, and every tool name keeps at least 25 chars of budget. A diagnostic notes the rename, `mcp add` prints the rewrite to stderr, and `mcp verify`/`remove`/`enable`/`disable` still accept the original long id.
- **Surface the provider's raw 400 detail in the turn error** (`kolega_code/llm/exceptions.py`): 400-class failures now read e.g. `OpenAI/gpt-x could not process this request: Error code: 400 - ... does not match '^[a-zA-Z0-9_-]{1,64}$' ...` (prefix stripped, whitespace collapsed, capped at 300 chars).
- **Make renames visible**: verification messages (`mcp verify` output, TUI verify toast, settings status row), the `mcp list` MESSAGE column, agent-startup warnings (CLI stderr and TUI log pane), a note appended to renamed tools' model-facing descriptions with the server-side name, and a new offline MCP section in `kolega-code doctor` that warns about adjusted names and points to `mcp list`.

## Compatibility note

Wire names change only for tools whose raw name was invalid or over 64 chars; valid short names are byte-identical. Exact-tool permission rules previously created against a raw invalid name (e.g. `mcp__srv__a.b`) will no longer match, so affected users get a one-time re-prompt for those tools. Servers with over-long ids are renamed deterministically (a diagnostic says so), and their previous verification state is keyed under the old id, so those servers need a one-time re-verify.

## Tests

New coverage in `tests/mcp/test_config_state_tools.py`, `tests/agent/llm/test_exceptions.py`, `tests/cli/test_mcp_cli.py`, and `tests/cli/test_main.py` for tool-name sanitization and dedupe, server-id rewriting (including `mcp add`/`remove` round-trip with the original long id), dispatch routing to original tool ids, verify/list/doctor warning output, and the enriched turn-error copy. Also stabilizes `test_flush_pacing_stretches_terminal_flush_under_loop_load`: it asserted a 0.5s Textual timer (real wall-clock) hadn't fired after a 0.1s real-time pause, which races on loaded CI runners; the timer is now stopped before the idle wait so the check is deterministic without losing coverage. All pre-commit hooks and repo-wide pyright pass.
