### PR TITLE
fix(agent): tag agent-loop retry nudges with a reminder source

### DIFF
--- a/kolega_code/agent/prompt_templates/auxiliary/agent_loop/silent_turn_exhausted.user.md
+++ b/kolega_code/agent/prompt_templates/auxiliary/agent_loop/silent_turn_exhausted.user.md
@@ -1,3 +1,3 @@
-<system-reminder>
+<system-reminder source="agent_loop">
 The turn was terminated by the runtime: the model ended four consecutive responses with no tool call and no visible message, despite three escalating reminders. No result was produced for the pending request.
 </system-reminder>

--- a/kolega_code/agent/prompt_templates/auxiliary/agent_loop/silent_turn_nudge.user.md.j2
+++ b/kolega_code/agent/prompt_templates/auxiliary/agent_loop/silent_turn_nudge.user.md.j2
@@ -1,4 +1,4 @@
-<system-reminder>
+<system-reminder source="agent_loop">
 {% if attempt == 1 %}
 Your last turn ended with only internal reasoning — no tool call and no visible message. Thinking is invisible and changes nothing on its own. Act now: emit the tool call you were planning, or reply with a visible message. Do not narrate what you will do — do it.
 {% elif attempt == 2 %}

--- a/kolega_code/agent/prompt_templates/auxiliary/agent_loop/truncated_turn_nudge.user.md.j2
+++ b/kolega_code/agent/prompt_templates/auxiliary/agent_loop/truncated_turn_nudge.user.md.j2
@@ -1,4 +1,4 @@
-<system-reminder>
+<system-reminder source="agent_loop">
 {% if attempt == 1 %}
 Your last message hit the output-token limit and was cut off mid-reply. Continue exactly from where it stopped — do not repeat what you already wrote. If you are producing a very large output, emit it in smaller pieces or write it to a file with a tool instead of one giant message.
 {% elif attempt == 2 %}

--- a/tests/agent/test_silent_turn_guard.py
+++ b/tests/agent/test_silent_turn_guard.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from kolega_code.agent.baseagent import BaseAgent
+from kolega_code.agent.prompts import SILENT_TURN_EXHAUSTED_NOTICE, build_silent_turn_nudge, build_truncated_turn_nudge
 from kolega_code.cli.session_store import SessionStore
 from kolega_code.llm.models import Message, TextBlock, ThinkingBlock, ToolCall, ToolResult
 
@@ -77,6 +78,24 @@ def _llm_status_events(connection_manager):
         if event is not None and getattr(event, "event_type", None) == "llm_status_update":
             events.append(event)
     return events
+
+
+def test_agent_loop_nudges_are_source_tagged_reminders() -> None:
+    # The TUI transcript filter hides standalone history items only when they start
+    # with '<system-reminder source="'. The agent-loop nudges must carry a source so
+    # a model switch or session resume never renders them as visible user messages.
+    nudges = [
+        build_silent_turn_nudge(1),
+        build_silent_turn_nudge(2),
+        build_silent_turn_nudge(3),
+        SILENT_TURN_EXHAUSTED_NOTICE,
+        build_truncated_turn_nudge(1),
+        build_truncated_turn_nudge(2),
+        build_truncated_turn_nudge(3),
+    ]
+    for nudge in nudges:
+        assert nudge.startswith('<system-reminder source="agent_loop">'), nudge
+        assert nudge.endswith("</system-reminder>"), nudge
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_app_persistence_history.py
+++ b/tests/cli/test_app_persistence_history.py
@@ -20,6 +20,7 @@ from kolega_code.llm.exceptions import (
 from kolega_code.llm.models import Message, TextBlock, ToolCall, ToolResult, WebSearchCallBlock
 from kolega_code.events import AgentEvent
 from kolega_code.agent.prompt_provider import AgentMode
+from kolega_code.agent.prompts import build_silent_turn_nudge
 from kolega_code.cli.config import build_agent_config, config_summary
 from kolega_code.cli.provider_registry import (
     DEEPSEEK_DEFAULT_MODEL,
@@ -121,6 +122,11 @@ def test_standalone_system_reminder_history_item_fast_path() -> None:
     session_reminder = '<system-reminder source="session">\nRuntime context\n</system-reminder>'
     assert _is_standalone_system_reminder_history_item(
         Message(role="user", content=[TextBlock(session_reminder)]).to_dict()
+    )
+    # Agent-loop retry nudges carry source="agent_loop" so the same fast path hides
+    # them from the transcript after a model switch or session resume.
+    assert _is_standalone_system_reminder_history_item(
+        Message(role="user", content=[TextBlock(build_silent_turn_nudge(1))]).to_dict()
     )
 
     large_ordinary_text = "x" * 1_000_000 + reminder
@@ -555,9 +561,11 @@ async def test_textual_app_renders_resumed_history_in_chat(tmp_path: Path, monke
     leading_text = f"Quoted reminder:\n{reminder}"
     trailing_text = f"{reminder}\nAdditional notes."
     tool_reminder = '<system-reminder source="tool">Tool output</system-reminder>'
+    nudge = build_silent_turn_nudge(1)
     history = [
         Message(role="user", content=[TextBlock("Please read the README")]).to_dict(),
         Message(role="user", content=[TextBlock(reminder)]).to_dict(),
+        Message(role="user", content=[TextBlock(nudge)]).to_dict(),
         Message(role="user", content=[TextBlock(prose)]).to_dict(),
         Message(role="user", content=[TextBlock(code_fence)]).to_dict(),
         Message(role="user", content=[TextBlock(leading_text)]).to_dict(),
@@ -604,6 +612,8 @@ async def test_textual_app_renders_resumed_history_in_chat(tmp_path: Path, monke
             ("tool_error", "Permission denied", "write_file"),
             ("assistant", "Done.", None),
         ]
+        # The retry nudge is runtime context, not a user message: never rendered.
+        assert not any("only internal reasoning" in entry.content for entry in app.conversation_entries)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

When a model ended a turn with no text and no tool call, the silent-turn guard's escalating retry nudges showed up as user messages in the TUI transcript after a model switch.

## Root cause

The retry guards inject their nudges as `<system-reminder>` user messages into history (`_record_context_user_message`). Every other runtime reminder carries a `source="..."` attribute, but the three agent-loop templates opened with a bare `<system-reminder>`. The TUI transcript filter hides standalone reminders by matching `startswith('<system-reminder source="')`, so the attribute-less nudges passed through whenever the transcript was rebuilt from history — model switch, settings change, or session resume. Live turns never render them (they're appended to history without streaming), which is why the leak only appeared after a rebuild.

## Fix

Per the "assume all reminders have source, and make that hold" approach, the three bundled templates now open with `<system-reminder source="agent_loop">`:

- `kolega_code/agent/prompt_templates/auxiliary/agent_loop/silent_turn_nudge.user.md.j2`
- `kolega_code/agent/prompt_templates/auxiliary/agent_loop/silent_turn_exhausted.user.md`
- `kolega_code/agent/prompt_templates/auxiliary/agent_loop/truncated_turn_nudge.user.md.j2`

The transcript filter itself is unchanged.

## Tests

- `tests/agent/test_silent_turn_guard.py`: new test pins the envelope shape (`<system-reminder source="agent_loop">` ... `</system-reminder>`) for all seven nudge variants.
- `tests/cli/test_app_persistence_history.py`: the fast-path filter test now asserts a real `build_silent_turn_nudge(1)` item is recognized; the resume-rendering test adds a nudge to persisted history and asserts it never appears in the transcript, while reminder-shaped prose/code fences/tool output stay visible.

## Notes

- Sessions that already persisted the old attribute-less nudges aren't migrated; `/clear` or compaction removes them.
- User prompt overrides that replace these templates without a `source=` attribute could reintroduce the leak (accepted tradeoff of the simpler approach).
- Model-visible content is otherwise unchanged; nudges still reach the model.
