### PR TITLE
feat(llm): add GLM-5.3-Flash to the Z.AI provider

### DIFF
--- a/docs/src/content/docs/configuration/providers-and-models.mdx
+++ b/docs/src/content/docs/configuration/providers-and-models.mdx
@@ -351,6 +351,7 @@ models in the TUI.
 | Kimi Coding Plan `k3`, `k3-256k` | `max` | `max` |
 | Kimi Coding Plan `kimi-for-coding`, `kimi-for-coding-highspeed` | `auto`, `none` | `auto` |
 | Z.AI `glm-5.3` | `high`, `max` | `max` |
+| Z.AI `glm-5.3-flash` | `high`, `max` | `max` |
 | Z.AI `glm-5.2` | `high`, `max` | `max` |
 | Z.AI `glm-5.1` | `auto`, `none` | `auto` |
 | Fireworks serverless reasoning models | `none`, `low`, `medium`, `high`, `max` | `medium` |

--- a/kolega_code/cli/provider_registry.py
+++ b/kolega_code/cli/provider_registry.py
@@ -75,6 +75,7 @@ MODEL_LABELS: dict[str, str] = {
     "deepseek-v4-flash-vision-exp": "DeepSeek V4 Flash Vision (Exp)",
     # Z.AI (GLM Coding Plan)
     "glm-5.3": "GLM-5.3",
+    "glm-5.3-flash": "GLM-5.3 Flash",
     "glm-5.2": "GLM-5.2",
     "glm-5.1": "GLM-5.1",
     # Anthropic

--- a/kolega_code/llm/specs/catalog/zai.py
+++ b/kolega_code/llm/specs/catalog/zai.py
@@ -14,6 +14,20 @@ ZAI_SPECS = {
             mode="zai_effort",
         ),
     },
+    ("zai", "glm-5.3-flash"): {
+        "context_length": 1000000,
+        "max_completion_tokens": 131072,
+        "input_budget": "window_minus_output",
+        "default_temperature": 0.6,
+        # Native multimodal input (image/video/file); shares GLM-5.3's
+        # forced-reasoning effort vocabulary (high/max).
+        "supports_vision": True,
+        "thinking_effort": ThinkingEffortSpec(
+            options=("high", "max"),
+            default="max",
+            mode="zai_effort",
+        ),
+    },
     ("zai", "glm-5.2"): {
         "context_length": 1000000,
         "max_completion_tokens": 131072,

--- a/tests/agent/llm/test_model_specs.py
+++ b/tests/agent/llm/test_model_specs.py
@@ -177,13 +177,17 @@ def test_deepseek_model_specs(model: str, max_completion_tokens: int):
 
 
 def test_zai_model_specs() -> None:
-    for model in ("glm-5.3", "glm-5.2"):
+    for model in ("glm-5.3", "glm-5.3-flash", "glm-5.2"):
         specs = get_model_specs("zai", model)
         assert specs["context_length"] == 1000000
         assert specs["max_completion_tokens"] == 131072
         assert specs["default_temperature"] == 0.6
         assert specs["thinking_effort"].options == ("high", "max")
         assert specs["thinking_effort"].default == "max"
+
+    # GLM-5.3-Flash is the first native-multimodal GLM-5 series model.
+    assert get_model_specs("zai", "glm-5.3-flash")["supports_vision"] is True
+    assert get_model_specs("zai", "glm-5.3")["supports_vision"] is False
 
 
 def test_fireworks_serverless_model_specs():

--- a/tests/agent/llm/test_supports_vision.py
+++ b/tests/agent/llm/test_supports_vision.py
@@ -37,6 +37,8 @@ def test_supports_vision_flag_present_on_every_entry():
         ("kimi_coding", "k3-256k", True),
         ("kimi_coding", "kimi-for-coding", True),
         ("kimi_coding", "kimi-for-coding-highspeed", True),
+        # Native multimodal GLM-5 series model (image/video/file input).
+        ("zai", "glm-5.3-flash", True),
         ("xai", "grok-4.6", True),
         ("xai", "grok-4.5", True),
         ("xai", "grok-4.3", True),

--- a/tests/cli/test_provider_registry.py
+++ b/tests/cli/test_provider_registry.py
@@ -49,6 +49,7 @@ def test_kimi_coding_exposes_plan_specific_k3_models():
 def test_zai_exposes_glm_models_and_defaults_to_glm_53() -> None:
     assert ui_model_options(ModelProvider.ZAI.value) == [
         ("GLM-5.3", "glm-5.3"),
+        ("GLM-5.3 Flash", "glm-5.3-flash"),
         ("GLM-5.2", "glm-5.2"),
         ("GLM-5.1", "glm-5.1"),
     ]


### PR DESCRIPTION
Adds `glm-5.3-flash` to the Z.AI (GLM Coding Plan) catalog. Z.AI's live `api.z.ai/api/anthropic/v1/models` now lists 10 models; the repo catalog carried only three, and GLM-5.3-Flash is the one genuinely new model (the others predate the cataloged set).

Spec (from docs.z.ai, snapshot 2026-09-02): 1M context, 128K max output, forced `high`/`max` reasoning effort (default `max`) matching GLM-5.3, and the first native-multimodal GLM-5 series model — `supports_vision: True` (image/video/file input).

Also wires the UI label (`GLM-5.3 Flash`) and the docs thinking-effort row.

Verification:
- Live probe through the repo's real request path (`LLMClient` → `AnthropicProvider` → Z.AI Anthropic endpoint): correct response with default effort/temperature.
- `ruff`/`pyright` clean; 174 targeted registry/spec/vision/effort/catalog tests pass; live Z.AI provider smoke tests pass.