### PR TITLE
fix(lsp): bound unresponsive shutdown during quit

### DIFF
--- a/kolega_code/services/lsp/manager.py
+++ b/kolega_code/services/lsp/manager.py
@@ -30,6 +30,8 @@ logger = logging.getLogger(__name__)
 _MAX_CONCURRENT_STARTS = 4
 # Maximum concurrent diagnostics queries for a multi-file edit.
 _MAX_CONCURRENT_DIAGNOSTICS = 4
+# Grace period for a language server to acknowledge shutdown before termination.
+_LSP_SHUTDOWN_REQUEST_TIMEOUT_SECONDS = 1.0
 
 # Client capabilities advertised in the initialize handshake.
 _CLIENT_CAPABILITIES: dict = {
@@ -960,10 +962,10 @@ class LspManager:
         for lang_id, client in list(self._sessions.items()):
             try:
                 if client.running:
-                    await client.request("shutdown")
+                    await client.request("shutdown", timeout=_LSP_SHUTDOWN_REQUEST_TIMEOUT_SECONDS)
                     await client.notify("exit")
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("Graceful shutdown failed for LSP session %s; forcing termination: %s", lang_id, exc)
             try:
                 await client.stop()
             except Exception:

--- a/tests/cli/test_app_lsp_settings_status.py
+++ b/tests/cli/test_app_lsp_settings_status.py
@@ -8,9 +8,11 @@ its ``lsp_manager``.
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -84,6 +86,38 @@ class _LspEnabledFakeAgent(FakeCoderAgent):
             "diagnostic_counts": {},
         }
         self.tool_collection.lsp_manager = manager
+
+
+@pytest.mark.asyncio
+async def test_action_quit_uses_bounded_lsp_shutdown_timeout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ctrl-Q delegates to bounded LSP cleanup and still force-stops on failure."""
+    from kolega_code.services.lsp.client import LspClientError
+    from kolega_code.services.lsp.config import LspConfig
+    from kolega_code.services.lsp.manager import LspManager, _LSP_SHUTDOWN_REQUEST_TIMEOUT_SECONDS
+
+    app = _make_app(tmp_path, monkeypatch)
+    manager = LspManager(tmp_path, config=LspConfig(enabled=True, prompt_on_missing=False))
+    client = MagicMock()
+    client.running = True
+    client.request = AsyncMock(side_effect=LspClientError("shutdown timed out"))
+    client.notify = AsyncMock()
+    client.stop = AsyncMock()
+    manager._sessions["python"] = client
+
+    async with app.run_test():
+        agent = app.agent
+        assert isinstance(agent, FakeCoderAgent)
+
+        async def cleanup_agent() -> None:
+            agent.cleanup_calls += 1
+            await manager.shutdown()
+
+        agent.cleanup = cleanup_agent
+        await asyncio.wait_for(app.action_quit(), timeout=1.0)
+
+    client.request.assert_awaited_once_with("shutdown", timeout=_LSP_SHUTDOWN_REQUEST_TIMEOUT_SECONDS)
+    client.stop.assert_awaited_once_with()
+    assert app.agent is None
 
 
 @pytest.mark.asyncio

--- a/tests/services/lsp/_fake_server.py
+++ b/tests/services/lsp/_fake_server.py
@@ -13,6 +13,7 @@ Configurable via environment variables:
 - ``FAKE_LSP_PULL_DIAGS``: if ``"0"``, disable pull diagnostics (force push-only).
 - ``FAKE_LSP_STRICT_OPEN``: if ``"1"``, ignore didChange for unopened docs.
 - ``FAKE_LSP_SOURCE``: diagnostic/source label (default ``"fake-lsp"``).
+- ``FAKE_LSP_IGNORE_SHUTDOWN``: if ``"1"``, consume shutdown without replying.
 """
 
 from __future__ import annotations
@@ -82,6 +83,7 @@ _DELAY = float(os.environ.get("FAKE_LSP_DELAY", "0"))
 _PULL_DIAGS = os.environ.get("FAKE_LSP_PULL_DIAGS", "1") != "0"
 _STRICT_OPEN = os.environ.get("FAKE_LSP_STRICT_OPEN", "0") == "1"
 _SOURCE = os.environ.get("FAKE_LSP_SOURCE", "fake-lsp")
+_IGNORE_SHUTDOWN = os.environ.get("FAKE_LSP_IGNORE_SHUTDOWN", "0") == "1"
 # When set, always publish diagnostics with this fixed document version
 # (simulates a server that does not track per-edit versions — used to test
 # the stale-diagnostics suppression branch).
@@ -570,6 +572,9 @@ def handle_incoming_message(msg: dict) -> bool:
         return True
 
     # Requests (have id → must respond)
+    if method == "shutdown" and _IGNORE_SHUTDOWN:
+        return True
+
     handlers = {
         "initialize": handle_initialize,
         "textDocument/diagnostic": handle_diagnostic,

--- a/tests/services/lsp/conftest.py
+++ b/tests/services/lsp/conftest.py
@@ -57,6 +57,39 @@ async def fake_lsp_manager(tmp_path: Path) -> AsyncGenerator["LspManager", None]
 
 
 @pytest_asyncio.fixture
+async def fake_lsp_manager_ignore_shutdown(tmp_path: Path) -> AsyncGenerator["LspManager", None]:
+    """Return a fake LSP manager whose server ignores shutdown requests."""
+    from kolega_code.services.lsp import LspConfig
+    from kolega_code.services.lsp.manager import LspManager
+
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "pyproject.toml").write_text("[project]\nname = 'test'\n", encoding="utf-8")
+    (project / "src.py").write_text("def hello():\n    pass\n", encoding="utf-8")
+
+    config = LspConfig(
+        enabled=True,
+        prompt_on_missing=False,
+        custom_servers={
+            "fake-lsp": {
+                "bin": sys.executable,
+                "args": [str(_FAKE_SERVER)],
+                "languages": ["python"],
+                "env": {"FAKE_LSP_IGNORE_SHUTDOWN": "1"},
+            },
+        },
+        preferences={"python": "fake-lsp"},
+    )
+
+    manager = LspManager(project, config=config)
+    await manager.initialize()
+
+    yield manager
+
+    await manager.shutdown()
+
+
+@pytest_asyncio.fixture
 async def fake_lsp_manager_no_pull(tmp_path: Path) -> AsyncGenerator["LspManager", None]:
     """Like ``fake_lsp_manager`` but the fake server doesn't support pull diagnostics."""
     from kolega_code.services.lsp import LspConfig

--- a/tests/services/lsp/test_integration.py
+++ b/tests/services/lsp/test_integration.py
@@ -8,6 +8,7 @@ code intelligence queries, and server→client request handling.
 from __future__ import annotations
 
 import asyncio
+import time
 
 import pytest
 
@@ -41,6 +42,23 @@ async def test_server_request_handled_no_hang(fake_lsp_manager):
     await manager.get_diagnostics("src.py")
     client = next(iter(manager._sessions.values()))
     assert client.status == "initialized"
+
+
+@pytest.mark.asyncio
+async def test_shutdown_terminates_server_that_ignores_graceful_request(fake_lsp_manager_ignore_shutdown):
+    """An unresponsive shutdown reply must not hold cleanup for the normal 30 seconds."""
+    manager = fake_lsp_manager_ignore_shutdown
+    await manager.get_diagnostics("src.py")
+    client = next(iter(manager._sessions.values()))
+
+    started = time.monotonic()
+    await manager.shutdown()
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 5.0
+    assert client.running is False
+    assert client.status == "stopped"
+    assert manager._sessions == {}
 
 
 @pytest.mark.asyncio

--- a/tests/services/lsp/test_manager.py
+++ b/tests/services/lsp/test_manager.py
@@ -12,11 +12,16 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from kolega_code.services.lsp.client import LspDiagnostic
+from kolega_code.services.lsp.client import LspClientError, LspDiagnostic
 from kolega_code.services.lsp.config import LspConfig
 from kolega_code.services.lsp.diagnostics import dedupe_and_sort
 from kolega_code.services.lsp.detector import DetectionReport, DetectionResult, ResolvedLanguage
-from kolega_code.services.lsp.manager import LspManager, _LspSession, _path_to_uri
+from kolega_code.services.lsp.manager import (
+    LspManager,
+    _LspSession,
+    _LSP_SHUTDOWN_REQUEST_TIMEOUT_SECONDS,
+    _path_to_uri,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -48,6 +53,55 @@ def manager(tmp_path: Path) -> LspManager:
     )
     m._resolved = {r.language_id: r for r in m.report.resolved}
     return m
+
+
+# ---------------------------------------------------------------------------
+# shutdown()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_shutdown_uses_short_graceful_timeout_and_stops_client(manager: LspManager):
+    """Shutdown uses its own short deadline, then sends exit and stops the client."""
+    client = MagicMock()
+    client.running = True
+    client.request = AsyncMock()
+    client.notify = AsyncMock()
+    client.stop = AsyncMock()
+    manager._sessions["python"] = client
+    manager._session_records["python"] = MagicMock()
+    manager._diagnostics["file:///test.py"] = []
+    manager._open_files["file:///test.py"] = "test.py"
+
+    await manager.shutdown()
+
+    client.request.assert_awaited_once_with("shutdown", timeout=_LSP_SHUTDOWN_REQUEST_TIMEOUT_SECONDS)
+    client.notify.assert_awaited_once_with("exit")
+    client.stop.assert_awaited_once_with()
+    assert manager._sessions == {}
+    assert manager._session_records == {}
+    assert manager._diagnostics == {}
+    assert manager._open_files == {}
+
+
+@pytest.mark.asyncio
+async def test_shutdown_stops_client_when_graceful_request_fails(manager: LspManager):
+    """A failed graceful request skips exit but does not skip forced termination."""
+    client = MagicMock()
+    client.running = True
+    client.request = AsyncMock(side_effect=LspClientError("shutdown timed out"))
+    client.notify = AsyncMock()
+    client.stop = AsyncMock()
+    manager._sessions["python"] = client
+    manager._session_records["python"] = MagicMock()
+
+    await manager.shutdown()
+
+    client.request.assert_awaited_once_with("shutdown", timeout=_LSP_SHUTDOWN_REQUEST_TIMEOUT_SECONDS)
+    client.notify.assert_not_awaited()
+    client.stop.assert_awaited_once_with()
+    assert manager._sessions == {}
+    assert manager._session_records == {}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- cap the graceful LSP shutdown request at one second during app cleanup and preserve forced termination
- log graceful-shutdown failures at debug level before process cleanup
- add unit, fake-server integration, and Textual Ctrl-Q regression coverage

## Testing
- `./run_tests.sh tests/services/lsp/test_manager.py tests/services/lsp/test_integration.py -q`
- `./run_tests.sh tests/cli/test_app_lsp_settings_status.py -q`
- `./run_tests.sh tests/services/lsp/test_client.py -q`
- `uv run pyright kolega_code/services/lsp/manager.py tests/services/lsp/_fake_server.py tests/services/lsp/conftest.py tests/services/lsp/test_manager.py tests/services/lsp/test_integration.py tests/cli/test_app_lsp_settings_status.py`
- `./run_tests.sh`