### PR TITLE
feat(cli): accept a planning prompt after /plan

### DIFF
--- a/docs/src/content/docs/tui/composer.md
+++ b/docs/src/content/docs/tui/composer.md
@@ -87,7 +87,7 @@ commands with descriptions:
 ```text
 /model        Show or switch the active model
 /effort       Show or set the active thinking effort
-/plan         Switch to plan mode
+/plan         Switch to plan mode, optionally with a planning prompt
 /context      Show current context token count
 ```
 

--- a/docs/src/content/docs/tui/modes.md
+++ b/docs/src/content/docs/tui/modes.md
@@ -69,6 +69,7 @@ read-only too.
 
 You don't have to use the keyboard shortcut — the
 [slash commands](../slash-commands/) `/plan` and `/build` switch modes too.
+`/plan <task>` switches to Plan mode and starts planning that task in one step.
 
 :::note
 All CLI sessions — including resumed ones — use the CLI-specific coding-agent

--- a/docs/src/content/docs/tui/slash-commands.md
+++ b/docs/src/content/docs/tui/slash-commands.md
@@ -37,7 +37,7 @@ These control the app and your session.
 | `/init` | Create or update `AGENTS.md` for this repository |
 | `/attach` | Attach an image: clipboard if no path, or `/attach <path>` for a file |
 | `/detach` | Remove pending image attachments |
-| `/plan` | Switch to [Plan mode](../modes/) |
+| `/plan` | Switch to [Plan mode](../modes/), optionally with a planning prompt (`/plan <task>`) |
 | `/build` | Switch to [Build mode](../modes/) |
 | `/sidebar` | Show or hide the side panel |
 | `/settings` | Open the full-screen Settings editor |

--- a/kolega_code/cli/slash_commands.py
+++ b/kolega_code/cli/slash_commands.py
@@ -52,7 +52,7 @@ TUI_COMMAND_ENTRIES: tuple[SlashCommandEntry, ...] = (
     ),
     SlashCommandEntry("detach", "Remove pending image attachments", CommandScope.TUI),
     SlashCommandEntry("init", "Create or update AGENTS.md for this repository", CommandScope.TUI),
-    SlashCommandEntry("plan", "Switch to plan mode", CommandScope.TUI),
+    SlashCommandEntry("plan", "Switch to plan mode, optionally with a planning prompt", CommandScope.TUI),
     SlashCommandEntry("build", "Switch to build mode", CommandScope.TUI),
     SlashCommandEntry("sidebar", "Show or hide the side panel", CommandScope.TUI),
     SlashCommandEntry("settings", "Open Settings", CommandScope.TUI),

--- a/kolega_code/cli/tui/command_handlers.py
+++ b/kolega_code/cli/tui/command_handlers.py
@@ -220,6 +220,20 @@ class CommandHandlersMixin(tui_app_base.KolegaAppBase):
         if self._mode_switch_blocked():
             return
         await self._set_interaction_mode(tui_constants.PLAN_INTERACTION_MODE)
+        prompt = args.strip()
+        if not prompt:
+            return
+        if self.agent is None:
+            self._set_settings_status(messages.SETTINGS_REQUIRED, tone="warning")
+            return
+        attachments = self._build_mention_attachments(prompt)
+        self._add_conversation_entry(tui_state.ConversationEntry(kind="user", content=prompt))
+        self.agent_worker = self.run_worker(
+            self._process_message(prompt, attachments),
+            name="kolega-turn",
+            group="turns",
+            exclusive=True,
+        )
 
     async def _command_build(self, args: str) -> None:
         if self._mode_switch_blocked():

--- a/tests/cli/test_app_navigation_commands.py
+++ b/tests/cli/test_app_navigation_commands.py
@@ -82,6 +82,118 @@ async def test_textual_app_plan_and_build_slash_commands_switch_mode(
 
 
 @pytest.mark.asyncio
+async def test_textual_app_plan_slash_command_starts_turn_with_trailing_prompt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    class FakePlanningAgent(FakeCoderAgent):
+        pass
+
+    install_fake_agents(monkeypatch, planning_cls=FakePlanningAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    prompt = "Plan adding a /auth/me endpoint"
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        composer.load_text(f"/plan {prompt}")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+        await pilot.pause()
+
+        assert app.interaction_mode == "plan"
+        assert isinstance(app.agent, FakePlanningAgent)
+        assert composer.text == ""
+        assert app.agent.messages == [prompt]
+        assert any(entry.kind == "user" and entry.content == prompt for entry in app.conversation_entries)
+        assert not any(entry.kind == "user" and "/plan" in entry.content for entry in app.conversation_entries)
+
+
+@pytest.mark.asyncio
+async def test_textual_app_plan_slash_command_starts_turn_when_already_in_plan_mode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    class FakePlanningAgent(FakeCoderAgent):
+        pass
+
+    install_fake_agents(monkeypatch, planning_cls=FakePlanningAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    prompt = "refine the auth approach"
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        composer.load_text("/plan")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+        assert app.interaction_mode == "plan"
+        assert isinstance(app.agent, FakePlanningAgent)
+        assert app.agent.messages == []
+
+        composer.load_text(f"/plan {prompt}")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+        await pilot.pause()
+
+        assert app.interaction_mode == "plan"
+        assert isinstance(app.agent, FakePlanningAgent)
+        assert app.agent.messages == [prompt]
+        assert any(entry.kind == "user" and entry.content == prompt for entry in app.conversation_entries)
+
+
+@pytest.mark.asyncio
+async def test_textual_app_plan_slash_command_blocks_during_active_turn(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from textual.widgets import Static
+
+    from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    class FakePlanningAgent(FakeCoderAgent):
+        pass
+
+    install_fake_agents(monkeypatch, planning_cls=FakePlanningAgent)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test():
+        composer = app.query_one("#composer", ChatComposer)
+        app._turn_active = True
+        composer.load_text("/plan do a thing")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+
+        assert app.interaction_mode == "build"
+        assert isinstance(app.agent, FakeCoderAgent)
+        assert app.agent.messages == []
+        assert "Stop the current turn before switching modes." in str(app.query_one("#composer_hint", Static).render())
+        app._turn_active = False
+
+
+@pytest.mark.asyncio
 async def test_textual_app_sidebar_slash_command_toggles_sidebar(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

`/plan` no longer discards trailing text. Bare `/plan` still only switches to plan mode. `/plan <task>` switches (if needed) and starts a planning turn whose user message is that trailing text.

Fixes #582.

## Behavior

- `/plan` — mode switch only (unchanged)
- `/plan Plan adding a /auth/me endpoint` — enter plan mode and start that planning turn
- Already in plan mode + `/plan refine the auth approach` — start the turn on the current planning agent
- Blocked the same way a mode switch is today (active turn, pending approval, plan-decision UI)
- Transcript and agent history get the prompt text, not `/plan …`

## Test plan

- [x] `./run_tests.sh tests/cli/test_app_navigation_commands.py tests/cli/test_slash_commands.py tests/cli/test_app_slash_dropdown.py -ra` (22 passed)
- [ ] In the TUI: `/plan` still switches with no turn
- [ ] `/plan add an /auth/me endpoint` switches and starts planning
- [ ] Same command while already in plan mode starts another planning turn
- [ ] `/plan do a thing` during an active turn is blocked