### PR TITLE
fix(gateway): tool activity as persistent per-round messages below the latest text

### DIFF
--- a/kolega_code/gateway/bridge.py
+++ b/kolega_code/gateway/bridge.py
@@ -13,7 +13,9 @@ turns:
   throttle until the turn ends (final-only transports get one message at the
   end);
 - tool activity lands in a separate "working…" status message, edited as
-  events arrive and deleted when the turn finishes;
+  events arrive and deleted when the turn finishes; once reply bubbles have
+  opened above it, the next tool event re-creates it below them (Telegram
+  cannot move messages), so new tool calls always show in the newest message;
 - text is chunked at the adapter's limit; the first chunk is the edited
   message and overflow chunks are sent as continuations on finalize.
 
@@ -73,6 +75,10 @@ class TurnRenderer:
         self._status_lines: list[str] = []
         self._status_sent_text = ""
         self._last_status_flush = 0.0
+        #: A reply send after the status message leaves it stranded above the
+        #: newest bubble; the next tool event then re-creates the status below
+        #: it (Telegram cannot move messages) instead of editing the old one.
+        self._status_stale = False
 
     async def run(self, chunks: AsyncIterator[dict[str, Any]]) -> str:
         """Consume the turn generator and mirror it into the chat.
@@ -144,6 +150,7 @@ class TurnRenderer:
                 return  # final-only transports send once, at the end
             self._reply_id = await self._adapter.send_text(self._chat_id, chunks[0])
             self._edited_text = chunks[0]
+            self._status_stale = True
             return
         if not final:
             if len(chunks) > 1:
@@ -155,6 +162,7 @@ class TurnRenderer:
         await self._edit_reply(chunks[0])
         for extra in chunks[1:]:
             await self._adapter.send_text(self._chat_id, extra)
+            self._status_stale = True
 
     async def _edit_reply(self, text: str) -> None:
         if text == self._edited_text:
@@ -196,15 +204,27 @@ class TurnRenderer:
         if not self._status_lines:
             return
         text = "\n".join(self._status_lines)
-        if text == self._status_sent_text:
+        stale = self._status_stale
+        self._status_stale = False
+        if text == self._status_sent_text and not stale:
             # Line-cap truncation can make a new event's rendered text
             # identical to the previous one; re-sending the same content is a
             # Telegram "message is not modified" error, not progress.
             return
         now = self._monotonic()
-        if self._status_id is not None and now - self._last_status_flush < self._edit_throttle:
+        if self._status_id is not None and not stale and now - self._last_status_flush < self._edit_throttle:
             return
         self._last_status_flush = now
+        if stale and self._status_id is not None:
+            # Telegram messages cannot move: reply bubbles have opened above
+            # the status since it was sent, so re-create it as the newest
+            # message instead of editing the stale one higher up the chat.
+            if self._adapter.capabilities.supports_delete:
+                stale_id, self._status_id = self._status_id, None
+                try:
+                    await self._adapter.delete_message(self._chat_id, stale_id)
+                except Exception:  # noqa: BLE001 — a stuck status message is cosmetic
+                    logger.debug("gateway: status reposition delete failed for chat %s", self._chat_id)
         if self._status_id is None:
             # No status message on transports that cannot edit it away.
             if not self._adapter.capabilities.supports_edits:

--- a/kolega_code/gateway/bridge.py
+++ b/kolega_code/gateway/bridge.py
@@ -12,10 +12,11 @@ turns:
 - a placeholder reply is created on first content and edited in place on a
   throttle until the turn ends (final-only transports get one message at the
   end);
-- tool activity lands in a separate "working…" status message, edited as
-  events arrive and deleted when the turn finishes; once reply bubbles have
-  opened above it, the next tool event re-creates it below them (Telegram
-  cannot move messages), so new tool calls always show in the newest message;
+- each round of tool activity lands in its own "working…" message below the
+  newest reply bubble: a round that starts after text was streamed opens a
+  fresh message (Telegram cannot move messages, so appending to an older one
+  would surface above the latest text), and the messages persist as a trail
+  of what the agent did during the turn;
 - text is chunked at the adapter's limit; the first chunk is the edited
   message and overflow chunks are sent as continuations on finalize.
 
@@ -36,10 +37,10 @@ from kolega_code.gateway.adapters.telegram.formatting import chunk_text
 
 logger = logging.getLogger(__name__)
 
-#: Cap on status-message lines so a chatty turn cannot spam an unbounded edit.
+#: Cap on a round message's lines so a chatty turn cannot spam an unbounded edit.
 MAX_STATUS_LINES = 8
-#: Events the status pump renders; everything else on the stream is ignored.
-STATUS_MESSAGE_TYPES = {"tool_call", "tool_result", "tool_error"}
+#: Rendered status line: (icon, tool description, tool call id).
+StatusLine = tuple[str, str, str]
 
 
 class TurnRenderer:
@@ -71,13 +72,16 @@ class TurnRenderer:
         self._reply_id: Optional[str] = None
         self._edited_text = ""
         self._last_flush = 0.0
+        #: The current tool round's message, one per burst of tool activity.
+        #: Older rounds' messages stay in the chat as a trail of the turn.
         self._status_id: Optional[str] = None
-        self._status_lines: list[str] = []
+        self._status_lines: list[StatusLine] = []
         self._status_sent_text = ""
         self._last_status_flush = 0.0
-        #: A reply send after the status message leaves it stranded above the
-        #: newest bubble; the next tool event then re-creates the status below
-        #: it (Telegram cannot move messages) instead of editing the old one.
+        #: Set when a reply message was sent after the current round message:
+        #: the next tool event then opens a fresh round message below the
+        #: newest bubble (Telegram cannot move messages) instead of appending
+        #: to the stale one higher up the chat.
         self._status_stale = False
 
     async def run(self, chunks: AsyncIterator[dict[str, Any]]) -> str:
@@ -124,7 +128,6 @@ class TurnRenderer:
                 except asyncio.CancelledError:
                     pass
             await self._adapter.set_typing(self._chat_id, False)
-            await self._finalize_status()
 
     # -- Reply messages (one per response segment) -------------------------
 
@@ -171,75 +174,72 @@ class TurnRenderer:
             await self._adapter.edit_text(self._chat_id, self._reply_id or "", text)
         self._edited_text = text
 
-    # -- Tool status message ----------------------------------------------
+    # -- Tool round messages ----------------------------------------------
 
     async def _event_pump(self) -> None:
         try:
             while True:
                 event = await self._events.get()
-                line = self._status_line_for(event)
-                if line is None:
+                record = self._line_record_for(event)
+                if record is None:
                     continue
-                self._status_lines.append(line)
-                self._status_lines = self._status_lines[-MAX_STATUS_LINES:]
+                if self._status_stale:
+                    # The newest reply bubble was sent after the current round
+                    # message: open a fresh round message below it instead of
+                    # appending to the stale one higher up the chat.
+                    self._status_stale = False
+                    self._status_id = None
+                    self._status_lines = []
+                self._record_line(record)
                 await self._flush_status()
         except asyncio.CancelledError:
             raise
 
     @staticmethod
-    def _status_line_for(event: AgentEvent) -> Optional[str]:
+    def _line_record_for(event: AgentEvent) -> Optional[StatusLine]:
         if event.event_type != "chat_message":
             return None
         message_type = event.content.get("message_type")
+        description = str(event.content.get("tool_description") or "tool")
+        call_id = str(event.content.get("tool_call_id") or "")
         if message_type == "tool_call":
-            description = event.content.get("tool_description") or "tool"
-            return f"⏳ {description}"
+            return ("⏳", description, call_id)
         if message_type == "tool_result":
-            return "✅ tool finished"
+            return ("✅", description, call_id)
         if message_type == "tool_error":
-            return "❌ tool failed"
+            return ("❌", description, call_id)
         return None
+
+    def _record_line(self, record: StatusLine) -> None:
+        icon, _, call_id = record
+        if icon != "⏳" and call_id:
+            # A finished call replaces its pending line so the round message
+            # reads as a settled trail (⏳ bash -> ✅ bash), not an append log.
+            for index, (pending_icon, _, pending_id) in enumerate(self._status_lines):
+                if pending_icon == "⏳" and pending_id == call_id:
+                    self._status_lines[index] = record
+                    return
+        self._status_lines.append(record)
+        self._status_lines = self._status_lines[-MAX_STATUS_LINES:]
 
     async def _flush_status(self) -> None:
         if not self._status_lines:
             return
-        text = "\n".join(self._status_lines)
-        stale = self._status_stale
-        self._status_stale = False
-        if text == self._status_sent_text and not stale:
+        text = "\n".join(f"{icon} {description}" for icon, description, _ in self._status_lines)
+        if text == self._status_sent_text:
             # Line-cap truncation can make a new event's rendered text
             # identical to the previous one; re-sending the same content is a
             # Telegram "message is not modified" error, not progress.
             return
         now = self._monotonic()
-        if self._status_id is not None and not stale and now - self._last_status_flush < self._edit_throttle:
+        if self._status_id is not None and now - self._last_status_flush < self._edit_throttle:
             return
         self._last_status_flush = now
-        if stale and self._status_id is not None:
-            # Telegram messages cannot move: reply bubbles have opened above
-            # the status since it was sent, so re-create it as the newest
-            # message instead of editing the stale one higher up the chat.
-            if self._adapter.capabilities.supports_delete:
-                stale_id, self._status_id = self._status_id, None
-                try:
-                    await self._adapter.delete_message(self._chat_id, stale_id)
-                except Exception:  # noqa: BLE001 — a stuck status message is cosmetic
-                    logger.debug("gateway: status reposition delete failed for chat %s", self._chat_id)
         if self._status_id is None:
-            # No status message on transports that cannot edit it away.
+            # No round message on transports that cannot edit it away.
             if not self._adapter.capabilities.supports_edits:
                 return
             self._status_id = await self._adapter.send_text(self._chat_id, text)
         else:
             await self._adapter.edit_text(self._chat_id, self._status_id, text)
         self._status_sent_text = text
-
-    async def _finalize_status(self) -> None:
-        if self._status_id is None:
-            return
-        message_id, self._status_id = self._status_id, None
-        if self._adapter.capabilities.supports_delete:
-            try:
-                await self._adapter.delete_message(self._chat_id, message_id)
-            except Exception:  # noqa: BLE001 — a stuck status message is cosmetic
-                logger.debug("gateway: status delete failed for chat %s", self._chat_id)

--- a/tests/gateway/test_bridge.py
+++ b/tests/gateway/test_bridge.py
@@ -145,6 +145,46 @@ async def test_tool_events_render_as_status_message_and_are_deleted() -> None:
 
 
 @pytest.mark.asyncio
+async def test_tool_status_recreates_below_newest_reply_bubble() -> None:
+    """Reply bubbles opened after the status message leave it stranded higher
+    up the conversation; the next tool event must re-create the status below
+    them — as the newest message — instead of editing the stale one."""
+    adapter = FakeAdapter()
+    queue: asyncio.Queue[AgentEvent] = asyncio.Queue()
+    r = TurnRenderer(adapter, "chat-1", event_queue=queue, edit_throttle_seconds=0.0)
+    await queue.put(tool_event("bash"))
+    gate = asyncio.Event()
+
+    async def tool_round() -> AsyncIterator[dict[str, Any]]:
+        yield {"type": "response", "content": "before", "complete": False, "uuid": "u-1"}
+        await gate.wait()
+        yield {"type": "response", "content": "", "complete": True, "uuid": "u-1"}
+        yield {"type": "response", "content": "after", "complete": True, "uuid": "u-2"}
+        await queue.put(tool_event("read"))
+        await asyncio.sleep(0.1)  # pump re-creates the status below "after"
+        yield {"type": "response", "content": "", "complete": True, "uuid": "u-2"}
+
+    run_task = asyncio.create_task(r.run(tool_round()))
+    await asyncio.sleep(0.05)  # pump creates the first status message
+    gate.set()
+    await run_task
+
+    sends = [call for call in adapter.calls if call[0] == "send"]
+    # Status first, then one bubble per segment, then the re-created status —
+    # carrying the earlier line — as the newest message of the conversation.
+    assert [call[3] for call in sends] == ["⏳ bash", "before", "after", "⏳ bash\n⏳ read"]
+    first, recreated = sends[0][2], sends[3][2]
+    # The stale status was deleted before its replacement was sent: a new
+    # message at the bottom, never an edit of the one higher up.
+    assert adapter.calls.index(("delete", "chat-1", first)) < adapter.calls.index(
+        ("send", "chat-1", recreated, "⏳ bash\n⏳ read")
+    )
+    assert not any(call[0] == "edit" and call[2] == first for call in adapter.calls)
+    # The replacement (now the conversation's last message) is cleaned up at finalize.
+    assert ("delete", "chat-1", recreated) in adapter.calls
+
+
+@pytest.mark.asyncio
 async def test_thinking_only_turns_send_nothing() -> None:
     adapter = FakeAdapter()
 

--- a/tests/gateway/test_bridge.py
+++ b/tests/gateway/test_bridge.py
@@ -56,11 +56,24 @@ def renderer(adapter: FakeAdapter, **kwargs: Any) -> TurnRenderer:
     return TurnRenderer(adapter, "chat-1", event_queue=asyncio.Queue(), edit_throttle_seconds=0.0, **kwargs)
 
 
-def tool_event(description: str = "bash") -> AgentEvent:
+def tool_event(description: str = "bash", call_id: str = "t-1") -> AgentEvent:
     return AgentEvent(
         event_type="chat_message",
         sender="system",
-        content={"message_type": "tool_call", "text": "", "tool_description": description, "tool_call_id": "t-1"},
+        content={"message_type": "tool_call", "text": "", "tool_description": description, "tool_call_id": call_id},
+    )
+
+
+def tool_result_event(description: str = "bash", call_id: str = "t-1", *, error: bool = False) -> AgentEvent:
+    return AgentEvent(
+        event_type="chat_message",
+        sender="system",
+        content={
+            "message_type": "tool_error" if error else "tool_result",
+            "text": "",
+            "tool_description": description,
+            "tool_call_id": call_id,
+        },
     )
 
 
@@ -117,71 +130,87 @@ async def test_edit_throttle_skips_intermediate_edits() -> None:
 
 
 @pytest.mark.asyncio
-async def test_tool_events_render_as_status_message_and_are_deleted() -> None:
+async def test_tool_round_renders_as_persistent_message() -> None:
     adapter = FakeAdapter()
     queue: asyncio.Queue[AgentEvent] = asyncio.Queue()
     r = TurnRenderer(adapter, "chat-1", event_queue=queue, edit_throttle_seconds=0.0)
     await queue.put(tool_event("bash"))
     await queue.put(tool_event("read"))
 
-    # A real turn runs long enough for the pump to drain the queued events;
-    # model that with a gate the pump can pass while the stream is suspended.
-    gate = asyncio.Event()
-
     async def slow_chunks() -> AsyncIterator[dict[str, Any]]:
+        # The pump drains the pre-queued round before the stream starts.
+        await asyncio.sleep(0.1)
         yield {"type": "response", "content": "do", "complete": False, "uuid": "u-1"}
-        await gate.wait()
         yield {"type": "response", "content": "ne", "complete": True, "uuid": "u-1"}
 
-    run_task = asyncio.create_task(r.run(slow_chunks()))
-    await asyncio.sleep(0.05)  # pump drains both tool events
-    gate.set()
-    text = await run_task
+    text = await r.run(slow_chunks())
     assert text == "done"
     status_id = [call[2] for call in adapter.calls if call[0] == "send" and call[3] != "done"][0]
     assert ("send", "chat-1", status_id, "⏳ bash") in adapter.calls
     assert ("edit", "chat-1", status_id, "⏳ bash\n⏳ read") in adapter.calls
-    assert ("delete", "chat-1", status_id) in adapter.calls
+    # The round message persists as the turn's trail: no cleanup at the end.
+    assert not [call for call in adapter.calls if call[0] == "delete"]
 
 
 @pytest.mark.asyncio
-async def test_tool_status_recreates_below_newest_reply_bubble() -> None:
-    """Reply bubbles opened after the status message leave it stranded higher
-    up the conversation; the next tool event must re-create the status below
-    them — as the newest message — instead of editing the stale one."""
+async def test_new_tool_round_opens_message_below_latest_text() -> None:
+    """A tool round that starts after a reply bubble was sent opens its own
+    message below the latest text — it never appends to the previous round's
+    message higher up the chat, and round messages persist as the trail."""
     adapter = FakeAdapter()
     queue: asyncio.Queue[AgentEvent] = asyncio.Queue()
     r = TurnRenderer(adapter, "chat-1", event_queue=queue, edit_throttle_seconds=0.0)
     await queue.put(tool_event("bash"))
     gate = asyncio.Event()
 
-    async def tool_round() -> AsyncIterator[dict[str, Any]]:
+    async def tool_rounds() -> AsyncIterator[dict[str, Any]]:
         yield {"type": "response", "content": "before", "complete": False, "uuid": "u-1"}
         await gate.wait()
         yield {"type": "response", "content": "", "complete": True, "uuid": "u-1"}
         yield {"type": "response", "content": "after", "complete": True, "uuid": "u-2"}
         await queue.put(tool_event("read"))
-        await asyncio.sleep(0.1)  # pump re-creates the status below "after"
+        await asyncio.sleep(0.1)  # pump opens the second round message
         yield {"type": "response", "content": "", "complete": True, "uuid": "u-2"}
 
-    run_task = asyncio.create_task(r.run(tool_round()))
-    await asyncio.sleep(0.05)  # pump creates the first status message
+    run_task = asyncio.create_task(r.run(tool_rounds()))
+    await asyncio.sleep(0.05)  # pump creates the first round message
     gate.set()
     await run_task
 
     sends = [call for call in adapter.calls if call[0] == "send"]
-    # Status first, then one bubble per segment, then the re-created status —
-    # carrying the earlier line — as the newest message of the conversation.
-    assert [call[3] for call in sends] == ["⏳ bash", "before", "after", "⏳ bash\n⏳ read"]
-    first, recreated = sends[0][2], sends[3][2]
-    # The stale status was deleted before its replacement was sent: a new
-    # message at the bottom, never an edit of the one higher up.
-    assert adapter.calls.index(("delete", "chat-1", first)) < adapter.calls.index(
-        ("send", "chat-1", recreated, "⏳ bash\n⏳ read")
-    )
-    assert not any(call[0] == "edit" and call[2] == first for call in adapter.calls)
-    # The replacement (now the conversation's last message) is cleaned up at finalize.
-    assert ("delete", "chat-1", recreated) in adapter.calls
+    # Round 1 first, then the reply bubbles, then round 2 as a fresh message
+    # below "after" carrying only its own tool line.
+    assert [call[3] for call in sends] == ["⏳ bash", "before", "after", "⏳ read"]
+    # Nothing is ever deleted: round messages are the turn's persistent trail.
+    assert not [call for call in adapter.calls if call[0] == "delete"]
+
+
+@pytest.mark.asyncio
+async def test_tool_results_replace_pending_lines_in_place() -> None:
+    """A finished call settles its pending line (⏳ bash -> ✅ bash) instead of
+    appending a generic 'tool finished' line, so the round message reads as a
+    settled trail in call order."""
+    adapter = FakeAdapter()
+    queue: asyncio.Queue[AgentEvent] = asyncio.Queue()
+    r = TurnRenderer(adapter, "chat-1", event_queue=queue, edit_throttle_seconds=0.0)
+    await queue.put(tool_event("bash", call_id="t-1"))
+    await queue.put(tool_event("read", call_id="t-2"))
+    await queue.put(tool_result_event("bash", call_id="t-1"))
+    await queue.put(tool_result_event("read", call_id="t-2"))
+
+    async def slow_chunks() -> AsyncIterator[dict[str, Any]]:
+        # The pump drains the pre-queued round before the stream starts.
+        await asyncio.sleep(0.1)
+        yield {"type": "response", "content": "hi!", "complete": True, "uuid": "u-1"}
+
+    text = await r.run(slow_chunks())
+    assert text == "hi!"
+
+    status_id = [call[2] for call in adapter.calls if call[0] == "send" and call[3] != "hi!"][0]
+    assert ("send", "chat-1", status_id, "⏳ bash") in adapter.calls
+    assert ("edit", "chat-1", status_id, "⏳ bash\n⏳ read") in adapter.calls
+    assert ("edit", "chat-1", status_id, "✅ bash\n⏳ read") in adapter.calls
+    assert ("edit", "chat-1", status_id, "✅ bash\n✅ read") in adapter.calls
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

In Telegram, all tool calls of a turn were rendered into a **single status message**: the renderer created it at the first tool event and only edited it afterwards. Since each tool round opens a new reply bubble below the previous one and Telegram cannot move messages, new tool calls kept being appended — by editing — to the message stranded **above** the agent's latest text, instead of appearing below it.

## Fix

`TurnRenderer` (`kolega_code/gateway/bridge.py`) now renders **one message per tool round, persisted as a visible trail**:

- A burst of tool activity opens its own "working…" message below the newest reply bubble. A round that starts after text was streamed always opens a fresh message — it never appends to a previous round's message higher up the chat.
- Within a round, a finished call settles its pending line in place (`⏳ bash` → `✅ bash`, `❌ bash` on error) instead of appending a generic "✅ tool finished", matching events by their shared `tool_call_id`.
- Round messages are **no longer deleted** when the turn finishes, so the chat keeps a readable trail: text → tools → text → tools → final answer.

A turn now looks like:

```
⏳ bash
✅ bash
Let me check the tests.
⏳ read
✅ read
Fixed it.
```

Line cap per round message stays at `MAX_STATUS_LINES = 8`; transports without edit support still send no tool messages (unchanged).

## Testing

- `test_new_tool_round_opens_message_below_latest_text`: a second tool round after reply bubbles opens a fresh message below the latest text, carrying only its own line; nothing is ever deleted.
- `test_tool_results_replace_pending_lines_in_place`: results settle their pending lines in call order (`✅ bash\n⏳ read` → `✅ bash\n✅ read`).
- `test_tool_round_renders_as_persistent_message`: a round accumulates its calls in one edited message and persists after the turn.
- Full gateway suite: 189 passed, 1 skipped (live Telegram test requiring real credentials); ruff + pyright clean; pre-commit hooks pass on both files.