### PR TITLE
feat(acp): serve kolega-code as an ACP agent for editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,38 @@ use Kolega Code as an ordinary terminal coding agent:
   (including OAuth-enabled HTTP servers) as permission-gated tools.
 - **Interactive or scriptable:** Textual TUI with queued follow-ups, one-shot
   `kolega-code ask` with JSON output, session list/export/resume, `doctor`.
+- **Editor integration:** drive the full agent from Zed or VS Code over the
+  Agent Client Protocol — streamed responses, tool cards, diffs, permission
+  prompts, plan/build approval, session restore, slash commands, and sub-agent
+  transcripts ([docs](https://kolega-ai.github.io/kolega-code/editor-integration/)).
 - **Extensibility:** agent skills, project prompt-template overrides
   ([docs](https://kolega-ai.github.io/kolega-code/configuration/prompt-overrides/)),
   lifecycle hooks, persistent project permission rules.
 - **Local-first state:** sessions, settings, permissions, OAuth tokens, and
   API-key settings stay on your machine with restrictive permissions where
   applicable.
+
+## Editor integration (ACP)
+
+`kolega-code acp` serves the Agent Client Protocol, so Zed and VS Code can host
+the full agent — including permissions, plan/build modes, and sub-agent
+transcripts. Configure Zed with:
+
+```json
+{
+  "agent_servers": {
+    "Kolega Code": {
+      "command": "/absolute/path/to/bin/kolega-code",
+      "args": ["acp", "--permission-mode", "ask"]
+    }
+  }
+}
+```
+
+Use an absolute binary path: a bare `kolega-code` resolves to whatever is on the
+editor's `PATH`, so an installed release can shadow a dev checkout. Full setup
+for Zed, VS Code, and other ACP clients is in the
+[editor integration docs](https://kolega-ai.github.io/kolega-code/editor-integration/).
 
 ## Quick start
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -129,6 +129,10 @@ export default defineConfig({
           items: [{ label: "Recurring Prompts", slug: "loop" }],
         },
         {
+          label: "Editor Integration",
+          items: [{ label: "Zed & VS Code (ACP)", slug: "editor-integration" }],
+        },
+        {
           label: "Troubleshooting",
           items: [
             {

--- a/docs/src/content/docs/editor-integration.mdx
+++ b/docs/src/content/docs/editor-integration.mdx
@@ -1,0 +1,150 @@
+---
+title: Editor Integration
+description: Use Kolega Code from Zed, VS Code, and other editors over the Agent Client Protocol (ACP).
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+**Editor integration** runs the full Kolega Code agent — models, tools, permissions,
+skills, plan/build modes, sub-agent fan-out — inside your editor. The editor spawns
+`kolega-code acp`, a small server that speaks the **Agent Client Protocol (ACP)**
+over stdio, and renders the agent's work natively.
+
+## How it works
+
+- `kolega-code acp` is one process per editor connection, owned by the editor's
+  agent-server lifecycle.
+- Each editor thread is an ordinary Kolega Code session: it persists to the same
+  session store as the TUI, so editor threads replay in the TUI, in `kolega-code
+  sessions`, in exports, and in `/share` like any other session.
+- Tool permissions, model selection, and plan/build mode are per-session. The
+  agent's tool set, skills, MCP servers, hooks, and project configuration behave
+  exactly as they do in the TUI.
+
+```txt
+usage: kolega-code acp [--debug] [--acp-log PATH] [--permission-mode {auto,ask}]
+```
+
+| Flag | Effect |
+| --- | --- |
+| `--permission-mode ask` (default) | Tool approvals are prompted through the editor. |
+| `--permission-mode auto` | Approve every tool call without prompting. |
+| `--debug` | Debug logging to stderr. |
+| `--acp-log PATH` | Append a JSON traffic log of every protocol frame to `PATH`. |
+
+## Zed
+
+Zed hosts ACP agents natively — no plugin needed.
+
+1. Open `~/.config/zed/settings.json` and add an `agent_servers` entry:
+
+```json
+{
+  "agent_servers": {
+    "Kolega Code": {
+      "command": "/absolute/path/to/bin/kolega-code",
+      "args": ["acp", "--permission-mode", "ask", "--acp-log", "/tmp/kolega-acp.log"]
+    }
+  }
+}
+```
+
+<Aside type="caution" title="Use an absolute binary path">
+A bare `kolega-code` resolves to whatever is on Zed's `PATH`, which is often a
+different binary than the one you think you are using — an installed release can
+shadow a dev checkout. Point `command` at the exact binary you want:
+`which kolega-code` (or `/path/to/checkout/.venv/bin/kolega-code` for a checkout).
+</Aside>
+
+2. Restart Zed, open the agent panel, select **Kolega Code**, and start a thread.
+
+Zed remembers changes you make through the session option selectors (model,
+permissions, mode) as its own defaults, and restores open threads across restarts
+by replaying the session.
+
+## VS Code
+
+VS Code has no native ACP support; use the community [ACP Client](https://marketplace.visualstudio.com/items?itemName=formulahendry.acp-client)
+extension.
+
+1. Install it (`code --install-extension formulahendry.acp-client`).
+2. Add Kolega Code to your VS Code user settings:
+
+```json
+{
+  "acp.agents": {
+    "kolega-code": {
+      "command": "/absolute/path/to/bin/kolega-code",
+      "args": ["acp", "--permission-mode", "ask", "--acp-log", "/tmp/kolega-acp.log"]
+    }
+  }
+}
+```
+
+3. Reload the window, open your project folder, and connect to the agent from the
+   ACP panel in the Activity Bar.
+
+<Aside>
+Setting `acp.agents` replaces the extension's built-in agent list while present;
+delete the setting to restore them.
+</Aside>
+
+## What the editor shows
+
+- **Conversation** — streamed responses and collapsible thinking blocks, with
+  durable threads: reopening a thread restores the full transcript, including
+  tool calls.
+- **Tool calls** — read/edit/execute cards; file edits render as diffs in Zed.
+- **Permissions** — approval prompts for commands, edits, and MCP tools. Allow
+  once, allow always, or deny; saved rules persist across sessions. Sub-agents
+  always run auto-approved, exactly as in the TUI.
+- **Session options** — a model selector, a permissions selector
+  (`Ask` / `Auto-approve`), and a plan/build mode selector, applied per session.
+- **Plan mode** — plan-mode turns end in an approval prompt
+  (**Implement plan** / **Clear context and implement plan** / **Discuss further**)
+  with the full plan text. Approving switches the session to build mode and
+  starts the implementation turn automatically.
+- **Task list** — the agent's shared task list renders in the editor's plan view
+  with checkbox status, kept in sync as the agent checks items off.
+- **Slash commands** — type `/` for autocomplete:
+
+| Command | Effect |
+| --- | --- |
+| `/help` | List available commands. |
+| `/compress` | Compress the conversation history. |
+| `/clear` | Clear message history. |
+| `/reset` | Alias of `/clear`. |
+| `/context` | Show the current context token count. |
+
+- **User questions** — when the agent calls `ask_user_choice`, Zed renders a
+  native question form. Clients without elicitation support get a tool error and
+  the model asks in chat instead.
+- **Sub-agents** — Gigacode fan-out and `dispatch_agent` show as tool cards with
+  live progress in the card title. In Zed, reopening a thread expands each
+  dispatch into a nested transcript card containing the sub-agent's full
+  conversation.
+- **Compaction** — when the conversation is compressed, the editor shows a
+  collapsible block with the summary, and restored threads replay the last one.
+- **Usage** — the context-window meter updates after each turn.
+
+## Client differences
+
+| Feature | Zed | vscode-acp |
+| --- | --- | --- |
+| Terminal output | Not rendered in the panel (client-owned terminals planned) | Rendered |
+| Diff rendering | Yes | Text results |
+| Session option selectors | Yes | Yes |
+| Elicitation forms | Yes | No — falls back to chat |
+| Nested sub-agent transcripts | Yes (on thread reopen) | Flat tool cards |
+
+## Troubleshooting
+
+- **Nothing renders, or the wrong agent behavior:** check which binary the editor
+  is actually launching (the shadowing caveat above) and restart the editor after
+  changing its config.
+- **Zed traffic:** `--acp-log /tmp/kolega-acp.log` writes every protocol frame;
+  `--debug` adds server-side detail to stderr.
+- **VS Code traffic:** the extension logs all frames to the *ACP Traffic* output
+  channel (`acp.logTraffic`).
+- **One turn at a time:** a second prompt while a turn is running is rejected;
+  cancel the running turn first.

--- a/kolega_code/acp/__init__.py
+++ b/kolega_code/acp/__init__.py
@@ -1,0 +1,27 @@
+"""ACP agent side for kolega-code (Phase 1: core turn loop).
+
+Makes kolega-code usable from ACP clients (Zed, JetBrains, VS Code via
+extensions, Neovim, Emacs) by serving the Agent Client Protocol v1 over
+stdio. The client spawns this process and owns its lifecycle.
+
+stdout carries only ACP JSON-RPC frames (owned by the SDK transport); all
+diagnostics go to stderr. See ``acp-implementation-plan.md`` (repo root) for
+the full design and phases.
+"""
+
+from __future__ import annotations
+
+from kolega_code.acp.agent_factory import ACP_AGENT_MODE, ACP_PERMISSION_MODE, AgentFactory
+from kolega_code.acp.bridge import TOOL_KINDS, AcpBridge
+from kolega_code.acp.server import AcpAgent
+from kolega_code.acp.session import AcpSession
+
+__all__ = [
+    "ACP_AGENT_MODE",
+    "ACP_PERMISSION_MODE",
+    "AcpAgent",
+    "AcpBridge",
+    "AcpSession",
+    "AgentFactory",
+    "TOOL_KINDS",
+]

--- a/kolega_code/acp/__init__.py
+++ b/kolega_code/acp/__init__.py
@@ -17,6 +17,7 @@ from kolega_code.acp.diffs import AcpDiffProvider
 from kolega_code.acp.permissions import AcpPermissionBroker
 from kolega_code.acp.server import AcpAgent
 from kolega_code.acp.session import AcpSession
+from kolega_code.acp.usage import build_usage_update, context_window_for
 
 __all__ = [
     "ACP_AGENT_MODE",
@@ -28,4 +29,6 @@ __all__ = [
     "AcpSession",
     "AgentFactory",
     "TOOL_KINDS",
+    "build_usage_update",
+    "context_window_for",
 ]

--- a/kolega_code/acp/__init__.py
+++ b/kolega_code/acp/__init__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from kolega_code.acp.agent_factory import ACP_AGENT_MODE, ACP_PERMISSION_MODE, AgentFactory
 from kolega_code.acp.bridge import TOOL_KINDS, AcpBridge
+from kolega_code.acp.diffs import AcpDiffProvider
 from kolega_code.acp.permissions import AcpPermissionBroker
 from kolega_code.acp.server import AcpAgent
 from kolega_code.acp.session import AcpSession
@@ -22,6 +23,7 @@ __all__ = [
     "ACP_PERMISSION_MODE",
     "AcpAgent",
     "AcpBridge",
+    "AcpDiffProvider",
     "AcpPermissionBroker",
     "AcpSession",
     "AgentFactory",

--- a/kolega_code/acp/__init__.py
+++ b/kolega_code/acp/__init__.py
@@ -11,10 +11,11 @@ the full design and phases.
 
 from __future__ import annotations
 
-from kolega_code.acp.agent_factory import ACP_AGENT_MODE, ACP_PERMISSION_MODE, AgentFactory
+from kolega_code.acp.agent_factory import ACP_AGENT_MODE, ACP_PERMISSION_MODE, MODE_BUILD, MODE_PLAN, AgentFactory
 from kolega_code.acp.bridge import TOOL_KINDS, AcpBridge
 from kolega_code.acp.diffs import AcpDiffProvider
 from kolega_code.acp.permissions import AcpPermissionBroker
+from kolega_code.acp.plans import plan_entries_from_markdown
 from kolega_code.acp.server import AcpAgent
 from kolega_code.acp.session import AcpSession
 from kolega_code.acp.usage import build_usage_update, context_window_for
@@ -22,6 +23,8 @@ from kolega_code.acp.usage import build_usage_update, context_window_for
 __all__ = [
     "ACP_AGENT_MODE",
     "ACP_PERMISSION_MODE",
+    "MODE_BUILD",
+    "MODE_PLAN",
     "AcpAgent",
     "AcpBridge",
     "AcpDiffProvider",
@@ -31,4 +34,5 @@ __all__ = [
     "TOOL_KINDS",
     "build_usage_update",
     "context_window_for",
+    "plan_entries_from_markdown",
 ]

--- a/kolega_code/acp/__init__.py
+++ b/kolega_code/acp/__init__.py
@@ -15,7 +15,7 @@ from kolega_code.acp.agent_factory import ACP_AGENT_MODE, ACP_PERMISSION_MODE, M
 from kolega_code.acp.bridge import TOOL_KINDS, AcpBridge
 from kolega_code.acp.diffs import AcpDiffProvider
 from kolega_code.acp.permissions import AcpPermissionBroker
-from kolega_code.acp.plans import plan_entries_from_markdown
+from kolega_code.acp.plans import task_entries_from_markdown
 from kolega_code.acp.server import AcpAgent
 from kolega_code.acp.session import AcpSession
 from kolega_code.acp.usage import build_usage_update, context_window_for
@@ -34,5 +34,5 @@ __all__ = [
     "TOOL_KINDS",
     "build_usage_update",
     "context_window_for",
-    "plan_entries_from_markdown",
+    "task_entries_from_markdown",
 ]

--- a/kolega_code/acp/__init__.py
+++ b/kolega_code/acp/__init__.py
@@ -1,4 +1,4 @@
-"""ACP agent side for kolega-code (Phase 1: core turn loop).
+"""ACP agent side for kolega-code.
 
 Makes kolega-code usable from ACP clients (Zed, JetBrains, VS Code via
 extensions, Neovim, Emacs) by serving the Agent Client Protocol v1 over
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from kolega_code.acp.agent_factory import ACP_AGENT_MODE, ACP_PERMISSION_MODE, AgentFactory
 from kolega_code.acp.bridge import TOOL_KINDS, AcpBridge
+from kolega_code.acp.permissions import AcpPermissionBroker
 from kolega_code.acp.server import AcpAgent
 from kolega_code.acp.session import AcpSession
 
@@ -21,6 +22,7 @@ __all__ = [
     "ACP_PERMISSION_MODE",
     "AcpAgent",
     "AcpBridge",
+    "AcpPermissionBroker",
     "AcpSession",
     "AgentFactory",
     "TOOL_KINDS",

--- a/kolega_code/acp/agent_factory.py
+++ b/kolega_code/acp/agent_factory.py
@@ -150,6 +150,10 @@ class AgentFactory:
             for record in records
         ]
 
+    def event_store(self, session_id: str) -> FileSessionEventStore:
+        """The session's durable event journal as a readable event store."""
+        return FileSessionEventStore(self._store.journal(session_id))
+
     # -- internal -----------------------------------------------------------
 
     @staticmethod

--- a/kolega_code/acp/agent_factory.py
+++ b/kolega_code/acp/agent_factory.py
@@ -289,6 +289,11 @@ class AgentFactory:
         freshest history state; ``restore=True`` loads it into the rebuild.
         """
         old = session.agent
+        # The approval flow rebuilds mid-turn, before prompt() persists the
+        # just-finished plan turn. Dump the live agent into the record first
+        # (as the TUI does before rebuilds) so the rebuild restores the full
+        # conversation, not the stale pre-turn snapshot.
+        self.persist(session)
         agent, manager = await self._construct_agent(
             session.record,
             config,

--- a/kolega_code/acp/agent_factory.py
+++ b/kolega_code/acp/agent_factory.py
@@ -49,6 +49,7 @@ ACP_AGENT_MODE = AgentMode.CLI
 ACP_PERMISSION_MODE = PermissionMode.ASK
 CONFIG_MODEL = "model"
 CONFIG_PERMISSION_AUTO = "permission-auto"
+CONFIG_MODE = "mode"
 MODE_BUILD = "build"
 MODE_PLAN = "plan"
 INTERACTION_MODES = {MODE_BUILD, MODE_PLAN}
@@ -103,7 +104,7 @@ class AgentFactory:
     # -- session config options -------------------------------------------
 
     def config_options_for(self, session: AcpSession) -> list[ConfigOption]:
-        return [self._model_option(session), self._permission_option(session)]
+        return [self._model_option(session), self._permission_option(session), self._mode_option(session)]
 
     async def set_permission_mode(self, session: AcpSession, mode: PermissionMode) -> None:
         session.agent.set_permission_mode(mode)
@@ -199,6 +200,19 @@ class AgentFactory:
             id=CONFIG_PERMISSION_AUTO,
             name="Auto-approve tools",
             current_value=session.agent.permission_mode == PermissionMode.AUTO,
+        )
+
+    @staticmethod
+    def _mode_option(session: AcpSession) -> SessionConfigOptionSelect:
+        return SessionConfigOptionSelect(
+            type="select",
+            id=CONFIG_MODE,
+            name="Mode",
+            current_value=session.record.interaction_mode or MODE_BUILD,
+            options=[
+                SessionConfigSelectOption(value=MODE_BUILD, name="Build"),
+                SessionConfigSelectOption(value=MODE_PLAN, name="Plan"),
+            ],
         )
 
     async def _rebuild_agent(self, session: AcpSession, config: Any) -> None:

--- a/kolega_code/acp/agent_factory.py
+++ b/kolega_code/acp/agent_factory.py
@@ -35,6 +35,7 @@ from kolega_code.agent import CoderAgent, ToolExtension
 from kolega_code.agent.planningagent import PlanningAgent
 from kolega_code.agent.prompt_provider import AgentMode
 from kolega_code.agent.tool_definitions import tool_description_asset
+from kolega_code.agent.volatile_context import VolatileSection
 from kolega_code.cli.config import CliConfigOverrides, build_agent_config, config_summary
 from kolega_code.cli.connection import CliConnectionManager
 from kolega_code.cli.provider_registry import PROVIDER_LABELS, ui_model_options
@@ -153,7 +154,9 @@ class AgentFactory:
 
     @staticmethod
     def _task_list_extension(record: SessionRecord, agent_holder: dict[str, Any], mode: str) -> ToolExtension:
-        """Shared task-list tools backed by the session record.
+        """Shared task-list tools backed by the session record — the same list
+        the TUI's ``update_task_list`` writes, so a session moves between the
+        TUI and the editor with one task list.
 
         Build mode can read and update the list; plan mode gets a read-only
         view (same split as the TUI). Updates broadcast a ``task_list_update``
@@ -180,7 +183,12 @@ class AgentFactory:
         return ToolExtension(
             name="acp-shared-task-list",
             tools=tools,
-            tool_descriptions={name: tool_description_asset(name) for name in tools},
+            tool_descriptions={
+                "get_task_list": tool_description_asset(
+                    "get_task_list" if mode == MODE_BUILD else "get_task_list_readonly"
+                ),
+                **({"update_task_list": tool_description_asset("update_task_list")} if mode == MODE_BUILD else {}),
+            },
             tool_schemas={
                 "get_task_list": {"type": "object", "properties": {}, "required": []},
                 "update_task_list": {
@@ -197,6 +205,17 @@ class AgentFactory:
             tool_groups={"planning_tools": list(tools)},
             propagate_to_sub_agents=False,
         )
+
+    @staticmethod
+    def _task_list_volatile_section(record: SessionRecord) -> Callable[[], VolatileSection]:
+        """The current shared task list as a volatile section (TUI parity: the
+        agent sees the latest list in context every turn without re-fetching).
+        An empty list is an absent section, exactly like the TUI."""
+
+        def provider() -> VolatileSection:
+            return VolatileSection("task_list", (record.task_list_markdown or "").strip())
+
+        return provider
 
     def _load_settings(self) -> None:
         settings_store = SettingsStore()
@@ -352,6 +371,7 @@ class AgentFactory:
             session_recorder=None if restore else recorder,
         )
         agent_holder["agent"] = agent
+        agent.add_volatile_section(self._task_list_volatile_section(record))
         lsp_messages = await agent.tool_collection.initialize()
         for message in lsp_messages:
             logger.debug("acp lsp: %s", message)

--- a/kolega_code/acp/agent_factory.py
+++ b/kolega_code/acp/agent_factory.py
@@ -30,10 +30,12 @@ from acp.schema import (
     SessionInfo,
 )
 
+from kolega_code.acp.questions import build_question_extension
 from kolega_code.acp.session import AcpSession
-from kolega_code.agent import CoderAgent, ToolExtension
+from kolega_code.agent import CoderAgent, PromptExtension, ToolExtension
 from kolega_code.agent.planningagent import PlanningAgent
 from kolega_code.agent.prompt_provider import AgentMode
+from kolega_code.agent.prompts import BUILD_QUESTION_PROMPT, PLANNING_QUESTION_PROMPT
 from kolega_code.agent.tool_definitions import tool_description_asset
 from kolega_code.agent.volatile_context import VolatileSection
 from kolega_code.cli.config import CliConfigOverrides, build_agent_config, config_summary
@@ -304,6 +306,7 @@ class AgentFactory:
             restore=True,
             permission_callback=session.permission_callback,
             permission_mode=old.permission_mode,
+            question_state=session.question_state,
         )
         session.agent = agent
         session.manager = manager
@@ -326,12 +329,14 @@ class AgentFactory:
             if restore
             else self._permission_mode
         )
+        question_state: dict[str, Any] = {}
         agent, manager = await self._construct_agent(
             record,
             config,
             restore=restore,
             permission_callback=permission_callback,
             permission_mode=permission_mode,
+            question_state=question_state,
         )
         session = AcpSession(
             session_id=record.session_id,
@@ -340,6 +345,7 @@ class AgentFactory:
             manager=manager,
             permission_callback=permission_callback,
             config=config,
+            question_state=question_state,
         )
         self._acp_sessions[record.session_id] = session
         return session
@@ -352,6 +358,7 @@ class AgentFactory:
         restore: bool,
         permission_callback: PermissionCallback | None,
         permission_mode: PermissionMode | None = None,
+        question_state: dict[str, Any] | None = None,
     ) -> tuple[CoderAgent, CliConnectionManager]:
         journal = self._store.journal(record.session_id)
         recorder = self._store.recorder(record.session_id)
@@ -365,6 +372,16 @@ class AgentFactory:
         interaction_mode = record.interaction_mode or MODE_BUILD
         agent_class = agent_class_for(interaction_mode)
         agent_holder: dict[str, Any] = {}
+        question_markdown = PLANNING_QUESTION_PROMPT if interaction_mode == MODE_PLAN else BUILD_QUESTION_PROMPT
+        prompt_extensions = [
+            PromptExtension(
+                id="acp-questions",
+                title="Asking the User",
+                markdown=question_markdown,
+                modes=[ACP_AGENT_MODE],
+                propagate_to_sub_agents=False,
+            ),
+        ]
         agent = agent_class(
             project_path=Path(record.project_path),
             workspace_id=record.workspace_id,
@@ -374,7 +391,11 @@ class AgentFactory:
             agent_mode=ACP_AGENT_MODE,
             permission_mode=permission_mode or self._permission_mode,
             permission_callback=permission_callback,
-            tool_extensions=[self._task_list_extension(record, agent_holder, interaction_mode)],
+            prompt_extensions=prompt_extensions,
+            tool_extensions=[
+                self._task_list_extension(record, agent_holder, interaction_mode),
+                build_question_extension(question_state or {}),
+            ],
             # Mirror the ask path: a resumed session hands the recorder over after
             # restoring history, so construction never double-records a resumed turn.
             session_recorder=None if restore else recorder,

--- a/kolega_code/acp/agent_factory.py
+++ b/kolega_code/acp/agent_factory.py
@@ -32,6 +32,7 @@ from acp.schema import (
 
 from kolega_code.acp.session import AcpSession
 from kolega_code.agent import CoderAgent
+from kolega_code.agent.planningagent import PlanningAgent
 from kolega_code.agent.prompt_provider import AgentMode
 from kolega_code.cli.config import CliConfigOverrides, build_agent_config, config_summary
 from kolega_code.cli.connection import CliConnectionManager
@@ -48,9 +49,16 @@ ACP_AGENT_MODE = AgentMode.CLI
 ACP_PERMISSION_MODE = PermissionMode.ASK
 CONFIG_MODEL = "model"
 CONFIG_PERMISSION_AUTO = "permission-auto"
+MODE_BUILD = "build"
+MODE_PLAN = "plan"
+INTERACTION_MODES = {MODE_BUILD, MODE_PLAN}
 
 PermissionCallback = Callable[[PermissionRequest], Awaitable[PermissionDecision]]
 ConfigOption = SessionConfigOptionSelect | SessionConfigOptionBoolean
+
+
+def agent_class_for(mode: str) -> type[CoderAgent]:
+    return PlanningAgent if mode == MODE_PLAN else CoderAgent
 
 
 class AgentFactory:
@@ -101,8 +109,14 @@ class AgentFactory:
         session.agent.set_permission_mode(mode)
         session.record.permission_mode = mode.value
 
+    async def set_interaction_mode(self, session: AcpSession, mode: str) -> None:
+        """Switch plan/build mode by rebuilding the session agent with the mode's class."""
+        session.record.interaction_mode = mode
+        await self._rebuild_agent(session, session.config)
+
     async def apply_model(self, session: AcpSession, provider: str, model: str) -> None:
         config = self._config_for(Path(session.record.project_path), provider=provider, model=model)
+        session.config = config
         await self._rebuild_agent(session, config)
 
     # -- persistence --------------------------------------------------------
@@ -235,6 +249,7 @@ class AgentFactory:
             agent=agent,
             manager=manager,
             permission_callback=permission_callback,
+            config=config,
         )
         self._acp_sessions[record.session_id] = session
         return session
@@ -257,7 +272,9 @@ class AgentFactory:
             session_id=record.session_id,
             artifact_store=FileArtifactStore(journal),
         )
-        agent = CoderAgent(
+        interaction_mode = record.interaction_mode or MODE_BUILD
+        agent_class = agent_class_for(interaction_mode)
+        agent = agent_class(
             project_path=Path(record.project_path),
             workspace_id=record.workspace_id,
             thread_id=record.thread_id,

--- a/kolega_code/acp/agent_factory.py
+++ b/kolega_code/acp/agent_factory.py
@@ -267,12 +267,19 @@ class AgentFactory:
         )
 
     @staticmethod
-    def _permission_option(session: AcpSession) -> SessionConfigOptionBoolean:
-        return SessionConfigOptionBoolean(
-            type="boolean",
+    def _permission_option(session: AcpSession) -> SessionConfigOptionSelect:
+        # A select rather than the ACP boolean: vscode-acp renders only
+        # select-type config options (its UI skips every other type), and Zed
+        # renders selects just as well.
+        return SessionConfigOptionSelect(
+            type="select",
             id=CONFIG_PERMISSION_AUTO,
-            name="Auto-approve tools",
-            current_value=session.agent.permission_mode == PermissionMode.AUTO,
+            name="Permissions",
+            current_value="auto" if session.agent.permission_mode == PermissionMode.AUTO else "ask",
+            options=[
+                SessionConfigSelectOption(value="ask", name="Ask"),
+                SessionConfigSelectOption(value="auto", name="Auto-approve"),
+            ],
         )
 
     @staticmethod

--- a/kolega_code/acp/agent_factory.py
+++ b/kolega_code/acp/agent_factory.py
@@ -31,9 +31,10 @@ from acp.schema import (
 )
 
 from kolega_code.acp.session import AcpSession
-from kolega_code.agent import CoderAgent
+from kolega_code.agent import CoderAgent, ToolExtension
 from kolega_code.agent.planningagent import PlanningAgent
 from kolega_code.agent.prompt_provider import AgentMode
+from kolega_code.agent.tool_definitions import tool_description_asset
 from kolega_code.cli.config import CliConfigOverrides, build_agent_config, config_summary
 from kolega_code.cli.connection import CliConnectionManager
 from kolega_code.cli.provider_registry import PROVIDER_LABELS, ui_model_options
@@ -149,6 +150,53 @@ class AgentFactory:
         ]
 
     # -- internal -----------------------------------------------------------
+
+    @staticmethod
+    def _task_list_extension(record: SessionRecord, agent_holder: dict[str, Any], mode: str) -> ToolExtension:
+        """Shared task-list tools backed by the session record.
+
+        Build mode can read and update the list; plan mode gets a read-only
+        view (same split as the TUI). Updates broadcast a ``task_list_update``
+        chat event so the bridge can refresh the editor's plan view live.
+        """
+
+        async def get_task_list() -> str:
+            return record.task_list_markdown or "No task list has been set."
+
+        async def update_task_list(task_list_markdown: str) -> str:
+            record.task_list_markdown = task_list_markdown.strip()
+            agent = agent_holder.get("agent")
+            if agent is not None:
+                await agent.send_chat_message(
+                    message_type="task_list_update",
+                    content=task_list_markdown.strip(),
+                    tool_call_id=str(getattr(agent, "current_tool_call_id", "") or ""),
+                )
+            return "Task list updated."
+
+        tools: dict[str, Any] = {"get_task_list": get_task_list}
+        if mode == MODE_BUILD:
+            tools["update_task_list"] = update_task_list
+        return ToolExtension(
+            name="acp-shared-task-list",
+            tools=tools,
+            tool_descriptions={name: tool_description_asset(name) for name in tools},
+            tool_schemas={
+                "get_task_list": {"type": "object", "properties": {}, "required": []},
+                "update_task_list": {
+                    "type": "object",
+                    "properties": {
+                        "task_list_markdown": {
+                            "type": "string",
+                            "description": "The full current shared task list as Markdown.",
+                        }
+                    },
+                    "required": ["task_list_markdown"],
+                },
+            },
+            tool_groups={"planning_tools": list(tools)},
+            propagate_to_sub_agents=False,
+        )
 
     def _load_settings(self) -> None:
         settings_store = SettingsStore()
@@ -288,6 +336,7 @@ class AgentFactory:
         )
         interaction_mode = record.interaction_mode or MODE_BUILD
         agent_class = agent_class_for(interaction_mode)
+        agent_holder: dict[str, Any] = {}
         agent = agent_class(
             project_path=Path(record.project_path),
             workspace_id=record.workspace_id,
@@ -297,10 +346,12 @@ class AgentFactory:
             agent_mode=ACP_AGENT_MODE,
             permission_mode=permission_mode or self._permission_mode,
             permission_callback=permission_callback,
+            tool_extensions=[self._task_list_extension(record, agent_holder, interaction_mode)],
             # Mirror the ask path: a resumed session hands the recorder over after
             # restoring history, so construction never double-records a resumed turn.
             session_recorder=None if restore else recorder,
         )
+        agent_holder["agent"] = agent
         lsp_messages = await agent.tool_collection.initialize()
         for message in lsp_messages:
             logger.debug("acp lsp: %s", message)

--- a/kolega_code/acp/agent_factory.py
+++ b/kolega_code/acp/agent_factory.py
@@ -1,0 +1,145 @@
+"""Headless agent composition for ACP sessions.
+
+Builds the same agent stack the CLI uses — settings, model config, durable
+session recording — one ``CoderAgent`` per ACP session.
+
+Sessions use ``AgentMode.CLI`` (the standard interactive coder template; the
+editor thread has a human present) with an *explicit* permission mode:
+``PermissionMode.AUTO`` in Phase 1, upgraded to ``ASK`` with the
+``session/request_permission`` bridge in Phase 2. The ``ASK`` agent mode is
+deliberately not used: it is the autonomous ``ask``-CLI template whose
+permission handling is hardcoded to auto-approve.
+
+Expected failures (missing model config, corrupt settings, unknown session)
+are converted to ACP JSON-RPC errors so the client gets a clean message and
+the process keeps serving.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from acp.exceptions import RequestError
+from acp.schema import SessionInfo
+
+from kolega_code.acp.session import AcpSession
+from kolega_code.agent import CoderAgent
+from kolega_code.agent.prompt_provider import AgentMode
+from kolega_code.cli.config import build_agent_config, config_summary
+from kolega_code.cli.connection import CliConnectionManager
+from kolega_code.cli.session_event_store import FileArtifactStore, FileSessionEventStore
+from kolega_code.cli.session_store import SessionStore, SessionStoreError
+from kolega_code.cli.settings import SettingsStore
+from kolega_code.permissions import PermissionMode
+from kolega_code.session.recording import RecordingConnectionManager
+
+logger = logging.getLogger(__name__)
+
+ACP_AGENT_MODE = AgentMode.CLI
+# Phase 1: auto-approve so turns complete without a permission bridge.
+# Phase 2: PermissionMode.ASK + permission_callback -> session/request_permission.
+ACP_PERMISSION_MODE = PermissionMode.AUTO
+
+
+class AgentFactory:
+    """Opens, loads, and persists ACP sessions backed by the session store."""
+
+    def __init__(self) -> None:
+        self._store = SessionStore()
+        self._acp_sessions: dict[str, AcpSession] = {}
+
+    async def open_session(self, cwd: str) -> AcpSession:
+        project_path = Path(cwd).resolve()
+        settings_store = SettingsStore()
+        settings = settings_store.load()
+        config = build_agent_config(project_path, settings=settings, settings_store=settings_store)
+        record = self._store.create(project_path, ACP_AGENT_MODE.value, config_summary(config))
+        return await self._build_session(record, config, restore=False)
+
+    async def load_session(self, cwd: str, session_id: str) -> AcpSession | None:
+        try:
+            record = self._store.load(session_id)
+        except SessionStoreError as exc:
+            logger.info("acp session/load: unknown session %s (%s)", session_id, exc)
+            return None
+        settings_store = SettingsStore()
+        settings = settings_store.load()
+        config = build_agent_config(Path(record.project_path), settings=settings, settings_store=settings_store)
+        return await self._build_session(record, config, restore=True)
+
+    def persist(self, session: AcpSession) -> None:
+        """Flush the agent's conversation state into the session record."""
+        session.record.history = session.agent.dump_message_history()
+        session.record.compaction = session.agent.dump_compaction_state()
+        self._store.save(session.record)
+
+    async def close_session(self, session_id: str) -> None:
+        session = self._acp_sessions.pop(session_id, None)
+        if session is None:
+            return
+        self.persist(session)
+        try:
+            await session.agent.cleanup()
+        except Exception:  # noqa: BLE001 — closing must not mask the primary outcome
+            logger.exception("acp session close: agent cleanup failed (session=%s)", session_id)
+
+    def list_sessions(self, cwd: str | None) -> list[SessionInfo]:
+        records = self._store.list(project_path=Path(cwd).resolve() if cwd else None)
+        return [
+            SessionInfo(
+                session_id=record.session_id, cwd=record.project_path, title=record.title, updated_at=record.updated_at
+            )
+            for record in records
+        ]
+
+    async def _build_session(
+        self,
+        record,
+        config,
+        *,
+        restore: bool,
+    ) -> AcpSession:
+        """Compose the durable agent stack for one session (the ``ask`` recipe + recording)."""
+        journal = self._store.journal(record.session_id)
+        recorder = self._store.recorder(record.session_id)
+        manager = CliConnectionManager()
+        recording = RecordingConnectionManager(
+            manager,
+            FileSessionEventStore(journal),
+            session_id=record.session_id,
+            artifact_store=FileArtifactStore(journal),
+        )
+        agent = CoderAgent(
+            project_path=Path(record.project_path),
+            workspace_id=record.workspace_id,
+            thread_id=record.thread_id,
+            connection_manager=recording,
+            config=config,
+            agent_mode=ACP_AGENT_MODE,
+            permission_mode=ACP_PERMISSION_MODE,
+            # Mirror the ask path: a resumed session hands the recorder over after
+            # restoring history, so construction never double-records a resumed turn.
+            session_recorder=None if restore else recorder,
+        )
+        lsp_messages = await agent.tool_collection.initialize()
+        for message in lsp_messages:
+            logger.debug("acp lsp: %s", message)
+        if restore:
+            agent.restore_message_history(record.history)
+            agent.restore_compaction_state(record.compaction)
+            agent.session_recorder = recorder
+        session = AcpSession(
+            session_id=record.session_id,
+            record=record,
+            agent=agent,
+            manager=manager,
+        )
+        self._acp_sessions[record.session_id] = session
+        return session
+
+    # -- error conversion -------------------------------------------------
+
+    @staticmethod
+    def protocol_error(exc: BaseException) -> RequestError:
+        return RequestError.internal_error({"message": str(exc) or exc.__class__.__name__})

--- a/kolega_code/acp/agent_factory.py
+++ b/kolega_code/acp/agent_factory.py
@@ -19,28 +19,38 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Awaitable, Callable
+from typing import Any, Awaitable, Callable, cast
 
 from acp.exceptions import RequestError
-from acp.schema import SessionInfo
+from acp.schema import (
+    SessionConfigOptionBoolean,
+    SessionConfigOptionSelect,
+    SessionConfigSelectGroup,
+    SessionConfigSelectOption,
+    SessionInfo,
+)
 
 from kolega_code.acp.session import AcpSession
 from kolega_code.agent import CoderAgent
 from kolega_code.agent.prompt_provider import AgentMode
-from kolega_code.cli.config import build_agent_config, config_summary
+from kolega_code.cli.config import CliConfigOverrides, build_agent_config, config_summary
 from kolega_code.cli.connection import CliConnectionManager
+from kolega_code.cli.provider_registry import PROVIDER_LABELS, ui_model_options
 from kolega_code.cli.session_event_store import FileArtifactStore, FileSessionEventStore
-from kolega_code.cli.session_store import SessionStore, SessionStoreError
-from kolega_code.cli.settings import SettingsStore
-from kolega_code.permissions import PermissionDecision, PermissionMode, PermissionRequest
+from kolega_code.cli.session_store import SessionRecord, SessionStore, SessionStoreError
+from kolega_code.cli.settings import CliSettings, SettingsStore
+from kolega_code.permissions import PermissionDecision, PermissionMode, PermissionRequest, normalize_permission_mode
 from kolega_code.session.recording import RecordingConnectionManager
 
 logger = logging.getLogger(__name__)
 
 ACP_AGENT_MODE = AgentMode.CLI
 ACP_PERMISSION_MODE = PermissionMode.ASK
+CONFIG_MODEL = "model"
+CONFIG_PERMISSION_AUTO = "permission-auto"
 
 PermissionCallback = Callable[[PermissionRequest], Awaitable[PermissionDecision]]
+ConfigOption = SessionConfigOptionSelect | SessionConfigOptionBoolean
 
 
 class AgentFactory:
@@ -49,6 +59,8 @@ class AgentFactory:
     def __init__(self, permission_mode: PermissionMode = ACP_PERMISSION_MODE) -> None:
         self._permission_mode = permission_mode
         self._store = SessionStore()
+        self._settings: CliSettings | None = None
+        self._settings_store: SettingsStore | None = None
         self._acp_sessions: dict[str, AcpSession] = {}
 
     async def open_session(
@@ -59,9 +71,8 @@ class AgentFactory:
         permission_callback: PermissionCallback | None = None,
     ) -> AcpSession:
         project_path = Path(cwd).resolve()
-        settings_store = SettingsStore()
-        settings = settings_store.load()
-        config = build_agent_config(project_path, settings=settings, settings_store=settings_store)
+        self._load_settings()
+        config = self._config_for(project_path)
         record = self._store.create(project_path, ACP_AGENT_MODE.value, config_summary(config), session_id=session_id)
         return await self._build_session(record, config, restore=False, permission_callback=permission_callback)
 
@@ -77,15 +88,30 @@ class AgentFactory:
         except SessionStoreError as exc:
             logger.info("acp session/load: unknown session %s (%s)", session_id, exc)
             return None
-        settings_store = SettingsStore()
-        settings = settings_store.load()
-        config = build_agent_config(Path(record.project_path), settings=settings, settings_store=settings_store)
+        self._load_settings()
+        config = self._config_for(Path(record.project_path))
         return await self._build_session(record, config, restore=True, permission_callback=permission_callback)
+
+    # -- session config options -------------------------------------------
+
+    def config_options_for(self, session: AcpSession) -> list[ConfigOption]:
+        return [self._model_option(session), self._permission_option(session)]
+
+    async def set_permission_mode(self, session: AcpSession, mode: PermissionMode) -> None:
+        session.agent.set_permission_mode(mode)
+        session.record.permission_mode = mode.value
+
+    async def apply_model(self, session: AcpSession, provider: str, model: str) -> None:
+        config = self._config_for(Path(session.record.project_path), provider=provider, model=model)
+        await self._rebuild_agent(session, config)
+
+    # -- persistence --------------------------------------------------------
 
     def persist(self, session: AcpSession) -> None:
         """Flush the agent's conversation state into the session record."""
         session.record.history = session.agent.dump_message_history()
         session.record.compaction = session.agent.dump_compaction_state()
+        session.record.permission_mode = session.agent.permission_mode.value
         self._store.save(session.record)
 
     async def close_session(self, session_id: str) -> None:
@@ -107,15 +133,121 @@ class AgentFactory:
             for record in records
         ]
 
+    # -- internal -----------------------------------------------------------
+
+    def _load_settings(self) -> None:
+        settings_store = SettingsStore()
+        self._settings_store = settings_store
+        self._settings = settings_store.load()
+
+    def _config_for(self, project_path: Path, *, provider: str | None = None, model: str | None = None) -> Any:
+        assert self._settings is not None and self._settings_store is not None
+        overrides = CliConfigOverrides(provider=provider, model=model) if provider and model else None
+        return build_agent_config(
+            project_path,
+            overrides=overrides,
+            settings=self._settings,
+            settings_store=self._settings_store,
+        )
+
+    def _model_option(self, session: AcpSession) -> SessionConfigOptionSelect:
+        assert self._settings is not None
+        groups: list[SessionConfigSelectGroup] = []
+        for provider, key in sorted(self._settings.api_keys.items()):
+            if not key:
+                continue
+            options = [
+                SessionConfigSelectOption(value=f"{provider}/{model}", name=label)
+                for label, model in ui_model_options(provider)
+            ]
+            if options:
+                groups.append(
+                    SessionConfigSelectGroup(
+                        group=provider,
+                        name=str(PROVIDER_LABELS.get(cast(Any, provider), provider)),
+                        options=options,
+                    ),
+                )
+        primary = session.agent.primary_model_config
+        current = f"{primary.provider.value}/{primary.model}"
+        return SessionConfigOptionSelect(
+            type="select",
+            id=CONFIG_MODEL,
+            name="Model",
+            current_value=current,
+            options=groups,
+        )
+
+    @staticmethod
+    def _permission_option(session: AcpSession) -> SessionConfigOptionBoolean:
+        return SessionConfigOptionBoolean(
+            type="boolean",
+            id=CONFIG_PERMISSION_AUTO,
+            name="Auto-approve tools",
+            current_value=session.agent.permission_mode == PermissionMode.AUTO,
+        )
+
+    async def _rebuild_agent(self, session: AcpSession, config: Any) -> None:
+        """Replace the session's agent with a rebuild carrying the same history.
+
+        Config options apply between turns, so the persisted record is the
+        freshest history state; ``restore=True`` loads it into the rebuild.
+        """
+        old = session.agent
+        agent, manager = await self._construct_agent(
+            session.record,
+            config,
+            restore=True,
+            permission_callback=session.permission_callback,
+            permission_mode=old.permission_mode,
+        )
+        session.agent = agent
+        session.manager = manager
+        try:
+            await old.cleanup()
+        except Exception:  # noqa: BLE001
+            logger.exception("acp model switch: old agent cleanup failed (session=%s)", session.session_id)
+
     async def _build_session(
         self,
-        record,
-        config,
+        record: SessionRecord,
+        config: Any,
         *,
         restore: bool,
         permission_callback: PermissionCallback | None,
     ) -> AcpSession:
         """Compose the durable agent stack for one session (the ``ask`` recipe + recording)."""
+        permission_mode = (
+            normalize_permission_mode(record.permission_mode, default=self._permission_mode)
+            if restore
+            else self._permission_mode
+        )
+        agent, manager = await self._construct_agent(
+            record,
+            config,
+            restore=restore,
+            permission_callback=permission_callback,
+            permission_mode=permission_mode,
+        )
+        session = AcpSession(
+            session_id=record.session_id,
+            record=record,
+            agent=agent,
+            manager=manager,
+            permission_callback=permission_callback,
+        )
+        self._acp_sessions[record.session_id] = session
+        return session
+
+    async def _construct_agent(
+        self,
+        record: SessionRecord,
+        config: Any,
+        *,
+        restore: bool,
+        permission_callback: PermissionCallback | None,
+        permission_mode: PermissionMode | None = None,
+    ) -> tuple[CoderAgent, CliConnectionManager]:
         journal = self._store.journal(record.session_id)
         recorder = self._store.recorder(record.session_id)
         manager = CliConnectionManager()
@@ -132,7 +264,7 @@ class AgentFactory:
             connection_manager=recording,
             config=config,
             agent_mode=ACP_AGENT_MODE,
-            permission_mode=self._permission_mode,
+            permission_mode=permission_mode or self._permission_mode,
             permission_callback=permission_callback,
             # Mirror the ask path: a resumed session hands the recorder over after
             # restoring history, so construction never double-records a resumed turn.
@@ -145,14 +277,7 @@ class AgentFactory:
             agent.restore_message_history(record.history)
             agent.restore_compaction_state(record.compaction)
             agent.session_recorder = recorder
-        session = AcpSession(
-            session_id=record.session_id,
-            record=record,
-            agent=agent,
-            manager=manager,
-        )
-        self._acp_sessions[record.session_id] = session
-        return session
+        return agent, manager
 
     # -- error conversion -------------------------------------------------
 

--- a/kolega_code/acp/agent_factory.py
+++ b/kolega_code/acp/agent_factory.py
@@ -5,8 +5,8 @@ session recording — one ``CoderAgent`` per ACP session.
 
 Sessions use ``AgentMode.CLI`` (the standard interactive coder template; the
 editor thread has a human present) with an *explicit* permission mode:
-``PermissionMode.AUTO`` in Phase 1, upgraded to ``ASK`` with the
-``session/request_permission`` bridge in Phase 2. The ``ASK`` agent mode is
+``PermissionMode.ASK`` with a client-bound ``permission_callback`` (the
+``session/request_permission`` bridge). The ``ASK`` agent mode is
 deliberately not used: it is the autonomous ``ask``-CLI template whose
 permission handling is hardcoded to auto-approve.
 
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Awaitable, Callable
 
 from acp.exceptions import RequestError
 from acp.schema import SessionInfo
@@ -31,33 +32,46 @@ from kolega_code.cli.connection import CliConnectionManager
 from kolega_code.cli.session_event_store import FileArtifactStore, FileSessionEventStore
 from kolega_code.cli.session_store import SessionStore, SessionStoreError
 from kolega_code.cli.settings import SettingsStore
-from kolega_code.permissions import PermissionMode
+from kolega_code.permissions import PermissionDecision, PermissionMode, PermissionRequest
 from kolega_code.session.recording import RecordingConnectionManager
 
 logger = logging.getLogger(__name__)
 
 ACP_AGENT_MODE = AgentMode.CLI
-# Phase 1: auto-approve so turns complete without a permission bridge.
-# Phase 2: PermissionMode.ASK + permission_callback -> session/request_permission.
-ACP_PERMISSION_MODE = PermissionMode.AUTO
+ACP_PERMISSION_MODE = PermissionMode.ASK
+
+PermissionCallback = Callable[[PermissionRequest], Awaitable[PermissionDecision]]
 
 
 class AgentFactory:
     """Opens, loads, and persists ACP sessions backed by the session store."""
 
-    def __init__(self) -> None:
+    def __init__(self, permission_mode: PermissionMode = ACP_PERMISSION_MODE) -> None:
+        self._permission_mode = permission_mode
         self._store = SessionStore()
         self._acp_sessions: dict[str, AcpSession] = {}
 
-    async def open_session(self, cwd: str) -> AcpSession:
+    async def open_session(
+        self,
+        cwd: str,
+        *,
+        session_id: str | None = None,
+        permission_callback: PermissionCallback | None = None,
+    ) -> AcpSession:
         project_path = Path(cwd).resolve()
         settings_store = SettingsStore()
         settings = settings_store.load()
         config = build_agent_config(project_path, settings=settings, settings_store=settings_store)
-        record = self._store.create(project_path, ACP_AGENT_MODE.value, config_summary(config))
-        return await self._build_session(record, config, restore=False)
+        record = self._store.create(project_path, ACP_AGENT_MODE.value, config_summary(config), session_id=session_id)
+        return await self._build_session(record, config, restore=False, permission_callback=permission_callback)
 
-    async def load_session(self, cwd: str, session_id: str) -> AcpSession | None:
+    async def load_session(
+        self,
+        cwd: str,
+        session_id: str,
+        *,
+        permission_callback: PermissionCallback | None = None,
+    ) -> AcpSession | None:
         try:
             record = self._store.load(session_id)
         except SessionStoreError as exc:
@@ -66,7 +80,7 @@ class AgentFactory:
         settings_store = SettingsStore()
         settings = settings_store.load()
         config = build_agent_config(Path(record.project_path), settings=settings, settings_store=settings_store)
-        return await self._build_session(record, config, restore=True)
+        return await self._build_session(record, config, restore=True, permission_callback=permission_callback)
 
     def persist(self, session: AcpSession) -> None:
         """Flush the agent's conversation state into the session record."""
@@ -99,6 +113,7 @@ class AgentFactory:
         config,
         *,
         restore: bool,
+        permission_callback: PermissionCallback | None,
     ) -> AcpSession:
         """Compose the durable agent stack for one session (the ``ask`` recipe + recording)."""
         journal = self._store.journal(record.session_id)
@@ -117,7 +132,8 @@ class AgentFactory:
             connection_manager=recording,
             config=config,
             agent_mode=ACP_AGENT_MODE,
-            permission_mode=ACP_PERMISSION_MODE,
+            permission_mode=self._permission_mode,
+            permission_callback=permission_callback,
             # Mirror the ask path: a resumed session hands the recorder over after
             # restoring history, so construction never double-records a resumed turn.
             session_recorder=None if restore else recorder,

--- a/kolega_code/acp/bridge.py
+++ b/kolega_code/acp/bridge.py
@@ -23,6 +23,7 @@ from acp.helpers import (
     tool_content,
     update_agent_message,
     update_agent_thought,
+    update_agent_thought_text,
     update_plan,
     update_tool_call,
     update_user_message,
@@ -188,6 +189,9 @@ class AcpBridge:
         if event.event_type in ("terminal_command", "terminal_output"):
             await self._handle_terminal_event(session_id, event)
             return
+        if event.event_type == "compaction_status":
+            await self._handle_compaction_event(session_id, event)
+            return
         if event.event_type == "llm_context_update" and event.content:
             tokens = event.content.get("input_tokens")
             if isinstance(tokens, int) and tokens >= 0:
@@ -228,6 +232,25 @@ class AcpBridge:
                 session_id,
                 update_tool_call(tool_call_id, status=status, content=blocks or None),
             )
+
+    async def _handle_compaction_event(self, session_id: str, event: AgentEvent) -> None:
+        """Compaction progress as a collapsible thought block (the editor's
+        "special view" for the conversation being compressed). A delegate's
+        compaction belongs to its own transcript and is not shown here."""
+        if event.sub_agent_info:
+            return
+        assert event.content is not None
+        phase = str(event.content.get("phase") or "")
+        text = str(event.content.get("summary") or event.content.get("message") or "").strip()
+        if phase == "started":
+            text = text or "Compacting conversation…"
+        elif phase == "finished":
+            text = f"Conversation compacted:\n{text}" if text else "Conversation compacted."
+        elif phase == "error":
+            text = f"Compaction failed: {text}" if text else "Compaction failed."
+        else:
+            return
+        await self.send(session_id, update_agent_thought_text(text))
 
     async def _handle_terminal_event(self, session_id: str, event: AgentEvent) -> None:
         assert event.content is not None

--- a/kolega_code/acp/bridge.py
+++ b/kolega_code/acp/bridge.py
@@ -23,12 +23,15 @@ from acp.helpers import (
     tool_content,
     update_agent_message,
     update_agent_thought,
+    update_plan,
     update_tool_call,
 )
 from acp.interfaces import Client
 from acp.schema import ToolCallStatus, ToolKind
 
+from kolega_code.acp.agent_factory import MODE_PLAN
 from kolega_code.acp.diffs import AcpDiffProvider
+from kolega_code.acp.plans import plan_entries_from_markdown
 from kolega_code.acp.usage import build_usage_update
 from kolega_code.events import AgentEvent
 
@@ -76,6 +79,7 @@ class AcpBridge:
         self._terminal_text: dict[str, str] = {}
         self._active_execute_tool: str | None = None
         self._latest_context_tokens: int | None = None
+        self._turn_response_parts: list[str] = []
 
     async def send(self, session_id: str, update: Any) -> None:
         if logger.isEnabledFor(logging.DEBUG):
@@ -125,10 +129,21 @@ class AcpBridge:
         if chunk.get("type") == "thinking":
             update = update_agent_thought(text_block(content))
         else:
+            self._turn_response_parts.append(content)
             update = update_agent_message(text_block(content))
         if stream_uuid:
             update.message_id = stream_uuid
         await self.send(session_id, update)
+
+    async def emit_plan(self, session_id: str, mode: str) -> None:
+        if mode != MODE_PLAN:
+            return
+        entries = plan_entries_from_markdown("".join(self._turn_response_parts))
+        if entries:
+            await self.send(session_id, update_plan(entries))
+
+    async def clear_plan(self, session_id: str) -> None:
+        await self.send(session_id, update_plan([]))
 
     async def handle_event(self, session_id: str, event: AgentEvent) -> None:
         """Map one agent event to tool-call lifecycle updates.

--- a/kolega_code/acp/bridge.py
+++ b/kolega_code/acp/bridge.py
@@ -70,14 +70,23 @@ class AcpBridge:
         await self._conn.session_update(session_id=session_id, update=update, source="kolega_code")
 
     async def emit_chunk(self, session_id: str, chunk: dict[str, Any]) -> None:
-        """Map one generator chunk to an agent message or thought update."""
+        """Map one generator chunk to an agent message or thought update.
+
+        Each contiguous stream segment (one ``uuid``) becomes one ACP message:
+        the messageId tells the client which chunks belong to the same block
+        and when a new block starts.
+        """
         content = str(chunk.get("content") or "")
         if not content:
             return
+        stream_uuid = str(chunk.get("uuid") or "")
         if chunk.get("type") == "thinking":
-            await self.send(session_id, update_agent_thought(text_block(content)))
+            update = update_agent_thought(text_block(content))
         else:
-            await self.send(session_id, update_agent_message(text_block(content)))
+            update = update_agent_message(text_block(content))
+        if stream_uuid:
+            update.message_id = stream_uuid
+        await self.send(session_id, update)
 
     async def handle_event(self, session_id: str, event: AgentEvent) -> None:
         """Map one agent event to tool-call lifecycle updates.

--- a/kolega_code/acp/bridge.py
+++ b/kolega_code/acp/bridge.py
@@ -29,9 +29,8 @@ from acp.helpers import (
 from acp.interfaces import Client
 from acp.schema import ToolCallStatus, ToolKind
 
-from kolega_code.acp.agent_factory import MODE_PLAN
 from kolega_code.acp.diffs import AcpDiffProvider
-from kolega_code.acp.plans import plan_entries_from_markdown
+from kolega_code.acp.plans import plan_entries_from_markdown, task_entries_from_markdown
 from kolega_code.acp.usage import build_usage_update
 from kolega_code.events import AgentEvent
 
@@ -135,15 +134,16 @@ class AcpBridge:
             update.message_id = stream_uuid
         await self.send(session_id, update)
 
-    async def emit_plan(self, session_id: str, mode: str) -> None:
-        if mode != MODE_PLAN:
-            return
-        entries = plan_entries_from_markdown("".join(self._turn_response_parts))
+    async def emit_plan(self, session_id: str, plan_markdown: str) -> None:
+        entries = plan_entries_from_markdown(plan_markdown)
         if entries:
             await self.send(session_id, update_plan(entries))
 
     async def clear_plan(self, session_id: str) -> None:
         await self.send(session_id, update_plan([]))
+
+    def response_text(self) -> str:
+        return "".join(self._turn_response_parts)
 
     async def handle_event(self, session_id: str, event: AgentEvent) -> None:
         """Map one agent event to tool-call lifecycle updates.
@@ -176,6 +176,9 @@ class AcpBridge:
                 session_id,
                 start_tool_call(tool_call_id, title, kind=TOOL_KINDS.get(name, "other"), status="pending"),
             )
+        elif message_type == "task_list_update":
+            entries = task_entries_from_markdown(str(content.get("text") or ""))
+            await self.send(session_id, update_plan(entries))
         elif message_type in ("tool_result", "tool_error"):
             if self._active_execute_tool == tool_call_id:
                 self._active_execute_tool = None

--- a/kolega_code/acp/bridge.py
+++ b/kolega_code/acp/bridge.py
@@ -214,20 +214,16 @@ class AcpBridge:
         call only positionally: exec tools are mutating and never run in
         parallel, so the single active execute tool is unambiguous.
         """
+        if event.sub_agent_info:
+            await self._handle_sub_agent_event(session_id, event)
+            return
         if event.event_type in ("terminal_command", "terminal_output"):
-            if event.sub_agent_info:
-                # Delegated terminal activity belongs to the nested transcript,
-                # not the parent trajectory.
-                return
             await self._handle_terminal_event(session_id, event)
             return
         if event.event_type == "compaction_status":
             await self._handle_compaction_event(session_id, event)
             return
         if event.event_type == "llm_context_update" and event.content:
-            if event.sub_agent_info:
-                # A delegate's context drives its own card, not the parent meter.
-                return
             tokens = event.content.get("input_tokens")
             if isinstance(tokens, int) and tokens >= 0:
                 self._latest_context_tokens = tokens
@@ -237,31 +233,6 @@ class AcpBridge:
         content = event.content
         message_type = str(content.get("message_type") or "")
         tool_call_id = str(content.get("tool_call_id") or "")
-
-        # Sub-agent lifecycle: status lines attach to the dispatching card, and
-        # its title carries the message so progress is visible live (Zed
-        # renders tool-card titles, not tool content).
-        if event.sub_agent_info and content.get("status") and content.get("message") and message_type == "":
-            parent_tool_call_id = str(event.sub_agent_info.get("parent_tool_call_id") or "")
-            if parent_tool_call_id:
-                message = str(content.get("message"))
-                label = self._dispatch_labels.get(parent_tool_call_id, "sub-agent")
-                await self.send(
-                    session_id,
-                    update_tool_call(
-                        parent_tool_call_id,
-                        title=f"{label} · {message}",
-                        status="in_progress",
-                        content=[tool_content(text_block(message))],
-                    ),
-                )
-            return
-
-        # Everything else from a delegate renders inside the nested transcript
-        # card (replayed through the sub-session load), never in the parent
-        # trajectory: suppress its tool calls live instead of flattening them.
-        if event.sub_agent_info:
-            return
 
         if message_type == "tool_call":
             name = str(content.get("tool_description") or "tool")
@@ -313,6 +284,63 @@ class AcpBridge:
         else:
             return
         await self.send(session_id, update_agent_thought_text(text))
+
+    async def _handle_sub_agent_event(self, session_id: str, event: AgentEvent) -> None:
+        """Route a delegate's activity to the dispatching card's title.
+
+        The nested transcript card only exists after the thread view is
+        rebuilt from replayed history; live, the dispatch card's title is the
+        one channel that updates as the delegate works (Zed renders tool-card
+        titles live). The delegate's own tool calls, terminal commands, and
+        lifecycle statuses all land there instead of polluting the parent
+        trajectory. Everything else is left to the recorded nested transcript.
+        """
+        if event.event_type == "compaction_status" or not event.content:
+            return
+        parent_tool_call_id = str((event.sub_agent_info or {}).get("parent_tool_call_id") or "")
+        if not parent_tool_call_id:
+            return
+        label = self._dispatch_labels.get(parent_tool_call_id, "sub-agent")
+        content = event.content
+        progress: str | None = None
+        status_message: str | None = None
+        if event.event_type == "terminal_command":
+            progress = str(content.get("command") or "").strip() or None
+        elif event.event_type == "chat_message":
+            message_type = str(content.get("message_type") or "")
+            if message_type == "" and content.get("status") and content.get("message"):
+                status_message = str(content.get("message"))
+            elif message_type == "tool_call":
+                progress = str(content.get("text") or content.get("tool_description") or "").strip() or None
+        if progress is None and status_message is None:
+            return
+        if status_message is not None:
+            await self.send(
+                session_id,
+                update_tool_call(
+                    parent_tool_call_id,
+                    title=self._progress_label(label, status_message),
+                    status="in_progress",
+                    content=[tool_content(text_block(status_message))],
+                ),
+            )
+            return
+        await self.send(
+            session_id,
+            update_tool_call(
+                parent_tool_call_id,
+                title=self._progress_label(label, progress or ""),
+                status="in_progress",
+            ),
+        )
+
+    @staticmethod
+    def _progress_label(label: str, text: str) -> str:
+        """One-line, length-capped card title (Zed truncates multi-line titles)."""
+        line = (text or "").strip().splitlines()[0].strip()
+        if len(line) > 80:
+            line = line[:79] + "…"
+        return f"{label} · {line}" if line else label
 
     async def _handle_terminal_event(self, session_id: str, event: AgentEvent) -> None:
         assert event.content is not None

--- a/kolega_code/acp/bridge.py
+++ b/kolega_code/acp/bridge.py
@@ -1,0 +1,119 @@
+"""Map kolega-code turn output onto ACP ``session/update`` notifications.
+
+Two sources feed one ACP session's rendering:
+
+- the ``process_message_stream`` generator, which yields response/thinking
+  text chunks (the primary prose);
+- the agent event stream (``AgentConnectionManager``), which is the only
+  place tool calls, tool results, and workflow progress surface.
+
+Consuming text from the generator and tools from the event stream avoids the
+known double-render: generator chunks are mirrored as ``assistant_delta``
+events for non-TUI frontends, so mapping both would duplicate every word.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from acp.helpers import (
+    SessionUpdate,
+    start_tool_call,
+    text_block,
+    tool_content,
+    update_agent_message,
+    update_agent_thought,
+    update_tool_call,
+)
+from acp.interfaces import Client
+from acp.schema import ToolCallStatus, ToolKind
+
+from kolega_code.events import AgentEvent
+
+logger = logging.getLogger(__name__)
+
+# ACP v1 tool kinds: coarse buckets that drive client-side icons/UX.
+TOOL_KINDS: dict[str, ToolKind] = {
+    "read": "read",
+    "read_file": "read",
+    "read_image": "read",
+    "edit": "edit",
+    "write": "edit",
+    "multi_edit": "edit",
+    "apply_patch": "edit",
+    "lsp_edit": "edit",
+    "claude_edit": "edit",
+    "claude_write": "edit",
+    "hashline_edit": "edit",
+    "hashline_write": "edit",
+    "exec_command": "execute",
+    "write_stdin": "execute",
+    "kill_command": "execute",
+    "list_sessions": "execute",
+    "eval": "execute",
+    "web_search": "search",
+    "web_fetch": "fetch",
+    "lsp": "search",
+    "run_workflow": "other",
+    "dispatch_agent": "other",
+}
+
+
+class AcpBridge:
+    """Renders one ACP session's turn output to the client."""
+
+    def __init__(self, conn: Client) -> None:
+        self._conn = conn
+
+    async def send(self, session_id: str, update: SessionUpdate) -> None:
+        await self._conn.session_update(session_id=session_id, update=update, source="kolega_code")
+
+    async def emit_chunk(self, session_id: str, chunk: dict[str, Any]) -> None:
+        """Map one generator chunk to an agent message or thought update."""
+        content = str(chunk.get("content") or "")
+        if not content:
+            return
+        if chunk.get("type") == "thinking":
+            await self.send(session_id, update_agent_thought(text_block(content)))
+        else:
+            await self.send(session_id, update_agent_message(text_block(content)))
+
+    async def handle_event(self, session_id: str, event: AgentEvent) -> None:
+        """Map one agent event to tool-call lifecycle updates.
+
+        Only ``chat_message`` events carry tool activity. ``workflow_*``
+        progress and terminal events have no stable ``tool_call_id`` in the
+        Phase 1 event stream and surface through the tool_call/tool_result
+        pair instead.
+        """
+        if event.event_type != "chat_message" or not event.content:
+            return
+        content = event.content
+        message_type = str(content.get("message_type") or "")
+        tool_call_id = str(content.get("tool_call_id") or "")
+
+        if message_type == "tool_call":
+            name = str(content.get("tool_description") or "tool")
+            title = str(content.get("text") or f"Calling {name}")
+            await self.send(
+                session_id,
+                start_tool_call(tool_call_id, title, kind=TOOL_KINDS.get(name, "other"), status="pending"),
+            )
+        elif message_type in ("tool_result", "tool_error"):
+            status: ToolCallStatus = "failed" if message_type == "tool_error" else "completed"
+            text = str(content.get("text") or "")
+            await self.send(
+                session_id,
+                update_tool_call(
+                    tool_call_id,
+                    status=status,
+                    content=[tool_content(text_block(text))] if text else None,
+                ),
+            )
+
+    async def emit_stop_reason_note(self, session_id: str, reason: str) -> None:
+        """Surface a non-end_turn stop reason as a short agent message."""
+        if reason == "end_turn":
+            return
+        await self.send(session_id, update_agent_message(text_block(f"[stopped: {reason}]")))

--- a/kolega_code/acp/bridge.py
+++ b/kolega_code/acp/bridge.py
@@ -29,6 +29,7 @@ from acp.helpers import (
 from acp.interfaces import Client
 from acp.schema import ToolCallStatus, ToolKind
 
+from kolega_code.acp.diffs import AcpDiffProvider
 from kolega_code.events import AgentEvent
 
 logger = logging.getLogger(__name__)
@@ -63,8 +64,9 @@ TOOL_KINDS: dict[str, ToolKind] = {
 class AcpBridge:
     """Renders one ACP session's turn output to the client."""
 
-    def __init__(self, conn: Client) -> None:
+    def __init__(self, conn: Client, diff_provider: AcpDiffProvider | None = None) -> None:
         self._conn = conn
+        self._diffs = diff_provider
 
     async def send(self, session_id: str, update: SessionUpdate) -> None:
         await self._conn.session_update(session_id=session_id, update=update, source="kolega_code")
@@ -112,13 +114,14 @@ class AcpBridge:
         elif message_type in ("tool_result", "tool_error"):
             status: ToolCallStatus = "failed" if message_type == "tool_error" else "completed"
             text = str(content.get("text") or "")
+            blocks: list[Any] = []
+            if status == "completed" and self._diffs is not None:
+                blocks.extend(self._diffs.build_for_tool_result(tool_call_id))
+            if text:
+                blocks.append(tool_content(text_block(text)))
             await self.send(
                 session_id,
-                update_tool_call(
-                    tool_call_id,
-                    status=status,
-                    content=[tool_content(text_block(text))] if text else None,
-                ),
+                update_tool_call(tool_call_id, status=status, content=blocks or None),
             )
 
     async def emit_stop_reason_note(self, session_id: str, reason: str) -> None:

--- a/kolega_code/acp/bridge.py
+++ b/kolega_code/acp/bridge.py
@@ -78,6 +78,12 @@ class AcpBridge:
         self._latest_context_tokens: int | None = None
 
     async def send(self, session_id: str, update: Any) -> None:
+        logger.debug(
+            "acp update kind=%s tc=%s st=%s",
+            getattr(update, "session_update", None) or type(update).__name__,
+            getattr(update, "tool_call_id", ""),
+            getattr(update, "status", ""),
+        )
         await self._conn.session_update(session_id=session_id, update=update, source="kolega_code")
 
     async def emit_usage(self, session_id: str) -> None:

--- a/kolega_code/acp/bridge.py
+++ b/kolega_code/acp/bridge.py
@@ -30,7 +30,7 @@ from acp.interfaces import Client
 from acp.schema import ToolCallStatus, ToolKind
 
 from kolega_code.acp.diffs import AcpDiffProvider
-from kolega_code.acp.plans import plan_entries_from_markdown, task_entries_from_markdown
+from kolega_code.acp.plans import task_entries_from_markdown
 from kolega_code.acp.usage import build_usage_update
 from kolega_code.events import AgentEvent
 
@@ -133,14 +133,6 @@ class AcpBridge:
         if stream_uuid:
             update.message_id = stream_uuid
         await self.send(session_id, update)
-
-    async def emit_plan(self, session_id: str, plan_markdown: str) -> None:
-        entries = plan_entries_from_markdown(plan_markdown)
-        if entries:
-            await self.send(session_id, update_plan(entries))
-
-    async def clear_plan(self, session_id: str) -> None:
-        await self.send(session_id, update_plan([]))
 
     def response_text(self) -> str:
         return "".join(self._turn_response_parts)

--- a/kolega_code/acp/bridge.py
+++ b/kolega_code/acp/bridge.py
@@ -18,7 +18,6 @@ import logging
 from typing import Any
 
 from acp.helpers import (
-    SessionUpdate,
     start_tool_call,
     text_block,
     tool_content,
@@ -30,6 +29,7 @@ from acp.interfaces import Client
 from acp.schema import ToolCallStatus, ToolKind
 
 from kolega_code.acp.diffs import AcpDiffProvider
+from kolega_code.acp.usage import build_usage_update
 from kolega_code.events import AgentEvent
 
 logger = logging.getLogger(__name__)
@@ -69,14 +69,21 @@ class AcpBridge:
 
     TERMINAL_BUFFER_MAX_CHARS = 20_000
 
-    def __init__(self, conn: Client, diff_provider: AcpDiffProvider | None = None) -> None:
+    def __init__(self, conn: Client, diff_provider: AcpDiffProvider | None = None, agent: Any = None) -> None:
         self._conn = conn
         self._diffs = diff_provider
+        self._agent = agent
         self._terminal_text: dict[str, str] = {}
         self._active_execute_tool: str | None = None
+        self._latest_context_tokens: int | None = None
 
-    async def send(self, session_id: str, update: SessionUpdate) -> None:
+    async def send(self, session_id: str, update: Any) -> None:
         await self._conn.session_update(session_id=session_id, update=update, source="kolega_code")
+
+    async def emit_usage(self, session_id: str) -> None:
+        update = build_usage_update(self._agent, self._latest_context_tokens)
+        if update is not None:
+            await self.send(session_id, update)
 
     async def emit_chunk(self, session_id: str, chunk: dict[str, Any]) -> None:
         """Map one generator chunk to an agent message or thought update.
@@ -107,6 +114,11 @@ class AcpBridge:
         """
         if event.event_type in ("terminal_command", "terminal_output"):
             await self._handle_terminal_event(session_id, event)
+            return
+        if event.event_type == "llm_context_update" and event.content:
+            tokens = event.content.get("input_tokens")
+            if isinstance(tokens, int) and tokens >= 0:
+                self._latest_context_tokens = tokens
             return
         if event.event_type != "chat_message" or not event.content:
             return

--- a/kolega_code/acp/bridge.py
+++ b/kolega_code/acp/bridge.py
@@ -39,6 +39,31 @@ from kolega_code.session.projection import ConversationItem
 
 logger = logging.getLogger(__name__)
 
+#: Prefix for synthetic sub-agent session ids Zed loads via session/load to
+#: render a delegated turn as a nested transcript card under the dispatch.
+SUB_SESSION_PREFIX = "sub-"
+
+#: Tools whose calls dispatch delegated agents; their tool cards carry the
+#: Zed subagent_session_info meta so the delegate's transcript nests under them.
+SUB_AGENT_DISPATCH_TOOLS = {"dispatch_agent", "run_workflow"}
+
+
+def sub_session_id(parent_session_id: str, tool_call_id: str) -> str:
+    """Deterministic child session id for one dispatch (parseable on load)."""
+    return f"{SUB_SESSION_PREFIX}{parent_session_id}-{tool_call_id}"
+
+
+def _subagent_meta(parent_session_id: str, tool_call_id: str, tool_name: str) -> dict[str, Any]:
+    """Zed's ``_meta.subagent_session_info`` convention for a dispatch card."""
+    return {
+        "subagent_session_info": {
+            "session_id": sub_session_id(parent_session_id, tool_call_id),
+            "message_start_index": 0,
+        },
+        "tool_name": tool_name,
+    }
+
+
 # ACP v1 tool kinds: coarse buckets that drive client-side icons/UX.
 TOOL_KINDS: dict[str, ToolKind] = {
     "read": "read",
@@ -165,10 +190,10 @@ class AcpBridge:
             elif item.kind == "tool":
                 tool_call_id = item.tool_call_id or f"replay-tool-{item.seq}"
                 name = item.tool_name or "tool"
-                await self.send(
-                    session_id,
-                    start_tool_call(tool_call_id, name, kind=TOOL_KINDS.get(name, "other"), status="pending"),
-                )
+                start = start_tool_call(tool_call_id, name, kind=TOOL_KINDS.get(name, "other"), status="pending")
+                if name in SUB_AGENT_DISPATCH_TOOLS:
+                    start.field_meta = _subagent_meta(session_id, tool_call_id, name)
+                await self.send(session_id, start)
                 if item.status == "failed":
                     status: ToolCallStatus = "failed"
                 elif item.status == "running":
@@ -203,15 +228,29 @@ class AcpBridge:
         message_type = str(content.get("message_type") or "")
         tool_call_id = str(content.get("tool_call_id") or "")
 
+        # Sub-agent lifecycle: status lines attach to the dispatching tool call.
+        if event.sub_agent_info and content.get("status") and content.get("message") and message_type == "":
+            parent_tool_call_id = str(event.sub_agent_info.get("parent_tool_call_id") or "")
+            if parent_tool_call_id:
+                await self.send(
+                    session_id,
+                    update_tool_call(
+                        parent_tool_call_id,
+                        status="in_progress",
+                        content=[tool_content(text_block(str(content.get("message"))))],
+                    ),
+                )
+            return
+
         if message_type == "tool_call":
             name = str(content.get("tool_description") or "tool")
             title = str(content.get("text") or f"Calling {name}")
             if name in EXECUTE_TOOLS:
                 self._active_execute_tool = tool_call_id
-            await self.send(
-                session_id,
-                start_tool_call(tool_call_id, title, kind=TOOL_KINDS.get(name, "other"), status="pending"),
-            )
+            start = start_tool_call(tool_call_id, title, kind=TOOL_KINDS.get(name, "other"), status="pending")
+            if name in SUB_AGENT_DISPATCH_TOOLS:
+                start.field_meta = _subagent_meta(session_id, tool_call_id, name)
+            await self.send(session_id, start)
         elif message_type == "task_list_update":
             entries = task_entries_from_markdown(str(content.get("text") or ""))
             await self.send(session_id, update_plan(entries))

--- a/kolega_code/acp/bridge.py
+++ b/kolega_code/acp/bridge.py
@@ -61,12 +61,19 @@ TOOL_KINDS: dict[str, ToolKind] = {
 }
 
 
+EXECUTE_TOOLS = frozenset(name for name, kind in TOOL_KINDS.items() if kind == "execute")
+
+
 class AcpBridge:
     """Renders one ACP session's turn output to the client."""
+
+    TERMINAL_BUFFER_MAX_CHARS = 20_000
 
     def __init__(self, conn: Client, diff_provider: AcpDiffProvider | None = None) -> None:
         self._conn = conn
         self._diffs = diff_provider
+        self._terminal_text: dict[str, str] = {}
+        self._active_execute_tool: str | None = None
 
     async def send(self, session_id: str, update: SessionUpdate) -> None:
         await self._conn.session_update(session_id=session_id, update=update, source="kolega_code")
@@ -93,11 +100,14 @@ class AcpBridge:
     async def handle_event(self, session_id: str, event: AgentEvent) -> None:
         """Map one agent event to tool-call lifecycle updates.
 
-        Only ``chat_message`` events carry tool activity. ``workflow_*``
-        progress and terminal events have no stable ``tool_call_id`` in the
-        Phase 1 event stream and surface through the tool_call/tool_result
-        pair instead.
+        ``chat_message`` events carry tool-call lifecycle. Terminal events are
+        emitted by the terminal manager itself, correlated to the running tool
+        call only positionally: exec tools are mutating and never run in
+        parallel, so the single active execute tool is unambiguous.
         """
+        if event.event_type in ("terminal_command", "terminal_output"):
+            await self._handle_terminal_event(session_id, event)
+            return
         if event.event_type != "chat_message" or not event.content:
             return
         content = event.content
@@ -107,22 +117,55 @@ class AcpBridge:
         if message_type == "tool_call":
             name = str(content.get("tool_description") or "tool")
             title = str(content.get("text") or f"Calling {name}")
+            if name in EXECUTE_TOOLS:
+                self._active_execute_tool = tool_call_id
             await self.send(
                 session_id,
                 start_tool_call(tool_call_id, title, kind=TOOL_KINDS.get(name, "other"), status="pending"),
             )
         elif message_type in ("tool_result", "tool_error"):
+            if self._active_execute_tool == tool_call_id:
+                self._active_execute_tool = None
             status: ToolCallStatus = "failed" if message_type == "tool_error" else "completed"
+            terminal_text = self._terminal_text.pop(tool_call_id, None)
             text = str(content.get("text") or "")
             blocks: list[Any] = []
             if status == "completed" and self._diffs is not None:
                 blocks.extend(self._diffs.build_for_tool_result(tool_call_id))
-            if text:
+            if terminal_text:
+                blocks.append(tool_content(text_block(terminal_text)))
+            elif text:
                 blocks.append(tool_content(text_block(text)))
             await self.send(
                 session_id,
                 update_tool_call(tool_call_id, status=status, content=blocks or None),
             )
+
+    async def _handle_terminal_event(self, session_id: str, event: AgentEvent) -> None:
+        assert event.content is not None
+        tool_call_id = str(event.content.get("tool_call_id") or self._active_execute_tool or "")
+        if not tool_call_id:
+            return
+        if event.event_type == "terminal_command":
+            command = str(event.content.get("command") or "")
+            if not command:
+                return
+            self._terminal_text[tool_call_id] = f"$ {command}\n"
+        else:
+            output = str(event.content.get("display_output") or event.content.get("output") or "")
+            if not output:
+                return
+            current = self._terminal_text.get(tool_call_id, "")
+            current = (current + output)[-self.TERMINAL_BUFFER_MAX_CHARS :]
+            self._terminal_text[tool_call_id] = current
+        await self.send(
+            session_id,
+            update_tool_call(
+                tool_call_id,
+                status="in_progress",
+                content=[tool_content(text_block(self._terminal_text[tool_call_id]))],
+            ),
+        )
 
     async def emit_stop_reason_note(self, session_id: str, reason: str) -> None:
         """Surface a non-end_turn stop reason as a short agent message."""

--- a/kolega_code/acp/bridge.py
+++ b/kolega_code/acp/bridge.py
@@ -162,6 +162,12 @@ class AcpBridge:
     async def _handle_terminal_event(self, session_id: str, event: AgentEvent) -> None:
         assert event.content is not None
         tool_call_id = str(event.content.get("tool_call_id") or self._active_execute_tool or "")
+        logger.debug(
+            "acp terminal event kind=%s terminal_id=%s attached_tc=%s",
+            event.event_type,
+            event.content.get("terminal_id"),
+            tool_call_id,
+        )
         if not tool_call_id:
             return
         if event.event_type == "terminal_command":

--- a/kolega_code/acp/bridge.py
+++ b/kolega_code/acp/bridge.py
@@ -78,12 +78,19 @@ class AcpBridge:
         self._latest_context_tokens: int | None = None
 
     async def send(self, session_id: str, update: Any) -> None:
-        logger.debug(
-            "acp update kind=%s tc=%s st=%s",
-            getattr(update, "session_update", None) or type(update).__name__,
-            getattr(update, "tool_call_id", ""),
-            getattr(update, "status", ""),
-        )
+        if logger.isEnabledFor(logging.DEBUG):
+            blocks = getattr(update, "content", None) or []
+            preview = ""
+            if blocks:
+                text = getattr(getattr(blocks[0], "content", blocks[0]), "text", "")
+                preview = f" ({len(blocks)} block(s), '{str(text)[:60]}')"
+            logger.debug(
+                "acp update kind=%s tc=%s st=%s%s",
+                getattr(update, "session_update", None) or type(update).__name__,
+                getattr(update, "tool_call_id", ""),
+                getattr(update, "status", ""),
+                preview,
+            )
         await self._conn.session_update(session_id=session_id, update=update, source="kolega_code")
 
     async def emit_usage(self, session_id: str) -> None:

--- a/kolega_code/acp/bridge.py
+++ b/kolega_code/acp/bridge.py
@@ -79,19 +79,32 @@ class AcpBridge:
 
     async def send(self, session_id: str, update: Any) -> None:
         if logger.isEnabledFor(logging.DEBUG):
-            blocks = getattr(update, "content", None) or []
-            preview = ""
-            if blocks:
-                text = getattr(getattr(blocks[0], "content", blocks[0]), "text", "")
-                preview = f" ({len(blocks)} block(s), '{str(text)[:60]}')"
             logger.debug(
                 "acp update kind=%s tc=%s st=%s%s",
                 getattr(update, "session_update", None) or type(update).__name__,
                 getattr(update, "tool_call_id", ""),
                 getattr(update, "status", ""),
-                preview,
+                self._content_preview(update),
             )
         await self._conn.session_update(session_id=session_id, update=update, source="kolega_code")
+
+    @staticmethod
+    def _content_preview(update: Any) -> str:
+        try:
+            blocks = getattr(update, "content", None)
+            if isinstance(blocks, list):
+                if not blocks:
+                    return ""
+                inner = getattr(blocks[0], "content", blocks[0])
+                text = str(getattr(inner, "text", "") or "")[:60]
+                return f" ({len(blocks)} block(s), '{text}')"
+            if blocks is not None:
+                inner = getattr(blocks, "content", blocks)
+                text = str(getattr(inner, "text", "") or "")[:60]
+                return f" ('{text}')"
+        except Exception:  # noqa: BLE001 — diagnostics must never break the wire
+            pass
+        return ""
 
     async def emit_usage(self, session_id: str) -> None:
         update = build_usage_update(self._agent, self._latest_context_tokens)

--- a/kolega_code/acp/bridge.py
+++ b/kolega_code/acp/bridge.py
@@ -25,6 +25,7 @@ from acp.helpers import (
     update_agent_thought,
     update_plan,
     update_tool_call,
+    update_user_message,
 )
 from acp.interfaces import Client
 from acp.schema import ToolCallStatus, ToolKind
@@ -33,6 +34,7 @@ from kolega_code.acp.diffs import AcpDiffProvider
 from kolega_code.acp.plans import task_entries_from_markdown
 from kolega_code.acp.usage import build_usage_update
 from kolega_code.events import AgentEvent
+from kolega_code.session.projection import ConversationItem
 
 logger = logging.getLogger(__name__)
 
@@ -136,6 +138,44 @@ class AcpBridge:
 
     def response_text(self) -> str:
         return "".join(self._turn_response_parts)
+
+    async def replay_conversation(self, session_id: str, items: list[ConversationItem]) -> None:
+        """Replay the persisted transcript as session updates (session/load).
+
+        ACP requires the agent to replay the entire conversation before
+        responding to ``session/load``. The items come from the same projection
+        the TUI restores, so the editor sees what the TUI would show. Live-only
+        notice items (system/status) are not conversation history and are
+        deliberately not replayed.
+        """
+        for item in items:
+            if item.kind == "user":
+                update = update_user_message(text_block(item.text))
+                if item.seq is not None:
+                    update.message_id = f"replay-{item.seq}-user"
+                await self.send(session_id, update)
+            elif item.kind == "assistant":
+                update = update_agent_message(text_block(item.text))
+                if item.seq is not None:
+                    update.message_id = f"replay-{item.seq}-assistant"
+                await self.send(session_id, update)
+            elif item.kind == "thinking":
+                await self.send(session_id, update_agent_thought(text_block(item.text)))
+            elif item.kind == "tool":
+                tool_call_id = item.tool_call_id or f"replay-tool-{item.seq}"
+                name = item.tool_name or "tool"
+                await self.send(
+                    session_id,
+                    start_tool_call(tool_call_id, name, kind=TOOL_KINDS.get(name, "other"), status="pending"),
+                )
+                if item.status == "failed":
+                    status: ToolCallStatus = "failed"
+                elif item.status == "running":
+                    status = "in_progress"
+                else:
+                    status = "completed"
+                content = [tool_content(text_block(item.text))] if item.text else None
+                await self.send(session_id, update_tool_call(tool_call_id, status=status, content=content))
 
     async def handle_event(self, session_id: str, event: AgentEvent) -> None:
         """Map one agent event to tool-call lifecycle updates.

--- a/kolega_code/acp/bridge.py
+++ b/kolega_code/acp/bridge.py
@@ -107,6 +107,9 @@ class AcpBridge:
         self._active_execute_tool: str | None = None
         self._latest_context_tokens: int | None = None
         self._turn_response_parts: list[str] = []
+        #: Dispatch tool_call_id -> tool name, so delegate status lines can
+        #: label the dispatching card's title.
+        self._dispatch_labels: dict[str, str] = {}
 
     async def send(self, session_id: str, update: Any) -> None:
         if logger.isEnabledFor(logging.DEBUG):
@@ -212,12 +215,19 @@ class AcpBridge:
         parallel, so the single active execute tool is unambiguous.
         """
         if event.event_type in ("terminal_command", "terminal_output"):
+            if event.sub_agent_info:
+                # Delegated terminal activity belongs to the nested transcript,
+                # not the parent trajectory.
+                return
             await self._handle_terminal_event(session_id, event)
             return
         if event.event_type == "compaction_status":
             await self._handle_compaction_event(session_id, event)
             return
         if event.event_type == "llm_context_update" and event.content:
+            if event.sub_agent_info:
+                # A delegate's context drives its own card, not the parent meter.
+                return
             tokens = event.content.get("input_tokens")
             if isinstance(tokens, int) and tokens >= 0:
                 self._latest_context_tokens = tokens
@@ -228,18 +238,29 @@ class AcpBridge:
         message_type = str(content.get("message_type") or "")
         tool_call_id = str(content.get("tool_call_id") or "")
 
-        # Sub-agent lifecycle: status lines attach to the dispatching tool call.
+        # Sub-agent lifecycle: status lines attach to the dispatching card, and
+        # its title carries the message so progress is visible live (Zed
+        # renders tool-card titles, not tool content).
         if event.sub_agent_info and content.get("status") and content.get("message") and message_type == "":
             parent_tool_call_id = str(event.sub_agent_info.get("parent_tool_call_id") or "")
             if parent_tool_call_id:
+                message = str(content.get("message"))
+                label = self._dispatch_labels.get(parent_tool_call_id, "sub-agent")
                 await self.send(
                     session_id,
                     update_tool_call(
                         parent_tool_call_id,
+                        title=f"{label} · {message}",
                         status="in_progress",
-                        content=[tool_content(text_block(str(content.get("message"))))],
+                        content=[tool_content(text_block(message))],
                     ),
                 )
+            return
+
+        # Everything else from a delegate renders inside the nested transcript
+        # card (replayed through the sub-session load), never in the parent
+        # trajectory: suppress its tool calls live instead of flattening them.
+        if event.sub_agent_info:
             return
 
         if message_type == "tool_call":
@@ -247,6 +268,8 @@ class AcpBridge:
             title = str(content.get("text") or f"Calling {name}")
             if name in EXECUTE_TOOLS:
                 self._active_execute_tool = tool_call_id
+            if name in SUB_AGENT_DISPATCH_TOOLS:
+                self._dispatch_labels[tool_call_id] = name
             start = start_tool_call(tool_call_id, title, kind=TOOL_KINDS.get(name, "other"), status="pending")
             if name in SUB_AGENT_DISPATCH_TOOLS:
                 start.field_meta = _subagent_meta(session_id, tool_call_id, name)

--- a/kolega_code/acp/diffs.py
+++ b/kolega_code/acp/diffs.py
@@ -1,0 +1,93 @@
+"""Full-file diff content for ACP tool results, sourced from snapshots.
+
+Edit tools record pre/post file states in the session's ``SnapshotService``
+keyed by tool-call id. The bridge turns those into ``FileEditToolCallContent``
+(ACP v1's oldText/newText diff) so clients render the change instead of bare
+result text. Missing snapshots, binary content, and oversized files fall back
+to the ordinary text rendering.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from acp.schema import FileEditToolCallContent
+
+from kolega_code.services.snapshots import FileState, SnapshotRecord, SnapshotService
+
+logger = logging.getLogger(__name__)
+
+MAX_DIFF_CHARS = 200_000
+_SNAPSHOT_SCAN_LIMIT = 50
+
+
+def _absolute(record: SnapshotRecord, path: str) -> str:
+    """Snapshot paths are project-relative; ACP requires absolute paths."""
+    if Path(path).is_absolute():
+        return path
+    return str(Path(record.project_path) / path)
+
+
+class AcpDiffProvider:
+    """Builds diff content for tool results from the session's snapshot store."""
+
+    def __init__(self, snapshot_service: SnapshotService | None) -> None:
+        self._snapshots = snapshot_service
+
+    @classmethod
+    def for_session(cls, session: Any) -> "AcpDiffProvider":
+        collection = getattr(session.agent, "tool_collection", None)
+        return cls(getattr(collection, "snapshot_service", None) if collection is not None else None)
+
+    def build_for_tool_result(self, tool_call_id: str) -> list[FileEditToolCallContent]:
+        if not tool_call_id or self._snapshots is None:
+            return []
+        record = self._find_record(tool_call_id)
+        if record is None:
+            return []
+        contents: list[FileEditToolCallContent] = []
+        for path in record.touched_paths:
+            content = self._build_one(_absolute(record, path), record.before.get(path), record.after.get(path))
+            if content is not None:
+                contents.append(content)
+        return contents
+
+    def _find_record(self, tool_call_id: str) -> SnapshotRecord | None:
+        assert self._snapshots is not None
+        try:
+            records = self._snapshots.list_snapshots(limit=_SNAPSHOT_SCAN_LIMIT)
+        except Exception:  # noqa: BLE001 — a broken snapshot store must never break rendering
+            logger.exception("acp diff: snapshot listing failed")
+            return None
+        return next((record for record in records if record.tool_call_id == tool_call_id), None)
+
+    def _build_one(
+        self, path: str, before: FileState | None, after: FileState | None
+    ) -> FileEditToolCallContent | None:
+        if after is None or after.kind != "file":
+            return None
+        if before is not None and before.kind != "file":
+            if before.kind != "missing":
+                return None
+            before = None
+        try:
+            old_text = None if before is None else self._read_text(before)
+            new_text = self._read_text(after)
+        except Exception:  # noqa: BLE001 — unreadable blobs fall back to text rendering
+            logger.debug("acp diff: blob read failed for %s", path)
+            return None
+        if old_text == new_text:
+            return None
+        if (old_text is not None and "\x00" in old_text) or "\x00" in new_text:
+            return None
+        if len(old_text or "") + len(new_text or "") > MAX_DIFF_CHARS:
+            return None
+        return FileEditToolCallContent(type="diff", path=path, old_text=old_text, new_text=new_text)
+
+    def _read_text(self, state: FileState) -> str:
+        assert self._snapshots is not None
+        if not state.blob_id:
+            raise ValueError("snapshot state has no blob")
+        return self._snapshots.read_blob(state).decode("utf-8")

--- a/kolega_code/acp/permissions.py
+++ b/kolega_code/acp/permissions.py
@@ -1,0 +1,109 @@
+"""Agent permission requests answered through the ACP client.
+
+Saved allow rules are matched first (same semantics as the TUI's
+``SessionRuntime``); otherwise the request is sent to the client via
+``session/request_permission`` and the outcome mapped back to a
+``PermissionDecision``. allow-always persists the chosen rule before
+answering.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any, Callable
+
+from acp.helpers import update_tool_call
+from acp.interfaces import Client
+from acp.schema import PermissionOption
+
+from kolega_code.acp.bridge import TOOL_KINDS
+from kolega_code.permissions import (
+    PermissionDecision,
+    PermissionRequest,
+    PermissionRule,
+    ProjectPermissionStore,
+    allow_rule_options,
+)
+from kolega_code.session.control import DEFAULT_REQUEST_TIMEOUT_SECONDS
+
+logger = logging.getLogger(__name__)
+
+OPTION_ALLOW_ONCE = "allow-once"
+OPTION_REJECT_ONCE = "reject-once"
+
+
+class AcpPermissionBroker:
+    """Prompt and rule handling for one ACP session's permission requests."""
+
+    def __init__(
+        self,
+        conn: Client,
+        session_id: str,
+        project_path: Path,
+        agent_provider: Callable[[], Any],
+        *,
+        timeout: float = DEFAULT_REQUEST_TIMEOUT_SECONDS,
+    ) -> None:
+        self._conn = conn
+        self._session_id = session_id
+        self._store = ProjectPermissionStore(project_path)
+        self._agent_provider = agent_provider
+        self._timeout = timeout
+
+    async def __call__(self, request: PermissionRequest) -> PermissionDecision:
+        saved = self._store.first_match(request)
+        if saved is not None:
+            return PermissionDecision(allowed=True, reason=f"Allowed by saved rule {saved.id}.", rule=saved)
+        return await self._prompt(request)
+
+    async def _prompt(self, request: PermissionRequest) -> PermissionDecision:
+        rules_by_option: dict[str, PermissionRule] = {}
+        options: list[PermissionOption] = [
+            PermissionOption(option_id=OPTION_ALLOW_ONCE, name="Allow once", kind="allow_once"),
+        ]
+        for index, candidate in enumerate(allow_rule_options(request)):
+            option_id = f"allow-always-{index}"
+            rules_by_option[option_id] = candidate.rule
+            options.append(PermissionOption(option_id=option_id, name=candidate.label, kind="allow_always"))
+        options.append(PermissionOption(option_id=OPTION_REJECT_ONCE, name="Reject", kind="reject_once"))
+
+        tool_call = update_tool_call(
+            self._current_tool_call_id(),
+            title=request.summary or request.tool_name,
+            kind=TOOL_KINDS.get(request.tool_name, "other"),
+            status="pending",
+            raw_input=request.inputs,
+        )
+        try:
+            response = await asyncio.wait_for(
+                self._conn.request_permission(self._session_id, tool_call, options),
+                timeout=self._timeout,
+            )
+        except asyncio.TimeoutError:
+            return PermissionDecision(allowed=False, reason="Timed out waiting for approval.")
+        except Exception:
+            logger.exception("acp permission request failed")
+            return PermissionDecision(allowed=False, reason="The permission prompt could not be shown.")
+
+        outcome = response.outcome
+        if getattr(outcome, "outcome", None) != "selected":
+            return PermissionDecision(allowed=False, reason="Denied by the user.")
+        option_id = str(getattr(outcome, "option_id", "") or "")
+        if option_id == OPTION_ALLOW_ONCE:
+            return PermissionDecision(allowed=True)
+        if option_id == OPTION_REJECT_ONCE:
+            return PermissionDecision(allowed=False, reason="Denied by the user.")
+        rule = rules_by_option.get(option_id)
+        if rule is None:
+            return PermissionDecision(allowed=False, reason="Unknown approval option.")
+        try:
+            self._store.add_rule(rule)
+        except Exception:
+            logger.exception("acp could not persist allow-always rule")
+        return PermissionDecision(allowed=True, reason="Allowed and remembered.", rule=rule)
+
+    def _current_tool_call_id(self) -> str:
+        agent = self._agent_provider()
+        return str(getattr(agent, "current_tool_call_id", "") or "") or "pending"

--- a/kolega_code/acp/permissions.py
+++ b/kolega_code/acp/permissions.py
@@ -87,10 +87,17 @@ class AcpPermissionBroker:
             logger.exception("acp permission request failed")
             return PermissionDecision(allowed=False, reason="The permission prompt could not be shown.")
 
-        outcome = response.outcome
-        if getattr(outcome, "outcome", None) != "selected":
+        outcome = getattr(response, "outcome", None)
+        if outcome is None and isinstance(response, dict):
+            outcome = response.get("outcome")
+        if isinstance(outcome, dict):
+            selected = outcome.get("outcome") == "selected"
+            option_id = str(outcome.get("optionId") or "")
+        else:
+            selected = getattr(outcome, "outcome", None) == "selected"
+            option_id = str(getattr(outcome, "option_id", "") or "")
+        if not selected:
             return PermissionDecision(allowed=False, reason="Denied by the user.")
-        option_id = str(getattr(outcome, "option_id", "") or "")
         if option_id == OPTION_ALLOW_ONCE:
             return PermissionDecision(allowed=True)
         if option_id == OPTION_REJECT_ONCE:

--- a/kolega_code/acp/plans.py
+++ b/kolega_code/acp/plans.py
@@ -1,0 +1,24 @@
+"""Plan-mode support: markdown plans mapped to ACP plan updates.
+
+The planning agent's response in plan mode is a markdown plan; the editor's
+plan view wants ``PlanEntry`` items. Top-level markdown headings become
+entries; a plan with no headings becomes a single entry.
+"""
+
+from __future__ import annotations
+
+from acp.helpers import plan_entry
+from acp.schema import PlanEntry
+
+
+def plan_entries_from_markdown(text: str) -> list[PlanEntry]:
+    entries: list[PlanEntry] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            content = stripped.lstrip("#").strip()
+            if content:
+                entries.append(plan_entry(content[:500]))
+    if not entries and text.strip():
+        entries.append(plan_entry(text.strip()[:500]))
+    return entries

--- a/kolega_code/acp/plans.py
+++ b/kolega_code/acp/plans.py
@@ -1,8 +1,11 @@
-"""Plan-mode support: markdown plans mapped to ACP plan updates.
+"""Task-list support: the agent's shared task list mapped to ACP plan updates.
 
-The planning agent's response in plan mode is a markdown plan; the editor's
-plan view wants ``PlanEntry`` items. Top-level markdown headings become
-entries; a plan with no headings becomes a single entry.
+The build agent's shared task list (the same ``SessionRecord.task_list_markdown``
+the TUI renders in its planning sidebar) is the only source of the editor's
+plan view. ``update_task_list`` writes are broadcast as ``task_list_update``
+events; each list item becomes a ``PlanEntry``, with checkbox markdown carrying
+the item's status. Plans never populate this view — the plan and the task list
+are distinct in the TUI, and the editor's plan view mirrors the task list only.
 """
 
 from __future__ import annotations
@@ -11,21 +14,8 @@ from acp.helpers import plan_entry
 from acp.schema import PlanEntry
 
 
-def plan_entries_from_markdown(text: str) -> list[PlanEntry]:
-    entries: list[PlanEntry] = []
-    for line in text.splitlines():
-        stripped = line.strip()
-        if stripped.startswith("#"):
-            content = stripped.lstrip("#").strip()
-            if content:
-                entries.append(plan_entry(content[:500]))
-    if not entries and text.strip():
-        entries.append(plan_entry(text.strip()[:500]))
-    return entries
-
-
 def task_entries_from_markdown(text: str) -> list[PlanEntry]:
-    """The shared task list's checkbox markdown as plan entries.
+    """The shared task list's markdown as plan entries.
 
     ``- [x]`` items map to completed entries; everything else pending, so the
     editor's plan view renders the TUI's checklist with live status.

--- a/kolega_code/acp/plans.py
+++ b/kolega_code/acp/plans.py
@@ -22,3 +22,29 @@ def plan_entries_from_markdown(text: str) -> list[PlanEntry]:
     if not entries and text.strip():
         entries.append(plan_entry(text.strip()[:500]))
     return entries
+
+
+def task_entries_from_markdown(text: str) -> list[PlanEntry]:
+    """The shared task list's checkbox markdown as plan entries.
+
+    ``- [x]`` items map to completed entries; everything else pending, so the
+    editor's plan view renders the TUI's checklist with live status.
+    """
+    entries: list[PlanEntry] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- [x]") or stripped.startswith("- [X]"):
+            content = stripped[5:].strip()
+            if content:
+                entries.append(plan_entry(content[:500], status="completed"))
+        elif stripped.startswith("- [ ]"):
+            content = stripped[5:].strip()
+            if content:
+                entries.append(plan_entry(content[:500]))
+        elif stripped.startswith("- "):
+            content = stripped[2:].strip()
+            if content:
+                entries.append(plan_entry(content[:500]))
+    if not entries and text.strip():
+        entries.append(plan_entry(text.strip()[:500]))
+    return entries

--- a/kolega_code/acp/questions.py
+++ b/kolega_code/acp/questions.py
@@ -1,0 +1,67 @@
+"""``ask_user_choice`` over ACP elicitation.
+
+The TUI answers planning questions on its control channel; the ACP server
+answers them through the client's ``elicitation/create`` (form mode), so the
+editor renders a native question form and the accepted value returns as the
+tool result. Clients without elicitation support get a tool error instead, so
+the model falls back to asking in the conversation.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Awaitable, Callable
+
+from kolega_code.agent import ToolExtension
+from kolega_code.agent.tool_definitions import tool_description_asset
+from kolega_code.tools import ASK_USER_CHOICE_INPUT_SCHEMA, ToolError
+from kolega_code.tools.ask_user import normalize_choice_questions
+
+QUESTION_TOOL_NAME = "ask_user_choice"
+
+#: Callable the server binds at session build: (question, labels, descriptions) -> chosen label.
+ElicitAnswer = Callable[[str, list[str], list[str]], Awaitable[str]]
+
+
+def build_question_extension(question_state: dict[str, Any]) -> ToolExtension:
+    """The ACP ``ask_user_choice`` tool, backed by a per-session state dict.
+
+    ``question_state`` carries the server-bound ``elicit`` callable (set when
+    the session registers with the transport) and the single-question-in-flight
+    guard, mirroring the TUI's one pending question at a time.
+    """
+
+    async def ask_user_choice(questions: list[dict]) -> str:
+        normalized = normalize_choice_questions(questions)
+        if question_state.get("pending"):
+            raise ToolError("A question is already waiting for an answer.")
+        elicit = question_state.get("elicit")
+        if elicit is None:
+            raise ToolError(
+                "This editor client does not support interactive questions; ask the user directly in chat instead."
+            )
+        question_state["pending"] = True
+        try:
+            answers: dict[str, str] = {}
+            for clean_question, header, labels, descriptions in normalized:
+                answer = await elicit(clean_question, labels, descriptions)
+                answers[header or clean_question] = answer
+            return json.dumps(answers)
+        finally:
+            question_state["pending"] = False
+
+    return ToolExtension(
+        name="acp-user-questions",
+        tools={QUESTION_TOOL_NAME: ask_user_choice},
+        tool_descriptions={QUESTION_TOOL_NAME: tool_description_asset(QUESTION_TOOL_NAME)},
+        tool_schemas={QUESTION_TOOL_NAME: ASK_USER_CHOICE_INPUT_SCHEMA},
+        # Both top-level agents expose it: PlanningAgent allows planning_tools,
+        # CoderAgent allows coder_agent_tools. Sub-agents get neither group
+        # from a non-propagating extension, so only the agent talking to the
+        # user asks.
+        tool_groups={
+            "planning_tools": [QUESTION_TOOL_NAME],
+            "coder_agent_tools": [QUESTION_TOOL_NAME],
+        },
+        propagate_to_sub_agents=False,
+    )

--- a/kolega_code/acp/server.py
+++ b/kolega_code/acp/server.py
@@ -62,6 +62,7 @@ from kolega_code.acp.usage import build_usage_update
 from kolega_code.agent.prompts import build_implement_plan_prompt
 from kolega_code.cli.config import CliConfigError
 from kolega_code.cli.session_store import SessionStoreError
+from kolega_code.llm.models import MessageHistory
 from kolega_code.permissions import PermissionDecision, PermissionMode, PermissionRequest
 from kolega_code.session.control import DEFAULT_REQUEST_TIMEOUT_SECONDS
 
@@ -386,6 +387,9 @@ class AcpAgent(Agent):
         )
         options = [
             PermissionOption(option_id="implement_plan", name="Implement plan", kind="allow_once"),
+            PermissionOption(
+                option_id="implement_plan_clear", name="Clear context and implement plan", kind="allow_once"
+            ),
             PermissionOption(option_id="discuss_plan", name="Discuss further", kind="reject_once"),
         ]
         try:
@@ -403,9 +407,11 @@ class AcpAgent(Agent):
         else:
             selected = getattr(outcome, "outcome", None) == "selected"
             option_id = str(getattr(outcome, "option_id", "") or "")
-        if selected and option_id == "implement_plan":
+        if selected and option_id in ("implement_plan", "implement_plan_clear"):
             session.record.plan_pending = False
             session.record.plan_reofferable = False
+            if option_id == "implement_plan_clear":
+                self._clear_agent_context(session)
             await self._factory.set_interaction_mode(session, MODE_BUILD)
             await self._emit_current_mode(session)
             await self._run_turn(session, build_implement_plan_prompt(plan))
@@ -418,6 +424,16 @@ class AcpAgent(Agent):
             return
         # Unanswered, cancelled, or unknown: keep the plan pending.
         logger.info("acp plan approval pending (session=%s)", session.session_id)
+
+    def _clear_agent_context(self, session: AcpSession) -> None:
+        recorder = getattr(session.agent, "session_recorder", None)
+        if recorder is not None and hasattr(recorder, "start_epoch"):
+            recorder.start_epoch("acp_implement_plan_clear")
+        session.agent.history = MessageHistory()
+        session.agent.last_compression_index = None
+        session.agent.reset_volatile_context()
+        session.record.history = []
+        session.record.compaction = {}
 
     async def _drive_turn(self, session: AcpSession, bridge: AcpBridge, text: str) -> str:
         try:

--- a/kolega_code/acp/server.py
+++ b/kolega_code/acp/server.py
@@ -20,7 +20,7 @@ from uuid import uuid4
 
 from acp import Agent, InitializeResponse, NewSessionResponse, PromptResponse
 from acp.exceptions import RequestError
-from acp.helpers import update_current_mode, update_plan
+from acp.helpers import text_block, tool_content, update_current_mode, update_plan, update_tool_call
 from acp.interfaces import Client
 from acp.schema import (
     AgentCapabilities,
@@ -33,6 +33,7 @@ from acp.schema import (
     ListSessionsResponse,
     LoadSessionResponse,
     McpServerStdio,
+    PermissionOption,
     ResourceContentBlock,
     SessionCapabilities,
     SessionCloseCapabilities,
@@ -50,6 +51,7 @@ from kolega_code.acp.agent_factory import (
     CONFIG_PERMISSION_AUTO,
     INTERACTION_MODES,
     MODE_BUILD,
+    MODE_PLAN,
     AgentFactory,
 )
 from kolega_code.acp.bridge import AcpBridge
@@ -57,9 +59,12 @@ from kolega_code.acp.diffs import AcpDiffProvider
 from kolega_code.acp.permissions import AcpPermissionBroker
 from kolega_code.acp.session import AcpSession
 from kolega_code.acp.usage import build_usage_update
+from kolega_code.agent.prompts import build_implement_plan_prompt
 from kolega_code.cli.config import CliConfigError
 from kolega_code.cli.session_store import SessionStoreError
+from kolega_code.llm.models import MessageHistory
 from kolega_code.permissions import PermissionDecision, PermissionMode, PermissionRequest
+from kolega_code.session.control import DEFAULT_REQUEST_TIMEOUT_SECONDS
 
 logger = logging.getLogger(__name__)
 
@@ -345,7 +350,91 @@ class AcpAgent(Agent):
             await self._drain_residual(session, bridge)
             session.turn_task = None
             await bridge.emit_usage(session.session_id)
-            await bridge.emit_plan(session.session_id, session.record.interaction_mode or MODE_BUILD)
+            plan = self._consume_plan(session, bridge)
+            if plan:
+                session.record.latest_plan_markdown = plan
+                session.record.plan_pending = True
+                await bridge.emit_plan(session.session_id, plan)
+                await self._request_plan_approval(session, plan)
+
+    def _consume_plan(self, session: AcpSession, bridge: AcpBridge) -> str | None:
+        """The plan from write_plan, else the planning turn's response text."""
+        consume = getattr(session.agent, "consume_completed_plan", None)
+        if callable(consume):
+            plan = consume()
+            if plan:
+                return str(plan)
+        if (session.record.interaction_mode or MODE_BUILD) == MODE_PLAN:
+            text = bridge.response_text().strip()
+            if text:
+                return text
+        return None
+
+    async def _request_plan_approval(self, session: AcpSession, plan: str) -> None:
+        """Plan approval mirroring the TUI's plan_actions: implement, implement
+        with cleared context, or discuss. Approving switches the session to
+        build mode and auto-starts the implementation turn."""
+        conn = getattr(self, "_conn", None)
+        if conn is None:
+            return
+        preview = plan[:400] + ("…" if len(plan) > 400 else "")
+        tool_call = update_tool_call(
+            f"plan-approval-{session.session_id[:8]}",
+            title="Approve implementation plan?",
+            kind="other",
+            status="pending",
+            content=[tool_content(text_block(preview))],
+        )
+        options = [
+            PermissionOption(option_id="implement_plan", name="Implement plan", kind="allow_once"),
+            PermissionOption(
+                option_id="implement_plan_clear", name="Implement with cleared context", kind="allow_once"
+            ),
+            PermissionOption(option_id="discuss_plan", name="Discuss", kind="reject_once"),
+        ]
+        try:
+            response = await asyncio.wait_for(
+                conn.request_permission(session.session_id, tool_call, options),
+                timeout=DEFAULT_REQUEST_TIMEOUT_SECONDS,
+            )
+        except Exception:  # noqa: BLE001 — approval prompts are best-effort
+            logger.exception("acp plan approval prompt failed (session=%s)", session.session_id)
+            return
+        outcome = getattr(response, "outcome", None)
+        if isinstance(outcome, dict):
+            selected = outcome.get("outcome") == "selected"
+            option_id = str(outcome.get("optionId") or "")
+        else:
+            selected = getattr(outcome, "outcome", None) == "selected"
+            option_id = str(getattr(outcome, "option_id", "") or "")
+        if selected and option_id in ("implement_plan", "implement_plan_clear"):
+            session.record.plan_pending = False
+            session.record.plan_reofferable = False
+            if option_id == "implement_plan_clear":
+                self._clear_agent_context(session)
+            await self._factory.set_interaction_mode(session, MODE_BUILD)
+            await self._emit_current_mode(session)
+            await self._run_turn(session, build_implement_plan_prompt(plan))
+            logger.info("acp plan approved and implementation started (session=%s)", session.session_id)
+            return
+        if selected and option_id == "discuss_plan":
+            session.record.plan_pending = False
+            session.record.plan_reofferable = True
+            logger.info("acp plan deferred for discussion (session=%s)", session.session_id)
+            return
+        # Unanswered, cancelled, or unknown: keep the plan pending.
+        logger.info("acp plan approval pending (session=%s)", session.session_id)
+
+    def _clear_agent_context(self, session: AcpSession) -> None:
+        """Wipe LLM context for a fresh implementation, mirroring the TUI."""
+        recorder = getattr(session.agent, "session_recorder", None)
+        if recorder is not None and hasattr(recorder, "start_epoch"):
+            recorder.start_epoch("acp_implement_plan_clear")
+        session.agent.history = MessageHistory()
+        session.agent.last_compression_index = None
+        session.agent.reset_volatile_context()
+        session.record.history = []
+        session.record.compaction = {}
 
     async def _drive_turn(self, session: AcpSession, bridge: AcpBridge, text: str) -> str:
         try:

--- a/kolega_code/acp/server.py
+++ b/kolega_code/acp/server.py
@@ -43,6 +43,7 @@ from acp.schema import (
 
 from kolega_code.acp.agent_factory import AgentFactory
 from kolega_code.acp.bridge import AcpBridge
+from kolega_code.acp.diffs import AcpDiffProvider
 from kolega_code.acp.permissions import AcpPermissionBroker
 from kolega_code.acp.session import AcpSession
 from kolega_code.cli.config import CliConfigError
@@ -253,7 +254,7 @@ class AcpAgent(Agent):
         results still render.
         """
         session.drain_events()
-        bridge = AcpBridge(self._conn)
+        bridge = AcpBridge(self._conn, diff_provider=AcpDiffProvider.for_session(session))
         session.turn_task = asyncio.create_task(self._drive_turn(session, bridge, text))
         pump = asyncio.create_task(self._pump_events(session, bridge))
         try:

--- a/kolega_code/acp/server.py
+++ b/kolega_code/acp/server.py
@@ -20,7 +20,7 @@ from uuid import uuid4
 
 from acp import Agent, InitializeResponse, NewSessionResponse, PromptResponse
 from acp.exceptions import RequestError
-from acp.helpers import text_block, tool_content, update_current_mode, update_plan, update_tool_call
+from acp.helpers import text_block, tool_content, update_current_mode, update_tool_call
 from acp.interfaces import Client
 from acp.schema import (
     AgentCapabilities,
@@ -237,8 +237,6 @@ class AcpAgent(Agent):
         await self._factory.set_interaction_mode(session, mode_id)
         logger.info("acp session mode -> %s (session=%s)", mode_id, session_id)
         await self._emit_current_mode(session)
-        if mode_id == MODE_BUILD:
-            await self._send_session_update(session, update_plan([]))
         return SetSessionModeResponse()
 
     async def set_config_option(
@@ -268,8 +266,6 @@ class AcpAgent(Agent):
             await self._factory.set_interaction_mode(session, str(value))
             logger.info("acp session config: mode -> %s (session=%s)", value, session_id)
             await self._emit_current_mode(session)
-            if value == MODE_BUILD:
-                await self._send_session_update(session, update_plan([]))
         else:
             raise RequestError.invalid_params({"message": f"unknown config option {config_id!r}"})
         # The spec requires the full option set with current values so the
@@ -354,7 +350,6 @@ class AcpAgent(Agent):
             if plan:
                 session.record.latest_plan_markdown = plan
                 session.record.plan_pending = True
-                await bridge.emit_plan(session.session_id, plan)
                 await self._request_plan_approval(session, plan)
 
     def _consume_plan(self, session: AcpSession, bridge: AcpBridge) -> str | None:

--- a/kolega_code/acp/server.py
+++ b/kolega_code/acp/server.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+from uuid import uuid4
 
 from acp import Agent, InitializeResponse, NewSessionResponse, PromptResponse
 from acp.exceptions import RequestError
@@ -37,9 +39,11 @@ from acp.schema import (
 
 from kolega_code.acp.agent_factory import AgentFactory
 from kolega_code.acp.bridge import AcpBridge
+from kolega_code.acp.permissions import AcpPermissionBroker
 from kolega_code.acp.session import AcpSession
 from kolega_code.cli.config import CliConfigError
 from kolega_code.cli.session_store import SessionStoreError
+from kolega_code.permissions import PermissionDecision, PermissionRequest
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +54,8 @@ _PromptBlock = (
 _McpServer = list[HttpMcpServer | SseMcpServer | McpServerStdio] | None
 
 _HANDLED_CONFIG_ERRORS = (CliConfigError, SessionStoreError)
+
+PermissionCallback = Callable[[PermissionRequest], Awaitable[PermissionDecision]]
 
 
 class AcpAgent(Agent):
@@ -63,6 +69,7 @@ class AcpAgent(Agent):
     def __init__(self, factory: AgentFactory | None = None) -> None:
         self._factory = factory or AgentFactory()
         self._sessions: dict[str, AcpSession] = {}
+        self._brokers: dict[str, AcpPermissionBroker] = {}
         self._conn: Client
 
     def on_connect(self, conn: Client) -> None:
@@ -88,8 +95,13 @@ class AcpAgent(Agent):
         **kwargs: Any,
     ) -> NewSessionResponse:
         logger.info("acp new session (cwd=%s)", cwd)
+        session_id = uuid4().hex
         try:
-            session = await self._factory.open_session(cwd)
+            session = await self._factory.open_session(
+                cwd,
+                session_id=session_id,
+                permission_callback=self._permission_callback_for(session_id),
+            )
         except _HANDLED_CONFIG_ERRORS as exc:
             raise AgentFactory.protocol_error(exc) from exc
         self._sessions[session.session_id] = session
@@ -106,7 +118,11 @@ class AcpAgent(Agent):
         if session_id in self._sessions:
             return LoadSessionResponse()
         try:
-            session = await self._factory.load_session(cwd, session_id)
+            session = await self._factory.load_session(
+                cwd,
+                session_id,
+                permission_callback=self._permission_callback_for(session_id),
+            )
         except _HANDLED_CONFIG_ERRORS as exc:
             raise AgentFactory.protocol_error(exc) from exc
         if session is None:
@@ -123,6 +139,7 @@ class AcpAgent(Agent):
     async def close_session(self, session_id: str, **kwargs: Any) -> None:
         logger.info("acp session/close (session=%s)", session_id)
         self._sessions.pop(session_id, None)
+        self._brokers.pop(session_id, None)
         await self._factory.close_session(session_id)
         return None
 
@@ -190,6 +207,28 @@ class AcpAgent(Agent):
 
     async def ext_notification(self, method: str, params: dict[str, Any]) -> None:
         logger.debug("acp ignoring extension notification %s", method)
+
+    # -- permissions --------------------------------------------------------
+
+    def _permission_callback_for(self, session_id: str) -> PermissionCallback:
+        """One per-session agent callback that answers through the ACP client."""
+
+        async def callback(request: PermissionRequest) -> PermissionDecision:
+            session = self._sessions.get(session_id)
+            if session is None:
+                return PermissionDecision(allowed=False, reason="Session is no longer active.")
+            broker = self._brokers.get(session_id)
+            if broker is None:
+                broker = AcpPermissionBroker(
+                    self._conn,
+                    session_id,
+                    Path(session.record.project_path),
+                    lambda: session.agent,
+                )
+                self._brokers[session_id] = broker
+            return await broker(request)
+
+        return callback
 
     # -- turn machinery ----------------------------------------------------
 

--- a/kolega_code/acp/server.py
+++ b/kolega_code/acp/server.py
@@ -41,14 +41,14 @@ from acp.schema import (
     TextContentBlock,
 )
 
-from kolega_code.acp.agent_factory import AgentFactory
+from kolega_code.acp.agent_factory import CONFIG_MODEL, CONFIG_PERMISSION_AUTO, AgentFactory
 from kolega_code.acp.bridge import AcpBridge
 from kolega_code.acp.diffs import AcpDiffProvider
 from kolega_code.acp.permissions import AcpPermissionBroker
 from kolega_code.acp.session import AcpSession
 from kolega_code.cli.config import CliConfigError
 from kolega_code.cli.session_store import SessionStoreError
-from kolega_code.permissions import PermissionDecision, PermissionRequest
+from kolega_code.permissions import PermissionDecision, PermissionMode, PermissionRequest
 
 logger = logging.getLogger(__name__)
 
@@ -119,7 +119,10 @@ class AcpAgent(Agent):
         except _HANDLED_CONFIG_ERRORS as exc:
             raise AgentFactory.protocol_error(exc) from exc
         self._sessions[session.session_id] = session
-        return NewSessionResponse(session_id=session.session_id)
+        return NewSessionResponse(
+            session_id=session.session_id,
+            config_options=self._factory.config_options_for(session),
+        )
 
     async def load_session(
         self,
@@ -130,7 +133,7 @@ class AcpAgent(Agent):
         **kwargs: Any,
     ) -> LoadSessionResponse | None:
         if session_id in self._sessions:
-            return LoadSessionResponse()
+            return LoadSessionResponse(config_options=self._factory.config_options_for(self._sessions[session_id]))
         try:
             session = await self._factory.load_session(
                 cwd,
@@ -142,7 +145,7 @@ class AcpAgent(Agent):
         if session is None:
             return None
         self._sessions[session.session_id] = session
-        return LoadSessionResponse()
+        return LoadSessionResponse(config_options=self._factory.config_options_for(session))
 
     async def list_sessions(
         self, cwd: str | None = None, cursor: str | None = None, **kwargs: Any
@@ -209,8 +212,27 @@ class AcpAgent(Agent):
         return None
 
     async def set_config_option(self, config_id: str, session_id: str, value: str | bool, **kwargs: Any) -> None:
-        logger.info("acp session/set_config_option not supported yet (config=%s)", config_id)
-        return None
+        session = self._sessions.get(session_id)
+        if session is None:
+            raise RequestError.resource_not_found(session_id)
+        if not session.idle():
+            raise RequestError.invalid_request({"message": "config options apply between turns only"})
+        if config_id == CONFIG_MODEL:
+            if not isinstance(value, str) or "/" not in value:
+                raise RequestError.invalid_params({"message": "model option expects 'provider/model'"})
+            provider, model = value.split("/", 1)
+            try:
+                await self._factory.apply_model(session, provider, model)
+            except _HANDLED_CONFIG_ERRORS as exc:
+                raise AgentFactory.protocol_error(exc) from exc
+            logger.info("acp session config: model -> %s/%s (session=%s)", provider, model, session_id)
+            return None
+        if config_id == CONFIG_PERMISSION_AUTO:
+            mode = PermissionMode.AUTO if bool(value) else PermissionMode.ASK
+            await self._factory.set_permission_mode(session, mode)
+            logger.info("acp session config: permission mode -> %s (session=%s)", mode.value, session_id)
+            return None
+        raise RequestError.invalid_params({"message": f"unknown config option {config_id!r}"})
 
     async def authenticate(self, method_id: str, **kwargs: Any) -> None:
         logger.info("acp authenticate not supported yet (method=%s)", method_id)

--- a/kolega_code/acp/server.py
+++ b/kolega_code/acp/server.py
@@ -62,7 +62,6 @@ from kolega_code.acp.usage import build_usage_update
 from kolega_code.agent.prompts import build_implement_plan_prompt
 from kolega_code.cli.config import CliConfigError
 from kolega_code.cli.session_store import SessionStoreError
-from kolega_code.llm.models import MessageHistory
 from kolega_code.permissions import PermissionDecision, PermissionMode, PermissionRequest
 from kolega_code.session.control import DEFAULT_REQUEST_TIMEOUT_SECONDS
 
@@ -387,9 +386,6 @@ class AcpAgent(Agent):
         )
         options = [
             PermissionOption(option_id="implement_plan", name="Implement plan", kind="allow_once"),
-            PermissionOption(
-                option_id="implement_plan_clear", name="Clear context and implement plan", kind="allow_once"
-            ),
             PermissionOption(option_id="discuss_plan", name="Discuss further", kind="reject_once"),
         ]
         try:
@@ -407,11 +403,9 @@ class AcpAgent(Agent):
         else:
             selected = getattr(outcome, "outcome", None) == "selected"
             option_id = str(getattr(outcome, "option_id", "") or "")
-        if selected and option_id in ("implement_plan", "implement_plan_clear"):
+        if selected and option_id == "implement_plan":
             session.record.plan_pending = False
             session.record.plan_reofferable = False
-            if option_id == "implement_plan_clear":
-                self._clear_agent_context(session)
             await self._factory.set_interaction_mode(session, MODE_BUILD)
             await self._emit_current_mode(session)
             await self._run_turn(session, build_implement_plan_prompt(plan))
@@ -424,17 +418,6 @@ class AcpAgent(Agent):
             return
         # Unanswered, cancelled, or unknown: keep the plan pending.
         logger.info("acp plan approval pending (session=%s)", session.session_id)
-
-    def _clear_agent_context(self, session: AcpSession) -> None:
-        """Wipe LLM context for a fresh implementation, mirroring the TUI."""
-        recorder = getattr(session.agent, "session_recorder", None)
-        if recorder is not None and hasattr(recorder, "start_epoch"):
-            recorder.start_epoch("acp_implement_plan_clear")
-        session.agent.history = MessageHistory()
-        session.agent.last_compression_index = None
-        session.agent.reset_volatile_context()
-        session.record.history = []
-        session.record.compaction = {}
 
     async def _drive_turn(self, session: AcpSession, bridge: AcpBridge, text: str) -> str:
         try:

--- a/kolega_code/acp/server.py
+++ b/kolega_code/acp/server.py
@@ -24,6 +24,7 @@ from acp.exceptions import RequestError
 from acp.helpers import (
     text_block,
     tool_content,
+    update_agent_thought_text,
     update_available_commands,
     update_current_mode,
     update_plan,
@@ -432,8 +433,18 @@ class AcpAgent(Agent):
         except Exception:  # noqa: BLE001 — a missing or unreadable journal must not block the load
             logger.exception("acp session/load: transcript replay failed (session=%s)", session.session_id)
             return
+        state = replay(events)
         bridge = AcpBridge(self._conn)
-        await bridge.replay_conversation(session.session_id, replay(events).conversation)
+        await bridge.replay_conversation(session.session_id, state.conversation)
+        # Restore the compaction marker: the last finished summary renders as a
+        # collapsible thought block, like the live event does.
+        compaction = state.compaction or {}
+        if str(compaction.get("phase") or "") == "finished":
+            summary = str(compaction.get("summary") or "").strip()
+            if summary:
+                await self._send_session_update(
+                    session, update_agent_thought_text(f"Conversation compacted:\n{summary}")
+                )
         task_list = (session.record.task_list_markdown or "").strip()
         if task_list:
             entries = task_entries_from_markdown(task_list)

--- a/kolega_code/acp/server.py
+++ b/kolega_code/acp/server.py
@@ -36,6 +36,7 @@ from acp.schema import (
     SessionCapabilities,
     SessionCloseCapabilities,
     SessionListCapabilities,
+    SetSessionConfigOptionResponse,
     SseMcpServer,
     StopReason,
     TextContentBlock,
@@ -214,7 +215,9 @@ class AcpAgent(Agent):
         logger.info("acp session/set_mode not supported yet (mode=%s)", mode_id)
         return None
 
-    async def set_config_option(self, config_id: str, session_id: str, value: str | bool, **kwargs: Any) -> None:
+    async def set_config_option(
+        self, config_id: str, session_id: str, value: str | bool, **kwargs: Any
+    ) -> SetSessionConfigOptionResponse:
         session = self._sessions.get(session_id)
         if session is None:
             raise RequestError.resource_not_found(session_id)
@@ -229,13 +232,15 @@ class AcpAgent(Agent):
             except _HANDLED_CONFIG_ERRORS as exc:
                 raise AgentFactory.protocol_error(exc) from exc
             logger.info("acp session config: model -> %s/%s (session=%s)", provider, model, session_id)
-            return None
-        if config_id == CONFIG_PERMISSION_AUTO:
+        elif config_id == CONFIG_PERMISSION_AUTO:
             mode = PermissionMode.AUTO if bool(value) else PermissionMode.ASK
             await self._factory.set_permission_mode(session, mode)
             logger.info("acp session config: permission mode -> %s (session=%s)", mode.value, session_id)
-            return None
-        raise RequestError.invalid_params({"message": f"unknown config option {config_id!r}"})
+        else:
+            raise RequestError.invalid_params({"message": f"unknown config option {config_id!r}"})
+        # The spec requires the full option set with current values so the
+        # client can refresh its UI state.
+        return SetSessionConfigOptionResponse(config_options=self._factory.config_options_for(session))
 
     async def authenticate(self, method_id: str, **kwargs: Any) -> None:
         logger.info("acp authenticate not supported yet (method=%s)", method_id)

--- a/kolega_code/acp/server.py
+++ b/kolega_code/acp/server.py
@@ -26,6 +26,7 @@ from acp.schema import (
     AgentCapabilities,
     AudioContentBlock,
     ClientCapabilities,
+    ConfigOptionUpdate,
     EmbeddedResourceContentBlock,
     HttpMcpServer,
     ImageContentBlock,
@@ -315,6 +316,16 @@ class AcpAgent(Agent):
     async def _emit_current_mode(self, session: AcpSession) -> None:
         mode = session.record.interaction_mode or MODE_BUILD
         await self._send_session_update(session, update_current_mode(mode))
+        # Mode is exposed as a config option (Zed 1.16 renders either the
+        # config-option or session-mode surface, never both), so a server-side
+        # switch — plan approval — must push refreshed options or the client's
+        # mode select keeps showing the stale value.
+        await self._send_session_update(
+            session,
+            ConfigOptionUpdate(
+                session_update="config_option_update", config_options=list(self._factory.config_options_for(session))
+            ),
+        )
 
     async def _send_session_update(self, session: AcpSession, update: Any) -> None:
         conn = getattr(self, "_conn", None)

--- a/kolega_code/acp/server.py
+++ b/kolega_code/acp/server.py
@@ -29,6 +29,7 @@ from acp.helpers import (
     update_current_mode,
     update_plan,
     update_tool_call,
+    update_user_message,
 )
 from acp.interfaces import Client
 from acp.schema import (
@@ -70,7 +71,7 @@ from kolega_code.acp.agent_factory import (
     MODE_PLAN,
     AgentFactory,
 )
-from kolega_code.acp.bridge import AcpBridge
+from kolega_code.acp.bridge import AcpBridge, SUB_SESSION_PREFIX
 from kolega_code.acp.diffs import AcpDiffProvider
 from kolega_code.acp.permissions import AcpPermissionBroker
 from kolega_code.acp.plans import task_entries_from_markdown
@@ -83,7 +84,7 @@ from kolega_code.cli.slash_commands import agent_command_entries
 from kolega_code.llm.models import MessageHistory
 from kolega_code.permissions import PermissionDecision, PermissionMode, PermissionRequest
 from kolega_code.session.control import DEFAULT_REQUEST_TIMEOUT_SECONDS
-from kolega_code.session.projection import replay
+from kolega_code.session.projection import replay, sub_agent_key
 from kolega_code.tools.core import ToolError
 
 logger = logging.getLogger(__name__)
@@ -173,6 +174,10 @@ class AcpAgent(Agent):
         additional_directories: list[str] | None = None,
         **kwargs: Any,
     ) -> LoadSessionResponse | None:
+        if session_id.startswith(SUB_SESSION_PREFIX):
+            # A synthetic sub-agent session Zed loads to render a delegated
+            # turn as a nested transcript card under the dispatch tool call.
+            return await self._load_sub_session(session_id)
         if session_id in self._sessions:
             existing = self._sessions[session_id]
             return LoadSessionResponse(config_options=self._factory.config_options_for(existing))
@@ -192,6 +197,46 @@ class AcpAgent(Agent):
         await self._send_available_commands(session)
         await self._replay_transcript(session)
         return LoadSessionResponse(config_options=self._factory.config_options_for(session))
+
+    async def _load_sub_session(self, session_id: str) -> LoadSessionResponse:
+        """Replay one delegated turn as its synthetic sub-session.
+
+        Zed renders ``_meta.subagent_session_info`` dispatch cards by loading
+        the referenced child session id through ``session/load`` and nesting
+        the replayed transcript under the dispatch. The child id encodes the
+        parent session and the dispatching tool call
+        (``sub-<parent>-<tool_call_id>``), which locates the delegate's events
+        in the parent's journal.
+        """
+        rest = session_id[len(SUB_SESSION_PREFIX) :]
+        parent_id, _, tool_call_id = rest.partition("-")
+        if not parent_id or not tool_call_id:
+            logger.info("acp sub-session load: malformed id %s", session_id)
+            return LoadSessionResponse()
+        try:
+            events = await self._factory.event_store(parent_id).read(parent_id)
+        except Exception:  # noqa: BLE001 — an unreadable journal yields an empty card
+            logger.exception("acp sub-session load: journal read failed (parent=%s)", parent_id)
+            return LoadSessionResponse()
+        key: str | None = None
+        for event in events:
+            info = event.sub_agent_info or {}
+            if str(info.get("parent_tool_call_id") or "") == tool_call_id:
+                key = sub_agent_key(info)
+                if key:
+                    break
+        if key is None:
+            logger.info("acp sub-session load: no delegate for %s", session_id)
+            return LoadSessionResponse()
+        activity = replay(events).sub_agents.get(key)
+        bridge = AcpBridge(self._conn)
+        task = activity.task if activity is not None else ""
+        if task:
+            update = update_user_message(text_block(task))
+            update.message_id = f"replay-sub-task-{tool_call_id}"
+            await bridge.send(session_id, update)
+        await bridge.replay_conversation(session_id, activity.steps if activity is not None else [])
+        return LoadSessionResponse()
 
     async def list_sessions(
         self, cwd: str | None = None, cursor: str | None = None, **kwargs: Any

--- a/kolega_code/acp/server.py
+++ b/kolega_code/acp/server.py
@@ -99,6 +99,11 @@ _HANDLED_CONFIG_ERRORS = (CliConfigError, SessionStoreError)
 
 PermissionCallback = Callable[[PermissionRequest], Awaitable[PermissionDecision]]
 
+#: Delay before post-response open updates so clients that only register the
+#: session once the NewSessionResponse is processed (Zed drops every
+#: pre-response notification for session/new) receive them after registration.
+OPEN_UPDATES_DELAY_SECONDS = 0.25
+
 
 class AcpAgent(Agent):
     """kolega-code as an ACP v1 agent, one client connection per process.
@@ -159,12 +164,15 @@ class AcpAgent(Agent):
             raise AgentFactory.protocol_error(exc) from exc
         self._sessions[session.session_id] = session
         self._attach_question_elicit(session)
-        await self._emit_initial_usage(session)
-        await self._send_available_commands(session)
-        return NewSessionResponse(
+        response = NewSessionResponse(
             session_id=session.session_id,
             config_options=self._factory.config_options_for(session),
         )
+        # Zed registers the session only once the NewSessionResponse is
+        # processed and drops any pre-response notification, so the open-time
+        # usage meter and command list go out just after the response instead.
+        self._schedule_open_updates(session.session_id)
+        return response
 
     async def load_session(
         self,
@@ -411,6 +419,19 @@ class AcpAgent(Agent):
         extension holds by reference, so it survives agent rebuilds.
         """
         session.question_state["elicit"] = functools.partial(self._elicit_answer, session.session_id)
+
+    def _schedule_open_updates(self, session_id: str) -> None:
+        """Send the open-time updates after the client has processed the
+        ``session/new`` response (Zed drops pre-response notifications)."""
+        asyncio.create_task(self._send_open_updates(session_id))
+
+    async def _send_open_updates(self, session_id: str) -> None:
+        await asyncio.sleep(OPEN_UPDATES_DELAY_SECONDS)
+        session = self._sessions.get(session_id)
+        if session is None:
+            return
+        await self._emit_initial_usage(session)
+        await self._send_available_commands(session)
 
     async def _send_available_commands(self, session: AcpSession) -> None:
         """Advertise the agent's slash commands for the client's command UI.

--- a/kolega_code/acp/server.py
+++ b/kolega_code/acp/server.py
@@ -20,6 +20,7 @@ from uuid import uuid4
 
 from acp import Agent, InitializeResponse, NewSessionResponse, PromptResponse
 from acp.exceptions import RequestError
+from acp.helpers import update_current_mode, update_plan
 from acp.interfaces import Client
 from acp.schema import (
     AgentCapabilities,
@@ -36,13 +37,23 @@ from acp.schema import (
     SessionCapabilities,
     SessionCloseCapabilities,
     SessionListCapabilities,
+    SessionMode,
+    SessionModeState,
     SetSessionConfigOptionResponse,
+    SetSessionModeResponse,
     SseMcpServer,
     StopReason,
     TextContentBlock,
 )
 
-from kolega_code.acp.agent_factory import CONFIG_MODEL, CONFIG_PERMISSION_AUTO, AgentFactory
+from kolega_code.acp.agent_factory import (
+    CONFIG_MODEL,
+    CONFIG_PERMISSION_AUTO,
+    INTERACTION_MODES,
+    MODE_BUILD,
+    MODE_PLAN,
+    AgentFactory,
+)
 from kolega_code.acp.bridge import AcpBridge
 from kolega_code.acp.diffs import AcpDiffProvider
 from kolega_code.acp.permissions import AcpPermissionBroker
@@ -125,6 +136,7 @@ class AcpAgent(Agent):
         return NewSessionResponse(
             session_id=session.session_id,
             config_options=self._factory.config_options_for(session),
+            modes=self._mode_state(session),
         )
 
     async def load_session(
@@ -136,7 +148,11 @@ class AcpAgent(Agent):
         **kwargs: Any,
     ) -> LoadSessionResponse | None:
         if session_id in self._sessions:
-            return LoadSessionResponse(config_options=self._factory.config_options_for(self._sessions[session_id]))
+            existing = self._sessions[session_id]
+            return LoadSessionResponse(
+                config_options=self._factory.config_options_for(existing),
+                modes=self._mode_state(existing),
+            )
         try:
             session = await self._factory.load_session(
                 cwd,
@@ -149,7 +165,10 @@ class AcpAgent(Agent):
             return None
         self._sessions[session.session_id] = session
         await self._emit_initial_usage(session)
-        return LoadSessionResponse(config_options=self._factory.config_options_for(session))
+        return LoadSessionResponse(
+            config_options=self._factory.config_options_for(session),
+            modes=self._mode_state(session),
+        )
 
     async def list_sessions(
         self, cwd: str | None = None, cursor: str | None = None, **kwargs: Any
@@ -211,9 +230,20 @@ class AcpAgent(Agent):
         logger.info("acp session/fork not supported yet (session=%s)", session_id)
         return None
 
-    async def set_session_mode(self, session_id: str, mode_id: str, **kwargs: Any) -> None:
-        logger.info("acp session/set_mode not supported yet (mode=%s)", mode_id)
-        return None
+    async def set_session_mode(self, session_id: str, mode_id: str, **kwargs: Any) -> SetSessionModeResponse | None:
+        session = self._sessions.get(session_id)
+        if session is None:
+            raise RequestError.resource_not_found(session_id)
+        if mode_id not in INTERACTION_MODES:
+            raise RequestError.invalid_params({"message": f"unknown mode {mode_id!r}; available: build, plan"})
+        if not session.idle():
+            raise RequestError.invalid_request({"message": "modes apply between turns only"})
+        await self._factory.set_interaction_mode(session, mode_id)
+        logger.info("acp session mode -> %s (session=%s)", mode_id, session_id)
+        await self._emit_current_mode(session)
+        if mode_id == MODE_BUILD:
+            await self._send_session_update(session, update_plan([]))
+        return SetSessionModeResponse()
 
     async def set_config_option(
         self, config_id: str, session_id: str, value: str | bool, **kwargs: Any
@@ -282,6 +312,28 @@ class AcpAgent(Agent):
         if update is not None:
             await conn.session_update(session_id=session.session_id, update=update, source="kolega_code")
 
+    def _mode_state(self, session: AcpSession) -> SessionModeState:
+        mode = session.record.interaction_mode or MODE_BUILD
+        if mode not in INTERACTION_MODES:
+            mode = MODE_BUILD
+        return SessionModeState(
+            current_mode_id=mode,
+            available_modes=[
+                SessionMode(id=MODE_BUILD, name="Build"),
+                SessionMode(id=MODE_PLAN, name="Plan"),
+            ],
+        )
+
+    async def _emit_current_mode(self, session: AcpSession) -> None:
+        mode = session.record.interaction_mode or MODE_BUILD
+        await self._send_session_update(session, update_current_mode(mode))
+
+    async def _send_session_update(self, session: AcpSession, update: Any) -> None:
+        conn = getattr(self, "_conn", None)
+        if conn is None:
+            return
+        await conn.session_update(session_id=session.session_id, update=update, source="kolega_code")
+
     # -- turn machinery ----------------------------------------------------
 
     async def _run_turn(self, session: AcpSession, text: str) -> StopReason:
@@ -306,6 +358,7 @@ class AcpAgent(Agent):
             await self._drain_residual(session, bridge)
             session.turn_task = None
             await bridge.emit_usage(session.session_id)
+            await bridge.emit_plan(session.session_id, session.record.interaction_mode or MODE_BUILD)
 
     async def _drive_turn(self, session: AcpSession, bridge: AcpBridge, text: str) -> str:
         try:

--- a/kolega_code/acp/server.py
+++ b/kolega_code/acp/server.py
@@ -37,8 +37,6 @@ from acp.schema import (
     SessionCapabilities,
     SessionCloseCapabilities,
     SessionListCapabilities,
-    SessionMode,
-    SessionModeState,
     SetSessionConfigOptionResponse,
     SetSessionModeResponse,
     SseMcpServer,
@@ -47,11 +45,11 @@ from acp.schema import (
 )
 
 from kolega_code.acp.agent_factory import (
+    CONFIG_MODE,
     CONFIG_MODEL,
     CONFIG_PERMISSION_AUTO,
     INTERACTION_MODES,
     MODE_BUILD,
-    MODE_PLAN,
     AgentFactory,
 )
 from kolega_code.acp.bridge import AcpBridge
@@ -136,7 +134,6 @@ class AcpAgent(Agent):
         return NewSessionResponse(
             session_id=session.session_id,
             config_options=self._factory.config_options_for(session),
-            modes=self._mode_state(session),
         )
 
     async def load_session(
@@ -149,10 +146,7 @@ class AcpAgent(Agent):
     ) -> LoadSessionResponse | None:
         if session_id in self._sessions:
             existing = self._sessions[session_id]
-            return LoadSessionResponse(
-                config_options=self._factory.config_options_for(existing),
-                modes=self._mode_state(existing),
-            )
+            return LoadSessionResponse(config_options=self._factory.config_options_for(existing))
         try:
             session = await self._factory.load_session(
                 cwd,
@@ -165,10 +159,7 @@ class AcpAgent(Agent):
             return None
         self._sessions[session.session_id] = session
         await self._emit_initial_usage(session)
-        return LoadSessionResponse(
-            config_options=self._factory.config_options_for(session),
-            modes=self._mode_state(session),
-        )
+        return LoadSessionResponse(config_options=self._factory.config_options_for(session))
 
     async def list_sessions(
         self, cwd: str | None = None, cursor: str | None = None, **kwargs: Any
@@ -266,6 +257,14 @@ class AcpAgent(Agent):
             mode = PermissionMode.AUTO if bool(value) else PermissionMode.ASK
             await self._factory.set_permission_mode(session, mode)
             logger.info("acp session config: permission mode -> %s (session=%s)", mode.value, session_id)
+        elif config_id == CONFIG_MODE:
+            if value not in INTERACTION_MODES:
+                raise RequestError.invalid_params({"message": f"unknown mode {value!r}; available: build, plan"})
+            await self._factory.set_interaction_mode(session, str(value))
+            logger.info("acp session config: mode -> %s (session=%s)", value, session_id)
+            await self._emit_current_mode(session)
+            if value == MODE_BUILD:
+                await self._send_session_update(session, update_plan([]))
         else:
             raise RequestError.invalid_params({"message": f"unknown config option {config_id!r}"})
         # The spec requires the full option set with current values so the
@@ -311,18 +310,6 @@ class AcpAgent(Agent):
         update = build_usage_update(session.agent)
         if update is not None:
             await conn.session_update(session_id=session.session_id, update=update, source="kolega_code")
-
-    def _mode_state(self, session: AcpSession) -> SessionModeState:
-        mode = session.record.interaction_mode or MODE_BUILD
-        if mode not in INTERACTION_MODES:
-            mode = MODE_BUILD
-        return SessionModeState(
-            current_mode_id=mode,
-            available_modes=[
-                SessionMode(id=MODE_BUILD, name="Build"),
-                SessionMode(id=MODE_PLAN, name="Plan"),
-            ],
-        )
 
     async def _emit_current_mode(self, session: AcpSession) -> None:
         mode = session.record.interaction_mode or MODE_BUILD

--- a/kolega_code/acp/server.py
+++ b/kolega_code/acp/server.py
@@ -13,6 +13,7 @@ Phase 0 (transport skeleton) is preserved in the module's git history; see
 from __future__ import annotations
 
 import asyncio
+import functools
 import logging
 from pathlib import Path
 from typing import Any, Awaitable, Callable
@@ -23,11 +24,16 @@ from acp.exceptions import RequestError
 from acp.helpers import text_block, tool_content, update_current_mode, update_plan, update_tool_call
 from acp.interfaces import Client
 from acp.schema import (
+    AcceptElicitationResponse,
     AgentCapabilities,
     AudioContentBlock,
     ClientCapabilities,
     ConfigOptionUpdate,
+    ElicitationFormSessionMode,
+    ElicitationSchema,
+    ElicitationStringPropertySchema,
     EmbeddedResourceContentBlock,
+    EnumOption,
     HttpMcpServer,
     ImageContentBlock,
     Implementation,
@@ -68,6 +74,7 @@ from kolega_code.llm.models import MessageHistory
 from kolega_code.permissions import PermissionDecision, PermissionMode, PermissionRequest
 from kolega_code.session.control import DEFAULT_REQUEST_TIMEOUT_SECONDS
 from kolega_code.session.projection import replay
+from kolega_code.tools.core import ToolError
 
 logger = logging.getLogger(__name__)
 
@@ -95,6 +102,7 @@ class AcpAgent(Agent):
         self._sessions: dict[str, AcpSession] = {}
         self._brokers: dict[str, AcpPermissionBroker] = {}
         self._conn: Client
+        self._client_capabilities: ClientCapabilities | None = None
 
     def on_connect(self, conn: Client) -> None:
         self._conn = conn
@@ -107,6 +115,7 @@ class AcpAgent(Agent):
         **kwargs: Any,
     ) -> InitializeResponse:
         logger.info("acp initialize (protocol %s, client=%s)", protocol_version, client_info)
+        self._client_capabilities = client_capabilities
         return InitializeResponse(
             protocol_version=protocol_version,
             agent_capabilities=AgentCapabilities(
@@ -138,6 +147,7 @@ class AcpAgent(Agent):
         except _HANDLED_CONFIG_ERRORS as exc:
             raise AgentFactory.protocol_error(exc) from exc
         self._sessions[session.session_id] = session
+        self._attach_question_elicit(session)
         await self._emit_initial_usage(session)
         return NewSessionResponse(
             session_id=session.session_id,
@@ -166,6 +176,7 @@ class AcpAgent(Agent):
         if session is None:
             return None
         self._sessions[session.session_id] = session
+        self._attach_question_elicit(session)
         await self._emit_initial_usage(session)
         await self._replay_transcript(session)
         return LoadSessionResponse(config_options=self._factory.config_options_for(session))
@@ -335,6 +346,52 @@ class AcpAgent(Agent):
         if conn is None:
             return
         await conn.session_update(session_id=session.session_id, update=update, source="kolega_code")
+
+    def _attach_question_elicit(self, session: AcpSession) -> None:
+        """Bind the elicitation bridge to the session's ask_user_choice tool.
+
+        The bound callable lives on ``session.question_state``, which the tool
+        extension holds by reference, so it survives agent rebuilds.
+        """
+        session.question_state["elicit"] = functools.partial(self._elicit_answer, session.session_id)
+
+    async def _elicit_answer(
+        self,
+        session_id: str,
+        question: str,
+        labels: list[str],
+        descriptions: list[str],
+    ) -> str:
+        """Ask one choice question through the client's elicitation surface."""
+        capabilities = self._client_capabilities
+        elicitation = getattr(capabilities, "elicitation", None) if capabilities is not None else None
+        if elicitation is None or not getattr(elicitation, "form", None):
+            raise ToolError(
+                "This editor client does not support interactive question forms; "
+                "ask the user directly in the conversation instead."
+            )
+        conn = getattr(self, "_conn", None)
+        if conn is None:
+            raise ToolError("No client connection is available for questions.")
+        options = [
+            EnumOption(const=label, title=label, description=description or None)
+            for label, description in zip(labels, descriptions)
+        ]
+        schema = ElicitationSchema(
+            properties={"answer": ElicitationStringPropertySchema(type="string", title=question, one_of=options)},
+            required=["answer"],
+        )
+        response = await conn.create_elicitation(
+            message=question,
+            mode=ElicitationFormSessionMode(session_id=session_id, requested_schema=schema),
+        )
+        if isinstance(response, AcceptElicitationResponse):
+            content = response.content or {}
+            answer = content.get("answer")
+            if answer:
+                return str(answer)
+            raise ToolError("The client accepted the question but returned no answer.")
+        raise ToolError("The user declined to answer the question.")
 
     async def _replay_transcript(self, session: AcpSession) -> None:
         """Replay the persisted transcript before responding to ``session/load``.

--- a/kolega_code/acp/server.py
+++ b/kolega_code/acp/server.py
@@ -388,9 +388,9 @@ class AcpAgent(Agent):
         options = [
             PermissionOption(option_id="implement_plan", name="Implement plan", kind="allow_once"),
             PermissionOption(
-                option_id="implement_plan_clear", name="Implement with cleared context", kind="allow_once"
+                option_id="implement_plan_clear", name="Clear context and implement plan", kind="allow_once"
             ),
-            PermissionOption(option_id="discuss_plan", name="Discuss", kind="reject_once"),
+            PermissionOption(option_id="discuss_plan", name="Discuss further", kind="reject_once"),
         ]
         try:
             response = await asyncio.wait_for(

--- a/kolega_code/acp/server.py
+++ b/kolega_code/acp/server.py
@@ -377,13 +377,12 @@ class AcpAgent(Agent):
         conn = getattr(self, "_conn", None)
         if conn is None:
             return
-        preview = plan[:400] + ("…" if len(plan) > 400 else "")
         tool_call = update_tool_call(
             f"plan-approval-{session.session_id[:8]}",
             title="Approve implementation plan?",
             kind="other",
             status="pending",
-            content=[tool_content(text_block(preview))],
+            content=[tool_content(text_block(plan))],
         )
         options = [
             PermissionOption(option_id="implement_plan", name="Implement plan", kind="allow_once"),

--- a/kolega_code/acp/server.py
+++ b/kolega_code/acp/server.py
@@ -21,12 +21,20 @@ from uuid import uuid4
 
 from acp import Agent, InitializeResponse, NewSessionResponse, PromptResponse
 from acp.exceptions import RequestError
-from acp.helpers import text_block, tool_content, update_current_mode, update_plan, update_tool_call
+from acp.helpers import (
+    text_block,
+    tool_content,
+    update_available_commands,
+    update_current_mode,
+    update_plan,
+    update_tool_call,
+)
 from acp.interfaces import Client
 from acp.schema import (
     AcceptElicitationResponse,
     AgentCapabilities,
     AudioContentBlock,
+    AvailableCommand,
     ClientCapabilities,
     ConfigOptionUpdate,
     ElicitationFormSessionMode,
@@ -70,6 +78,7 @@ from kolega_code.acp.usage import build_usage_update
 from kolega_code.agent.prompts import build_implement_plan_prompt
 from kolega_code.cli.config import CliConfigError
 from kolega_code.cli.session_store import SessionStoreError
+from kolega_code.cli.slash_commands import agent_command_entries
 from kolega_code.llm.models import MessageHistory
 from kolega_code.permissions import PermissionDecision, PermissionMode, PermissionRequest
 from kolega_code.session.control import DEFAULT_REQUEST_TIMEOUT_SECONDS
@@ -149,6 +158,7 @@ class AcpAgent(Agent):
         self._sessions[session.session_id] = session
         self._attach_question_elicit(session)
         await self._emit_initial_usage(session)
+        await self._send_available_commands(session)
         return NewSessionResponse(
             session_id=session.session_id,
             config_options=self._factory.config_options_for(session),
@@ -178,6 +188,7 @@ class AcpAgent(Agent):
         self._sessions[session.session_id] = session
         self._attach_question_elicit(session)
         await self._emit_initial_usage(session)
+        await self._send_available_commands(session)
         await self._replay_transcript(session)
         return LoadSessionResponse(config_options=self._factory.config_options_for(session))
 
@@ -354,6 +365,19 @@ class AcpAgent(Agent):
         extension holds by reference, so it survives agent rebuilds.
         """
         session.question_state["elicit"] = functools.partial(self._elicit_answer, session.session_id)
+
+    async def _send_available_commands(self, session: AcpSession) -> None:
+        """Advertise the agent's slash commands for the client's command UI.
+
+        The agent's process loop dispatches exact-match commands itself (the
+        same ``CommandProcessor`` decorator the CLI uses), so advertising is
+        all the ACP server needs; the client sends ``/name args`` as a normal
+        prompt and the agent turns it into the command result.
+        """
+        commands = [
+            AvailableCommand(name=entry.name, description=entry.description) for entry in agent_command_entries()
+        ]
+        await self._send_session_update(session, update_available_commands(commands))
 
     async def _elicit_answer(
         self,

--- a/kolega_code/acp/server.py
+++ b/kolega_code/acp/server.py
@@ -22,6 +22,7 @@ from acp import Agent, InitializeResponse, NewSessionResponse, PromptResponse
 from acp.exceptions import RequestError
 from acp.interfaces import Client
 from acp.schema import (
+    AgentCapabilities,
     AudioContentBlock,
     ClientCapabilities,
     EmbeddedResourceContentBlock,
@@ -32,6 +33,9 @@ from acp.schema import (
     LoadSessionResponse,
     McpServerStdio,
     ResourceContentBlock,
+    SessionCapabilities,
+    SessionCloseCapabilities,
+    SessionListCapabilities,
     SseMcpServer,
     StopReason,
     TextContentBlock,
@@ -83,7 +87,16 @@ class AcpAgent(Agent):
         **kwargs: Any,
     ) -> InitializeResponse:
         logger.info("acp initialize (protocol %s, client=%s)", protocol_version, client_info)
-        return InitializeResponse(protocol_version=protocol_version)
+        return InitializeResponse(
+            protocol_version=protocol_version,
+            agent_capabilities=AgentCapabilities(
+                load_session=True,
+                session_capabilities=SessionCapabilities(
+                    list=SessionListCapabilities(),
+                    close=SessionCloseCapabilities(),
+                ),
+            ),
+        )
 
     # -- session lifecycle ------------------------------------------------
 

--- a/kolega_code/acp/server.py
+++ b/kolega_code/acp/server.py
@@ -46,6 +46,7 @@ from kolega_code.acp.bridge import AcpBridge
 from kolega_code.acp.diffs import AcpDiffProvider
 from kolega_code.acp.permissions import AcpPermissionBroker
 from kolega_code.acp.session import AcpSession
+from kolega_code.acp.usage import build_usage_update
 from kolega_code.cli.config import CliConfigError
 from kolega_code.cli.session_store import SessionStoreError
 from kolega_code.permissions import PermissionDecision, PermissionMode, PermissionRequest
@@ -119,6 +120,7 @@ class AcpAgent(Agent):
         except _HANDLED_CONFIG_ERRORS as exc:
             raise AgentFactory.protocol_error(exc) from exc
         self._sessions[session.session_id] = session
+        await self._emit_initial_usage(session)
         return NewSessionResponse(
             session_id=session.session_id,
             config_options=self._factory.config_options_for(session),
@@ -145,6 +147,7 @@ class AcpAgent(Agent):
         if session is None:
             return None
         self._sessions[session.session_id] = session
+        await self._emit_initial_usage(session)
         return LoadSessionResponse(config_options=self._factory.config_options_for(session))
 
     async def list_sessions(
@@ -266,6 +269,14 @@ class AcpAgent(Agent):
 
         return callback
 
+    async def _emit_initial_usage(self, session: AcpSession) -> None:
+        conn = getattr(self, "_conn", None)
+        if conn is None:
+            return
+        update = build_usage_update(session.agent)
+        if update is not None:
+            await conn.session_update(session_id=session.session_id, update=update, source="kolega_code")
+
     # -- turn machinery ----------------------------------------------------
 
     async def _run_turn(self, session: AcpSession, text: str) -> StopReason:
@@ -276,7 +287,7 @@ class AcpAgent(Agent):
         results still render.
         """
         session.drain_events()
-        bridge = AcpBridge(self._conn, diff_provider=AcpDiffProvider.for_session(session))
+        bridge = AcpBridge(self._conn, diff_provider=AcpDiffProvider.for_session(session), agent=session.agent)
         session.turn_task = asyncio.create_task(self._drive_turn(session, bridge, text))
         pump = asyncio.create_task(self._pump_events(session, bridge))
         try:
@@ -289,6 +300,7 @@ class AcpAgent(Agent):
                 pass
             await self._drain_residual(session, bridge)
             session.turn_task = None
+            await bridge.emit_usage(session.session_id)
 
     async def _drive_turn(self, session: AcpSession, bridge: AcpBridge, text: str) -> str:
         try:

--- a/kolega_code/acp/server.py
+++ b/kolega_code/acp/server.py
@@ -337,7 +337,13 @@ class AcpAgent(Agent):
                 raise AgentFactory.protocol_error(exc) from exc
             logger.info("acp session config: model -> %s/%s (session=%s)", provider, model, session_id)
         elif config_id == CONFIG_PERMISSION_AUTO:
-            mode = PermissionMode.AUTO if bool(value) else PermissionMode.ASK
+            # The option is a select ("ask"/"auto"); legacy clients that
+            # persisted the older boolean values keep working.
+            if isinstance(value, str):
+                auto = value.strip().lower() in ("auto", "true", "1", "yes")
+            else:
+                auto = bool(value)
+            mode = PermissionMode.AUTO if auto else PermissionMode.ASK
             await self._factory.set_permission_mode(session, mode)
             logger.info("acp session config: permission mode -> %s (session=%s)", mode.value, session_id)
         elif config_id == CONFIG_MODE:

--- a/kolega_code/acp/server.py
+++ b/kolega_code/acp/server.py
@@ -1,0 +1,253 @@
+"""The ACP agent server: kolega-code presented to editors as an ACP agent.
+
+Phase 1 wires the transport to real ``CoderAgent`` turns: ``session/new``
+and ``session/load`` create/resume durable kolega-code sessions, and
+``session/prompt`` drives one turn, streaming text chunks and tool-call
+lifecycle as ACP ``session/update`` notifications. ``session/cancel``
+cancels the in-flight turn.
+
+Phase 0 (transport skeleton) is preserved in the module's git history; see
+``acp-implementation-plan.md`` for the full design.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from acp import Agent, InitializeResponse, NewSessionResponse, PromptResponse
+from acp.exceptions import RequestError
+from acp.interfaces import Client
+from acp.schema import (
+    AudioContentBlock,
+    ClientCapabilities,
+    EmbeddedResourceContentBlock,
+    HttpMcpServer,
+    ImageContentBlock,
+    Implementation,
+    ListSessionsResponse,
+    LoadSessionResponse,
+    McpServerStdio,
+    ResourceContentBlock,
+    SseMcpServer,
+    StopReason,
+    TextContentBlock,
+)
+
+from kolega_code.acp.agent_factory import AgentFactory
+from kolega_code.acp.bridge import AcpBridge
+from kolega_code.acp.session import AcpSession
+from kolega_code.cli.config import CliConfigError
+from kolega_code.cli.session_store import SessionStoreError
+
+logger = logging.getLogger(__name__)
+
+_PromptBlock = (
+    TextContentBlock | ImageContentBlock | AudioContentBlock | ResourceContentBlock | EmbeddedResourceContentBlock
+)
+
+_McpServer = list[HttpMcpServer | SseMcpServer | McpServerStdio] | None
+
+_HANDLED_CONFIG_ERRORS = (CliConfigError, SessionStoreError)
+
+
+class AcpAgent(Agent):
+    """kolega-code as an ACP v1 agent, one client connection per process.
+
+    The editor spawns this process, negotiates via ``initialize``, creates
+    sessions, and drives turns with ``session/prompt``. One ``CoderAgent``
+    per session; sessions persist as regular ``SessionRecord``s.
+    """
+
+    def __init__(self, factory: AgentFactory | None = None) -> None:
+        self._factory = factory or AgentFactory()
+        self._sessions: dict[str, AcpSession] = {}
+        self._conn: Client
+
+    def on_connect(self, conn: Client) -> None:
+        self._conn = conn
+
+    async def initialize(
+        self,
+        protocol_version: int,
+        client_capabilities: ClientCapabilities | None = None,
+        client_info: Implementation | None = None,
+        **kwargs: Any,
+    ) -> InitializeResponse:
+        logger.info("acp initialize (protocol %s, client=%s)", protocol_version, client_info)
+        return InitializeResponse(protocol_version=protocol_version)
+
+    # -- session lifecycle ------------------------------------------------
+
+    async def new_session(
+        self,
+        cwd: str,
+        additional_directories: list[str] | None = None,
+        mcp_servers: _McpServer = None,
+        **kwargs: Any,
+    ) -> NewSessionResponse:
+        logger.info("acp new session (cwd=%s)", cwd)
+        try:
+            session = await self._factory.open_session(cwd)
+        except _HANDLED_CONFIG_ERRORS as exc:
+            raise AgentFactory.protocol_error(exc) from exc
+        self._sessions[session.session_id] = session
+        return NewSessionResponse(session_id=session.session_id)
+
+    async def load_session(
+        self,
+        cwd: str,
+        session_id: str,
+        mcp_servers: _McpServer = None,
+        additional_directories: list[str] | None = None,
+        **kwargs: Any,
+    ) -> LoadSessionResponse | None:
+        if session_id in self._sessions:
+            return LoadSessionResponse()
+        try:
+            session = await self._factory.load_session(cwd, session_id)
+        except _HANDLED_CONFIG_ERRORS as exc:
+            raise AgentFactory.protocol_error(exc) from exc
+        if session is None:
+            return None
+        self._sessions[session.session_id] = session
+        return LoadSessionResponse()
+
+    async def list_sessions(
+        self, cwd: str | None = None, cursor: str | None = None, **kwargs: Any
+    ) -> ListSessionsResponse:
+        logger.info("acp session/list (cwd=%s)", cwd)
+        return ListSessionsResponse(sessions=self._factory.list_sessions(cwd))
+
+    async def close_session(self, session_id: str, **kwargs: Any) -> None:
+        logger.info("acp session/close (session=%s)", session_id)
+        self._sessions.pop(session_id, None)
+        await self._factory.close_session(session_id)
+        return None
+
+    # -- turns ------------------------------------------------------------
+
+    async def prompt(self, session_id: str, prompt: list[_PromptBlock], **kwargs: Any) -> PromptResponse:
+        session = self._sessions.get(session_id)
+        if session is None:
+            raise RequestError.resource_not_found(session_id)
+        if not session.idle():
+            raise RequestError.invalid_request({"message": "a turn is already running for this session"})
+        text = self._extract_text(prompt)
+        if not text:
+            raise RequestError.invalid_request({"message": "prompt contains no text"})
+        stop_reason = await self._run_turn(session, text)
+        self._factory.persist(session)
+        return PromptResponse(stop_reason=stop_reason)
+
+    async def cancel(self, session_id: str, **kwargs: Any) -> None:
+        session = self._sessions.get(session_id)
+        if session is None or session.turn_task is None:
+            logger.debug("acp session/cancel: nothing to cancel (session=%s)", session_id)
+            return
+        logger.info("acp session/cancel (session=%s)", session_id)
+        session.turn_task.cancel()
+
+    # -- unsupported surfaces (null = "not supported" per ACP) -------------
+
+    async def resume_session(
+        self,
+        session_id: str,
+        cwd: str,
+        additional_directories: list[str] | None = None,
+        mcp_servers: _McpServer = None,
+        **kwargs: Any,
+    ) -> None:
+        logger.info("acp session/resume not supported yet (session=%s)", session_id)
+        return None
+
+    async def fork_session(
+        self,
+        session_id: str,
+        cwd: str,
+        additional_directories: list[str] | None = None,
+        mcp_servers: _McpServer = None,
+        **kwargs: Any,
+    ) -> None:
+        logger.info("acp session/fork not supported yet (session=%s)", session_id)
+        return None
+
+    async def set_session_mode(self, session_id: str, mode_id: str, **kwargs: Any) -> None:
+        logger.info("acp session/set_mode not supported yet (mode=%s)", mode_id)
+        return None
+
+    async def set_config_option(self, config_id: str, session_id: str, value: str | bool, **kwargs: Any) -> None:
+        logger.info("acp session/set_config_option not supported yet (config=%s)", config_id)
+        return None
+
+    async def authenticate(self, method_id: str, **kwargs: Any) -> None:
+        logger.info("acp authenticate not supported yet (method=%s)", method_id)
+        return None
+
+    async def ext_method(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        raise RequestError.method_not_found(f"_{method}")
+
+    async def ext_notification(self, method: str, params: dict[str, Any]) -> None:
+        logger.debug("acp ignoring extension notification %s", method)
+
+    # -- turn machinery ----------------------------------------------------
+
+    async def _run_turn(self, session: AcpSession, text: str) -> StopReason:
+        """Drive one agent turn, mapping its output to ACP updates.
+
+        Returns the ACP stop reason. The event pump runs until the turn task
+        completes, then any residual queued events are drained so late tool
+        results still render.
+        """
+        session.drain_events()
+        bridge = AcpBridge(self._conn)
+        session.turn_task = asyncio.create_task(self._drive_turn(session, bridge, text))
+        pump = asyncio.create_task(self._pump_events(session, bridge))
+        try:
+            return await session.turn_task
+        finally:
+            pump.cancel()
+            try:
+                await pump
+            except asyncio.CancelledError:
+                pass
+            await self._drain_residual(session, bridge)
+            session.turn_task = None
+
+    async def _drive_turn(self, session: AcpSession, bridge: AcpBridge, text: str) -> str:
+        try:
+            async for chunk in session.agent.process_message_stream(text):
+                await bridge.emit_chunk(session.session_id, chunk)
+            return "end_turn"
+        except asyncio.CancelledError:
+            return "cancelled"
+
+    async def _pump_events(self, session: AcpSession, bridge: AcpBridge) -> None:
+        queue = session.manager.events
+        while True:
+            event = await queue.get()
+            try:
+                await bridge.handle_event(session.session_id, event)
+            except Exception:  # noqa: BLE001 — a bad mapping must not kill the turn
+                logger.exception("acp event mapping failed (session=%s)", session.session_id)
+
+    async def _drain_residual(self, session: AcpSession, bridge: AcpBridge) -> None:
+        while not session.manager.events.empty():
+            try:
+                event = session.manager.events.get_nowait()
+            except asyncio.QueueEmpty:
+                return
+            try:
+                await bridge.handle_event(session.session_id, event)
+            except Exception:  # noqa: BLE001
+                logger.exception("acp residual event mapping failed (session=%s)", session.session_id)
+
+    @staticmethod
+    def _extract_text(prompt: list[_PromptBlock]) -> str:
+        parts: list[str] = []
+        for block in prompt:
+            text = block.get("text", "") if isinstance(block, dict) else getattr(block, "text", "")
+            if text:
+                parts.append(str(text))
+        return "\n".join(parts)

--- a/kolega_code/acp/server.py
+++ b/kolega_code/acp/server.py
@@ -20,7 +20,7 @@ from uuid import uuid4
 
 from acp import Agent, InitializeResponse, NewSessionResponse, PromptResponse
 from acp.exceptions import RequestError
-from acp.helpers import text_block, tool_content, update_current_mode, update_tool_call
+from acp.helpers import text_block, tool_content, update_current_mode, update_plan, update_tool_call
 from acp.interfaces import Client
 from acp.schema import (
     AgentCapabilities,
@@ -58,6 +58,7 @@ from kolega_code.acp.agent_factory import (
 from kolega_code.acp.bridge import AcpBridge
 from kolega_code.acp.diffs import AcpDiffProvider
 from kolega_code.acp.permissions import AcpPermissionBroker
+from kolega_code.acp.plans import task_entries_from_markdown
 from kolega_code.acp.session import AcpSession
 from kolega_code.acp.usage import build_usage_update
 from kolega_code.agent.prompts import build_implement_plan_prompt
@@ -66,6 +67,7 @@ from kolega_code.cli.session_store import SessionStoreError
 from kolega_code.llm.models import MessageHistory
 from kolega_code.permissions import PermissionDecision, PermissionMode, PermissionRequest
 from kolega_code.session.control import DEFAULT_REQUEST_TIMEOUT_SECONDS
+from kolega_code.session.projection import replay
 
 logger = logging.getLogger(__name__)
 
@@ -165,6 +167,7 @@ class AcpAgent(Agent):
             return None
         self._sessions[session.session_id] = session
         await self._emit_initial_usage(session)
+        await self._replay_transcript(session)
         return LoadSessionResponse(config_options=self._factory.config_options_for(session))
 
     async def list_sessions(
@@ -332,6 +335,29 @@ class AcpAgent(Agent):
         if conn is None:
             return
         await conn.session_update(session_id=session.session_id, update=update, source="kolega_code")
+
+    async def _replay_transcript(self, session: AcpSession) -> None:
+        """Replay the persisted transcript before responding to ``session/load``.
+
+        The ACP spec requires the whole conversation to be re-sent as
+        ``session/update`` notifications on load. The journal's presentation
+        events fold through the same projection the TUI restores, so the editor
+        sees the same transcript; live-only notices are excluded by the bridge.
+        The plan view is then refreshed from the shared task list, mirroring the
+        TUI's restored sidebar.
+        """
+        try:
+            events = await self._factory.event_store(session.session_id).read(session.session_id)
+        except Exception:  # noqa: BLE001 — a missing or unreadable journal must not block the load
+            logger.exception("acp session/load: transcript replay failed (session=%s)", session.session_id)
+            return
+        bridge = AcpBridge(self._conn)
+        await bridge.replay_conversation(session.session_id, replay(events).conversation)
+        task_list = (session.record.task_list_markdown or "").strip()
+        if task_list:
+            entries = task_entries_from_markdown(task_list)
+            if entries:
+                await self._send_session_update(session, update_plan(entries))
 
     # -- turn machinery ----------------------------------------------------
 

--- a/kolega_code/acp/session.py
+++ b/kolega_code/acp/session.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
+from typing import Any
 
 from kolega_code.agent import CoderAgent
 from kolega_code.cli.connection import CliConnectionManager
@@ -23,6 +24,8 @@ class AcpSession:
     record: SessionRecord
     agent: CoderAgent
     manager: CliConnectionManager
+    #: Bound at build time so a model-switch rebuild reattaches the same callback.
+    permission_callback: Any = None
     #: In-flight turn task; None when the session is idle. Set and cleared by the server.
     turn_task: asyncio.Task | None = field(default=None, repr=False)
 

--- a/kolega_code/acp/session.py
+++ b/kolega_code/acp/session.py
@@ -28,6 +28,9 @@ class AcpSession:
     permission_callback: Any = None
     #: The AgentConfig the agent was built with, reused by mode-switch rebuilds.
     config: Any = None
+    #: Shared with the ask_user_choice tool extension; the server binds the
+    #: ``elicit`` callable here so questions survive agent rebuilds.
+    question_state: dict[str, Any] = field(default_factory=dict)
     #: In-flight turn task; None when the session is idle. Set and cleared by the server.
     turn_task: asyncio.Task | None = field(default=None, repr=False)
 

--- a/kolega_code/acp/session.py
+++ b/kolega_code/acp/session.py
@@ -24,8 +24,10 @@ class AcpSession:
     record: SessionRecord
     agent: CoderAgent
     manager: CliConnectionManager
-    #: Bound at build time so a model-switch rebuild reattaches the same callback.
+    #: Bound at build time so a model/mode-switch rebuild reattaches the same callback.
     permission_callback: Any = None
+    #: The AgentConfig the agent was built with, reused by mode-switch rebuilds.
+    config: Any = None
     #: In-flight turn task; None when the session is idle. Set and cleared by the server.
     turn_task: asyncio.Task | None = field(default=None, repr=False)
 

--- a/kolega_code/acp/session.py
+++ b/kolega_code/acp/session.py
@@ -1,0 +1,38 @@
+"""One ACP session: the kolega-code session record plus its live agent.
+
+The ACP server drives one ``CoderAgent`` per session; the session is the
+durable ``SessionRecord`` so ACP-driven threads replay in the TUI, export,
+and thread import like any other session.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+
+from kolega_code.agent import CoderAgent
+from kolega_code.cli.connection import CliConnectionManager
+from kolega_code.cli.session_store import SessionRecord
+
+
+@dataclass
+class AcpSession:
+    """Live state for one ACP session."""
+
+    session_id: str
+    record: SessionRecord
+    agent: CoderAgent
+    manager: CliConnectionManager
+    #: In-flight turn task; None when the session is idle. Set and cleared by the server.
+    turn_task: asyncio.Task | None = field(default=None, repr=False)
+
+    def idle(self) -> bool:
+        return self.turn_task is None or self.turn_task.done()
+
+    def drain_events(self) -> None:
+        """Drop any events left over from a previous turn (stale mapping inputs)."""
+        while not self.manager.events.empty():
+            try:
+                self.manager.events.get_nowait()
+            except asyncio.QueueEmpty:
+                break

--- a/kolega_code/acp/usage.py
+++ b/kolega_code/acp/usage.py
@@ -1,0 +1,30 @@
+"""Context usage reporting via ACP ``usage_update`` notifications.
+
+``used``/``size`` mirror the TUI's context gauge: input tokens from the
+agent's per-request ``llm_context_update`` events, window from the agent's
+effective model limits.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from acp.schema import UsageUpdate
+
+
+def context_window_for(agent: Any) -> int | None:
+    for attribute in ("model_max_input_tokens", "model_context_length"):
+        value = getattr(agent, attribute, None)
+        if value:
+            return int(value)
+    primary = getattr(agent, "primary_model_config", None)
+    value = getattr(primary, "context_window_tokens", None) if primary is not None else None
+    return int(value) if value else None
+
+
+def build_usage_update(agent: Any, used: int | None = None) -> UsageUpdate | None:
+    size = context_window_for(agent)
+    if not size:
+        return None
+    resolved_used = min(int(used or 0), size)
+    return UsageUpdate(session_update="usage_update", used=resolved_used, size=size)

--- a/kolega_code/agent/baseagent.py
+++ b/kolega_code/agent/baseagent.py
@@ -147,6 +147,7 @@ class BaseAgent(LogMixin):
     # sub-agent runs its own multi-turn LLM loop, so an unbounded fan-out would
     # multiply token spend and shared-resource pressure).
     PARALLEL_TOOL_LIMIT = 8
+    STREAM_FLUSH_CHARS = 16
     # Cap on how many times a Stop hook may force the agent to keep working in one
     # turn, so a misbehaving "don't stop until X" hook cannot loop forever.
     MAX_STOP_HOOK_OVERRIDES = 5
@@ -2521,6 +2522,7 @@ class BaseAgent(LogMixin):
                 current_response = ""
                 current_thinking = ""
                 thinking_started = False
+                response_started = False
                 # Use the same UUID for each segment of the response
                 response_uuid = str(uuid.uuid4())
                 thinking_uuid = str(uuid.uuid4())
@@ -2569,10 +2571,21 @@ class BaseAgent(LogMixin):
                     async with stream_cm as stream:
                         async for event in stream:
                             if event.type == "text":
+                                if thinking_started or current_thinking:
+                                    yield {
+                                        "type": "thinking",
+                                        "content": current_thinking,
+                                        "complete": True,
+                                        "uuid": thinking_uuid,
+                                    }
+                                    current_thinking = ""
+                                    thinking_started = False
+                                    thinking_uuid = str(uuid.uuid4())
+
                                 current_response += event.text
 
                                 # Send periodic updates as the response grows
-                                if len(current_response) >= 50:
+                                if len(current_response) >= self.STREAM_FLUSH_CHARS:
                                     yield {
                                         "type": "response",
                                         "content": current_response,
@@ -2580,11 +2593,23 @@ class BaseAgent(LogMixin):
                                         "uuid": response_uuid,
                                     }
                                     current_response = ""
+                                    response_started = True
 
                             elif event.type == "thinking" and event.thinking:
+                                if response_started or current_response:
+                                    yield {
+                                        "type": "response",
+                                        "content": current_response,
+                                        "complete": True,
+                                        "uuid": response_uuid,
+                                    }
+                                    current_response = ""
+                                    response_started = False
+                                    response_uuid = str(uuid.uuid4())
+
                                 current_thinking += event.thinking
 
-                                if len(current_thinking) >= 50:
+                                if len(current_thinking) >= self.STREAM_FLUSH_CHARS:
                                     thinking_started = True
                                     yield {
                                         "type": "thinking",
@@ -2603,6 +2628,7 @@ class BaseAgent(LogMixin):
                                     "uuid": response_uuid,
                                 }
                                 current_response = ""
+                                response_started = False
 
                                 await self.on_tool_use_start(event.tool_call_delta)
 
@@ -2640,6 +2666,7 @@ class BaseAgent(LogMixin):
                                     "uuid": response_uuid,
                                 }
                                 current_response = ""
+                                response_started = False
                                 response_uuid = str(uuid.uuid4())
                                 await self._emit_hosted_tool_call(event.tool_call_delta)
 

--- a/kolega_code/agent/tool_backend/agent_tool.py
+++ b/kolega_code/agent/tool_backend/agent_tool.py
@@ -354,8 +354,12 @@ class AgentTool(BaseTool):
                 prompt_provider=getattr(self.caller, "prompt_provider", None) if self.caller else None,
                 prompt_extensions=self._sub_agent_extensions(getattr(self.caller, "prompt_extensions", None)),
                 tool_extensions=self._sub_agent_extensions(getattr(self.caller, "tool_extensions", None)),
-                permission_mode=getattr(self.caller, "permission_mode", None) if self.caller else None,
-                permission_callback=getattr(self.caller, "permission_callback", None) if self.caller else None,
+                # Dispatched sub-agents run their delegated task unattended inside
+                # the parent's turn, so they run in AUTO permission mode regardless
+                # of the session's mode — per-tool prompts cannot be answered from
+                # a delegated transcript, matching the workflow fan-out path.
+                permission_mode=PermissionMode.AUTO,
+                permission_callback=auto_allow_permission_callback,
                 usage_recorder=getattr(self.caller, "usage_recorder", None) if self.caller else None,
                 sub_agent_recorder=getattr(self.caller, "sub_agent_recorder", None) if self.caller else None,
                 usage_ledger=getattr(self.caller, "usage_ledger", None) if self.caller else None,

--- a/kolega_code/cli/acp.py
+++ b/kolega_code/cli/acp.py
@@ -3,16 +3,41 @@
 The editor (or any ACP client) spawns this process and drives it over
 JSON-RPC 2.0 on stdio. stdout is reserved for protocol frames; all logging
 goes to stderr so client parsing is never corrupted.
+
+``--acp-log PATH`` appends a JSON line per protocol update sent, for
+client-side debugging independent of the editor's own log viewer.
 """
 
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import sys
 from typing import Any
 
 log = logging.getLogger("kolega_code.cli.acp")
+
+
+def _json_logger(path: str) -> logging.Handler:
+    handler = logging.FileHandler(path)
+    handler.setLevel(logging.DEBUG)
+
+    def format_record(record: logging.LogRecord) -> str:
+        try:
+            return json.dumps(
+                {
+                    "ts": record.created,
+                    "level": record.levelname,
+                    "message": record.getMessage(),
+                },
+            )
+        except Exception:  # noqa: BLE001 — formatting must never break the process
+            return f"{record.levelname} {record.getMessage()}"
+
+    handler.setFormatter(logging.Formatter())  # type: ignore[arg-type]
+    handler.format = format_record  # type: ignore[method-assign]
+    return handler
 
 
 def run_acp(args: Any) -> int:
@@ -26,6 +51,13 @@ def run_acp(args: Any) -> int:
         stream=sys.stderr,
         format="kolega-code[acp] %(levelname)s %(message)s",
     )
+    acp_log_path = getattr(args, "acp_log", None)
+    if acp_log_path:
+        root = logging.getLogger("kolega_code.acp")
+        root.setLevel(logging.DEBUG)
+        root.addHandler(_json_logger(acp_log_path))
+        log.info("acp traffic log -> %s", acp_log_path)
+
     from acp import run_agent
 
     from kolega_code import __version__ as kolega_version

--- a/kolega_code/cli/acp.py
+++ b/kolega_code/cli/acp.py
@@ -28,10 +28,16 @@ def run_acp(args: Any) -> int:
     )
     from acp import run_agent
 
+    from kolega_code.acp.agent_factory import AgentFactory
     from kolega_code.acp.server import AcpAgent
+    from kolega_code.permissions import PermissionMode, normalize_permission_mode
 
+    permission_mode = normalize_permission_mode(
+        getattr(args, "permission_mode", None),
+        default=PermissionMode.ASK,
+    )
     try:
-        asyncio.run(run_agent(AcpAgent()))
+        asyncio.run(run_agent(AcpAgent(factory=AgentFactory(permission_mode=permission_mode))))
     except KeyboardInterrupt:
         return 130
     return 0

--- a/kolega_code/cli/acp.py
+++ b/kolega_code/cli/acp.py
@@ -1,0 +1,37 @@
+"""``kolega-code acp`` — serve kolega-code as an ACP agent on stdio.
+
+The editor (or any ACP client) spawns this process and drives it over
+JSON-RPC 2.0 on stdio. stdout is reserved for protocol frames; all logging
+goes to stderr so client parsing is never corrupted.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from typing import Any
+
+log = logging.getLogger("kolega_code.cli.acp")
+
+
+def run_acp(args: Any) -> int:
+    """Serve one client connection until the client closes stdio.
+
+    The SDK import is lazy so every other ``kolega-code`` command stays
+    importable without the ACP dependency resolving.
+    """
+    logging.basicConfig(
+        level=logging.DEBUG if getattr(args, "debug", False) else logging.INFO,
+        stream=sys.stderr,
+        format="kolega-code[acp] %(levelname)s %(message)s",
+    )
+    from acp import run_agent
+
+    from kolega_code.acp.server import AcpAgent
+
+    try:
+        asyncio.run(run_agent(AcpAgent()))
+    except KeyboardInterrupt:
+        return 130
+    return 0

--- a/kolega_code/cli/acp.py
+++ b/kolega_code/cli/acp.py
@@ -28,10 +28,12 @@ def run_acp(args: Any) -> int:
     )
     from acp import run_agent
 
+    from kolega_code import __version__ as kolega_version
     from kolega_code.acp.agent_factory import AgentFactory
     from kolega_code.acp.server import AcpAgent
     from kolega_code.permissions import PermissionMode, normalize_permission_mode
 
+    log.info("kolega-code acp %s starting (permission-mode=%s)", kolega_version, getattr(args, "permission_mode", None))
     permission_mode = normalize_permission_mode(
         getattr(args, "permission_mode", None),
         default=PermissionMode.ASK,

--- a/kolega_code/cli/app.py
+++ b/kolega_code/cli/app.py
@@ -891,9 +891,13 @@ class KolegaCodeApp(
             self.session.updated_at = updated_at
 
     def _restore_plan_action_visibility(self) -> None:
+        # A pending plan always gets the full decision set on restore:
+        # `_plan_decision_active` is in-memory only, so gating on it hid
+        # "Clear context and implement plan" and "Discuss further" whenever a
+        # session with a pending plan was resumed.
         self._set_plan_actions_visible(
             self.interaction_mode == tui_constants.PLAN_INTERACTION_MODE and self._plan_pending,
-            allow_discuss=self._plan_decision_active,
+            allow_discuss=self._plan_pending,
         )
 
     def _restore_prompt_history(self) -> None:

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -797,6 +797,7 @@ def _build_subcommand_parser() -> argparse.ArgumentParser:
     )
     acp.set_defaults(command="acp")
     acp.add_argument("--debug", action="store_true", help="Enable debug logging (to stderr).")
+    acp.add_argument("--acp-log", metavar="PATH", help="Append JSON traffic log lines to PATH (client diagnostics).")
     acp.add_argument(
         "--permission-mode",
         choices=[mode.value for mode in PermissionMode],

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -157,6 +157,7 @@ SUBCOMMANDS = {
     "models",
     "tui",
     "share",
+    "acp",
 }
 RESUME_LATEST = "__latest__"
 CLI_AGENT_MODE = AgentMode.CLI.value
@@ -198,6 +199,10 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
             return _run_browser(args)
         if args.command == "mcp":
             return asyncio.run(_run_mcp(args))
+        if args.command == "acp":
+            from .acp import run_acp
+
+            return run_acp(args)
         if args.command == "update":
             return _run_update()
         if args.command == "tui":
@@ -785,6 +790,13 @@ def _build_subcommand_parser() -> argparse.ArgumentParser:
     disable.add_argument("--project-config", action="store_true", help="Update <project>/.kolega/mcp_servers.json.")
 
     subparsers.add_parser("update", help="Update Kolega Code to the latest version.")
+
+    acp = subparsers.add_parser(
+        "acp",
+        help="Serve kolega-code as an ACP (Agent Client Protocol) agent on stdio, for editors like Zed.",
+    )
+    acp.set_defaults(command="acp")
+    acp.add_argument("--debug", action="store_true", help="Enable debug logging (to stderr).")
 
     return parser
 

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -797,6 +797,12 @@ def _build_subcommand_parser() -> argparse.ArgumentParser:
     )
     acp.set_defaults(command="acp")
     acp.add_argument("--debug", action="store_true", help="Enable debug logging (to stderr).")
+    acp.add_argument(
+        "--permission-mode",
+        choices=[mode.value for mode in PermissionMode],
+        default=PermissionMode.ASK.value,
+        help="Tool permission mode: ask (prompt through the editor) or auto (approve everything).",
+    )
 
     return parser
 

--- a/kolega_code/cli/tui/prompt_flows.py
+++ b/kolega_code/cli/tui/prompt_flows.py
@@ -25,7 +25,8 @@ from kolega_code.permissions import (
     allow_rule_options,
 )
 from kolega_code.agent.tool_definitions import tool_description_asset
-from kolega_code.tools import ASK_USER_CHOICE_INPUT_SCHEMA, ASK_USER_CHOICE_SHAPE_HINT, ToolError
+from kolega_code.tools import ASK_USER_CHOICE_INPUT_SCHEMA, ToolError
+from kolega_code.tools.ask_user import normalize_choice_questions
 
 from .. import messages, theme
 from . import app_base as tui_app_base
@@ -183,50 +184,7 @@ class PromptFlowMixin(tui_app_base.KolegaAppBase):
         Strict: rejects malformed input with an instructive ToolError instead of coercing.
         Each result is (question_text, header, option_labels, option_descriptions).
         """
-        if not isinstance(questions, list) or not questions:
-            raise ToolError("'questions' must be a non-empty array of question objects. " + ASK_USER_CHOICE_SHAPE_HINT)
-
-        normalized: list[tuple[str, str, list[str], list[str]]] = []
-        for question in questions:
-            if not isinstance(question, dict):
-                raise ToolError("each item in 'questions' must be an object. " + ASK_USER_CHOICE_SHAPE_HINT)
-
-            clean_question = str(question.get("question", "")).strip()
-            if not clean_question:
-                raise ToolError("each question must include non-empty 'question' text. " + ASK_USER_CHOICE_SHAPE_HINT)
-
-            header = str(question.get("header", "")).strip()
-
-            raw_options = question.get("options")
-            if not isinstance(raw_options, list):
-                raise ToolError(
-                    "each question's 'options' must be an array of {label, description} objects. "
-                    + ASK_USER_CHOICE_SHAPE_HINT
-                )
-
-            labels: list[str] = []
-            descriptions: list[str] = []
-            for option in raw_options:
-                if not isinstance(option, dict):
-                    raise ToolError(
-                        "each option must be an object with a 'label' (and ideally a 'description'). "
-                        + ASK_USER_CHOICE_SHAPE_HINT
-                    )
-                label = str(option.get("label", "")).strip()
-                if not label:
-                    continue
-                labels.append(label)
-                descriptions.append(str(option.get("description", "")).strip())
-
-            if len(labels) < 2:
-                raise ToolError(
-                    "each question needs at least two options, each with a non-empty 'label'. "
-                    + ASK_USER_CHOICE_SHAPE_HINT
-                )
-
-            normalized.append((clean_question, header, labels, descriptions))
-
-        return normalized
+        return normalize_choice_questions(questions)
 
     async def _ask_user_choice(
         self, question: str, options: list[str], descriptions: Optional[list[str]] = None

--- a/kolega_code/session/projection.py
+++ b/kolega_code/session/projection.py
@@ -287,6 +287,18 @@ def fold(state: PresentationState, event: AgentEvent) -> PresentationState:
 # ---------------------------------------------------------------------------
 
 
+def sub_agent_key(info: Optional[dict]) -> Optional[str]:
+    """Identity of the delegate an event belongs to (public helper).
+
+    ``agent_id`` matters as much as ``dispatch_id``: a workflow leaves
+    ``dispatch_id`` unset, so keying on the name alone folded every agent of a
+    fan-out into one activity.
+    """
+    if not info:
+        return None
+    return str(info.get("dispatch_id") or info.get("agent_id") or info.get("agent_name") or "sub-agent")
+
+
 def _sub_agent_key(event: AgentEvent) -> Optional[str]:
     """Identity of the delegate an event belongs to.
 
@@ -295,10 +307,7 @@ def _sub_agent_key(event: AgentEvent) -> Optional[str]:
     fan-out into one activity — a dozen parallel agents appearing as a single
     "general-agent" whose task line was whichever one happened to arrive first.
     """
-    info = event.sub_agent_info
-    if not info:
-        return None
-    return str(info.get("dispatch_id") or info.get("agent_id") or info.get("agent_name") or "sub-agent")
+    return sub_agent_key(event.sub_agent_info)
 
 
 def _sub_agent(state: PresentationState, key: str, event: AgentEvent) -> SubAgentActivity:

--- a/kolega_code/tools/ask_user.py
+++ b/kolega_code/tools/ask_user.py
@@ -1,0 +1,63 @@
+"""Shared ``ask_user_choice`` input normalization for interactive hosts.
+
+Both the TUI (control-channel questions) and the ACP server (elicitation
+forms) expose the same ``ask_user_choice`` tool contract
+(``ASK_USER_CHOICE_INPUT_SCHEMA``). This module owns the strict input
+validation so the two hosts can never drift apart.
+"""
+
+from __future__ import annotations
+
+from kolega_code.tools.core import ToolError
+from kolega_code.tools.definitions import ASK_USER_CHOICE_SHAPE_HINT
+
+
+def normalize_choice_questions(questions: object) -> list[tuple[str, str, list[str], list[str]]]:
+    """Validate the structured questions input and return normalized questions.
+
+    Strict: rejects malformed input with an instructive ToolError instead of coercing.
+    Each result is (question_text, header, option_labels, option_descriptions).
+    """
+    if not isinstance(questions, list) or not questions:
+        raise ToolError("'questions' must be a non-empty array of question objects. " + ASK_USER_CHOICE_SHAPE_HINT)
+
+    normalized: list[tuple[str, str, list[str], list[str]]] = []
+    for question in questions:
+        if not isinstance(question, dict):
+            raise ToolError("each item in 'questions' must be an object. " + ASK_USER_CHOICE_SHAPE_HINT)
+
+        clean_question = str(question.get("question", "")).strip()
+        if not clean_question:
+            raise ToolError("each question must include non-empty 'question' text. " + ASK_USER_CHOICE_SHAPE_HINT)
+
+        header = str(question.get("header", "")).strip()
+
+        raw_options = question.get("options")
+        if not isinstance(raw_options, list):
+            raise ToolError(
+                "each question's 'options' must be an array of {label, description} objects. "
+                + ASK_USER_CHOICE_SHAPE_HINT
+            )
+
+        labels: list[str] = []
+        descriptions: list[str] = []
+        for option in raw_options:
+            if not isinstance(option, dict):
+                raise ToolError(
+                    "each option must be an object with a 'label' (and ideally a 'description'). "
+                    + ASK_USER_CHOICE_SHAPE_HINT
+                )
+            label = str(option.get("label", "")).strip()
+            if not label:
+                continue
+            labels.append(label)
+            descriptions.append(str(option.get("description", "")).strip())
+
+        if len(labels) < 2:
+            raise ToolError(
+                "each question needs at least two options, each with a non-empty 'label'. " + ASK_USER_CHOICE_SHAPE_HINT
+            )
+
+        normalized.append((clean_question, header, labels, descriptions))
+
+    return normalized

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ dependencies = [
     "trafilatura==2.0.0",
     "uvicorn==0.49.0",
     "websockets==16.0",
+    "agent-client-protocol==0.12.0",
 ]
 
 [project.urls]

--- a/tests/acp/test_bridge.py
+++ b/tests/acp/test_bridge.py
@@ -285,3 +285,84 @@ async def test_compaction_status_started_and_subagent_filtered() -> None:
     thoughts = [u for u in conn.updates if isinstance(u, AgentThoughtChunk)]
     assert len(thoughts) == 1
     assert "working" in thoughts[0].content.text
+
+
+@pytest.mark.asyncio
+async def test_dispatch_tool_call_carries_subagent_session_meta() -> None:
+    from acp.schema import ToolCallStart
+
+    from kolega_code.acp.bridge import sub_session_id
+
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn))
+    await bridge.handle_event("s1", _chat_event("tool_call", "Calling dispatch_agent", "tc1", "dispatch_agent"))
+
+    starts = [u for u in conn.updates if isinstance(u, ToolCallStart)]
+    assert len(starts) == 1
+    meta = starts[0].field_meta or {}
+    assert meta["tool_name"] == "dispatch_agent"
+    info = meta["subagent_session_info"]
+    assert info["session_id"] == sub_session_id("s1", "tc1")
+    assert info["message_start_index"] == 0
+
+
+@pytest.mark.asyncio
+async def test_subagent_status_attaches_to_dispatch_tool() -> None:
+    from acp.schema import ToolCallProgress
+
+    from kolega_code.events import AgentEvent
+
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn))
+    await bridge.handle_event(
+        "s1",
+        AgentEvent(
+            event_type="chat_message",
+            sender="agent",
+            content={"status": "GENERATING", "message": "Starting review task"},
+            sub_agent_info={"agent_id": "a1", "parent_tool_call_id": "tc9"},
+        ),
+    )
+
+    progress = [u for u in conn.updates if isinstance(u, ToolCallProgress)]
+    assert len(progress) == 1
+    assert progress[0].tool_call_id == "tc9"
+    assert progress[0].status == "in_progress"
+    assert progress[0].content is not None and "Starting review task" in progress[0].content[0].content.text
+
+
+@pytest.mark.asyncio
+async def test_replay_marks_dispatch_tool_cards() -> None:
+    from acp.schema import ToolCallStart
+
+    from kolega_code.acp.bridge import sub_session_id
+    from kolega_code.session.projection import ConversationItem
+
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn))
+    await bridge.replay_conversation(
+        "s1",
+        [
+            ConversationItem(
+                kind="tool",
+                text="result",
+                tool_name="dispatch_agent",
+                tool_call_id="tc1",
+                status="done",
+                seq=7,
+            ),
+            ConversationItem(
+                kind="tool",
+                text="result",
+                tool_name="read",
+                tool_call_id="tc2",
+                status="done",
+                seq=8,
+            ),
+        ],
+    )
+
+    starts = [u for u in conn.updates if isinstance(u, ToolCallStart)]
+    assert [s.tool_call_id for s in starts] == ["tc1", "tc2"]
+    assert (starts[0].field_meta or {})["subagent_session_info"]["session_id"] == sub_session_id("s1", "tc1")
+    assert starts[1].field_meta is None

--- a/tests/acp/test_bridge.py
+++ b/tests/acp/test_bridge.py
@@ -106,3 +106,77 @@ async def test_empty_chunks_are_dropped() -> None:
     bridge = AcpBridge(cast(Client, conn))
     await bridge.emit_chunk("s1", {"type": "response", "content": "", "complete": True, "uuid": "u1"})
     assert conn.updates == []
+
+
+def _terminal_event(event_type: str, content: dict[str, Any]) -> AgentEvent:
+    return AgentEvent(sender="agent", event_type=event_type, content=content, is_streaming=False)
+
+
+@pytest.mark.asyncio
+async def test_terminal_command_marks_tool_in_progress_with_command() -> None:
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn))
+
+    await bridge.handle_event("s1", _chat_event("tool_call", "Calling exec_command", "c1", "exec_command"))
+    await bridge.handle_event("s1", _terminal_event("terminal_command", {"command": "pytest -q", "terminal_id": "s_1"}))
+
+    command_update = conn.updates[1]
+    assert isinstance(command_update, ToolCallProgress)
+    assert command_update.status == "in_progress"
+    assert command_update.content is not None
+    assert command_update.content[0].content.text == "$ pytest -q\n"
+
+
+@pytest.mark.asyncio
+async def test_terminal_output_appends_to_tool_content() -> None:
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn))
+
+    await bridge.handle_event("s1", _chat_event("tool_call", "Calling exec_command", "c1", "exec_command"))
+    await bridge.handle_event("s1", _terminal_event("terminal_command", {"command": "pytest", "terminal_id": "s_1"}))
+    await bridge.handle_event(
+        "s1", _terminal_event("terminal_output", {"display_output": "collecting...\n", "terminal_id": "s_1"})
+    )
+    await bridge.handle_event("s1", _terminal_event("terminal_output", {"output": "passed\n", "terminal_id": "s_1"}))
+
+    assert conn.updates[2].content[0].content.text == "$ pytest\ncollecting...\n"
+    assert conn.updates[3].content[0].content.text == "$ pytest\ncollecting...\npassed\n"
+
+
+@pytest.mark.asyncio
+async def test_terminal_result_uses_terminal_buffer_over_markdown_text() -> None:
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn))
+
+    await bridge.handle_event("s1", _chat_event("tool_call", "Calling exec_command", "c1", "exec_command"))
+    await bridge.handle_event("s1", _terminal_event("terminal_command", {"command": "pytest", "terminal_id": "s_1"}))
+    await bridge.handle_event("s1", _terminal_event("terminal_output", {"output": "passed\n", "terminal_id": "s_1"}))
+    await bridge.handle_event("s1", _chat_event("tool_result", "Status: exited\n\nOutput:\npassed", "c1"))
+
+    final = conn.updates[3]
+    assert final.status == "completed"
+    assert final.content[0].content.text == "$ pytest\npassed\n"
+    assert bridge._terminal_text == {}  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_terminal_events_without_active_execute_tool_are_ignored() -> None:
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn))
+
+    await bridge.handle_event("s1", _terminal_event("terminal_command", {"command": "pytest", "terminal_id": "s_1"}))
+    await bridge.handle_event("s1", _terminal_event("terminal_output", {"output": "passed\n", "terminal_id": "s_1"}))
+
+    assert conn.updates == []
+
+
+@pytest.mark.asyncio
+async def test_background_terminal_noise_does_not_leak_into_other_tools() -> None:
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn))
+
+    await bridge.handle_event("s1", _chat_event("tool_call", "Calling read", "c1", "read"))
+    await bridge.handle_event("s1", _terminal_event("terminal_output", {"output": "noise\n", "terminal_id": "s_old"}))
+
+    assert conn.updates[0].status == "pending"
+    assert len(conn.updates) == 1

--- a/tests/acp/test_bridge.py
+++ b/tests/acp/test_bridge.py
@@ -180,3 +180,22 @@ async def test_background_terminal_noise_does_not_leak_into_other_tools() -> Non
 
     assert conn.updates[0].status == "pending"
     assert len(conn.updates) == 1
+
+
+@pytest.mark.asyncio
+async def test_debug_logging_handles_single_block_and_list_content() -> None:
+    import logging
+
+    logger = logging.getLogger("kolega_code.acp.bridge")
+    previous_level = logger.level
+    logger.setLevel(logging.DEBUG)
+    try:
+        conn = _FakeConn()
+        bridge = AcpBridge(cast(Client, conn))
+        await bridge.emit_chunk("s1", {"type": "response", "content": "hello", "complete": True, "uuid": "u1"})
+        await bridge.emit_chunk("s1", {"type": "thinking", "content": "hmm", "complete": False, "uuid": "u2"})
+        await bridge.handle_event("s1", _chat_event("tool_call", "Calling read", "c1", "read"))
+        await bridge.handle_event("s1", _chat_event("tool_result", "Wrote file", "c1"))
+        assert len(conn.updates) == 4
+    finally:
+        logger.setLevel(previous_level)

--- a/tests/acp/test_bridge.py
+++ b/tests/acp/test_bridge.py
@@ -366,3 +366,79 @@ async def test_replay_marks_dispatch_tool_cards() -> None:
     assert [s.tool_call_id for s in starts] == ["tc1", "tc2"]
     assert (starts[0].field_meta or {})["subagent_session_info"]["session_id"] == sub_session_id("s1", "tc1")
     assert starts[1].field_meta is None
+
+
+@pytest.mark.asyncio
+async def test_dispatch_card_title_tracks_subagent_status() -> None:
+    from acp.schema import ToolCallProgress, ToolCallStart
+
+    from kolega_code.events import AgentEvent
+
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn))
+    await bridge.handle_event("s1", _chat_event("tool_call", "Calling dispatch_agent", "tc1", "dispatch_agent"))
+    await bridge.handle_event(
+        "s1",
+        AgentEvent(
+            event_type="chat_message",
+            sender="agent",
+            content={"status": "GENERATING", "message": "Starting review task"},
+            sub_agent_info={"agent_id": "a1", "parent_tool_call_id": "tc1"},
+        ),
+    )
+
+    starts = [u for u in conn.updates if isinstance(u, ToolCallStart)]
+    progress = [u for u in conn.updates if isinstance(u, ToolCallProgress)]
+    assert len(starts) == 1
+    assert len(progress) == 1
+    assert progress[0].tool_call_id == "tc1"
+    assert progress[0].title == "dispatch_agent · Starting review task"
+
+
+@pytest.mark.asyncio
+async def test_subagent_tool_calls_do_not_enter_parent_trajectory() -> None:
+    from acp.schema import ToolCallProgress, ToolCallStart
+
+    from kolega_code.events import AgentEvent
+
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn))
+    sub_info = {"agent_id": "a1", "parent_tool_call_id": "tc1"}
+    await bridge.handle_event(
+        "s1",
+        AgentEvent(
+            event_type="chat_message",
+            sender="agent",
+            content={
+                "message_type": "tool_call",
+                "text": "Calling exec",
+                "tool_description": "exec_command",
+                "tool_call_id": "sub-exec-1",
+            },
+            sub_agent_info=sub_info,
+        ),
+    )
+    await bridge.handle_event(
+        "s1",
+        AgentEvent(
+            event_type="chat_message",
+            sender="agent",
+            content={"message_type": "tool_result", "text": "done", "tool_call_id": "sub-exec-1"},
+            sub_agent_info=sub_info,
+        ),
+    )
+    await bridge.handle_event(
+        "s1",
+        AgentEvent(
+            event_type="terminal_output",
+            sender="agent",
+            content={"output": "stdout", "terminal_id": "t1"},
+            sub_agent_info=sub_info,
+        ),
+    )
+    # The main agent's own calls still map.
+    await bridge.handle_event("s1", _chat_event("tool_call", "Calling read", "main-1", "read"))
+
+    starts = [u for u in conn.updates if isinstance(u, ToolCallStart)]
+    assert [s.tool_call_id for s in starts] == ["main-1"]
+    assert not any(isinstance(u, ToolCallProgress) for u in conn.updates)

--- a/tests/acp/test_bridge.py
+++ b/tests/acp/test_bridge.py
@@ -199,3 +199,40 @@ async def test_debug_logging_handles_single_block_and_list_content() -> None:
         assert len(conn.updates) == 4
     finally:
         logger.setLevel(previous_level)
+
+
+@pytest.mark.asyncio
+async def test_replay_conversation_maps_transcript_items() -> None:
+    from acp.schema import AgentMessageChunk, ToolCallProgress, ToolCallStart, UserMessageChunk
+
+    from kolega_code.session.projection import ConversationItem
+
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn))
+    items = [
+        ConversationItem(kind="user", text="hello", seq=1),
+        ConversationItem(kind="thinking", text="hmm", seq=2),
+        ConversationItem(kind="assistant", text="hi there", seq=3),
+        ConversationItem(kind="tool", text="output text", tool_name="exec", tool_call_id="tc1", status="done", seq=4),
+        ConversationItem(kind="tool", text="boom", tool_name="edit", tool_call_id="tc2", status="failed", seq=5),
+        ConversationItem(kind="system", text="live notice", seq=6),
+    ]
+
+    await bridge.replay_conversation("s1", items)
+
+    updates = conn.updates
+    user = [u for u in updates if isinstance(u, UserMessageChunk)]
+    agent = [u for u in updates if isinstance(u, AgentMessageChunk)]
+    starts = [u for u in updates if isinstance(u, ToolCallStart)]
+    progresses = [u for u in updates if isinstance(u, ToolCallProgress)]
+    assert len(user) == 1
+    assert user[0].content.type == "text" and user[0].content.text == "hello"
+    assert user[0].message_id == "replay-1-user"
+    assert len(agent) == 1
+    assert agent[0].content.type == "text" and agent[0].content.text == "hi there"
+    assert agent[0].message_id == "replay-3-assistant"
+    assert len(starts) == 2
+    assert [s.title for s in starts] == ["exec", "edit"]
+    assert [(p.tool_call_id, p.status) for p in progresses] == [("tc1", "completed"), ("tc2", "failed")]
+    assert progresses[0].content is not None and progresses[0].content[0].content.text == "output text"
+    assert "live notice" not in [getattr(u, "text", "") for u in updates]

--- a/tests/acp/test_bridge.py
+++ b/tests/acp/test_bridge.py
@@ -403,6 +403,7 @@ async def test_subagent_tool_calls_do_not_enter_parent_trajectory() -> None:
 
     conn = _FakeConn()
     bridge = AcpBridge(cast(Client, conn))
+    await bridge.handle_event("s1", _chat_event("tool_call", "Calling dispatch_agent", "tc1", "dispatch_agent"))
     sub_info = {"agent_id": "a1", "parent_tool_call_id": "tc1"}
     await bridge.handle_event(
         "s1",
@@ -439,6 +440,61 @@ async def test_subagent_tool_calls_do_not_enter_parent_trajectory() -> None:
     # The main agent's own calls still map.
     await bridge.handle_event("s1", _chat_event("tool_call", "Calling read", "main-1", "read"))
 
+    # No new cards for the delegate's tools: the only start is the main
+    # agent's read, and the only progress updates target the dispatch card.
     starts = [u for u in conn.updates if isinstance(u, ToolCallStart)]
-    assert [s.tool_call_id for s in starts] == ["main-1"]
-    assert not any(isinstance(u, ToolCallProgress) for u in conn.updates)
+    assert [s.tool_call_id for s in starts] == ["tc1", "main-1"]
+    progress = [u for u in conn.updates if isinstance(u, ToolCallProgress)]
+    assert progress and all(p.tool_call_id == "tc1" for p in progress)
+    assert progress[0].title == "dispatch_agent · Calling exec"
+
+
+@pytest.mark.asyncio
+async def test_subagent_terminal_command_tracks_dispatch_card() -> None:
+    from acp.schema import ToolCallProgress
+
+    from kolega_code.events import AgentEvent
+
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn))
+    await bridge.handle_event("s1", _chat_event("tool_call", "Calling dispatch_agent", "tc1", "dispatch_agent"))
+    await bridge.handle_event(
+        "s1",
+        AgentEvent(
+            event_type="terminal_command",
+            sender="agent",
+            content={"command": "git status --porcelain\nsecond line", "terminal_id": "t1"},
+            sub_agent_info={"agent_id": "a1", "parent_tool_call_id": "tc1"},
+        ),
+    )
+
+    progress = [u for u in conn.updates if isinstance(u, ToolCallProgress)]
+    assert len(progress) == 1
+    assert progress[0].tool_call_id == "tc1"
+    # Multi-line commands collapse to the first line for the card title.
+    assert progress[0].title == "dispatch_agent · git status --porcelain"
+
+
+@pytest.mark.asyncio
+async def test_subagent_progress_title_is_length_capped() -> None:
+    from acp.schema import ToolCallProgress
+
+    from kolega_code.events import AgentEvent
+
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn))
+    await bridge.handle_event("s1", _chat_event("tool_call", "Calling dispatch_agent", "tc1", "dispatch_agent"))
+    await bridge.handle_event(
+        "s1",
+        AgentEvent(
+            event_type="terminal_command",
+            sender="agent",
+            content={"command": "x" * 200, "terminal_id": "t1"},
+            sub_agent_info={"agent_id": "a1", "parent_tool_call_id": "tc1"},
+        ),
+    )
+
+    progress = [u for u in conn.updates if isinstance(u, ToolCallProgress)]
+    assert progress and progress[0].title is not None
+    assert progress[0].title.endswith("…")
+    assert len(progress[0].title) <= len("dispatch_agent · ") + 80

--- a/tests/acp/test_bridge.py
+++ b/tests/acp/test_bridge.py
@@ -1,0 +1,108 @@
+"""Unit tests for the ACP event bridge (Phase 1)."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+from acp.interfaces import Client
+from acp.schema import AgentMessageChunk, AgentThoughtChunk, ToolCallProgress, ToolCallStart
+
+from kolega_code.acp.bridge import AcpBridge
+from kolega_code.events import AgentEvent
+
+
+class _FakeConn:
+    def __init__(self) -> None:
+        self.updates: list[Any] = []
+
+    async def session_update(self, session_id: str, update: Any, source: str = "") -> None:
+        self.updates.append(update)
+
+
+def _chat_event(message_type: str, text: str = "", tool_call_id: str = "", tool_description: str = "") -> AgentEvent:
+    content: dict[str, Any] = {"message_type": message_type, "text": text, "tool_call_id": tool_call_id}
+    if tool_description:
+        content["tool_description"] = tool_description
+    return AgentEvent(sender="agent", event_type="chat_message", content=content, is_streaming=False)
+
+
+@pytest.mark.asyncio
+async def test_tool_call_event_starts_tool_call_with_mapped_kind() -> None:
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn))
+
+    await bridge.handle_event("s1", _chat_event("tool_call", "Calling read", "c1", "read"))
+    await bridge.handle_event("s1", _chat_event("tool_call", "Calling edit", "c2", "multi_edit"))
+    await bridge.handle_event("s1", _chat_event("tool_call", "Calling frobnicate", "c3", "frobnicate"))
+
+    assert len(conn.updates) == 3
+    first, second, third = conn.updates
+    assert isinstance(first, ToolCallStart)
+    assert first.tool_call_id == "c1"
+    assert first.kind == "read"
+    assert first.status == "pending"
+    assert isinstance(second, ToolCallStart)
+    assert second.kind == "edit"
+    assert isinstance(third, ToolCallStart)
+    assert third.kind == "other"
+
+
+@pytest.mark.asyncio
+async def test_tool_result_completes_with_text_content() -> None:
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn))
+    await bridge.handle_event("s1", _chat_event("tool_result", "Wrote file", "c1"))
+    assert len(conn.updates) == 1
+    update = conn.updates[0]
+    assert isinstance(update, ToolCallProgress)
+    assert update.tool_call_id == "c1"
+    assert update.status == "completed"
+    assert update.content is not None
+    assert update.content[0].content.text == "Wrote file"
+
+
+@pytest.mark.asyncio
+async def test_tool_error_marks_failed() -> None:
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn))
+    await bridge.handle_event("s1", _chat_event("tool_error", "boom", "c1"))
+    update = conn.updates[0]
+    assert update.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_non_chat_events_are_ignored() -> None:
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn))
+    event = AgentEvent(sender="agent", event_type="assistant_delta", content={"text": "hi"}, is_streaming=True)
+    await bridge.handle_event("s1", event)
+    assert conn.updates == []
+
+
+@pytest.mark.asyncio
+async def test_response_chunk_emits_agent_message() -> None:
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn))
+    await bridge.emit_chunk("s1", {"type": "response", "content": "hello", "complete": False, "uuid": "u1"})
+    assert len(conn.updates) == 1
+    update = conn.updates[0]
+    assert isinstance(update, AgentMessageChunk)
+    assert update.content.text == "hello"
+
+
+@pytest.mark.asyncio
+async def test_thinking_chunk_emits_thought_update() -> None:
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn))
+    await bridge.emit_chunk("s1", {"type": "thinking", "content": "hmm", "complete": False, "uuid": "u1"})
+    assert isinstance(conn.updates[0], AgentThoughtChunk)
+    assert conn.updates[0].content.text == "hmm"
+
+
+@pytest.mark.asyncio
+async def test_empty_chunks_are_dropped() -> None:
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn))
+    await bridge.emit_chunk("s1", {"type": "response", "content": "", "complete": True, "uuid": "u1"})
+    assert conn.updates == []

--- a/tests/acp/test_bridge.py
+++ b/tests/acp/test_bridge.py
@@ -236,3 +236,52 @@ async def test_replay_conversation_maps_transcript_items() -> None:
     assert [(p.tool_call_id, p.status) for p in progresses] == [("tc1", "completed"), ("tc2", "failed")]
     assert progresses[0].content is not None and progresses[0].content[0].content.text == "output text"
     assert "live notice" not in [getattr(u, "text", "") for u in updates]
+
+
+@pytest.mark.asyncio
+async def test_compaction_status_renders_as_thought_block() -> None:
+    from acp.schema import AgentThoughtChunk
+
+    from kolega_code.events import AgentEvent
+
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn))
+    await bridge.handle_event(
+        "s1",
+        AgentEvent(
+            event_type="compaction_status",
+            sender="agent",
+            content={"phase": "finished", "message": "done", "summary": "compressed 12 turns"},
+        ),
+    )
+
+    thoughts = [u for u in conn.updates if isinstance(u, AgentThoughtChunk)]
+    assert len(thoughts) == 1
+    assert "compressed 12 turns" in thoughts[0].content.text
+
+
+@pytest.mark.asyncio
+async def test_compaction_status_started_and_subagent_filtered() -> None:
+    from acp.schema import AgentThoughtChunk
+
+    from kolega_code.events import AgentEvent
+
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn))
+    await bridge.handle_event(
+        "s1",
+        AgentEvent(event_type="compaction_status", sender="agent", content={"phase": "started", "message": "working"}),
+    )
+    await bridge.handle_event(
+        "s1",
+        AgentEvent(
+            event_type="compaction_status",
+            sender="agent",
+            content={"phase": "finished", "message": "", "summary": "delegate summary"},
+            sub_agent_info={"agent_id": "a1"},
+        ),
+    )
+
+    thoughts = [u for u in conn.updates if isinstance(u, AgentThoughtChunk)]
+    assert len(thoughts) == 1
+    assert "working" in thoughts[0].content.text

--- a/tests/acp/test_cli.py
+++ b/tests/acp/test_cli.py
@@ -1,0 +1,60 @@
+"""End-to-end: `kolega-code acp` driven by the SDK's programmatic client.
+
+Spawns the real CLI subprocess exactly the way an editor would (stdio
+JSON-RPC) and asserts the transport handshake plus a config-independent
+round trip (``session/list``). Turn behavior and config-error conversion are
+covered in-process in ``test_server.py``: whether ``session/new`` needs real
+API keys depends on the machine (macOS keychain), so it cannot be asserted
+here deterministically.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from typing import Any
+
+import pytest
+from acp import PROTOCOL_VERSION, spawn_agent_process
+from acp.helpers import SessionUpdate
+from acp.interfaces import Client
+from acp.schema import ToolCallUpdate
+
+
+class _CollectingClient(Client):
+    def __init__(self) -> None:
+        self.updates: list[SessionUpdate] = []
+
+    async def session_update(self, session_id: str, update: SessionUpdate, **kwargs: Any) -> None:
+        self.updates.append(update)
+
+    async def request_permission(
+        self, session_id: str, tool_call: ToolCallUpdate, options: list[Any], **kwargs: Any
+    ) -> Any:
+        return {"outcome": {"outcome": "cancelled"}}
+
+
+@pytest.mark.asyncio
+async def test_acp_subprocess_handshake_and_session_list(isolated_cli_env: None) -> None:
+    client = _CollectingClient()  # pyright: ignore[reportAbstractUsage]
+    # The SDK spawns children with a sanitized default environment, so the
+    # fixture's hermetic env (isolated state dir, no API keys) must be passed
+    # explicitly to reach the child.
+    env = dict(os.environ)
+    async with asyncio.timeout(60):
+        async with spawn_agent_process(
+            client,
+            sys.executable,
+            "-m",
+            "kolega_code.cli.main",
+            "acp",
+            env=env,
+        ) as (conn, proc):
+            await conn.initialize(protocol_version=PROTOCOL_VERSION)
+            # session/list is config-independent: an empty state dir lists no sessions.
+            listed = await conn.list_sessions()
+            assert listed.sessions == []
+            # The transport keeps answering after the round trip.
+            await conn.initialize(protocol_version=PROTOCOL_VERSION)
+            assert proc.returncode is None

--- a/tests/acp/test_cli.py
+++ b/tests/acp/test_cli.py
@@ -51,7 +51,9 @@ async def test_acp_subprocess_handshake_and_session_list(isolated_cli_env: None)
             "acp",
             env=env,
         ) as (conn, proc):
-            await conn.initialize(protocol_version=PROTOCOL_VERSION)
+            initialized = await conn.initialize(protocol_version=PROTOCOL_VERSION)
+            assert initialized.agent_capabilities is not None
+            assert initialized.agent_capabilities.load_session is True
             # session/list is config-independent: an empty state dir lists no sessions.
             listed = await conn.list_sessions()
             assert listed.sessions == []

--- a/tests/acp/test_config_options.py
+++ b/tests/acp/test_config_options.py
@@ -158,7 +158,7 @@ async def test_real_factory_builds_both_options(isolated_cli_env: None, tmp_path
 
 
 @pytest.mark.asyncio
-async def test_set_config_option_mode_switches_and_clears_plan_on_build(tmp_path: Path) -> None:
+async def test_set_config_option_mode_switches_without_touching_task_list(tmp_path: Path) -> None:
     from acp.schema import AgentPlanUpdate, CurrentModeUpdate
 
     session, _cm = _make_session(tmp_path, StreamingLLM())
@@ -174,9 +174,9 @@ async def test_set_config_option_mode_switches_and_clears_plan_on_build(tmp_path
     assert [mode for _, mode in factory.interaction_mode_calls] == ["plan", "build"]
     modes = [u for u in conn.updates if isinstance(u, CurrentModeUpdate)]
     assert [u.current_mode_id for u in modes] == ["plan", "build"]
-    plans = [u for u in conn.updates if isinstance(u, AgentPlanUpdate)]
-    assert len(plans) == 1
-    assert plans[0].entries == []
+    # The plan view mirrors the shared task list, which persists across mode
+    # switches in the TUI; a mode change must not clear it.
+    assert not any(isinstance(u, AgentPlanUpdate) for u in conn.updates)
 
 
 @pytest.mark.asyncio

--- a/tests/acp/test_config_options.py
+++ b/tests/acp/test_config_options.py
@@ -51,10 +51,18 @@ async def test_set_config_option_flips_permission_mode(tmp_path: Path) -> None:
     agent = AcpAgent(factory=cast(Any, factory))
     new_session = await agent.new_session(cwd=str(tmp_path))
 
-    first = await agent.set_config_option(CONFIG_PERMISSION_AUTO, new_session.session_id, True)
-    second = await agent.set_config_option(CONFIG_PERMISSION_AUTO, new_session.session_id, False)
+    first = await agent.set_config_option(CONFIG_PERMISSION_AUTO, new_session.session_id, "auto")
+    second = await agent.set_config_option(CONFIG_PERMISSION_AUTO, new_session.session_id, "ask")
+    # Legacy clients that persisted the older boolean values keep working.
+    await agent.set_config_option(CONFIG_PERMISSION_AUTO, new_session.session_id, True)
+    await agent.set_config_option(CONFIG_PERMISSION_AUTO, new_session.session_id, False)
 
-    assert [mode for _, mode in factory.permission_mode_calls] == [PermissionMode.AUTO, PermissionMode.ASK]
+    assert [mode for _, mode in factory.permission_mode_calls] == [
+        PermissionMode.AUTO,
+        PermissionMode.ASK,
+        PermissionMode.AUTO,
+        PermissionMode.ASK,
+    ]
     assert first.config_options == factory.config_options
     assert second.config_options == factory.config_options
 
@@ -150,8 +158,9 @@ async def test_real_factory_builds_both_options(isolated_cli_env: None, tmp_path
     model_option, permission_option, mode_option = options
     assert isinstance(model_option, SessionConfigOptionSelect)
     assert model_option.current_value == "anthropic/claude-haiku-4-5-20251001"
-    assert isinstance(permission_option, SessionConfigOptionBoolean)
-    assert permission_option.current_value is False
+    assert isinstance(permission_option, SessionConfigOptionSelect)
+    assert permission_option.current_value == "ask"
+    assert [entry.value for entry in permission_option.options] == ["ask", "auto"]
     assert isinstance(mode_option, SessionConfigOptionSelect)
     assert mode_option.current_value == "build"
     assert [entry.value for entry in mode_option.options] == ["build", "plan"]

--- a/tests/acp/test_config_options.py
+++ b/tests/acp/test_config_options.py
@@ -1,0 +1,151 @@
+"""Session config option tests: model select + permission toggle wiring."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from acp.exceptions import RequestError
+from acp.schema import SessionConfigOptionBoolean, SessionConfigOptionSelect
+
+from kolega_code.acp.agent_factory import CONFIG_MODEL, CONFIG_PERMISSION_AUTO, AgentFactory
+from kolega_code.acp.server import AcpAgent
+from kolega_code.acp.session import AcpSession
+from kolega_code.cli.session_store import SessionRecord
+from kolega_code.permissions import PermissionMode
+
+from tests.agent.compaction_helpers import build_agent
+from tests.acp.test_server import StreamingLLM, _FakeConn, _FakeFactory, _make_session
+
+from acp.interfaces import Client  # noqa: E402
+
+
+def _options(agent: AcpAgent, session: AcpSession) -> list[Any]:
+    return agent._factory.config_options_for(session)  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_new_session_response_advertises_options(tmp_path: Path) -> None:
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    factory = _FakeFactory(session)
+    factory.config_options = [
+        SessionConfigOptionSelect(type="select", id=CONFIG_MODEL, name="Model", current_value="x/y", options=[]),
+        SessionConfigOptionBoolean(
+            type="boolean", id=CONFIG_PERMISSION_AUTO, name="Auto-approve tools", current_value=False
+        ),
+    ]
+    agent = AcpAgent(factory=cast(Any, factory))
+    agent.on_connect(cast(Client, _FakeConn()))
+
+    response = await agent.new_session(cwd=str(tmp_path))
+
+    assert response.config_options == factory.config_options
+
+
+@pytest.mark.asyncio
+async def test_set_config_option_flips_permission_mode(tmp_path: Path) -> None:
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    factory = _FakeFactory(session)
+    agent = AcpAgent(factory=cast(Any, factory))
+    new_session = await agent.new_session(cwd=str(tmp_path))
+
+    await agent.set_config_option(CONFIG_PERMISSION_AUTO, new_session.session_id, True)
+    await agent.set_config_option(CONFIG_PERMISSION_AUTO, new_session.session_id, False)
+
+    assert [mode for _, mode in factory.permission_mode_calls] == [PermissionMode.AUTO, PermissionMode.ASK]
+
+
+@pytest.mark.asyncio
+async def test_set_config_option_applies_model(tmp_path: Path) -> None:
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    factory = _FakeFactory(session)
+    agent = AcpAgent(factory=cast(Any, factory))
+    new_session = await agent.new_session(cwd=str(tmp_path))
+
+    await agent.set_config_option(CONFIG_MODEL, new_session.session_id, "deepseek/deepseek-v4-pro")
+
+    assert factory.model_calls == [(new_session.session_id, "deepseek", "deepseek-v4-pro")]
+
+
+@pytest.mark.asyncio
+async def test_set_config_option_rejects_malformed_model_value(tmp_path: Path) -> None:
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    factory = _FakeFactory(session)
+    agent = AcpAgent(factory=cast(Any, factory))
+    new_session = await agent.new_session(cwd=str(tmp_path))
+
+    with pytest.raises(RequestError):
+        await agent.set_config_option(CONFIG_MODEL, new_session.session_id, "no-slash")
+    assert factory.model_calls == []
+
+
+@pytest.mark.asyncio
+async def test_set_config_option_rejects_unknown_option(tmp_path: Path) -> None:
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    agent = AcpAgent(factory=cast(Any, _FakeFactory(session)))
+    new_session = await agent.new_session(cwd=str(tmp_path))
+
+    with pytest.raises(RequestError):
+        await agent.set_config_option("nope", new_session.session_id, True)
+
+
+@pytest.mark.asyncio
+async def test_set_config_option_rejects_unknown_session(tmp_path: Path) -> None:
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    agent = AcpAgent(factory=cast(Any, _FakeFactory(session)))
+
+    with pytest.raises(RequestError):
+        await agent.set_config_option(CONFIG_PERMISSION_AUTO, "missing", True)
+
+
+@pytest.mark.asyncio
+async def test_set_config_option_rejects_active_turn(tmp_path: Path) -> None:
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    factory = _FakeFactory(session)
+    agent = AcpAgent(factory=cast(Any, factory))
+    new_session = await agent.new_session(cwd=str(tmp_path))
+
+    async def _forever() -> None:
+        await asyncio.Event().wait()
+
+    registered = agent._sessions[new_session.session_id]  # noqa: SLF001
+    registered.turn_task = asyncio.create_task(_forever())
+    try:
+        with pytest.raises(RequestError):
+            await agent.set_config_option(CONFIG_PERMISSION_AUTO, new_session.session_id, True)
+    finally:
+        registered.turn_task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_real_factory_permission_mode_updates_agent_and_record(tmp_path: Path) -> None:
+    agent, _cm = build_agent(tmp_path)
+    record = SessionRecord.create(Path(tmp_path), "cli", {})
+    session = AcpSession(session_id=record.session_id, record=record, agent=agent, manager=_cm)
+    factory = AgentFactory()
+
+    await factory.set_permission_mode(session, PermissionMode.AUTO)
+
+    assert session.agent.permission_mode == PermissionMode.AUTO
+    assert session.record.permission_mode == "auto"
+
+
+@pytest.mark.asyncio
+async def test_real_factory_builds_both_options(isolated_cli_env: None, tmp_path: Path) -> None:
+    agent, cm = build_agent(tmp_path)
+    record = SessionRecord.create(Path(tmp_path), "cli", {})
+    session = AcpSession(session_id=record.session_id, record=record, agent=agent, manager=cm)
+    agent.set_permission_mode(PermissionMode.ASK)
+    factory = AgentFactory()
+    factory._load_settings()  # noqa: SLF001
+
+    options = factory.config_options_for(session)
+
+    assert [option.id for option in options] == [CONFIG_MODEL, CONFIG_PERMISSION_AUTO]
+    model_option, permission_option = options
+    assert isinstance(model_option, SessionConfigOptionSelect)
+    assert model_option.current_value == "anthropic/claude-haiku-4-5-20251001"
+    assert isinstance(permission_option, SessionConfigOptionBoolean)
+    assert permission_option.current_value is False

--- a/tests/acp/test_config_options.py
+++ b/tests/acp/test_config_options.py
@@ -10,7 +10,7 @@ import pytest
 from acp.exceptions import RequestError
 from acp.schema import SessionConfigOptionBoolean, SessionConfigOptionSelect
 
-from kolega_code.acp.agent_factory import CONFIG_MODEL, CONFIG_PERMISSION_AUTO, AgentFactory
+from kolega_code.acp.agent_factory import CONFIG_MODE, CONFIG_MODEL, CONFIG_PERMISSION_AUTO, AgentFactory
 from kolega_code.acp.server import AcpAgent
 from kolega_code.acp.session import AcpSession
 from kolega_code.cli.session_store import SessionRecord
@@ -146,9 +146,44 @@ async def test_real_factory_builds_both_options(isolated_cli_env: None, tmp_path
 
     options = factory.config_options_for(session)
 
-    assert [option.id for option in options] == [CONFIG_MODEL, CONFIG_PERMISSION_AUTO]
-    model_option, permission_option = options
+    assert [option.id for option in options] == [CONFIG_MODEL, CONFIG_PERMISSION_AUTO, CONFIG_MODE]
+    model_option, permission_option, mode_option = options
     assert isinstance(model_option, SessionConfigOptionSelect)
     assert model_option.current_value == "anthropic/claude-haiku-4-5-20251001"
     assert isinstance(permission_option, SessionConfigOptionBoolean)
     assert permission_option.current_value is False
+    assert isinstance(mode_option, SessionConfigOptionSelect)
+    assert mode_option.current_value == "build"
+    assert [entry.value for entry in mode_option.options] == ["build", "plan"]
+
+
+@pytest.mark.asyncio
+async def test_set_config_option_mode_switches_and_clears_plan_on_build(tmp_path: Path) -> None:
+    from acp.schema import AgentPlanUpdate, CurrentModeUpdate
+
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    factory = _FakeFactory(session)
+    conn = _FakeConn()
+    agent = AcpAgent(factory=cast(Any, factory))
+    agent.on_connect(cast(Client, conn))
+    new_session = await agent.new_session(cwd=str(tmp_path))
+
+    await agent.set_config_option(CONFIG_MODE, new_session.session_id, "plan")
+    await agent.set_config_option(CONFIG_MODE, new_session.session_id, "build")
+
+    assert [mode for _, mode in factory.interaction_mode_calls] == ["plan", "build"]
+    modes = [u for u in conn.updates if isinstance(u, CurrentModeUpdate)]
+    assert [u.current_mode_id for u in modes] == ["plan", "build"]
+    plans = [u for u in conn.updates if isinstance(u, AgentPlanUpdate)]
+    assert len(plans) == 1
+    assert plans[0].entries == []
+
+
+@pytest.mark.asyncio
+async def test_set_config_option_mode_rejects_unknown_mode(tmp_path: Path) -> None:
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    agent = AcpAgent(factory=cast(Any, _FakeFactory(session)))
+    new_session = await agent.new_session(cwd=str(tmp_path))
+
+    with pytest.raises(RequestError):
+        await agent.set_config_option(CONFIG_MODE, new_session.session_id, "vibe")

--- a/tests/acp/test_config_options.py
+++ b/tests/acp/test_config_options.py
@@ -51,10 +51,12 @@ async def test_set_config_option_flips_permission_mode(tmp_path: Path) -> None:
     agent = AcpAgent(factory=cast(Any, factory))
     new_session = await agent.new_session(cwd=str(tmp_path))
 
-    await agent.set_config_option(CONFIG_PERMISSION_AUTO, new_session.session_id, True)
-    await agent.set_config_option(CONFIG_PERMISSION_AUTO, new_session.session_id, False)
+    first = await agent.set_config_option(CONFIG_PERMISSION_AUTO, new_session.session_id, True)
+    second = await agent.set_config_option(CONFIG_PERMISSION_AUTO, new_session.session_id, False)
 
     assert [mode for _, mode in factory.permission_mode_calls] == [PermissionMode.AUTO, PermissionMode.ASK]
+    assert first.config_options == factory.config_options
+    assert second.config_options == factory.config_options
 
 
 @pytest.mark.asyncio
@@ -64,9 +66,10 @@ async def test_set_config_option_applies_model(tmp_path: Path) -> None:
     agent = AcpAgent(factory=cast(Any, factory))
     new_session = await agent.new_session(cwd=str(tmp_path))
 
-    await agent.set_config_option(CONFIG_MODEL, new_session.session_id, "deepseek/deepseek-v4-pro")
+    response = await agent.set_config_option(CONFIG_MODEL, new_session.session_id, "deepseek/deepseek-v4-pro")
 
     assert factory.model_calls == [(new_session.session_id, "deepseek", "deepseek-v4-pro")]
+    assert response.config_options == factory.config_options
 
 
 @pytest.mark.asyncio

--- a/tests/acp/test_diffs.py
+++ b/tests/acp/test_diffs.py
@@ -1,0 +1,168 @@
+"""Diff provider tests: snapshot-sourced old/new content for ACP tool results."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from acp.interfaces import Client
+from acp.schema import FileEditToolCallContent, ToolCallProgress, ToolCallStart
+
+from kolega_code.acp.bridge import AcpBridge
+from kolega_code.acp.diffs import AcpDiffProvider
+from kolega_code.events import AgentEvent
+from kolega_code.services.file_system import LocalFileSystem
+from kolega_code.services.snapshots import SnapshotService
+
+
+class _FakeConn:
+    def __init__(self) -> None:
+        self.updates: list[Any] = []
+
+    async def session_update(self, session_id: str, update: Any, source: str = "") -> None:
+        self.updates.append(update)
+
+
+def _chat_event(message_type: str, text: str = "", tool_call_id: str = "", tool_description: str = "") -> AgentEvent:
+    content: dict[str, Any] = {"message_type": message_type, "text": text, "tool_call_id": tool_call_id}
+    if tool_description:
+        content["tool_description"] = tool_description
+    return AgentEvent(sender="agent", event_type="chat_message", content=content, is_streaming=False)
+
+
+def _service(tmp_path: Path) -> SnapshotService:
+    return SnapshotService(
+        Path(tmp_path),
+        "ws",
+        "thread",
+        "sess",
+        LocalFileSystem(root_path=tmp_path),
+        root=tmp_path / "state",
+    )
+
+
+def _mutate(service: SnapshotService, tmp_path: Path, mutate: Any) -> None:
+    target = tmp_path / "f.txt"
+    service.record_mutation(
+        tool_name="edit",
+        tool_call_id="call-1",
+        reason="test",
+        paths=[str(target)],
+        mutate=mutate,
+    )
+
+
+@pytest.mark.asyncio
+async def test_existing_file_edit_produces_old_new_text(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    target = tmp_path / "f.txt"
+    target.write_text("hello\n")
+
+    def mutate() -> None:
+        target.write_text("hello\nworld\n")
+
+    _mutate(service, tmp_path, mutate)
+
+    contents = AcpDiffProvider(service).build_for_tool_result("call-1")
+    assert len(contents) == 1
+    assert contents[0].path == str(target)
+    assert contents[0].old_text == "hello\n"
+    assert contents[0].new_text == "hello\nworld\n"
+
+
+@pytest.mark.asyncio
+async def test_new_file_has_no_old_text(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    target = tmp_path / "f.txt"
+
+    def mutate() -> None:
+        target.write_text("brand new\n")
+
+    _mutate(service, tmp_path, mutate)
+
+    contents = AcpDiffProvider(service).build_for_tool_result("call-1")
+    assert len(contents) == 1
+    assert contents[0].old_text is None
+    assert contents[0].new_text == "brand new\n"
+
+
+@pytest.mark.asyncio
+async def test_unchanged_mutation_produces_no_diff(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    target = tmp_path / "f.txt"
+    target.write_text("same\n")
+
+    def mutate() -> None:
+        target.write_text("same\n")
+
+    _mutate(service, tmp_path, mutate)
+
+    assert AcpDiffProvider(service).build_for_tool_result("call-1") == []
+
+
+@pytest.mark.asyncio
+async def test_unknown_tool_call_produces_no_diff(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    target = tmp_path / "f.txt"
+    target.write_text("hello\n")
+
+    def mutate() -> None:
+        target.write_text("hello\nworld\n")
+
+    _mutate(service, tmp_path, mutate)
+
+    assert AcpDiffProvider(service).build_for_tool_result("call-other") == []
+
+
+@pytest.mark.asyncio
+async def test_no_snapshot_service_produces_no_diff(tmp_path: Path) -> None:
+    assert AcpDiffProvider(None).build_for_tool_result("call-1") == []
+
+
+@pytest.mark.asyncio
+async def test_bridge_attaches_diff_content_to_tool_result(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    target = tmp_path / "f.txt"
+    target.write_text("hello\n")
+
+    def mutate() -> None:
+        target.write_text("hello\nworld\n")
+
+    _mutate(service, tmp_path, mutate)
+
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn), diff_provider=AcpDiffProvider(service))
+    await bridge.handle_event("s1", _chat_event("tool_call", "Calling edit", "call-1", "edit"))
+    await bridge.handle_event("s1", _chat_event("tool_result", "Edited f.txt", "call-1"))
+
+    assert isinstance(conn.updates[0], ToolCallStart)
+    progress = conn.updates[1]
+    assert isinstance(progress, ToolCallProgress)
+    assert progress.status == "completed"
+    assert progress.content is not None
+    assert len(progress.content) == 2
+    assert isinstance(progress.content[0], FileEditToolCallContent)
+    assert progress.content[0].old_text == "hello\n"
+    assert progress.content[0].new_text == "hello\nworld\n"
+    assert progress.content[1].content.text == "Edited f.txt"
+
+
+@pytest.mark.asyncio
+async def test_bridge_skips_diff_content_on_tool_error(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    target = tmp_path / "f.txt"
+    target.write_text("hello\n")
+
+    def mutate() -> None:
+        target.write_text("hello\nworld\n")
+
+    _mutate(service, tmp_path, mutate)
+
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn), diff_provider=AcpDiffProvider(service))
+    await bridge.handle_event("s1", _chat_event("tool_error", "boom", "call-1"))
+
+    progress = conn.updates[0]
+    assert progress.status == "failed"
+    assert all(not isinstance(block, FileEditToolCallContent) for block in (progress.content or []))

--- a/tests/acp/test_permissions.py
+++ b/tests/acp/test_permissions.py
@@ -1,0 +1,216 @@
+"""Permission bridge tests: broker mapping and the real agent gate."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Callable, cast
+from unittest.mock import MagicMock
+
+import pytest
+from acp.interfaces import Client
+from acp.schema import RequestPermissionResponse
+
+from kolega_code.acp.permissions import OPTION_ALLOW_ONCE, OPTION_REJECT_ONCE, AcpPermissionBroker
+from kolega_code.cli.connection import CliConnectionManager
+from kolega_code.llm.models import ToolCall
+from kolega_code.permissions import (
+    PermissionKind,
+    PermissionMode,
+    PermissionRequest,
+    PermissionRule,
+    ProjectPermissionStore,
+)
+
+from tests.agent.compaction_helpers import build_agent
+
+
+class _FakeConn:
+    def __init__(self, responder: Callable[..., Any] | None = None) -> None:
+        self.responder = responder or (lambda session_id, tool_call, options: None)
+        self.calls: list[tuple[str, Any, list[Any]]] = []
+
+    async def request_permission(self, session_id: str, tool_call: Any, options: list[Any], **kwargs: Any) -> Any:
+        self.calls.append((session_id, tool_call, options))
+        result = self.responder(session_id, tool_call, options)
+        if asyncio.iscoroutine(result):
+            result = await result
+        return result
+
+
+def _selected(option_id: str) -> Any:
+    return RequestPermissionResponse.model_validate({"outcome": {"outcome": "selected", "optionId": option_id}})
+
+
+def _cancelled() -> Any:
+    return RequestPermissionResponse.model_validate({"outcome": {"outcome": "cancelled"}})
+
+
+def _command_request(command: str = "rm -rf /tmp/x") -> PermissionRequest:
+    return PermissionRequest(
+        kind=PermissionKind.COMMAND,
+        tool_name="exec_command",
+        inputs={"command": command},
+        command=command,
+    )
+
+
+def _broker(conn: _FakeConn, tmp_path: Path, agent: Any = None, **kwargs: Any) -> AcpPermissionBroker:
+    return AcpPermissionBroker(cast(Client, conn), "s1", Path(tmp_path), lambda: agent, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_saved_rule_short_circuits_prompt(tmp_path: Path) -> None:
+    request = _command_request()
+    ProjectPermissionStore(Path(tmp_path)).add_rule(
+        PermissionRule.create(kind=PermissionKind.COMMAND, tool="*", match_type="exact", pattern=request.command),
+    )
+    conn = _FakeConn(responder=lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not prompt")))
+
+    decision = await _broker(conn, tmp_path)(request)
+
+    assert decision.allowed is True
+    assert "saved rule" in decision.reason
+    assert conn.calls == []
+
+
+@pytest.mark.asyncio
+async def test_allow_once(tmp_path: Path) -> None:
+    conn = _FakeConn(responder=lambda *a, **k: _selected(OPTION_ALLOW_ONCE))
+    decision = await _broker(conn, tmp_path)(_command_request())
+    assert decision.allowed is True
+    assert decision.rule is None
+    assert ProjectPermissionStore(Path(tmp_path)).load() == []
+
+
+@pytest.mark.asyncio
+async def test_allow_always_persists_matching_rule(tmp_path: Path) -> None:
+    request = _command_request()
+    conn = _FakeConn(responder=lambda *a, **k: _selected("allow-always-0"))
+    decision = await _broker(conn, tmp_path)(request)
+
+    assert decision.allowed is True
+    assert decision.rule is not None
+    saved = ProjectPermissionStore(Path(tmp_path)).first_match(request)
+    assert saved is not None
+    assert saved.matches(request)
+
+
+@pytest.mark.asyncio
+async def test_options_carry_rule_candidates(tmp_path: Path) -> None:
+    conn = _FakeConn(responder=lambda *a, **k: _selected(OPTION_ALLOW_ONCE))
+    await _broker(conn, tmp_path)(_command_request())
+    _, _, options = conn.calls[0]
+
+    kinds = [option.kind for option in options]
+    assert kinds[0] == "allow_once"
+    assert kinds[-1] == "reject_once"
+    assert kinds.count("allow_always") >= 2
+    assert options[1].name == "Always allow this exact command"
+
+
+@pytest.mark.asyncio
+async def test_reject_once_denies(tmp_path: Path) -> None:
+    conn = _FakeConn(responder=lambda *a, **k: _selected(OPTION_REJECT_ONCE))
+    decision = await _broker(conn, tmp_path)(_command_request())
+    assert decision.allowed is False
+
+
+@pytest.mark.asyncio
+async def test_cancelled_outcome_denies(tmp_path: Path) -> None:
+    conn = _FakeConn(responder=lambda *a, **k: _cancelled())
+    decision = await _broker(conn, tmp_path)(_command_request())
+    assert decision.allowed is False
+
+
+@pytest.mark.asyncio
+async def test_client_error_denies(tmp_path: Path) -> None:
+    def responder(*a: Any, **k: Any) -> Any:
+        raise RuntimeError("client exploded")
+
+    conn = _FakeConn(responder=responder)
+    decision = await _broker(conn, tmp_path)(_command_request())
+    assert decision.allowed is False
+    assert "could not be shown" in decision.reason
+
+
+@pytest.mark.asyncio
+async def test_timeout_denies(tmp_path: Path) -> None:
+    async def responder(*a: Any, **k: Any) -> Any:
+        await asyncio.Event().wait()
+
+    conn = _FakeConn(responder=responder)
+    decision = await _broker(conn, tmp_path, timeout=0.05)(_command_request())
+    assert decision.allowed is False
+    assert "Timed out" in decision.reason
+
+
+@pytest.mark.asyncio
+async def test_pending_tool_call_carries_tool_context(tmp_path: Path) -> None:
+    agent = SimpleNamespace(current_tool_call_id="call-7")
+    request = _command_request()
+    conn = _FakeConn(responder=lambda *a, **k: _selected(OPTION_ALLOW_ONCE))
+    await _broker(conn, tmp_path, agent=agent)(request)
+
+    _, tool_call, _ = conn.calls[0]
+    assert tool_call.tool_call_id == "call-7"
+    assert tool_call.kind == "execute"
+    assert tool_call.status == "pending"
+    assert tool_call.title == request.command
+    assert tool_call.raw_input == request.inputs
+
+
+class _FakeRegistry:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+
+    def __contains__(self, item: object) -> bool:
+        return True
+
+    def names(self) -> list[str]:
+        return ["exec_command"]
+
+    def get(self, name: str) -> object:
+        return object()
+
+    async def call(self, name: str, **inputs: Any) -> str:
+        self.calls.append((name, inputs))
+        return "ok"
+
+
+def _gated_agent(tmp_path: Path, conn: _FakeConn) -> tuple[Any, _FakeRegistry]:
+    manager = CliConnectionManager()
+    agent, _cm = build_agent(tmp_path, connection_manager=manager)
+    registry = _FakeRegistry()
+    assert agent.tool_collection is not None
+    agent.tool_collection.registry = MagicMock(return_value=registry)
+    broker = _broker(conn, tmp_path, agent=agent)
+    agent.set_permission_mode(PermissionMode.ASK)
+    agent.set_permission_callback(broker)
+    return agent, registry
+
+
+@pytest.mark.asyncio
+async def test_agent_gate_denies_tool_when_client_rejects(tmp_path: Path) -> None:
+    conn = _FakeConn(responder=lambda *a, **k: _cancelled())
+    agent, registry = _gated_agent(tmp_path, conn)
+
+    result = await agent.execute_single_tool(ToolCall(id="t1", name="exec_command", input={"command": "echo hi"}))
+
+    assert result.is_error is True
+    assert "denied" in str(result.content).lower()
+    assert registry.calls == []
+    assert conn.calls
+
+
+@pytest.mark.asyncio
+async def test_agent_gate_allows_tool_when_client_approves(tmp_path: Path) -> None:
+    conn = _FakeConn(responder=lambda *a, **k: _selected(OPTION_ALLOW_ONCE))
+    agent, registry = _gated_agent(tmp_path, conn)
+
+    result = await agent.execute_single_tool(ToolCall(id="t1", name="exec_command", input={"command": "echo hi"}))
+
+    assert result.is_error is False
+    assert result.content == "ok"
+    assert registry.calls == [("exec_command", {"command": "echo hi"})]

--- a/tests/acp/test_permissions.py
+++ b/tests/acp/test_permissions.py
@@ -214,3 +214,17 @@ async def test_agent_gate_allows_tool_when_client_approves(tmp_path: Path) -> No
     assert result.is_error is False
     assert result.content == "ok"
     assert registry.calls == [("exec_command", {"command": "echo hi"})]
+
+
+@pytest.mark.asyncio
+async def test_dict_shaped_permission_outcome_is_accepted(tmp_path: Path) -> None:
+    conn = _FakeConn(responder=lambda *a, **k: {"outcome": {"outcome": "selected", "optionId": OPTION_ALLOW_ONCE}})
+    decision = await _broker(conn, tmp_path)(_command_request())
+    assert decision.allowed is True
+
+
+@pytest.mark.asyncio
+async def test_dict_shaped_cancelled_outcome_denies(tmp_path: Path) -> None:
+    conn = _FakeConn(responder=lambda *a, **k: {"outcome": {"outcome": "cancelled"}})
+    decision = await _broker(conn, tmp_path)(_command_request())
+    assert decision.allowed is False

--- a/tests/acp/test_plan_mode.py
+++ b/tests/acp/test_plan_mode.py
@@ -9,7 +9,13 @@ from typing import Any, cast
 import pytest
 from acp.exceptions import RequestError
 from acp.interfaces import Client
-from acp.schema import AgentPlanUpdate, CurrentModeUpdate, SetSessionModeResponse
+from acp.schema import (
+    AgentPlanUpdate,
+    ConfigOptionUpdate,
+    CurrentModeUpdate,
+    SessionConfigOptionSelect,
+    SetSessionModeResponse,
+)
 
 from kolega_code.acp.agent_factory import MODE_BUILD, MODE_PLAN, agent_class_for
 from kolega_code.events import AgentEvent
@@ -156,7 +162,7 @@ async def test_bridge_maps_task_list_update_to_plan_view() -> None:
 
 @pytest.mark.asyncio
 async def test_plan_approval_implement_switches_to_build(tmp_path: Path) -> None:
-    from acp.schema import CurrentModeUpdate
+    from kolega_code.acp.agent_factory import CONFIG_MODE, AgentFactory
 
     plan_text = "## Step one\n## Step two"
     session, _cm = _make_session(tmp_path, StreamingLLM(events=[_text_event(plan_text)]))
@@ -164,6 +170,9 @@ async def test_plan_approval_implement_switches_to_build(tmp_path: Path) -> None
     holder = {"plan": plan_text}
     setattr(session.agent, "consume_completed_plan", lambda: holder.pop("plan", None))
     factory = _FakeFactory(session)
+    # The fake's config surface reflects the record live, so the pushed
+    # option update after the server-side switch shows the new mode.
+    factory.config_options_for = lambda s: [AgentFactory._mode_option(s)]  # type: ignore[method-assign]
     conn = _FakeConn()
     agent = AcpAgent(factory=cast(Any, factory))
     agent.on_connect(cast(Client, conn))
@@ -177,6 +186,16 @@ async def test_plan_approval_implement_switches_to_build(tmp_path: Path) -> None
     modes = [u.current_mode_id for u in conn.updates if isinstance(u, CurrentModeUpdate)]
     assert modes[-1] == MODE_BUILD
     assert not any(isinstance(u, AgentPlanUpdate) for u in conn.updates)
+    # The mode select is a config option in Zed; the approval must push a
+    # refreshed option set or the client keeps showing the stale mode.
+    option_updates = [u for u in conn.updates if isinstance(u, ConfigOptionUpdate)]
+    assert option_updates
+    mode_selects = [
+        option
+        for option in option_updates[-1].config_options
+        if isinstance(option, SessionConfigOptionSelect) and option.id == CONFIG_MODE
+    ]
+    assert mode_selects and mode_selects[0].current_value == MODE_BUILD
 
 
 @pytest.mark.asyncio
@@ -287,3 +306,44 @@ def test_task_list_extension_matches_tui_split(tmp_path: Path) -> None:
     assert set(plan.tools) == {"get_task_list"}
     assert build.tool_descriptions["get_task_list"] == tool_description_asset("get_task_list")
     assert plan.tool_descriptions["get_task_list"] == tool_description_asset("get_task_list_readonly")
+
+
+@pytest.mark.asyncio
+async def test_rebuild_agent_persists_live_history_first(tmp_path: Path) -> None:
+    from unittest.mock import AsyncMock
+
+    from kolega_code.acp.agent_factory import AgentFactory
+    from kolega_code.cli.session_store import SessionStore
+    from kolega_code.llm.models import Message, MessageHistory, TextBlock
+
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    # The approval flow rebuilds mid-turn: the live agent has the just-finished
+    # plan turn, while the persisted record still holds the pre-turn history.
+    session.agent.history = MessageHistory()
+    session.agent.history.append(Message(role="user", content=[TextBlock(text="plan turn text")]))
+    assert session.record.history == []
+
+    captured: dict[str, Any] = {}
+
+    class _StubFactory(AgentFactory):
+        async def _construct_agent(
+            self,
+            record: Any,
+            config: Any,
+            *,
+            restore: bool,
+            permission_callback: Any,
+            permission_mode: Any = None,
+        ) -> tuple[Any, Any]:
+            captured["history"] = record.history
+            return session.agent, session.manager
+
+    # The real factory registers records in the store before persisting; do
+    # the same here so persist() can save.
+    SessionStore().create(Path(tmp_path), "cli", {}, session_id=session.record.session_id)
+    session.agent.cleanup = AsyncMock()  # type: ignore[method-assign]
+    factory = _StubFactory()
+    await factory._rebuild_agent(session, session.config)
+
+    assert captured["history"] == session.record.history
+    assert any("plan turn text" in str(msg) for msg in captured["history"])

--- a/tests/acp/test_plan_mode.py
+++ b/tests/acp/test_plan_mode.py
@@ -13,7 +13,6 @@ from acp.schema import AgentPlanUpdate, CurrentModeUpdate, SetSessionModeRespons
 
 from kolega_code.acp.agent_factory import MODE_BUILD, MODE_PLAN, agent_class_for
 from kolega_code.events import AgentEvent
-from kolega_code.acp.plans import plan_entries_from_markdown
 from kolega_code.acp.server import AcpAgent
 
 from tests.acp.test_server import StreamingLLM, _FakeConn, _FakeFactory, _make_agent, _make_session, _text_event
@@ -25,22 +24,6 @@ def test_agent_class_choice() -> None:
     assert agent_class_for(MODE_PLAN) is PlanningAgent
     assert agent_class_for(MODE_BUILD).__name__ == "CoderAgent"
     assert agent_class_for("anything-else").__name__ == "CoderAgent"
-
-
-def test_plan_entries_from_markdown_parses_headings() -> None:
-    text = "# Big plan\n\n## Step one\nbody\n## Step two\nmore\n### Nested"
-    entries = plan_entries_from_markdown(text)
-    assert [entry.content for entry in entries] == ["Big plan", "Step one", "Step two", "Nested"]
-    assert all(entry.status == "pending" for entry in entries)
-
-
-def test_plan_entries_from_markdown_falls_back_to_single_entry() -> None:
-    entries = plan_entries_from_markdown("A plan without headings, just prose.")
-    assert [entry.content for entry in entries] == ["A plan without headings, just prose."]
-
-
-def test_plan_entries_from_markdown_empty() -> None:
-    assert plan_entries_from_markdown("") == []
 
 
 @pytest.mark.asyncio
@@ -75,7 +58,7 @@ async def test_set_session_mode_switches_and_updates_client(tmp_path: Path) -> N
 
 
 @pytest.mark.asyncio
-async def test_set_session_mode_build_clears_plan(tmp_path: Path) -> None:
+async def test_set_session_mode_build_keeps_task_list_view(tmp_path: Path) -> None:
     session, _cm = _make_session(tmp_path, StreamingLLM())
     factory = _FakeFactory(session)
     conn = _FakeConn()
@@ -85,9 +68,9 @@ async def test_set_session_mode_build_clears_plan(tmp_path: Path) -> None:
 
     await agent.set_session_mode(new_session.session_id, MODE_BUILD)
 
-    plans = [update for update in conn.updates if isinstance(update, AgentPlanUpdate)]
-    assert len(plans) == 1
-    assert plans[0].entries == []
+    # The plan view mirrors the shared task list, which survives mode switches
+    # in the TUI; switching modes must not clear it.
+    assert not any(isinstance(update, AgentPlanUpdate) for update in conn.updates)
 
 
 @pytest.mark.asyncio
@@ -119,18 +102,23 @@ async def test_set_session_mode_rejects_active_turn(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_plan_turn_emits_plan_update(tmp_path: Path) -> None:
+async def test_plan_turn_does_not_populate_task_list_view(tmp_path: Path) -> None:
     plan_text = "## Investigate the repo\nDetails.\n## Propose a design\nMore details."
     session, _cm = _make_session(tmp_path, StreamingLLM(events=[_text_event(plan_text)]))
     session.record.interaction_mode = MODE_PLAN
+    holder = {"plan": plan_text}
+    setattr(session.agent, "consume_completed_plan", lambda: holder.pop("plan", None))
     agent, conn = _make_agent(session)
     new_session = await agent.new_session(cwd=str(tmp_path))
 
     await agent.prompt(session_id=new_session.session_id, prompt=[{"type": "text", "text": "make a plan"}])  # pyright: ignore[reportArgumentType]
 
-    plans = [update for update in conn.updates if isinstance(update, AgentPlanUpdate)]
-    assert plans
-    assert [entry.content for entry in plans[-1].entries] == ["Investigate the repo", "Propose a design"]
+    # The plan and the task list are distinct in the TUI; the plan must not
+    # feed the editor's plan view (which mirrors the task list only). The plan
+    # still reaches the user through the approval prompt.
+    assert not any(isinstance(update, AgentPlanUpdate) for update in conn.updates)
+    assert conn.permission_calls
+    assert conn.permission_calls[0][1].title == "Approve implementation plan?"
 
 
 def test_task_entries_from_markdown_maps_checkboxes() -> None:
@@ -188,8 +176,7 @@ async def test_plan_approval_implement_switches_to_build(tmp_path: Path) -> None
     assert factory.interaction_mode_calls == [(new_session.session_id, MODE_BUILD)]
     modes = [u.current_mode_id for u in conn.updates if isinstance(u, CurrentModeUpdate)]
     assert modes[-1] == MODE_BUILD
-    plans = [u for u in conn.updates if isinstance(u, AgentPlanUpdate)]
-    assert [entry.content for entry in plans[0].entries] == ["Step one", "Step two"]
+    assert not any(isinstance(u, AgentPlanUpdate) for u in conn.updates)
 
 
 @pytest.mark.asyncio
@@ -270,3 +257,33 @@ async def test_plan_approval_prompt_contains_full_plan(tmp_path: Path) -> None:
     content = conn.permission_calls[0][1].content[0].content
     assert content.type == "text"
     assert content.text == plan_text
+
+
+def test_task_list_volatile_section_mirrors_record(tmp_path: Path) -> None:
+    from kolega_code.acp.agent_factory import AgentFactory
+
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    provider = AgentFactory._task_list_volatile_section(session.record)
+
+    assert provider().text == ""
+
+    session.record.task_list_markdown = "- [ ] do the thing\n- [x] done thing"
+    section = provider()
+    assert section.key == "task_list"
+    assert section.text == "- [ ] do the thing\n- [x] done thing"
+
+
+def test_task_list_extension_matches_tui_split(tmp_path: Path) -> None:
+    from kolega_code.agent.tool_definitions import tool_description_asset
+
+    from kolega_code.acp.agent_factory import AgentFactory
+
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    holder: dict[str, Any] = {}
+    build = AgentFactory._task_list_extension(session.record, holder, MODE_BUILD)
+    plan = AgentFactory._task_list_extension(session.record, holder, MODE_PLAN)
+
+    assert set(build.tools) == {"get_task_list", "update_task_list"}
+    assert set(plan.tools) == {"get_task_list"}
+    assert build.tool_descriptions["get_task_list"] == tool_description_asset("get_task_list")
+    assert plan.tool_descriptions["get_task_list"] == tool_description_asset("get_task_list_readonly")

--- a/tests/acp/test_plan_mode.py
+++ b/tests/acp/test_plan_mode.py
@@ -12,6 +12,7 @@ from acp.interfaces import Client
 from acp.schema import AgentPlanUpdate, CurrentModeUpdate, SetSessionModeResponse
 
 from kolega_code.acp.agent_factory import MODE_BUILD, MODE_PLAN, agent_class_for
+from kolega_code.events import AgentEvent
 from kolega_code.acp.plans import plan_entries_from_markdown
 from kolega_code.acp.server import AcpAgent
 
@@ -130,3 +131,121 @@ async def test_plan_turn_emits_plan_update(tmp_path: Path) -> None:
     plans = [update for update in conn.updates if isinstance(update, AgentPlanUpdate)]
     assert plans
     assert [entry.content for entry in plans[-1].entries] == ["Investigate the repo", "Propose a design"]
+
+
+def test_task_entries_from_markdown_maps_checkboxes() -> None:
+    from kolega_code.acp.plans import task_entries_from_markdown
+
+    entries = task_entries_from_markdown("- [x] Done thing\n- [ ] Pending thing\n- plain item")
+    assert [(entry.content, entry.status) for entry in entries] == [
+        ("Done thing", "completed"),
+        ("Pending thing", "pending"),
+        ("plain item", "pending"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_bridge_maps_task_list_update_to_plan_view() -> None:
+    from kolega_code.acp.bridge import AcpBridge
+
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn))
+    event = AgentEvent(
+        sender="agent",
+        event_type="chat_message",
+        content={"message_type": "task_list_update", "text": "- [x] a\n- [ ] b", "tool_call_id": "c1"},
+        is_streaming=False,
+    )
+    await bridge.handle_event("s1", event)
+
+    plans = [update for update in conn.updates if isinstance(update, AgentPlanUpdate)]
+    assert len(plans) == 1
+    assert [(entry.content, entry.status) for entry in plans[0].entries] == [
+        ("a", "completed"),
+        ("b", "pending"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_plan_approval_implement_switches_to_build(tmp_path: Path) -> None:
+    from acp.schema import CurrentModeUpdate
+
+    plan_text = "## Step one\n## Step two"
+    session, _cm = _make_session(tmp_path, StreamingLLM(events=[_text_event(plan_text)]))
+    session.record.interaction_mode = MODE_PLAN
+    holder = {"plan": plan_text}
+    setattr(session.agent, "consume_completed_plan", lambda: holder.pop("plan", None))
+    factory = _FakeFactory(session)
+    conn = _FakeConn()
+    agent = AcpAgent(factory=cast(Any, factory))
+    agent.on_connect(cast(Client, conn))
+    new_session = await agent.new_session(cwd=str(tmp_path))
+
+    await agent.prompt(session_id=new_session.session_id, prompt=[{"type": "text", "text": "make a plan"}])  # pyright: ignore[reportArgumentType]
+
+    assert session.record.plan_pending is False
+    assert session.record.latest_plan_markdown == plan_text
+    assert factory.interaction_mode_calls == [(new_session.session_id, MODE_BUILD)]
+    modes = [u.current_mode_id for u in conn.updates if isinstance(u, CurrentModeUpdate)]
+    assert modes[-1] == MODE_BUILD
+    plans = [u for u in conn.updates if isinstance(u, AgentPlanUpdate)]
+    assert [entry.content for entry in plans[0].entries] == ["Step one", "Step two"]
+
+
+@pytest.mark.asyncio
+async def test_plan_approval_discuss_keeps_mode_and_sets_reofferable(tmp_path: Path) -> None:
+    from acp.schema import RequestPermissionResponse
+
+    plan_text = "## Step one\n## Step two"
+    session, _cm = _make_session(tmp_path, StreamingLLM(events=[_text_event(plan_text)]))
+    session.record.interaction_mode = MODE_PLAN
+    holder = {"plan": plan_text}
+    setattr(session.agent, "consume_completed_plan", lambda: holder.pop("plan", None))
+    factory = _FakeFactory(session)
+    conn = _FakeConn()
+
+    async def discuss(*a: Any, **k: Any) -> Any:
+        return RequestPermissionResponse.model_validate(
+            {"outcome": {"outcome": "selected", "optionId": "discuss_plan"}}
+        )
+
+    conn.request_permission = discuss  # type: ignore[method-assign]
+    agent = AcpAgent(factory=cast(Any, factory))
+    agent.on_connect(cast(Client, conn))
+    new_session = await agent.new_session(cwd=str(tmp_path))
+
+    await agent.prompt(session_id=new_session.session_id, prompt=[{"type": "text", "text": "make a plan"}])  # pyright: ignore[reportArgumentType]
+
+    assert session.record.plan_pending is False
+    assert session.record.plan_reofferable is True
+    assert factory.interaction_mode_calls == []
+
+
+@pytest.mark.asyncio
+async def test_plan_approval_clear_wipes_history(tmp_path: Path) -> None:
+    from acp.schema import RequestPermissionResponse
+
+    plan_text = "## Step one"
+    session, _cm = _make_session(tmp_path, StreamingLLM(events=[_text_event(plan_text)]))
+    session.record.interaction_mode = MODE_PLAN
+    holder = {"plan": plan_text}
+    setattr(session.agent, "consume_completed_plan", lambda: holder.pop("plan", None))
+    factory = _FakeFactory(session)
+    conn = _FakeConn()
+
+    async def implement_clear(*a: Any, **k: Any) -> Any:
+        return RequestPermissionResponse.model_validate(
+            {"outcome": {"outcome": "selected", "optionId": "implement_plan_clear"}}
+        )
+
+    conn.request_permission = implement_clear  # type: ignore[method-assign]
+    agent = AcpAgent(factory=cast(Any, factory))
+    agent.on_connect(cast(Client, conn))
+    new_session = await agent.new_session(cwd=str(tmp_path))
+
+    await agent.prompt(session_id=new_session.session_id, prompt=[{"type": "text", "text": "make a plan"}])  # pyright: ignore[reportArgumentType]
+
+    assert session.record.plan_pending is False
+    assert not any("make a plan" in msg.get_text_content() for msg in session.agent.history)
+    assert sum("Step one" in msg.get_text_content() for msg in session.agent.history) == 1
+    assert factory.interaction_mode_calls == [(new_session.session_id, MODE_BUILD)]

--- a/tests/acp/test_plan_mode.py
+++ b/tests/acp/test_plan_mode.py
@@ -219,33 +219,3 @@ async def test_plan_approval_discuss_keeps_mode_and_sets_reofferable(tmp_path: P
     assert session.record.plan_pending is False
     assert session.record.plan_reofferable is True
     assert factory.interaction_mode_calls == []
-
-
-@pytest.mark.asyncio
-async def test_plan_approval_clear_wipes_history(tmp_path: Path) -> None:
-    from acp.schema import RequestPermissionResponse
-
-    plan_text = "## Step one"
-    session, _cm = _make_session(tmp_path, StreamingLLM(events=[_text_event(plan_text)]))
-    session.record.interaction_mode = MODE_PLAN
-    holder = {"plan": plan_text}
-    setattr(session.agent, "consume_completed_plan", lambda: holder.pop("plan", None))
-    factory = _FakeFactory(session)
-    conn = _FakeConn()
-
-    async def implement_clear(*a: Any, **k: Any) -> Any:
-        return RequestPermissionResponse.model_validate(
-            {"outcome": {"outcome": "selected", "optionId": "implement_plan_clear"}}
-        )
-
-    conn.request_permission = implement_clear  # type: ignore[method-assign]
-    agent = AcpAgent(factory=cast(Any, factory))
-    agent.on_connect(cast(Client, conn))
-    new_session = await agent.new_session(cwd=str(tmp_path))
-
-    await agent.prompt(session_id=new_session.session_id, prompt=[{"type": "text", "text": "make a plan"}])  # pyright: ignore[reportArgumentType]
-
-    assert session.record.plan_pending is False
-    assert not any("make a plan" in msg.get_text_content() for msg in session.agent.history)
-    assert sum("Step one" in msg.get_text_content() for msg in session.agent.history) == 1
-    assert factory.interaction_mode_calls == [(new_session.session_id, MODE_BUILD)]

--- a/tests/acp/test_plan_mode.py
+++ b/tests/acp/test_plan_mode.py
@@ -249,3 +249,24 @@ async def test_plan_approval_clear_wipes_history(tmp_path: Path) -> None:
     assert not any("make a plan" in msg.get_text_content() for msg in session.agent.history)
     assert sum("Step one" in msg.get_text_content() for msg in session.agent.history) == 1
     assert factory.interaction_mode_calls == [(new_session.session_id, MODE_BUILD)]
+
+
+@pytest.mark.asyncio
+async def test_plan_approval_prompt_contains_full_plan(tmp_path: Path) -> None:
+    plan_text = "## Step one\n" + ("body text. " * 80) + "## Step two\n" + ("more body. " * 80)
+    assert len(plan_text) > 400
+    session, _cm = _make_session(tmp_path, StreamingLLM(events=[_text_event(plan_text)]))
+    session.record.interaction_mode = MODE_PLAN
+    holder = {"plan": plan_text}
+    setattr(session.agent, "consume_completed_plan", lambda: holder.pop("plan", None))
+    conn = _FakeConn()
+    agent = AcpAgent(factory=cast(Any, _FakeFactory(session)))
+    agent.on_connect(cast(Client, conn))
+    new_session = await agent.new_session(cwd=str(tmp_path))
+
+    await agent.prompt(session_id=new_session.session_id, prompt=[{"type": "text", "text": "make a plan"}])  # pyright: ignore[reportArgumentType]
+
+    assert conn.permission_calls
+    content = conn.permission_calls[0][1].content[0].content
+    assert content.type == "text"
+    assert content.text == plan_text

--- a/tests/acp/test_plan_mode.py
+++ b/tests/acp/test_plan_mode.py
@@ -334,6 +334,7 @@ async def test_rebuild_agent_persists_live_history_first(tmp_path: Path) -> None
             restore: bool,
             permission_callback: Any,
             permission_mode: Any = None,
+            question_state: Any = None,
         ) -> tuple[Any, Any]:
             captured["history"] = record.history
             return session.agent, session.manager

--- a/tests/acp/test_plan_mode.py
+++ b/tests/acp/test_plan_mode.py
@@ -219,3 +219,33 @@ async def test_plan_approval_discuss_keeps_mode_and_sets_reofferable(tmp_path: P
     assert session.record.plan_pending is False
     assert session.record.plan_reofferable is True
     assert factory.interaction_mode_calls == []
+
+
+@pytest.mark.asyncio
+async def test_plan_approval_clear_wipes_history(tmp_path: Path) -> None:
+    from acp.schema import RequestPermissionResponse
+
+    plan_text = "## Step one"
+    session, _cm = _make_session(tmp_path, StreamingLLM(events=[_text_event(plan_text)]))
+    session.record.interaction_mode = MODE_PLAN
+    holder = {"plan": plan_text}
+    setattr(session.agent, "consume_completed_plan", lambda: holder.pop("plan", None))
+    factory = _FakeFactory(session)
+    conn = _FakeConn()
+
+    async def implement_clear(*a: Any, **k: Any) -> Any:
+        return RequestPermissionResponse.model_validate(
+            {"outcome": {"outcome": "selected", "optionId": "implement_plan_clear"}}
+        )
+
+    conn.request_permission = implement_clear  # type: ignore[method-assign]
+    agent = AcpAgent(factory=cast(Any, factory))
+    agent.on_connect(cast(Client, conn))
+    new_session = await agent.new_session(cwd=str(tmp_path))
+
+    await agent.prompt(session_id=new_session.session_id, prompt=[{"type": "text", "text": "make a plan"}])  # pyright: ignore[reportArgumentType]
+
+    assert session.record.plan_pending is False
+    assert not any("make a plan" in msg.get_text_content() for msg in session.agent.history)
+    assert sum("Step one" in msg.get_text_content() for msg in session.agent.history) == 1
+    assert factory.interaction_mode_calls == [(new_session.session_id, MODE_BUILD)]

--- a/tests/acp/test_plan_mode.py
+++ b/tests/acp/test_plan_mode.py
@@ -43,16 +43,16 @@ def test_plan_entries_from_markdown_empty() -> None:
 
 
 @pytest.mark.asyncio
-async def test_new_session_advertises_modes(tmp_path: Path) -> None:
+async def test_new_session_does_not_advertise_modes_field(tmp_path: Path) -> None:
     session, _cm = _make_session(tmp_path, StreamingLLM())
     agent = AcpAgent(factory=cast(Any, _FakeFactory(session)))
     agent.on_connect(cast(Client, _FakeConn()))
 
     response = await agent.new_session(cwd=str(tmp_path))
 
-    assert response.modes is not None
-    assert response.modes.current_mode_id == MODE_BUILD
-    assert [mode.id for mode in response.modes.available_modes] == [MODE_BUILD, MODE_PLAN]
+    # Mode switching rides the config-options surface (Zed 1.16 renders either
+    # config options or the modes/model selector surface, never both).
+    assert response.modes is None
 
 
 @pytest.mark.asyncio

--- a/tests/acp/test_plan_mode.py
+++ b/tests/acp/test_plan_mode.py
@@ -1,0 +1,132 @@
+"""Plan/build mode tests: session modes, mode switching, plan updates."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from acp.exceptions import RequestError
+from acp.interfaces import Client
+from acp.schema import AgentPlanUpdate, CurrentModeUpdate, SetSessionModeResponse
+
+from kolega_code.acp.agent_factory import MODE_BUILD, MODE_PLAN, agent_class_for
+from kolega_code.acp.plans import plan_entries_from_markdown
+from kolega_code.acp.server import AcpAgent
+
+from tests.acp.test_server import StreamingLLM, _FakeConn, _FakeFactory, _make_agent, _make_session, _text_event
+
+
+def test_agent_class_choice() -> None:
+    from kolega_code.agent.planningagent import PlanningAgent
+
+    assert agent_class_for(MODE_PLAN) is PlanningAgent
+    assert agent_class_for(MODE_BUILD).__name__ == "CoderAgent"
+    assert agent_class_for("anything-else").__name__ == "CoderAgent"
+
+
+def test_plan_entries_from_markdown_parses_headings() -> None:
+    text = "# Big plan\n\n## Step one\nbody\n## Step two\nmore\n### Nested"
+    entries = plan_entries_from_markdown(text)
+    assert [entry.content for entry in entries] == ["Big plan", "Step one", "Step two", "Nested"]
+    assert all(entry.status == "pending" for entry in entries)
+
+
+def test_plan_entries_from_markdown_falls_back_to_single_entry() -> None:
+    entries = plan_entries_from_markdown("A plan without headings, just prose.")
+    assert [entry.content for entry in entries] == ["A plan without headings, just prose."]
+
+
+def test_plan_entries_from_markdown_empty() -> None:
+    assert plan_entries_from_markdown("") == []
+
+
+@pytest.mark.asyncio
+async def test_new_session_advertises_modes(tmp_path: Path) -> None:
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    agent = AcpAgent(factory=cast(Any, _FakeFactory(session)))
+    agent.on_connect(cast(Client, _FakeConn()))
+
+    response = await agent.new_session(cwd=str(tmp_path))
+
+    assert response.modes is not None
+    assert response.modes.current_mode_id == MODE_BUILD
+    assert [mode.id for mode in response.modes.available_modes] == [MODE_BUILD, MODE_PLAN]
+
+
+@pytest.mark.asyncio
+async def test_set_session_mode_switches_and_updates_client(tmp_path: Path) -> None:
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    factory = _FakeFactory(session)
+    conn = _FakeConn()
+    agent = AcpAgent(factory=cast(Any, factory))
+    agent.on_connect(cast(Client, conn))
+    new_session = await agent.new_session(cwd=str(tmp_path))
+
+    response = await agent.set_session_mode(new_session.session_id, MODE_PLAN)
+
+    assert isinstance(response, SetSessionModeResponse)
+    assert factory.interaction_mode_calls == [(new_session.session_id, MODE_PLAN)]
+    updates = conn.updates
+    assert any(isinstance(update, CurrentModeUpdate) and update.current_mode_id == MODE_PLAN for update in updates)
+    assert not any(isinstance(update, AgentPlanUpdate) for update in updates)  # entering plan clears nothing
+
+
+@pytest.mark.asyncio
+async def test_set_session_mode_build_clears_plan(tmp_path: Path) -> None:
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    factory = _FakeFactory(session)
+    conn = _FakeConn()
+    agent = AcpAgent(factory=cast(Any, factory))
+    agent.on_connect(cast(Client, conn))
+    new_session = await agent.new_session(cwd=str(tmp_path))
+
+    await agent.set_session_mode(new_session.session_id, MODE_BUILD)
+
+    plans = [update for update in conn.updates if isinstance(update, AgentPlanUpdate)]
+    assert len(plans) == 1
+    assert plans[0].entries == []
+
+
+@pytest.mark.asyncio
+async def test_set_session_mode_rejects_unknown_mode(tmp_path: Path) -> None:
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    agent = AcpAgent(factory=cast(Any, _FakeFactory(session)))
+    new_session = await agent.new_session(cwd=str(tmp_path))
+
+    with pytest.raises(RequestError):
+        await agent.set_session_mode(new_session.session_id, "vibe")
+
+
+@pytest.mark.asyncio
+async def test_set_session_mode_rejects_active_turn(tmp_path: Path) -> None:
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    agent = AcpAgent(factory=cast(Any, _FakeFactory(session)))
+    new_session = await agent.new_session(cwd=str(tmp_path))
+
+    async def _forever() -> None:
+        await asyncio.Event().wait()
+
+    registered = agent._sessions[new_session.session_id]  # noqa: SLF001
+    registered.turn_task = asyncio.create_task(_forever())
+    try:
+        with pytest.raises(RequestError):
+            await agent.set_session_mode(new_session.session_id, MODE_PLAN)
+    finally:
+        registered.turn_task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_plan_turn_emits_plan_update(tmp_path: Path) -> None:
+    plan_text = "## Investigate the repo\nDetails.\n## Propose a design\nMore details."
+    session, _cm = _make_session(tmp_path, StreamingLLM(events=[_text_event(plan_text)]))
+    session.record.interaction_mode = MODE_PLAN
+    agent, conn = _make_agent(session)
+    new_session = await agent.new_session(cwd=str(tmp_path))
+
+    await agent.prompt(session_id=new_session.session_id, prompt=[{"type": "text", "text": "make a plan"}])  # pyright: ignore[reportArgumentType]
+
+    plans = [update for update in conn.updates if isinstance(update, AgentPlanUpdate)]
+    assert plans
+    assert [entry.content for entry in plans[-1].entries] == ["Investigate the repo", "Propose a design"]

--- a/tests/acp/test_questions.py
+++ b/tests/acp/test_questions.py
@@ -1,0 +1,172 @@
+"""ask_user_choice over ACP elicitation: tool extension + server bridge."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from acp.interfaces import Client
+from acp.schema import (
+    AcceptElicitationResponse,
+    ClientCapabilities,
+    DeclineElicitationResponse,
+    ElicitationCapabilities,
+    ElicitationFormCapabilities,
+)
+
+from kolega_code.acp.questions import QUESTION_TOOL_NAME, build_question_extension
+from kolega_code.acp.server import AcpAgent
+from kolega_code.tools import ToolError
+
+from tests.acp.test_server import StreamingLLM, _FakeFactory, _make_session
+
+_QUESTIONS = [
+    {
+        "question": "Which approach?",
+        "header": "approach",
+        "options": [
+            {"label": "Conservative", "description": "safer"},
+            {"label": "Aggressive", "description": "faster"},
+        ],
+    },
+    {
+        "question": "Ship it?",
+        "header": "",
+        "options": [{"label": "Yes", "description": ""}, {"label": "No", "description": ""}],
+    },
+]
+
+
+@pytest.mark.asyncio
+async def test_question_extension_elicits_each_question_in_order() -> None:
+    state: dict[str, Any] = {}
+    calls: list[tuple[str, list[str], list[str]]] = []
+
+    async def elicit(question: str, labels: list[str], descriptions: list[str]) -> str:
+        calls.append((question, labels, descriptions))
+        return labels[len(calls) - 1]
+
+    state["elicit"] = elicit
+    extension = build_question_extension(state)
+
+    result = json.loads(await extension.tools[QUESTION_TOOL_NAME](_QUESTIONS))
+    assert result == {"approach": "Conservative", "Ship it?": "No"}
+    assert [call[0] for call in calls] == ["Which approach?", "Ship it?"]
+    assert [call[1] for call in calls] == [["Conservative", "Aggressive"], ["Yes", "No"]]
+    assert state.get("pending") is False
+
+
+@pytest.mark.asyncio
+async def test_question_extension_rejects_when_pending() -> None:
+    state: dict[str, Any] = {"pending": True, "elicit": _stub_elicit}
+    extension = build_question_extension(state)
+
+    with pytest.raises(ToolError, match="already waiting"):
+        await extension.tools[QUESTION_TOOL_NAME](_QUESTIONS[:1])
+
+
+@pytest.mark.asyncio
+async def test_question_extension_errors_without_client_support() -> None:
+    extension = build_question_extension({})
+
+    with pytest.raises(ToolError, match="does not support"):
+        await extension.tools[QUESTION_TOOL_NAME](_QUESTIONS[:1])
+
+
+@pytest.mark.asyncio
+async def test_question_extension_resets_pending_on_decline() -> None:
+    state: dict[str, Any] = {}
+
+    async def elicit(question: str, labels: list[str], descriptions: list[str]) -> str:
+        raise ToolError("declined")
+
+    state["elicit"] = elicit
+    extension = build_question_extension(state)
+
+    with pytest.raises(ToolError, match="declined"):
+        await extension.tools[QUESTION_TOOL_NAME](_QUESTIONS[:1])
+    assert state.get("pending") is False
+
+
+class _ElicitConn:
+    def __init__(self, responses: list[Any]) -> None:
+        self.responses = responses
+        self.calls: list[tuple[str, Any]] = []
+        self.updates: list[Any] = []
+
+    async def create_elicitation(self, message: str, mode: Any, **kwargs: Any) -> Any:
+        self.calls.append((message, mode))
+        return self.responses.pop(0)
+
+    async def session_update(self, session_id: str, update: Any, source: str = "") -> None:
+        self.updates.append(update)
+
+
+@pytest.mark.asyncio
+async def test_elicit_answer_gates_on_client_capabilities(tmp_path: Path) -> None:
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    agent = AcpAgent(factory=cast(Any, _FakeFactory(session)))
+
+    with pytest.raises(ToolError, match="does not support"):
+        await agent._elicit_answer(session.session_id, "Q?", ["A", "B"], ["", ""])  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_elicit_answer_returns_accepted_option(tmp_path: Path) -> None:
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    agent = AcpAgent(factory=cast(Any, _FakeFactory(session)))
+    await agent.initialize(
+        protocol_version=1,
+        client_capabilities=ClientCapabilities(elicitation=ElicitationCapabilities(form=ElicitationFormCapabilities())),
+    )
+    conn = _ElicitConn([AcceptElicitationResponse(action="accept", content={"answer": "B"})])
+    agent.on_connect(cast(Client, conn))
+
+    answer = await agent._elicit_answer(session.session_id, "Pick one", ["A", "B"], ["", ""])  # noqa: SLF001
+
+    assert answer == "B"
+    message, mode = conn.calls[0]
+    assert message == "Pick one"
+    assert mode.session_id == session.session_id
+    schema = mode.requested_schema
+    assert schema.required == ["answer"]
+    assert [option.const for option in schema.properties["answer"].one_of or []] == ["A", "B"]
+
+
+@pytest.mark.asyncio
+async def test_elicit_answer_errors_on_decline(tmp_path: Path) -> None:
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    agent = AcpAgent(factory=cast(Any, _FakeFactory(session)))
+    await agent.initialize(
+        protocol_version=1,
+        client_capabilities=ClientCapabilities(elicitation=ElicitationCapabilities(form=ElicitationFormCapabilities())),
+    )
+    conn = _ElicitConn([DeclineElicitationResponse(action="decline")])
+    agent.on_connect(cast(Client, conn))
+
+    with pytest.raises(ToolError, match="declined"):
+        await agent._elicit_answer(session.session_id, "Q?", ["A", "B"], ["", ""])  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_new_session_binds_elicit(tmp_path: Path) -> None:
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    agent = AcpAgent(factory=cast(Any, _FakeFactory(session)))
+    await agent.initialize(
+        protocol_version=1,
+        client_capabilities=ClientCapabilities(elicitation=ElicitationCapabilities(form=ElicitationFormCapabilities())),
+    )
+    conn = _ElicitConn([AcceptElicitationResponse(action="accept", content={"answer": "A"})])
+    agent.on_connect(cast(Client, conn))
+    response = await agent.new_session(cwd=str(tmp_path))
+    registered = agent._sessions[response.session_id]  # noqa: SLF001
+
+    answer = await registered.question_state["elicit"]("Q?", ["A", "B"], ["", ""])
+    assert answer == "A"
+    assert conn.calls[0][1].session_id == response.session_id
+
+
+async def _stub_elicit(question: str, labels: list[str], descriptions: list[str]) -> str:
+    return labels[0]

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -107,6 +107,7 @@ class _FakeFactory:
         self._session = session
         self.config_options: list[Any] = []
         self.permission_mode_calls: list[tuple[str, Any]] = []
+        self.interaction_mode_calls: list[tuple[str, str]] = []
         self.model_calls: list[tuple[str, str, str]] = []
 
     async def open_session(
@@ -129,6 +130,10 @@ class _FakeFactory:
 
     async def set_permission_mode(self, session: AcpSession, mode: Any) -> None:
         self.permission_mode_calls.append((session.session_id, mode))
+
+    async def set_interaction_mode(self, session: AcpSession, mode: str) -> None:
+        self.interaction_mode_calls.append((session.session_id, mode))
+        session.record.interaction_mode = mode
 
     async def apply_model(self, session: AcpSession, provider: str, model: str) -> None:
         self.model_calls.append((session.session_id, provider, model))

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -15,14 +15,16 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from acp.interfaces import Client
-from acp.schema import AgentMessageChunk
+from acp.schema import AgentMessageChunk, RequestPermissionResponse
 
+from kolega_code.acp.permissions import OPTION_ALLOW_ONCE
 from kolega_code.acp.server import AcpAgent
 from kolega_code.acp.session import AcpSession
 from kolega_code.cli.connection import CliConnectionManager
 from kolega_code.cli.session_store import SessionRecord
 from kolega_code.llm.models import Message, TextBlock
 from kolega_code.llm.providers.models import TokenCount
+from kolega_code.permissions import PermissionKind, PermissionRequest
 
 from tests.agent.compaction_helpers import build_agent
 
@@ -30,9 +32,16 @@ from tests.agent.compaction_helpers import build_agent
 class _FakeConn:
     def __init__(self) -> None:
         self.updates: list[Any] = []
+        self.permission_calls: list[tuple[str, Any, list[Any]]] = []
 
     async def session_update(self, session_id: str, update: Any, source: str = "") -> None:
         self.updates.append(update)
+
+    async def request_permission(self, session_id: str, tool_call: Any, options: list[Any], **kwargs: Any) -> Any:
+        self.permission_calls.append((session_id, tool_call, options))
+        return RequestPermissionResponse.model_validate(
+            {"outcome": {"outcome": "selected", "optionId": OPTION_ALLOW_ONCE}}
+        )
 
 
 class EventStream:
@@ -97,8 +106,20 @@ class _FakeFactory:
     def __init__(self, session: AcpSession) -> None:
         self._session = session
 
-    async def open_session(self, cwd: str) -> AcpSession:
-        return self._session
+    async def open_session(
+        self,
+        cwd: str,
+        *,
+        session_id: str | None = None,
+        permission_callback: Any = None,
+    ) -> AcpSession:
+        resolved_id = session_id or self._session.session_id
+        return AcpSession(
+            session_id=resolved_id,
+            record=self._session.record,
+            agent=self._session.agent,
+            manager=self._session.manager,
+        )
 
     def persist(self, session: AcpSession) -> None:
         pass
@@ -131,9 +152,9 @@ async def test_prompt_streams_text_and_completes(tmp_path: Path) -> None:
     llm = StreamingLLM(events=[_text_event("hello " * 12)])  # >50 chars guarantees a chunk yield
     session, _cm = _make_session(tmp_path, llm)
     agent, conn = _make_agent(session)
-    await agent.new_session(cwd=str(tmp_path))
+    new_session = await agent.new_session(cwd=str(tmp_path))
 
-    response = await agent.prompt(session_id=session.session_id, prompt=[{"type": "text", "text": "hi"}])  # pyright: ignore[reportArgumentType]
+    response = await agent.prompt(session_id=new_session.session_id, prompt=[{"type": "text", "text": "hi"}])  # pyright: ignore[reportArgumentType]
 
     assert response.stop_reason == "end_turn"
     texts = [u.content.text for u in conn.updates if isinstance(u, AgentMessageChunk)]
@@ -147,13 +168,13 @@ async def test_cancel_interrupts_turn_with_cancelled_stop_reason(tmp_path: Path)
     blocking.stream = AsyncMock(side_effect=lambda *a, **k: BlockingStream())
     session, _cm = _make_session(tmp_path, blocking)
     agent, _conn = _make_agent(session)
-    await agent.new_session(cwd=str(tmp_path))
+    new_session = await agent.new_session(cwd=str(tmp_path))
 
     prompt_task = asyncio.create_task(
-        agent.prompt(session_id=session.session_id, prompt=[{"type": "text", "text": "hi"}])  # pyright: ignore[reportArgumentType],
+        agent.prompt(session_id=new_session.session_id, prompt=[{"type": "text", "text": "hi"}])  # pyright: ignore[reportArgumentType],
     )
     await asyncio.sleep(0.05)
-    await agent.cancel(session_id=session.session_id)
+    await agent.cancel(session_id=new_session.session_id)
     response = await prompt_task
 
     assert response.stop_reason == "cancelled"
@@ -186,7 +207,13 @@ async def test_new_session_converts_config_errors_to_protocol_errors(tmp_path: P
     from kolega_code.cli.config import CliConfigError
 
     class _RaisingFactory(_FakeFactory):
-        async def open_session(self, cwd: str) -> AcpSession:
+        async def open_session(
+            self,
+            cwd: str,
+            *,
+            session_id: str | None = None,
+            permission_callback: Any = None,
+        ) -> AcpSession:
             raise CliConfigError("no model configured")
 
     session, _cm = _make_session(tmp_path, StreamingLLM())
@@ -200,4 +227,31 @@ async def test_new_session_registers_and_returns_session_id(tmp_path: Path) -> N
     session, _cm = _make_session(tmp_path, StreamingLLM())
     agent, _conn = _make_agent(session)
     response = await agent.new_session(cwd=str(tmp_path))
-    assert response.session_id == session.session_id
+    assert response.session_id
+    assert response.session_id != session.session_id
+    assert agent._sessions[response.session_id].agent is session.agent  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_permission_callback_prompts_through_client(tmp_path: Path) -> None:
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    agent, conn = _make_agent(session)
+    new_session = await agent.new_session(cwd=str(tmp_path))
+    session.agent.current_tool_call_id = "call-9"
+
+    callback = agent._permission_callback_for(new_session.session_id)  # noqa: SLF001
+    decision = await callback(
+        PermissionRequest(
+            kind=PermissionKind.COMMAND,
+            tool_name="exec_command",
+            inputs={"command": "echo hi"},
+            command="echo hi",
+        ),
+    )
+
+    assert decision.allowed is True
+    assert len(conn.permission_calls) == 1
+    prompted_session_id, tool_call, options = conn.permission_calls[0]
+    assert prompted_session_id == new_session.session_id
+    assert tool_call.tool_call_id == "call-9"
+    assert options[0].kind == "allow_once"

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -309,6 +309,13 @@ async def test_load_session_replays_transcript(tmp_path: Path) -> None:
     await store.append(
         AgentEvent(event_type="turn_ended", sender="agent", content={"turn_id": "t1", "status": "completed"})
     )
+    await store.append(
+        AgentEvent(
+            event_type="compaction_status",
+            sender="agent",
+            content={"phase": "finished", "message": "done", "summary": "compressed 12 turns"},
+        )
+    )
 
     factory = _FakeFactory(session)
     factory.event_store = lambda session_id: store  # type: ignore[method-assign]
@@ -331,6 +338,11 @@ async def test_load_session_replays_transcript(tmp_path: Path) -> None:
     assert users[0].message_id
     assert agents and agents[0].content.text == "hi there"
     assert agents[0].message_id
+    # The last finished compaction renders as a thought block on restore.
+    from acp.schema import AgentThoughtChunk
+
+    thoughts = [u for u in conn.updates if isinstance(u, AgentThoughtChunk)]
+    assert thoughts and "compressed 12 turns" in thoughts[-1].content.text
     # The replay follows the initial usage update and precedes the response:
     # user prompt first, then the agent's reply.
     assert [

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -277,3 +277,63 @@ async def test_permission_callback_prompts_through_client(tmp_path: Path) -> Non
     assert prompted_session_id == new_session.session_id
     assert tool_call.tool_call_id == "call-9"
     assert options[0].kind == "allow_once"
+
+
+@pytest.mark.asyncio
+async def test_load_session_replays_transcript(tmp_path: Path) -> None:
+    from acp.schema import AgentMessageChunk, LoadSessionResponse, UserMessageChunk
+
+    from kolega_code.cli.session_event_store import FileSessionEventStore
+    from kolega_code.cli.session_journal import SessionJournal
+    from kolega_code.events import AgentEvent
+
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    journal = SessionJournal(session.session_id, tmp_path / "journal")
+    journal.start_epoch("test")
+    store = FileSessionEventStore(journal)
+    await store.append(
+        AgentEvent(
+            event_type="turn_started",
+            sender="agent",
+            content={"turn_id": "t1", "user_text": "hello"},
+        )
+    )
+    await store.append(
+        AgentEvent(
+            event_type="assistant_delta",
+            sender="agent",
+            content={"text": "hi there", "complete": True},
+            uuid="u1",
+        )
+    )
+    await store.append(
+        AgentEvent(event_type="turn_ended", sender="agent", content={"turn_id": "t1", "status": "completed"})
+    )
+
+    factory = _FakeFactory(session)
+    factory.event_store = lambda session_id: store  # type: ignore[method-assign]
+
+    async def _load(cwd: str, session_id: str, *, permission_callback: Any = None) -> AcpSession:
+        return session
+
+    factory.load_session = _load  # type: ignore[method-assign]
+
+    conn = _FakeConn()
+    agent = AcpAgent(factory=cast(Any, factory))
+    agent.on_connect(cast(Client, conn))
+
+    response = await agent.load_session(cwd=str(tmp_path), session_id=session.session_id)
+
+    assert isinstance(response, LoadSessionResponse)
+    users = [u for u in conn.updates if isinstance(u, UserMessageChunk)]
+    agents = [u for u in conn.updates if isinstance(u, AgentMessageChunk)]
+    assert users and users[0].content.text == "hello"
+    assert users[0].message_id
+    assert agents and agents[0].content.text == "hi there"
+    assert agents[0].message_id
+    # The replay follows the initial usage update and precedes the response:
+    # user prompt first, then the agent's reply.
+    assert [type(u).__name__ for u in conn.updates if type(u).__name__ != "UsageUpdate"][:2] == [
+        "UserMessageChunk",
+        "AgentMessageChunk",
+    ]

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -361,7 +361,14 @@ async def test_new_session_advertises_slash_commands(tmp_path: Path) -> None:
     agent, conn = _make_agent(session)
     await agent.new_session(cwd=str(tmp_path))
 
-    updates = [u for u in conn.updates if isinstance(u, AvailableCommandsUpdate)]
+    # The command list goes out just after the NewSessionResponse (clients
+    # like Zed drop pre-response notifications for session/new).
+    updates: list[Any] = []
+    for _ in range(100):
+        updates = [u for u in conn.updates if isinstance(u, AvailableCommandsUpdate)]
+        if updates:
+            break
+        await asyncio.sleep(0.02)
     assert len(updates) == 1
     names = [command.name for command in updates[0].available_commands]
     assert names == ["help", "compress", "clear", "reset", "context"]

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1,0 +1,203 @@
+"""In-process tests for the ACP server's real turn loop (Phase 1).
+
+No network and no settings: a fake factory hands the server an ``AcpSession``
+whose agent runs on a scripted fake LLM. The protocol client is faked, so
+these tests assert the full prompt -> stream -> complete (and cancel) flow.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from acp.interfaces import Client
+from acp.schema import AgentMessageChunk
+
+from kolega_code.acp.server import AcpAgent
+from kolega_code.acp.session import AcpSession
+from kolega_code.cli.connection import CliConnectionManager
+from kolega_code.cli.session_store import SessionRecord
+from kolega_code.llm.models import Message, TextBlock
+from kolega_code.llm.providers.models import TokenCount
+
+from tests.agent.compaction_helpers import build_agent
+
+
+class _FakeConn:
+    def __init__(self) -> None:
+        self.updates: list[Any] = []
+
+    async def session_update(self, session_id: str, update: Any, source: str = "") -> None:
+        self.updates.append(update)
+
+
+class EventStream:
+    """LLM stream that yields scripted raw events, then a final message."""
+
+    def __init__(self, events: list[Any], final: Message) -> None:
+        self._events = events
+        self._final = final
+
+    async def __aenter__(self) -> EventStream:
+        return self
+
+    async def __aexit__(self, *exc: Any) -> bool:
+        return False
+
+    def __aiter__(self) -> EventStream:
+        return self
+
+    async def __anext__(self) -> Any:
+        if self._events:
+            return self._events.pop(0)
+        raise StopAsyncIteration
+
+    async def get_final_message(self) -> Message:
+        return self._final
+
+
+class BlockingStream(EventStream):
+    """Stream whose next event blocks until cancelled (for cancel tests)."""
+
+    def __init__(self) -> None:
+        self._gate = asyncio.Event()
+        super().__init__([], Message(role="assistant", content=[TextBlock(text="ok")], stop_reason="end_turn"))
+
+    async def __anext__(self) -> Any:
+        await self._gate.wait()
+        raise StopAsyncIteration
+
+
+class StreamingLLM:
+    """Drop-in ``agent.llm`` scripting one turn of stream events."""
+
+    def __init__(self, events: list[Any] | None = None, final_text: str = "done") -> None:
+        self._events = list(events or [])
+        self._final = Message(role="assistant", content=[TextBlock(text=final_text)], stop_reason="end_turn")
+        self.provider = MagicMock(base_url="https://api.test.example/v1")
+        self.count_tokens = AsyncMock(return_value=TokenCount(input_tokens=0))
+        self.generate = AsyncMock(return_value=self._final)
+        self.stream = AsyncMock(side_effect=self._stream)
+
+    async def _stream(self, *args: Any, **kwargs: Any) -> EventStream:
+        return EventStream(self._events, self._final)
+
+
+def _text_event(text: str) -> SimpleNamespace:
+    return SimpleNamespace(type="text", text=text)
+
+
+class _FakeFactory:
+    """Factory stub returning one prebuilt session; the server only calls open_session."""
+
+    def __init__(self, session: AcpSession) -> None:
+        self._session = session
+
+    async def open_session(self, cwd: str) -> AcpSession:
+        return self._session
+
+    def persist(self, session: AcpSession) -> None:
+        pass
+
+
+def _make_session(tmp_path: Path, llm: Any) -> tuple[AcpSession, CliConnectionManager]:
+    manager = CliConnectionManager()
+    agent, cm = build_agent(tmp_path, connection_manager=manager, llm=llm)
+    record = SessionRecord.create(Path(tmp_path), "cli", {})
+    session = AcpSession(session_id=record.session_id, record=record, agent=agent, manager=cm)
+    return session, cm
+
+
+def _make_agent(session: AcpSession) -> tuple[AcpAgent, _FakeConn]:
+    conn = _FakeConn()
+    agent = AcpAgent(factory=_FakeFactory(session))  # pyright: ignore[reportArgumentType]
+    agent.on_connect(cast(Client, conn))
+    return agent, conn
+
+
+@pytest.mark.asyncio
+async def test_initialize_echoes_protocol_version() -> None:
+    agent = AcpAgent(factory=_FakeFactory(cast(AcpSession, None)))  # pyright: ignore[reportArgumentType]
+    response = await agent.initialize(protocol_version=1, client_capabilities=None)
+    assert response.protocol_version == 1
+
+
+@pytest.mark.asyncio
+async def test_prompt_streams_text_and_completes(tmp_path: Path) -> None:
+    llm = StreamingLLM(events=[_text_event("hello " * 12)])  # >50 chars guarantees a chunk yield
+    session, _cm = _make_session(tmp_path, llm)
+    agent, conn = _make_agent(session)
+    await agent.new_session(cwd=str(tmp_path))
+
+    response = await agent.prompt(session_id=session.session_id, prompt=[{"type": "text", "text": "hi"}])  # pyright: ignore[reportArgumentType]
+
+    assert response.stop_reason == "end_turn"
+    texts = [u.content.text for u in conn.updates if isinstance(u, AgentMessageChunk)]
+    assert texts, "expected streamed agent text"
+    assert "hello" in "".join(texts)
+
+
+@pytest.mark.asyncio
+async def test_cancel_interrupts_turn_with_cancelled_stop_reason(tmp_path: Path) -> None:
+    blocking = StreamingLLM(events=[])
+    blocking.stream = AsyncMock(side_effect=lambda *a, **k: BlockingStream())
+    session, _cm = _make_session(tmp_path, blocking)
+    agent, _conn = _make_agent(session)
+    await agent.new_session(cwd=str(tmp_path))
+
+    prompt_task = asyncio.create_task(
+        agent.prompt(session_id=session.session_id, prompt=[{"type": "text", "text": "hi"}])  # pyright: ignore[reportArgumentType],
+    )
+    await asyncio.sleep(0.05)
+    await agent.cancel(session_id=session.session_id)
+    response = await prompt_task
+
+    assert response.stop_reason == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_prompt_rejects_unknown_session() -> None:
+    from acp.exceptions import RequestError
+
+    session, _cm = _make_session(Path("/tmp"), StreamingLLM())
+    agent, _conn = _make_agent(session)
+    with pytest.raises(RequestError):
+        await agent.prompt(session_id="nope", prompt=[{"type": "text", "text": "hi"}])  # pyright: ignore[reportArgumentType]
+
+
+@pytest.mark.asyncio
+async def test_prompt_rejects_empty_text() -> None:
+    from acp.exceptions import RequestError
+
+    session, _cm = _make_session(Path("/tmp"), StreamingLLM())
+    agent, _conn = _make_agent(session)
+    with pytest.raises(RequestError):
+        await agent.prompt(session_id=session.session_id, prompt=[{"type": "text", "text": ""}])  # pyright: ignore[reportArgumentType]
+
+
+@pytest.mark.asyncio
+async def test_new_session_converts_config_errors_to_protocol_errors(tmp_path: Path) -> None:
+    from acp.exceptions import RequestError
+
+    from kolega_code.cli.config import CliConfigError
+
+    class _RaisingFactory(_FakeFactory):
+        async def open_session(self, cwd: str) -> AcpSession:
+            raise CliConfigError("no model configured")
+
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    agent = AcpAgent(factory=_RaisingFactory(session))  # pyright: ignore[reportArgumentType]
+    with pytest.raises(RequestError):
+        await agent.new_session(cwd=str(tmp_path))
+
+
+@pytest.mark.asyncio
+async def test_new_session_registers_and_returns_session_id(tmp_path: Path) -> None:
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    agent, _conn = _make_agent(session)
+    response = await agent.new_session(cwd=str(tmp_path))
+    assert response.session_id == session.session_id

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -141,10 +141,16 @@ def _make_agent(session: AcpSession) -> tuple[AcpAgent, _FakeConn]:
 
 
 @pytest.mark.asyncio
-async def test_initialize_echoes_protocol_version() -> None:
+async def test_initialize_echoes_protocol_version_and_advertises_load() -> None:
     agent = AcpAgent(factory=_FakeFactory(cast(AcpSession, None)))  # pyright: ignore[reportArgumentType]
     response = await agent.initialize(protocol_version=1, client_capabilities=None)
     assert response.protocol_version == 1
+    capabilities = response.agent_capabilities
+    assert capabilities is not None
+    assert capabilities.load_session is True
+    assert capabilities.session_capabilities is not None
+    assert capabilities.session_capabilities.list is not None
+    assert capabilities.session_capabilities.close is not None
 
 
 @pytest.mark.asyncio

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -39,9 +39,8 @@ class _FakeConn:
 
     async def request_permission(self, session_id: str, tool_call: Any, options: list[Any], **kwargs: Any) -> Any:
         self.permission_calls.append((session_id, tool_call, options))
-        return RequestPermissionResponse.model_validate(
-            {"outcome": {"outcome": "selected", "optionId": OPTION_ALLOW_ONCE}}
-        )
+        option_id = options[0].option_id if options else OPTION_ALLOW_ONCE
+        return RequestPermissionResponse.model_validate({"outcome": {"outcome": "selected", "optionId": option_id}})
 
 
 class EventStream:

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -333,7 +333,23 @@ async def test_load_session_replays_transcript(tmp_path: Path) -> None:
     assert agents[0].message_id
     # The replay follows the initial usage update and precedes the response:
     # user prompt first, then the agent's reply.
-    assert [type(u).__name__ for u in conn.updates if type(u).__name__ != "UsageUpdate"][:2] == [
+    assert [
+        type(u).__name__ for u in conn.updates if type(u).__name__ not in ("UsageUpdate", "AvailableCommandsUpdate")
+    ][:2] == [
         "UserMessageChunk",
         "AgentMessageChunk",
     ]
+
+
+@pytest.mark.asyncio
+async def test_new_session_advertises_slash_commands(tmp_path: Path) -> None:
+    from acp.schema import AvailableCommandsUpdate
+
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    agent, conn = _make_agent(session)
+    await agent.new_session(cwd=str(tmp_path))
+
+    updates = [u for u in conn.updates if isinstance(u, AvailableCommandsUpdate)]
+    assert len(updates) == 1
+    names = [command.name for command in updates[0].available_commands]
+    assert names == ["help", "compress", "clear", "reset", "context"]

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -105,6 +105,9 @@ class _FakeFactory:
 
     def __init__(self, session: AcpSession) -> None:
         self._session = session
+        self.config_options: list[Any] = []
+        self.permission_mode_calls: list[tuple[str, Any]] = []
+        self.model_calls: list[tuple[str, str, str]] = []
 
     async def open_session(
         self,
@@ -120,6 +123,15 @@ class _FakeFactory:
             agent=self._session.agent,
             manager=self._session.manager,
         )
+
+    def config_options_for(self, session: AcpSession) -> list[Any]:
+        return self.config_options
+
+    async def set_permission_mode(self, session: AcpSession, mode: Any) -> None:
+        self.permission_mode_calls.append((session.session_id, mode))
+
+    async def apply_model(self, session: AcpSession, provider: str, model: str) -> None:
+        self.model_calls.append((session.session_id, provider, model))
 
     def persist(self, session: AcpSession) -> None:
         pass

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -365,3 +365,75 @@ async def test_new_session_advertises_slash_commands(tmp_path: Path) -> None:
     assert len(updates) == 1
     names = [command.name for command in updates[0].available_commands]
     assert names == ["help", "compress", "clear", "reset", "context"]
+
+
+@pytest.mark.asyncio
+async def test_load_sub_session_replays_delegated_turn(tmp_path: Path) -> None:
+    from acp.schema import AgentMessageChunk, AgentThoughtChunk, LoadSessionResponse, UserMessageChunk
+
+    from kolega_code.acp.bridge import sub_session_id
+    from kolega_code.cli.session_event_store import FileSessionEventStore
+    from kolega_code.cli.session_journal import SessionJournal
+    from kolega_code.events import AgentEvent
+
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    journal = SessionJournal(session.session_id, tmp_path / "journal")
+    journal.start_epoch("test")
+    store = FileSessionEventStore(journal)
+    await store.append(
+        AgentEvent(
+            event_type="chat_message",
+            sender="agent",
+            content={
+                "message_type": "tool_call",
+                "text": "Calling dispatch_agent",
+                "tool_description": "dispatch_agent",
+                "tool_call_id": "tc1",
+            },
+        )
+    )
+    await store.append(
+        AgentEvent(
+            event_type="assistant_delta",
+            sender="agent",
+            uuid="sa1",
+            content={"text": "Found three issues", "complete": True},
+            sub_agent_info={
+                "agent_id": "a1",
+                "agent_name": "review",
+                "task": "Review the diff",
+                "parent_tool_call_id": "tc1",
+            },
+        )
+    )
+    await store.append(
+        AgentEvent(
+            event_type="thinking_delta",
+            sender="agent",
+            uuid="st1",
+            content={"text": "hmm", "complete": True},
+            sub_agent_info={"agent_id": "a1", "parent_tool_call_id": "tc1"},
+        )
+    )
+    await store.append(
+        AgentEvent(
+            event_type="chat_message",
+            sender="agent",
+            content={"message_type": "tool_result", "text": "done", "tool_call_id": "tc1"},
+        )
+    )
+
+    factory = _FakeFactory(session)
+    factory.event_store = lambda session_id: store  # type: ignore[method-assign]
+    conn = _FakeConn()
+    agent = AcpAgent(factory=cast(Any, factory))
+    agent.on_connect(cast(Client, conn))
+
+    response = await agent.load_session(cwd=str(tmp_path), session_id=sub_session_id(session.session_id, "tc1"))
+
+    assert isinstance(response, LoadSessionResponse)
+    users = [u for u in conn.updates if isinstance(u, UserMessageChunk)]
+    agents = [u for u in conn.updates if isinstance(u, AgentMessageChunk)]
+    assert users and users[0].content.text == "Review the diff"
+    assert agents and agents[0].content.text == "Found three issues"
+    assert any(isinstance(u, AgentThoughtChunk) for u in conn.updates)

--- a/tests/acp/test_usage.py
+++ b/tests/acp/test_usage.py
@@ -1,0 +1,111 @@
+"""Usage meter tests: ACP usage_update from llm_context_update events."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from acp.interfaces import Client
+from acp.schema import UsageUpdate
+
+from kolega_code.acp.bridge import AcpBridge
+from kolega_code.acp.usage import build_usage_update, context_window_for
+from kolega_code.events import AgentEvent
+
+from tests.agent.compaction_helpers import build_agent
+from tests.acp.test_server import StreamingLLM, _FakeConn, _make_agent, _make_session
+
+
+def _context_event(input_tokens: int) -> AgentEvent:
+    return AgentEvent(
+        sender="agent",
+        event_type="llm_context_update",
+        content={"input_tokens": input_tokens, "model_context_length": 1000},
+        is_streaming=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_usage_update_uses_agent_window(tmp_path: Path) -> None:
+    agent, _cm = build_agent(tmp_path)
+    assert context_window_for(agent) == 1000
+    update = build_usage_update(agent, 321)
+    assert update is not None
+    assert update.used == 321
+    assert update.size == 1000
+
+
+@pytest.mark.asyncio
+async def test_usage_clamps_to_window(tmp_path: Path) -> None:
+    agent, _cm = build_agent(tmp_path)
+    update = build_usage_update(agent, 5000)
+    assert update is not None
+    assert update.used == 1000
+
+
+@pytest.mark.asyncio
+async def test_build_usage_update_skips_without_window(tmp_path: Path) -> None:
+    agent, _cm = build_agent(tmp_path)
+    setattr(agent, "model_max_input_tokens", None)
+    setattr(agent, "model_context_length", None)
+    setattr(agent, "primary_model_config", SimpleNamespace(context_window_tokens=None))
+    assert context_window_for(agent) is None
+    assert build_usage_update(agent, 10) is None
+
+
+@pytest.mark.asyncio
+async def test_bridge_tracks_context_events_and_emits_usage(tmp_path: Path) -> None:
+    agent, _cm = build_agent(tmp_path)
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn), agent=agent)
+
+    await bridge.handle_event("s1", _context_event(42))
+    await bridge.emit_usage("s1")
+    await bridge.handle_event("s1", _context_event(77))
+    await bridge.emit_usage("s1")
+
+    usage_updates = [update for update in conn.updates if isinstance(update, UsageUpdate)]
+    assert [(update.used, update.size) for update in usage_updates] == [(42, 1000), (77, 1000)]
+
+
+@pytest.mark.asyncio
+async def test_emit_usage_skipped_without_window(tmp_path: Path) -> None:
+    agent, _cm = build_agent(tmp_path)
+    setattr(agent, "model_max_input_tokens", None)
+    setattr(agent, "model_context_length", None)
+    setattr(agent, "primary_model_config", SimpleNamespace(context_window_tokens=None))
+    conn = _FakeConn()
+    bridge = AcpBridge(cast(Client, conn), agent=agent)
+
+    await bridge.handle_event("s1", _context_event(42))
+    await bridge.emit_usage("s1")
+
+    assert conn.updates == []
+
+
+@pytest.mark.asyncio
+async def test_new_session_emits_initial_usage(tmp_path: Path) -> None:
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    agent, conn = _make_agent(session)
+
+    await agent.new_session(cwd=str(tmp_path))
+
+    usage_updates = [update for update in conn.updates if isinstance(update, UsageUpdate)]
+    assert len(usage_updates) == 1
+    assert usage_updates[0].used == 0
+    assert usage_updates[0].size == 1000
+
+
+@pytest.mark.asyncio
+async def test_prompt_emits_usage_after_turn(tmp_path: Path) -> None:
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    agent, conn = _make_agent(session)
+    new_session = await agent.new_session(cwd=str(tmp_path))
+
+    await agent.prompt(session_id=new_session.session_id, prompt=[{"type": "text", "text": "hi"}])  # pyright: ignore[reportArgumentType]
+
+    usage_updates = [update for update in conn.updates if isinstance(update, UsageUpdate)]
+    assert usage_updates
+    assert usage_updates[-1].size == 1000

--- a/tests/acp/test_usage.py
+++ b/tests/acp/test_usage.py
@@ -87,12 +87,22 @@ async def test_emit_usage_skipped_without_window(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_new_session_emits_initial_usage(tmp_path: Path) -> None:
+    import asyncio
+    from typing import Any
+
     session, _cm = _make_session(tmp_path, StreamingLLM())
     agent, conn = _make_agent(session)
 
     await agent.new_session(cwd=str(tmp_path))
 
-    usage_updates = [update for update in conn.updates if isinstance(update, UsageUpdate)]
+    # The open-time usage meter goes out just after the NewSessionResponse
+    # (clients like Zed drop pre-response notifications for session/new).
+    usage_updates: list[Any] = []
+    for _ in range(100):
+        usage_updates = [update for update in conn.updates if isinstance(update, UsageUpdate)]
+        if usage_updates:
+            break
+        await asyncio.sleep(0.02)
     assert len(usage_updates) == 1
     assert usage_updates[0].used == 0
     assert usage_updates[0].size == 1000

--- a/tests/agent/test_stream_segment_transitions.py
+++ b/tests/agent/test_stream_segment_transitions.py
@@ -1,0 +1,120 @@
+"""Contiguous per-type stream segments at reasoning/prose transitions.
+
+Arrival-order consumers (ACP clients, journal printers) render chunks in
+arrival order, so the loop must close a thinking segment the moment prose
+starts — and close a prose segment when reasoning resumes. Also pins the
+``STREAM_FLUSH_CHARS`` cadence: partial chunks are capped at the flush
+threshold.
+"""
+
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kolega_code.agent.baseagent import BaseAgent
+from kolega_code.llm.models import Message, MessageChunk, TextBlock
+
+from .compaction_helpers import FakeLLM, FakeStream, build_agent
+
+THINK_ONE = "reason one " + "t" * 30
+ANSWER_ONE = "answer one " + "a" * 30
+THINK_TWO = "reason two " + "u" * 30
+ANSWER_TWO = "answer two " + "v" * 30
+
+
+class _ScriptedStream(FakeStream):
+    def __init__(self, events: list[Any], final_message: Message) -> None:
+        super().__init__(final_message)
+        self._events = list(events)
+
+    async def __anext__(self) -> Any:
+        if self._events:
+            return self._events.pop(0)
+        raise StopAsyncIteration
+
+
+def _think(text: str) -> MessageChunk:
+    return MessageChunk(type="thinking", thinking=text)
+
+
+def _text(text: str) -> MessageChunk:
+    return MessageChunk(type="text", text=text)
+
+
+def _configure(agent: BaseAgent, events: list[Any]) -> None:
+    agent.system_prompt = Message(role="system", content=[TextBlock(text="sys")])
+    agent.tool_collection = MagicMock()
+    agent.tool_collection.get_tool_list = MagicMock(return_value=[])
+    agent.send_chat_message = AsyncMock()
+    agent.log_info = AsyncMock()
+    agent.log_error = AsyncMock()
+    agent.llm = cast(Any, FakeLLM(token_script=[100]))
+    final = Message(role="assistant", content=[TextBlock(text="done")], stop_reason="end_turn")
+    agent.llm.stream = AsyncMock(side_effect=lambda *args, **kwargs: _ScriptedStream(events, final))
+
+
+async def _chunks(agent: BaseAgent) -> list[dict]:
+    return [chunk async for chunk in agent.process_message_stream("go")]
+
+
+def _by_uuid(chunks: list[dict], chunk_type: str) -> dict[str, str]:
+    ordered: list[tuple[str, str]] = []
+    index: dict[str, int] = {}
+    for chunk in chunks:
+        if chunk["type"] != chunk_type:
+            continue
+        uuid_value = str(chunk["uuid"])
+        if uuid_value in index:
+            ordered[index[uuid_value]] = (uuid_value, ordered[index[uuid_value]][1] + chunk["content"])
+        else:
+            index[uuid_value] = len(ordered)
+            ordered.append((uuid_value, chunk["content"]))
+    return dict(ordered)
+
+
+@pytest.mark.asyncio
+async def test_interleaved_stream_yields_contiguous_segments(tmp_path: Path) -> None:
+    agent, _cm = build_agent(tmp_path)
+    _configure(agent, [_think(THINK_ONE), _text(ANSWER_ONE), _think(THINK_TWO), _text(ANSWER_TWO)])
+    chunks = await _chunks(agent)
+
+    assert list(_by_uuid(chunks, "thinking").values()) == [THINK_ONE, THINK_TWO]
+    assert list(_by_uuid(chunks, "response").values()) == [ANSWER_ONE, ANSWER_TWO]
+
+    first_response = next(i for i, c in enumerate(chunks) if c["type"] == "response")
+    thinking_one_closed = next(i for i, c in enumerate(chunks) if c["type"] == "thinking" and c["complete"])
+    assert thinking_one_closed < first_response
+
+    first_thinking_uuid = str(chunks[0]["uuid"])
+    thinking_two = next(i for i, c in enumerate(chunks) if c["type"] == "thinking" and c["uuid"] != first_thinking_uuid)
+    response_one_closed = next(
+        i for i, c in enumerate(chunks) if c["type"] == "response" and c["complete"] and c["uuid"] != chunks[-1]["uuid"]
+    )
+    assert response_one_closed < thinking_two
+
+
+@pytest.mark.asyncio
+async def test_reasoning_first_turn_closes_thinking_before_prose(tmp_path: Path) -> None:
+    agent, _cm = build_agent(tmp_path)
+    _configure(agent, [_think(THINK_ONE), _text(ANSWER_ONE)])
+    chunks = await _chunks(agent)
+
+    assert list(_by_uuid(chunks, "thinking").values()) == [THINK_ONE]
+    assert list(_by_uuid(chunks, "response").values()) == [ANSWER_ONE]
+    first_response = next(i for i, c in enumerate(chunks) if c["type"] == "response")
+    assert first_response > 0
+    assert all(c["type"] == "thinking" for c in chunks[:first_response])
+    assert any(c["type"] == "thinking" and c["complete"] for c in chunks[:first_response])
+
+
+@pytest.mark.asyncio
+async def test_flush_threshold_caps_partial_chunks(tmp_path: Path) -> None:
+    agent, _cm = build_agent(tmp_path)
+    _configure(agent, [_text("12345") for _ in range(12)])
+    chunks = await _chunks(agent)
+
+    lengths = [len(c["content"]) for c in chunks if c["type"] == "response" and c["content"]]
+    assert lengths == [20, 20, 20]
+    assert chunks[-1]["complete"] is True

--- a/tests/agent/tool_backend/test_agent_tool.py
+++ b/tests/agent/tool_backend/test_agent_tool.py
@@ -819,3 +819,43 @@ def test_construct_workflow_sub_agent_threads_callers_llm_trace_sink(agent_tool,
     agent = agent_tool._construct_workflow_sub_agent(MockAgent, config=None, extra_tool_extensions=None)
 
     assert agent.init_kwargs["llm_trace_sink"] is sink
+
+
+@pytest.mark.asyncio
+class TestDispatchPermissions:
+    """Dispatched sub-agents run AUTO regardless of the parent's mode."""
+
+    async def test_dispatch_agent_forces_auto_permission_mode(self, agent_tool, mock_connection_manager, mock_caller):
+        import builtins
+
+        from unittest.mock import patch
+
+        from kolega_code.permissions import PermissionMode, auto_allow_permission_callback
+
+        async def parent_callback(request):  # noqa: ANN001
+            raise AssertionError("the parent callback must not reach sub-agents")
+
+        mock_caller.permission_mode = PermissionMode.ASK
+        mock_caller.permission_callback = parent_callback
+
+        original_import = builtins.__import__
+        with patch.object(builtins, "__import__") as mock_import:
+            mock_module = MagicMock()
+            mock_module.MockAgent = MockAgent
+
+            def mock_import_func(name, *args, **kwargs):
+                if name == "test.module":
+                    return mock_module
+                return original_import(name, *args, **kwargs)
+
+            mock_import.side_effect = mock_import_func
+            MockAgent.configure_streaming([{"content": "Done.", "complete": True, "uuid": str(uuid.uuid4())}])
+            MockAgent.last_instance = None
+            try:
+                await agent_tool._dispatch_agent(agent_class_import="test.module.MockAgent", task="Test task")
+            finally:
+                MockAgent.configure_streaming([])
+
+        assert MockAgent.last_instance is not None
+        assert MockAgent.last_instance.init_kwargs["permission_mode"] == PermissionMode.AUTO
+        assert MockAgent.last_instance.init_kwargs["permission_callback"] is auto_allow_permission_callback

--- a/tests/cli/test_app_planning_restore.py
+++ b/tests/cli/test_app_planning_restore.py
@@ -87,7 +87,11 @@ async def test_textual_app_restores_saved_plan_and_interaction_mode(
         assert app.query_one("#planning_plan_markdown", PlanningMarkdown).source == saved_plan
         plan_actions = app.query_one("#plan_actions", ActionList)
         assert plan_actions.display is True
-        assert [option.id for option in plan_actions.options] == ["implement_plan"]
+        assert [option.id for option in plan_actions.options] == [
+            "implement_plan",
+            "implement_plan_clear",
+            "discuss_plan",
+        ]
         assert app.query_one("#composer", ChatComposer).disabled is False
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -27,6 +27,18 @@ tinker = "2026-08-09T00:00:00Z"
 h2 = "2026-08-04T00:00:00Z"
 
 [[package]]
+name = "agent-client-protocol"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/50/65bfb4e3e13f350a52c368cbfc4bc36a1b3b3f34a6b3f5a2e3551e1bd63b/agent_client_protocol-0.12.0.tar.gz", hash = "sha256:4d42ac680388556b038cb6dd58dbbbd1561f9e545a334c1a352cc055f98b1c79", size = 135037, upload-time = "2026-08-01T15:58:22.35Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/c7/b84b8698879464bd8f869551bac31454bed14a3a22910f65d9693f3701bd/agent_client_protocol-0.12.0-py3-none-any.whl", hash = "sha256:233626748034896214de118f5cf5a319484ad2186705fd595219afee92237ccc", size = 92992, upload-time = "2026-08-01T15:58:21.216Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1790,6 +1802,7 @@ name = "kolega-code"
 version = "0.31.0"
 source = { editable = "." }
 dependencies = [
+    { name = "agent-client-protocol" },
     { name = "anthropic" },
     { name = "atif" },
     { name = "beautifulsoup4" },
@@ -1855,6 +1868,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "agent-client-protocol", specifier = "==0.12.0" },
     { name = "anthropic", specifier = "==0.101.0" },
     { name = "atif", specifier = "==1.7.0" },
     { name = "beautifulsoup4", specifier = "==4.14.3" },


### PR DESCRIPTION
## What

Adds the **ACP (Agent Client Protocol) agent side** so editors that host ACP agents — Zed and JetBrains natively, VS Code / Neovim / Emacs via community clients — can drive kolega-code over stdio JSON-RPC. One implementation buys every editor; we write no editor plugins.

WIP: this PR covers Phase 0 (transport skeleton) + Phase 1 (core turn loop) of the plan; more commits are coming (permissions, diffs, terminal delegation, VS Code validation).

### Included

- `kolega-code acp [--debug]` subcommand — one client connection per process; stdout reserved for protocol frames, all logging on stderr
- `kolega_code/acp/` package:
  - `server.py` — `AcpAgent`: `initialize`, `session/new|load|list|close`, `session/prompt`, `session/cancel`
  - `agent_factory.py` — headless composition (settings → `build_agent_config` → `CoderAgent`), durable recording stack
  - `bridge.py` — generator text/thinking chunks → `agent_message_chunk`/`agent_thought_chunk`; tool events → `tool_call_update` with kind mapping
  - `session.py` — `AcpSession`
- Sessions persist as regular `SessionRecord`s (mode `"cli"`), so ACP threads replay in the TUI, export, and thread import like any other session
- Config errors surface as JSON-RPC errors instead of killing the process
- `agent-client-protocol==0.12.0` pinned; 15 tests including a real subprocess round trip via the SDK's programmatic client

### Design notes

- **`AgentMode.CLI`, not `ASK`**: an editor thread has a human present, so it gets the interactive coder template. The ask mode is the autonomous template with hardcoded auto-approve permissions.
- **Permission mode is explicit** on the agent constructor: `PermissionMode.AUTO` for now; Phase 2 upgrades to `ASK` with the `session/request_permission` bridge.
- **No double-render**: text comes from the `process_message_stream` generator; tools come from the event stream (generator chunks are mirrored as events for other frontends).
- Fan-out (`dispatch_agent`/`run_workflow`) renders as ordinary tool calls — flattened baseline; ACP has no first-class subagent rendering (v1 or v2 draft).

### Testing

- New: `tests/acp/` — 15 tests (bridge mapping, in-process turn with scripted fake LLM, cancel semantics, config-error conversion, subprocess handshake) — all passing
- Lint/format/typecheck + pre-commit hooks green
- Local full-suite: stalls at ~95% in pre-existing TUI tests (reproduced identically on this branch; unrelated to these changes) — CI will be the authority

### Try it in Zed

```jsonc
// Settings → agent_servers
{
  "agent_servers": {
    "Kolega Code": {
      "type": "custom",
      "command": "/abs/path/to/kolega-code",
      "args": ["acp"]
    }
  }
}
```
