### PR TITLE
feat(tui): recall previous prompts with the up arrow

### DIFF
--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -55,7 +55,7 @@ broad enough to benefit from fan-out.
    - Mention files with `@` — start typing `@src/` and pick from the dropdown.
    - Run a command with `/` — e.g. `/help`, `/model`, `/context`.
    - Insert a newline without sending with `Shift+Enter`.
-   - Recall a previous prompt with `↑` (from the first line of the composer); `↓` walks forward.
+   - Recall a previous prompt with `↑` (from the first line of the composer); `↓` walks forward. Prompt history is kept per project across runs.
 
 4. **Turn on Gigacode for broad work.**
 

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -55,6 +55,7 @@ broad enough to benefit from fan-out.
    - Mention files with `@` — start typing `@src/` and pick from the dropdown.
    - Run a command with `/` — e.g. `/help`, `/model`, `/context`.
    - Insert a newline without sending with `Shift+Enter`.
+   - Recall a previous prompt with `↑` (from the first line of the composer); `↓` walks forward.
 
 4. **Turn on Gigacode for broad work.**
 

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -68,6 +68,7 @@ from .loop import LOOP_TICK_SECONDS, LoopState
 from .diagnostics import DiagnosticsLog, ResponsivenessWatchdog
 from .file_index import WorkspaceFileIndex
 from .mentions import build_file_attachments
+from .prompt_history import load_prompt_history, save_prompt_history
 from .provider_registry import default_ui_thinking_effort
 from .session_journal import RewindOutcome, TurnSummary
 from .session_store import SessionRecord, SessionStore, resolve_active_project
@@ -483,6 +484,7 @@ class KolegaCodeApp(
 
     async def on_mount(self) -> None:
         self.settings = self.settings_store.load()
+        self._restore_prompt_history()
         # Attach usage persistence before any turn can run: the sink journals
         # every ledger-settled non-history response, and its start marker must
         # precede the first covered turn so coverage boundaries are exact.
@@ -894,9 +896,34 @@ class KolegaCodeApp(
             allow_discuss=self._plan_decision_active,
         )
 
+    def _restore_prompt_history(self) -> None:
+        """Seed the composer's recall history from per-project local state.
+
+        History is project-scoped (shell-like), so it crosses sessions and app
+        runs; a missing or corrupt file simply starts recall empty.
+        """
+        try:
+            composer = self.query_one("#composer", tui_widgets.ChatComposer)
+        except Exception:
+            return
+        composer.restore_prompt_history(load_prompt_history(self.store.root))
+
+    def _persist_prompt_history(self, composer: tui_widgets.ChatComposer) -> None:
+        """Write the composer's recall history through to local state.
+
+        Runs after ChatComposer.action_submit has already recorded the entry,
+        so dumping the widget's list is the single source of truth. Persistence
+        must never break a submit.
+        """
+        try:
+            save_prompt_history(self.store.root, composer.prompt_history)
+        except Exception:
+            pass
+
     async def on_chat_composer_submitted(self, event: tui_widgets.ChatComposer.Submitted) -> None:
         text = event.value
         stripped_text = text.strip()
+        self._persist_prompt_history(event.composer)
         if stripped_text.lower() in THREAD_RESET_COMMANDS:
             if self._turn_active or self.agent_worker is not None:
                 self._show_composer_hint(messages.BLOCK_STOP_BEFORE_RESET)

--- a/kolega_code/cli/prompt_history.py
+++ b/kolega_code/cli/prompt_history.py
@@ -1,0 +1,55 @@
+"""Per-project prompt history persisted in the local state directory.
+
+The composer's recall history (GitHub #622) is project-scoped and shell-like:
+prompts submitted in any session under the project's state root are recallable
+in later runs. The file is small (capped list of strings), so persistence is a
+whole-file dump on every submit; concurrent instances last-write-win, which is
+benign for a recall list.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List
+
+from kolega_code.local_state import write_private_text
+
+PROMPT_HISTORY_FILENAME = "prompt_history.json"
+PROMPT_HISTORY_MAX = 100
+
+
+def prompt_history_path(state_root: Path) -> Path:
+    """Location of the persisted prompt history inside a state root."""
+    return state_root / PROMPT_HISTORY_FILENAME
+
+
+def load_prompt_history(state_root: Path) -> List[str]:
+    """Load persisted prompts, oldest first (newest last).
+
+    A missing, corrupt, or unexpected-shape file yields an empty list — recall
+    history is a convenience and must never block startup.
+    """
+    try:
+        raw = prompt_history_path(state_root).read_text(encoding="utf-8")
+    except OSError:
+        return []
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(data, list):
+        return []
+    return [entry for entry in data if isinstance(entry, str)][:PROMPT_HISTORY_MAX]
+
+
+def save_prompt_history(state_root: Path, entries: List[str]) -> None:
+    """Persist the capped prompt list (newest last) as private local state.
+
+    Writing an empty list is a no-op so runs without submitted prompts never
+    create the file.
+    """
+    capped = entries[-PROMPT_HISTORY_MAX:]
+    if not capped:
+        return
+    write_private_text(prompt_history_path(state_root), json.dumps(capped, ensure_ascii=False, indent=2))

--- a/kolega_code/cli/tui/widgets.py
+++ b/kolega_code/cli/tui/widgets.py
@@ -888,6 +888,7 @@ class ChatComposer(TextArea):
     MENTION_QUERY_RE = re.compile(r"(?:^|(?<=\s))@(\S*)$")
     SLASH_QUERY_RE = re.compile(r"^\s*/([\w-]*)$")
     MENTION_ACTIONS = {"mention_prev", "mention_next", "mention_accept", "mention_dismiss"}
+    PROMPT_HISTORY_MAX = 100
 
     @dataclass
     class Submitted(TextualMessage):
@@ -897,6 +898,76 @@ class ChatComposer(TextArea):
         @property
         def control(self) -> ChatComposer:
             return self.composer
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        # Prompt-history recall (GitHub #622): prompts submitted this run, the
+        # current navigation index (None when not navigating), and the draft
+        # saved when navigation began so Down-past-newest can restore it.
+        self._prompt_history: list[str] = []
+        self._history_index: Optional[int] = None
+        self._history_draft: str = ""
+
+    def _reset_history_navigation(self) -> None:
+        """Leave history-navigation mode, discarding the saved draft."""
+        self._history_index = None
+        self._history_draft = ""
+
+    def _record_submitted_prompt(self, text: str) -> None:
+        """Append a submitted prompt to the recall history (shell-like).
+
+        Empty submissions and consecutive duplicates are skipped; the list is
+        capped so a long session cannot grow it without bound.
+        """
+        entry = text.strip()
+        if entry and (not self._prompt_history or self._prompt_history[-1] != entry):
+            self._prompt_history.append(entry)
+            del self._prompt_history[: -self.PROMPT_HISTORY_MAX]
+        self._reset_history_navigation()
+
+    def load_text(self, text: str) -> None:
+        # Programmatic rewrites (submit-clear, queued-restore, slash commands)
+        # start navigation fresh — never continue from a stale history index.
+        self._reset_history_navigation()
+        super().load_text(text)
+
+    def _load_history_text(self, text: str) -> None:
+        """Replace the composer text for history recall, cursor at the end."""
+        super().load_text(text)
+        self.move_cursor(self.document.end, record_width=False)
+
+    def _recall_history(self, backward: bool) -> bool:
+        """Walk the prompt history; returns False when there is nothing to recall.
+
+        Up enters navigation (saving the current draft) and walks backward; Down
+        only walks forward while already navigating, and past the newest entry
+        restores the draft saved when navigation began.
+        """
+        if not self._prompt_history:
+            return False
+        if backward:
+            index = self._history_index
+            if index is None:
+                self._history_draft = self.text
+                index = len(self._prompt_history) - 1
+            elif index > 0:
+                index -= 1
+            self._history_index = index
+            self._load_history_text(self._prompt_history[index])
+            return True
+        index = self._history_index
+        if index is None:
+            return False
+        index += 1
+        if index >= len(self._prompt_history):
+            # Capture the draft before resetting — the reset clears it.
+            draft = self._history_draft
+            self._reset_history_navigation()
+            self._load_history_text(draft)
+        else:
+            self._history_index = index
+            self._load_history_text(self._prompt_history[index])
+        return True
 
     def check_action(self, action: str, parameters: tuple) -> bool | None:
         if action in self.MENTION_ACTIONS:
@@ -973,6 +1044,7 @@ class ChatComposer(TextArea):
     def action_submit(self) -> None:
         if self._accept_mention_completion():
             return
+        self._record_submitted_prompt(self.text)
         self.post_message(self.Submitted(self, self.text))
 
     def action_insert_newline(self) -> None:
@@ -1003,7 +1075,7 @@ class ChatComposer(TextArea):
             self._delete_via_keyboard((row - 1, 0), (row, 0))
 
     def action_cursor_up(self, select: bool = False) -> None:
-        """Move up in the draft, or from the top line back to active options."""
+        """Move up in the draft, from the top line to active options, or recall prompt history."""
         if select:
             super().action_cursor_up(select)
             return
@@ -1018,8 +1090,32 @@ class ChatComposer(TextArea):
             focus_prompt = getattr(self.app, "_focus_active_prompt_from_composer", None)
             if callable(focus_prompt) and focus_prompt():
                 return
+            # Prompt-history recall (GitHub #622) — only when the cursor cannot
+            # move up within the input, so multiline editing keeps its arrows.
+            if self.navigator.is_first_wrapped_line(self.cursor_location) and self._recall_history(backward=True):
+                return
 
         super().action_cursor_up(select)
+
+    def action_cursor_down(self, select: bool = False) -> None:
+        """Move down in the draft, or walk prompt history forward from the last line."""
+        if select:
+            super().action_cursor_down(select)
+            return
+
+        dropdown = self.mention_dropdown()
+        if dropdown is not None and dropdown.is_open:
+            dropdown.action_cursor_down()
+            return
+
+        if (
+            self._history_index is not None
+            and self.navigator.is_last_wrapped_line(self.cursor_location)
+            and self._recall_history(backward=False)
+        ):
+            return
+
+        super().action_cursor_down(select)
 
     def action_mention_prev(self) -> None:
         dropdown = self.mention_dropdown()

--- a/kolega_code/cli/tui/widgets.py
+++ b/kolega_code/cli/tui/widgets.py
@@ -23,6 +23,7 @@ from textual.widgets.option_list import Option
 
 from .. import theme as cli_theme
 from ..file_index import IndexEntry
+from ..prompt_history import PROMPT_HISTORY_MAX
 from ..slash_commands import SlashCommandEntry
 from .app_base import KolegaAppBase
 from .state import ConversationEntry
@@ -888,7 +889,6 @@ class ChatComposer(TextArea):
     MENTION_QUERY_RE = re.compile(r"(?:^|(?<=\s))@(\S*)$")
     SLASH_QUERY_RE = re.compile(r"^\s*/([\w-]*)$")
     MENTION_ACTIONS = {"mention_prev", "mention_next", "mention_accept", "mention_dismiss"}
-    PROMPT_HISTORY_MAX = 100
 
     @dataclass
     class Submitted(TextualMessage):
@@ -922,7 +922,17 @@ class ChatComposer(TextArea):
         entry = text.strip()
         if entry and (not self._prompt_history or self._prompt_history[-1] != entry):
             self._prompt_history.append(entry)
-            del self._prompt_history[: -self.PROMPT_HISTORY_MAX]
+            del self._prompt_history[:-PROMPT_HISTORY_MAX]
+        self._reset_history_navigation()
+
+    @property
+    def prompt_history(self) -> list[str]:
+        """A copy of the recall history, oldest first (newest last)."""
+        return list(self._prompt_history)
+
+    def restore_prompt_history(self, entries: list[str]) -> None:
+        """Seed the recall history from persisted state (oldest first)."""
+        self._prompt_history = list(entries[-PROMPT_HISTORY_MAX:])
         self._reset_history_navigation()
 
     def load_text(self, text: str) -> None:

--- a/tests/cli/test_app_composer_input.py
+++ b/tests/cli/test_app_composer_input.py
@@ -1236,3 +1236,78 @@ async def test_textual_app_composer_up_arrow_prefers_question_options_over_histo
 
         app._pending_question = None
         app._set_question_actions_visible(False)
+
+
+@pytest.mark.asyncio
+async def test_textual_app_composer_prompt_history_persists_across_runs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.cli.prompt_history import load_prompt_history, prompt_history_path
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    install_fake_agents(monkeypatch)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+
+    async def run_submitting_app(app_session) -> None:
+        app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=app_session)
+        async with app.run_test() as pilot:
+            composer = app.query_one("#composer", ChatComposer)
+            await _submit_via_enter(pilot, app, composer, "persisted prompt")
+            # A consecutive duplicate is not persisted twice.
+            await _submit_via_enter(pilot, app, composer, "persisted prompt")
+
+    await run_submitting_app(session)
+
+    assert prompt_history_path(store.root).exists()
+    assert load_prompt_history(store.root) == ["persisted prompt"]
+
+    # A later run in the same project recalls the persisted prompt.
+    second_session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=second_session)
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        composer.focus()
+
+        await pilot.press("up")
+
+        assert composer.text == "persisted prompt"
+
+
+@pytest.mark.asyncio
+async def test_textual_app_composer_prompt_history_restored_on_mount_orders_newest_last(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.app import KolegaCodeApp
+    from kolega_code.cli.prompt_history import save_prompt_history
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    install_fake_agents(monkeypatch)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    save_prompt_history(store.root, ["older", "newer"])
+
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        composer.focus()
+        assert composer.prompt_history == ["older", "newer"]
+
+        await pilot.press("up")
+        assert composer.text == "newer"
+        await pilot.press("up")
+        assert composer.text == "older"

--- a/tests/cli/test_app_composer_input.py
+++ b/tests/cli/test_app_composer_input.py
@@ -977,3 +977,262 @@ async def test_tasks_command_rejects_arguments(tmp_path: Path, monkeypatch: pyte
         assert content == "Usage: /tasks"
         assert app.agent_worker is None
         assert getattr(app.agent, "messages") == []
+
+
+async def _submit_via_enter(pilot, app, composer, text: str) -> None:
+    """Submit through a real Enter press (so ChatComposer records history) and settle the turn.
+
+    Awaiting the turn worker plus a short pause avoids the queued-message-drain
+    teardown race (a 10ms timer fires after turn completion).
+    """
+    composer.focus()
+    composer.load_text(text)
+    await pilot.press("enter")
+    worker = app.agent_worker
+    if worker is not None:
+        await worker.wait()
+    await pilot.pause(0.05)
+
+
+@pytest.mark.asyncio
+async def test_textual_app_composer_up_arrow_recalls_last_submitted_prompt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    app = _build_mention_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        composer.focus()
+
+        await _submit_via_enter(pilot, app, composer, "first prompt")
+        assert composer.text == ""
+
+        await pilot.press("up")
+
+        assert composer.text == "first prompt"
+        assert composer.cursor_location == composer.document.end
+
+
+@pytest.mark.asyncio
+async def test_textual_app_composer_up_down_arrows_walk_prompt_history(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    app = _build_mention_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        composer.focus()
+
+        for text in ("one", "two", "three"):
+            await _submit_via_enter(pilot, app, composer, text)
+
+        await pilot.press("up")
+        assert composer.text == "three"
+        await pilot.press("up")
+        assert composer.text == "two"
+        await pilot.press("up")
+        assert composer.text == "one"
+        # Clamped at the oldest entry.
+        await pilot.press("up")
+        assert composer.text == "one"
+
+        await pilot.press("down")
+        assert composer.text == "two"
+        await pilot.press("down")
+        assert composer.text == "three"
+
+
+@pytest.mark.asyncio
+async def test_textual_app_composer_down_past_newest_restores_draft(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    app = _build_mention_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        composer.focus()
+
+        for text in ("one", "two"):
+            await _submit_via_enter(pilot, app, composer, text)
+
+        composer.load_text("my draft")
+        composer.move_cursor(composer.document.end, record_width=False)
+
+        await pilot.press("up")
+        assert composer.text == "two"
+        await pilot.press("up")
+        assert composer.text == "one"
+
+        await pilot.press("down")
+        assert composer.text == "two"
+        # Forward past the newest submitted prompt restores the draft.
+        await pilot.press("down")
+        assert composer.text == "my draft"
+        # Navigation is over: Down falls back to normal cursor movement.
+        await pilot.press("down")
+        assert composer.text == "my draft"
+
+
+@pytest.mark.asyncio
+async def test_textual_app_composer_up_arrow_multiline_movement_not_hijacked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    app = _build_mention_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        composer.focus()
+
+        await _submit_via_enter(pilot, app, composer, "one")
+
+        composer.load_text("l1\nl2\nl3")
+        composer.move_cursor(composer.document.end, record_width=False)
+
+        # While the cursor can still move up within the draft, Up moves the cursor.
+        await pilot.press("up")
+        assert composer.text == "l1\nl2\nl3"
+        assert composer.cursor_location[0] == 1
+        await pilot.press("up")
+        assert composer.text == "l1\nl2\nl3"
+        assert composer.cursor_location[0] == 0
+
+        # From the top line, Up recalls history instead.
+        await pilot.press("up")
+        assert composer.text == "one"
+
+
+@pytest.mark.asyncio
+async def test_textual_app_composer_up_arrow_soft_wrapped_line_moves_within_line(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    app = _build_mention_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test(size=(40, 30)) as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        composer.focus()
+
+        await _submit_via_enter(pilot, app, composer, "one")
+
+        long_line = "word " * 30
+        composer.load_text(long_line)
+        composer.move_cursor(composer.document.end, record_width=False)
+        await pilot.pause()
+
+        # The cursor is on a lower visual row of the soft-wrapped first line,
+        # so Up moves within the line rather than recalling history.
+        await pilot.press("up")
+
+        assert composer.text == long_line
+        assert composer.cursor_location[0] == 0
+        assert 0 < composer.cursor_location[1] < len(long_line)
+        assert composer._history_index is None
+
+
+@pytest.mark.asyncio
+async def test_textual_app_composer_history_skips_empty_and_consecutive_duplicates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    app = _build_mention_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        composer.focus()
+
+        await _submit_via_enter(pilot, app, composer, "same")
+        await _submit_via_enter(pilot, app, composer, "same")
+        composer.load_text("")
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert composer._prompt_history == ["same"]
+
+
+@pytest.mark.asyncio
+async def test_textual_app_composer_submit_resets_history_navigation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.widgets import ChatComposer
+
+    app = _build_mention_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        composer.focus()
+
+        await _submit_via_enter(pilot, app, composer, "one")
+
+        # Recall and edit the prompt, then submit the edited version.
+        await pilot.press("up")
+        assert composer.text == "one"
+        await pilot.press("x")
+        assert composer.text == "onex"
+        await pilot.press("enter")
+        worker = app.agent_worker
+        if worker is not None:
+            await worker.wait()
+        await pilot.pause(0.05)
+
+        assert composer._prompt_history == ["one", "onex"]
+        # Fresh navigation recalls the newest entry, not a stale index.
+        await pilot.press("up")
+        assert composer.text == "onex"
+
+
+@pytest.mark.asyncio
+async def test_textual_app_composer_up_arrow_prefers_question_options_over_history(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui.state import PendingQuestion
+    from kolega_code.cli.tui.widgets import ActionList, ChatComposer
+
+    app = _build_mention_test_app(tmp_path, monkeypatch)
+
+    async with app.run_test() as pilot:
+        composer = app.query_one("#composer", ChatComposer)
+        await _submit_via_enter(pilot, app, composer, "earlier prompt")
+
+        # An ask_user_choice question is pending: its option list wins over history recall.
+        app._pending_question = PendingQuestion(question="Choose?", options=["A", "B"], request_id="req-test")
+        app._show_question_options("Choose?", ["A", "B"])
+        app._set_chat_enabled(True)
+        composer.focus()
+        composer.load_text("custom answer draft")
+        composer.move_cursor((0, 0), record_width=False)
+        await pilot.pause()
+
+        await pilot.press("up")
+
+        question_actions = app.query_one("#question_actions", ActionList)
+        assert app.focused is question_actions
+        assert composer.text == "custom answer draft"
+
+        app._pending_question = None
+        app._set_question_actions_visible(False)

--- a/tests/cli/test_prompt_history.py
+++ b/tests/cli/test_prompt_history.py
@@ -1,0 +1,48 @@
+import json
+from pathlib import Path
+
+from kolega_code.cli.prompt_history import (
+    PROMPT_HISTORY_MAX,
+    load_prompt_history,
+    prompt_history_path,
+    save_prompt_history,
+)
+
+
+def test_load_missing_file_returns_empty(tmp_path: Path) -> None:
+    assert load_prompt_history(tmp_path) == []
+
+
+def test_save_load_roundtrip_newest_last(tmp_path: Path) -> None:
+    save_prompt_history(tmp_path, ["one", "two", "three"])
+    assert load_prompt_history(tmp_path) == ["one", "two", "three"]
+
+
+def test_save_caps_at_limit(tmp_path: Path) -> None:
+    entries = [f"prompt {index}" for index in range(PROMPT_HISTORY_MAX + 20)]
+    save_prompt_history(tmp_path, entries)
+    loaded = load_prompt_history(tmp_path)
+    assert len(loaded) == PROMPT_HISTORY_MAX
+    assert loaded[0] == "prompt 20"
+    assert loaded[-1] == f"prompt {PROMPT_HISTORY_MAX + 19}"
+
+
+def test_save_empty_list_writes_no_file(tmp_path: Path) -> None:
+    save_prompt_history(tmp_path, [])
+    assert not prompt_history_path(tmp_path).exists()
+
+
+def test_load_corrupt_json_returns_empty(tmp_path: Path) -> None:
+    path = prompt_history_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json", encoding="utf-8")
+    assert load_prompt_history(tmp_path) == []
+
+
+def test_load_filters_non_list_payload_and_non_string_entries(tmp_path: Path) -> None:
+    path = prompt_history_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"nope": True}), encoding="utf-8")
+    assert load_prompt_history(tmp_path) == []
+    path.write_text(json.dumps(["ok", 42, None, "fine"]), encoding="utf-8")
+    assert load_prompt_history(tmp_path) == ["ok", "fine"]


### PR DESCRIPTION
Closes #622

## Summary

Adds readline-style prompt history to the TUI chat composer. With the prompt input focused, pressing `↑` from the first visual row recalls the most recently submitted prompt; repeated `↑` walks backward through earlier prompts, `↓` walks forward, and navigating forward past the newest entry restores the draft that was present before history navigation began.

History is **project-scoped and persisted across runs** (shell-like): every submission is written through to `prompt_history.json` in the project's local state dir (atomic, owner-only, capped at 100 entries) and seeded into the composer on mount, so recall works across sessions and app restarts.

- **Recording**: every submission through a real `Enter` appends the stripped text; empty submissions and consecutive duplicates are skipped; the list is capped at 100 entries. The composer's in-memory list is the single source of truth; persistence is a whole-file dump.
- **Boundary gating**: recall only fires when the cursor cannot move vertically within the current input (`navigator.is_first_wrapped_line` / `is_last_wrapped_line` — soft-wrap aware), so normal multiline cursor movement is never hijacked, for drafts and recalled entries alike.
- **Prompt surfaces keep precedence**: the existing option-list focus handoff (`_focus_active_prompt_from_composer`) runs before history recall, so `ask_user_choice` questions, permission approvals, model/effort/theme selections, and plan decisions all win over recall on `↑`.
- **Fresh navigation**: submitting, walking forward past the newest entry, or any programmatic `load_text` (submit-clear, queued-restore, slash commands) resets navigation state — no stale history index.
- **Robust persistence**: missing/corrupt history files degrade to an empty list; writes never create the file for an empty history.

## Testing

10 new tests: recall + cursor placement, backward/forward walking with clamping, draft restoration, multiline and soft-wrapped cursor movement, empty/duplicate suppression, submit-resets-navigation, question-options precedence with populated history, plus persistence roundtrip/cap/corruption unit tests and app-level restart-recall tests (submit in one app instance → `↑` recalls it in a second instance on the same state root).

- `./run_tests.sh tests/cli/` — 1664 passed
- `ruff check` / `ruff format --check` / `pyright` clean on changed files; pre-commit hooks pass
- Manually verified live in the TUI: `↑` recalls the last submitted prompt.

## Docs

One bullet in the quick-start composer list documenting `↑`/`↓` recall and per-project persistence.