### PR TITLE
feat(llm): add Gemini 3.8 Flash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+### Added
+
+- Added Google Gemini 3.8 Flash (`gemini-3.8-flash`): 1M-token context, 64K
+  output, vision and function calling, and `low`/`medium`/`high` thinking
+  levels. It omits Google's deprecated temperature parameter and is now the
+  default Google model.
+
 ## 0.34.0 - 2026-09-02
 
 ### Added

--- a/docs/src/content/docs/configuration/providers-and-models.mdx
+++ b/docs/src/content/docs/configuration/providers-and-models.mdx
@@ -357,6 +357,7 @@ models in the TUI.
 | Fireworks serverless reasoning models | `none`, `low`, `medium`, `high`, `max` | `medium` |
 | Ollama Cloud thinking models | `none`, `low`, `medium`, `high`, `max` | `medium` |
 | Ollama Cloud `gpt-oss:*` | `low`, `medium`, `high` | `medium` |
+| Google `gemini-3.8-flash` | `low`, `medium`, `high` | `medium` |
 | Google `gemini-3.7-flash` | `low`, `medium`, `high` | `medium` |
 | Google `gemini-3.6-flash` | `minimal`, `low`, `medium`, `high` | `medium` |
 | Google `gemini-3.5-flash-lite` | `minimal`, `low`, `medium`, `high` | `minimal` |

--- a/kolega_code/cli/provider_registry.py
+++ b/kolega_code/cli/provider_registry.py
@@ -98,6 +98,7 @@ MODEL_LABELS: dict[str, str] = {
     "gpt-5.4-mini": "GPT-5.4 Mini",
     "gpt-5.3-codex-spark": "GPT-5.3 Codex Spark",
     # Google
+    "gemini-3.8-flash": "Gemini 3.8 Flash",
     "gemini-3.7-flash": "Gemini 3.7 Flash",
     "gemini-3.6-flash": "Gemini 3.6 Flash",
     "gemini-3.5-flash-lite": "Gemini 3.5 Flash-Lite",
@@ -167,7 +168,7 @@ PROVIDER_DEFAULT_MODEL: dict[ModelProvider, str] = {
     ModelProvider.ANTHROPIC: "claude-opus-5",
     ModelProvider.OPENAI: "gpt-5.6-sol",
     ModelProvider.OPENAI_CHATGPT: "gpt-5.6-sol",
-    ModelProvider.GOOGLE: "gemini-3.7-flash",
+    ModelProvider.GOOGLE: "gemini-3.8-flash",
     ModelProvider.XAI: "grok-4.5",
     ModelProvider.FIREWORKS: "accounts/fireworks/models/glm-5p2",
     ModelProvider.TOGETHER: "moonshotai/Kimi-K2.7-Code",

--- a/kolega_code/llm/specs/catalog/google.py
+++ b/kolega_code/llm/specs/catalog/google.py
@@ -2,6 +2,19 @@ from kolega_code.llm.specs.types import ThinkingEffortSpec
 
 # Google models
 GOOGLE_SPECS = {
+    ("google", "gemini-3.8-flash"): {
+        "context_length": 1048576,
+        "max_completion_tokens": 65536,
+        "input_budget": "separate_output_limit",
+        "default_temperature": 1.0,
+        "supports_temperature": False,
+        "supports_vision": True,
+        "thinking_effort": ThinkingEffortSpec(
+            options=("low", "medium", "high"),
+            default="medium",
+            mode="google_thinking_level",
+        ),
+    },
     ("google", "gemini-3.7-flash"): {
         "context_length": 1048576,
         "max_completion_tokens": 65536,

--- a/tests/agent/llm/test_google_provider.py
+++ b/tests/agent/llm/test_google_provider.py
@@ -44,6 +44,7 @@ class _FakeGoogleModels:
 @pytest.mark.parametrize(
     "model,thinking,expected_temperature",
     [
+        ("gemini-3.8-flash", "medium", None),
         ("gemini-3.7-flash", "medium", None),
         ("gemini-3.6-flash", "medium", None),
         ("gemini-3.5-flash-lite", "minimal", None),

--- a/tests/agent/llm/test_google_tool_signature_live.py
+++ b/tests/agent/llm/test_google_tool_signature_live.py
@@ -17,7 +17,7 @@ from kolega_code.llm.models import ToolDefinition, ToolParameter
 
 pytestmark = pytest.mark.integration
 
-MODEL = "gemini-3.7-flash"
+MODEL = "gemini-3.8-flash"
 SKIP_IN_CI = bool(os.getenv("CI")) or bool(os.getenv("GITLAB_CI"))
 
 SYSTEM = Message(role="system", content=[TextBlock(text="You are a helpful coding assistant.")])

--- a/tests/agent/llm/test_model_specs.py
+++ b/tests/agent/llm/test_model_specs.py
@@ -11,6 +11,7 @@ from kolega_code.llm.specs import (
 @pytest.mark.parametrize(
     "model,thinking_options,default_thinking",
     [
+        ("gemini-3.8-flash", ("low", "medium", "high"), "medium"),
         ("gemini-3.7-flash", ("low", "medium", "high"), "medium"),
         ("gemini-3.6-flash", ("minimal", "low", "medium", "high"), "medium"),
         ("gemini-3.5-flash-lite", ("minimal", "low", "medium", "high"), "minimal"),

--- a/tests/agent/llm/test_thinking_effort.py
+++ b/tests/agent/llm/test_thinking_effort.py
@@ -23,6 +23,8 @@ def test_model_specs_expose_provider_specific_thinking_efforts() -> None:
     assert default_thinking_effort("moonshot", "kimi-k2.6") == "auto"
     assert thinking_effort_options("deepseek", "deepseek-v4-pro") == ("none", "low", "high", "max")
     assert default_thinking_effort("deepseek", "deepseek-v4-pro") == "high"
+    assert thinking_effort_options("google", "gemini-3.8-flash") == ("low", "medium", "high")
+    assert default_thinking_effort("google", "gemini-3.8-flash") == "medium"
     assert thinking_effort_options("google", "gemini-3.7-flash") == ("low", "medium", "high")
     assert default_thinking_effort("google", "gemini-3.7-flash") == "medium"
     assert thinking_effort_options("google", "gemini-3.6-flash") == ("minimal", "low", "medium", "high")
@@ -250,6 +252,9 @@ def test_google_gemini_3_pro_uses_thinking_level() -> None:
 @pytest.mark.parametrize(
     "model,effort",
     [
+        ("gemini-3.8-flash", "low"),
+        ("gemini-3.8-flash", "medium"),
+        ("gemini-3.8-flash", "high"),
         ("gemini-3.7-flash", "low"),
         ("gemini-3.7-flash", "medium"),
         ("gemini-3.7-flash", "high"),
@@ -277,6 +282,8 @@ def test_new_google_models_use_supported_thinking_levels(model: str, effort: str
 @pytest.mark.parametrize(
     "model,effort",
     [
+        ("gemini-3.8-flash", "minimal"),
+        ("gemini-3.8-flash", "xhigh"),
         ("gemini-3.7-flash", "minimal"),
         ("gemini-3.7-flash", "xhigh"),
         ("gemini-3.6-flash", "xhigh"),

--- a/tests/cli/test_provider_registry.py
+++ b/tests/cli/test_provider_registry.py
@@ -78,15 +78,21 @@ def test_gpt56_models_are_first_and_sol_is_default_for_openai_providers():
     ]
 
 
-def test_google_models_include_37_and_use_it_as_default() -> None:
+def test_google_models_include_38_and_use_it_as_default() -> None:
     options = ui_model_options(ModelProvider.GOOGLE.value)
 
-    assert options[:3] == [
+    assert options[:4] == [
+        ("Gemini 3.8 Flash", "gemini-3.8-flash"),
         ("Gemini 3.7 Flash", "gemini-3.7-flash"),
         ("Gemini 3.6 Flash", "gemini-3.6-flash"),
         ("Gemini 3.5 Flash-Lite", "gemini-3.5-flash-lite"),
     ]
-    assert default_model_for_provider(ModelProvider.GOOGLE) == "gemini-3.7-flash"
+    assert default_model_for_provider(ModelProvider.GOOGLE) == "gemini-3.8-flash"
+    assert ui_thinking_effort_options("google", "gemini-3.8-flash") == [
+        ("Low", "low"),
+        ("Medium", "medium"),
+        ("High", "high"),
+    ]
     assert ui_thinking_effort_options("google", "gemini-3.7-flash") == [
         ("Low", "low"),
         ("Medium", "medium"),
@@ -106,6 +112,7 @@ def test_google_models_include_37_and_use_it_as_default() -> None:
     ]
 
     vision_options = dict(ui_model_options(ModelProvider.GOOGLE.value, vision_only=True))
+    assert vision_options["Gemini 3.8 Flash"] == "gemini-3.8-flash"
     assert vision_options["Gemini 3.7 Flash"] == "gemini-3.7-flash"
     assert vision_options["Gemini 3.6 Flash"] == "gemini-3.6-flash"
     assert vision_options["Gemini 3.5 Flash-Lite"] == "gemini-3.5-flash-lite"

--- a/tests/gateway/test_sessions.py
+++ b/tests/gateway/test_sessions.py
@@ -245,6 +245,23 @@ async def wait_for(predicate, timeout: float = 5.0) -> bool:
     return False
 
 
+async def wait_for_turn_done(handler: AgentTurnHandler, chat: ChatRef, timeout: float = 5.0) -> None:
+    """Wait until the chat's turn task has fully settled.
+
+    The reply reaching the adapter is not a completion signal: the final
+    ``complete`` response chunk is yielded before the assistant message is
+    journaled (``record_assistant`` runs after the last streamed chunk), so
+    shutting down in that window cancels the turn and loses history. The
+    worker clears ``turn_task`` only after the stream was fully consumed and
+    the turn persisted. Precondition: the turn has demonstrably started
+    (e.g. its reply already reached the adapter), otherwise the poll would
+    pass before the worker even dequeues the message.
+    """
+    entry = handler._registry.get(chat)
+    assert entry is not None
+    assert await wait_for(lambda: entry.payload.turn_task is None, timeout), "turn never settled"
+
+
 def session_map(state_dir: Path) -> dict[str, str]:
     return json.loads((state_dir / "gateway_sessions.json").read_text(encoding="utf-8"))
 
@@ -254,6 +271,7 @@ async def test_turn_streams_and_persists(tmp_path: Path) -> None:
     handler, adapter, config = make_handler(tmp_path)
     await handler.handle(chat_ref(), inbound("hello", message_id="m-1"))
     assert await wait_for(lambda: "hello from the scripted model" in all_sent_texts(adapter))
+    await wait_for_turn_done(handler, chat_ref())
     await handler.shutdown()
 
     # The turn is persisted through the journal and the session record.
@@ -272,6 +290,7 @@ async def test_resumed_session_continues_across_handler_instances(tmp_path: Path
     first, adapter, config = make_handler(tmp_path, store=store)
     await first.handle(chat_ref(), inbound("first", message_id="m-1"))
     assert await wait_for(lambda: "hello from the scripted model" in all_sent_texts(adapter))
+    await wait_for_turn_done(first, chat_ref())
     await first.shutdown()
     store.release_session_locks()
 
@@ -279,6 +298,7 @@ async def test_resumed_session_continues_across_handler_instances(tmp_path: Path
     second, adapter2, _ = make_handler(tmp_path, store=store)
     await second.handle(chat_ref(), inbound("second", message_id="m-2"))
     assert await wait_for(lambda: len(adapter2.sent) >= 1)
+    await wait_for_turn_done(second, chat_ref())
     await second.shutdown()
 
     # Same session both times; the second turn appended to its history.
@@ -312,6 +332,7 @@ async def test_new_command_starts_a_fresh_session(tmp_path: Path) -> None:
     await handler.handle(chat_ref(), inbound("fresh", message_id="m-3"))
     # "fresh" is the user message — the turn's arrival shows as a second reply.
     assert await wait_for(lambda: all_sent_texts(adapter).count("hello from the scripted model") >= 2)
+    await wait_for_turn_done(handler, chat_ref())
 
     new_session_id = session_map(config.state_dir)[chat_ref().key]
     assert new_session_id != old_session_id
@@ -402,6 +423,7 @@ async def test_model_switch_rebuilds_and_keeps_history(tmp_path: Path) -> None:
     assert entry.payload.runtime.agent is not agent_before
     await handler.handle(chat_ref(), inbound("still here?", message_id="m-3"))
     assert await wait_for(lambda: all_sent_texts(adapter).count("hello from the scripted model") >= 2)
+    await wait_for_turn_done(handler, chat_ref())
     await handler.shutdown()
 
     session_id = session_map(config.state_dir)[chat_ref().key]
@@ -423,6 +445,7 @@ async def test_voice_note_transcribes_and_runs_the_turn(tmp_path: Path) -> None:
     )
     assert await wait_for(lambda: "hello from the scripted model" in all_sent_texts(adapter))
     assert transcriber.calls == [str(voice_path)]
+    await wait_for_turn_done(handler, chat_ref())
     await handler.shutdown()
 
     session_id = session_map(config.state_dir)[chat_ref().key]
@@ -449,6 +472,7 @@ async def test_voice_note_keeps_the_caption_with_the_transcript(tmp_path: Path) 
     )
     await handler.handle(chat_ref(), message)
     assert await wait_for(lambda: "hello from the scripted model" in all_sent_texts(adapter))
+    await wait_for_turn_done(handler, chat_ref())
     await handler.shutdown()
 
     session_id = session_map(config.state_dir)[chat_ref().key]
@@ -486,6 +510,7 @@ async def test_image_attachment_reaches_the_agent(tmp_path: Path) -> None:
         inbound_with_media((Attachment(kind="image", source=str(image_path)),)),
     )
     assert await wait_for(lambda: "hello from the scripted model" in all_sent_texts(adapter))
+    await wait_for_turn_done(handler, chat_ref())
     await handler.shutdown()
 
     session_id = session_map(config.state_dir)[chat_ref().key]
@@ -516,6 +541,7 @@ async def test_document_note_points_the_model_at_the_file(tmp_path: Path) -> Non
         inbound_with_media((Attachment(kind="document", source=str(doc_path), file_name="report.pdf"),)),
     )
     assert await wait_for(lambda: "hello from the scripted model" in all_sent_texts(adapter))
+    await wait_for_turn_done(handler, chat_ref())
     await handler.shutdown()
 
     session_id = session_map(config.state_dir)[chat_ref().key]


### PR DESCRIPTION
## Summary

Adds support for **Gemini 3.8 Flash** (`gemini-3.8-flash`), GA'd by Google on 2026-09-02. Specs match Gemini 3.7 Flash: 1M-token context, 64K max output, vision + function calling, `low`/`medium`/`high` thinking levels (`minimal` is no longer supported on 3.8), and the deprecated `temperature` parameter omitted.

Following the Gemini 3.7 Flash precedent (#-of-that-PR), it becomes the default Google model — it is Google's most capable Flash workhorse at the same introductory price ($0.75/$3.75 per 1M in/out through 2026-12-31), and Google has made it the default for its own managed agents.

## Changes

- `kolega_code/llm/specs/catalog/google.py` — new `gemini-3.8-flash` spec (1M context, 64K output, `separate_output_limit`, vision, `google_thinking_level` `low`/`medium`/`high`, default `medium`)
- `kolega_code/cli/provider_registry.py` — picker label + Google default → `gemini-3.8-flash`
- Tests: catalog spec matrix, provider temperature handling, thinking-level accept/reject params, picker order/default/vision filters; live tool-signature probe retargeted to 3.8
- Docs: thinking-efforts table row; CHANGELOG entry under Unreleased

## Testing

- `./run_tests.sh` on the four affected suites: 97 passed
- Full fast suite: 5271 passed; the only 6 failures are pre-existing live-provider tests (stale ChatGPT OAuth token → 401, Together connection error) — confirmed failing with these changes stashed
- `ruff check`, `ruff format --check`, `pyright`, and `pre-commit` (all hooks) pass on the changed files

Docs source: [Gemini API release notes / latest-model guide](https://ai.google.dev/gemini-api/docs/latest-model)

## Also fixes (commit 2)

`test(gateway): wait for turn settlement before asserting persisted history` — the CI flake this PR initially hit on Python 3.11 (`test_resumed_session_continues_across_handler_instances`) is a pre-existing race also failing on `main` (run 33645413539): the final `complete` response chunk is yielded before `record_assistant` is journaled, so waiting for the adapter reply is not a completion signal. Tests that assert persisted history now poll the turn task (`turn_task is None` ⇒ stream consumed + turn persisted) instead. Gateway suite: 21 passed, 7 consecutive runs incl. `-n 8` xdist contention.
