### PR TITLE
chore(skills): sync bundled skills v0.3.3

### DIFF
--- a/docs/src/content/docs/skills.mdx
+++ b/docs/src/content/docs/skills.mdx
@@ -26,7 +26,7 @@ Skills come from three scopes:
 | **Project** | `<project>/.agents/skills/` |
 
 The bundled catalog is pinned to
-[`kolega-skills` v0.3.2](https://github.com/kolega-ai/kolega-skills/tree/v0.3.2)
+[`kolega-skills` v0.3.3](https://github.com/kolega-ai/kolega-skills/tree/v0.3.3)
 and includes `deep-research`, `docx`, `humanizer`, `pdf`, `pptx`, `review`, `skill-authoring`, and `xlsx`.
 It is part of the installed package, so listing and activating these skills does not
 download anything or follow the upstream repository's latest branch.

--- a/kolega_code/_bundled_skills/manifest.json
+++ b/kolega_code/_bundled_skills/manifest.json
@@ -154,7 +154,7 @@
     },
     {
       "path": "skills/review/SKILL.md",
-      "sha256": "c1075593eea35e27d744c7180636210fab6092059d6e08b3faa1bf1e45e97a67"
+      "sha256": "8f533bfb1a4471eeba3ed3b95ad02c43270e89d24d151ea81eb3ccc3afe3a3ae"
     },
     {
       "path": "skills/review/references/github-publishing.md",
@@ -217,8 +217,8 @@
     "xlsx"
   ],
   "source": {
-    "commit": "2de7491964d92e3dc78f13290d875c800ac6e22d",
+    "commit": "0d8188f00af97c4f98c58dc2ebe090099481e216",
     "repository": "https://github.com/kolega-ai/kolega-skills",
-    "tag": "v0.3.2"
+    "tag": "v0.3.3"
   }
 }

--- a/kolega_code/_bundled_skills/skills/review/SKILL.md
+++ b/kolega_code/_bundled_skills/skills/review/SKILL.md
@@ -91,9 +91,10 @@ output and collect:
 - base/head names and full object IDs;
 - changed paths and the complete patch.
 
-Stop without reviewing when the PR is not open, is a draft, has no effective changes, or
-cannot be read. Give the reason. Do not exclude a change merely because automation authored
-it.
+Review PRs in any state: open, draft, closed, or merged. Stop without reviewing only when
+the PR cannot be read or has no effective changes; give the reason. Note the state and draft
+status in the report when the PR is not open. Do not exclude a change merely because
+automation authored it.
 
 Reject a PR URL whose host is not GitHub before retrieval. Explain that local and branch
 review remain available for changes hosted elsewhere.


### PR DESCRIPTION
Vendors kolega-skills `v0.3.3` (PR #18: review any PR state) into the bundled catalog.

- `review/SKILL.md` updated to review PRs in any state (open, draft, closed, merged) instead of gating on open/draft; state and draft status are noted in the report when the PR is not open
- Manifest re-pinned to tag v0.3.3 (`0d8188f`)
- Docs catalog pin bumped v0.3.2 -> v0.3.3
- Verified: bundled-skills tests pass; every bundled file byte-matches the tag archive
