### PR TITLE
fix(acp): allow permission mode changes mid-turn

### DIFF
--- a/kolega_code/acp/server.py
+++ b/kolega_code/acp/server.py
@@ -325,6 +325,16 @@ class AcpAgent(Agent):
         session = self._sessions.get(session_id)
         if session is None:
             raise RequestError.resource_not_found(session_id)
+        if config_id == CONFIG_PERMISSION_AUTO:
+            # Live flag flip (no rebuild), so it stays settable mid-turn.
+            if isinstance(value, str):
+                auto = value.strip().lower() in ("auto", "true", "1", "yes")
+            else:
+                auto = bool(value)
+            mode = PermissionMode.AUTO if auto else PermissionMode.ASK
+            await self._factory.set_permission_mode(session, mode)
+            logger.info("acp session config: permission mode -> %s (session=%s)", mode.value, session_id)
+            return SetSessionConfigOptionResponse(config_options=self._factory.config_options_for(session))
         if not session.idle():
             raise RequestError.invalid_request({"message": "config options apply between turns only"})
         if config_id == CONFIG_MODEL:
@@ -336,16 +346,6 @@ class AcpAgent(Agent):
             except _HANDLED_CONFIG_ERRORS as exc:
                 raise AgentFactory.protocol_error(exc) from exc
             logger.info("acp session config: model -> %s/%s (session=%s)", provider, model, session_id)
-        elif config_id == CONFIG_PERMISSION_AUTO:
-            # The option is a select ("ask"/"auto"); legacy clients that
-            # persisted the older boolean values keep working.
-            if isinstance(value, str):
-                auto = value.strip().lower() in ("auto", "true", "1", "yes")
-            else:
-                auto = bool(value)
-            mode = PermissionMode.AUTO if auto else PermissionMode.ASK
-            await self._factory.set_permission_mode(session, mode)
-            logger.info("acp session config: permission mode -> %s (session=%s)", mode.value, session_id)
         elif config_id == CONFIG_MODE:
             if value not in INTERACTION_MODES:
                 raise RequestError.invalid_params({"message": f"unknown mode {value!r}; available: build, plan"})

--- a/tests/acp/test_config_options.py
+++ b/tests/acp/test_config_options.py
@@ -112,6 +112,27 @@ async def test_set_config_option_rejects_unknown_session(tmp_path: Path) -> None
 
 
 @pytest.mark.asyncio
+async def test_set_config_option_permission_mode_allowed_mid_turn(tmp_path: Path) -> None:
+    session, _cm = _make_session(tmp_path, StreamingLLM())
+    factory = _FakeFactory(session)
+    agent = AcpAgent(factory=cast(Any, factory))
+    new_session = await agent.new_session(cwd=str(tmp_path))
+
+    async def _forever() -> None:
+        await asyncio.Event().wait()
+
+    registered = agent._sessions[new_session.session_id]  # noqa: SLF001
+    registered.turn_task = asyncio.create_task(_forever())
+    try:
+        response = await agent.set_config_option(CONFIG_PERMISSION_AUTO, new_session.session_id, "auto")
+    finally:
+        registered.turn_task.cancel()
+
+    assert [mode for _, mode in factory.permission_mode_calls] == [PermissionMode.AUTO]
+    assert response.config_options == factory.config_options
+
+
+@pytest.mark.asyncio
 async def test_set_config_option_rejects_active_turn(tmp_path: Path) -> None:
     session, _cm = _make_session(tmp_path, StreamingLLM())
     factory = _FakeFactory(session)
@@ -125,9 +146,13 @@ async def test_set_config_option_rejects_active_turn(tmp_path: Path) -> None:
     registered.turn_task = asyncio.create_task(_forever())
     try:
         with pytest.raises(RequestError):
-            await agent.set_config_option(CONFIG_PERMISSION_AUTO, new_session.session_id, True)
+            await agent.set_config_option(CONFIG_MODE, new_session.session_id, "plan")
+        with pytest.raises(RequestError):
+            await agent.set_config_option(CONFIG_MODEL, new_session.session_id, "x/y")
     finally:
         registered.turn_task.cancel()
+    assert factory.interaction_mode_calls == []
+    assert factory.model_calls == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

In the VS Code ACP client, toggling the permissions option (ask / auto) while a turn was running failed with `Failed to set permission-auto: Invalid request` (-32600).

## Root cause

`set_config_option` rejected every config-option change while a turn was in flight ("config options apply between turns only"). VS Code's ACP client keeps the config pickers clickable mid-turn — and the permission toggle is wanted exactly when a permission prompt is pending — so the toggle hit the gate. Zed masks the issue because its UI only lets you toggle between turns, and VS Code surfaces only the error's `message` ("Invalid request"), hiding the explanatory `data`.

## Fix

`permission-auto` is a live flag flip on the running agent (`set_permission_mode`, no rebuild, no history changes), so it is now settable at any time; an in-flight turn picks the new mode up for subsequent tool calls. `model` and `mode` still require an idle session because those rebuild the agent.

## Tests

- Added `test_set_config_option_permission_mode_allowed_mid_turn`.
- Updated `test_set_config_option_rejects_active_turn` to cover `mode`/`model` (the options that rebuild the agent).

Verified: all 98 ACP tests pass; ruff, pyright, and pre-commit clean. Also exercised the request through the real ACP router for idle, mid-turn, and legacy boolean shapes.