### PR TITLE
fix(build): pin hatchling to keep Metadata-Version at 2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [build-system]
-requires = ["hatchling"]
+# hatchling 1.32.0 (released 2026-08-11) emits Metadata-Version 2.5 wheels;
+# twine 6.2.0 (dev extra) hard-caps metadata validation at 2.4, so the release
+# workflow's `twine check` fails on 2.5. Pin the last 2.4-emitting hatchling to
+# keep the build deterministic as the uv `exclude-newer` cutoff advances.
+requires = ["hatchling==1.31.0"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
## Problem

The `v0.31.0` release workflow failed at `twine check`:

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

- `uv build` resolves build requirements fresh, so advancing the `exclude-newer` cutoff (via `uv lock`) pulled in **hatchling 1.32.0** (2026-08-11), which emits **Metadata-Version 2.5** wheels.
- **twine 6.2.0** (dev extra) hard-caps metadata validation at 2.4 (it monkeypatches `packaging.metadata._VALID_METADATA_VERSIONS`), so no `packaging` upgrade can fix this.
- All previous releases shipped Metadata-Version 2.4.

## Fix

Pin `hatchling==1.31.0` (last 2.4-emitting release, 2026-07-08) in `[build-system] requires`, with a comment explaining why. Verified locally:

- wheel and sdist both build at Metadata-Version 2.4
- `uv run twine check dist/*` passes with the project's locked twine 6.2.0 / packaging 25.0
- `uv lock --check` passes (no lockfile churn)

After merge, tag `v0.31.0` will be moved to the new main HEAD and the Release workflow re-run (nothing was published; the failed run stopped before PyPI).
