### PR TITLE
fix(cli): show skill invocations clearly in the chat transcript

### DIFF
--- a/kolega_code/cli/skills.py
+++ b/kolega_code/cli/skills.py
@@ -474,6 +474,12 @@ def skill_names_in_text(text: str) -> list[str]:
     return SKILL_CONTENT_RE.findall(text)
 
 
+def skill_activation_label(*names: str) -> str:
+    """One-line transcript label for a skill activation (live and restored)."""
+    listed = ", ".join(f"`/{name}`" for name in names)
+    return f"Activated skill {listed}."
+
+
 def _iter_skill_files(root: Path) -> Iterable[Path]:
     if not root.is_dir():
         return []

--- a/kolega_code/cli/tui/command_handlers.py
+++ b/kolega_code/cli/tui/command_handlers.py
@@ -42,7 +42,7 @@ from ..provider_registry import (
     ui_model_options,
     ui_thinking_effort_options,
 )
-from ..skills import activated_skill_names
+from ..skills import activated_skill_names, skill_activation_label
 from ..slash_commands import SKILLS_LIST_COMMAND, TUI_COMMAND_NAMES, agent_command_names
 from ..diagnostics import assemble_bug_bundle
 from ..session_store import SessionStoreError
@@ -1500,15 +1500,18 @@ class CommandHandlersMixin(tui_app_base.KolegaAppBase):
             self._set_settings_status(messages.SETTINGS_REQUIRED_SKILL, tone="warning")
             return True
 
-        activated = self._activate_skill_in_agent(command_name)
-        self._add_conversation_entry(tui_state.ConversationEntry(kind="skill", content=activated))
+        self._activate_skill_in_agent(command_name)
+        self._add_conversation_entry(
+            tui_state.ConversationEntry(kind="skill", content=skill_activation_label(command_name))
+        )
         self._notify_user(messages.SKILL_ACTIVATED.format(name=command_name))
 
         if prompt:
+            command_line = f"/{command_name} {prompt}"
             attachments = self._build_mention_attachments(prompt)
-            self._add_conversation_entry(tui_state.ConversationEntry(kind="user", content=prompt))
+            self._add_conversation_entry(tui_state.ConversationEntry(kind="user", content=command_line))
             self.agent_worker = self.run_worker(
-                self._process_message(prompt, attachments), name="kolega-turn", group="turns", exclusive=True
+                self._process_message(command_line, attachments), name="kolega-turn", group="turns", exclusive=True
             )
         else:
             await self._save_session_history_async()

--- a/kolega_code/cli/tui/loop_runtime.py
+++ b/kolega_code/cli/tui/loop_runtime.py
@@ -39,6 +39,7 @@ from ..loop import (
     read_loop_md,
 )
 from ..slash_commands import TUI_COMMAND_NAMES, agent_command_names
+from ..skills import skill_activation_label
 from . import app_base as tui_app_base
 from . import state as tui_state
 
@@ -300,8 +301,10 @@ class LoopRuntimeMixin(tui_app_base.KolegaAppBase):
         skill_name = command.removeprefix("/")
         if self.skill_catalog.get(skill_name) is None:
             return prompt
-        activated = self._activate_skill_in_agent(skill_name)
-        self._add_conversation_entry(tui_state.ConversationEntry(kind="skill", content=activated))
+        self._activate_skill_in_agent(skill_name)
+        self._add_conversation_entry(
+            tui_state.ConversationEntry(kind="skill", content=skill_activation_label(skill_name))
+        )
         return remainder.strip() or f"Apply the {skill_name} skill now."
 
     def _drain_loop_tokens(self, state: LoopState, mark) -> None:

--- a/kolega_code/cli/tui/transcript.py
+++ b/kolega_code/cli/tui/transcript.py
@@ -27,7 +27,7 @@ from kolega_code.llm.models import (
 from kolega_code.services.lsp import extract_lsp_label
 
 from .. import messages, theme
-from ..skills import skill_names_in_text
+from ..skills import skill_activation_label, skill_names_in_text
 from ..theme import Color, Glyph
 from .constants import QUESTION_TOOL_NAME, STARTUP_WORDMARK
 from .state import (
@@ -303,8 +303,7 @@ class TranscriptRenderingMixin(tui_app_base.KolegaAppBase):
     def _conversation_entry_for_text(self, role: str, text: str) -> ConversationEntry:
         names = skill_names_in_text(text)
         if names:
-            skill_list = ", ".join(f"`/{name}`" for name in names)
-            return ConversationEntry(kind="skill", content=f"Activated skill {skill_list}.")
+            return ConversationEntry(kind="skill", content=skill_activation_label(*names))
         return ConversationEntry(kind=self._entry_kind_for_role(role), content=text)
 
     def _entry_kind_for_role(self, role: str) -> str:

--- a/tests/cli/test_app_loop_command.py
+++ b/tests/cli/test_app_loop_command.py
@@ -702,7 +702,7 @@ async def test_skill_prefixed_prompt_activates_the_skill(tmp_path, monkeypatch, 
 
         skill_entries = [entry for entry in app.conversation_entries if entry.kind == "skill"]
         assert len(skill_entries) == 1
-        assert "demo-skill" in skill_entries[0].content
+        assert skill_entries[0].content == "Activated skill `/demo-skill`."
         # Activation is injected into the agent's history, not the turn prompt.
         history_text = "\n".join(
             getattr(block, "text", "") or "" for message in agent.history for block in (message.content or [])

--- a/tests/cli/test_app_skill_commands.py
+++ b/tests/cli/test_app_skill_commands.py
@@ -79,6 +79,8 @@ async def test_textual_app_skill_slash_commands_list_and_activate(
         await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
 
         assert app.conversation_entries[-1].kind == "skill"
+        assert app.conversation_entries[-1].content == "Activated skill `/demo-skill`."
+        assert "Follow demo instructions." not in app.conversation_entries[-1].content
         assert app.agent is not None
         assert '<skill_content name="demo-skill">' in app.agent.history[-1].get_text_content()
         assert '<skill_content name="demo-skill">' in store.load(session.session_id).history[-1]["content"][0]["text"]
@@ -114,6 +116,58 @@ async def test_textual_app_skill_slash_command_with_prompt_starts_turn(
         await pilot.pause()
 
         assert app.agent is not None
-        assert getattr(app.agent, "messages") == ["Build the feature"]
-        assert any(entry.kind == "skill" for entry in app.conversation_entries)
-        assert any(entry.kind == "user" and entry.content == "Build the feature" for entry in app.conversation_entries)
+        assert getattr(app.agent, "messages") == ["/demo-skill Build the feature"]
+        assert any(
+            entry.kind == "skill" and entry.content == "Activated skill `/demo-skill`."
+            for entry in app.conversation_entries
+        )
+        assert any(
+            entry.kind == "user" and entry.content == "/demo-skill Build the feature"
+            for entry in app.conversation_entries
+        )
+        # The skill body must never leak into the transcript as a wall of text.
+        assert all("Follow demo instructions." not in entry.content for entry in app.conversation_entries)
+
+
+def _text_history_message(role: str, text: str) -> dict:
+    return {"role": role, "content": [{"type": "text", "text": text}]}
+
+
+@pytest.mark.asyncio
+async def test_skill_invocation_with_arguments_restores_identically(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.app import KolegaCodeApp
+
+    install_fake_agents(monkeypatch)
+
+    project = tmp_path / "project"
+    skill_dir = project / ".agents" / "skills" / "demo-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: demo-skill\ndescription: Use this demo skill.\n---\n\nFollow demo instructions.\n",
+        encoding="utf-8",
+    )
+    config = build_test_config(project)
+    store = SessionStore(tmp_path / "state")
+    session = store.create(project, "code", config_summary(config))
+    app = KolegaCodeApp(project_path=project, config=config, mode="code", store=store, session=session)
+
+    # History exactly as the live path records it: the activation context
+    # message, then the submitted command line as the user turn message.
+    history = [
+        _text_history_message("user", '<skill_content name="demo-skill">Follow demo instructions.</skill_content>'),
+        _text_history_message("user", "/demo-skill Build the feature"),
+    ]
+
+    async with app.run_test():
+        app._restore_conversation_history(history)
+
+        restored = [entry for entry in app.conversation_entries if entry.kind in {"skill", "user"}]
+        assert [(entry.kind, entry.content) for entry in restored] == [
+            ("skill", "Activated skill `/demo-skill`."),
+            ("user", "/demo-skill Build the feature"),
+        ]
+        assert all("Follow demo instructions." not in entry.content for entry in app.conversation_entries)


### PR DESCRIPTION
Fixes #624

## Summary

Submitting `/review pr 51` used to render a transcript that showed only `pr 51` as the user message, plus a `Skill` entry that dumped the entire activation content (the whole `SKILL.md` body and resource listing) into the chat.

The transcript now shows:

- a one-line activation entry: `Activated skill \`/review\`.`
- a user entry with the complete submitted command: `/review pr 51`

## How replay parity works

Transcript entries are never persisted; restore always rebuilds from agent history. So the command line itself (`/review pr 51`) is now what gets appended as the user turn message. Restored/replayed sessions then render byte-identically to the live transcript with no restore-path heuristics. The restore path already collapsed activation messages to a one-liner; live and restore now share `skill_activation_label()` in `cli/skills.py` so the formats cannot drift.

The agent receives the full command line as the turn prompt instead of the bare arguments. This is safe and natural: the skill catalog system prompt already documents that users invoke skills with `/skill-name`, and the activation content still precedes it as its own user message. Side benefit: the session journal and Changes-screen checkpoint labels record what the user actually typed.

## Also

- The scheduled-loop skill prefix (`/loop 5m /demo-skill …`) gets the same short label; its turn-prompt semantics are unchanged.
- Headless `kolega-code ask "/skill args"` is unchanged (no transcript).

## Tests

- Updated the two live skill-invocation tests: exact label, full command line, and a regression guard that the skill body never leaks into any transcript entry.
- New `test_skill_invocation_with_arguments_restores_identically` covers replay parity.
- Tightened the loop test to the exact label.

## Verification

- `./run_tests.sh tests/cli/test_app_skill_commands.py tests/cli/test_app_loop_command.py tests/cli/test_app_rendering_entries.py tests/cli/test_skills.py` — 83 passed.
- Full fast suite `./run_tests.sh` — 4857 passed, 1 skipped (env-dependent browser test).
- `ruff check`, `ruff format --check`, `pyright` clean on all touched files; pre-commit hooks passed on the commit.