### PR TITLE
fix(agent): retry empty compaction summaries before fail-closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+### Fixed
+
+- Compaction now uses the primary model's thinking setting instead of
+  omitting it. Empty or reasoning-only helper completions are retried,
+  then can still take the zero-tail recovery path instead of being
+  treated as a final `llm_error`.
+
 ## 0.30.0 - 2026-08-14
 
 ### Added

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -1224,9 +1224,10 @@ class BaseAgent(LogMixin):
                 llm=self.llm,
                 model=self.primary_model_config.model,
                 temperature=self.model_default_temperature,
-                # No extended thinking: a bounded summary doesn't need it, and the
-                # thinking budget could otherwise exceed the small summary max_tokens.
-                thinking=None,
+                # Same thinking setting as the primary request. Omitting it is not a
+                # disable: some endpoints default to reasoning-on, and some reject a
+                # missing effort. A None effort (no thinking spec) still omits the field.
+                thinking=self.primary_model_config.thinking_effort,
                 on_info=on_info,
                 on_error=on_error,
                 system_prompt_text=compaction_system_prompt,
@@ -2448,9 +2449,11 @@ class BaseAgent(LogMixin):
                     # at the model (llm_error — the provider client already applied
                     # its retry policy, so another summarization request buys
                     # nothing) or hit the minimum-history guard (too_few — a zero
-                    # tail must not weaken it). A nothing_to_summarize result MAY
-                    # proceed: with no retained tail, the safe boundary can advance
-                    # past the previous one even when the six-message tail could not.
+                    # tail must not weaken it). An empty_summary or
+                    # nothing_to_summarize result MAY proceed: empty completions
+                    # already exhausted in-pass retries, and with no retained tail
+                    # the safe boundary can advance past the previous one even
+                    # when the six-message tail could not.
                     if token_count.input_tokens > self.model_max_input_tokens and result.reason not in (
                         "llm_error",
                         "too_few",

--- a/kolega_code/agent/compression.py
+++ b/kolega_code/agent/compression.py
@@ -264,21 +264,6 @@ class HistoryCompressor:
             # The helper origin spans the whole request: providers may sample and
             # emit their trace record at context entry or final-message time, not
             # at stream().
-            async def drain_summary() -> Message:
-                with llm_call_origin(helper_origin("compression")):
-                    stream_cm = await llm.stream(
-                        messages=messages,
-                        system=system_message,
-                        temperature=temperature,
-                        model=model,
-                        max_completion_tokens=self.SUMMARY_MAX_TOKENS,
-                        thinking=thinking,
-                    )
-                    async with stream_cm as stream:
-                        async for _event in stream:
-                            pass
-                    return await stream.get_final_message()
-
             response = None
             last_error: Optional[LLMContextWindowExceededError] = None
             dispatched_gap: Optional[tuple[int, int]] = None
@@ -291,7 +276,19 @@ class HistoryCompressor:
                         # re-sending it would only be rejected again.
                         continue
                 try:
-                    response = await drain_summary()
+                    with llm_call_origin(helper_origin("compression")):
+                        stream_cm = await llm.stream(
+                            messages=messages,
+                            system=system_message,
+                            temperature=temperature,
+                            model=model,
+                            max_completion_tokens=self.SUMMARY_MAX_TOKENS,
+                            thinking=thinking,
+                        )
+                        async with stream_cm as stream:
+                            async for _event in stream:
+                                pass
+                        response = await stream.get_final_message()
                     break
                 except LLMContextWindowExceededError as exc:
                     if max_input_tokens is None:
@@ -328,7 +325,19 @@ class HistoryCompressor:
                 else:
                     logger.info(retry_msg)
                 # Same fitted request: empty completions are not a budget-fit failure.
-                response = await drain_summary()
+                with llm_call_origin(helper_origin("compression")):
+                    stream_cm = await llm.stream(
+                        messages=messages,
+                        system=system_message,
+                        temperature=temperature,
+                        model=model,
+                        max_completion_tokens=self.SUMMARY_MAX_TOKENS,
+                        thinking=thinking,
+                    )
+                    async with stream_cm as stream:
+                        async for _event in stream:
+                            pass
+                    response = await stream.get_final_message()
 
             if on_error:
                 await on_error(last_empty_message)

--- a/kolega_code/agent/compression.py
+++ b/kolega_code/agent/compression.py
@@ -117,6 +117,37 @@ def _bundles_tool_results(message: Message) -> bool:
     return isinstance(message.content, list) and any(isinstance(block, ToolResult) for block in message.content)
 
 
+async def _stream_summary(
+    llm,
+    messages: MessageHistory,
+    system: Message,
+    temperature: float,
+    model: str,
+    thinking,
+) -> Message:
+    """Issue the compaction helper request and return the completed message.
+
+    Stream and consume events rather than calling ``generate()``: the Anthropic
+    SDK rejects non-streaming requests whose max_tokens is large enough to risk
+    a >10-minute response. The helper origin spans the whole request because
+    providers may sample and emit their trace record at context entry or
+    final-message time, not at ``stream()``.
+    """
+    with llm_call_origin(helper_origin("compression")):
+        stream_cm = await llm.stream(
+            messages=messages,
+            system=system,
+            temperature=temperature,
+            model=model,
+            max_completion_tokens=HistoryCompressor.SUMMARY_MAX_TOKENS,
+            thinking=thinking,
+        )
+        async with stream_cm as stream:
+            async for _event in stream:
+                pass
+        return await stream.get_final_message()
+
+
 class HistoryCompressor:
     """Summarizes a conversation non-destructively when it crosses the budget threshold."""
 
@@ -257,13 +288,6 @@ class HistoryCompressor:
                     head_end, tail_start = new_head, new_tail
                     messages = build_request(head_end, tail_start)
 
-            # Stream and drain rather than calling generate(): the Anthropic SDK
-            # rejects non-streaming requests whose max_tokens is large enough to risk
-            # a >10-minute response, which the model's full completion budget triggers.
-            #
-            # The helper origin spans the whole request: providers may sample and
-            # emit their trace record at context entry or final-message time, not
-            # at stream().
             response = None
             last_error: Optional[LLMContextWindowExceededError] = None
             dispatched_gap: Optional[tuple[int, int]] = None
@@ -276,19 +300,14 @@ class HistoryCompressor:
                         # re-sending it would only be rejected again.
                         continue
                 try:
-                    with llm_call_origin(helper_origin("compression")):
-                        stream_cm = await llm.stream(
-                            messages=messages,
-                            system=system_message,
-                            temperature=temperature,
-                            model=model,
-                            max_completion_tokens=self.SUMMARY_MAX_TOKENS,
-                            thinking=thinking,
-                        )
-                        async with stream_cm as stream:
-                            async for _event in stream:
-                                pass
-                        response = await stream.get_final_message()
+                    response = await _stream_summary(
+                        llm,
+                        messages=messages,
+                        system=system_message,
+                        temperature=temperature,
+                        model=model,
+                        thinking=thinking,
+                    )
                     break
                 except LLMContextWindowExceededError as exc:
                     if max_input_tokens is None:
@@ -325,19 +344,14 @@ class HistoryCompressor:
                 else:
                     logger.info(retry_msg)
                 # Same fitted request: empty completions are not a budget-fit failure.
-                with llm_call_origin(helper_origin("compression")):
-                    stream_cm = await llm.stream(
-                        messages=messages,
-                        system=system_message,
-                        temperature=temperature,
-                        model=model,
-                        max_completion_tokens=self.SUMMARY_MAX_TOKENS,
-                        thinking=thinking,
-                    )
-                    async with stream_cm as stream:
-                        async for _event in stream:
-                            pass
-                    response = await stream.get_final_message()
+                response = await _stream_summary(
+                    llm,
+                    messages=messages,
+                    system=system_message,
+                    temperature=temperature,
+                    model=model,
+                    thinking=thinking,
+                )
 
             if on_error:
                 await on_error(last_empty_message)

--- a/kolega_code/agent/compression.py
+++ b/kolega_code/agent/compression.py
@@ -23,7 +23,7 @@ LogCallback = Callable[[str], Awaitable[None]]
 class CompactionResult:
     """Outcome of a compaction attempt, surfaced to callers and the UI.
 
-    ``reason`` is a machine tag: "ok" | "too_few" | "nothing_to_summarize" | "llm_error".
+    ``reason`` is a machine tag: "ok" | "too_few" | "nothing_to_summarize" | "empty_summary" | "llm_error".
     ``message`` is a human-readable line for the command output / logs.
     """
 
@@ -131,6 +131,9 @@ class HistoryCompressor:
     # summary. A generous ceiling gives reasoning headroom while still staying
     # well under the model's full completion budget.
     SUMMARY_MAX_TOKENS = 8192
+    # Completed-but-empty summaries (reasoning-only, whitespace, no text) are
+    # retried on the same fitted request before the pass is reported unusable.
+    SUMMARY_EMPTY_ATTEMPTS = 3
     # Attempts at widening the omission gap per budget rung.
     MAX_FIT_ATTEMPTS = 6
 
@@ -261,6 +264,21 @@ class HistoryCompressor:
             # The helper origin spans the whole request: providers may sample and
             # emit their trace record at context entry or final-message time, not
             # at stream().
+            async def drain_summary() -> Message:
+                with llm_call_origin(helper_origin("compression")):
+                    stream_cm = await llm.stream(
+                        messages=messages,
+                        system=system_message,
+                        temperature=temperature,
+                        model=model,
+                        max_completion_tokens=self.SUMMARY_MAX_TOKENS,
+                        thinking=thinking,
+                    )
+                    async with stream_cm as stream:
+                        async for _event in stream:
+                            pass
+                    return await stream.get_final_message()
+
             response = None
             last_error: Optional[LLMContextWindowExceededError] = None
             dispatched_gap: Optional[tuple[int, int]] = None
@@ -273,19 +291,7 @@ class HistoryCompressor:
                         # re-sending it would only be rejected again.
                         continue
                 try:
-                    with llm_call_origin(helper_origin("compression")):
-                        stream_cm = await llm.stream(
-                            messages=messages,
-                            system=system_message,
-                            temperature=temperature,
-                            model=model,
-                            max_completion_tokens=self.SUMMARY_MAX_TOKENS,
-                            thinking=thinking,
-                        )
-                        async with stream_cm as stream:
-                            async for _event in stream:
-                                pass
-                        response = await stream.get_final_message()
+                    response = await drain_summary()
                     break
                 except LLMContextWindowExceededError as exc:
                     if max_input_tokens is None:
@@ -297,22 +303,38 @@ class HistoryCompressor:
                 assert last_error is not None
                 raise last_error
 
-            summary_text = response.get_text_content()
-            if not summary_text or not summary_text.strip():
-                msg = "Compression produced an empty summary; history left unchanged."
-                if on_error:
-                    await on_error(msg)
+            last_empty_message = "Compression produced an empty summary; history left unchanged."
+            for attempt in range(1, self.SUMMARY_EMPTY_ATTEMPTS + 1):
+                summary_text = response.get_text_content()
+                if summary_text and summary_text.strip():
+                    folded = split - prior_through
+                    conversation.apply_compaction(summary_text, split)
+                    done = f"Compressed {folded} older message(s) into a summary; kept the latest turns verbatim."
+                    if on_info:
+                        await on_info(done)
+                    return CompactionResult(ok=True, reason="ok", summarized_messages=folded, message=done)
+
+                stop = getattr(response, "stop_reason", None)
+                stop_note = f" (stop_reason={stop})" if stop else ""
+                last_empty_message = f"Compression produced an empty summary{stop_note}; history left unchanged."
+                if attempt >= self.SUMMARY_EMPTY_ATTEMPTS:
+                    break
+                retry_msg = (
+                    f"Compression produced an empty summary{stop_note}; "
+                    f"retrying ({attempt + 1}/{self.SUMMARY_EMPTY_ATTEMPTS})."
+                )
+                if on_info:
+                    await on_info(retry_msg)
                 else:
-                    logger.error(msg)
-                return CompactionResult(ok=False, reason="llm_error", message=msg)
+                    logger.info(retry_msg)
+                # Same fitted request: empty completions are not a budget-fit failure.
+                response = await drain_summary()
 
-            folded = split - prior_through
-            conversation.apply_compaction(summary_text, split)
-
-            done = f"Compressed {folded} older message(s) into a summary; kept the latest turns verbatim."
-            if on_info:
-                await on_info(done)
-            return CompactionResult(ok=True, reason="ok", summarized_messages=folded, message=done)
+            if on_error:
+                await on_error(last_empty_message)
+            else:
+                logger.error(last_empty_message)
+            return CompactionResult(ok=False, reason="empty_summary", message=last_empty_message)
 
         except Exception as e:
             # Never swallow into a fake success: log the full traceback and surface

--- a/kolega_code/agent/utils/commands.py
+++ b/kolega_code/agent/utils/commands.py
@@ -58,9 +58,9 @@ class CommandProcessor:
                 f"Compressed history: {result.summarized_messages} older message(s) summarized. "
                 f"Context {pct(before)}% → {pct(after)}% of the input budget."
             )
-        if result.reason == "llm_error":
-            return f"Compression failed: {result.message}"
-        return f"Nothing to compress. {result.message} (context {pct(before)}% of the input budget)."
+        if result.reason in ("too_few", "nothing_to_summarize"):
+            return f"Nothing to compress. {result.message} (context {pct(before)}% of the input budget)."
+        return f"Compression failed: {result.message}"
 
     async def _handle_clear(self) -> str:
         """Handle the /clear command."""

--- a/tests/agent/compaction_helpers.py
+++ b/tests/agent/compaction_helpers.py
@@ -9,7 +9,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 from kolega_code.events import AgentConnectionManager
-from kolega_code.llm.models import Message, MessageHistory, TextBlock, ToolCall, ToolResult
+from kolega_code.llm.models import Message, MessageHistory, TextBlock, ThinkingBlock, ToolCall, ToolResult
 from kolega_code.llm.providers.models import TokenCount
 
 
@@ -103,6 +103,14 @@ class FakeLLM:
 
 def text_msg(role: str, text: str) -> Message:
     return Message(role=role, content=[TextBlock(text=text)])
+
+
+def thinking_only_msg(
+    thinking: str = "reasoned at length without writing a summary.",
+    stop_reason: str = "max_tokens",
+) -> Message:
+    """A completed helper response that spent its budget on reasoning only."""
+    return Message(role="assistant", content=[ThinkingBlock(thinking=thinking)], stop_reason=stop_reason)
 
 
 def skill_msg(name: str = "kolega-skill", body: str = "protected body") -> Message:

--- a/tests/agent/test_commands.py
+++ b/tests/agent/test_commands.py
@@ -91,6 +91,24 @@ async def test_handle_compress_nothing_to_compress(command_processor, mock_agent
 
 
 @pytest.mark.asyncio
+async def test_handle_compress_empty_summary_is_failure(command_processor, mock_agent):
+    """An unusable helper completion is a failure, not a no-op."""
+    mock_agent.compress_history = AsyncMock(
+        return_value=CompactionResult(
+            ok=False,
+            reason="empty_summary",
+            message="Compression produced an empty summary; history left unchanged.",
+        )
+    )
+
+    result = await command_processor._handle_compress()
+
+    assert result.startswith("Compression failed:")
+    assert "empty summary" in result
+    assert "Nothing to compress" not in result
+
+
+@pytest.mark.asyncio
 async def test_handle_clear(command_processor, mock_agent, mock_message):
     """Test the /clear command handler"""
     # Add some messages to history first

--- a/tests/agent/test_compaction_integration.py
+++ b/tests/agent/test_compaction_integration.py
@@ -14,10 +14,12 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from kolega_code.agent.compression import HistoryCompressor
 from kolega_code.hooks.events import HookEvent
 from kolega_code.llm.exceptions import LLMContextWindowExceededError
+from kolega_code.llm.models import Message, TextBlock
 
-from .compaction_helpers import FakeLLM, FakeStream, build_agent, context_update_events, long_history
+from .compaction_helpers import FakeLLM, FakeStream, build_agent, context_update_events, long_history, thinking_only_msg
 
 
 def _hook_spy(agent):
@@ -253,6 +255,52 @@ async def test_full_loop_strict_cap_raises_after_too_few(tmp_path):
             pass
 
     fake.stream.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_full_loop_strict_cap_retries_empty_summary_then_zero_tail(tmp_path):
+    # Reasoning-only max_tokens completions are not llm_error: the ordinary
+    # pass retries, then zero-tail recovery still runs before fail-closed.
+    attempts = HistoryCompressor.SUMMARY_EMPTY_ATTEMPTS
+    fake = FakeLLM(
+        token_script=[700, 900, 900, 900],
+        message_script=[thinking_only_msg()] * (attempts * 2),
+    )
+    agent, _cm = build_agent(tmp_path, llm=fake, strict_budget=(1000, 200))
+    agent.history = long_history(6)
+    fired = _hook_payload_spy(agent)
+
+    with pytest.raises(LLMContextWindowExceededError):
+        async for _chunk in agent.process_message_stream("hello"):
+            pass
+
+    assert _compaction_triggers(fired) == ["auto", "auto_tail_fallback"]
+    assert fake.stream.await_count == attempts * 2  # both passes; the primary model was never called
+    assert agent.conversation.summary is None
+
+
+@pytest.mark.asyncio
+async def test_full_loop_zero_tail_recovers_after_empty_ordinary_pass(tmp_path):
+    attempts = HistoryCompressor.SUMMARY_EMPTY_ATTEMPTS
+    fallback_text = "ZERO-TAIL SUMMARY"
+    fake = FakeLLM(
+        token_script=[900, 800, 1100, 1100, 800, 400],
+        message_script=[thinking_only_msg()] * attempts
+        + [Message(role="assistant", content=[TextBlock(text=fallback_text)], stop_reason="end_turn")],
+    )
+    agent, _cm = build_agent(tmp_path, llm=fake)
+    agent.history = long_history(6)
+    fired = _hook_payload_spy(agent)
+
+    async for _chunk in agent.process_message_stream("hello"):
+        pass
+
+    assert _compaction_triggers(fired) == ["auto", "auto_tail_fallback"]
+    assert fake.stream.await_count == attempts + 2  # empty retries + fallback summary + primary
+    primary_messages = fake.stream.await_args_list[-1].kwargs["messages"]
+    assert [m.get_text_content() for m in primary_messages] == [fallback_text]
+    assert agent.conversation.summary is not None
+    assert agent.conversation.summary.get_text_content() == fallback_text
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_compression.py
+++ b/tests/agent/test_compression.py
@@ -8,8 +8,8 @@ import pytest
 from kolega_code.agent.compression import COMPRESSION_SUMMARY_SYSTEM_PROMPT, CompactionResult, HistoryCompressor
 from kolega_code.agent.conversation import Conversation
 
-from .compaction_helpers import FakeLLM, build_agent, long_history, tool_pair, text_msg
-from kolega_code.llm.models import MessageHistory
+from .compaction_helpers import FakeLLM, build_agent, long_history, text_msg, thinking_only_msg, tool_pair
+from kolega_code.llm.models import Message, MessageHistory, TextBlock
 
 
 class SummarizeKwargs(TypedDict):
@@ -170,10 +170,61 @@ async def test_summarize_llm_error_is_nondestructive():
 @pytest.mark.asyncio
 async def test_summarize_empty_output_is_error():
     conv = Conversation(list(long_history(6)))
-    result = await HistoryCompressor().summarize(conv, llm=FakeLLM(summary_text="   "), **SUMMARIZE_KW)
+    llm = FakeLLM(summary_text="   ")
+    result = await HistoryCompressor().summarize(conv, llm=llm, **SUMMARIZE_KW)
     assert result.ok is False
-    assert result.reason == "llm_error"
+    assert result.reason == "empty_summary"
     assert conv.summary is None
+    assert llm.stream.await_count == HistoryCompressor.SUMMARY_EMPTY_ATTEMPTS
+
+
+@pytest.mark.asyncio
+async def test_summarize_retries_reasoning_only_completion_then_succeeds():
+    conv = Conversation(list(long_history(6)))
+    llm = FakeLLM(
+        message_script=[
+            thinking_only_msg(),
+            thinking_only_msg(),
+            Message(role="assistant", content=[TextBlock(text="SUMMARY: recovered")], stop_reason="end_turn"),
+        ]
+    )
+    result = await HistoryCompressor().summarize(conv, llm=llm, **SUMMARIZE_KW)
+
+    assert result.ok is True
+    assert result.reason == "ok"
+    assert conv.summary is not None
+    assert conv.summary.get_text_content() == "SUMMARY: recovered"
+    assert llm.stream.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_summarize_reasoning_only_completion_is_empty_summary():
+    history = long_history(6)
+    conv = Conversation(list(history))
+    llm = FakeLLM(message_script=[thinking_only_msg()] * HistoryCompressor.SUMMARY_EMPTY_ATTEMPTS)
+    result = await HistoryCompressor().summarize(conv, llm=llm, **SUMMARIZE_KW)
+
+    assert result.ok is False
+    assert result.reason == "empty_summary"
+    assert "max_tokens" in result.message
+    assert conv.summary is None
+    assert list(conv.history) == list(history)
+    assert llm.stream.await_count == HistoryCompressor.SUMMARY_EMPTY_ATTEMPTS
+
+
+@pytest.mark.asyncio
+async def test_agent_compaction_forwards_primary_thinking_effort(tmp_path):
+    fake = FakeLLM(summary_text="SUMMARY: earlier turns")
+    agent, _ = build_agent(tmp_path, llm=fake)
+    agent.history = MessageHistory(list(long_history(6)))
+    agent.primary_model_config = agent.primary_model_config.model_copy(update={"thinking_effort": "high"})
+
+    result = await agent.compress_history()
+
+    assert result.ok is True
+    assert fake.stream.await_args is not None
+    assert fake.stream.await_args.kwargs["thinking"] == "high"
+    assert all(call.kwargs.get("thinking") == "high" for call in fake.count_tokens.await_args_list)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

A completed compaction helper that spent its output budget on reasoning and returned no summary text was tagged `llm_error`. That skipped `auto_tail_fallback`, so a strict-cap run failed immediately with `LLMContextWindowExceededError` as if recovery had already been exhausted.

- Pass the primary model's `thinking_effort` into the helper (`thinking=None` omits the field; it does not disable reasoning).
- Retry empty / reasoning-only completions up to 3 times on the same fitted request.
- Report those as `empty_summary` so zero-tail recovery can still run. Real transport/model exceptions stay `llm_error` and still skip fallback.
- Report `empty_summary` from `/compress` as a failure, not "Nothing to compress."

## Test plan

- [x] `./run_tests.sh tests/agent/test_compression.py tests/agent/test_compaction_integration.py tests/agent/test_commands.py tests/agent/test_base_agent_compaction.py tests/agent/test_compaction_request_budget.py tests/agent/llm/test_client_context_budget.py tests/agent/test_compaction_tui_events.py`
- [x] Pre-commit hooks on commit (ruff, pyright)
- [ ] CI on this PR
