### PR TITLE
feat(gateway): add restart command and auto-restart gateway on update

### DIFF
--- a/docs/src/content/docs/cli/gateway.md
+++ b/docs/src/content/docs/cli/gateway.md
@@ -48,10 +48,12 @@ below).
 | `status` | Show whether the daemon is running, with a heartbeat freshness check. |
 | `telegram setup` | Save the @BotFather token (with optional `--verify`, `--allow <ids>`, `--clear`). |
 | `pairing list` / `pairing approve <code>` | List pending sender pairing requests, or admit a sender. |
-| `install` / `uninstall` | Install or remove the gateway as a user-level background service (systemd user unit / launchd agent — no root needed). |
+| `install` / `uninstall` / `restart` | Install, remove, or restart the gateway as a user-level background service (systemd user unit / launchd agent — no root needed). |
 
 `run` options: `--adapter echo|telegram`, `--project`, `--state-dir`,
 `--provider`, `--model`.
+
+Running `kolega-code update` automatically restarts the gateway service if it is installed, so the running daemon picks up new versions immediately.
 
 ## In-chat commands
 

--- a/kolega_code/cli/gateway.py
+++ b/kolega_code/cli/gateway.py
@@ -31,6 +31,8 @@ from kolega_code.gateway.service import (
     LAUNCHD_LABEL,
     SERVICE_NAME,
     install_service,
+    is_service_installed,
+    restart_service,
     uninstall_service,
 )
 
@@ -76,6 +78,9 @@ def add_gateway_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentP
     uninstall = gateway_sub.add_parser("uninstall", help="Remove the gateway background service.")
     uninstall.add_argument("--state-dir", type=Path, default=None, help="Override the state directory.")
 
+    restart = gateway_sub.add_parser("restart", help="Restart the gateway background service.")
+    restart.add_argument("--state-dir", type=Path, default=None, help="Override the state directory.")
+
     telegram = gateway_sub.add_parser("telegram", help="Telegram adapter setup.")
     telegram_sub = telegram.add_subparsers(dest="telegram_command", required=True)
     setup = telegram_sub.add_parser("setup", help="Save the @BotFather bot token (stored in settings.json).")
@@ -112,7 +117,7 @@ async def _run_gateway(args: argparse.Namespace) -> int:
         return _gateway_pairing(args, config)
     if args.gateway_command == "telegram":
         return await _gateway_telegram(args, config)
-    if args.gateway_command in ("install", "uninstall"):
+    if args.gateway_command in ("install", "uninstall", "restart"):
         return _gateway_service(args, config)
     return await _gateway_run(config, args)
 
@@ -189,6 +194,20 @@ def _gateway_service(args: argparse.Namespace, config: GatewayConfig) -> int:
         for note in _activate_service(args.gateway_command, result.unit_path):
             print(f"gateway: {note}")
         return 0
+    if args.gateway_command == "restart":
+        if not is_service_installed():
+            print(
+                "gateway: background service is not installed (run 'kolega-code gateway install' to set it up)",
+                file=sys.stderr,
+            )
+            return 1
+        success, notes = restart_service()
+        for note in notes:
+            if success:
+                print(f"gateway: {note}")
+            else:
+                print(f"gateway: {note}", file=sys.stderr)
+        return 0 if success else 1
     for note in _activate_service("uninstall", None):
         print(f"gateway: {note}")
     for note in uninstall_service(config):

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -1015,6 +1015,8 @@ def _run_update() -> int:
         _print_styled(result.error, style="error", stderr=True)
     if result.returncode == 0:
         print("Kolega Code update completed. Run `kolega-code --version` to confirm.")
+        for note in result.gateway_restart_notes:
+            print(f"gateway: {note}")
     elif not result.error:
         _print_styled("Kolega Code update failed.", style="error", stderr=True)
     return result.returncode

--- a/kolega_code/cli/tui/command_handlers.py
+++ b/kolega_code/cli/tui/command_handlers.py
@@ -1528,6 +1528,8 @@ class CommandHandlersMixin(tui_app_base.KolegaAppBase):
         severity = "information" if result.returncode == 0 else "error"
         if result.returncode == 0:
             lines = [messages.UPDATE_COMPLETED]
+            for note in result.gateway_restart_notes:
+                lines.append(f"Gateway: {note}")
         else:
             lines = [messages.UPDATE_FAILED.format(code=result.returncode)]
             if result.error:

--- a/kolega_code/cli/updater.py
+++ b/kolega_code/cli/updater.py
@@ -35,6 +35,7 @@ class UpdateRunResult:
     stdout: str = ""
     stderr: str = ""
     error: Optional[str] = None
+    gateway_restart_notes: tuple[str, ...] = ()
 
 
 def current_version() -> str:
@@ -75,7 +76,7 @@ def update_status_message(
     return None
 
 
-def run_self_update(*, capture_output: bool = False) -> UpdateRunResult:
+def run_self_update(*, capture_output: bool = False, restart_gateway: bool = True) -> UpdateRunResult:
     if shutil.which(UPDATE_COMMAND[0]) is None:
         return UpdateRunResult(
             returncode=2,
@@ -92,8 +93,20 @@ def run_self_update(*, capture_output: bool = False) -> UpdateRunResult:
     except OSError as exc:
         return UpdateRunResult(returncode=2, error=str(exc))
 
+    gateway_notes: list[str] = []
+    if completed.returncode == 0 and restart_gateway:
+        try:
+            from kolega_code.gateway.service import is_service_installed, restart_service
+
+            if is_service_installed():
+                _, notes = restart_service()
+                gateway_notes.extend(notes)
+        except Exception as exc:  # noqa: BLE001
+            gateway_notes.append(f"could not restart gateway service: {exc}")
+
     return UpdateRunResult(
         returncode=completed.returncode,
         stdout=completed.stdout or "",
         stderr=completed.stderr or "",
+        gateway_restart_notes=tuple(gateway_notes),
     )

--- a/kolega_code/gateway/service.py
+++ b/kolega_code/gateway/service.py
@@ -10,9 +10,11 @@ environment. Uninstall unloads and removes everything.
 
 from __future__ import annotations
 
+import os
 import plistlib
 import shlex
 import shutil
+import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -135,3 +137,87 @@ def uninstall_service(
             unit_path.unlink()
             notes.append(f"removed {unit_path}")
     return notes
+
+
+def service_unit_path(
+    *,
+    systemd_dir: Optional[Path] = None,
+    launchd_dir: Optional[Path] = None,
+    platform: Optional[str] = None,
+) -> Path:
+    """Resolve the destination path for the gateway's background service unit."""
+    platform = platform if platform is not None else sys.platform
+    if platform == "darwin":
+        launchd_dir = launchd_dir or (Path.home() / "Library" / "LaunchAgents")
+        return launchd_dir / LAUNCHD_PLIST_NAME
+    systemd_dir = systemd_dir or (Path.home() / ".config" / "systemd" / "user")
+    return systemd_dir / SYSTEMD_UNIT_NAME
+
+
+def is_service_installed(
+    *,
+    systemd_dir: Optional[Path] = None,
+    launchd_dir: Optional[Path] = None,
+    platform: Optional[str] = None,
+) -> bool:
+    """Return whether the gateway background service definition exists on disk."""
+    return service_unit_path(
+        systemd_dir=systemd_dir,
+        launchd_dir=launchd_dir,
+        platform=platform,
+    ).exists()
+
+
+def run_service_command(argv: list[str]) -> subprocess.CompletedProcess[str] | None:
+    """Run a service command with safe timeouts and error handling."""
+    try:
+        return subprocess.run(argv, capture_output=True, text=True, check=False, timeout=30)
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(f"gateway: warning: {argv[0]} failed: {exc}", file=sys.stderr)
+        return None
+
+
+def restart_service(
+    *,
+    unit_path: Optional[Path] = None,
+    systemd_dir: Optional[Path] = None,
+    launchd_dir: Optional[Path] = None,
+    platform: Optional[str] = None,
+) -> tuple[bool, list[str]]:
+    """Restart the background gateway service if installed.
+
+    Returns ``(success, notes)``.
+    """
+    platform = platform if platform is not None else sys.platform
+    target_unit = unit_path or service_unit_path(
+        systemd_dir=systemd_dir,
+        launchd_dir=launchd_dir,
+        platform=platform,
+    )
+    if not target_unit.exists():
+        return False, ["gateway background service is not installed"]
+
+    notes: list[str] = []
+    if platform == "darwin":
+        uid = os.getuid()
+        proc = run_service_command(["launchctl", "kickstart", "-k", f"gui/{uid}/{LAUNCHD_LABEL}"])
+        if proc is not None and proc.returncode == 0:
+            notes.append("launchd agent restarted")
+            return True, notes
+
+        # Fallback: if kickstart failed (e.g. not loaded yet), bootout then bootstrap
+        run_service_command(["launchctl", "bootout", f"gui/{uid}", LAUNCHD_LABEL])
+        boot_proc = run_service_command(["launchctl", "bootstrap", f"gui/{uid}", str(target_unit)])
+        if boot_proc is not None and boot_proc.returncode == 0:
+            notes.append("launchd agent restarted")
+            return True, notes
+        notes.append("failed to restart launchd agent")
+        return False, notes
+
+    run_service_command(["systemctl", "--user", "daemon-reload"])
+    restart_proc = run_service_command(["systemctl", "--user", "restart", SERVICE_NAME])
+    if restart_proc is not None and restart_proc.returncode == 0:
+        notes.append("systemd unit restarted")
+        return True, notes
+    notes.append("failed to restart systemd unit")
+    return False, notes

--- a/scripts/install-kolega-code.sh
+++ b/scripts/install-kolega-code.sh
@@ -137,5 +137,10 @@ fi
 
 ensure_ripgrep || true
 
+# If the gateway background service is installed, restart it so it picks up the update.
+if [ -f "$HOME/.config/systemd/user/kolega-code-gateway.service" ] || [ -f "$HOME/Library/LaunchAgents/com.kolega.gateway.plist" ]; then
+    "$PACKAGE_NAME" gateway restart || true
+fi
+
 "$PACKAGE_NAME" --version
 info "Kolega Code is installed. Run: kolega-code ."

--- a/tests/cli/test_app_misc_commands.py
+++ b/tests/cli/test_app_misc_commands.py
@@ -115,6 +115,36 @@ async def test_textual_app_update_slash_command_runs_self_update(
 
 
 @pytest.mark.asyncio
+async def test_textual_app_update_slash_command_includes_gateway_restart_notes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("textual")
+
+    from kolega_code.cli.tui import command_handlers as command_handlers_module
+    from kolega_code.cli.tui.widgets import ChatComposer
+    from kolega_code.cli.updater import UpdateRunResult
+
+    app = _build_mention_test_app(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        command_handlers_module,
+        "run_self_update",
+        lambda *, capture_output=False: UpdateRunResult(
+            returncode=0, stdout="installed\n", gateway_restart_notes=("systemd unit restarted",)
+        ),
+    )
+
+    async with app.run_test():
+        composer = app.query_one("#composer", ChatComposer)
+        composer.load_text("/update")
+        await app.on_chat_composer_submitted(ChatComposer.Submitted(composer, composer.text))
+
+        entry = app.conversation_entries[-1]
+        assert entry.kind == "system"
+        assert "Kolega Code update completed" in entry.content
+        assert "Gateway: systemd unit restarted" in entry.content
+
+
+@pytest.mark.asyncio
 async def test_textual_app_startup_update_check_notifies_when_newer(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -404,6 +404,23 @@ def test_update_subcommand_runs_self_update(capsys, monkeypatch: pytest.MonkeyPa
     assert "update completed" in capsys.readouterr().out
 
 
+def test_update_subcommand_prints_gateway_restart_notes(capsys, monkeypatch: pytest.MonkeyPatch) -> None:
+    from kolega_code.cli import main as main_module
+
+    monkeypatch.setattr(
+        main_module,
+        "run_self_update",
+        lambda: UpdateRunResult(returncode=0, gateway_restart_notes=("systemd unit restarted",)),
+    )
+
+    exit_code = main_module.main(["update"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "update completed" in out
+    assert "gateway: systemd unit restarted" in out
+
+
 def test_update_subcommand_reports_missing_uv(capsys, monkeypatch: pytest.MonkeyPatch) -> None:
     from kolega_code.cli import main as main_module
 

--- a/tests/cli/test_updater.py
+++ b/tests/cli/test_updater.py
@@ -91,3 +91,56 @@ def test_run_self_update_runs_uv_tool_upgrade(monkeypatch) -> None:
             {"text": True, "capture_output": True, "check": False},
         )
     ]
+
+
+def test_run_self_update_restarts_gateway_when_installed(monkeypatch) -> None:
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append((args, kwargs))
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(updater.shutil, "which", lambda command: "/usr/bin/uv")
+    monkeypatch.setattr(updater.subprocess, "run", fake_run)
+    monkeypatch.setattr("kolega_code.gateway.service.is_service_installed", lambda: True)
+    monkeypatch.setattr(
+        "kolega_code.gateway.service.restart_service",
+        lambda: (True, ["launchd agent restarted"]),
+    )
+
+    result = updater.run_self_update(capture_output=True)
+
+    assert result.returncode == 0
+    assert result.gateway_restart_notes == ("launchd agent restarted",)
+
+
+def test_run_self_update_skips_gateway_restart_when_not_installed(monkeypatch) -> None:
+    def fake_run(args, **kwargs):
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(updater.shutil, "which", lambda command: "/usr/bin/uv")
+    monkeypatch.setattr(updater.subprocess, "run", fake_run)
+    monkeypatch.setattr("kolega_code.gateway.service.is_service_installed", lambda: False)
+
+    result = updater.run_self_update(capture_output=True)
+
+    assert result.returncode == 0
+    assert result.gateway_restart_notes == ()
+
+
+def test_run_self_update_gateway_restart_failure_is_non_fatal(monkeypatch) -> None:
+    def fake_run(args, **kwargs):
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(updater.shutil, "which", lambda command: "/usr/bin/uv")
+    monkeypatch.setattr(updater.subprocess, "run", fake_run)
+    monkeypatch.setattr("kolega_code.gateway.service.is_service_installed", lambda: True)
+    monkeypatch.setattr(
+        "kolega_code.gateway.service.restart_service",
+        lambda: (False, ["failed to restart systemd unit"]),
+    )
+
+    result = updater.run_self_update(capture_output=True)
+
+    assert result.returncode == 0
+    assert result.gateway_restart_notes == ("failed to restart systemd unit",)

--- a/tests/gateway/test_cli_gateway.py
+++ b/tests/gateway/test_cli_gateway.py
@@ -36,6 +36,37 @@ def test_parse_gateway_status() -> None:
     assert args.gateway_command == "status"
 
 
+def test_parse_gateway_restart() -> None:
+    args = parse_args(["gateway", "restart"])
+    assert args.gateway_command == "restart"
+
+
+def test_gateway_restart_reports_error_when_not_installed(capsys, monkeypatch) -> None:
+    from kolega_code.cli.gateway import run_gateway
+
+    monkeypatch.setattr("kolega_code.cli.gateway.is_service_installed", lambda: False)
+    args = parse_args(["gateway", "restart"])
+    exit_code = run_gateway(args)
+    assert exit_code == 1
+    err = capsys.readouterr().err
+    assert "not installed" in err
+
+
+def test_gateway_restart_succeeds_when_installed(capsys, monkeypatch) -> None:
+    from kolega_code.cli.gateway import run_gateway
+
+    monkeypatch.setattr("kolega_code.cli.gateway.is_service_installed", lambda: True)
+    monkeypatch.setattr(
+        "kolega_code.cli.gateway.restart_service",
+        lambda: (True, ["launchd agent restarted"]),
+    )
+    args = parse_args(["gateway", "restart"])
+    exit_code = run_gateway(args)
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "launchd agent restarted" in out
+
+
 def test_parse_gateway_pairing_subcommands() -> None:
     args = parse_args(["gateway", "pairing", "list"])
     assert args.pairing_command == "list"

--- a/tests/gateway/test_service.py
+++ b/tests/gateway/test_service.py
@@ -1,15 +1,20 @@
 """Service installation: systemd user units and launchd agents, file-level."""
 
 import plistlib
+import subprocess
 from pathlib import Path
 
 from kolega_code.gateway.config import GatewayConfig
 from kolega_code.gateway.service import (
     LAUNCHD_LABEL,
     LAUNCHD_PLIST_NAME,
+    SERVICE_NAME,
     SYSTEMD_UNIT_NAME,
     install_service,
+    is_service_installed,
+    restart_service,
     service_command,
+    service_unit_path,
     uninstall_service,
 )
 
@@ -91,3 +96,103 @@ def test_uninstall_removes_the_unit(tmp_path: Path) -> None:
     notes = uninstall_service(config, systemd_dir=systemd_dir, launchd_dir=tmp_path / "launchd", platform="linux")
     assert not (systemd_dir / SYSTEMD_UNIT_NAME).exists()
     assert notes  # reports what it removed
+
+
+def test_service_unit_path_resolves_platform_defaults(tmp_path: Path) -> None:
+    systemd_dir = tmp_path / "systemd"
+    launchd_dir = tmp_path / "launchd"
+
+    linux_path = service_unit_path(systemd_dir=systemd_dir, launchd_dir=launchd_dir, platform="linux")
+    assert linux_path == systemd_dir / SYSTEMD_UNIT_NAME
+
+    darwin_path = service_unit_path(systemd_dir=systemd_dir, launchd_dir=launchd_dir, platform="darwin")
+    assert darwin_path == launchd_dir / LAUNCHD_PLIST_NAME
+
+
+def test_is_service_installed(tmp_path: Path) -> None:
+    systemd_dir = tmp_path / "systemd"
+    systemd_dir.mkdir(parents=True)
+    assert not is_service_installed(systemd_dir=systemd_dir, platform="linux")
+
+    unit_path = systemd_dir / SYSTEMD_UNIT_NAME
+    unit_path.write_text("[Unit]", encoding="utf-8")
+    assert is_service_installed(systemd_dir=systemd_dir, platform="linux")
+
+
+def test_restart_service_linux_runs_daemon_reload_and_restart(tmp_path: Path, monkeypatch) -> None:
+    systemd_dir = tmp_path / "systemd"
+    systemd_dir.mkdir(parents=True)
+    unit_path = systemd_dir / SYSTEMD_UNIT_NAME
+    unit_path.write_text("[Unit]", encoding="utf-8")
+
+    commands_run = []
+
+    def fake_run(argv, **kwargs):
+        commands_run.append(argv)
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    success, notes = restart_service(systemd_dir=systemd_dir, platform="linux")
+    assert success is True
+    assert "systemd unit restarted" in notes
+    assert commands_run == [
+        ["systemctl", "--user", "daemon-reload"],
+        ["systemctl", "--user", "restart", SERVICE_NAME],
+    ]
+
+
+def test_restart_service_darwin_kickstart(tmp_path: Path, monkeypatch) -> None:
+    launchd_dir = tmp_path / "launchd"
+    launchd_dir.mkdir(parents=True)
+    plist_path = launchd_dir / LAUNCHD_PLIST_NAME
+    plist_path.write_text("<plist></plist>", encoding="utf-8")
+
+    commands_run = []
+
+    def fake_run(argv, **kwargs):
+        commands_run.append(argv)
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    success, notes = restart_service(launchd_dir=launchd_dir, platform="darwin")
+    assert success is True
+    assert "launchd agent restarted" in notes
+    assert len(commands_run) == 1
+    assert commands_run[0][:3] == ["launchctl", "kickstart", "-k"]
+    assert LAUNCHD_LABEL in commands_run[0][3]
+
+
+def test_restart_service_darwin_fallback(tmp_path: Path, monkeypatch) -> None:
+    launchd_dir = tmp_path / "launchd"
+    launchd_dir.mkdir(parents=True)
+    plist_path = launchd_dir / LAUNCHD_PLIST_NAME
+    plist_path.write_text("<plist></plist>", encoding="utf-8")
+
+    commands_run = []
+
+    def fake_run(argv, **kwargs):
+        commands_run.append(argv)
+        # First kickstart fails (e.g. exit code 113)
+        if "kickstart" in argv:
+            return subprocess.CompletedProcess(args=argv, returncode=113, stdout="", stderr="not found")
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    success, notes = restart_service(launchd_dir=launchd_dir, platform="darwin")
+    assert success is True
+    assert "launchd agent restarted" in notes
+    assert len(commands_run) == 3
+    assert commands_run[0][:3] == ["launchctl", "kickstart", "-k"]
+    assert commands_run[1][:2] == ["launchctl", "bootout"]
+    assert commands_run[2][:2] == ["launchctl", "bootstrap"]
+    assert str(plist_path) in commands_run[2]
+
+
+def test_restart_service_not_installed(tmp_path: Path) -> None:
+    systemd_dir = tmp_path / "systemd"
+    success, notes = restart_service(systemd_dir=systemd_dir, platform="linux")
+    assert success is False
+    assert any("not installed" in note for note in notes)


### PR DESCRIPTION
## Summary
Adds a `kolega-code gateway restart` command and ensures that running `kolega-code update` (as well as the `/update` TUI command and `install-kolega-code.sh`) automatically restarts the gateway background service when it is installed.

Supports both:
- **Linux**: `systemd` user service (`systemctl --user daemon-reload && systemctl --user restart kolega-code-gateway`)
- **macOS**: `launchd` LaunchAgent (`launchctl kickstart -k ...`, with fallback to `bootout` + `bootstrap`)

## Changes
- **`kolega_code/gateway/service.py`**:
  - Added `service_unit_path` and `is_service_installed` helpers for Linux and macOS.
  - Added `restart_service` with proper cross-platform lifecycle controls and timeouts.
- **`kolega_code/cli/gateway.py`**:
  - Added `restart` subcommand under `kolega-code gateway`.
  - Reports status notes on success; exits with 1 and descriptive guidance if the background service is not installed.
- **`kolega_code/cli/updater.py`, `kolega_code/cli/main.py`, `kolega_code/cli/tui/command_handlers.py`**:
  - `UpdateRunResult` tracks `gateway_restart_notes`.
  - `run_self_update()` checks `is_service_installed()` and restarts the gateway after a successful package upgrade.
  - CLI and TUI output notify the user when the gateway service has been restarted.
- **`scripts/install-kolega-code.sh`**:
  - Checks if the service unit exists after upgrade and invokes `gateway restart`.
- **`docs/src/content/docs/cli/gateway.md`**:
  - Documented `restart` command and update restart behavior.
- **Tests**:
  - Unit tests covering `service_unit_path`, `is_service_installed`, `restart_service` (Linux systemd and macOS launchd paths), CLI argument parsing & execution, and updater hooks.

## Verification
- `uv run ruff check kolega_code tests` passed.
- `uv run ruff format --check kolega_code tests` passed.
- `uv run pyright` passed with 0 errors.
- Unit and integration tests in `tests/gateway/` and `tests/cli/` passed.