### PR TITLE
fix(gateway): launch the background service through the user's login shell

### DIFF
--- a/docs/src/content/docs/cli/gateway.md
+++ b/docs/src/content/docs/cli/gateway.md
@@ -55,6 +55,12 @@ below).
 
 Running `kolega-code update` automatically restarts the gateway service if it is installed, so the running daemon picks up new versions immediately.
 
+The background service launches through your login shell (`$SHELL`), so the
+daemon sees the same environment as an interactive terminal — service
+managers alone provide a minimal `PATH` that would hide user-installed tools
+from gateway-driven sessions. Restart the service after changing your shell
+profile to pick up the new environment.
+
 ## In-chat commands
 
 `/new`, `/status`, `/model [model]`, `/permissions [ask|auto]`, `/stop`, `/help`.

--- a/kolega_code/gateway/service.py
+++ b/kolega_code/gateway/service.py
@@ -50,6 +50,34 @@ class ServiceInstallResult:
     unit_path: Optional[Path] = None
 
 
+def login_shell(platform: Optional[str] = None) -> str:
+    """The user's login shell: ``$SHELL`` when set, else the platform default.
+
+    launchd and systemd start service programs directly, so the daemon would
+    inherit the service manager's minimal environment (launchd gives agents
+    ``PATH=/usr/bin:/bin:/usr/sbin:/sbin``), which starves gateway-driven
+    agent sessions of Homebrew and other user-installed tools.  The service
+    therefore launches through the user's login shell: ``-l`` runs the shell
+    profile files, so the daemon's environment matches what an interactive
+    terminal sees, and nothing is captured at install time.
+    """
+    platform = platform if platform is not None else sys.platform
+    from_env = os.environ.get("SHELL")
+    if from_env:
+        return from_env
+    return "/bin/zsh" if platform == "darwin" else "/bin/bash"
+
+
+def service_launch_command(config: GatewayConfig, executable: str, *, shell: str) -> list[str]:
+    """The service-level argv: the login shell exec-ing the daemon.
+
+    ``exec`` replaces the shell process, so termination signals reach the
+    daemon directly and launchd/KeepAlive track the real process.
+    """
+    inner = " ".join(shlex.quote(part) for part in service_command(config, executable))
+    return [shell, "-l", "-c", f"exec {inner}"]
+
+
 def service_command(config: GatewayConfig, executable: str) -> list[str]:
     """The exact argv the service runs."""
     return [
@@ -69,6 +97,7 @@ def install_service(
     config: GatewayConfig,
     *,
     executable: Optional[str] = None,
+    shell: Optional[str] = None,
     systemd_dir: Optional[Path] = None,
     launchd_dir: Optional[Path] = None,
     platform: Optional[str] = None,
@@ -76,12 +105,16 @@ def install_service(
     """Write the service definition.
 
     ``systemd_dir``/``launchd_dir`` are the unit destination directories;
-    callers resolve the platform defaults (tests pass temp dirs).
+    callers resolve the platform defaults (tests pass temp dirs).  ``shell``
+    overrides the login shell the service launches through (tests pass one
+    for determinism); by default the user's ``$SHELL`` or the platform
+    default is used.
     """
     platform = platform if platform is not None else sys.platform
     executable = executable or shutil.which("kolega-code") or ""
     if not executable:
         raise RuntimeError("kolega-code executable not found; is it on PATH?")
+    launch_shell = shell or login_shell(platform)
     config.state_dir.mkdir(parents=True, exist_ok=True)
     result = ServiceInstallResult()
     if platform == "darwin":
@@ -90,7 +123,7 @@ def install_service(
         plist_path = launchd_dir / LAUNCHD_PLIST_NAME
         plist: dict[str, object] = {
             "Label": LAUNCHD_LABEL,
-            "ProgramArguments": service_command(config, executable),
+            "ProgramArguments": service_launch_command(config, executable, shell=launch_shell),
             "RunAtLoad": True,
             "KeepAlive": True,
             "StandardOutPath": str(config.state_dir / "gateway.log"),
@@ -103,10 +136,16 @@ def install_service(
         systemd_dir = systemd_dir or (Path.home() / ".config" / "systemd" / "user")
         systemd_dir.mkdir(parents=True, exist_ok=True)
         unit_path = systemd_dir / SYSTEMD_UNIT_NAME
-        command = " ".join(shlex.quote(part) for part in service_command(config, executable))
+        command = " ".join(
+            shlex.quote(part) for part in service_launch_command(config, executable, shell=launch_shell)
+        )
         unit_path.write_text(_SYSTEMD_UNIT_TEMPLATE.format(command=command), encoding="utf-8")
         result.unit_path = unit_path
         result.notes.append(f"systemd user unit written to {unit_path}")
+    result.notes.append(
+        f"the service launches via your login shell ({launch_shell}), so it inherits your "
+        "normal terminal environment; restart it after changing your shell profile"
+    )
     result.notes.append(
         "the service reads settings.json from the same state dir — make sure your provider "
         "API keys are saved in Settings (they apply to the gateway too)"

--- a/kolega_code/gateway/service.py
+++ b/kolega_code/gateway/service.py
@@ -136,9 +136,7 @@ def install_service(
         systemd_dir = systemd_dir or (Path.home() / ".config" / "systemd" / "user")
         systemd_dir.mkdir(parents=True, exist_ok=True)
         unit_path = systemd_dir / SYSTEMD_UNIT_NAME
-        command = " ".join(
-            shlex.quote(part) for part in service_launch_command(config, executable, shell=launch_shell)
-        )
+        command = " ".join(shlex.quote(part) for part in service_launch_command(config, executable, shell=launch_shell))
         unit_path.write_text(_SYSTEMD_UNIT_TEMPLATE.format(command=command), encoding="utf-8")
         result.unit_path = unit_path
         result.notes.append(f"systemd user unit written to {unit_path}")

--- a/tests/gateway/test_service.py
+++ b/tests/gateway/test_service.py
@@ -12,8 +12,10 @@ from kolega_code.gateway.service import (
     SYSTEMD_UNIT_NAME,
     install_service,
     is_service_installed,
+    login_shell,
     restart_service,
     service_command,
+    service_launch_command,
     service_unit_path,
     uninstall_service,
 )
@@ -44,12 +46,34 @@ def test_service_command_argv() -> None:
     ]
 
 
+def test_service_launch_command_wraps_the_daemon_in_a_login_shell() -> None:
+    config = make_config(Path("/tmp/x"))
+    argv = service_launch_command(config, "/usr/local/bin/kolega-code", shell="/bin/zsh")
+    assert argv[:3] == ["/bin/zsh", "-l", "-c"]
+    # `exec` replaces the shell so signals reach the daemon directly.
+    assert argv[3].startswith("exec /usr/local/bin/kolega-code gateway run")
+    assert f"--state-dir {config.state_dir}" in argv[3]
+
+
+def test_service_launch_command_quotes_paths_with_spaces() -> None:
+    config = GatewayConfig(
+        adapter="telegram",
+        project_path=Path("/tmp/my project"),
+        state_dir=Path("/tmp/ Application Support/state"),
+        telegram_token="123:fake-bot-token-for-tests-only",
+    )
+    argv = service_launch_command(config, "/usr/local/bin/kolega-code", shell="/bin/bash")
+    assert "'/tmp/ Application Support/state'" in argv[3]
+    assert "'/tmp/my project'" in argv[3]
+
+
 def test_install_writes_systemd_unit_without_env_file(tmp_path: Path) -> None:
     config = make_config(tmp_path)
     systemd_dir = tmp_path / "systemd-user"
     result = install_service(
         config,
         executable="/usr/local/bin/kolega-code",
+        shell="/bin/bash",
         systemd_dir=systemd_dir,
         launchd_dir=tmp_path / "launchd",
         platform="linux",
@@ -58,7 +82,9 @@ def test_install_writes_systemd_unit_without_env_file(tmp_path: Path) -> None:
     assert result.unit_path == unit_path
     assert unit_path.exists()
     unit_text = unit_path.read_text(encoding="utf-8")
-    assert "ExecStart=/usr/local/bin/kolega-code gateway run" in unit_text
+    # The daemon launches through the login shell so it inherits the user's
+    # normal environment (launchd/systemd alone provide a minimal PATH).
+    assert "ExecStart=/bin/bash -l -c 'exec /usr/local/bin/kolega-code gateway run" in unit_text
     assert f"--state-dir {config.state_dir}" in unit_text
     # Configuration comes from settings.json, so no EnvironmentFile.
     assert "EnvironmentFile" not in unit_text
@@ -71,6 +97,7 @@ def test_install_writes_launchd_plist_without_env_variables(tmp_path: Path) -> N
     result = install_service(
         config,
         executable="/usr/local/bin/kolega-code",
+        shell="/bin/zsh",
         systemd_dir=tmp_path / "systemd-user",
         launchd_dir=launchd_dir,
         platform="darwin",
@@ -79,8 +106,42 @@ def test_install_writes_launchd_plist_without_env_variables(tmp_path: Path) -> N
     assert result.unit_path == plist_path
     plist = plistlib.loads(plist_path.read_bytes())
     assert plist["Label"] == LAUNCHD_LABEL
-    assert plist["ProgramArguments"][:3] == ["/usr/local/bin/kolega-code", "gateway", "run"]
+    argv = plist["ProgramArguments"]
+    assert argv[:3] == ["/bin/zsh", "-l", "-c"]
+    assert argv[3].startswith("exec /usr/local/bin/kolega-code gateway run")
     assert "EnvironmentVariables" not in plist
+    assert any("login shell" in note for note in result.notes)
+
+
+def test_install_uses_shell_env_var_when_set(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("SHELL", "/bin/fish")
+    launchd_dir = tmp_path / "LaunchAgents"
+    install_service(
+        make_config(tmp_path),
+        executable="/usr/local/bin/kolega-code",
+        systemd_dir=tmp_path / "systemd-user",
+        launchd_dir=launchd_dir,
+        platform="darwin",
+    )
+    plist = plistlib.loads((launchd_dir / LAUNCHD_PLIST_NAME).read_bytes())
+    assert plist["ProgramArguments"][0] == "/bin/fish"
+
+
+def test_install_falls_back_to_platform_default_shell(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.delenv("SHELL", raising=False)
+    assert login_shell(platform="darwin") == "/bin/zsh"
+    assert login_shell(platform="linux") == "/bin/bash"
+
+    launchd_dir = tmp_path / "LaunchAgents"
+    install_service(
+        make_config(tmp_path),
+        executable="/usr/local/bin/kolega-code",
+        systemd_dir=tmp_path / "systemd-user",
+        launchd_dir=launchd_dir,
+        platform="darwin",
+    )
+    plist = plistlib.loads((launchd_dir / LAUNCHD_PLIST_NAME).read_bytes())
+    assert plist["ProgramArguments"][0] == "/bin/zsh"
 
 
 def test_uninstall_removes_the_unit(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

`gateway install` writes a launchd plist / systemd unit that executes the daemon directly. Service managers start programs with a minimal environment — launchd agents get `PATH=/usr/bin:/bin:/usr/sbin:/sbin` — so gateway-driven agent sessions could not see Homebrew or other user-installed tools (`rg`, `node`, …). Verified live: a running gateway daemon had exactly that starved PATH, while foreground runs inherited the interactive shell and worked.

## Fix

The service definition now launches through the user's login shell:

```
["/bin/zsh", "-l", "-c", "exec <kolega-code> gateway run …"]
```

- `-l` sources the shell profile files, so the daemon's environment matches an interactive terminal.
- `exec` replaces the shell process, so signals reach the daemon directly and `KeepAlive`/`Restart` track the real pid.
- Nothing is captured at install time: the no-captured-environment design (settings.json for all config) is unchanged, and the plist still contains no `EnvironmentVariables`.

`$SHELL` is used when set, with platform defaults (`/bin/zsh` on macOS, `/bin/bash` on Linux). The install notes tell the user to restart the service after changing their shell profile. Docs updated in `docs/src/content/docs/cli/gateway.md`.

## Test plan

- [x] `tests/gateway/test_service.py`: updated the two install tests for the wrapper; added coverage for the wrapper shape (`exec`, quoting of paths with spaces), `$SHELL` honored, and platform fallback.
- [x] `pytest tests/gateway/test_service.py tests/gateway/test_cli_gateway.py` — 37 passed.
- [x] `ruff check` clean on both files.
