### PR TITLE
chore: release v0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.30.0 - 2026-08-14
+
 ### Added
 
 - Added Google Gemini 3.7 Flash (`gemini-3.7-flash`): 1M-token context, 64K
@@ -15,12 +17,32 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 - DeepSeek V4-Pro now routes to the Responses API by default (joining V4-Flash),
   removing the model-name carve-out. Both DeepSeek models support `none`, `low`,
   `high`, and `max` reasoning effort (`low` is new; `none` disables reasoning).
+  Hosted web search is now available on V4-Pro as well as V4-Flash.
 - Added support for xAI Grok 4.6 (`grok-4.6`): 500K-token context, vision input,
   and `low`/`medium`/`high`/`xhigh` reasoning effort. Selectable in the Settings
   UI, `/model` picker, CLI flags, and env vars.
 - Added support for Z.AI GLM-5.3 (`glm-5.3`) on the GLM Coding Plan provider:
   1M-token context, 128K max output, and `high`/`max` thinking effort. GLM-5.3
   is now the Z.AI default model.
+- Added the Perplexity Agent API provider (`perplexity_agent`): one
+  `PERPLEXITY_API_KEY` reaches OpenAI, Anthropic, Google, xAI, and Perplexity
+  models through Perplexity's Responses-compatible Agent API, with optional
+  hosted search tools.
+- `/plan` accepts an optional prompt: `/plan <task>` switches to plan mode and
+  starts that planning turn. Bare `/plan` still only switches mode.
+
+### Fixed
+
+- Google Gemini models no longer reject builtin tool calls with a 400 about
+  `additionalProperties` in function-declaration schemas.
+- Quitting the TUI no longer waits up to 30s for an unresponsive language
+  server to acknowledge shutdown.
+- The Z.AI context-window gauge now counts tokens locally (Z.AI's count
+  endpoint reports 0 for GLM-5.3) and residual usage calibrates from
+  multi-provider response billing.
+- MCP tools whose names contain invalid characters or exceed provider length
+  limits are sanitized at collection time, and provider 400 details are shown
+  in the turn error instead of a generic failure.
 
 ## 0.29.0 - 2026-08-13
 

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -174,4 +174,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.29.0"
+__version__ = "0.30.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.29.0"
+__version__ = "0.30.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.29.0"
+version = "0.30.0"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -1787,7 +1787,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.29.0"
+version = "0.30.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Release v0.30.0

Bumps the version to 0.30.0 in `pyproject.toml`, `uv.lock`, and both `__version__` values; moves the changelog entry from Unreleased.

### Highlights

- **Gemini 3.7 Flash** — new default Google model with 1M-token context, vision, and `low`/`medium`/`high` thinking.
- **Grok 4.6, GLM-5.3, DeepSeek V4-Pro Responses** — new xAI and Z.AI models; DeepSeek V4-Pro now uses the Responses API with hosted web search and `none`/`low`/`high`/`max` reasoning effort.
- **Perplexity Agent API** — one `PERPLEXITY_API_KEY` reaches OpenAI, Anthropic, Google, xAI, and Perplexity models through Perplexity's Agent API.
- **`/plan` prompt** — optional planning prompt after `/plan`.
- **Fixes** — Gemini builtin-tool 400s, LSP quit delay, Z.AI context-window gauge, MCP tool-name sanitization.

Verified locally: fast test suite (4826 passed; 3 Tinker live tests also pass with the optional extra) and pre-commit hooks green in a disposable `.venv-release` environment.
