### PR TITLE
fix(llm): drop unsupported additionalProperties from Google tool schemas

### DIFF
--- a/kolega_code/llm/models.py
+++ b/kolega_code/llm/models.py
@@ -859,11 +859,13 @@ class ToolDefinition(ContentBlock):
         ):
             if json_name in schema:
                 kwargs[google_name] = schema[json_name]
-        if "additionalProperties" in schema:
-            additional = schema["additionalProperties"]
-            kwargs["additional_properties"] = (
-                cls._dict_to_google_schema(additional) if isinstance(additional, dict) else additional
-            )
+        # ``additionalProperties`` is deliberately NOT forwarded. Gemini's
+        # function-declaration parameters use an OpenAPI 3.0 schema subset whose
+        # proto has no such field, so the live API rejects it in either spelling
+        # with 400 INVALID_ARGUMENT "Unknown name ... Cannot find field"
+        # (verified against gemini-3.5/3.6/3.7-flash, 2026-08-14). Dropping the
+        # key matches the pre-Jul-10 behavior and only loses the "no extra
+        # properties" hint, which most function-calling backends ignore anyway.
         return genai_types.Schema(**kwargs)
 
     def to_anthropic(self) -> Dict[str, Any]:

--- a/tests/tools/test_definitions.py
+++ b/tests/tools/test_definitions.py
@@ -88,6 +88,32 @@ def _dispatch_definition() -> ToolDefinition:
     )
 
 
+def test_builtin_tool_specs_serialize_for_google_without_additional_properties():
+    """No builtin schema may put additionalProperties on the Google wire.
+
+    Gemini's function-declaration parameters are an OpenAPI 3.0 subset with no
+    such field; the API rejects it in either spelling with 400 INVALID_ARGUMENT
+    (seen live on gemini-3.5/3.6/3.7-flash). Several builtin schemas legitimately
+    declare ``additionalProperties: false`` for other providers, so every spec is
+    swept to catch reintroductions at any nesting depth.
+    """
+    import json
+
+    from kolega_code.agent.tool_definitions import BUILTIN_TOOL_SPECS, builtin_tool_definition
+
+    assert BUILTIN_TOOL_SPECS, "builtin tool specs must not be empty"
+    checked = 0
+    for spec_key in BUILTIN_TOOL_SPECS:
+        tool = builtin_tool_definition(spec_key).to_google()
+        assert tool.function_declarations is not None
+        for declaration in tool.function_declarations:
+            payload = json.dumps(declaration.model_dump(by_alias=True, exclude_none=True))
+            assert "additionalProperties" not in payload, spec_key
+            assert "additional_properties" not in payload, spec_key
+            checked += 1
+    assert checked >= len(BUILTIN_TOOL_SPECS)
+
+
 def test_explicit_schema_passed_through_for_anthropic():
     definition = _nested_definition()
     payload = definition.to_anthropic()
@@ -135,12 +161,14 @@ def test_strict_nested_google_schema_keeps_in_memory_schema_models() -> None:
     assert tool.function_declarations is not None
     params = tool.function_declarations[0].parameters
     assert isinstance(params, genai_types.Schema)
-    assert params.additional_properties is False
+    # Gemini's function-declaration schema has no additionalProperties field;
+    # forwarding it 400s at the API ("Unknown name ... Cannot find field").
+    assert params.additional_properties is None
     assert params.properties is not None
 
     model_override = params.properties["model_override"]
     assert isinstance(model_override, genai_types.Schema)
-    assert model_override.additional_properties is False
+    assert model_override.additional_properties is None
     assert model_override.properties is not None
     assert set(model_override.properties) == {"provider", "model", "thinking_effort"}
     assert model_override.properties["provider"].min_length == 1
@@ -190,8 +218,8 @@ async def test_google_mldev_serializes_nested_schema_aliases_without_renaming_pr
     model_override = parameters["properties"]["model_override"]
     thinking_effort = model_override["properties"]["thinking_effort"]
 
-    assert parameters["additionalProperties"] is False
-    assert model_override["additionalProperties"] is False
+    assert "additionalProperties" not in parameters
+    assert "additionalProperties" not in model_override
     assert model_override["properties"]["provider"]["minLength"] == 1
     assert model_override["properties"]["model"]["minLength"] == 1
     assert thinking_effort["anyOf"][0]["enum"] == ["low", "medium", "high"]


### PR DESCRIPTION
## Summary

- `ToolDefinition._dict_to_google_schema` no longer forwards `additionalProperties` to the Gemini API, restoring the pre-`bb939330` behavior of dropping the key.
- Updates the two tests that codified the old wire shape and adds a sweep test over every builtin tool spec.

## Problem

Every Google model — including the just-added `gemini-3.7-flash` — returned the same error on any chat that included builtin tools:

```
400 INVALID_ARGUMENT
Unknown name "additionalProperties" at 'tools[0].function_declarations[0].parameters': Cannot find field.
```

## Root cause

Gemini's function-declaration `parameters` use an OpenAPI 3.0 schema subset whose proto has **no** `additionalProperties` field, so the API rejects the key in either spelling (`additionalProperties` / `additional_properties`).

- `bb939330` (Jul 10) taught the Google converter to forward the key (previously it was silently ignored, which was harmless).
- `6feb63fb` (Jul 26) later hit the snake_case spelling of this same rejection and fixed only the serialization alias, with tests asserting the field *is* on the wire — the camelCase spelling is equally rejected.
- `7bc76d31` (Aug 10) introduced `additionalProperties: false` into the builtin tool schemas (e.g. `hashline_edit` top-level, `dispatch_agent`'s nested `model_override`). From that commit on, **all** Gemini models 400'd on builtin tools; adding gemini-3.7-flash merely surfaced it.

Reproduced live pre-fix against `gemini-3.5-flash`, `gemini-3.6-flash`, and `gemini-3.7-flash` — identical 400 on all three.

## Fix

Drop the key in `_dict_to_google_schema` (with a comment documenting why). The only semantic loss is the "no extra properties" hint, which most function-calling backends ignore anyway.

## Tests

- `test_strict_nested_google_schema_keeps_in_memory_schema_models` / `test_google_mldev_serializes_nested_schema_aliases_without_renaming_properties`: now assert the field is absent instead of present.
- New `test_builtin_tool_specs_serialize_for_google_without_additional_properties`: sweeps every `BUILTIN_TOOL_SPECS` entry and asserts neither spelling appears at any nesting depth in the serialized declaration.

## Verification

- Live: all 52 builtin tools sent to gemini-3.5/3.6/3.7-flash — 400 before the fix, 200 after (3.6 answered normally).
- `./run_tests.sh tests/agent/llm tests/tools tests/agent/test_tool_collection_config.py` — 871 passed.
- `ruff check`, `ruff format --check`, `pyright`, and `pre-commit run` clean on the changed files.
