### PR TITLE
chore: release v0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.31.0 - 2026-08-20
+
+### Added
+
+- Prompt history: submitted prompts are saved per project (capped at 100)
+  and persist across sessions. Press the up arrow in the composer to recall
+  previous prompts, even after restarting the app.
+
+### Changed
+
+- Kolega Code is now licensed under the Business Source License 1.1.
+- Bundled skills updated to v0.3.3.
+- Model catalogs refreshed: OpenRouter now lists 273 models, Tinker 26,
+  Ollama Cloud 19, and the Perplexity Agent catalog (45 models) is now
+  generated from live endpoints.
+- Bundled prompts are now stable across projects and no longer carry
+  open-source secrecy language.
+
 ### Fixed
 
 - Cancelling a turn (Ctrl-C) while a terminal tool call (`exec_command` /
@@ -13,6 +31,12 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   command is still killed and its partial output is kept in the transcript,
   but the agent no longer swallows the cancellation and continues with
   another model request.
+- Tinker models reserve their full max output against the shared
+  input/output window, so a near-full prompt can no longer leave generation
+  with almost no room.
+- Skill invocations now appear in the transcript as a one-line "Activated
+  skill `/name`." label followed by the complete submitted command, instead
+  of dumping the skill's activation contents into the chat.
 
 ## 0.30.1 - 2026-08-17
 

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -174,4 +174,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.30.1"
+__version__ = "0.31.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.30.1"
+__version__ = "0.31.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.30.1"
+version = "0.31.0"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = "BUSL-1.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1787,7 +1787,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.30.1"
+version = "0.31.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Release v0.31.0

Bumps the version in `pyproject.toml`, `uv.lock`, `kolega_code/__init__.py`, and `kolega_code/agent/__init__.py`, and updates `CHANGELOG.md`.

### Highlights

- **Prompt history**: submitted prompts persist per project and can be recalled with the up arrow across sessions.
- **BSL 1.1 license** adoption.
- **Ctrl-C** now stops the agent on the first press even while a terminal tool call is in flight.
- Tinker models reserve output headroom against the shared window; skill invocations render clearly in the transcript.
- Bundled skills v0.3.3 and refreshed model catalogs (OpenRouter 273, Tinker 26, Ollama Cloud 19, Perplexity Agent 45).

Checks: fast test suite (4860 passed, 1 skipped) and pre-commit (ruff, pyright, etc.) run locally in the isolated `.venv-release` environment.

Tag `v0.31.0` will be created after merge.