### PR TITLE
chore: release v0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.32.0 - 2026-08-24
+
+### Added
+
+- **Editor integration over the Agent Client Protocol (ACP).** `kolega-code acp`
+  serves the full Kolega Code agent — models, tools, permissions, skills,
+  plan/build modes, sub-agent fan-out — to editors over stdio; Zed hosts it
+  natively through an `agent_servers` entry, and the new Editor Integration
+  docs page covers setup and flags (`--permission-mode`, `--acp-log`,
+  `--debug`). Each editor thread is an ordinary persisted Kolega Code session
+  that replays in the TUI, `kolega-code sessions`, exports, and `/share`.
+  Over the wire the agent server provides: TUI-faithful plan/build session
+  modes with task-list checklist rendering in the plan view and mid-turn mode
+  switching; tool approvals prompted through the editor
+  (`session/request_permission`) plus a model select and auto-approve toggle
+  as session config options; sub-agent dispatch cards with live progress and
+  per-subagent transcripts (Zed's `subagent_session_info` convention);
+  compaction shown as a collapsible thought view; advertised slash commands;
+  user questions via client elicitation; file edits rendered as diffs;
+  streamed terminal output; context-usage updates; and session load/restore so
+  clients can reopen previous threads.
+- Added DeepSeek V4 Flash Vision (`deepseek-v4-flash-vision-exp`),
+  DeepSeek's first multimodal model (experimental): 1M-token context, image
+  input, hosted web search, and `none`/`low`/`high`/`max` reasoning effort on
+  the Responses API.
+
+### Changed
+
+- OpenRouter catalog refreshed from the 2026-08-24 snapshots: 274 tool-capable
+  models, 20 featured.
+
+### Fixed
+
+- Sub-agents launched by `dispatch_agent` now run in auto permission mode.
+  An ask-mode parent previously passed its approval callback down to the
+  sub-agent, which could hang a turn waiting for a prompt that ACP clients
+  cannot render for delegated work.
+- Streaming consumers now receive reasoning and response text as clean,
+  ordered segments: thinking is flushed the moment prose starts (and vice
+  versa) instead of interleaving at buffer boundaries, and a lower flush
+  threshold makes streaming feel more responsive in every frontend.
+
 ## 0.31.0 - 2026-08-20
 
 ### Added

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -174,4 +174,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.31.0"
+__version__ = "0.32.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.31.0"
+__version__ = "0.32.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.31.0"
+version = "0.32.0"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = "BUSL-1.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1799,7 +1799,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.31.0"
+version = "0.32.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Release v0.32.0

Version bump to `0.32.0` in `pyproject.toml`, `uv.lock`, and both package `__version__` values; changelog updated in the same PR.

### Since 0.31.0
- **Added:** Editor integration over ACP — `kolega-code acp` serves the full agent (permissions, plan/build modes, sub-agents, skills) to editors; Zed native via `agent_servers`. (#642)
- **Added:** DeepSeek V4 Flash Vision experimental model — first multimodal DeepSeek model, 1M context, image input, hosted web search. (#643)
- **Changed:** OpenRouter catalog refreshed from 2026-08-24 snapshots (274 tool-capable models). (#645)
- **Fixed:** Permission mode changes mid-turn over ACP. (#646)
- **Fixed:** dispatched sub-agents run auto-permission; stream segments flush cleanly at reasoning/prose transitions.

### Checks
- Fast suite: 4963 passed + affected live modules re-run green after installing the optional `[tinker]` extra into `.venv-release`.
- `pre-commit run --all-files`: all hooks passed (CI parity).