### PR TITLE
test(cli): stabilize flush-pacing test against wall-clock timer race

### DIFF
--- a/tests/cli/test_app_rendering_terminal_logs.py
+++ b/tests/cli/test_app_rendering_terminal_logs.py
@@ -874,8 +874,15 @@ async def test_flush_pacing_stretches_terminal_flush_under_loop_load(
         app._queue_terminal_output("paced output\n")
         assert app._terminal_flush_timer is not None
         assert app._terminal_flush_timer._interval == pacing.PACING_CEILING
+        # Queueing never flushes synchronously: the only drain path in an idle app
+        # is the armed ceiling timer (0.5s), not the healthy base cadence.
+        assert app._terminal_output_buffer == ["paced output\n"]
+
+        # Stop the timer so a real-time pause can never race its firing on a loaded
+        # runner (a 0.1s sleep stretched past the 0.5s ceiling would otherwise
+        # drain the buffer); still verify nothing else flushes during an idle wait.
+        app._terminal_flush_timer.stop()
         await pilot.pause(0.1)
-        # At the healthy cadence this would already have flushed.
         assert app._terminal_output_buffer == ["paced output\n"]
 
         app._flush_terminal_output()  # forced drains bypass pacing


### PR DESCRIPTION
## Problem

`tests/cli/test_app_rendering_terminal_logs.py::test_flush_pacing_stretches_terminal_flush_under_loop_load` failed on CI for PR #590:

```
assert [] == ['paced output\n']
```

The test asserted that a 0.5s ceiling-pacing timer had not fired after a 0.1s real-time pause. Textual timers run on real monotonic time, so on a loaded CI runner a stretched pause can overshoot the ceiling — the timer legitimately fires, drains the buffer, and the assertion fails. Not a product regression; a wall-clock assumption in the test.

## Fix

Keep the same coverage, drop the wall-clock assumption:

- Assert the buffer is intact **immediately** after `_queue_terminal_output` (queueing never flushes synchronously; the only drain path in an idle app is the armed timer, whose interval is asserted to be `PACING_CEILING`).
- Stop the armed timer before the idle `pilot.pause(0.1)` so no real-time overshoot can race its firing, and still verify nothing else drains the buffer during the wait.
- Forced `_flush_terminal_output()` drain assertion unchanged.

The test still catches real regressions: a synchronous flush on queue, a wrong timer interval, or any other code path draining the buffer during an idle wait.

Verified: 10 consecutive runs of the test plus the full `test_app_rendering_terminal_logs.py` module (27 tests) pass locally; the failure was not reproducible locally even under all-core CPU stress (macOS keeps the pause short), consistent with a heavily loaded CI runner.
