### PR TITLE
feat(llm): add GLM-5.3 to the Z.AI provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 - Added support for xAI Grok 4.6 (`grok-4.6`): 500K-token context, vision input,
   and `low`/`medium`/`high`/`xhigh` reasoning effort. Selectable in the Settings
   UI, `/model` picker, CLI flags, and env vars.
+- Added support for Z.AI GLM-5.3 (`glm-5.3`) on the GLM Coding Plan provider:
+  1M-token context, 128K max output, and `high`/`max` thinking effort. GLM-5.3
+  is now the Z.AI default model.
 
 ## 0.29.0 - 2026-08-13
 

--- a/docs/src/content/docs/configuration/providers-and-models.mdx
+++ b/docs/src/content/docs/configuration/providers-and-models.mdx
@@ -41,9 +41,9 @@ Anthropic-compatible):
 
 <Aside type="tip">
 **Z.AI GLM Coding Plan.** The `zai` provider targets Z.AI's Anthropic-compatible
-endpoint (`https://api.z.ai/api/anthropic`) and exposes **GLM-5.2** (default) and
-**GLM-5.1**. Set `ZAI_API_KEY` to your GLM Coding Plan key (the key Z.AI also
-documents as `ANTHROPIC_AUTH_TOKEN`).
+endpoint (`https://api.z.ai/api/anthropic`) and exposes **GLM-5.3** (default),
+**GLM-5.2** and **GLM-5.1**. Set `ZAI_API_KEY` to your GLM Coding Plan key (the key
+Z.AI also documents as `ANTHROPIC_AUTH_TOKEN`).
 </Aside>
 
 <Aside type="tip">
@@ -321,6 +321,7 @@ models in the TUI.
 | Moonshot `kimi-k2.6` | `auto`, `none` | `auto` |
 | Kimi Coding Plan `k3`, `k3-256k` | `max` | `max` |
 | Kimi Coding Plan `kimi-for-coding`, `kimi-for-coding-highspeed` | `auto`, `none` | `auto` |
+| Z.AI `glm-5.3` | `high`, `max` | `max` |
 | Z.AI `glm-5.2` | `high`, `max` | `max` |
 | Z.AI `glm-5.1` | `auto`, `none` | `auto` |
 | Fireworks serverless reasoning models | `none`, `low`, `medium`, `high`, `max` | `medium` |

--- a/kolega_code/cli/provider_registry.py
+++ b/kolega_code/cli/provider_registry.py
@@ -64,6 +64,7 @@ MODEL_LABELS: dict[str, str] = {
     "deepseek-v4-pro": "DeepSeek V4 Pro",
     "deepseek-v4-flash": "DeepSeek V4 Flash",
     # Z.AI (GLM Coding Plan)
+    "glm-5.3": "GLM-5.3",
     "glm-5.2": "GLM-5.2",
     "glm-5.1": "GLM-5.1",
     # Anthropic
@@ -149,7 +150,7 @@ MODEL_LABELS: dict[str, str] = {
 PROVIDER_DEFAULT_MODEL: dict[ModelProvider, str] = {
     ModelProvider.MOONSHOT: "kimi-k3",
     ModelProvider.DEEPSEEK: "deepseek-v4-pro",
-    ModelProvider.ZAI: "glm-5.2",
+    ModelProvider.ZAI: "glm-5.3",
     ModelProvider.KIMI_CODING: "kimi-for-coding",
     ModelProvider.ANTHROPIC: "claude-opus-5",
     ModelProvider.OPENAI: "gpt-5.6-sol",

--- a/kolega_code/llm/specs/catalog/zai.py
+++ b/kolega_code/llm/specs/catalog/zai.py
@@ -2,6 +2,18 @@ from kolega_code.llm.specs.types import ThinkingEffortSpec
 
 # Z.AI (GLM Coding Plan) models — Anthropic-compatible endpoint (recommended default first)
 ZAI_SPECS = {
+    ("zai", "glm-5.3"): {
+        "context_length": 1000000,
+        "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
+        "default_temperature": 0.6,
+        "supports_vision": False,
+        "thinking_effort": ThinkingEffortSpec(
+            options=("high", "max"),
+            default="max",
+            mode="zai_effort",
+        ),
+    },
     ("zai", "glm-5.2"): {
         "context_length": 1000000,
         "max_completion_tokens": 131072,

--- a/tests/agent/llm/test_model_specs.py
+++ b/tests/agent/llm/test_model_specs.py
@@ -174,6 +174,16 @@ def test_deepseek_model_specs(model: str, max_completion_tokens: int):
     assert specs["thinking_effort"].default == "high"
 
 
+def test_zai_model_specs() -> None:
+    for model in ("glm-5.3", "glm-5.2"):
+        specs = get_model_specs("zai", model)
+        assert specs["context_length"] == 1000000
+        assert specs["max_completion_tokens"] == 131072
+        assert specs["default_temperature"] == 0.6
+        assert specs["thinking_effort"].options == ("high", "max")
+        assert specs["thinking_effort"].default == "max"
+
+
 def test_fireworks_serverless_model_specs():
     expected = {
         "accounts/fireworks/models/glm-5p2": (1048576, 131072),

--- a/tests/agent/llm/test_supports_vision.py
+++ b/tests/agent/llm/test_supports_vision.py
@@ -55,6 +55,7 @@ def test_supports_vision_flag_present_on_every_entry():
         ("fireworks", "accounts/fireworks/models/qwen3p7-plus", False),
         ("dashscope", "qwen3-coder-plus", False),
         ("dashscope", "qwen3-coder-flash", False),
+        ("zai", "glm-5.3", False),
         ("zai", "glm-5.2", False),
         ("zai", "glm-5.1", False),
         ("xai", "grok-build-0.1", False),

--- a/tests/agent/llm/test_thinking_effort.py
+++ b/tests/agent/llm/test_thinking_effort.py
@@ -29,6 +29,8 @@ def test_model_specs_expose_provider_specific_thinking_efforts() -> None:
     assert default_thinking_effort("google", "gemini-3.5-flash-lite") == "minimal"
     assert thinking_effort_options("google", "gemini-3.1-pro-preview") == ("low", "medium", "high")
     assert default_thinking_effort("google", "gemini-3.1-pro-preview") == "high"
+    assert thinking_effort_options("zai", "glm-5.3") == ("high", "max")
+    assert default_thinking_effort("zai", "glm-5.3") == "max"
     assert thinking_effort_options("zai", "glm-5.2") == ("high", "max")
     assert default_thinking_effort("zai", "glm-5.2") == "max"
     assert thinking_effort_options("zai", "glm-5.1") == ("auto", "none")
@@ -83,6 +85,19 @@ def test_anthropic_default_request_uses_opus_5_adaptive_thinking_without_tempera
     assert generation_params["thinking"] == {"type": "adaptive"}
     assert generation_params["output_config"] == {"effort": "medium"}
     assert "temperature" not in generation_params
+
+
+def test_zai_glm53_thinking_effort_serialization() -> None:
+    provider = AnthropicProvider(api_key="test-key", provider_name="zai")
+
+    max_params = {"model": "glm-5.3"}
+    provider._apply_thinking_params(max_params, GenerationParams(thinking="max"))
+    assert max_params["thinking"] == {"type": "enabled"}
+    assert max_params["output_config"] == {"effort": "max"}
+
+    high_params = {"model": "glm-5.3"}
+    provider._apply_thinking_params(high_params, GenerationParams(thinking="high"))
+    assert high_params["output_config"] == {"effort": "high"}
 
 
 def test_zai_glm52_thinking_effort_serialization() -> None:

--- a/tests/cli/test_provider_registry.py
+++ b/tests/cli/test_provider_registry.py
@@ -46,6 +46,16 @@ def test_kimi_coding_exposes_plan_specific_k3_models():
     assert ui_thinking_effort_options("kimi_coding", "k3") == [("Max", "max")]
 
 
+def test_zai_exposes_glm_models_and_defaults_to_glm_53() -> None:
+    assert ui_model_options(ModelProvider.ZAI.value) == [
+        ("GLM-5.3", "glm-5.3"),
+        ("GLM-5.2", "glm-5.2"),
+        ("GLM-5.1", "glm-5.1"),
+    ]
+    assert default_model_for_provider(ModelProvider.ZAI) == "glm-5.3"
+    assert ui_thinking_effort_options("zai", "glm-5.3") == [("High", "high"), ("Max", "max")]
+
+
 def test_gpt56_models_are_first_and_sol_is_default_for_openai_providers():
     expected = [
         ("GPT-5.6 Sol", "gpt-5.6-sol"),


### PR DESCRIPTION
## Summary

Adds **GLM-5.3** to the Z.AI (GLM Coding Plan) provider and makes it the default.

Z.AI released GLM-5.3 today; it shares GLM-5.2's base model, so the spec mirrors GLM-5.2 (1M-token context, 128K max output, `high`/`max` thinking effort via `output_config.effort`, default `max`).

## Live API probe (ZAI_API_KEY from `.env`)

- `glm-5.3` is callable on the Anthropic-compatible endpoint (`https://api.z.ai/api/anthropic/v1/messages`) — not yet listed by `GET /v1/models`, but accepted.
- Returns a native Anthropic `thinking` block with a signature.
- Accepts `output_config.effort` = `high` and `max`; `max_tokens=131072` is accepted.

## Changes

- `kolega_code/llm/specs/catalog/zai.py` — add `glm-5.3` (listed first, recommended default).
- `kolega_code/cli/provider_registry.py` — `GLM-5.3` label; `zai` default is now `glm-5.3`.
- `docs` — coding-plan Aside and thinking-effort table updated.
- `CHANGELOG.md` — Unreleased entry.
- Tests — spec, vision, thinking-effort serialization, and provider-registry assertions.

## Verification

- Focused tests: 122 passed.
- Live integration against the real key: both `test_live_provider_generate[zai]` and `test_live_provider_thinking_effort[zai]` pass (these now exercise `glm-5.3` as the default).
- Full fast suite: 4760 passed (3 unrelated ChatGPT-OAuth live failures, connection error — no sign-in token in this env).
