### PR TITLE
chore: release v0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.33.0 - 2026-08-26
+
+### Added
+
+- **Cross-session messaging.** Running sessions on the same machine can now
+  message each other over local sockets. `/peers` lists reachable sessions,
+  `/rename` and `--name` let you address them by a stable friendly name, and
+  agents get `list_agents` and `send_message` tools (sending is gated behind
+  the message permission). Incoming messages arrive in the recipient like
+  typed input, and sessions started by other processes — including headless
+  `--goal`/`--loop` runs — participate in the same world.
+- New sessions get a generated friendly name instead of the project
+  directory basename, so multiple sessions in one project are easy to tell
+  apart.
+
+### Fixed
+
+- Cross-process discovery on a stock macOS install: socket names exceeded
+  the filesystem's path limit, so every host silently degraded to
+  in-process-only and peer lists always appeared empty.
+- Message-size handling is now consistent end to end: multibyte (for
+  example CJK) text is no longer refused after passing validation, and
+  oversized lines fail cleanly instead of crashing the connection.
+- Stale sockets left behind by recycled process ids no longer show up as
+  permanently unreachable ghosts, and a resumed session gets its address
+  back.
+- Headless `--goal`/`--loop` runs now deliver peer messages that arrived
+  during the final turn instead of discarding them at shutdown.
+- Internal retry notices no longer leak into the session transcript.
+
 ## 0.32.0 - 2026-08-24
 
 ### Added

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -174,4 +174,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.32.0"
+__version__ = "0.33.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.32.0"
+__version__ = "0.33.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.32.0"
+version = "0.33.0"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = "BUSL-1.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1799,7 +1799,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.32.0"
+version = "0.33.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Release v0.33.0

Version bump to `0.33.0` in `pyproject.toml`, `uv.lock`, and both package `__version__` values; changelog updated in the same PR.

### Since 0.32.0
- **Added:** Cross-session messaging — sessions on the same machine message each other over local sockets (`/peers`, `/rename`, `--name`, `list_agents`/`send_message` tools, permission-gated sends), and new sessions get a generated friendly name. (#652)
- **Fixed:** peer discovery on stock macOS (socket path length), end-to-end 64 KiB message-size contract (multibyte/oversized lines), stale recycled-pid sockets, headless run inbox drain at exit, and agent-loop retry nudges leaking into transcripts. (#650, #652)

### Checks
- Fast suite in `.venv-release` (dev+tinker extras): 5062 passed; the 3 failures are ChatGPT live tests hitting `OpenAI APIError: Connection error` (network-side; CI skips live tests — no keys).
- `pre-commit run --all-files`: all hooks passed (CI parity).
