### PR TITLE
chore: release v0.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.35.1 - 2026-09-03
+
+### Fixed
+
+- **Gateway (Telegram):** the tool-activity status now re-appears below the
+  newest reply bubble. Previously it stayed stranded in an older message once
+  a reply opened, so later tool calls looked detached from the conversation.
+  Adapters without message-delete support keep the edit-in-place behavior.
+- **Gateway service:** the background daemon now launches through the user's
+  login shell, so gateway-driven agent sessions see user-installed tools such
+  as Homebrew instead of the minimal `PATH` that launchd and systemd provide.
+
 ## 0.35.0 - 2026-09-03
 
 ### Added

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -174,4 +174,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.35.0"
+__version__ = "0.35.1"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.35.0"
+__version__ = "0.35.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.35.0"
+version = "0.35.1"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = "BUSL-1.1"

--- a/tests/cli/test_updater.py
+++ b/tests/cli/test_updater.py
@@ -80,6 +80,8 @@ def test_run_self_update_runs_uv_tool_upgrade(monkeypatch) -> None:
 
     monkeypatch.setattr(updater.shutil, "which", lambda command: "/usr/bin/uv")
     monkeypatch.setattr(updater.subprocess, "run", fake_run)
+    # Run regardless of whether this machine has the gateway service installed.
+    monkeypatch.setattr("kolega_code.gateway.service.is_service_installed", lambda: False)
 
     result = updater.run_self_update(capture_output=True)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1825,7 +1825,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.35.0"
+version = "0.35.1"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Release v0.35.1

Patch release with two gateway fixes shipped since v0.35.0:

- **Gateway (Telegram):** re-create the tool-activity status below the newest reply bubble instead of leaving it stranded in an older message (#671).
- **Gateway service:** launch the background daemon through the user's login shell so agent sessions see user-installed tools such as Homebrew (#672).

Also includes a test-only fix making `test_run_self_update_runs_uv_tool_upgrade` independent of whether the local machine has the gateway service installed.

Changelog and version bumps (`pyproject.toml`, `kolega_code/__init__.py`, `kolega_code/agent/__init__.py`, `uv.lock`) are in this PR per RELEASING.md.