### PR TITLE
chore: release v0.30.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.30.1 - 2026-08-17
+
 ### Fixed
 
 - Compaction now uses the primary model's thinking setting instead of

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -174,4 +174,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.30.0"
+__version__ = "0.30.1"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.30.0"
+__version__ = "0.30.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.30.0"
+version = "0.30.1"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -1787,7 +1787,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.30.0"
+version = "0.30.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Release v0.30.1

Patch release with one fix since v0.30.0:

- Compaction now uses the primary model's thinking setting instead of omitting it; empty or reasoning-only helper completions are retried before the zero-tail recovery path.

Version bumped in `pyproject.toml`, `uv.lock`, `kolega_code/__init__.py`, `kolega_code/agent/__init__.py`; `CHANGELOG.md` updated.

Local checks: fast suite (4829 passed, tinker live tests pass with optional extra), pre-commit all green.
