### PR TITLE
feat(llm): add Gemini 3.7 Flash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ### Added
 
+- Added Google Gemini 3.7 Flash (`gemini-3.7-flash`): 1M-token context, 64K
+  output, vision and function calling, and `low`/`medium`/`high` thinking
+  levels. It omits Google's deprecated temperature parameter and is now the
+  default Google model.
 - DeepSeek V4-Pro now routes to the Responses API by default (joining V4-Flash),
   removing the model-name carve-out. Both DeepSeek models support `none`, `low`,
   `high`, and `max` reasoning effort (`low` is new; `none` disables reasoning).

--- a/docs/src/content/docs/configuration/providers-and-models.mdx
+++ b/docs/src/content/docs/configuration/providers-and-models.mdx
@@ -356,6 +356,7 @@ models in the TUI.
 | Fireworks serverless reasoning models | `none`, `low`, `medium`, `high`, `max` | `medium` |
 | Ollama Cloud thinking models | `none`, `low`, `medium`, `high`, `max` | `medium` |
 | Ollama Cloud `gpt-oss:*` | `low`, `medium`, `high` | `medium` |
+| Google `gemini-3.7-flash` | `low`, `medium`, `high` | `medium` |
 | Google `gemini-3.6-flash` | `minimal`, `low`, `medium`, `high` | `medium` |
 | Google `gemini-3.5-flash-lite` | `minimal`, `low`, `medium`, `high` | `minimal` |
 | Google `gemini-3.5-flash` | `minimal`, `low`, `medium`, `high` | `medium` |

--- a/kolega_code/cli/provider_registry.py
+++ b/kolega_code/cli/provider_registry.py
@@ -88,6 +88,7 @@ MODEL_LABELS: dict[str, str] = {
     "gpt-5.4-mini": "GPT-5.4 Mini",
     "gpt-5.3-codex-spark": "GPT-5.3 Codex Spark",
     # Google
+    "gemini-3.7-flash": "Gemini 3.7 Flash",
     "gemini-3.6-flash": "Gemini 3.6 Flash",
     "gemini-3.5-flash-lite": "Gemini 3.5 Flash-Lite",
     "gemini-3.1-pro-preview": "Gemini 3.1 Pro",
@@ -156,7 +157,7 @@ PROVIDER_DEFAULT_MODEL: dict[ModelProvider, str] = {
     ModelProvider.ANTHROPIC: "claude-opus-5",
     ModelProvider.OPENAI: "gpt-5.6-sol",
     ModelProvider.OPENAI_CHATGPT: "gpt-5.6-sol",
-    ModelProvider.GOOGLE: "gemini-3.1-pro-preview",
+    ModelProvider.GOOGLE: "gemini-3.7-flash",
     ModelProvider.XAI: "grok-4.5",
     ModelProvider.FIREWORKS: "accounts/fireworks/models/glm-5p2",
     ModelProvider.TOGETHER: "moonshotai/Kimi-K2.7-Code",

--- a/kolega_code/llm/specs/catalog/google.py
+++ b/kolega_code/llm/specs/catalog/google.py
@@ -2,6 +2,19 @@ from kolega_code.llm.specs.types import ThinkingEffortSpec
 
 # Google models
 GOOGLE_SPECS = {
+    ("google", "gemini-3.7-flash"): {
+        "context_length": 1048576,
+        "max_completion_tokens": 65536,
+        "input_budget": "separate_output_limit",
+        "default_temperature": 1.0,
+        "supports_temperature": False,
+        "supports_vision": True,
+        "thinking_effort": ThinkingEffortSpec(
+            options=("low", "medium", "high"),
+            default="medium",
+            mode="google_thinking_level",
+        ),
+    },
     ("google", "gemini-3.6-flash"): {
         "context_length": 1048576,
         "max_completion_tokens": 65536,

--- a/tests/agent/llm/test_google_provider.py
+++ b/tests/agent/llm/test_google_provider.py
@@ -44,6 +44,7 @@ class _FakeGoogleModels:
 @pytest.mark.parametrize(
     "model,thinking,expected_temperature",
     [
+        ("gemini-3.7-flash", "medium", None),
         ("gemini-3.6-flash", "medium", None),
         ("gemini-3.5-flash-lite", "minimal", None),
         ("gemini-3.1-pro-preview", "high", 0.7),

--- a/tests/agent/llm/test_google_tool_signature_live.py
+++ b/tests/agent/llm/test_google_tool_signature_live.py
@@ -17,7 +17,7 @@ from kolega_code.llm.models import ToolDefinition, ToolParameter
 
 pytestmark = pytest.mark.integration
 
-MODEL = "gemini-3.5-flash"
+MODEL = "gemini-3.7-flash"
 SKIP_IN_CI = bool(os.getenv("CI")) or bool(os.getenv("GITLAB_CI"))
 
 SYSTEM = Message(role="system", content=[TextBlock(text="You are a helpful coding assistant.")])

--- a/tests/agent/llm/test_model_specs.py
+++ b/tests/agent/llm/test_model_specs.py
@@ -11,6 +11,7 @@ from kolega_code.llm.specs import (
 @pytest.mark.parametrize(
     "model,thinking_options,default_thinking",
     [
+        ("gemini-3.7-flash", ("low", "medium", "high"), "medium"),
         ("gemini-3.6-flash", ("minimal", "low", "medium", "high"), "medium"),
         ("gemini-3.5-flash-lite", ("minimal", "low", "medium", "high"), "minimal"),
     ],
@@ -24,6 +25,7 @@ def test_new_google_model_specs(
 
     assert specs["context_length"] == 1048576
     assert specs["max_completion_tokens"] == 65536
+    assert specs["input_budget"] == "separate_output_limit"
     assert specs["default_temperature"] == 1.0
     assert specs["supports_temperature"] is False
     assert specs["supports_vision"] is True

--- a/tests/agent/llm/test_thinking_effort.py
+++ b/tests/agent/llm/test_thinking_effort.py
@@ -23,6 +23,8 @@ def test_model_specs_expose_provider_specific_thinking_efforts() -> None:
     assert default_thinking_effort("moonshot", "kimi-k2.6") == "auto"
     assert thinking_effort_options("deepseek", "deepseek-v4-pro") == ("none", "low", "high", "max")
     assert default_thinking_effort("deepseek", "deepseek-v4-pro") == "high"
+    assert thinking_effort_options("google", "gemini-3.7-flash") == ("low", "medium", "high")
+    assert default_thinking_effort("google", "gemini-3.7-flash") == "medium"
     assert thinking_effort_options("google", "gemini-3.6-flash") == ("minimal", "low", "medium", "high")
     assert default_thinking_effort("google", "gemini-3.6-flash") == "medium"
     assert thinking_effort_options("google", "gemini-3.5-flash-lite") == ("minimal", "low", "medium", "high")
@@ -248,6 +250,9 @@ def test_google_gemini_3_pro_uses_thinking_level() -> None:
 @pytest.mark.parametrize(
     "model,effort",
     [
+        ("gemini-3.7-flash", "low"),
+        ("gemini-3.7-flash", "medium"),
+        ("gemini-3.7-flash", "high"),
         ("gemini-3.6-flash", "minimal"),
         ("gemini-3.6-flash", "low"),
         ("gemini-3.6-flash", "medium"),
@@ -272,6 +277,8 @@ def test_new_google_models_use_supported_thinking_levels(model: str, effort: str
 @pytest.mark.parametrize(
     "model,effort",
     [
+        ("gemini-3.7-flash", "minimal"),
+        ("gemini-3.7-flash", "xhigh"),
         ("gemini-3.6-flash", "xhigh"),
         ("gemini-3.5-flash-lite", "xhigh"),
     ],

--- a/tests/cli/test_provider_registry.py
+++ b/tests/cli/test_provider_registry.py
@@ -77,14 +77,20 @@ def test_gpt56_models_are_first_and_sol_is_default_for_openai_providers():
     ]
 
 
-def test_new_google_models_are_selectable_without_changing_default() -> None:
+def test_google_models_include_37_and_use_it_as_default() -> None:
     options = ui_model_options(ModelProvider.GOOGLE.value)
 
-    assert options[:2] == [
+    assert options[:3] == [
+        ("Gemini 3.7 Flash", "gemini-3.7-flash"),
         ("Gemini 3.6 Flash", "gemini-3.6-flash"),
         ("Gemini 3.5 Flash-Lite", "gemini-3.5-flash-lite"),
     ]
-    assert default_model_for_provider(ModelProvider.GOOGLE) == "gemini-3.1-pro-preview"
+    assert default_model_for_provider(ModelProvider.GOOGLE) == "gemini-3.7-flash"
+    assert ui_thinking_effort_options("google", "gemini-3.7-flash") == [
+        ("Low", "low"),
+        ("Medium", "medium"),
+        ("High", "high"),
+    ]
     assert ui_thinking_effort_options("google", "gemini-3.6-flash") == [
         ("Minimal", "minimal"),
         ("Low", "low"),
@@ -99,6 +105,7 @@ def test_new_google_models_are_selectable_without_changing_default() -> None:
     ]
 
     vision_options = dict(ui_model_options(ModelProvider.GOOGLE.value, vision_only=True))
+    assert vision_options["Gemini 3.7 Flash"] == "gemini-3.7-flash"
     assert vision_options["Gemini 3.6 Flash"] == "gemini-3.6-flash"
     assert vision_options["Gemini 3.5 Flash-Lite"] == "gemini-3.5-flash-lite"
 


### PR DESCRIPTION
## Summary
- Add direct Google `gemini-3.7-flash` support and make it the default Google model.
- Expose its label, vision capability, and `low`/`medium`/`high` thinking levels.
- Cover the catalog, provider requests, picker behavior, docs, and changelog.

## Verification
- `uv run ruff check .`
- `uv run pyright`
- `npm run build` (from `docs/`)
- Focused Gemini/provider tests: `89 passed`
- `PYTHONDONTWRITEBYTECODE=1 ./run_tests.sh` — 4822 passed, 2 skipped; the 3 failures require the optional native Tinker stack and are unrelated to this change.