### PR TITLE
fix(llm): enable local token counting and multi-provider residual usage for Z.AI

### DIFF
--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -1145,7 +1145,15 @@ class BaseAgent(LogMixin):
         if new_calls:
             self._context_residual_tokens += self.HOSTED_SEARCH_PROVISIONAL_TOKENS * new_calls
             return
-        billed = (assistant_message.usage_metadata or {}).get("prompt_tokens")
+        billed = (
+            assistant_message.usage.input_tokens
+            if assistant_message.usage and assistant_message.usage.reported
+            else (
+                (assistant_message.usage_metadata or {}).get("prompt_tokens")
+                or (assistant_message.usage_metadata or {}).get("input_tokens")
+                or (assistant_message.usage_metadata or {}).get("prompt_token_count")
+            )
+        )
         counted = self._last_raw_context_count
         if not isinstance(billed, int) or counted is None:
             return

--- a/kolega_code/llm/providers/anthropic.py
+++ b/kolega_code/llm/providers/anthropic.py
@@ -121,7 +121,7 @@ class AnthropicProvider(BaseLLMProvider):
         # so local counting is only a preflight context-size estimate for those models.
         # Billing/accounting must use provider response usage metadata instead.
         self.use_local_token_counting = (
-            provider_name in {"moonshot", "kimi_coding"}
+            provider_name in {"moonshot", "kimi_coding", "zai"}
             or provider_name.startswith("custom:")
             or os.getenv("ANTHROPIC_USE_LOCAL_TOKEN_COUNTING", "false").lower() == "true"
         )

--- a/tests/agent/llm/test_dashscope_mapping.py
+++ b/tests/agent/llm/test_dashscope_mapping.py
@@ -22,6 +22,17 @@ def test_llm_client_maps_moonshot_to_anthropic_provider():
     assert thinking == "auto"
 
 
+def test_llm_client_maps_zai_to_anthropic_provider():
+    client = LLMClient(provider="zai", api_key="sk-test")
+    assert isinstance(client.provider, AnthropicProvider)
+    assert client.provider.base_url == "https://api.z.ai/api/anthropic"
+    assert client.provider.provider_name == "zai"
+    assert client.provider.use_local_token_counting is True
+
+    thinking = client._prepare_thinking_param("max", model="glm-5.3")
+    assert thinking == "max"
+
+
 def test_llm_client_maps_deepseek_to_responses_provider():
     client = LLMClient(provider="deepseek", api_key="sk-test")
     assert isinstance(client.provider, DeepSeekResponsesProvider)

--- a/tests/agent/test_context_residual_accounting.py
+++ b/tests/agent/test_context_residual_accounting.py
@@ -105,6 +105,36 @@ class TestResidualUpdates:
         agent._update_context_residual(Message(role="assistant", content=[TextBlock(text="ok")], usage_metadata={}))
         assert agent._context_residual_tokens == 5_000
 
+    def test_anthropic_input_tokens_usage_metadata(self, agent):
+        agent._last_raw_context_count = 1_000
+        msg = Message(role="assistant", content=[TextBlock(text="ok")], usage_metadata={"input_tokens": 1_800})
+        agent._update_context_residual(msg)
+        assert agent._context_residual_tokens == 800
+
+    def test_normalized_usage_takes_precedence(self, agent):
+        from kolega_code.llm.usage import NormalizedUsage
+
+        agent._last_raw_context_count = 1_000
+        msg = Message(
+            role="assistant",
+            content=[TextBlock(text="ok")],
+            usage_metadata={"input_tokens": 1_500},
+            usage=NormalizedUsage(
+                provider="zai",
+                model="glm-5.3",
+                reported=True,
+                input_tokens=2_200,
+                output_tokens=50,
+                total_tokens=2_250,
+                cache_read_input_tokens=None,
+                cache_write_input_tokens=None,
+                reasoning_output_tokens=None,
+                unavailable_reason=None,
+            ),
+        )
+        agent._update_context_residual(msg)
+        assert agent._context_residual_tokens == 1_200
+
 
 class TestGaugeApplication:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Enable `use_local_token_counting` for the `zai` provider in `AnthropicProvider`. Z.AI's Anthropic-compatible `/v1/messages/count_tokens` endpoint returns `input_tokens: 0` for `glm-5.3` (the default model), causing the sidebar context gauge to report 0% / 0 tokens.
- Update `BaseAgent._update_context_residual` to check `assistant_message.usage.input_tokens` (normalized usage across providers) and fallback to `prompt_tokens`, `input_tokens`, or `prompt_token_count`, ensuring Anthropic-shaped and Google providers also properly calibrate context residuals from response billing.
- Add test coverage in `tests/agent/llm/test_dashscope_mapping.py` and `tests/agent/test_context_residual_accounting.py`.

## Verification
- Pre-commit checks passed (`ruff`, `pyright`, etc.).
- Fast test suite passed (4,830 passed).
- Live tested against Z.AI endpoint verifying token counting and response usage.