### PR TITLE
perf(prompts): stabilize bundled prompts across projects

### DIFF
--- a/docs/src/content/docs/configuration/prompt-overrides.md
+++ b/docs/src/content/docs/configuration/prompt-overrides.md
@@ -88,7 +88,10 @@ kolega-code prompts validate --project .
 
 Validation uses the same strict Jinja rendering check that runs during startup. Missing optional files are not errors. The terminal command exits `0` when all existing supported overrides are valid (or no overrides exist), and exits `1` when any override cannot render.
 
-Dumped files are editable Markdown templates. Environment values are written as Jinja tags, not frozen current values. For example:
+Dumped files are editable Markdown templates. The bundled templates omit session-specific environment
+facts so equivalent agents can share the same cached system-prompt prefix. The same variables remain
+available to project overrides. If an override intentionally needs them, it can add Jinja expressions
+such as:
 
 ```md
 - Working directory: {{ context.project_path }}
@@ -98,12 +101,11 @@ Dumped files are editable Markdown templates. Environment values are written as 
 - Model supports vision: {{ context.model_supports_vision | lower }}
 ```
 
-The bundled prompts deliberately omit values that change while a session runs — the
-date, repository guidance, and project memory. Anything in the system prompt is
-processed ahead of every message, so a change there invalidates the cached prefix for
-the whole conversation; those values are delivered to the agent as `<system-reminder>`
-context updates instead, each time they change. The variables remain available to your
-overrides if you want them, at that cost.
+The bundled prompts deliver working directory, Git status, platform, model, and vision capability in
+the initial runtime-authored `<system-reminder source="session">` history message. Values that can
+change while a session runs — the date, repository guidance, and project memory — arrive as later
+`<system-reminder>` context updates. Anything added to a project override remains part of the system
+prompt and therefore changes its cache key.
 
 ## Template variables
 

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -914,8 +914,8 @@ class BaseAgent(LogMixin):
         """Build PromptContext from agent state."""
         import platform
 
-        # Check if it's a git repository
-        is_git_repo = self.filesystem.exists(".git") and self.filesystem.is_dir(".git")
+        # Repository roots use a .git directory; linked worktrees use a .git file.
+        is_git_repo = self.filesystem.exists(".git")
 
         project_guidance_file, project_guidance = self._load_project_guidance()
         # ``private_memory`` (policy + the memory itself) is still populated for callers that

--- a/kolega_code/agent/prompt_templates/system/agents/browser.md.j2
+++ b/kolega_code/agent/prompt_templates/system/agents/browser.md.j2
@@ -3,14 +3,6 @@
 You are a web browser agent for {{ context.system_name }}. Your purpose is to use the tools at your disposal to complete
 the task that Kolega Code gives you. The task will usually be related to performing QA on a web application frontend.
 
-Here is some useful information about the environment you are running in:
-
-- Working directory: {{ context.project_path }}
-- Is directory a git repo: {{ context.is_git_repo }}
-- Platform: {{ context.platform }}
-- Model: {{ context.model_name }}
-- Model supports vision: {{ context.model_supports_vision | lower }}
-
 {% if context.memories and context.memories|length > 0 %}
 ## Workspace Memories
 

--- a/kolega_code/agent/prompt_templates/system/agents/coder_base.md.j2
+++ b/kolega_code/agent/prompt_templates/system/agents/coder_base.md.j2
@@ -14,14 +14,6 @@ You help developers understand, modify, test, and maintain codebases in the curr
 You are {{ context.system_name }}, a powerful autonomous AI coding agent running non-interactively. You are given one task and must carry it through to a finished, verified result by yourself, using tools, before your turn ends. There is no human to consult while you work: never ask for input, approval, or clarification — infer what you need from the workspace and proceed.
 {% endif %}
 
-Here is useful information about the environment:
-
-- Working directory: {{ context.project_path }}
-- Is directory a git repo: {{ context.is_git_repo }}
-- Platform: {{ context.platform }}
-- Model: {{ context.model_name }}
-- Model supports vision: {{ context.model_supports_vision | lower }}
-
 ## Approach to Work
 
 See the task through: implementation and verification, not just analysis or a plan. When a command fails or a check breaks, diagnose and fix it and keep going — a failing step is an obstacle, not a blocker. Don't cut scope because the work feels long.
@@ -78,7 +70,7 @@ When creating a branch or opening a pull request, follow repository or user conv
 {% if interactive %}
 Work in the checkout you were started in. Do not create a Git worktree unless the user explicitly asks for one: a task that merely sounds isolatable — a risky refactor, a long experiment, parallel work, or a plan you would rather implement separately — is not such a request. When isolation looks genuinely useful, suggest it and let the user decide instead of acting.
 
-When the user has asked for an auxiliary Git worktree, place it at `{{ context.project_path }}/.kolega/worktrees/<slug>`, never in the OS temp directory or session scratchpad. Derive a descriptive filesystem-safe slug from the branch or purpose by replacing path separators, whitespace, and unsafe characters with hyphens; use `worktree` if nothing remains. Before creating it, inspect both the filesystem and `git worktree list`; if the name collides, add a suffix instead of overwriting, deleting, or silently reusing an existing worktree.
+When the user has asked for an auxiliary Git worktree, place it under the project-local `.kolega/worktrees/<slug>` directory, never in the OS temp directory or session scratchpad. Derive a descriptive filesystem-safe slug from the branch or purpose by replacing path separators, whitespace, and unsafe characters with hyphens; use `worktree` if nothing remains. Before creating it, inspect both the filesystem and `git worktree list`; if the name collides, add a suffix instead of overwriting, deleting, or silently reusing an existing worktree.
 
 Kolega Code normally excludes `.kolega/worktrees/` through the repository's shared Git `info/exclude`. Verify the path is ignored before running `git worktree add`. If automatic setup was ineffective, add only `/.kolega/worktrees/` to the shared `info/exclude`. Never ignore all of `.kolega/` or modify tracked ignore/config files solely for runtime worktree storage because other `.kolega` project configuration must remain trackable. Do not move or remove any existing worktree, including one under a session scratchpad, unless the user explicitly requests it.
 

--- a/kolega_code/agent/prompt_templates/system/agents/general.md.j2
+++ b/kolega_code/agent/prompt_templates/system/agents/general.md.j2
@@ -12,14 +12,6 @@ run commands.
 - CRITICAL: WE ARE ON A BUDGET, SAVE COSTS ON TOKENS
 - CRITICAL: IF THERE IS A DESIGN-BRIEF FILE IN THE PROJECT, CONSTANTLY CHECK AND STICK TO IT!
 
-Here is some useful information about the environment you are running in:
-
-- Working directory: {{ context.project_path }}
-- Is directory a git repo: {{ context.is_git_repo }}
-- Platform: {{ context.platform }}
-- Model: {{ context.model_name }}
-- Model supports vision: {{ context.model_supports_vision | lower }}
-
 {% if context.memories and context.memories|length > 0 %}
 ## Workspace Memories
 

--- a/kolega_code/agent/prompt_templates/system/agents/investigation.md.j2
+++ b/kolega_code/agent/prompt_templates/system/agents/investigation.md.j2
@@ -9,14 +9,6 @@ the task that Kolega Code gives you. The task will usually be related to explain
 - CRITICAL: WE ARE ON A BUDGET, SAVE COSTS ON TOKENS
 - CRITICAL: IF THERE IS A DESIGN-BRIEF FILE IN THE PROJECT, CONSTANTLY CHECK AND STICK TO IT!
 
-Here is some useful information about the environment you are running in:
-
-- Working directory: {{ context.project_path }}
-- Is directory a git repo: {{ context.is_git_repo }}
-- Platform: {{ context.platform }}
-- Model: {{ context.model_name }}
-- Model supports vision: {{ context.model_supports_vision | lower }}
-
 {% if context.memories and context.memories|length > 0 %}
 ## Workspace Memories
 

--- a/kolega_code/agent/prompt_templates/system/agents/planning.md.j2
+++ b/kolega_code/agent/prompt_templates/system/agents/planning.md.j2
@@ -3,14 +3,6 @@
 You are {{ system_name }}'s planning agent, running in a local developer CLI.
 You help developers turn feature requests, bug reports, refactors, and investigations into precise implementation plans.
 
-Here is useful information about the environment:
-
-- Working directory: {{ project_path }}
-- Is directory a git repo: {{ is_git_repo }}
-- Platform: {{ platform }}
-- Model: {{ model_name }}
-- Model supports vision: {{ model_supports_vision | lower }}
-
 ## Operating Mode
 
 You are in planning mode. Do not implement code changes, create files, edit files, start servers, or perform other mutating actions.

--- a/tests/agent/test_base_agent_prompt_context.py
+++ b/tests/agent/test_base_agent_prompt_context.py
@@ -79,6 +79,18 @@ class TestBaseAgent:
         assert context.project_guidance_file == ""
         assert context.project_guidance == ""
 
+    @pytest.mark.parametrize("marker_kind", ["directory", "file"])
+    def test_build_prompt_context_recognizes_git_roots_and_linked_worktrees(self, base_agent, tmp_path, marker_kind):
+        marker = tmp_path / ".git"
+        if marker_kind == "directory":
+            marker.mkdir()
+        else:
+            marker.write_text("gitdir: /tmp/example.git/worktrees/project\n", encoding="utf-8")
+
+        context = base_agent.build_prompt_context()
+
+        assert context.is_git_repo is True
+
     def test_build_prompt_context_reports_vision_support_for_resolved_model(self, base_agent):
         context = base_agent.build_prompt_context()
 

--- a/tests/agent/test_prompt_cache_stability.py
+++ b/tests/agent/test_prompt_cache_stability.py
@@ -15,6 +15,7 @@ import pytest
 
 from kolega_code.agent.prompt_provider import AgentMode, AgentType
 from kolega_code.memory import ProjectMemoryManager
+from kolega_code.scratchpad import SCRATCHPAD_PROMPT_EXTENSION_ID
 
 from .compaction_helpers import FakeLLM, build_agent
 
@@ -109,6 +110,46 @@ class TestHarnessIsMeaningful:
         assert len(system_text) > 2000
         assert "## Private project memory" in system_text
         assert "## Context Updates" in system_text
+
+
+class TestCrossProjectStaticPromptStability:
+    def test_equivalent_agents_keep_bundled_prompt_bytes_stable_across_projects(self, tmp_path):
+        first_project = tmp_path / "first-project"
+        second_project = tmp_path / "second-project"
+        first_project.mkdir()
+        second_project.mkdir()
+        (first_project / ".git").mkdir()
+
+        first_agent, _first_cm = build_agent(first_project)
+        second_agent, _second_cm = build_agent(second_project)
+
+        # The concrete scratchpad path is a known generation-specific extension
+        # tracked for Stage 2. This test isolates the bundled static prompt whose
+        # five core environment facts moved into ordinary session history.
+        for agent in (first_agent, second_agent):
+            agent.prompt_extensions = [
+                extension for extension in agent.prompt_extensions if extension.id != SCRATCHPAD_PROMPT_EXTENSION_ID
+            ]
+
+        first_prompt = first_agent.build_agent_system_prompt(AgentType.CODER, AgentMode.CLI)
+        second_prompt = second_agent.build_agent_system_prompt(AgentType.CODER, AgentMode.CLI)
+
+        assert first_prompt == second_prompt
+        assert str(first_project) not in first_prompt
+        assert str(second_project) not in second_prompt
+
+        first_baseline = first_agent.session_context_message.get_text_content()
+        second_baseline = second_agent.session_context_message.get_text_content()
+
+        assert first_baseline != second_baseline
+        assert f"Working directory: {first_project}" in first_baseline
+        assert "Is directory a git repo: true" in first_baseline
+        assert f"Working directory: {second_project}" in second_baseline
+        assert "Is directory a git repo: false" in second_baseline
+        for baseline in (first_baseline, second_baseline):
+            assert "Platform:" in baseline
+            assert "Model: claude-haiku-4-5-20251001" in baseline
+            assert "Model supports vision: true" in baseline
 
 
 async def run_turn(agent, message: str) -> None:

--- a/tests/agent/test_prompt_dump.py
+++ b/tests/agent/test_prompt_dump.py
@@ -23,14 +23,15 @@ def test_dump_prompt_overrides_creates_all_uppercase_files(tmp_path):
 
     coder_text = (tmp_path / PROMPT_OVERRIDE_DIR / "CODER.md").read_text(encoding="utf-8")
     assert "powerful AI coding assistant" in coder_text
-    assert "- Working directory: {{ context.project_path }}" in coder_text
-    assert "- Is directory a git repo: {{ context.is_git_repo }}" in coder_text
-    assert "- Platform: {{ context.platform }}" in coder_text
-    # The date is injected into the conversation, not rendered here: it would otherwise change
-    # the system prompt every midnight and invalidate the cached prefix.
-    assert "date_today" not in coder_text
-    assert "- Model: {{ context.model_name }}" in coder_text
-    assert "- Model supports vision: {{ context.model_supports_vision | lower }}" in coder_text
+    for dynamic_field in (
+        "context.project_path",
+        "context.is_git_repo",
+        "context.platform",
+        "date_today",
+        "context.model_name",
+        "context.model_supports_vision",
+    ):
+        assert dynamic_field not in coder_text
     assert str(tmp_path) not in coder_text
     assert "continuity briefing" in (tmp_path / PROMPT_OVERRIDE_DIR / "COMPACTION.md").read_text(encoding="utf-8")
 
@@ -52,17 +53,25 @@ def test_dump_prompt_overrides_skips_existing_by_default_and_force_overwrites(tm
     assert "powerful AI coding assistant" in coder.read_text(encoding="utf-8")
 
 
-def test_prompt_dump_contents_use_placeholders_for_agent_environment(tmp_path):
+def test_prompt_dump_contents_omit_session_environment_fields(tmp_path):
     contents = prompt_dump_contents(tmp_path)
 
     for filename in ["CODER.md", "PLANNING.md", "GENERAL.md", "INVESTIGATION.md", "BROWSER.md"]:
         text = contents[filename]
-        assert "{{ context.project_path }}" in text
-        assert "{{ context.is_git_repo }}" in text
-        assert "{{ context.platform }}" in text
-        assert "date_today" not in text
-        assert "{{ context.model_name }}" in text
-        assert "- Model supports vision: {{ context.model_supports_vision | lower }}" in text
+        for dynamic_field in (
+            "context.project_path",
+            "project_path",
+            "context.is_git_repo",
+            "is_git_repo",
+            "context.platform",
+            "platform",
+            "date_today",
+            "context.model_name",
+            "model_name",
+            "context.model_supports_vision",
+            "model_supports_vision",
+        ):
+            assert f"{{{{ {dynamic_field}" not in text
         assert str(tmp_path) not in text
 
 

--- a/tests/agent/test_prompt_provider.py
+++ b/tests/agent/test_prompt_provider.py
@@ -2,6 +2,7 @@
 Unit tests for the PromptProvider class.
 """
 
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -50,7 +51,7 @@ class TestPromptProvider:
         assert prompt is not None
         assert "local developer CLI" in prompt
         assert "Kolega Code" in prompt
-        assert "/test/project" in prompt
+        assert "/test/project" not in prompt
         # Repository guidance is injected into the conversation on change, not rendered into the
         # prompt, so editing AGENTS.md no longer invalidates the cached prefix for the whole
         # conversation. The prompt describes the channel that delivers it instead.
@@ -98,7 +99,8 @@ class TestPromptProvider:
             agent_type=AgentType.CODER, mode=AgentMode.CLI, context=prompt_context
         )
 
-        assert "/test/project/.kolega/worktrees/<slug>" in prompt
+        assert "project-local `.kolega/worktrees/<slug>` directory" in prompt
+        assert "/test/project" not in prompt
         assert "never in the OS temp directory or session scratchpad" in prompt
         assert "inspect both the filesystem and `git worktree list`" in prompt
         assert "use `worktree` if nothing remains" in prompt
@@ -128,31 +130,31 @@ class TestPromptProvider:
             (AgentType.BROWSER, None),
         ],
     )
-    @pytest.mark.parametrize(
-        ("supports_vision", "expected"),
-        [
-            (True, "- Model supports vision: true"),
-            (False, "- Model supports vision: false"),
-        ],
-    )
-    def test_agent_prompts_render_lowercase_vision_support(
-        self,
-        prompt_provider,
-        prompt_context,
-        agent_type,
-        mode,
-        supports_vision,
-        expected,
+    def test_bundled_agent_prompts_are_stable_across_session_environments(
+        self, prompt_provider, prompt_context, agent_type, mode
     ):
-        prompt_context.model_supports_vision = supports_vision
-
-        prompt = prompt_provider.get_system_prompt(
-            agent_type=agent_type,
-            mode=mode,
-            context=prompt_context,
+        other_context = replace(
+            prompt_context,
+            project_path="/different/project",
+            is_git_repo=False,
+            platform="Linux",
+            model_name="different-model",
+            model_supports_vision=False,
         )
 
-        assert expected in prompt
+        first = prompt_provider.get_system_prompt(agent_type=agent_type, mode=mode, context=prompt_context)
+        second = prompt_provider.get_system_prompt(agent_type=agent_type, mode=mode, context=other_context)
+
+        assert first == second
+        for value in (
+            prompt_context.project_path,
+            prompt_context.platform,
+            prompt_context.model_name,
+            other_context.project_path,
+            other_context.platform,
+            other_context.model_name,
+        ):
+            assert value not in first
 
     @pytest.mark.parametrize("mode", [AgentMode.CODE, AgentMode.VIBE, AgentMode.FIX])
     def test_hosted_coder_modes_require_host_template(self, prompt_provider, prompt_context, mode):
@@ -184,7 +186,7 @@ class TestPromptProvider:
         assert len(prompt) > 0
         assert "code investigation agent" in prompt
         assert "explaining a codebase" in prompt
-        assert "/test/project" in prompt
+        assert "/test/project" not in prompt
 
     def test_browser_agent_prompt_generation(self, prompt_provider, prompt_context):
         """Test that browser agent prompts can be generated."""

--- a/tests/agent/test_prompts.py
+++ b/tests/agent/test_prompts.py
@@ -306,7 +306,7 @@ def test_skill_catalog_prompt_renders_catalog() -> None:
     assert "{catalog}" in prompts.SKILL_CATALOG_PROMPT_TEMPLATE
 
 
-def test_planning_agent_prompt_renders_environment() -> None:
+def test_planning_agent_prompt_omits_session_environment() -> None:
     rendered = prompts.build_planning_agent_system_prompt(
         system_name="Kolega Code",
         project_path="/repo",
@@ -318,10 +318,9 @@ def test_planning_agent_prompt_renders_environment() -> None:
     )
 
     assert "Kolega Code's planning agent" in rendered
-    assert "Working directory: /repo" in rendered
-    assert "Is directory a git repo: True" in rendered
-    assert "Model: test-model" in rendered
-    assert "Model supports vision: true" in rendered
+    assert "/repo" not in rendered
+    assert "test-model" not in rendered
+    assert "Model supports vision" not in rendered
     assert "submit it through `write_plan`; do not only print the plan" in rendered
     assert "complete replacement plan that incorporates those decisions" in rendered
 


### PR DESCRIPTION
## Summary

- remove working directory, Git status, platform, model, and vision capability from the five bundled static agent prompts now that they live in the ordinary persisted session baseline
- keep coder worktree policy static by using the project-relative `.kolega/worktrees/<slug>` path, and recognize linked worktrees whose `.git` marker is a file
- add all-agent cross-environment rendering coverage, real cross-project `BaseAgent` stability coverage, linked-worktree tests, and updated prompt-override documentation

The existing ordinary-history lifecycle remains unchanged: this does not add a separate provider request layer or special session-context metadata.

## Verification

- `uv run pytest -q tests/agent/test_prompt_provider.py tests/agent/test_prompt_dump.py tests/agent/test_prompts.py tests/agent/test_base_agent_prompt_context.py tests/agent/test_prompt_cache_stability.py tests/agent/test_session_context.py tests/agent/test_prompt_overrides.py` — 118 passed
- `./run_tests.sh` — 4840 passed, 1 skipped
- `uv run pre-commit run --all-files` — passed
- `cd docs && npm run build` — passed
- `git diff --check` — passed
