### PR TITLE
chore: remove pointless comments

### DIFF
--- a/kolega_code/agent/tool_backend/agent_tool.py
+++ b/kolega_code/agent/tool_backend/agent_tool.py
@@ -399,7 +399,7 @@ class AgentTool(BaseTool):
                 agent.session_recorder = scoped_recorder
 
             # Track messages and their sequence
-            last_saved_index = -1  # Track what we've already saved
+            last_saved_index = -1
             streamed_messages = {}  # Track messages by UUID for assembly
 
             # Process the task and stream messages

--- a/kolega_code/agent/tools.py
+++ b/kolega_code/agent/tools.py
@@ -302,16 +302,13 @@ class ToolCollection(LogMixin):
         self.workspace_id = workspace_id
         self.thread_id = thread_id
 
-        # Convert string path to Path object if needed
         self.project_path = Path(project_path) if isinstance(project_path, str) else project_path
 
-        # Create filesystem instance if not provided
         if filesystem is None:
             self.filesystem = LocalFileSystem(root_path=self.project_path)
         else:
             self.filesystem = filesystem
 
-        # Create terminal manager instance if not provided
         if terminal_manager is None:
             self.terminal_manager = LocalTerminalManager(
                 workspace_id, thread_id, connection_manager, default_workdir=self.project_path
@@ -319,7 +316,6 @@ class ToolCollection(LogMixin):
         else:
             self.terminal_manager = terminal_manager
 
-        # Create browser manager instance if not provided
         if browser_manager is None:
             self.browser_manager = PlaywrightBrowserManager()
         else:
@@ -388,7 +384,6 @@ class ToolCollection(LogMixin):
         }
         self.tool_exclusions.extend(tool_config.tool_exclusions)
 
-        # Initialize tool backends
         self._initialize_tools()
         self._register_tool_extensions()
 
@@ -619,7 +614,6 @@ class ToolCollection(LogMixin):
             browser_manager=self.browser_manager,
         )
 
-        # Build tool
         self.build_tool = BuildTool(
             self.project_path,
             self.workspace_id,

--- a/kolega_code/cli/theme.py
+++ b/kolega_code/cli/theme.py
@@ -36,24 +36,24 @@ class Color:
 class Glyph:
     """Unicode glyphs used in the UI. Use g() to apply ASCII fallbacks."""
 
-    USER = "❯"  # ❯
-    AGENT = "●"  # ●
-    STATUS = "●"  # ●
-    TOOL = "⏺"  # ⏺
-    SUB_AGENT = "◆"  # ◆
-    PLAN = "◆"  # ◆
+    USER = "❯"
+    AGENT = "●"
+    STATUS = "●"
+    TOOL = "⏺"
+    SUB_AGENT = "◆"
+    PLAN = "◆"
     QUESTION = "?"
-    INSET_BAR = "│"  # │
-    INSET_ELBOW = "└"  # └
-    ELLIPSIS = "…"  # …
-    BULLET_SEP = "·"  # ·
-    BAR_FILLED = "█"  # █
-    BAR_EMPTY = "░"  # ░
-    CHECK = "✓"  # ✓
-    CROSS = "✗"  # ✗
-    DOWN = "↓"  # ↓
-    PENDING = "○"  # ○ — phase not started
-    RUNNING = "▶"  # ▶ — phase in progress
+    INSET_BAR = "│"
+    INSET_ELBOW = "└"
+    ELLIPSIS = "…"
+    BULLET_SEP = "·"
+    BAR_FILLED = "█"
+    BAR_EMPTY = "░"
+    CHECK = "✓"
+    CROSS = "✗"
+    DOWN = "↓"
+    PENDING = "○"  # phase not started
+    RUNNING = "▶"  # phase in progress
 
 
 ASCII_FALLBACKS = {
@@ -74,7 +74,7 @@ ASCII_FALLBACKS = {
     Glyph.RUNNING: ">",
 }
 
-SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"  # ⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏
+SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 SPINNER_FRAMES_ASCII = "|/-\\"
 SPINNER_INTERVAL = 0.25
 

--- a/kolega_code/llm/models.py
+++ b/kolega_code/llm/models.py
@@ -1569,8 +1569,6 @@ class Message:
             if thinking is not None:
                 usage_metadata["reasoning_output_tokens"] = thinking
 
-        # print(f"Stop reason: {message.stop_reason if hasattr(message, 'stop_reason') else ''}")
-
         return cls(
             role=message.role,
             content=content_blocks,
@@ -1844,7 +1842,7 @@ class Message:
         """Deserializes a Message object from a dictionary."""
         deserialized_content: Union[str, List[ContentBlock]]
         raw_content = data.get("content")
-        tool_calls = []  # Initialize tool_calls
+        tool_calls = []
 
         if isinstance(raw_content, str):
             deserialized_content = raw_content

--- a/kolega_code/llm/providers/anthropic.py
+++ b/kolega_code/llm/providers/anthropic.py
@@ -28,8 +28,8 @@ class AnthropicStreamWrapper:
         # Track tool calls being streamed
         self.tool_execution_ids = ToolExecutionIdRegistry()
         self.current_tool_calls = {}  # Maps tool_call_id to accumulated data
-        self.tool_call_order = []  # Track order of tool calls
-        self.current_block_index = None  # Track which content block we're processing
+        self.tool_call_order = []
+        self.current_block_index = None
 
     async def __aenter__(self):
         self.generator = await self.anthropic_stream.__aenter__()
@@ -145,8 +145,8 @@ class AnthropicProvider(BaseLLMProvider):
     def _prepare_generation_params(self, params: Optional[GenerationParams] = None) -> Dict[str, Any]:
         """Convert common parameters to provider-specific format"""
         generation_params = {
-            "model": "claude-opus-5",  # Default model
-            "max_tokens": 1024,  # Default max tokens
+            "model": "claude-opus-5",
+            "max_tokens": 1024,
         }
 
         if params:

--- a/kolega_code/llm/providers/openai.py
+++ b/kolega_code/llm/providers/openai.py
@@ -324,7 +324,7 @@ class OpenAIProvider(BaseLLMProvider):
     def _prepare_generation_params(self, params: Optional[GenerationParams] = None) -> Dict[str, Any]:
         """Convert common parameters to provider-specific format"""
         generation_params: Dict[str, Any] = {
-            "model": "gpt-5.5",  # Default model
+            "model": "gpt-5.5",
         }
 
         if params:

--- a/kolega_code/sandbox/async_filesystem.py
+++ b/kolega_code/sandbox/async_filesystem.py
@@ -159,7 +159,6 @@ class AsyncSandboxFileSystem(FileSystem):
                 # to avoid E2B files API text encoding issues
                 encoded_content = base64.b64encode(content).decode("ascii")
 
-                # Write the base64 encoded content and decode it
                 result = await self.sandbox.commands.run(f"echo '{encoded_content}' | base64 -d > {full_path}")
 
                 if result.exit_code != 0:
@@ -382,7 +381,6 @@ class AsyncSandboxFileSystem(FileSystem):
         try:
 
             async def _glob():
-                # Handle different types of glob patterns
                 if pattern.startswith("**/"):
                     # Recursive pattern like **/*.py or **/*
                     remaining_pattern = pattern[3:]  # Remove '**/'
@@ -427,7 +425,6 @@ class AsyncSandboxFileSystem(FileSystem):
                     else:
                         return []
 
-                # Process the result
                 if result.exit_code == 0 and result.stdout.strip():
                     paths = [line.strip() for line in result.stdout.strip().split("\n") if line.strip()]
                     # Filter out empty strings and current directory

--- a/kolega_code/sandbox/filesystem.py
+++ b/kolega_code/sandbox/filesystem.py
@@ -90,7 +90,6 @@ class SandboxFileSystem(FileSystem):
             # to avoid E2B files API text encoding issues
             encoded_content = base64.b64encode(content).decode("ascii")
 
-            # Write the base64 encoded content and decode it
             result = self.sandbox.commands.run(f"echo '{encoded_content}' | base64 -d > {full_path}")
 
             if result.exit_code != 0:
@@ -249,7 +248,6 @@ class SandboxFileSystem(FileSystem):
     def glob(self, pattern: str) -> List[str]:
         """Find paths matching pattern."""
         try:
-            # Handle different types of glob patterns
             if pattern.startswith("**/"):
                 # Recursive pattern like **/*.py or **/*
                 remaining_pattern = pattern[3:]  # Remove '**/'
@@ -294,7 +292,6 @@ class SandboxFileSystem(FileSystem):
                 else:
                     return []
 
-            # Process the result
             if result.exit_code == 0 and result.stdout.strip():
                 paths = [line.strip() for line in result.stdout.strip().split("\n") if line.strip()]
                 # Filter out empty strings and current directory

--- a/kolega_code/sandbox/serializer.py
+++ b/kolega_code/sandbox/serializer.py
@@ -16,7 +16,6 @@ class TerminalStateSerializer:
         if not hasattr(terminal_manager, "terminals"):
             return state  # Can't serialize local terminal managers
 
-        # Serialize terminals
         for terminal_id, info in terminal_manager.terminals.items():
             state.terminals[terminal_id] = TerminalInfo(
                 terminal_id=terminal_id,
@@ -44,12 +43,10 @@ class TerminalStateSerializer:
                 )
                 output_size = len(output["data"].encode("utf-8"))
 
-                # Check if adding this output would exceed limits
                 if (
                     terminal_size + output_size > state.MAX_OUTPUT_PER_TERMINAL
                     or total_size + output_size > state.MAX_OUTPUT_SIZE
                 ):
-                    # Add truncation notice at the beginning
                     if not any(o.type == "truncation" for o in terminal_outputs):
                         terminal_outputs.insert(
                             0,
@@ -63,13 +60,12 @@ class TerminalStateSerializer:
                         )
                     break
 
-                terminal_outputs.insert(0, terminal_output)  # Insert at beginning to maintain order
+                terminal_outputs.insert(0, terminal_output)
                 terminal_size += output_size
                 total_size += output_size
 
             state.outputs[terminal_id] = terminal_outputs
 
-            # Break if we've hit total size limit
             if total_size >= state.MAX_OUTPUT_SIZE:
                 break
 
@@ -84,11 +80,9 @@ class TerminalStateSerializer:
         if not state or not hasattr(terminal_manager, "terminals"):
             return
 
-        # Clear existing state
         terminal_manager.terminals.clear()
         terminal_manager.outputs.clear()
 
-        # Restore terminals
         for terminal_id, terminal_info in state.terminals.items():
             terminal_manager.terminals[terminal_id] = {
                 "created_at": terminal_info.created_at,
@@ -100,7 +94,6 @@ class TerminalStateSerializer:
                 "active_commands": {},  # Active commands start fresh
             }
 
-        # Restore outputs
         for terminal_id, outputs in state.outputs.items():
             restored_outputs = [
                 {
@@ -111,12 +104,11 @@ class TerminalStateSerializer:
                     "exit_code": output.exit_code,
                 }
                 for output in outputs
-                if output.type != "truncation"  # Skip truncation notices
+                if output.type != "truncation"
             ]
             output_buffer_type = getattr(type(terminal_manager), "output_buffer_type", list)
             terminal_manager.outputs[terminal_id] = output_buffer_type(restored_outputs)
 
-        # Restore default terminal ID
         if hasattr(terminal_manager, "_default_terminal_id"):
             terminal_manager._default_terminal_id = state.default_terminal_id
 
@@ -139,8 +131,8 @@ class TerminalStateSerializer:
                 elif output.type == "exit":
                     content += f"{output.data}\n"
 
-            if content:  # Only add tabs with content
-                terminal_tabs.append({"id": terminal_id, "content": content.rstrip()})  # Remove trailing whitespace
+            if content:
+                terminal_tabs.append({"id": terminal_id, "content": content.rstrip()})
 
         return {"terminals": terminal_tabs}
 
@@ -153,7 +145,6 @@ class TerminalStateSerializer:
         recent_outputs = []
         line_count = 0
 
-        # Process outputs in reverse order
         for output in reversed(outputs):
             if output["type"] in ["stdout", "stderr"]:
                 lines = output["data"].count("\n") + 1

--- a/kolega_code/sandbox/terminal.py
+++ b/kolega_code/sandbox/terminal.py
@@ -384,7 +384,6 @@ class SandboxTerminalManager(TerminalManager):
             current_dir: The current working directory
             terminal_info: Terminal info dict to update
         """
-        # Check if this is a cd command
         # Match cd followed by path, stopping at ; or && or ||
         cd_match = re.match(r"^\s*cd\s+([^;&|]+)", command.strip())
         if not cd_match:
@@ -392,27 +391,20 @@ class SandboxTerminalManager(TerminalManager):
 
         new_dir = cd_match.group(1).strip()
 
-        # Remove quotes if present
         if (new_dir.startswith('"') and new_dir.endswith('"')) or (new_dir.startswith("'") and new_dir.endswith("'")):
             new_dir = new_dir[1:-1]
 
-        # Handle relative and absolute paths
         if new_dir.startswith("/"):
-            # Absolute path
             new_working_dir = new_dir
         elif new_dir == "..":
-            # Parent directory
             new_working_dir = os.path.dirname(current_dir.rstrip("/"))
             if not new_working_dir:
                 new_working_dir = "/"
         elif new_dir == ".":
-            # Current directory (no change)
             new_working_dir = current_dir
         elif new_dir == "~":
-            # Home directory
             new_working_dir = "/home/user"
         else:
-            # Relative path
             new_working_dir = os.path.join(current_dir, new_dir)
 
         # Normalize the path (handle double slashes)
@@ -421,7 +413,6 @@ class SandboxTerminalManager(TerminalManager):
         if new_working_dir.startswith("//"):
             new_working_dir = new_working_dir[1:]
 
-        # Update the terminal's stored working directory
         terminal_info["cwd"] = new_working_dir
 
     async def _create_output_handler(
@@ -442,7 +433,6 @@ class SandboxTerminalManager(TerminalManager):
         """
 
         async def handler(data: str) -> None:
-            # Store output
             self.outputs[terminal_id].append(
                 {"type": output_type, "data": data, "timestamp": datetime.now(timezone.utc)}
             )
@@ -493,19 +483,16 @@ class SandboxTerminalManager(TerminalManager):
         # Ensure the working directory exists (E2B specific fix)
         if working_dir != "/home/user":
             try:
-                # Try to create the directory if it doesn't exist
                 await self.sandbox.commands.run(f"test -d {working_dir} || mkdir -p {working_dir}")
             except Exception:
                 # If we can't create it, fall back to /home/user
                 working_dir = "/home/user"
 
         try:
-            # Determine timeout settings
             sandbox_timeout = timeout if timeout is not None else 60  # Default to 60s for backward compatibility
 
             # For utility commands, we don't need streaming
             if sandbox_timeout == 0:
-                # No timeout - let it run indefinitely
                 result = await self.sandbox.commands.run(command, cwd=working_dir, timeout=0)
             else:
                 # Use timeout with buffer for asyncio
@@ -514,7 +501,6 @@ class SandboxTerminalManager(TerminalManager):
                     timeout=sandbox_timeout + 5,  # Give 5 seconds more than the sandbox timeout
                 )
 
-            # Return the combined output (stdout + stderr)
             output = ""
             if result.stdout:
                 output += result.stdout
@@ -546,23 +532,18 @@ class SandboxTerminalManager(TerminalManager):
         if terminal_id is None:
             terminal_id = str(uuid.uuid4())
 
-        # Extract terminal options
         cwd = terminal_kwargs.get("cwd", "/home/user/workspace")
         env = terminal_kwargs.get("env", {})
 
         # Convert Path objects to strings for E2B compatibility
-        if hasattr(cwd, "__fspath__"):  # Check if it's a Path-like object
+        if hasattr(cwd, "__fspath__"):
             cwd = str(cwd)
 
-        # Ensure the directory exists (try to create if it doesn't)
         try:
-            # Check if directory exists
             await self.sandbox.commands.run(f"test -d {cwd}")
         except Exception:
-            # Directory doesn't exist, try to create it
             try:
                 await self.sandbox.commands.run(f"mkdir -p {cwd}")
-                # Directory now exists (either already existed or was created)
             except Exception as e:
                 # If we can't create the directory, fall back to /home/user
                 print(f"Warning: Could not ensure directory {cwd} exists: {e}")
@@ -575,7 +556,7 @@ class SandboxTerminalManager(TerminalManager):
             "process": None,
             "last_command": "",
             "last_command_purpose": "",
-            "active_commands": {},  # Track commands for this terminal
+            "active_commands": {},
         }
         self.outputs[terminal_id] = BoundedTerminalOutputs()
 
@@ -604,42 +585,34 @@ class SandboxTerminalManager(TerminalManager):
 
         terminal_info = self.terminals[terminal_id]
 
-        # Update last command info
-        terminal_info["last_command"] = command.rstrip("\n")  # Strip trailing newline for consistency
+        terminal_info["last_command"] = command.rstrip("\n")
         terminal_info["last_command_purpose"] = purpose or ""
 
-        # Use terminal's working directory
         working_dir = terminal_info["cwd"]
 
         # Convert Path objects to strings for E2B compatibility
-        if hasattr(working_dir, "__fspath__"):  # Check if it's a Path-like object
+        if hasattr(working_dir, "__fspath__"):
             working_dir = str(working_dir)
 
         # Forward the terminal's environment to the sandbox command.
         env = terminal_info.get("env") or {}
 
-        # Store command in output
         self.outputs[terminal_id].append(
             {"type": "command", "data": command, "timestamp": datetime.now(timezone.utc), "purpose": purpose}
         )
 
-        # Broadcast command if connection manager available
         if self.connection_manager:
             try:
                 await self._broadcast_output(terminal_id, f"$ {command}\n")
             except Exception:
                 pass  # Don't fail if broadcast fails
 
-        # Create streaming output handlers
         stdout_handler = await self._create_output_handler(terminal_id, "stdout")
         stderr_handler = await self._create_output_handler(terminal_id, "stderr")
 
-        # Execute command in sandbox with streaming
         try:
-            # Determine timeout settings
-            sandbox_timeout = timeout if timeout is not None else 0  # Default to no timeout
+            sandbox_timeout = timeout if timeout is not None else 0
 
-            # If no timeout requested (0), don't use asyncio.wait_for
             if sandbox_timeout == 0:
                 result = await self.sandbox.commands.run(
                     command,
@@ -647,7 +620,7 @@ class SandboxTerminalManager(TerminalManager):
                     envs=env,
                     on_stdout=stdout_handler,
                     on_stderr=stderr_handler,
-                    timeout=0,  # No timeout for sandbox
+                    timeout=0,
                 )
             else:
                 # Use timeout with buffer for asyncio
@@ -663,7 +636,6 @@ class SandboxTerminalManager(TerminalManager):
                     timeout=sandbox_timeout + 5,  # Give 5 seconds more than the sandbox timeout
                 )
 
-            # Store exit code
             self.outputs[terminal_id].append(
                 {
                     "type": "exit",
@@ -673,24 +645,20 @@ class SandboxTerminalManager(TerminalManager):
                 }
             )
 
-            # Broadcast exit status
             if self.connection_manager:
                 await self._broadcast_output(terminal_id, f"Process exited with code {result.exit_code}\n")
 
-            # If it was a successful cd command, update the terminal's working directory
             if result.exit_code == 0:
                 self._handle_cd_command(command, working_dir, terminal_info)
 
-            return result.exit_code == 0  # Return True only if command succeeded
+            return result.exit_code == 0
 
         except asyncio.TimeoutError:
-            # Handle timeout specifically
             error_msg = f"Command execution timed out after {sandbox_timeout + 5} seconds"
             self.outputs[terminal_id].append(
                 {"type": "stderr", "data": error_msg, "timestamp": datetime.now(timezone.utc)}
             )
 
-            # Broadcast error
             if self.connection_manager:
                 await self._broadcast_output(terminal_id, error_msg)
 
@@ -703,20 +671,17 @@ class SandboxTerminalManager(TerminalManager):
                 }
             )
 
-            # Broadcast exit status
             if self.connection_manager:
                 await self._broadcast_output(terminal_id, "Process exited with code 1\n")
 
             return False  # Command failed due to timeout
 
         except Exception as e:
-            # Store error
             error_msg = f"Command failed: {str(e)}"
             self.outputs[terminal_id].append(
                 {"type": "stderr", "data": error_msg, "timestamp": datetime.now(timezone.utc)}
             )
 
-            # Broadcast error
             if self.connection_manager:
                 await self._broadcast_output(terminal_id, error_msg)
 
@@ -729,7 +694,6 @@ class SandboxTerminalManager(TerminalManager):
                 }
             )
 
-            # Broadcast exit status
             if self.connection_manager:
                 await self._broadcast_output(terminal_id, "Process exited with code 1\n")
 
@@ -815,11 +779,9 @@ class SandboxTerminalManager(TerminalManager):
         if terminal_id not in self.terminals:
             raise KeyError(f"Terminal {terminal_id} not found")
 
-        # Generate command ID
         self.command_counter += 1
         command_id = f"{terminal_id}_{self.command_counter}"
 
-        # Record command in history
         start_time = datetime.now(timezone.utc)
         self.command_history[command_id] = {
             "command": command.strip(),
@@ -834,23 +796,18 @@ class SandboxTerminalManager(TerminalManager):
         }
         self._output_accumulators[command_id] = TerminalOutputAccumulator(self._spill_store)
 
-        # Also track in terminal's active commands
         self.terminals[terminal_id]["active_commands"][command_id] = self.command_history[command_id]
 
-        # Get terminal info
         terminal_info = self.terminals[terminal_id]
         working_dir = terminal_info["cwd"]
 
-        # Store command in output
         self.outputs[terminal_id].append(
             {"type": "command", "data": command, "timestamp": datetime.now(timezone.utc), "purpose": purpose}
         )
 
-        # Broadcast command
         if self.connection_manager:
             await self._broadcast_output(terminal_id, f"$ {command}\n")
 
-        # Start command execution asynchronously without waiting
         task = asyncio.create_task(self._execute_command_async(command_id, terminal_id, command, working_dir, timeout))
         self._command_tasks[command_id] = task
 
@@ -862,7 +819,7 @@ class SandboxTerminalManager(TerminalManager):
         """Execute a command asynchronously and track its status."""
         try:
             # Convert Path objects to strings for E2B compatibility
-            if hasattr(working_dir, "__fspath__"):  # Check if it's a Path-like object
+            if hasattr(working_dir, "__fspath__"):
                 working_dir = str(working_dir)
 
             # Forward the terminal's environment to the sandbox command.
@@ -872,8 +829,7 @@ class SandboxTerminalManager(TerminalManager):
             stdout_handler = await self._create_output_handler(terminal_id, "stdout", command_id)
             stderr_handler = await self._create_output_handler(terminal_id, "stderr", command_id)
 
-            # Determine timeout settings
-            sandbox_timeout = timeout if timeout is not None else 0  # Default to no timeout
+            sandbox_timeout = timeout if timeout is not None else 0
 
             # Execute with streaming and keep stdin open for interactive prompts.
             try:
@@ -920,7 +876,6 @@ class SandboxTerminalManager(TerminalManager):
             if accumulator is not None:
                 accumulator.finalize()
 
-            # Command completed
             if self.command_history[command_id].get("kill_requested"):
                 self.command_history[command_id]["status"] = "terminated"
             else:
@@ -928,7 +883,6 @@ class SandboxTerminalManager(TerminalManager):
             self.command_history[command_id]["return_code"] = result.exit_code
             self.command_history[command_id]["end_time"] = datetime.now(timezone.utc)
 
-            # Store exit code
             self.outputs[terminal_id].append(
                 {
                     "type": "exit",
@@ -938,25 +892,20 @@ class SandboxTerminalManager(TerminalManager):
                 }
             )
 
-            # Broadcast exit status
             if self.connection_manager:
                 await self._broadcast_output(terminal_id, f"Process exited with code {result.exit_code}\n")
 
-            # If it was a successful cd command, update the terminal's working directory
             if result.exit_code == 0 and terminal_id in self.terminals:
                 terminal_info = self.terminals[terminal_id]
                 self._handle_cd_command(command, working_dir, terminal_info)
 
-            # Remove from active commands
             if terminal_id in self.terminals:
                 self.terminals[terminal_id]["active_commands"].pop(command_id, None)
         except Exception as e:
-            # Command failed
             self.command_history[command_id]["status"] = "failed"
             self.command_history[command_id]["return_code"] = 1
             self.command_history[command_id]["end_time"] = datetime.now(timezone.utc)
 
-            # Store error
             error_msg = f"Command failed: {str(e)}"
             self.outputs[terminal_id].append(
                 {"type": "stderr", "data": error_msg, "timestamp": datetime.now(timezone.utc)}
@@ -966,11 +915,9 @@ class SandboxTerminalManager(TerminalManager):
                 accumulator.append_text(error_msg)
                 accumulator.finalize()
 
-            # Broadcast error
             if self.connection_manager:
                 await self._broadcast_output(terminal_id, error_msg)
 
-            # Store exit info
             self.outputs[terminal_id].append(
                 {
                     "type": "exit",
@@ -980,11 +927,9 @@ class SandboxTerminalManager(TerminalManager):
                 }
             )
 
-            # Broadcast exit status
             if self.connection_manager:
                 await self._broadcast_output(terminal_id, "Process exited with code 1\n")
 
-            # Remove from active commands
             if terminal_id in self.terminals:
                 self.terminals[terminal_id]["active_commands"].pop(command_id, None)
         finally:
@@ -1008,7 +953,6 @@ class SandboxTerminalManager(TerminalManager):
         if terminal_id not in self.terminals:
             raise KeyError(f"Terminal {terminal_id} not found")
 
-        # Reconstruct full output from stored outputs
         full_output = ""
         for output in self.outputs[terminal_id]:
             if output["type"] == "command":
@@ -1027,7 +971,6 @@ class SandboxTerminalManager(TerminalManager):
             return ""
 
         if offset == 0:
-            # Default behavior: read last num_chars characters
             if total_chars <= num_chars:
                 return full_output
             else:
@@ -1064,7 +1007,6 @@ class SandboxTerminalManager(TerminalManager):
 
         command_info = self.command_history[command_id]
 
-        # Calculate duration
         if "end_time" in command_info:
             duration = (command_info["end_time"] - command_info["start_time"]).total_seconds()
         else:
@@ -1076,7 +1018,7 @@ class SandboxTerminalManager(TerminalManager):
             "purpose": command_info.get("purpose"),
             "duration": duration,
             "return_code": command_info.get("return_code"),
-            "child_pids": [],  # No child process tracking in sandbox
+            "child_pids": [],
         }
 
     async def get_terminal_status(self, terminal_id: str) -> dict:
@@ -1097,7 +1039,6 @@ class SandboxTerminalManager(TerminalManager):
 
         terminal_info = self.terminals[terminal_id]
 
-        # Get active commands for this terminal
         active_commands = {}
         for cmd_id, cmd_info in terminal_info["active_commands"].items():
             active_commands[cmd_id] = self.get_command_status(terminal_id, cmd_id)
@@ -1151,7 +1092,6 @@ class SandboxTerminalManager(TerminalManager):
 
         outputs = self.outputs[terminal_id]
 
-        # Apply filters if provided
         last_n_lines = kwargs.get("last_n_lines")
         since_timestamp = kwargs.get("since_timestamp")
 
@@ -1160,7 +1100,6 @@ class SandboxTerminalManager(TerminalManager):
         if since_timestamp:
             filtered_outputs = [o for o in filtered_outputs if o["timestamp"] > since_timestamp]
 
-        # Convert to string
         lines = []
         for output in filtered_outputs:
             if output["type"] in ["stdout", "stderr"]:
@@ -1188,7 +1127,6 @@ class SandboxTerminalManager(TerminalManager):
         if terminal_id not in self.terminals:
             raise KeyError(f"Terminal {terminal_id} not found")
 
-        # Clean up
         for command_id in list(self.terminals[terminal_id]["active_commands"]):
             try:
                 await self.kill_session(command_id, "TERM")

--- a/kolega_code/sandbox/utils.py
+++ b/kolega_code/sandbox/utils.py
@@ -93,7 +93,6 @@ async def get_modified_files_from_sandbox(sandbox_manager: SandboxManager, sandb
         List of modified file paths
     """
     try:
-        # Get the sandbox's terminal manager
         terminal_manager = sandbox_manager.get_terminal_manager(sandbox_id)
 
         # Run git status with core.quotePath=false to get raw filenames without escaping
@@ -125,7 +124,6 @@ async def get_git_diff_from_sandbox(
         Git diff output as string
     """
     try:
-        # Get the sandbox's terminal manager
         terminal_manager = sandbox_manager.get_terminal_manager(sandbox_id)
 
         # Include untracked files in the diff without staging their contents.
@@ -134,7 +132,6 @@ async def get_git_diff_from_sandbox(
         except Exception as add_error:
             logger.warning(f"Failed to mark untracked files for diff in sandbox {sandbox_id}: {add_error}")
 
-        # Build git diff command
         if files:
             # Diff specific files
             files_arg = " ".join(shlex.quote(f) for f in files)
@@ -168,7 +165,6 @@ async def run_project_tests_in_sandbox(
         Dictionary with test results
     """
     try:
-        # Get the terminal manager
         terminal_manager = sandbox_manager.get_terminal_manager(sandbox_id)
 
         # Try to read project manifest

--- a/kolega_code/services/file_system.py
+++ b/kolega_code/services/file_system.py
@@ -608,7 +608,7 @@ class LocalFileSystem(FileSystem):
             "accessed_time": stat_result.st_atime,
             "is_directory": resolved_path.is_dir(),
             "is_file": resolved_path.is_file(),
-            "stat_result": stat_result,  # Include the full stat result for advanced operations
+            "stat_result": stat_result,
         }
 
     def mkdir(self, path: str, parents: bool = False, exist_ok: bool = False) -> None:
@@ -652,7 +652,6 @@ class LocalFileSystem(FileSystem):
         # If we have a root path, we need to make the pattern relative to it
         if self.root_path:
             paths = list(self.root_path.glob(pattern))
-            # Return paths relative to the root path
             return [str(p.relative_to(self.root_path)) for p in paths]
         else:
             return [str(p) for p in Path().glob(pattern)]
@@ -660,7 +659,6 @@ class LocalFileSystem(FileSystem):
     def is_binary_file(self, path: str) -> bool:
         resolved_path = self._resolve_path(path)
 
-        # Check extension for common binary formats
         binary_extensions = {
             ".pyc",
             ".so",
@@ -698,7 +696,6 @@ class LocalFileSystem(FileSystem):
         if resolved_path.suffix.lower() in binary_extensions:
             return True
 
-        # Sample file content to check for null bytes
         try:
             with resolved_path.open("rb") as f:
                 sample = f.read(1024)

--- a/kolega_code/services/html.py
+++ b/kolega_code/services/html.py
@@ -19,7 +19,6 @@ def extract_interactive_elements_from_html(html_content: str) -> List[Dict]:
     """
     soup = BeautifulSoup(html_content, "html.parser")
 
-    # Define interactive elements to look for
     interactive_elements = [
         # Links
         "a",
@@ -48,16 +47,13 @@ def extract_interactive_elements_from_html(html_content: str) -> List[Dict]:
 
     results = []
 
-    # Process each type of interactive element
     for selector in interactive_elements:
         try:
             if "[" in selector:
-                # Handle attribute-based selectors
                 tag_name, attr_part = selector.split("[", 1)
                 attr_part = attr_part.rstrip("]")
 
                 if "=" in attr_part:
-                    # Attribute with specific value
                     attr_name, attr_value = attr_part.split("=", 1)
                     attr_value = attr_value.strip("\"'")
                     # Use find_all with attrs dict instead of select to avoid selector syntax issues
@@ -70,27 +66,21 @@ def extract_interactive_elements_from_html(html_content: str) -> List[Dict]:
                             # If select fails, continue with empty list
                             elements = []
                 else:
-                    # Just the presence of an attribute
                     elements = soup.find_all(lambda tag: tag.has_attr(attr_part))
             else:
-                # Simple tag selector
                 elements = soup.find_all(selector)
         except Exception as e:
             print(f"Warning: Error processing selector '{selector}': {e}")
             elements = []
 
         for element in elements:
-            # Build a unique CSS selector for this element
             element_selector = build_css_selector(element)
 
-            # Get the text associated with this element
             element_text = get_associated_text(element)
 
-            # Get element type and attributes
             element_type = element.name
             attributes = {k: v for k, v in element.attrs.items()}
 
-            # Add to results
             results.append(
                 {
                     "element_type": element_type,
@@ -113,7 +103,6 @@ def get_associated_text(element) -> str:
         if not text and element.get("value") and element["type"] not in ["password", "hidden"]:
             text = element["value"]
 
-        # Try to find associated label
         element_id = element.get("id")
         if element_id:
             label = element.find_parent().find("label", attrs={"for": element_id})
@@ -123,11 +112,9 @@ def get_associated_text(element) -> str:
         return text
 
     elif element.name == "button":
-        # Get button text or value
         return element.get_text(strip=True) or element.get("value", "")
 
     elif element.name == "a":
-        # Get link text or title
         return element.get_text(strip=True) or element.get("title", "")
 
     elif element.name == "select":
@@ -135,7 +122,6 @@ def get_associated_text(element) -> str:
         option_texts = [opt.get_text(strip=True) for opt in element.find_all("option")]
         return ", ".join(filter(None, option_texts))
 
-    # Default: just return the text content
     return element.get_text(strip=True)
 
 
@@ -149,7 +135,6 @@ def build_css_selector(element) -> str:
     if element.get("id"):
         return f"#{element['id']}"
 
-    # If element has classes, try to use them
     if element.get("class"):
         # Create individual class selectors and escape colons with backslashes
         escaped_classes = []
@@ -167,7 +152,6 @@ def build_css_selector(element) -> str:
             # If selector is invalid, fall back to other methods
             pass
 
-    # Try with tag name and attribute combinations
     tag_name = element.name
     attributes = element.attrs
 
@@ -206,12 +190,9 @@ def build_css_selector(element) -> str:
         if current is None or current.name == "html":
             break
 
-    # Construct the selector path
     selector = " > ".join(reversed(parents))
 
-    # Validate the selector to make sure it's valid CSS
     try:
-        # Test if the selector is valid by attempting to use it
         soup = BeautifulSoup("<html><body></body></html>", "html.parser")
         soup.select(selector)
         return selector

--- a/kolega_code/services/lsp/manager.py
+++ b/kolega_code/services/lsp/manager.py
@@ -268,7 +268,6 @@ class LspManager:
         if spec and spec.family:
             effective_id = spec.family
 
-        # Get or start session
         try:
             client = await self._get_session(effective_id, rl)
             if client is None:
@@ -1267,7 +1266,6 @@ class LspManager:
             if not resolved_bin:
                 continue
 
-            # Build a ResolvedLanguage for the extra server
             extra_rl = ResolvedLanguage(
                 language_id=lang_id,
                 display_name=spec.display_name,

--- a/kolega_code/services/lsp/registry.py
+++ b/kolega_code/services/lsp/registry.py
@@ -35,7 +35,6 @@ class LspRegistry:
         if config:
             self._apply_user_config(config)
 
-        # Build reverse indexes
         for lang_id, spec in self._languages.items():
             if lang_id in (config.disabled_languages if config else []):
                 continue


### PR DESCRIPTION
Remove commented-out code and comments that merely restate the adjacent code, across `kolega_code/` (excluding vendored `_bundled_skills/` and `tests/`).

## What changed

- **Commented-out code**: removed one dead debug `# print(...)` line in `llm/models.py`.
- **Restated-code comments**: removed trailing inline restatements and standalone labels that repeat what the code already says (e.g. `# Store exit code`, `# Determine timeout settings`, `# Check if it's a Path-like object`, redundant glyph-repeat comments in `cli/theme.py`).

Highest density was `sandbox/terminal.py`, plus `serializer.py`, `services/html.py`, `services/file_system.py`, `agent/tools.py`, and several `llm/` provider modules.

All "why"/invariant/magic-number/disambiguation comments and lint-suppression markers (`# noqa`, `# type: ignore`, `# pyright: ignore`, `# pragma: no cover`) were preserved.

## Verification

- `ruff check` + `ruff format --check` clean
- `pyright` 0 errors
- Fast suite: 4756 passed, 1 skipped, 3 failed (all 3 are `openai_chatgpt` live tests failing with `LLMConnectionError: Connection error`, environmental)