### PR TITLE
feat(llm): enable hosted web search for deepseek-v4-pro

### DIFF
--- a/kolega_code/llm/specs/catalog/deepseek.py
+++ b/kolega_code/llm/specs/catalog/deepseek.py
@@ -26,6 +26,7 @@ DEEPSEEK_SPECS = {
         "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
+        "supports_hosted_web_search": True,
         "preferred_edit_protocol": "claude_code",
         "thinking_effort": ThinkingEffortSpec(
             options=("none", "low", "high", "max"),

--- a/tests/cli/test_app_persistence_history.py
+++ b/tests/cli/test_app_persistence_history.py
@@ -2,6 +2,7 @@
 from pathlib import Path
 import asyncio
 import json
+import threading
 import time
 
 import pytest
@@ -206,8 +207,12 @@ async def test_textual_app_history_save_runs_off_event_loop(tmp_path: Path, monk
     _persist_history(store, session, saved_history)
     original_save = store.save
 
+    release_save = threading.Event()
+
     def slow_save(record):
-        time.sleep(0.2)
+        # Block the worker thread (not the event loop) until the test has
+        # observed the loop staying responsive while the save is in flight.
+        release_save.wait(timeout=5)
         original_save(record)
 
     monkeypatch.setattr(store, "save", slow_save)
@@ -217,10 +222,11 @@ async def test_textual_app_history_save_runs_off_event_loop(tmp_path: Path, monk
 
     save_task = asyncio.create_task(app._save_session_history_async())
     marker_task = asyncio.create_task(asyncio.sleep(0.05))
-    done, _ = await asyncio.wait({save_task, marker_task}, timeout=0.1, return_when=asyncio.FIRST_COMPLETED)
+    done, _ = await asyncio.wait({save_task, marker_task}, timeout=5, return_when=asyncio.FIRST_COMPLETED)
 
     assert marker_task in done
     assert not save_task.done()
+    release_save.set()
     await save_task
     assert store.load(session.session_id).history == saved_history
 


### PR DESCRIPTION
## Summary
- Set `supports_hosted_web_search: True` on the `deepseek-v4-pro` entry in `kolega_code/llm/specs/catalog/deepseek.py`, so the DeepSeek Responses provider requests the server-side `{"type": "web_search"}` tool for pro, matching `deepseek-v4-flash`.

## Verification
- Live-probed pro with `findings/probes/hosted_web_search_probe.py` (4 requests): `tools:[{"type":"web_search"}]` produced a real `web_search_call` executed server-side (~3.6k residual billed input = injected page content); replaying the `web_search_call` items answered correctly from restored search content; replay with the tool absent was tolerated (no 400). Behavior is identical to flash.
- `./run_tests.sh tests/agent/llm/test_responses_hosted_web_search.py tests/agent/test_agent_tools_inventory.py tests/cli/test_ask_web_search_mode.py tests/agent/test_context_residual_accounting.py` — 69 passed.

## Notes
- Stacked on #601: branch is based on `feat/zai-glm-5.3`; only the last commit is new.