### PR TITLE
feat(mcp): support pre-registered OAuth credentials and TUI management

### DIFF
--- a/docs/src/content/docs/configuration/mcp.md
+++ b/docs/src/content/docs/configuration/mcp.md
@@ -153,7 +153,7 @@ OAuth configuration options:
 
 Providing a client ID enables OAuth unless `enabled` is explicitly `false`. A secret or secret environment variable requires a client ID; `client_secret_post` and `client_secret_basic` also require a secret. When both secret fields are set, the direct secret takes precedence. Callback URIs cannot contain embedded credentials or fragments.
 
-Cached tokens are tied to the server URL and OAuth configuration. Changing credentials, scopes, or the configured redirect URI requires verification again. Tokens saved before this binding was introduced require one new authorization for pre-registered clients. Expiry and authorization-server metadata are saved with new tokens so token refresh works across connections.
+Cached tokens are tied to the server URL and OAuth configuration using a salted PBKDF2 fingerprint. Changing credentials, scopes, or the configured redirect URI requires verification again. Pre-registered tokens without this binding, and tokens using the earlier SHA-256 fingerprint format, require one new authorization. Expiry and authorization-server metadata are saved with new tokens so token refresh works across connections.
 
 ### Managing OAuth in the TUI
 

--- a/docs/src/content/docs/configuration/mcp.md
+++ b/docs/src/content/docs/configuration/mcp.md
@@ -116,9 +116,10 @@ Use `--no-browser` to print the authorization URL instead of opening a browser. 
 
 ### Pre-registered OAuth servers (HubSpot, Slack, Enterprise IdPs)
 
-Many hosted MCP servers (such as HubSpot at `https://mcp.hubspot.com`, Slack at `https://mcp.slack.com/mcp`, or servers fronted by Entra ID / Azure AD, Okta, and Keycloak) do not implement Dynamic Client Registration (RFC 7591). Instead, you create an application in the provider's developer dashboard to obtain a static `client_id` and `client_secret`.
+Some hosted MCP servers require a pre-registered OAuth application instead of Dynamic Client Registration (RFC 7591). For example, [HubSpot's setup guide](https://developers.hubspot.com/docs/apps/developer-platform/build-apps/integrate-with-the-remote-hubspot-mcp-server) describes creating an MCP auth app, and [Slack's MCP documentation](https://docs.slack.dev/ai/slack-mcp-server/) describes its client registration requirements. Follow your provider's instructions to obtain a `client_id` and, for confidential clients, a `client_secret`. Public clients use a client ID with PKCE and no secret.
 
 When registering the app in the provider's dashboard:
+
 1. Set the redirect URI to a fixed localhost port, for example `http://127.0.0.1:33418/callback`.
 2. Configure the exact same `redirect_uri` in your server entry so the local callback server listens on that port.
 
@@ -147,17 +148,24 @@ OAuth configuration options:
 | `client_secret` | Direct client secret (suitable for global user config). |
 | `client_secret_env` | Environment variable name holding the client secret (recommended for version control). |
 | `redirect_uri` | Callback URI. Must be an `http` URL on `127.0.0.1` or `localhost`. Omitting the port uses an ephemeral port. |
-| `scope` | Space-separated OAuth scopes to request. |
+| `scope` | Space-separated OAuth scopes to request. When set, these override the server-advertised defaults. |
 | `token_endpoint_auth_method` | `client_secret_post`, `client_secret_basic`, or `none` (defaults to `client_secret_post` when a secret is configured). |
+
+Providing a client ID enables OAuth unless `enabled` is explicitly `false`. A secret or secret environment variable requires a client ID; `client_secret_post` and `client_secret_basic` also require a secret. When both secret fields are set, the direct secret takes precedence. Callback URIs cannot contain embedded credentials or fragments.
+
+Cached tokens are tied to the server URL and OAuth configuration. Changing credentials, scopes, or the configured redirect URI requires verification again. Tokens saved before this binding was introduced require one new authorization for pre-registered clients. Expiry and authorization-server metadata are saved with new tokens so token refresh works across connections.
 
 ### Managing OAuth in the TUI
 
 In the Textual TUI (**Settings** → **MCP Servers**):
+
 1. Select or create an HTTP MCP server.
 2. Set **OAuth** to **Enabled**.
 3. Fill in **OAuth Client ID**, **OAuth Client Secret** (or **OAuth Client Secret Env Var**), **OAuth Redirect URI**, and optional scopes.
 4. Click **Save Server**, then click **Verify** to authenticate via your browser.
 5. The **Clear OAuth** button clears cached session tokens without erasing your configured client credentials.
+
+Setting **OAuth** to **Disabled** also preserves your credentials so you can enable it again later.
 
 ## CLI management
 

--- a/docs/src/content/docs/configuration/mcp.md
+++ b/docs/src/content/docs/configuration/mcp.md
@@ -114,6 +114,51 @@ kolega-code mcp verify oauth-server --project .
 
 Use `--no-browser` to print the authorization URL instead of opening a browser. Tokens and dynamic client registration data are stored locally in `<state_dir>/mcp_oauth_tokens.json`. Kolega Code writes this file with owner-only permissions where the platform supports POSIX modes, redacts those values from diagnostics, and does not encrypt the file beyond the protection provided by the OS and filesystem permissions.
 
+### Pre-registered OAuth servers (HubSpot, Slack, Enterprise IdPs)
+
+Many hosted MCP servers (such as HubSpot at `https://mcp.hubspot.com`, Slack at `https://mcp.slack.com/mcp`, or servers fronted by Entra ID / Azure AD, Okta, and Keycloak) do not implement Dynamic Client Registration (RFC 7591). Instead, you create an application in the provider's developer dashboard to obtain a static `client_id` and `client_secret`.
+
+When registering the app in the provider's dashboard:
+1. Set the redirect URI to a fixed localhost port, for example `http://127.0.0.1:33418/callback`.
+2. Configure the exact same `redirect_uri` in your server entry so the local callback server listens on that port.
+
+Configure the credentials in `.kolega/mcp_servers.json` (or via global config or the TUI):
+
+```json
+{
+  "id": "hubspot",
+  "transport": "streamable_http",
+  "url": "https://mcp.hubspot.com",
+  "oauth": {
+    "enabled": true,
+    "client_id": "your-hubspot-client-id",
+    "client_secret_env": "HUBSPOT_MCP_CLIENT_SECRET",
+    "redirect_uri": "http://127.0.0.1:33418/callback",
+    "token_endpoint_auth_method": "client_secret_post"
+  }
+}
+```
+
+OAuth configuration options:
+
+| Field | Description |
+| --- | --- |
+| `client_id` | Pre-registered OAuth client ID. |
+| `client_secret` | Direct client secret (suitable for global user config). |
+| `client_secret_env` | Environment variable name holding the client secret (recommended for version control). |
+| `redirect_uri` | Callback URI. Must be an `http` URL on `127.0.0.1` or `localhost`. Omitting the port uses an ephemeral port. |
+| `scope` | Space-separated OAuth scopes to request. |
+| `token_endpoint_auth_method` | `client_secret_post`, `client_secret_basic`, or `none` (defaults to `client_secret_post` when a secret is configured). |
+
+### Managing OAuth in the TUI
+
+In the Textual TUI (**Settings** → **MCP Servers**):
+1. Select or create an HTTP MCP server.
+2. Set **OAuth** to **Enabled**.
+3. Fill in **OAuth Client ID**, **OAuth Client Secret** (or **OAuth Client Secret Env Var**), **OAuth Redirect URI**, and optional scopes.
+4. Click **Save Server**, then click **Verify** to authenticate via your browser.
+5. The **Clear OAuth** button clears cached session tokens without erasing your configured client credentials.
+
 ## CLI management
 
 List servers and status:
@@ -129,6 +174,18 @@ kolega-code mcp --project . add docs \
   --transport streamable_http \
   --url https://mcp.example.com/mcp \
   --header 'Authorization=Bearer ...'
+```
+
+Add a remote server with pre-registered OAuth:
+
+```bash
+kolega-code mcp --project . add hubspot \
+  --transport streamable_http \
+  --url https://mcp.hubspot.com \
+  --oauth-client-id "your-client-id" \
+  --oauth-client-secret-env "HUBSPOT_MCP_CLIENT_SECRET" \
+  --redirect-uri "http://127.0.0.1:33418/callback" \
+  --oauth-auth-method "client_secret_post"
 ```
 
 Add a project config server:

--- a/kolega_code/cli/main.py
+++ b/kolega_code/cli/main.py
@@ -796,6 +796,14 @@ def _build_subcommand_parser() -> argparse.ArgumentParser:
     add.add_argument("--env", action="append", default=[], help="Environment variable as NAME=VALUE (repeatable).")
     add.add_argument("--cwd", help="Working directory for stdio command; relative paths resolve under project.")
     add.add_argument("--oauth", action="store_true", help="Enable OAuth for this HTTP MCP server.")
+    add.add_argument("--oauth-client-id", help="Pre-registered OAuth client ID.")
+    add.add_argument("--oauth-client-secret", help="Pre-registered OAuth client secret.")
+    add.add_argument("--oauth-client-secret-env", help="Environment variable name holding the OAuth client secret.")
+    add.add_argument(
+        "--oauth-auth-method",
+        choices=["client_secret_post", "client_secret_basic", "none"],
+        help="Token endpoint authentication method.",
+    )
     add.add_argument("--oauth-scope", help="OAuth scopes to request.")
     add.add_argument("--redirect-uri", help="OAuth redirect URI; defaults to an ephemeral localhost callback.")
     add.add_argument("--disabled", action="store_true", help="Add the server disabled.")
@@ -2697,6 +2705,12 @@ def _mcp_mutation_target(args: argparse.Namespace, project_path: Path, state_dir
 def _server_config_from_add_args(args: argparse.Namespace) -> MCPServerConfig:
     headers = _parse_key_value_options(getattr(args, "header", []) or [], "--header")
     env = _parse_key_value_options(getattr(args, "env", []) or [], "--env")
+    oauth_client_id = getattr(args, "oauth_client_id", None)
+    oauth_client_secret = getattr(args, "oauth_client_secret", None)
+    oauth_client_secret_env = getattr(args, "oauth_client_secret_env", None)
+    oauth_auth_method = getattr(args, "oauth_auth_method", None)
+    oauth_enabled = bool(args.oauth) or bool(oauth_client_id or oauth_client_secret or oauth_client_secret_env)
+
     payload: dict[str, Any] = {
         "id": args.server_id,
         "name": args.name,
@@ -2709,9 +2723,13 @@ def _server_config_from_add_args(args: argparse.Namespace) -> MCPServerConfig:
         "env": env,
         "cwd": args.cwd,
         "oauth": {
-            "enabled": bool(args.oauth),
+            "enabled": oauth_enabled,
             "scope": args.oauth_scope,
             "redirect_uri": args.redirect_uri,
+            "client_id": oauth_client_id,
+            "client_secret": oauth_client_secret,
+            "client_secret_env": oauth_client_secret_env,
+            "token_endpoint_auth_method": oauth_auth_method,
         },
     }
     return MCPServerConfig.model_validate(payload)

--- a/kolega_code/cli/tui/settings_panel.py
+++ b/kolega_code/cli/tui/settings_panel.py
@@ -1675,7 +1675,8 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         enabled = str(self._settings_query_one("#mcp_enabled_select", Select).value) == "true"
         url = self._settings_query_one("#mcp_url_input", Input).value.strip() or None
         headers_text = self._settings_query_one("#mcp_headers_input", Input).value.strip()
-        oauth_enabled = str(self._settings_query_one("#mcp_oauth_select", Select).value) == "true"
+        http = transport in {"streamable_http", "sse"}
+        oauth_enabled = http and str(self._settings_query_one("#mcp_oauth_select", Select).value) == "true"
         command = self._settings_query_one("#mcp_command_input", Input).value.strip() or None
         args_text = self._settings_query_one("#mcp_args_input", Input).value.strip()
         env_text = self._settings_query_one("#mcp_env_input", Input).value.strip()
@@ -1701,7 +1702,7 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         oauth_scope = None
         oauth_auth_method: Optional[Literal["client_secret_post", "client_secret_basic", "none"]] = None
 
-        if oauth_enabled:
+        if http:
             try:
                 oauth_client_id = self._settings_query_one("#mcp_oauth_client_id_input", Input).value.strip() or None
             except NoMatches:

--- a/kolega_code/cli/tui/settings_panel.py
+++ b/kolega_code/cli/tui/settings_panel.py
@@ -104,6 +104,12 @@ MCP_TRANSPORT_OPTIONS = [
     ("stdio command", "stdio"),
 ]
 MCP_ENABLED_OPTIONS = [("Enabled", "true"), ("Disabled", "false")]
+MCP_OAUTH_AUTH_METHOD_OPTIONS = [
+    ("Auto (POST if secret, none if public)", "auto"),
+    ("client_secret_post", "client_secret_post"),
+    ("client_secret_basic", "client_secret_basic"),
+    ("none (public client / PKCE)", "none"),
+]
 MCP_STATUS_MESSAGE_MAX = 96
 MCP_STATUS_NAME_MAX = 34
 # Compression threshold select: "default" maps to None (the agent's built-in 95%).
@@ -415,6 +421,16 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
 
         if select_id == "mcp_transport_select":
             self._update_mcp_transport_fields(str(event.value))
+            return
+
+        if select_id == "mcp_oauth_select":
+            transport = "streamable_http"
+            try:
+                transport = str(self._settings_query_one("#mcp_transport_select", Select).value)
+            except NoMatches:
+                pass
+            http = transport in {"streamable_http", "sse"}
+            self._update_mcp_oauth_fields(http and str(event.value) == "true")
             return
 
         row = _row_for_widget(select_id)
@@ -1477,6 +1493,12 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             set_input("mcp_url_input", "")
             set_input("mcp_headers_input", "")
             set_select("mcp_oauth_select", "false")
+            set_input("mcp_oauth_client_id_input", "")
+            set_input("mcp_oauth_client_secret_input", "")
+            set_input("mcp_oauth_client_secret_env_input", "")
+            set_input("mcp_oauth_redirect_uri_input", "")
+            set_input("mcp_oauth_scope_input", "")
+            set_select("mcp_oauth_auth_method_select", "auto")
             set_input("mcp_command_input", "")
             set_input("mcp_args_input", "")
             set_input("mcp_env_input", "")
@@ -1491,6 +1513,12 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         set_input("mcp_url_input", server.url or "")
         set_input("mcp_headers_input", json.dumps(server.headers, sort_keys=True) if server.headers else "")
         set_select("mcp_oauth_select", "true" if server.oauth.enabled else "false")
+        set_input("mcp_oauth_client_id_input", server.oauth.client_id or "")
+        set_input("mcp_oauth_client_secret_input", server.oauth.client_secret or "")
+        set_input("mcp_oauth_client_secret_env_input", server.oauth.client_secret_env or "")
+        set_input("mcp_oauth_redirect_uri_input", server.oauth.redirect_uri or "")
+        set_input("mcp_oauth_scope_input", server.oauth.scope or "")
+        set_select("mcp_oauth_auth_method_select", server.oauth.token_endpoint_auth_method or "auto")
         set_input("mcp_command_input", server.command or "")
         set_input("mcp_args_input", " ".join(shlex.quote(arg) for arg in server.args))
         set_input("mcp_env_input", json.dumps(server.env, sort_keys=True) if server.env else "")
@@ -1502,6 +1530,26 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
         else:
             self._set_mcp_source_hint("This server is stored in your global MCP config.")
         self._update_mcp_transport_fields(server.transport)
+
+    def _update_mcp_oauth_fields(self, visible: bool) -> None:
+        for widget_id in (
+            "mcp_oauth_client_id_label",
+            "mcp_oauth_client_id_input",
+            "mcp_oauth_client_secret_label",
+            "mcp_oauth_client_secret_input",
+            "mcp_oauth_client_secret_env_label",
+            "mcp_oauth_client_secret_env_input",
+            "mcp_oauth_redirect_uri_label",
+            "mcp_oauth_redirect_uri_input",
+            "mcp_oauth_scope_label",
+            "mcp_oauth_scope_input",
+            "mcp_oauth_auth_method_label",
+            "mcp_oauth_auth_method_select",
+        ):
+            try:
+                self._settings_query_one(f"#{widget_id}").display = visible
+            except NoMatches:
+                pass
 
     def _update_mcp_transport_fields(self, transport: str) -> None:
         http = transport in {"streamable_http", "sse"}
@@ -1525,6 +1573,12 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
                 self._settings_query_one(f"#{widget_id}").display = visible
             except NoMatches:
                 pass
+        oauth_enabled = False
+        try:
+            oauth_enabled = http and str(self._settings_query_one("#mcp_oauth_select", Select).value) == "true"
+        except NoMatches:
+            pass
+        self._update_mcp_oauth_fields(oauth_enabled)
         try:
             url_input = self._settings_query_one("#mcp_url_input", Input)
             if transport == "streamable_http":
@@ -1640,6 +1694,77 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             else selected
         )
 
+        oauth_client_id = None
+        oauth_client_secret = None
+        oauth_client_secret_env = None
+        oauth_redirect_uri = None
+        oauth_scope = None
+        oauth_auth_method: Optional[Literal["client_secret_post", "client_secret_basic", "none"]] = None
+
+        if oauth_enabled:
+            try:
+                oauth_client_id = self._settings_query_one("#mcp_oauth_client_id_input", Input).value.strip() or None
+            except NoMatches:
+                pass
+            try:
+                oauth_client_secret = (
+                    self._settings_query_one("#mcp_oauth_client_secret_input", Input).value.strip() or None
+                )
+            except NoMatches:
+                pass
+            try:
+                oauth_client_secret_env = (
+                    self._settings_query_one("#mcp_oauth_client_secret_env_input", Input).value.strip() or None
+                )
+            except NoMatches:
+                pass
+            try:
+                oauth_redirect_uri = (
+                    self._settings_query_one("#mcp_oauth_redirect_uri_input", Input).value.strip() or None
+                )
+            except NoMatches:
+                pass
+            try:
+                oauth_scope = self._settings_query_one("#mcp_oauth_scope_input", Input).value.strip() or None
+            except NoMatches:
+                pass
+            try:
+                method_val = str(self._settings_query_one("#mcp_oauth_auth_method_select", Select).value)
+                if method_val in {"client_secret_post", "client_secret_basic", "none"}:
+                    oauth_auth_method = cast(Literal["client_secret_post", "client_secret_basic", "none"], method_val)
+            except NoMatches:
+                pass
+
+        client_name = "Kolega Code"
+        client_uri = None
+        client_metadata_url = None
+        timeout_seconds = 300.0
+        if selected != MCP_NEW_SERVER_VALUE:
+            try:
+                config = self._load_mcp_config_for_ui()
+                existing = config.servers.get(selected)
+                if existing:
+                    client_name = existing.oauth.client_name
+                    client_uri = existing.oauth.client_uri
+                    client_metadata_url = existing.oauth.client_metadata_url
+                    timeout_seconds = existing.oauth.timeout_seconds
+            except Exception:
+                pass
+
+        oauth = MCPOAuthConfig(
+            enabled=oauth_enabled,
+            client_id=oauth_client_id,
+            client_secret=oauth_client_secret,
+            client_secret_env=oauth_client_secret_env,
+            redirect_uri=oauth_redirect_uri,
+            scope=oauth_scope,
+            token_endpoint_auth_method=oauth_auth_method,
+            client_name=client_name,
+            client_uri=client_uri,
+            client_metadata_url=client_metadata_url,
+            timeout_seconds=timeout_seconds,
+        )
+
         return MCPServerConfig(
             id=server_id,
             name=name,
@@ -1647,7 +1772,7 @@ class SettingsPanelMixin(tui_app_base.KolegaAppBase):
             enabled=enabled,
             url=url,
             headers=headers,
-            oauth=MCPOAuthConfig(enabled=oauth_enabled),
+            oauth=oauth,
             command=command,
             args=args,
             env=env,

--- a/kolega_code/cli/tui/settings_screen.py
+++ b/kolega_code/cli/tui/settings_screen.py
@@ -588,6 +588,26 @@ class SettingsScreen(ModalScreen[None]):
                     allow_blank=False,
                     value="false",
                 )
+                yield Label("OAuth Client ID", id="mcp_oauth_client_id_label")
+                yield Input(id="mcp_oauth_client_id_input", placeholder="e.g. client_abc123")
+                yield Label("OAuth Client Secret", id="mcp_oauth_client_secret_label")
+                yield Input(id="mcp_oauth_client_secret_input", placeholder="optional direct secret", password=True)
+                yield Label("OAuth Client Secret Env Var", id="mcp_oauth_client_secret_env_label")
+                yield Input(id="mcp_oauth_client_secret_env_input", placeholder="e.g. HUBSPOT_MCP_CLIENT_SECRET")
+                yield Label("OAuth Redirect URI", id="mcp_oauth_redirect_uri_label")
+                yield Input(
+                    id="mcp_oauth_redirect_uri_input",
+                    placeholder="e.g. http://127.0.0.1:33418/callback (default: ephemeral port)",
+                )
+                yield Label("OAuth Scopes", id="mcp_oauth_scope_label")
+                yield Input(id="mcp_oauth_scope_input", placeholder="e.g. read write")
+                yield Label("OAuth Token Auth Method", id="mcp_oauth_auth_method_label")
+                yield Select(
+                    settings_panel.MCP_OAUTH_AUTH_METHOD_OPTIONS,
+                    id="mcp_oauth_auth_method_select",
+                    allow_blank=False,
+                    value="auto",
+                )
                 yield Label("Command", id="mcp_command_label")
                 yield Input(id="mcp_command_input", placeholder="npx")
                 yield Label("Arguments", id="mcp_args_label")

--- a/kolega_code/mcp/config.py
+++ b/kolega_code/mcp/config.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Mapping, Optional
+from urllib.parse import urlparse
 
 from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 
@@ -22,6 +24,7 @@ _SERVER_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 # least 25 chars of budget for the tool id after the ``mcp__{server}__`` prefix.
 _SERVER_ID_MAX_LENGTH = 32
 _SERVER_ID_PREFIX_LENGTH = 24
+_ENV_VAR_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 def sanitize_mcp_server_id(value: str) -> str:
@@ -53,10 +56,57 @@ class MCPOAuthConfig(BaseModel):
     enabled: bool = False
     redirect_uri: Optional[str] = None
     scope: Optional[str] = None
+    client_id: Optional[str] = None
+    client_secret: Optional[str] = None
+    client_secret_env: Optional[str] = None
+    token_endpoint_auth_method: Optional[Literal["client_secret_post", "client_secret_basic", "none"]] = None
     client_name: str = "Kolega Code"
     client_uri: Optional[str] = None
     client_metadata_url: Optional[str] = None
     timeout_seconds: float = Field(default=300.0, gt=0)
+
+    @field_validator("redirect_uri")
+    @classmethod
+    def _validate_redirect_uri(cls, value: Optional[str]) -> Optional[str]:
+        if not value:
+            return None
+        parsed = urlparse(value)
+        if parsed.scheme != "http" or parsed.hostname not in {"127.0.0.1", "localhost"}:
+            raise ValueError(
+                "MCP OAuth redirect_uri must be a localhost http URL (e.g. http://127.0.0.1:33418/callback)"
+            )
+        return value
+
+    @field_validator("client_secret_env")
+    @classmethod
+    def _validate_client_secret_env(cls, value: Optional[str]) -> Optional[str]:
+        if not value:
+            return None
+        stripped = value.strip()
+        if not _ENV_VAR_RE.match(stripped):
+            raise ValueError("client_secret_env must be a valid environment variable name")
+        return stripped
+
+    @model_validator(mode="after")
+    def _validate_oauth_fields(self) -> "MCPOAuthConfig":
+        if self.client_id or self.client_secret or self.client_secret_env:
+            self.enabled = True
+        return self
+
+    def resolve_client_secret(self, env: Optional[Mapping[str, str]] = None) -> Optional[str]:
+        if self.client_secret:
+            return self.client_secret
+        if self.client_secret_env:
+            source_env = os.environ if env is None else env
+            return source_env.get(self.client_secret_env) or None
+        return None
+
+    def resolve_auth_method(self, env: Optional[Mapping[str, str]] = None) -> str:
+        if self.token_endpoint_auth_method:
+            return self.token_endpoint_auth_method
+        if self.resolve_client_secret(env=env):
+            return "client_secret_post"
+        return "none"
 
 
 class MCPServerConfig(BaseModel):
@@ -130,6 +180,9 @@ class MCPServerConfig(BaseModel):
             payload["headers"] = {key: "‹secret›" for key in payload["headers"]}
         if payload.get("env"):
             payload["env"] = {key: "‹secret›" for key in payload["env"]}
+        if payload.get("oauth") and isinstance(payload["oauth"], dict):
+            if payload["oauth"].get("client_secret"):
+                payload["oauth"]["client_secret"] = "‹secret›"
         return payload
 
 
@@ -349,4 +402,8 @@ def mcp_secret_values(config: LoadedMCPConfig) -> list[str]:
     for server in config.servers.values():
         values.extend(value for value in server.headers.values() if value)
         values.extend(value for value in server.env.values() if value)
+        if server.oauth.enabled:
+            secret = server.oauth.resolve_client_secret()
+            if secret:
+                values.append(secret)
     return values

--- a/kolega_code/mcp/config.py
+++ b/kolega_code/mcp/config.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any, Literal, Mapping, Optional
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
 from kolega_code.local_state import write_private_secret_text
 
@@ -53,6 +53,8 @@ class MCPConfigError(ValueError):
 class MCPOAuthConfig(BaseModel):
     """OAuth settings for an HTTP MCP server."""
 
+    model_config = ConfigDict(hide_input_in_errors=True)
+
     enabled: bool = False
     redirect_uri: Optional[str] = None
     scope: Optional[str] = None
@@ -75,6 +77,10 @@ class MCPOAuthConfig(BaseModel):
             raise ValueError(
                 "MCP OAuth redirect_uri must be a localhost http URL (e.g. http://127.0.0.1:33418/callback)"
             )
+        # Accessing port also rejects malformed and out-of-range values.
+        _ = parsed.port
+        if parsed.username is not None or parsed.password is not None or parsed.fragment:
+            raise ValueError("MCP OAuth redirect_uri must not contain credentials or a fragment")
         return value
 
     @field_validator("client_secret_env")
@@ -89,7 +95,12 @@ class MCPOAuthConfig(BaseModel):
 
     @model_validator(mode="after")
     def _validate_oauth_fields(self) -> "MCPOAuthConfig":
-        if self.client_id or self.client_secret or self.client_secret_env:
+        if (self.client_secret or self.client_secret_env) and not self.client_id:
+            raise ValueError("OAuth client_secret and client_secret_env require a client_id")
+        if self.token_endpoint_auth_method in {"client_secret_post", "client_secret_basic"}:
+            if not self.client_id or not (self.client_secret or self.client_secret_env):
+                raise ValueError("OAuth client secret authentication requires a client_id and client secret")
+        if "enabled" not in self.model_fields_set and self.client_id:
             self.enabled = True
         return self
 
@@ -111,6 +122,8 @@ class MCPOAuthConfig(BaseModel):
 
 class MCPServerConfig(BaseModel):
     """One configured MCP server."""
+
+    model_config = ConfigDict(hide_input_in_errors=True)
 
     id: str
     name: Optional[str] = None
@@ -187,6 +200,8 @@ class MCPServerConfig(BaseModel):
 
 
 class MCPConfigFile(BaseModel):
+    model_config = ConfigDict(hide_input_in_errors=True)
+
     schema_version: int = MCP_CONFIG_SCHEMA_VERSION
     servers: list[MCPServerConfig] = Field(default_factory=list)
 
@@ -402,8 +417,7 @@ def mcp_secret_values(config: LoadedMCPConfig) -> list[str]:
     for server in config.servers.values():
         values.extend(value for value in server.headers.values() if value)
         values.extend(value for value in server.env.values() if value)
-        if server.oauth.enabled:
-            secret = server.oauth.resolve_client_secret()
-            if secret:
-                values.append(secret)
+        secret = server.oauth.resolve_client_secret()
+        if secret:
+            values.append(secret)
     return values

--- a/kolega_code/mcp/oauth.py
+++ b/kolega_code/mcp/oauth.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import hashlib
+import hmac
 import json
+import secrets
 import sys
 import webbrowser
 from dataclasses import dataclass
@@ -19,6 +21,9 @@ if TYPE_CHECKING:
     from mcp.client.auth import OAuthClientProvider
     from mcp.client.auth.oauth2 import OAuthContext
     from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+_FINGERPRINT_ITERATIONS = 600_000
+_FINGERPRINT_SALT_BYTES = 16
 
 
 class MCPOAuthError(RuntimeError):
@@ -45,26 +50,48 @@ class MCPFileTokenStorage:
         self.redirect_uri = redirect_uri
         self.context: Optional[OAuthContext] = None
 
-    def _config_fingerprint(self) -> Optional[str]:
+    async def _config_fingerprint(self, stored: Optional[str] = None) -> Optional[str]:
         if self.server is None:
             return None
+        if stored is not None:
+            parts = stored.split("$")
+            if len(parts) != 4 or parts[:2] != ["pbkdf2-sha256", str(_FINGERPRINT_ITERATIONS)]:
+                return None
+            try:
+                salt = bytes.fromhex(parts[2])
+                digest = bytes.fromhex(parts[3])
+            except ValueError:
+                return None
+            if len(salt) != _FINGERPRINT_SALT_BYTES or len(digest) != 32:
+                return None
+        else:
+            salt = secrets.token_bytes(_FINGERPRINT_SALT_BYTES)
         oauth = self.server.oauth.model_dump(exclude={"enabled", "timeout_seconds", "client_name", "client_uri"})
         oauth["client_secret"] = self.server.oauth.resolve_client_secret()
         payload = json.dumps({"url": self.server.url, "oauth": oauth}, sort_keys=True)
-        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+        # The fingerprint includes a client secret: use a salted password KDF,
+        # and keep its CPU work off the event loop used by the TUI and agents.
+        derived = await asyncio.to_thread(
+            hashlib.pbkdf2_hmac, "sha256", payload.encode("utf-8"), salt, _FINGERPRINT_ITERATIONS
+        )
+        return f"pbkdf2-sha256${_FINGERPRINT_ITERATIONS}${salt.hex()}${derived.hex()}"
 
     async def get_tokens(self) -> Optional[OAuthToken]:
         from mcp.shared.auth import OAuthMetadata, OAuthToken, ProtectedResourceMetadata
 
         record = self.token_store.get(self.server_id)
-        if self.server and record.config_fingerprint != self._config_fingerprint():
-            # Legacy DCR tokens remain usable. Pre-registered credentials must
-            # never reuse tokens whose client/configuration cannot be established.
-            if record.config_fingerprint or self.server.oauth.client_id:
-                return None
         raw = record.tokens
         if not raw:
             return None
+        if self.server:
+            if record.config_fingerprint:
+                fingerprint = await self._config_fingerprint(record.config_fingerprint)
+                if fingerprint is None or not hmac.compare_digest(record.config_fingerprint, fingerprint):
+                    return None
+            elif self.server.oauth.client_id:
+                # Legacy DCR tokens remain usable. Pre-registered credentials
+                # require tokens bound to their configuration.
+                return None
         # The SDK does not restore expiry or discovery metadata itself. Each MCP
         # tool call opens a new provider, so preserve these alongside the token
         # to refresh expired tokens at the discovered authorization server.
@@ -97,7 +124,7 @@ class MCPFileTokenStorage:
         self.token_store.set_tokens(
             self.server_id,
             tokens.model_dump(mode="json"),
-            config_fingerprint=self._config_fingerprint(),
+            config_fingerprint=await self._config_fingerprint(),
             oauth_context=context,
         )
 

--- a/kolega_code/mcp/oauth.py
+++ b/kolega_code/mcp/oauth.py
@@ -4,14 +4,21 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hashlib
+import json
 import sys
 import webbrowser
 from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Optional, Union
 from urllib.parse import parse_qs, urlparse
 
-from .config import MCPServerConfig
+from .config import MCPOAuthConfig, MCPServerConfig
 from .state import MCPOAuthTokenStore
+
+if TYPE_CHECKING:
+    from mcp.client.auth import OAuthClientProvider
+    from mcp.client.auth.oauth2 import OAuthContext
+    from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 
 
 class MCPOAuthError(RuntimeError):
@@ -36,22 +43,65 @@ class MCPFileTokenStorage:
             self.server_id = server
         self.token_store = token_store
         self.redirect_uri = redirect_uri
+        self.context: Optional[OAuthContext] = None
 
-    async def get_tokens(self):
-        from mcp.shared.auth import OAuthToken
+    def _config_fingerprint(self) -> Optional[str]:
+        if self.server is None:
+            return None
+        oauth = self.server.oauth.model_dump(exclude={"enabled", "timeout_seconds", "client_name", "client_uri"})
+        oauth["client_secret"] = self.server.oauth.resolve_client_secret()
+        payload = json.dumps({"url": self.server.url, "oauth": oauth}, sort_keys=True)
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
-        raw = self.token_store.get(self.server_id).tokens
+    async def get_tokens(self) -> Optional[OAuthToken]:
+        from mcp.shared.auth import OAuthMetadata, OAuthToken, ProtectedResourceMetadata
+
+        record = self.token_store.get(self.server_id)
+        if self.server and record.config_fingerprint != self._config_fingerprint():
+            # Legacy DCR tokens remain usable. Pre-registered credentials must
+            # never reuse tokens whose client/configuration cannot be established.
+            if record.config_fingerprint or self.server.oauth.client_id:
+                return None
+        raw = record.tokens
         if not raw:
             return None
+        # The SDK does not restore expiry or discovery metadata itself. Each MCP
+        # tool call opens a new provider, so preserve these alongside the token
+        # to refresh expired tokens at the discovered authorization server.
+        if self.context is not None and record.oauth_context:
+            saved = record.oauth_context
+            self.context.token_expiry_time = saved.get("token_expiry_time")
+            if saved.get("oauth_metadata"):
+                self.context.oauth_metadata = OAuthMetadata.model_validate(saved["oauth_metadata"])
+            if saved.get("protected_resource_metadata"):
+                self.context.protected_resource_metadata = ProtectedResourceMetadata.model_validate(
+                    saved["protected_resource_metadata"]
+                )
         return OAuthToken.model_validate(raw)
 
-    async def set_tokens(self, tokens) -> None:
+    async def set_tokens(self, tokens: Optional[OAuthToken]) -> None:
         if tokens is None:
             self.token_store.set_tokens(self.server_id, None)
             return
-        self.token_store.set_tokens(self.server_id, tokens.model_dump(mode="json"))
+        context = None
+        if self.context is not None:
+            context = {
+                "token_expiry_time": self.context.token_expiry_time,
+                "oauth_metadata": self.context.oauth_metadata.model_dump(mode="json")
+                if self.context.oauth_metadata
+                else None,
+                "protected_resource_metadata": self.context.protected_resource_metadata.model_dump(mode="json")
+                if self.context.protected_resource_metadata
+                else None,
+            }
+        self.token_store.set_tokens(
+            self.server_id,
+            tokens.model_dump(mode="json"),
+            config_fingerprint=self._config_fingerprint(),
+            oauth_context=context,
+        )
 
-    async def get_client_info(self):
+    async def get_client_info(self) -> Optional[OAuthClientInformationFull]:
         from mcp.shared.auth import OAuthClientInformationFull
 
         if self.server and self.server.oauth.client_id:
@@ -85,7 +135,7 @@ class MCPFileTokenStorage:
             return None
         return OAuthClientInformationFull.model_validate(raw)
 
-    async def set_client_info(self, client_info) -> None:
+    async def set_client_info(self, client_info: Optional[OAuthClientInformationFull]) -> None:
         if self.server and self.server.oauth.client_id:
             return
         if client_info is None:
@@ -116,12 +166,20 @@ class LocalOAuthCallbackServer:
         self._path = "/callback"
 
     async def __aenter__(self) -> "LocalOAuthCallbackServer":
+        try:
+            MCPOAuthConfig(redirect_uri=self._configured_redirect_uri)
+        except ValueError as exc:
+            raise MCPOAuthError(str(exc)) from exc
         parsed = urlparse(self._configured_redirect_uri or "http://127.0.0.1:0/callback")
         if parsed.scheme != "http" or parsed.hostname not in {"127.0.0.1", "localhost"}:
             raise MCPOAuthError("MCP OAuth redirect_uri must be a localhost http URL")
-        self._path = parsed.path or "/callback"
+        self._path = parsed.path or "/"
         host = parsed.hostname or "127.0.0.1"
         port = parsed.port or 0
+        if port == 0:
+            # localhost can bind IPv4 and IPv6 on different ephemeral ports.
+            # Use the same IPv4 address that the generated callback advertises.
+            host = "127.0.0.1"
         self._future = asyncio.get_running_loop().create_future()
         try:
             self._server = await asyncio.start_server(self._handle_client, host=host, port=port)
@@ -139,7 +197,7 @@ class LocalOAuthCallbackServer:
             # Prefer 127.0.0.1 in metadata even if the OS reports localhost/::1.
             if bound_host in {"0.0.0.0", "::", "::1"}:
                 bound_host = "127.0.0.1"
-            self.redirect_uri = f"http://{bound_host}:{bound_port}{self._path}"
+            self.redirect_uri = parsed._replace(netloc=f"{bound_host}:{bound_port}").geturl()
         return self
 
     async def __aexit__(self, exc_type, exc, tb) -> None:
@@ -208,14 +266,23 @@ class LocalOAuthCallbackServer:
 
 
 async def default_redirect_handler(url: str, *, open_browser: bool = True, output=None) -> None:
+    from rich.console import Console
+
     stream = output or sys.stderr
-    print("MCP OAuth authorization required:", file=stream)
-    print(url, file=stream)
+
+    def write(message: str) -> None:
+        if isinstance(stream, Console):
+            stream.print(message, markup=False, highlight=False, soft_wrap=True)
+        else:
+            print(message, file=stream)
+
+    write("MCP OAuth authorization required:")
+    write(url)
     if open_browser:
         try:
             await asyncio.to_thread(webbrowser.open, url)
         except Exception:
-            print("Could not open a browser automatically; open the URL above manually.", file=stream)
+            write("Could not open a browser automatically; open the URL above manually.")
 
 
 async def build_oauth_provider(
@@ -223,7 +290,7 @@ async def build_oauth_provider(
     token_store: MCPOAuthTokenStore,
     *,
     interaction: Optional[OAuthInteraction] = None,
-):
+) -> Optional[OAuthClientProvider]:
     """Build an MCP SDK OAuthClientProvider for a server."""
     if not server.oauth.enabled:
         return None
@@ -237,6 +304,14 @@ async def build_oauth_provider(
 
     from mcp.client.auth import OAuthClientProvider
     from mcp.shared.auth import OAuthClientMetadata
+
+    class ConfiguredOAuthClientProvider(OAuthClientProvider):
+        async def _perform_authorization_code_grant(self) -> tuple[str, str]:
+            # SDK discovery replaces client_metadata.scope with server-advertised
+            # scopes. An explicitly configured scope must remain authoritative.
+            if server.oauth.scope:
+                self.context.client_metadata.scope = server.oauth.scope
+            return await super()._perform_authorization_code_grant()
 
     redirect_uri = interaction.redirect_uri if interaction else server.oauth.redirect_uri
     if not redirect_uri:
@@ -253,16 +328,21 @@ async def build_oauth_provider(
         metadata_kwargs["scope"] = server.oauth.scope
     if server.oauth.client_uri:
         metadata_kwargs["client_uri"] = server.oauth.client_uri
+    if server.oauth.token_endpoint_auth_method:
+        metadata_kwargs["token_endpoint_auth_method"] = server.oauth.token_endpoint_auth_method
 
-    return OAuthClientProvider(
+    storage = MCPFileTokenStorage(server, token_store, redirect_uri=redirect_uri)
+    provider = ConfiguredOAuthClientProvider(
         server_url=server.url,
         client_metadata=OAuthClientMetadata(**metadata_kwargs),
-        storage=MCPFileTokenStorage(server, token_store, redirect_uri=redirect_uri),
+        storage=storage,
         redirect_handler=interaction.redirect_handler if interaction else None,
         callback_handler=interaction.callback_handler if interaction else None,
         timeout=server.oauth.timeout_seconds,
         client_metadata_url=server.oauth.client_metadata_url,
     )
+    storage.context = provider.context
+    return provider
 
 
 @contextlib.asynccontextmanager

--- a/kolega_code/mcp/oauth.py
+++ b/kolega_code/mcp/oauth.py
@@ -7,7 +7,7 @@ import contextlib
 import sys
 import webbrowser
 from dataclasses import dataclass
-from typing import Awaitable, Callable, Optional
+from typing import Any, Awaitable, Callable, Optional, Union
 from urllib.parse import parse_qs, urlparse
 
 from .config import MCPServerConfig
@@ -21,9 +21,21 @@ class MCPOAuthError(RuntimeError):
 class MCPFileTokenStorage:
     """Adapter from Kolega's token store to the MCP SDK TokenStorage protocol."""
 
-    def __init__(self, server_id: str, token_store: MCPOAuthTokenStore) -> None:
-        self.server_id = server_id
+    def __init__(
+        self,
+        server: Union[MCPServerConfig, str],
+        token_store: MCPOAuthTokenStore,
+        *,
+        redirect_uri: Optional[str] = None,
+    ) -> None:
+        if isinstance(server, MCPServerConfig):
+            self.server: Optional[MCPServerConfig] = server
+            self.server_id: str = server.id
+        else:
+            self.server = None
+            self.server_id = server
         self.token_store = token_store
+        self.redirect_uri = redirect_uri
 
     async def get_tokens(self):
         from mcp.shared.auth import OAuthToken
@@ -42,12 +54,40 @@ class MCPFileTokenStorage:
     async def get_client_info(self):
         from mcp.shared.auth import OAuthClientInformationFull
 
+        if self.server and self.server.oauth.client_id:
+            redirect_uris: list[str] = []
+            if self.redirect_uri:
+                redirect_uris.append(self.redirect_uri)
+            elif self.server.oauth.redirect_uri:
+                redirect_uris.append(self.server.oauth.redirect_uri)
+            else:
+                redirect_uris.append("http://127.0.0.1:1/callback")
+
+            kwargs: dict[str, Any] = {
+                "client_id": self.server.oauth.client_id,
+                "redirect_uris": redirect_uris,
+                "token_endpoint_auth_method": self.server.oauth.resolve_auth_method(),
+            }
+            secret = self.server.oauth.resolve_client_secret()
+            if secret:
+                kwargs["client_secret"] = secret
+            if self.server.oauth.scope:
+                kwargs["scope"] = self.server.oauth.scope
+            if self.server.oauth.client_name:
+                kwargs["client_name"] = self.server.oauth.client_name
+            if self.server.oauth.client_uri:
+                kwargs["client_uri"] = self.server.oauth.client_uri
+
+            return OAuthClientInformationFull.model_validate(kwargs)
+
         raw = self.token_store.get(self.server_id).client_info
         if not raw:
             return None
         return OAuthClientInformationFull.model_validate(raw)
 
     async def set_client_info(self, client_info) -> None:
+        if self.server and self.server.oauth.client_id:
+            return
         if client_info is None:
             self.token_store.set_client_info(self.server_id, None)
             return
@@ -83,13 +123,23 @@ class LocalOAuthCallbackServer:
         host = parsed.hostname or "127.0.0.1"
         port = parsed.port or 0
         self._future = asyncio.get_running_loop().create_future()
-        self._server = await asyncio.start_server(self._handle_client, host=host, port=port)
+        try:
+            self._server = await asyncio.start_server(self._handle_client, host=host, port=port)
+        except OSError as exc:
+            if port != 0:
+                raise MCPOAuthError(
+                    f"Could not bind OAuth callback server to {self._configured_redirect_uri}: {exc}"
+                ) from exc
+            raise
         socket = self._server.sockets[0]
         bound_host, bound_port = socket.getsockname()[:2]
-        # Prefer 127.0.0.1 in metadata even if the OS reports localhost/::1.
-        if bound_host in {"0.0.0.0", "::", "::1"}:
-            bound_host = "127.0.0.1"
-        self.redirect_uri = f"http://{bound_host}:{bound_port}{self._path}"
+        if self._configured_redirect_uri and parsed.port:
+            self.redirect_uri = self._configured_redirect_uri
+        else:
+            # Prefer 127.0.0.1 in metadata even if the OS reports localhost/::1.
+            if bound_host in {"0.0.0.0", "::", "::1"}:
+                bound_host = "127.0.0.1"
+            self.redirect_uri = f"http://{bound_host}:{bound_port}{self._path}"
         return self
 
     async def __aexit__(self, exc_type, exc, tb) -> None:
@@ -179,6 +229,11 @@ async def build_oauth_provider(
         return None
     if not server.url:
         raise MCPOAuthError(f"MCP server '{server.id}' has OAuth enabled but no URL")
+    if server.oauth.client_secret_env and not server.oauth.resolve_client_secret():
+        raise MCPOAuthError(
+            f"MCP server '{server.id}' requires environment variable '{server.oauth.client_secret_env}' "
+            "for OAuth client secret, but it is not set."
+        )
 
     from mcp.client.auth import OAuthClientProvider
     from mcp.shared.auth import OAuthClientMetadata
@@ -202,7 +257,7 @@ async def build_oauth_provider(
     return OAuthClientProvider(
         server_url=server.url,
         client_metadata=OAuthClientMetadata(**metadata_kwargs),
-        storage=MCPFileTokenStorage(server.id, token_store),
+        storage=MCPFileTokenStorage(server, token_store, redirect_uri=redirect_uri),
         redirect_handler=interaction.redirect_handler if interaction else None,
         callback_handler=interaction.callback_handler if interaction else None,
         timeout=server.oauth.timeout_seconds,

--- a/kolega_code/mcp/service.py
+++ b/kolega_code/mcp/service.py
@@ -33,8 +33,16 @@ MCP_FAILURE_MESSAGE_OAUTH_REGISTRATION = (
     "bearer-token header."
 )
 MCP_FAILURE_MESSAGE_OAUTH_REGISTRATION_NON_DCR = (
-    "OAuth dynamic client registration failed. This server does not support dynamic client registration — "
-    "configure a pre-registered OAuth client ID."
+    "OAuth dynamic client registration failed. Check the server's registration requirements; "
+    "if it requires pre-registered credentials, configure an OAuth client ID."
+)
+MCP_FAILURE_MESSAGE_OAUTH_SECRET_ENV = (
+    "The OAuth client secret environment variable is missing or empty. "
+    "Set the configured client_secret_env variable and verify again."
+)
+MCP_FAILURE_MESSAGE_OAUTH_CALLBACK = (
+    "Could not listen on the configured OAuth callback address. "
+    "Check that its port is available and the redirect URI matches the registered application."
 )
 MCP_FAILURE_MESSAGE_OAUTH_UNAUTHORIZED = (
     "MCP OAuth authorization failed. Check the server credentials or bearer-token header."
@@ -57,6 +65,8 @@ _SAFE_FAILED_STATUS_MESSAGES = (
     MCP_FAILURE_MESSAGE_GITHUB_COPILOT_OAUTH,
     MCP_FAILURE_MESSAGE_OAUTH_REGISTRATION,
     MCP_FAILURE_MESSAGE_OAUTH_REGISTRATION_NON_DCR,
+    MCP_FAILURE_MESSAGE_OAUTH_SECRET_ENV,
+    MCP_FAILURE_MESSAGE_OAUTH_CALLBACK,
     MCP_FAILURE_MESSAGE_OAUTH_UNAUTHORIZED,
     MCP_FAILURE_MESSAGE_UNAUTHORIZED,
     MCP_FAILURE_MESSAGE_NOT_FOUND,
@@ -267,6 +277,11 @@ def _exception_text_for_matching(exc: BaseException) -> str:
 
 
 def _safe_mcp_failure_message(server: MCPServerConfig, lower_message: str) -> str:
+    if server.oauth.enabled:
+        if "for oauth client secret, but it is not set" in lower_message:
+            return MCP_FAILURE_MESSAGE_OAUTH_SECRET_ENV
+        if "could not bind oauth callback server" in lower_message:
+            return MCP_FAILURE_MESSAGE_OAUTH_CALLBACK
     if server.oauth.enabled and _contains_any(lower_message, ("registration failed", "dynamic client")):
         if _is_github_copilot_api_url(server.url):
             return MCP_FAILURE_MESSAGE_GITHUB_COPILOT_OAUTH

--- a/kolega_code/mcp/service.py
+++ b/kolega_code/mcp/service.py
@@ -32,6 +32,10 @@ MCP_FAILURE_MESSAGE_OAUTH_REGISTRATION = (
     "OAuth dynamic client registration failed. This server may require a pre-registered OAuth client or "
     "bearer-token header."
 )
+MCP_FAILURE_MESSAGE_OAUTH_REGISTRATION_NON_DCR = (
+    "OAuth dynamic client registration failed. This server does not support dynamic client registration — "
+    "configure a pre-registered OAuth client ID."
+)
 MCP_FAILURE_MESSAGE_OAUTH_UNAUTHORIZED = (
     "MCP OAuth authorization failed. Check the server credentials or bearer-token header."
 )
@@ -52,6 +56,7 @@ _SAFE_FAILED_STATUS_MESSAGES = (
     MCP_FAILURE_MESSAGE_GENERIC,
     MCP_FAILURE_MESSAGE_GITHUB_COPILOT_OAUTH,
     MCP_FAILURE_MESSAGE_OAUTH_REGISTRATION,
+    MCP_FAILURE_MESSAGE_OAUTH_REGISTRATION_NON_DCR,
     MCP_FAILURE_MESSAGE_OAUTH_UNAUTHORIZED,
     MCP_FAILURE_MESSAGE_UNAUTHORIZED,
     MCP_FAILURE_MESSAGE_NOT_FOUND,
@@ -265,6 +270,8 @@ def _safe_mcp_failure_message(server: MCPServerConfig, lower_message: str) -> st
     if server.oauth.enabled and _contains_any(lower_message, ("registration failed", "dynamic client")):
         if _is_github_copilot_api_url(server.url):
             return MCP_FAILURE_MESSAGE_GITHUB_COPILOT_OAUTH
+        if not server.oauth.client_id:
+            return MCP_FAILURE_MESSAGE_OAUTH_REGISTRATION_NON_DCR
         return MCP_FAILURE_MESSAGE_OAUTH_REGISTRATION
     if _contains_any(lower_message, _UNAUTHORIZED_MARKERS):
         return MCP_FAILURE_MESSAGE_OAUTH_UNAUTHORIZED if server.oauth.enabled else MCP_FAILURE_MESSAGE_UNAUTHORIZED

--- a/kolega_code/mcp/state.py
+++ b/kolega_code/mcp/state.py
@@ -93,6 +93,8 @@ class MCPStatusFile(BaseModel):
 
 class MCPOAuthServerTokens(BaseModel):
     tokens: Optional[dict[str, Any]] = None
+    config_fingerprint: Optional[str] = None
+    oauth_context: Optional[dict[str, Any]] = None
     client_info: Optional[dict[str, Any]] = None
     updated_at: str = Field(default_factory=lambda: _now_iso())
 
@@ -175,10 +177,19 @@ class MCPOAuthTokenStore:
     def get(self, server_id: str) -> MCPOAuthServerTokens:
         return self.load().servers.get(server_id, MCPOAuthServerTokens())
 
-    def set_tokens(self, server_id: str, tokens: Optional[dict[str, Any]]) -> None:
+    def set_tokens(
+        self,
+        server_id: str,
+        tokens: Optional[dict[str, Any]],
+        *,
+        config_fingerprint: Optional[str] = None,
+        oauth_context: Optional[dict[str, Any]] = None,
+    ) -> None:
         data = self.load()
         record = data.servers.get(server_id, MCPOAuthServerTokens())
         record.tokens = dict(tokens) if tokens else None
+        record.config_fingerprint = config_fingerprint
+        record.oauth_context = oauth_context
         record.updated_at = _now_iso()
         data.servers[server_id] = record
         self.save(data)

--- a/tests/cli/test_mcp_cli.py
+++ b/tests/cli/test_mcp_cli.py
@@ -317,3 +317,29 @@ def test_mcp_add_with_pre_registered_oauth(tmp_path: Path, capsys) -> None:
     assert oauth["redirect_uri"] == "http://127.0.0.1:33418/callback"
     assert oauth["token_endpoint_auth_method"] == "client_secret_post"
     assert oauth["scope"] == "crm.objects.contacts.read"
+
+
+def test_mcp_add_rejects_incomplete_oauth_without_exposing_secret(tmp_path: Path, capsys) -> None:
+    state = tmp_path / "state"
+    exit_code = main(
+        [
+            "mcp",
+            "--project",
+            str(tmp_path),
+            "--state-dir",
+            str(state),
+            "add",
+            "example",
+            "--transport",
+            "streamable_http",
+            "--url",
+            "https://mcp.example/mcp",
+            "--oauth-client-secret",
+            "fake-private-secret",
+        ]
+    )
+    assert exit_code == 2
+    output = capsys.readouterr()
+    assert "client_id" in output.err
+    assert "fake-private-secret" not in output.err + output.out
+    assert not global_mcp_config_path(state).exists()

--- a/tests/cli/test_mcp_cli.py
+++ b/tests/cli/test_mcp_cli.py
@@ -274,3 +274,46 @@ def test_build_agent_config_loads_trusted_project_mcp(tmp_path: Path, monkeypatc
     assert config.mcp_config is not None
     assert set(config.mcp_config.servers) == {"project-docs"}
     assert config.mcp_config.project_trusted is True
+
+
+def test_mcp_add_with_pre_registered_oauth(tmp_path: Path, capsys) -> None:
+    project = tmp_path / "project"
+    state = tmp_path / "state"
+    project.mkdir()
+
+    exit_code = main(
+        [
+            "mcp",
+            "--project",
+            str(project),
+            "--state-dir",
+            str(state),
+            "add",
+            "hubspot",
+            "--transport",
+            "streamable_http",
+            "--url",
+            "https://mcp.hubspot.com",
+            "--oauth-client-id",
+            "hubspot-client-id-123",
+            "--oauth-client-secret-env",
+            "HUBSPOT_MCP_CLIENT_SECRET",
+            "--redirect-uri",
+            "http://127.0.0.1:33418/callback",
+            "--oauth-auth-method",
+            "client_secret_post",
+            "--oauth-scope",
+            "crm.objects.contacts.read",
+        ]
+    )
+    assert exit_code == 0
+    payload = json.loads(global_mcp_config_path(state).read_text(encoding="utf-8"))
+    saved = payload["servers"][0]
+    assert saved["id"] == "hubspot"
+    oauth = saved["oauth"]
+    assert oauth["enabled"] is True
+    assert oauth["client_id"] == "hubspot-client-id-123"
+    assert oauth["client_secret_env"] == "HUBSPOT_MCP_CLIENT_SECRET"
+    assert oauth["redirect_uri"] == "http://127.0.0.1:33418/callback"
+    assert oauth["token_endpoint_auth_method"] == "client_secret_post"
+    assert oauth["scope"] == "crm.objects.contacts.read"

--- a/tests/cli/test_tui_settings_screens.py
+++ b/tests/cli/test_tui_settings_screens.py
@@ -1702,8 +1702,33 @@ async def test_mcp_settings_page_oauth_controls_and_saving(
         assert screen.query_one("#mcp_oauth_client_secret_input", Input).password is True
 
         # Test Clear OAuth: clears tokens from token store without erasing configured credentials
+        from kolega_code.mcp.state import MCPOAuthTokenStore
+
+        token_store = MCPOAuthTokenStore(settings_store.root)
+        token_store.set_tokens(saved.id, {"access_token": "fake-access-token", "token_type": "Bearer"})
         app._clear_mcp_tokens_from_ui()
+        assert token_store.get(saved.id).tokens is None
         cfg_after = load_mcp_config(app.project_path, settings_store.root, project_trusted=False)
         server_after = cfg_after.servers[saved.id]
         assert server_after.oauth.client_id == "test-cid-123"
         assert server_after.oauth.client_secret == "test-secret-456"
+
+        # Disable and re-enable OAuth without having to re-enter credentials.
+        screen.query_one("#mcp_oauth_select", Select).value = "false"
+        await app._handle_mcp_settings_button("mcp_save_server")
+        cfg_disabled = load_mcp_config(app.project_path, settings_store.root, project_trusted=False)
+        assert cfg_disabled.servers[saved.id].oauth.enabled is False
+        assert cfg_disabled.servers[saved.id].oauth.client_id == "test-cid-123"
+        assert cfg_disabled.servers[saved.id].oauth.client_secret == "test-secret-456"
+        screen.query_one("#mcp_oauth_select", Select).value = "true"
+        await app._handle_mcp_settings_button("mcp_save_server")
+        cfg_enabled = load_mcp_config(app.project_path, settings_store.root, project_trusted=False)
+        assert cfg_enabled.servers[saved.id].oauth.enabled is True
+
+        # Hidden HTTP OAuth fields cannot prevent saving a stdio transport.
+        screen.query_one("#mcp_transport_select", Select).value = "stdio"
+        screen.query_one("#mcp_command_input", Input).value = "fake-mcp-command"
+        await app._handle_mcp_settings_button("mcp_save_server")
+        cfg_stdio = load_mcp_config(app.project_path, settings_store.root, project_trusted=False)
+        assert cfg_stdio.servers[saved.id].transport == "stdio"
+        assert cfg_stdio.servers[saved.id].oauth.enabled is False

--- a/tests/cli/test_tui_settings_screens.py
+++ b/tests/cli/test_tui_settings_screens.py
@@ -1626,3 +1626,84 @@ async def test_gateway_settings_page_rejects_a_bad_token(
         screen.query_one("#gateway_token_input", Input).value = "not-a-botfather-token"
         await app._save_settings_from_ui()
         assert settings_store.load().telegram_bot_token is None
+
+
+@pytest.mark.asyncio
+async def test_mcp_settings_page_oauth_controls_and_saving(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_cli_env: None,
+) -> None:
+    pytest.importorskip("textual")
+    from textual.widgets import Input, Select
+
+    from kolega_code.cli.tui.settings_screen import SettingsScreen
+    from kolega_code.mcp.config import load_mcp_config
+
+    app, settings_store = _configured_app(tmp_path, monkeypatch)
+
+    async with app.run_test(size=(100, 40)) as pilot:
+        app.action_open_settings()
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+        screen._show_category("mcp")
+        await pilot.pause()
+
+        # Initially, OAuth is Disabled and OAuth detail inputs are hidden
+        assert screen.query_one("#mcp_oauth_select", Select).value == "false"
+        assert screen.query_one("#mcp_oauth_client_id_input", Input).display is False
+        assert screen.query_one("#mcp_oauth_client_secret_input", Input).display is False
+
+        # Toggling OAuth to Enabled shows the OAuth detail inputs
+        screen.query_one("#mcp_oauth_select", Select).value = "true"
+        await pilot.pause()
+        assert screen.query_one("#mcp_oauth_client_id_input", Input).display is True
+        assert screen.query_one("#mcp_oauth_client_secret_input", Input).display is True
+        assert screen.query_one("#mcp_oauth_redirect_uri_input", Input).display is True
+
+        # Switching transport to stdio hides all OAuth controls
+        screen.query_one("#mcp_transport_select", Select).value = "stdio"
+        await pilot.pause()
+        assert screen.query_one("#mcp_oauth_select", Select).display is False
+        assert screen.query_one("#mcp_oauth_client_id_input", Input).display is False
+
+        # Switching back to streamable_http restores OAuth controls
+        screen.query_one("#mcp_transport_select", Select).value = "streamable_http"
+        await pilot.pause()
+        assert screen.query_one("#mcp_oauth_select", Select).display is True
+        assert screen.query_one("#mcp_oauth_client_id_input", Input).display is True
+
+        # Fill in server details with pre-registered OAuth
+        screen.query_one("#mcp_name_input", Input).value = "HubSpot CRM"
+        screen.query_one("#mcp_url_input", Input).value = "https://mcp.hubspot.com"
+        screen.query_one("#mcp_oauth_client_id_input", Input).value = "test-cid-123"
+        screen.query_one("#mcp_oauth_client_secret_input", Input).value = "test-secret-456"
+        screen.query_one("#mcp_oauth_client_secret_env_input", Input).value = "HUBSPOT_CLIENT_SECRET"
+        screen.query_one("#mcp_oauth_redirect_uri_input", Input).value = "http://127.0.0.1:33418/callback"
+        screen.query_one("#mcp_oauth_scope_input", Input).value = "crm.contacts.read"
+        screen.query_one("#mcp_oauth_auth_method_select", Select).value = "client_secret_post"
+
+        await app._handle_mcp_settings_button("mcp_save_server")
+        await pilot.pause()
+
+        # Check that server was saved to global MCP config
+        cfg = load_mcp_config(app.project_path, settings_store.root, project_trusted=False)
+        saved = next(s for s in cfg.servers.values() if s.name == "HubSpot CRM")
+        assert saved.oauth.enabled is True
+        assert saved.oauth.client_id == "test-cid-123"
+        assert saved.oauth.client_secret == "test-secret-456"
+        assert saved.oauth.client_secret_env == "HUBSPOT_CLIENT_SECRET"
+        assert saved.oauth.redirect_uri == "http://127.0.0.1:33418/callback"
+        assert saved.oauth.scope == "crm.contacts.read"
+        assert saved.oauth.token_endpoint_auth_method == "client_secret_post"
+
+        # Verify password mask on client secret input
+        assert screen.query_one("#mcp_oauth_client_secret_input", Input).password is True
+
+        # Test Clear OAuth: clears tokens from token store without erasing configured credentials
+        app._clear_mcp_tokens_from_ui()
+        cfg_after = load_mcp_config(app.project_path, settings_store.root, project_trusted=False)
+        server_after = cfg_after.servers[saved.id]
+        assert server_after.oauth.client_id == "test-cid-123"
+        assert server_after.oauth.client_secret == "test-secret-456"

--- a/tests/mcp/test_config_state_tools.py
+++ b/tests/mcp/test_config_state_tools.py
@@ -8,7 +8,9 @@ from pathlib import Path
 import pytest
 
 from kolega_code.mcp.config import (
+    LoadedMCPConfig,
     MCPConfigFile,
+    MCPOAuthConfig,
     MCPServerConfig,
     global_mcp_config_path,
     load_mcp_config,
@@ -346,3 +348,100 @@ async def test_verify_server_message_notes_adjusted_tool_names(tmp_path: Path, m
         "1 tool name was adjusted for provider compatibility (mcp__docs__get.file → mcp__docs__get_file)."
         in result.message
     )
+
+
+def test_mcp_oauth_config_defaults_and_validation() -> None:
+    # Defaults
+    oauth = MCPOAuthConfig()
+    assert oauth.enabled is False
+    assert oauth.client_id is None
+    assert oauth.client_secret is None
+    assert oauth.client_secret_env is None
+    assert oauth.redirect_uri is None
+    assert oauth.token_endpoint_auth_method is None
+    assert oauth.resolve_auth_method() == "none"
+
+    # Auto-enabling when credentials are provided
+    oauth_with_id = MCPOAuthConfig(client_id="my-client")
+    assert oauth_with_id.enabled is True
+    assert oauth_with_id.resolve_auth_method() == "none"
+
+    oauth_with_secret = MCPOAuthConfig(client_secret="sec")
+    assert oauth_with_secret.enabled is True
+    assert oauth_with_secret.resolve_auth_method() == "client_secret_post"
+
+    # Explicit auth method
+    oauth_basic = MCPOAuthConfig(client_secret="sec", token_endpoint_auth_method="client_secret_basic")
+    assert oauth_basic.resolve_auth_method() == "client_secret_basic"
+
+    # Valid redirect URI
+    oauth_valid_uri = MCPOAuthConfig(redirect_uri="http://127.0.0.1:33418/callback")
+    assert oauth_valid_uri.redirect_uri == "http://127.0.0.1:33418/callback"
+    oauth_valid_localhost = MCPOAuthConfig(redirect_uri="http://localhost:8080/callback")
+    assert oauth_valid_localhost.redirect_uri == "http://localhost:8080/callback"
+
+    # Invalid redirect URIs
+    with pytest.raises(ValueError, match="localhost http URL"):
+        MCPOAuthConfig(redirect_uri="https://example.com/callback")
+    with pytest.raises(ValueError, match="localhost http URL"):
+        MCPOAuthConfig(redirect_uri="http://example.com:8080/callback")
+
+    # Invalid env var name
+    with pytest.raises(ValueError, match="valid environment variable name"):
+        MCPOAuthConfig(client_secret_env="invalid-name!")
+
+
+def test_mcp_oauth_config_secret_resolution_and_redaction(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TEST_MCP_SECRET_ENV", "env-secret-val-123")
+
+    oauth_direct = MCPOAuthConfig(client_id="cid", client_secret="direct-secret-456")
+    assert oauth_direct.resolve_client_secret() == "direct-secret-456"
+
+    oauth_env = MCPOAuthConfig(client_id="cid", client_secret_env="TEST_MCP_SECRET_ENV")
+    assert oauth_env.resolve_client_secret() == "env-secret-val-123"
+
+    # Server sanitization masks direct secret but shows env var name
+    server = MCPServerConfig(
+        id="hubspot",
+        transport="streamable_http",
+        url="https://mcp.hubspot.com",
+        oauth=MCPOAuthConfig(
+            client_id="cid",
+            client_secret="direct-secret-456",
+            client_secret_env="TEST_MCP_SECRET_ENV",
+            redirect_uri="http://127.0.0.1:33418/callback",
+        ),
+    )
+    sanitized = server.sanitized_for_display()
+    assert sanitized["oauth"]["client_secret"] == "‹secret›"
+    assert sanitized["oauth"]["client_id"] == "cid"
+    assert sanitized["oauth"]["client_secret_env"] == "TEST_MCP_SECRET_ENV"
+
+    # mcp_secret_values collects the resolved secrets for diagnostics redaction
+    config = LoadedMCPConfig(servers={"hubspot": server})
+    secrets = mcp_secret_values(config)
+    assert "direct-secret-456" in secrets
+
+
+def test_server_fingerprint_updates_on_oauth_changes() -> None:
+    server = MCPServerConfig(
+        id="hubspot",
+        transport="streamable_http",
+        url="https://mcp.hubspot.com",
+        oauth=MCPOAuthConfig(enabled=True),
+    )
+    fp_base = server_fingerprint(server)
+
+    server_with_client = server.model_copy(update={"oauth": MCPOAuthConfig(enabled=True, client_id="cid-1")})
+    assert server_fingerprint(server_with_client) != fp_base
+
+    server_with_redirect = server_with_client.model_copy(
+        update={
+            "oauth": MCPOAuthConfig(
+                enabled=True,
+                client_id="cid-1",
+                redirect_uri="http://127.0.0.1:33418/callback",
+            )
+        }
+    )
+    assert server_fingerprint(server_with_redirect) != server_fingerprint(server_with_client)

--- a/tests/mcp/test_config_state_tools.py
+++ b/tests/mcp/test_config_state_tools.py
@@ -366,12 +366,14 @@ def test_mcp_oauth_config_defaults_and_validation() -> None:
     assert oauth_with_id.enabled is True
     assert oauth_with_id.resolve_auth_method() == "none"
 
-    oauth_with_secret = MCPOAuthConfig(client_secret="sec")
+    oauth_with_secret = MCPOAuthConfig(client_id="my-client", client_secret="sec")
     assert oauth_with_secret.enabled is True
     assert oauth_with_secret.resolve_auth_method() == "client_secret_post"
 
     # Explicit auth method
-    oauth_basic = MCPOAuthConfig(client_secret="sec", token_endpoint_auth_method="client_secret_basic")
+    oauth_basic = MCPOAuthConfig(
+        client_id="my-client", client_secret="sec", token_endpoint_auth_method="client_secret_basic"
+    )
     assert oauth_basic.resolve_auth_method() == "client_secret_basic"
 
     # Valid redirect URI

--- a/tests/mcp/test_oauth.py
+++ b/tests/mcp/test_oauth.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import io
+import json
+from pathlib import Path
+from typing import Any, Literal
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+from mcp.shared.auth import OAuthToken
+from rich.console import Console
+
+from kolega_code.mcp.config import MCPOAuthConfig, MCPServerConfig
+from kolega_code.mcp.oauth import (
+    LocalOAuthCallbackServer,
+    MCPFileTokenStorage,
+    MCPOAuthError,
+    OAuthInteraction,
+    build_oauth_provider,
+    default_redirect_handler,
+)
+from kolega_code.mcp.state import MCPOAuthTokenStore
+
+
+def _server(**oauth: Any) -> MCPServerConfig:
+    return MCPServerConfig(
+        id="example",
+        url="https://mcp.example/mcp",
+        oauth=MCPOAuthConfig(client_id="fake-client", **oauth),
+    )
+
+
+def test_explicitly_disabled_oauth_survives_round_trip() -> None:
+    server = _server(enabled=False, client_secret="fake-secret")
+    assert not server.oauth.enabled
+    assert not MCPServerConfig.model_validate_json(server.model_dump_json()).oauth.enabled
+
+
+@pytest.mark.parametrize(
+    "oauth",
+    [
+        {"client_secret": "fake-secret"},
+        {"client_secret_env": "FAKE_OAUTH_SECRET"},
+        {"client_id": "fake-client", "token_endpoint_auth_method": "client_secret_basic"},
+        {"client_id": "fake-client", "token_endpoint_auth_method": "client_secret_post"},
+    ],
+)
+def test_incomplete_credentials_fail_without_exposing_secrets(oauth: dict[str, str]) -> None:
+    with pytest.raises(ValueError, match="client_id") as exc:
+        MCPServerConfig.model_validate({"id": "example", "url": "https://mcp.example/mcp", "oauth": oauth})
+    assert "fake-secret" not in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "http://localhost:bad/callback",
+        "http://localhost:65536/callback",
+        "http://fake-user:fake-password@localhost:1234/callback",
+        "http://localhost:1234/callback#fragment",
+    ],
+)
+def test_invalid_callback_uri_rejected_on_configuration(uri: str) -> None:
+    with pytest.raises(ValueError):
+        MCPOAuthConfig(redirect_uri=uri)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost"])
+@pytest.mark.parametrize("suffix", ["", "/callback", "/callback?tenant=example"])
+async def test_fixed_callback_uri_receives_code(host: str, suffix: str, unused_tcp_port: int) -> None:
+    uri = f"http://{host}:{unused_tcp_port}{suffix}"
+    async with LocalOAuthCallbackServer(uri, timeout_seconds=2) as callback:
+        assert callback.redirect_uri == uri
+        separator = "&" if "?" in uri else "?"
+        async with httpx.AsyncClient(trust_env=False) as client:
+            response = await client.get(uri + separator + "code=fake-code&state=fake-state")
+        assert response.status_code == 200
+        assert await callback.wait_for_callback() == ("fake-code", "fake-state")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("host", ["localhost", "127.0.0.1"])
+async def test_ephemeral_callback_preserves_query(host: str) -> None:
+    async with LocalOAuthCallbackServer(f"http://{host}:0/callback?tenant=example") as callback:
+        assert urlparse(callback.redirect_uri).query == "tenant=example"
+        async with httpx.AsyncClient(trust_env=False) as client:
+            response = await client.get(callback.redirect_uri + "&code=fake-code&state=fake-state")
+        assert response.status_code == 200
+        assert await callback.wait_for_callback() == ("fake-code", "fake-state")
+
+
+@pytest.mark.asyncio
+async def test_occupied_callback_port_has_actionable_error(unused_tcp_port: int) -> None:
+    async def ignore_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        writer.close()
+        await writer.wait_closed()
+
+    async with await asyncio.start_server(ignore_client, "127.0.0.1", unused_tcp_port):
+        with pytest.raises(MCPOAuthError, match="Could not bind OAuth callback"):
+            async with LocalOAuthCallbackServer(f"http://127.0.0.1:{unused_tcp_port}/callback"):
+                pytest.fail("An occupied port must not silently become an ephemeral callback")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("rich_console", [False, True])
+async def test_authorization_url_output_supports_cli_and_tui(rich_console: bool) -> None:
+    stream = io.StringIO()
+    output = Console(file=stream, width=40) if rich_console else stream
+    url = "https://auth.example/authorize?state=fake-state&client_id=fake-client"
+    await default_redirect_handler(url, open_browser=False, output=output)
+    assert url in stream.getvalue()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("changed", ["client_id", "scope", "redirect_uri", "url", "secret_env"])
+async def test_cached_tokens_follow_oauth_configuration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, changed: str
+) -> None:
+    monkeypatch.setenv("FAKE_OAUTH_SECRET", "fake-old-secret")
+    server = _server(client_secret_env="FAKE_OAUTH_SECRET")
+    store = MCPOAuthTokenStore(tmp_path)
+    tokens = OAuthToken(access_token="fake-access-token", token_type="Bearer")
+    await MCPFileTokenStorage(server, store).set_tokens(tokens)
+    assert await MCPFileTokenStorage(server, store).get_tokens() == tokens
+    if changed == "url":
+        server = server.model_copy(update={"url": "https://other.example/mcp"})
+    elif changed == "secret_env":
+        monkeypatch.setenv("FAKE_OAUTH_SECRET", "fake-new-secret")
+    else:
+        new_value = "http://127.0.0.1:1234/callback" if changed == "redirect_uri" else "new-value"
+        server = server.model_copy(update={"oauth": server.oauth.model_copy(update={changed: new_value})})
+    assert await MCPFileTokenStorage(server, store).get_tokens() is None
+    persisted = store.path.read_text()
+    assert "fake-old-secret" not in persisted
+    assert "fake-new-secret" not in persisted
+
+
+@pytest.mark.asyncio
+async def test_legacy_tokens_are_not_reused_for_pre_registered_client(tmp_path: Path) -> None:
+    store = MCPOAuthTokenStore(tmp_path)
+    store.set_tokens("example", {"access_token": "fake-legacy-token", "token_type": "Bearer"})
+    assert await MCPFileTokenStorage(_server(), store).get_tokens() is None
+    dcr_server = MCPServerConfig(id="example", url="https://mcp.example/mcp", oauth=MCPOAuthConfig(enabled=True))
+    assert await MCPFileTokenStorage(dcr_server, store).get_tokens() is not None
+
+
+@pytest.mark.asyncio
+async def test_explicit_public_auth_method_is_used_for_dynamic_registration(tmp_path: Path) -> None:
+    server = MCPServerConfig(
+        id="example",
+        url="https://mcp.example/mcp",
+        oauth=MCPOAuthConfig(enabled=True, token_endpoint_auth_method="none"),
+    )
+    provider = await build_oauth_provider(server, MCPOAuthTokenStore(tmp_path))
+    assert provider is not None
+    from mcp.client.auth.utils import create_client_registration_request
+
+    request = create_client_registration_request(None, provider.context.client_metadata, "https://mcp.example")
+    assert json.loads(request.content)["token_endpoint_auth_method"] == "none"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["client_secret_post", "client_secret_basic", "none"])
+async def test_pre_registered_oauth_authorization_refresh_and_reconnect(
+    tmp_path: Path, method: Literal["client_secret_post", "client_secret_basic", "none"]
+) -> None:
+    server = _server(
+        client_secret="fake-secret" if method != "none" else None,
+        token_endpoint_auth_method=method,
+        redirect_uri="http://127.0.0.1:1234/callback",
+        scope="read",
+    )
+    store = MCPOAuthTokenStore(tmp_path)
+    authorization: dict[str, list[str]] = {}
+    grants: list[str] = []
+    redirects: list[str] = []
+
+    async def redirect_handler(url: str) -> None:
+        redirects.append(url)
+        authorization.update(parse_qs(urlparse(url).query))
+
+    async def callback_handler() -> tuple[str, str | None]:
+        return "fake-code", authorization["state"][0]
+
+    async def close() -> None:
+        return None
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if url == server.url:
+            if request.headers.get("Authorization") == "Bearer fake-access-token":
+                return httpx.Response(200, json={"ok": True})
+            return httpx.Response(
+                401, headers={"WWW-Authenticate": 'Bearer resource_metadata="https://mcp.example/prm"'}
+            )
+        if url == "https://mcp.example/prm":
+            return httpx.Response(
+                200,
+                json={
+                    "resource": server.url,
+                    "authorization_servers": ["https://auth.example"],
+                    "scopes_supported": ["read", "write"],
+                },
+            )
+        if url == "https://auth.example/.well-known/oauth-authorization-server":
+            return httpx.Response(
+                200,
+                json={
+                    "issuer": "https://auth.example",
+                    "authorization_endpoint": "https://auth.example/authorize",
+                    "token_endpoint": "https://auth.example/token",
+                    "response_types_supported": ["code"],
+                    "code_challenge_methods_supported": ["S256"],
+                },
+            )
+        if url == "https://auth.example/token":
+            data = parse_qs(request.content.decode())
+            grants.append(data["grant_type"][0])
+            assert data["client_id"] == ["fake-client"]
+            if method == "client_secret_post":
+                assert data["client_secret"] == ["fake-secret"]
+                assert "Authorization" not in request.headers
+            elif method == "client_secret_basic":
+                assert "client_secret" not in data
+                assert (
+                    base64.b64decode(request.headers["Authorization"].removeprefix("Basic "))
+                    == b"fake-client:fake-secret"
+                )
+            else:
+                assert "client_secret" not in data
+                assert "Authorization" not in request.headers
+            if grants[-1] == "authorization_code":
+                assert data["redirect_uri"] == [server.oauth.redirect_uri]
+                digest = hashlib.sha256(data["code_verifier"][0].encode()).digest()
+                assert authorization["code_challenge"] == [base64.urlsafe_b64encode(digest).decode().rstrip("=")]
+                assert authorization["code_challenge_method"] == ["S256"]
+                assert authorization["scope"] == ["read"]
+            else:
+                assert data["refresh_token"] == ["fake-refresh-token"]
+            return httpx.Response(
+                200,
+                json={
+                    "access_token": "fake-access-token",
+                    "refresh_token": "fake-refresh-token",
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                },
+            )
+        pytest.fail(f"Unexpected OAuth request (including any dynamic registration): {request.method} {url}")
+
+    interaction = OAuthInteraction(server.oauth.redirect_uri or "", redirect_handler, callback_handler, close)
+    provider = await build_oauth_provider(server, store, interaction=interaction)
+    assert provider is not None
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle), auth=provider) as client:
+        assert (await client.get(server.url or "")).status_code == 200
+        provider.context.token_expiry_time = 1.0
+        assert (await client.get(server.url or "")).status_code == 200
+    assert grants == ["authorization_code", "refresh_token"]
+
+    # Expiration after a restart must refresh at the discovered auth server,
+    # without needing another interactive browser session.
+    saved = store.load()
+    saved_context = saved.servers[server.id].oauth_context
+    assert saved_context is not None
+    saved_context["token_expiry_time"] = 1.0
+    store.save(saved)
+    provider = await build_oauth_provider(server, store)
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle), auth=provider) as client:
+        assert (await client.get(server.url or "")).status_code == 200
+    assert grants == ["authorization_code", "refresh_token", "refresh_token"]
+    assert len(redirects) == 1
+    assert store.get(server.id).client_info is None
+
+    # A new non-interactive connection uses the saved token without registration.
+    provider = await build_oauth_provider(server, store)
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle), auth=provider) as client:
+        assert (await client.get(server.url or "")).status_code == 200
+    assert grants == ["authorization_code", "refresh_token", "refresh_token"]
+
+
+@pytest.mark.asyncio
+async def test_oauth_rejects_wrong_callback_state(tmp_path: Path) -> None:
+    async def redirect_handler(url: str) -> None:
+        return None
+
+    async def callback_handler() -> tuple[str, str | None]:
+        return "fake-code", "wrong-state"
+
+    async def close() -> None:
+        return None
+
+    interaction = OAuthInteraction("http://127.0.0.1:1234/callback", redirect_handler, callback_handler, close)
+    provider = await build_oauth_provider(_server(), MCPOAuthTokenStore(tmp_path), interaction=interaction)
+    assert provider is not None
+    await provider._initialize()
+    with pytest.raises(Exception, match="State parameter mismatch"):
+        await provider._perform_authorization_code_grant()

--- a/tests/mcp/test_oauth.py
+++ b/tests/mcp/test_oauth.py
@@ -5,6 +5,7 @@ import base64
 import hashlib
 import io
 import json
+import threading
 from pathlib import Path
 from typing import Any, Literal
 from urllib.parse import parse_qs, urlparse
@@ -138,6 +139,58 @@ async def test_cached_tokens_follow_oauth_configuration(
     persisted = store.path.read_text()
     assert "fake-old-secret" not in persisted
     assert "fake-new-secret" not in persisted
+
+
+@pytest.mark.asyncio
+async def test_cached_token_fingerprints_are_salted_and_derived_off_event_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    server = _server(client_secret="fake-client-secret")
+    store = MCPOAuthTokenStore(tmp_path)
+    storage = MCPFileTokenStorage(server, store)
+    tokens = OAuthToken(access_token="fake-access-token", token_type="Bearer")
+    event_loop_thread = threading.get_ident()
+    derivation_threads: list[int] = []
+    pbkdf2_hmac = hashlib.pbkdf2_hmac
+
+    def tracked_pbkdf2(algorithm: str, data: bytes, salt: bytes, iterations: int) -> bytes:
+        derivation_threads.append(threading.get_ident())
+        return pbkdf2_hmac(algorithm, data, salt, iterations)
+
+    monkeypatch.setattr(hashlib, "pbkdf2_hmac", tracked_pbkdf2)
+    await storage.set_tokens(tokens)
+    first = store.get(server.id).config_fingerprint
+    assert first is not None
+    assert first.startswith("pbkdf2-sha256$600000$")
+    assert await MCPFileTokenStorage(server, store).get_tokens() == tokens
+
+    await storage.set_tokens(tokens)
+    second = store.get(server.id).config_fingerprint
+    assert second is not None
+    assert first.split("$")[2] != second.split("$")[2]
+    assert await MCPFileTokenStorage(server, store).get_tokens() == tokens
+    assert derivation_threads and event_loop_thread not in derivation_threads
+    assert "fake-client-secret" not in store.path.read_text()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "fingerprint",
+    [
+        "a" * 64,
+        "pbkdf2-sha256$1$" + "aa" * 16 + "$" + "bb" * 32,
+        "pbkdf2-sha256$600000$not-hex$" + "bb" * 32,
+        "pbkdf2-sha256$600000$aa$" + "bb" * 32,
+    ],
+)
+async def test_legacy_or_invalid_fingerprints_require_new_authorization(tmp_path: Path, fingerprint: str) -> None:
+    store = MCPOAuthTokenStore(tmp_path)
+    store.set_tokens(
+        "example",
+        {"access_token": "fake-access-token", "token_type": "Bearer"},
+        config_fingerprint=fingerprint,
+    )
+    assert await MCPFileTokenStorage(_server(), store).get_tokens() is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_transport.py
+++ b/tests/test_mcp_transport.py
@@ -21,6 +21,7 @@ from kolega_code.mcp.service import (
     MCPService,
     MCP_FAILURE_MESSAGE_GENERIC,
     MCP_FAILURE_MESSAGE_OAUTH_REGISTRATION_NON_DCR,
+    MCP_FAILURE_MESSAGE_OAUTH_SECRET_ENV,
     MCP_TOOL_FAILURE_MESSAGE_TIMEOUT,
     _is_github_copilot_api_url,
 )
@@ -522,6 +523,11 @@ async def test_build_oauth_provider_checks_missing_secret_env(tmp_path: Path) ->
     )
     with pytest.raises(MCPOAuthError, match="requires environment variable 'NON_EXISTENT_ENV_VAR_12345'"):
         await build_oauth_provider(server, token_store)
+
+    service = MCPService(LoadedMCPConfig(servers={server.id: server}), state_dir=tmp_path, project_path=tmp_path)
+    result = await service.verify_server(server.id)
+    assert result.message == MCP_FAILURE_MESSAGE_OAUTH_SECRET_ENV
+    assert service.list_status_rows()[0]["message"] == MCP_FAILURE_MESSAGE_OAUTH_SECRET_ENV
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_transport.py
+++ b/tests/test_mcp_transport.py
@@ -12,9 +12,15 @@ import pytest
 from mcp.types import CallToolResult, TextContent
 
 from kolega_code.mcp.config import LoadedMCPConfig, MCPOAuthConfig, MCPServerConfig, server_fingerprint
+from kolega_code.mcp.oauth import (
+    MCPFileTokenStorage,
+    MCPOAuthError,
+    build_oauth_provider,
+)
 from kolega_code.mcp.service import (
     MCPService,
     MCP_FAILURE_MESSAGE_GENERIC,
+    MCP_FAILURE_MESSAGE_OAUTH_REGISTRATION_NON_DCR,
     MCP_TOOL_FAILURE_MESSAGE_TIMEOUT,
     _is_github_copilot_api_url,
 )
@@ -428,3 +434,121 @@ def test_list_status_rows_replaces_legacy_failed_status_messages(tmp_path: Path)
     assert rows[0]["status"] == "failed"
     assert rows[0]["message"] == MCP_FAILURE_MESSAGE_GENERIC
     assert "legacy-secret" not in rows[0]["message"]
+
+
+@pytest.mark.asyncio
+async def test_mcp_file_token_storage_returns_configured_client_info(tmp_path: Path) -> None:
+    token_store = MCPOAuthTokenStore(tmp_path)
+    server = MCPServerConfig(
+        id="hubspot",
+        transport="streamable_http",
+        url="https://mcp.hubspot.com",
+        oauth=MCPOAuthConfig(
+            client_id="hubspot-cid-123",
+            client_secret="hubspot-secret-456",
+            token_endpoint_auth_method="client_secret_post",
+            redirect_uri="http://127.0.0.1:33418/callback",
+            scope="crm.objects.contacts.read",
+        ),
+    )
+    storage = MCPFileTokenStorage(server, token_store)
+    client_info = await storage.get_client_info()
+
+    assert client_info is not None
+    assert client_info.client_id == "hubspot-cid-123"
+    assert client_info.client_secret == "hubspot-secret-456"
+    assert client_info.token_endpoint_auth_method == "client_secret_post"
+    assert client_info.redirect_uris is not None
+    assert str(client_info.redirect_uris[0]) == "http://127.0.0.1:33418/callback"
+    assert client_info.scope == "crm.objects.contacts.read"
+
+
+@pytest.mark.asyncio
+async def test_oauth_provider_uses_configured_client_and_formats_token_auth(tmp_path: Path) -> None:
+    token_store = MCPOAuthTokenStore(tmp_path)
+    server = MCPServerConfig(
+        id="hubspot",
+        transport="streamable_http",
+        url="https://mcp.hubspot.com",
+        oauth=MCPOAuthConfig(
+            client_id="hubspot-cid",
+            client_secret="hubspot-sec",
+            token_endpoint_auth_method="client_secret_post",
+            redirect_uri="http://127.0.0.1:33418/callback",
+        ),
+    )
+    provider = await build_oauth_provider(server, token_store)
+    assert provider is not None
+    await provider._initialize()
+    assert provider.context.client_info is not None
+    assert provider.context.client_info.client_id == "hubspot-cid"
+
+    # client_secret_post includes client_secret in data
+    data, headers = provider.context.prepare_token_auth({"grant_type": "authorization_code"}, {})
+    assert data["client_secret"] == "hubspot-sec"
+    assert "Authorization" not in headers
+
+    # client_secret_basic sets Basic Auth header
+    server_basic = server.model_copy(
+        update={
+            "oauth": MCPOAuthConfig(
+                client_id="hubspot-cid",
+                client_secret="hubspot-sec",
+                token_endpoint_auth_method="client_secret_basic",
+                redirect_uri="http://127.0.0.1:33418/callback",
+            )
+        }
+    )
+    provider_basic = await build_oauth_provider(server_basic, token_store)
+    assert provider_basic is not None
+    await provider_basic._initialize()
+    data_b, headers_b = provider_basic.context.prepare_token_auth({"grant_type": "authorization_code"}, {})
+    assert "client_secret" not in data_b
+    assert "Authorization" in headers_b
+    assert headers_b["Authorization"].startswith("Basic ")
+
+
+@pytest.mark.asyncio
+async def test_build_oauth_provider_checks_missing_secret_env(tmp_path: Path) -> None:
+    token_store = MCPOAuthTokenStore(tmp_path)
+    server = MCPServerConfig(
+        id="hubspot",
+        transport="streamable_http",
+        url="https://mcp.hubspot.com",
+        oauth=MCPOAuthConfig(
+            client_id="hubspot-cid",
+            client_secret_env="NON_EXISTENT_ENV_VAR_12345",
+        ),
+    )
+    with pytest.raises(MCPOAuthError, match="requires environment variable 'NON_EXISTENT_ENV_VAR_12345'"):
+        await build_oauth_provider(server, token_store)
+
+
+@pytest.mark.asyncio
+async def test_verify_server_reports_non_dcr_failure_when_no_client_id(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kolega_code.mcp.service as service_module
+
+    @asynccontextmanager
+    async def fake_open_mcp_session(*args, **kwargs):
+        raise RuntimeError("Registration failed: 404 Not Found")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(service_module, "open_mcp_session", fake_open_mcp_session)
+    server = MCPServerConfig(
+        id="hubspot",
+        transport="streamable_http",
+        url="https://mcp.hubspot.com",
+        oauth=MCPOAuthConfig(enabled=True),
+    )
+    service = MCPService(
+        LoadedMCPConfig(servers={server.id: server}),
+        state_dir=tmp_path,
+        project_path=tmp_path,
+    )
+
+    result = await service.verify_server(server.id, interactive_oauth=True)
+    assert result.ok is False
+    assert result.message == MCP_FAILURE_MESSAGE_OAUTH_REGISTRATION_NON_DCR


### PR DESCRIPTION
Remote MCP servers that require a pre-registered OAuth client currently fail during dynamic client registration. This change lets users supply a client ID and optional secret through configuration, `kolega-code mcp add`, or TUI settings, then authenticate with the authorization-code flow and PKCE.

Closes #658.

## Behavior

- Support `client_id`, direct or environment-backed client secrets, and `client_secret_post`, `client_secret_basic`, or public-client authentication. Configured client credentials bypass dynamic registration; explicitly configured scopes and authentication methods are honored.
- Add CLI flags and TUI controls for credentials, scopes, and callback URLs. Disabling OAuth preserves credentials and respects an explicit `enabled: false`; clearing cached OAuth tokens also preserves configured credentials. Switching to stdio does not leave hidden OAuth controls enabled.
- Bind cached tokens to the server URL and OAuth configuration so changing credentials or scopes cannot reuse tokens from the previous configuration. Because this binding includes the client secret, derive fingerprints with PBKDF2-HMAC-SHA256, 600,000 iterations, and a random 128-bit salt. Perform derivation off the event loop and compare fingerprints in constant time. Persist token expiry and discovered authorization-server metadata so expired tokens refresh across connections without another browser login.
- Preserve fixed callback hosts, ports, paths, and queries, including root-path callbacks. Keep ephemeral localhost callbacks reachable, reject malformed callback URLs, and support authorization URL output in both the CLI and TUI.
- Reject incomplete credentials without exposing secrets in validation errors. Report missing secret environment variables and occupied callback ports clearly, and avoid treating every registration failure as proof that a server lacks dynamic registration.

Pre-registered tokens without configuration binding, and tokens with the earlier unsalted SHA-256 fingerprint format, require one new authorization. Legacy dynamic-registration tokens without fingerprints remain usable.

## Validation

- Affected MCP, CLI, and TUI tests after the PBKDF2 change: **127 passed**. Additional regressions check salt uniqueness, derivation off the event loop, cache reuse across instances, credential changes, and rejection of old or malformed fingerprints.
- `env CI=1 ./run_tests.sh --coverage -m 'not slow and not integration' -q` on `bf156f68`: **5,268 passed, 4 skipped; 84.37% coverage**.
- Regression coverage exercises complete mocked HTTP authorization and refresh flows for all three authentication methods, PKCE and state validation, token reuse after reconnecting, refresh after expiry across connections, configuration changes, real localhost callbacks, CLI validation, and TUI settings persistence.
- `uv run pre-commit run --all-files --show-diff-on-failure`, hooks for the new test file, Ruff, and Pyright passed.
- `npm run build` in `docs/` passed.
- The broader `./run_tests.sh --coverage -q` run had **5,346 passed, 5 skipped, and 6 failures** in unrelated live-provider tests: three ChatGPT tests failed on OAuth refresh HTTP 401, and three Together tests failed because `moonshotai/Kimi-K2.7-Code` requires a dedicated endpoint.

Live HubSpot and Slack account authorization was not exercised.
