### PR TITLE
fix(gateway): keep the typing indicator alive for the whole turn

### DIFF
--- a/kolega_code/gateway/bridge.py
+++ b/kolega_code/gateway/bridge.py
@@ -18,7 +18,10 @@ turns:
   would surface above the latest text), and the messages persist as a trail
   of what the agent did during the turn;
 - text is chunked at the adapter's limit; the first chunk is the edited
-  message and overflow chunks are sent as continuations on finalize.
+  message and overflow chunks are sent as continuations on finalize;
+- a typing action is re-sent every few seconds for the whole turn (chat
+  platforms expire it after ~5s), so thinking and long tool runs keep
+  showing "typing…" until the reply lands.
 
 Chunk content is *incremental*, so the renderer appends and re-renders the
 accumulated text — it never replaces with the last segment.
@@ -39,6 +42,10 @@ logger = logging.getLogger(__name__)
 
 #: Cap on a round message's lines so a chatty turn cannot spam an unbounded edit.
 MAX_STATUS_LINES = 8
+#: Chat platforms expire a typing action after ~5 seconds (Telegram: "status
+#: is set for 5 seconds or less"); refresh slightly faster so the indicator
+#: never lapses while a turn is in progress.
+TYPING_REFRESH_SECONDS = 4.0
 #: Rendered status line: (icon, tool description, tool call id).
 StatusLine = tuple[str, str, str]
 
@@ -54,6 +61,7 @@ class TurnRenderer:
         event_queue: asyncio.Queue[AgentEvent],
         chunk_limit: Optional[int] = None,
         edit_throttle_seconds: float = 1.0,
+        typing_refresh_seconds: float = TYPING_REFRESH_SECONDS,
         monotonic: Any = time.monotonic,
     ) -> None:
         self._adapter = adapter
@@ -61,6 +69,7 @@ class TurnRenderer:
         self._events = event_queue
         self._chunk_limit = chunk_limit or adapter.capabilities.text_chunk_limit
         self._edit_throttle = edit_throttle_seconds
+        self._typing_refresh = typing_refresh_seconds
         self._monotonic = monotonic
         # Per-segment state, mirroring the TUI's stream fold: a segment is one
         # contiguous assistant response identified by its chunk uuid (the
@@ -92,10 +101,12 @@ class TurnRenderer:
         reply stays visible.
         """
         pump: Optional[asyncio.Task[None]] = None
+        typing: Optional[asyncio.Task[None]] = None
         if self._events is not None:
             pump = asyncio.create_task(self._event_pump(), name="gateway-turn-event-pump")
         try:
             await self._adapter.set_typing(self._chat_id, True)
+            typing = asyncio.create_task(self._typing_keepalive(), name="gateway-turn-typing")
             async for chunk in chunks:
                 if chunk.get("type") != "response":
                     # Thinking chunks stay off the wire; they are reasoning, not output.
@@ -121,13 +132,30 @@ class TurnRenderer:
             await self._finalize_segment()
             return self._total_text
         finally:
-            if pump is not None:
-                pump.cancel()
-                try:
-                    await pump
-                except asyncio.CancelledError:
-                    pass
+            for task in (pump, typing):
+                if task is not None:
+                    task.cancel()
+                    try:
+                        await task
+                    except asyncio.CancelledError:
+                        pass
             await self._adapter.set_typing(self._chat_id, False)
+
+    async def _typing_keepalive(self) -> None:
+        """Re-send the typing action so the indicator outlives its ~5s expiry.
+
+        Covers the silent stretches of a turn — model thinking before the
+        first chunk and long-running tool calls, where no message is sent or
+        edited. Refresh only (never hides: the ``False`` call is the
+        adapter's business); a failing adapter must not end the loop, since
+        typing is cosmetic.
+        """
+        while True:
+            await asyncio.sleep(self._typing_refresh)
+            try:
+                await self._adapter.set_typing(self._chat_id, True)
+            except Exception:  # noqa: BLE001 — typing indicators are cosmetic
+                logger.debug("gateway: typing refresh failed", exc_info=True)
 
     # -- Reply messages (one per response segment) -------------------------
 

--- a/tests/gateway/test_bridge.py
+++ b/tests/gateway/test_bridge.py
@@ -91,6 +91,33 @@ async def test_streams_with_edit_in_place() -> None:
 
 
 @pytest.mark.asyncio
+async def test_typing_is_refreshed_while_the_turn_runs() -> None:
+    """Chat platforms expire the typing action after ~5s: a slow turn must
+    re-send it so the indicator keeps showing through thinking and tool
+    runs, and stops when the turn ends."""
+    adapter = FakeAdapter()
+
+    async def slow_chunks() -> AsyncIterator[dict[str, Any]]:
+        for _ in range(3):
+            await asyncio.sleep(0.05)
+            yield {"type": "response", "content": "x", "complete": False, "uuid": "u-1"}
+        yield {"type": "response", "content": "!", "complete": True, "uuid": "u-1"}
+
+    r = TurnRenderer(
+        adapter,
+        "chat-1",
+        event_queue=asyncio.Queue(),
+        edit_throttle_seconds=0.0,
+        typing_refresh_seconds=0.01,
+    )
+    await r.run(slow_chunks())
+    typing_on = [call for call in adapter.calls if call == ("typing", "chat-1", True)]
+    # The initial action plus refreshes across the turn's quiet stretches.
+    assert len(typing_on) >= 3
+    assert adapter.calls[-1] == ("typing", "chat-1", False)
+
+
+@pytest.mark.asyncio
 async def test_final_only_transport_sends_once() -> None:
     adapter = FakeAdapter(edits=False)
     text = await renderer(adapter).run(chunks("hello", " world"))


### PR DESCRIPTION
## Problem

Telegram's `sendChatAction` typing indicator expires server-side after ~5 seconds. The gateway sent it exactly once, at turn start, so the "typing…" indicator vanished during precisely the stretches where a user is watching and nothing else is happening:

- **model thinking** before the first response chunk lands (often far longer than 5s, longer still for reasoning models),
- **long-running tool calls**, where the only surface was the static ⏳/✅ status trail (message edits don't produce typing).

## Fix

`TurnRenderer` now runs a typing keep-alive task for the whole turn:

- re-sends the typing action every 4 seconds (`TYPING_REFRESH_SECONDS`, just under the 5s expiry; configurable via the new `typing_refresh_seconds` constructor param),
- lifecycle is turn-scoped — started in `run()`, cancelled in the existing `finally` cleanup next to the event pump, so it stops on reply, `/stop`, or error,
- adapter failures inside the loop are swallowed and debug-logged (typing is cosmetic; a flaky adapter must not end the loop or surface into the finally),
- refresh-only: hiding on completion stays the adapter's `set_typing(False)` business (Telegram's indicator decays on its own; other adapters can implement it).

## Testing

- New `test_typing_is_refreshed_while_the_turn_runs`: a slow turn re-sends the action periodically and stops (last call `typing=False`) when the turn ends.
- Full gateway suite: 194 passed, 1 skipped (live Telegram test, needs a real token); `ruff check`, `ruff format`, and `pyright` clean.