### PR TITLE
feat(llm): add deepseek-v4-flash-vision-exp

### DIFF
--- a/docs/src/content/docs/configuration/providers-and-models.mdx
+++ b/docs/src/content/docs/configuration/providers-and-models.mdx
@@ -344,7 +344,7 @@ models in the TUI.
 | Anthropic `claude-fable-5` | `low`, `medium`, `high`, `xhigh`, `max` | `medium` |
 | Anthropic `claude-opus-5` | `low`, `medium`, `high`, `xhigh`, `max` | `medium` |
 | Anthropic `claude-sonnet-5` | `low`, `medium`, `high`, `xhigh`, `max` | `medium` |
-| DeepSeek `deepseek-v4-pro`, `deepseek-v4-flash` | `none`, `low`, `high`, `max` | `high` |
+| DeepSeek `deepseek-v4-pro`, `deepseek-v4-flash`, `deepseek-v4-flash-vision-exp` | `none`, `low`, `high`, `max` | `high` |
 | Moonshot `kimi-k3` | `max` | `max` |
 | Moonshot `kimi-k2.7-code` | `auto` | `auto` |
 | Moonshot `kimi-k2.6` | `auto`, `none` | `auto` |

--- a/kolega_code/cli/provider_registry.py
+++ b/kolega_code/cli/provider_registry.py
@@ -64,6 +64,7 @@ MODEL_LABELS: dict[str, str] = {
     # DeepSeek
     "deepseek-v4-pro": "DeepSeek V4 Pro",
     "deepseek-v4-flash": "DeepSeek V4 Flash",
+    "deepseek-v4-flash-vision-exp": "DeepSeek V4 Flash Vision (Exp)",
     # Z.AI (GLM Coding Plan)
     "glm-5.3": "GLM-5.3",
     "glm-5.2": "GLM-5.2",

--- a/kolega_code/llm/specs/accessors.py
+++ b/kolega_code/llm/specs/accessors.py
@@ -202,7 +202,7 @@ def preferred_edit_protocol(provider: str, model_name: str) -> Optional[str]:
 DEEPSEEK_WIRE_OUTPUT_CAP = 64000
 
 # Routes whose catalog max_completion_tokens is itself the real ceiling.
-_UNCLAMPED_DEEPSEEK_ROUTES = {("deepseek", "deepseek-v4-flash")}
+_UNCLAMPED_DEEPSEEK_ROUTES = {("deepseek", "deepseek-v4-flash"), ("deepseek", "deepseek-v4-flash-vision-exp")}
 
 
 def is_deepseek_model(model_name: str) -> bool:

--- a/kolega_code/llm/specs/catalog/deepseek.py
+++ b/kolega_code/llm/specs/catalog/deepseek.py
@@ -65,4 +65,18 @@ DEEPSEEK_SPECS = {
             mode="openai_responses_reasoning",
         ),
     },
+    ("deepseek", "deepseek-v4-flash-vision-exp"): {
+        "context_length": 1000000,
+        "max_completion_tokens": 384000,
+        "input_budget": "window_minus_output",
+        "default_temperature": 1.0,
+        "supports_vision": True,
+        "supports_hosted_web_search": True,
+        "preferred_edit_protocol": "claude_code",
+        "thinking_effort": ThinkingEffortSpec(
+            options=("none", "low", "high", "max"),
+            default="high",
+            mode="openai_responses_reasoning",
+        ),
+    },
 }

--- a/tests/agent/llm/test_deepseek_requests.py
+++ b/tests/agent/llm/test_deepseek_requests.py
@@ -179,3 +179,13 @@ def test_responses_build_request_clamps_pro_cap() -> None:
     oversized = _responses_request(GenerationParams(max_completion_tokens=384000), model=pro)
     assert oversized["max_output_tokens"] == 64000
     assert _responses_request(GenerationParams(max_completion_tokens=4096), model=pro)["max_output_tokens"] == 4096
+
+
+def test_responses_build_request_passes_vision_exp_cap_through() -> None:
+    vision = "deepseek-v4-flash-vision-exp"
+    # Flash-family: the catalog's real 384K ceiling passes through unclamped.
+    assert _responses_request(None, model=vision)["max_output_tokens"] == 384000
+    assert (
+        _responses_request(GenerationParams(max_completion_tokens=384000), model=vision)["max_output_tokens"] == 384000
+    )
+    assert _responses_request(GenerationParams(max_completion_tokens=4096), model=vision)["max_output_tokens"] == 4096

--- a/tests/agent/llm/test_deepseek_responses_live.py
+++ b/tests/agent/llm/test_deepseek_responses_live.py
@@ -1,9 +1,11 @@
-"""Credential-gated live smoke for deepseek-v4-flash over the **Responses API**.
+"""Credential-gated live smoke for DeepSeek over the **Responses API**.
 
-`deepseek-v4-flash` is the one DeepSeek model routed to the Responses API (see
-DeepSeekResponsesProvider); every other DeepSeek model stays on Chat Completions.
-These tests hit the real ``https://api.deepseek.com`` Responses endpoint, so they are
-marked ``slow``/``integration`` and skip when ``DEEPSEEK_API_KEY`` is unset. Run with:
+The first-party ``deepseek`` provider (``deepseek-v4-flash``, ``deepseek-v4-pro``,
+and ``deepseek-v4-flash-vision-exp``) routes to the Responses API (see
+DeepSeekResponsesProvider); DeepSeek models on other providers stay on Chat
+Completions. These tests hit the real ``https://api.deepseek.com`` Responses
+endpoint, so they are marked ``slow``/``integration`` and skip when
+``DEEPSEEK_API_KEY`` is unset. Run with:
 
     ./run_tests.sh --all tests/agent/llm/test_deepseek_responses_live.py
 """
@@ -13,12 +15,30 @@ import os
 import pytest
 
 from kolega_code.llm.client import LLMClient
-from kolega_code.llm.models import Message, MessageHistory, TextBlock, ToolCall, ToolDefinition, ToolParameter
+from kolega_code.llm.models import (
+    ImageBlock,
+    Message,
+    MessageHistory,
+    TextBlock,
+    ToolCall,
+    ToolDefinition,
+    ToolParameter,
+    WebSearchCallBlock,
+)
 from kolega_code.llm.providers.deepseek_responses import DeepSeekResponsesProvider
 
 pytestmark = [pytest.mark.slow, pytest.mark.integration]
 
 _MODEL = "deepseek-v4-flash"
+_VISION_MODEL = "deepseek-v4-flash-vision-exp"
+
+# 64x64 solid red PNG (generated with PIL, base64-encoded).
+_RED_PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAf0lEQVR4nNXOQREA"
+    "IAzAsFIN868HWYjgsWsU5NwZyiRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO"
+    "4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO"
+    "4iRO4iRO4iRO4iRO4iRO4twO/Hp+awFwlXGz8wAAAABJRU5ErkJggg=="
+)
 
 
 @pytest.fixture
@@ -96,3 +116,103 @@ async def test_tool_call_over_responses_api(deepseek_flash_client):
     assert isinstance(call.input, dict)
     assert "city" in call.input
     assert response.stop_reason == "tool_use"
+
+
+# --- deepseek-v4-flash-vision-exp (first multimodal DeepSeek model) ----------------
+
+
+@pytest.fixture
+def deepseek_vision_client() -> LLMClient:
+    api_key = os.getenv("DEEPSEEK_API_KEY")
+    if not api_key:
+        pytest.skip("DEEPSEEK_API_KEY not set")
+    return LLMClient(provider="deepseek", api_key=api_key, model=_VISION_MODEL)
+
+
+def test_vision_client_routes_to_responses_provider(deepseek_vision_client):
+    # The live client must actually be on the Responses transport (bare host, no /v1).
+    provider = deepseek_vision_client.provider
+    assert isinstance(provider, DeepSeekResponsesProvider)
+    assert provider.base_url == "https://api.deepseek.com"
+    assert provider.provider_name == "deepseek"
+
+
+@pytest.mark.asyncio
+async def test_vision_generate_text_with_thinking(deepseek_vision_client):
+    messages = MessageHistory([Message("user", [TextBlock("Reply with exactly: vision-ok")])])
+    system = Message("system", [TextBlock("Follow the user's instruction exactly.")])
+
+    response = await deepseek_vision_client.generate(
+        messages=messages,
+        system=system,
+        model=_VISION_MODEL,
+        thinking="high",
+        temperature=1.0,
+    )
+
+    assert isinstance(response, Message)
+    assert response.get_text_content().strip() == "vision-ok"
+    usage = response.usage_metadata or {}
+    assert usage.get("provider") == "deepseek"
+    assert usage.get("completion_tokens", 0) > 0
+
+
+@pytest.mark.asyncio
+async def test_vision_image_input_identifies_color(deepseek_vision_client):
+    # Real multimodal check: a solid red PNG must come back as "red" — verifies the
+    # base64 input_image path (DeepSeek bills images as tokens; one <= 384 tokens).
+    image = ImageBlock(image_type="base64", media_type="image/png", data=_RED_PNG_B64)
+    messages = MessageHistory(
+        [Message("user", [TextBlock("What color is this image? Reply with one color name only."), image])]
+    )
+
+    response = await deepseek_vision_client.generate(
+        messages=messages,
+        system=None,
+        model=_VISION_MODEL,
+        thinking="none",
+        temperature=0.0,
+    )
+
+    assert isinstance(response, Message)
+    assert "red" in response.get_text_content().strip().lower()
+
+
+@pytest.mark.asyncio
+async def test_vision_hosted_web_search(deepseek_vision_client):
+    # The /responses server-side web_search tool (bare {"type": "web_search"})
+    # must be captured as WebSearchCallBlock items on the vision model too.
+    messages = MessageHistory([Message("user", [TextBlock("What is the newest DeepSeek model? One sentence.")])])
+
+    response = await deepseek_vision_client.generate(
+        messages=messages,
+        system=None,
+        model=_VISION_MODEL,
+        thinking="none",
+        temperature=0.0,
+        max_completion_tokens=512,
+        hosted_web_search=True,
+    )
+
+    assert isinstance(response, Message)
+    assert any(isinstance(block, WebSearchCallBlock) for block in response.content)
+    assert response.get_text_content().strip()
+
+
+@pytest.mark.asyncio
+async def test_vision_accepts_full_output_cap(deepseek_vision_client):
+    # Flash-family ceiling: the server accepts max_output_tokens=384000 (the
+    # value the unclamped catalog entry puts on the wire when no cap is requested).
+    messages = MessageHistory([Message("user", [TextBlock("Say ok")])])
+
+    response = await deepseek_vision_client.generate(
+        messages=messages,
+        system=None,
+        model=_VISION_MODEL,
+        thinking="none",
+        temperature=0.0,
+        max_completion_tokens=384000,
+    )
+
+    assert isinstance(response, Message)
+    assert response.get_text_content().strip()

--- a/tests/agent/llm/test_deepseek_responses_routing.py
+++ b/tests/agent/llm/test_deepseek_responses_routing.py
@@ -1,10 +1,11 @@
 # ruff: noqa: E402
 """Provider-level API routing for DeepSeek.
 
-The whole ``deepseek`` provider (``deepseek-v4-pro`` and ``deepseek-v4-flash``)
-speaks the Responses API via :class:`DeepSeekResponsesProvider`. DeepSeek models
-hosted on other providers (Fireworks/OpenRouter/Ollama-Cloud) still use Chat
-Completions. See ``LLMClient._provider_class``.
+The whole ``deepseek`` provider (``deepseek-v4-pro``, ``deepseek-v4-flash``, and
+``deepseek-v4-flash-vision-exp``) speaks the Responses API via
+:class:`DeepSeekResponsesProvider`. DeepSeek models hosted on other providers
+(Fireworks/OpenRouter/Ollama-Cloud) still use Chat Completions. See
+``LLMClient._provider_class``.
 """
 
 from kolega_code.llm.client import LLMClient
@@ -22,6 +23,12 @@ class TestDeepSeekModelRouting:
 
     def test_pro_routes_to_responses_provider(self):
         provider = LLMClient(provider="deepseek", api_key="sk-test", model="deepseek-v4-pro").provider
+        assert isinstance(provider, DeepSeekResponsesProvider)
+        assert provider.base_url == "https://api.deepseek.com"
+        assert provider.provider_name == "deepseek"
+
+    def test_flash_vision_routes_to_responses_provider(self):
+        provider = LLMClient(provider="deepseek", api_key="sk-test", model="deepseek-v4-flash-vision-exp").provider
         assert isinstance(provider, DeepSeekResponsesProvider)
         assert provider.base_url == "https://api.deepseek.com"
         assert provider.provider_name == "deepseek"
@@ -51,3 +58,11 @@ class TestDeepSeekReasoningShape:
         # Both carry reasoning as Responses reasoning ITEMS, not a flat field.
         assert reasoning_replay_field("deepseek", "deepseek-v4-flash") is None
         assert reasoning_replay_field("deepseek", "deepseek-v4-pro") is None
+
+    def test_flash_vision_emits_responses_reasoning_block(self):
+        for effort in ("none", "low", "high", "max"):
+            params = build_thinking_request_params("deepseek", "deepseek-v4-flash-vision-exp", effort)
+            assert params == {"reasoning": {"effort": effort, "summary": "auto"}}
+
+    def test_flash_vision_excluded_from_flat_replay(self):
+        assert reasoning_replay_field("deepseek", "deepseek-v4-flash-vision-exp") is None

--- a/tests/agent/llm/test_edit_protocol_resolution.py
+++ b/tests/agent/llm/test_edit_protocol_resolution.py
@@ -86,4 +86,5 @@ def test_direct_deepseek_models_prefer_claude_code() -> None:
     assert deepseek_models == {
         ("deepseek", "deepseek-v4-pro"): EditProtocol.CLAUDE_CODE.value,
         ("deepseek", "deepseek-v4-flash"): EditProtocol.CLAUDE_CODE.value,
+        ("deepseek", "deepseek-v4-flash-vision-exp"): EditProtocol.CLAUDE_CODE.value,
     }

--- a/tests/agent/llm/test_supports_vision.py
+++ b/tests/agent/llm/test_supports_vision.py
@@ -48,6 +48,8 @@ def test_supports_vision_flag_present_on_every_entry():
         # Non-vision models
         ("deepseek", "deepseek-v4-pro", False),
         ("deepseek", "deepseek-v4-flash", False),
+        # First multimodal DeepSeek model (launched 2026-08-21).
+        ("deepseek", "deepseek-v4-flash-vision-exp", True),
         ("fireworks", "accounts/fireworks/models/deepseek-v4-pro", False),
         ("fireworks", "accounts/fireworks/models/deepseek-v4-flash", False),
         ("fireworks", "accounts/fireworks/models/glm-5p2", False),

--- a/tests/cli/test_provider_registry.py
+++ b/tests/cli/test_provider_registry.py
@@ -136,7 +136,9 @@ def test_vision_only_model_options_follow_catalog_capabilities():
         "Kimi K2.7 Code": "accounts/fireworks/models/kimi-k2p7-code",
         "MiniMax M3": "accounts/fireworks/models/minimax-m3",
     }
-    assert ui_model_options("deepseek", vision_only=True) == []
+    assert dict(ui_model_options("deepseek", vision_only=True)) == {
+        "DeepSeek V4 Flash Vision (Exp)": "deepseek-v4-flash-vision-exp"
+    }
 
 
 def test_ollama_cloud_smoke_model_is_available_without_live_call():


### PR DESCRIPTION
## Summary

Adds DeepSeek's first multimodal model, `deepseek-v4-flash-vision-exp` (experimental, launched 2026-08-21), as a first-party model in the `deepseek` provider.

- **Catalog** (`llm/specs/catalog/deepseek.py`): 1M context, 384K output ceiling, vision via base64 `input_image` items (≤384 tokens each), hosted `web_search` support, thinking `none/low/high/max` via Responses reasoning block.
- **Wire** (`llm/specs/accessors.py`): flash-family route stays unclamped — the real 384K ceiling passes through instead of the 64K default clamp.
- **UI** (`cli/provider_registry.py`): model label for the TUI picker.
- **Tests**: routing, reasoning shape, edit-protocol exact set, vision matrix, provider-registry picker, wire cap, plus credential-gated live probes (`test_deepseek_responses_live.py`) covering text, image color, hosted web search, and full-cap acceptance (verified live 2026-08-21).
- **Docs**: effort-table row in `providers-and-models.mdx`.

## Test plan

- Full fast suite: 4966 passed, 1 skipped (BROWSERLESS_API_KEY unset).
- Pre-commit (ruff/format/pyright) passes on the commit.