### PR TITLE
chore: release v0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,33 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.35.0 - 2026-09-03
+
 ### Added
 
 - Added Google Gemini 3.8 Flash (`gemini-3.8-flash`): 1M-token context, 64K
   output, vision and function calling, and `low`/`medium`/`high` thinking
   levels. It omits Google's deprecated temperature parameter and is now the
   default Google model.
+- **Descriptive session titles.** Sessions now get a natural-language title
+  and a short description generated in the background by the active LLM after
+  substantive turns, while the stable session name keeps its role as the
+  peer-addressing handle. `/retitle` regenerates them on demand, a dedicated
+  Session card in the sidebar shows them, and the header, status dashboard,
+  startup banner, and `sessions` CLI output all display the title.
+- **`kolega-code gateway restart` and auto-restart on update.** The new
+  subcommand restarts an installed gateway service in place (systemd user
+  unit on Linux, launchd agent on macOS). `kolega-code update`, the `/update`
+  TUI command, and the shell installer now restart the gateway automatically
+  when the service is installed, so an update picks up the new build without
+  a manual daemon restart.
+
+### Changed
+
+- OpenRouter catalog refreshed from the live endpoint (2026-09-03 snapshot):
+  277 tool-capable models (20 featured), adding `google/gemini-3.8-flash` and
+  the `meta/muse-spark-1.3` pair, with featured order re-ranked by the latest
+  weekly token volume.
 
 ## 0.34.0 - 2026-09-02
 

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -174,4 +174,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.34.0"
+__version__ = "0.35.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.34.0"
+__version__ = "0.35.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.34.0"
+version = "0.35.0"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = "BUSL-1.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1825,7 +1825,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.34.0"
+version = "0.35.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary
Release v0.35.0: version bump to 0.35.0 in `pyproject.toml` + both `__init__.py` files, `uv.lock` refresh, and the 0.35.0 CHANGELOG section.

Highlights since v0.34.0:
- Added Google Gemini 3.8 Flash as the default Google model
- Descriptive session titles generated by the active LLM (`/retitle`, Session card)
- `kolega-code gateway restart` + gateway auto-restart on update
- OpenRouter catalog refresh (2026-09-03 snapshot, 277 tool-capable models)

## Checks
- Fast suite in `.venv-release`: 5300 passed; 6 failures are live provider tests only (ChatGPT connection-error flake; Together retired serverless access to `Kimi-K2.7-Code`) — environmental, CI skips live tests
- `pre-commit run --all-files`: all hooks pass