### PR TITLE
feat(llm): support GPT-6 Astra in OpenAI and ChatGPT providers

### DIFF
--- a/docs/src/content/docs/configuration/providers-and-models.mdx
+++ b/docs/src/content/docs/configuration/providers-and-models.mdx
@@ -40,6 +40,15 @@ Anthropic-compatible):
 | Perplexity Agent API | `perplexity_agent` | `PERPLEXITY_API_KEY` |
 | Llama (local) | `llama` | _none — local model_ |
 
+**GPT-6 Astra** (`gpt-6-astra`) is available in the model picker for both `openai`
+and `openai_chatgpt`. It supports image input, hosted web search, and reasoning
+efforts from `low` through `max`, with `medium` as the Kolega Code default.
+Reasoning cannot be disabled for Astra. The API provider uses its
+[1,050,000-token context window](https://developers.openai.com/api/docs/models/gpt-6-astra)
+with 128,000 tokens reserved for output. The ChatGPT provider keeps a conservative
+400,000-token budget (272,000 input tokens), matching the existing subscription
+models. Subscription availability depends on your account and OpenAI's rollout.
+
 <Aside type="tip">
 **Z.AI GLM Coding Plan.** The `zai` provider targets Z.AI's Anthropic-compatible
 endpoint (`https://api.z.ai/api/anthropic`) and exposes **GLM-5.3** (default),
@@ -363,6 +372,7 @@ models in the TUI.
 | Google `gemini-3.5-flash-lite` | `minimal`, `low`, `medium`, `high` | `minimal` |
 | Google `gemini-3.5-flash` | `minimal`, `low`, `medium`, `high` | `medium` |
 | Google `gemini-3.1-pro-preview` | `low`, `medium`, `high` | `high` |
+| OpenAI / ChatGPT `gpt-6-astra` | `low`, `medium`, `high`, `xhigh`, `max` | `medium` |
 | OpenAI `gpt-5.6-*` | `none`, `low`, `medium`, `high`, `xhigh`, `max` | `medium` |
 | OpenAI `gpt-5.5` | `minimal`, `low`, `medium`, `high`, `xhigh` | `medium` |
 | OpenAI `gpt-5.4*` | `minimal`, `low`, `medium`, `high` | `medium` |

--- a/docs/src/content/docs/configuration/sign-in-with-chatgpt.mdx
+++ b/docs/src/content/docs/configuration/sign-in-with-chatgpt.mdx
@@ -48,7 +48,8 @@ model line-up:
 
 | Model | Label |
 | --- | --- |
-| `gpt-5.6-sol` | GPT-5.6 Sol — default, strongest capability for complex work |
+| `gpt-6-astra` | GPT-6 Astra — most capable model for complex work |
+| `gpt-5.6-sol` | GPT-5.6 Sol — default, strong capability for complex work |
 | `gpt-5.6-terra` | GPT-5.6 Terra — balanced capability and cost |
 | `gpt-5.6-luna` | GPT-5.6 Luna — fast and affordable for clear, repeatable work |
 | `gpt-5.5` | GPT-5.5 — previous-generation frontier model |

--- a/kolega_code/cli/provider_registry.py
+++ b/kolega_code/cli/provider_registry.py
@@ -90,6 +90,7 @@ MODEL_LABELS: dict[str, str] = {
     "claude-opus-4-5-20251101": "Claude Opus 4.5",
     "claude-haiku-4-5-20251001": "Claude Haiku 4.5",
     # OpenAI (shared labels across the API and ChatGPT-subscription providers)
+    "gpt-6-astra": "GPT-6 Astra",
     "gpt-5.6-sol": "GPT-5.6 Sol",
     "gpt-5.6-terra": "GPT-5.6 Terra",
     "gpt-5.6-luna": "GPT-5.6 Luna",

--- a/kolega_code/llm/specs/catalog/openai.py
+++ b/kolega_code/llm/specs/catalog/openai.py
@@ -11,6 +11,21 @@ from kolega_code.llm.specs.types import ThinkingEffortSpec
 # The ChatGPT-subscription backend (openai_chatgpt) carries the flag too,
 # verified through its own OAuth transport the same day.
 OPENAI_SPECS = {
+    ("openai", "gpt-6-astra"): {
+        "context_length": 1050000,
+        "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
+        "default_temperature": 1.0,
+        "supports_temperature": False,
+        "supports_vision": True,
+        "supports_hosted_web_search": True,
+        "preferred_edit_protocol": "codex_apply_patch",
+        "thinking_effort": ThinkingEffortSpec(
+            options=("low", "medium", "high", "xhigh", "max"),
+            default="medium",
+            mode="openai_responses_reasoning",
+        ),
+    },
     ("openai", "gpt-5.6-sol"): {
         "context_length": 1050000,
         "max_completion_tokens": 128000,

--- a/kolega_code/llm/specs/catalog/openai_chatgpt.py
+++ b/kolega_code/llm/specs/catalog/openai_chatgpt.py
@@ -13,6 +13,23 @@ from kolega_code.llm.specs.types import ThinkingEffortSpec
 # GPT-5.5, despite the API models exposing a larger window. Keep the
 # subscription-specific values here so compression runs before backend limits.
 OPENAI_CHATGPT_SPECS = {
+    ("openai_chatgpt", "gpt-6-astra"): {
+        # Retain the conservative subscription budget used by GPT-5.6 until
+        # Astra's larger input window is verified on the Codex backend.
+        "context_length": 400000,
+        "max_completion_tokens": 128000,
+        "input_budget": "window_minus_output",
+        "default_temperature": 1.0,
+        "supports_temperature": False,
+        "supports_vision": True,
+        "supports_hosted_web_search": True,
+        "preferred_edit_protocol": "codex_apply_patch",
+        "thinking_effort": ThinkingEffortSpec(
+            options=("low", "medium", "high", "xhigh", "max"),
+            default="medium",
+            mode="openai_responses_reasoning",
+        ),
+    },
     ("openai_chatgpt", "gpt-5.6-sol"): {
         "context_length": 400000,
         "max_completion_tokens": 128000,

--- a/tests/agent/llm/test_chatgpt_oauth_provider_generate.py
+++ b/tests/agent/llm/test_chatgpt_oauth_provider_generate.py
@@ -71,7 +71,13 @@ class _FakeResponses:
 
 
 @pytest.mark.asyncio
-async def test_provider_generate_builds_codex_shaped_request(monkeypatch):
+@pytest.mark.parametrize(
+    "model,effort",
+    [("gpt-5.5", "high"), *[("gpt-6-astra", effort) for effort in ("low", "medium", "high", "xhigh", "max")]],
+)
+async def test_provider_generate_builds_codex_shaped_request(
+    monkeypatch: pytest.MonkeyPatch, model: str, effort: str
+) -> None:
     provider = ChatGPTOAuthProvider(token_manager=ChatGPTTokenManager(_tokens()))
     completed = _ns(
         output=[_ns(type="message", content=[_ns(type="output_text", text="hi")])],
@@ -82,25 +88,25 @@ async def test_provider_generate_builds_codex_shaped_request(monkeypatch):
     fake = _FakeResponses(_FakeStream([_ns(type="response.completed", response=completed)]))
     monkeypatch.setattr(provider, "async_client", _ns(responses=fake))
 
-    params = GenerationParams(max_completion_tokens=256, thinking="high")
+    params = GenerationParams(max_completion_tokens=256, thinking=effort, temperature=0.5)
     message = await provider.generate(
         MessageHistory([Message(role="user", content=[TextBlock(text="hello")])]),
         system=Message(role="system", content=[TextBlock(text="sys")]),
         params=params,
-        model="gpt-5.5",
+        model=model,
     )
 
     assert message.get_text_content() == "hi"
     assert message.usage_metadata["provider"] == "openai_chatgpt"
     kwargs = fake.last_kwargs
     assert kwargs is not None
-    assert kwargs["model"] == "gpt-5.5"
+    assert kwargs["model"] == model
     assert kwargs["store"] is False
     assert kwargs["stream"] is True  # backend is SSE-only; generate streams too
     assert kwargs["instructions"] == "sys"
     # summary="auto" so the backend streams a reasoning summary for the thinking
     # display; this is independent of continuity, which rides on `include` below.
-    assert kwargs["reasoning"] == {"effort": "high", "summary": "auto"}
+    assert kwargs["reasoning"] == {"effort": effort, "summary": "auto"}
     # Reasoning continuity: ask the backend for the encrypted reasoning blob so it
     # can be resent next turn (matches Codex; the cause of the long-thinking gap).
     assert kwargs["include"] == ["reasoning.encrypted_content"]
@@ -109,6 +115,7 @@ async def test_provider_generate_builds_codex_shaped_request(monkeypatch):
     assert "prompt_cache_key" in kwargs
     # Codex never sends max_output_tokens; sending it triggers a 400.
     assert "max_output_tokens" not in kwargs
+    assert "temperature" not in kwargs
     assert kwargs["input"] == [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}]
 
 

--- a/tests/agent/llm/test_model_specs.py
+++ b/tests/agent/llm/test_model_specs.py
@@ -35,6 +35,29 @@ def test_new_google_model_specs(
     assert specs["thinking_effort"].mode == "google_thinking_level"
 
 
+@pytest.mark.parametrize("provider,context_length", [("openai", 1050000), ("openai_chatgpt", 400000)])
+def test_gpt6_astra_model_specs(provider: str, context_length: int) -> None:
+    specs = get_model_specs(provider, "gpt-6-astra")
+
+    assert specs["context_length"] == context_length
+    assert specs["max_completion_tokens"] == 128000
+    assert resolve_max_input_tokens(specs) == context_length - 128000
+    assert specs["supports_temperature"] is False
+    assert specs["supports_vision"] is True
+    assert specs["supports_hosted_web_search"] is True
+    assert specs["preferred_edit_protocol"] == "codex_apply_patch"
+    assert specs["thinking_effort"].options == ("low", "medium", "high", "xhigh", "max")
+    assert specs["thinking_effort"].default == "medium"
+    assert specs["thinking_effort"].mode == "openai_responses_reasoning"
+
+
+@pytest.mark.parametrize("provider", ["openai", "openai_chatgpt"])
+@pytest.mark.parametrize("effort", ["none", "minimal", "ultra"])
+def test_gpt6_astra_rejects_unsupported_efforts(provider: str, effort: str) -> None:
+    with pytest.raises(ValueError, match="Unsupported thinking effort"):
+        build_thinking_request_params(provider, "gpt-6-astra", effort)
+
+
 @pytest.mark.parametrize("model", ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"])
 @pytest.mark.parametrize("provider,context_length", [("openai", 1050000), ("openai_chatgpt", 400000)])
 def test_gpt56_model_specs(provider, context_length, model):

--- a/tests/agent/llm/test_openai_responses_provider.py
+++ b/tests/agent/llm/test_openai_responses_provider.py
@@ -151,28 +151,32 @@ def test_llmclient_routes_compatible_provider_to_chat_completions():
 # --- request building (no network) ----------------------------------------------
 
 
-def test_build_request_is_responses_shaped_with_reasoning():
+@pytest.mark.parametrize(
+    "model,effort",
+    [("gpt-5.5", "high"), *[("gpt-6-astra", effort) for effort in ("low", "medium", "high", "xhigh", "max")]],
+)
+def test_build_request_is_responses_shaped_with_reasoning(model: str, effort: str) -> None:
     provider = OpenAIResponsesProvider(api_key="sk-test")
     tool = ToolDefinition(
         name="read_file",
         description="Read a file",
         parameters=[ToolParameter(name="path", type="string", description="path", required=True)],
     )
-    params = GenerationParams(tools=[tool], thinking="high", max_completion_tokens=256, temperature=0.5)
+    params = GenerationParams(tools=[tool], thinking=effort, max_completion_tokens=256, temperature=0.5)
     request = provider._build_request(
         MessageHistory([Message(role="user", content=[TextBlock(text="hello")])]),
         Message(role="system", content=[TextBlock(text="sys")]),
         params,
-        {"model": "gpt-5.5"},
+        {"model": model},
     )
 
-    assert request["model"] == "gpt-5.5"
+    assert request["model"] == model
     assert request["stream"] is True
     assert request["store"] is False
     assert request["tool_choice"] == "auto"
     assert request["parallel_tool_calls"] is True
     assert request["instructions"] == "sys"
-    assert request["reasoning"] == {"effort": "high", "summary": "auto"}
+    assert request["reasoning"] == {"effort": effort, "summary": "auto"}
     assert request["include"] == ["reasoning.encrypted_content"]
     assert request["tools"][0]["type"] == "function"
     assert request["tools"][0]["name"] == "read_file"

--- a/tests/cli/test_provider_registry.py
+++ b/tests/cli/test_provider_registry.py
@@ -57,16 +57,24 @@ def test_zai_exposes_glm_models_and_defaults_to_glm_53() -> None:
     assert ui_thinking_effort_options("zai", "glm-5.3") == [("High", "high"), ("Max", "max")]
 
 
-def test_gpt56_models_are_first_and_sol_is_default_for_openai_providers():
+def test_astra_is_first_and_sol_is_default_for_openai_providers() -> None:
     expected = [
+        ("GPT-6 Astra", "gpt-6-astra"),
         ("GPT-5.6 Sol", "gpt-5.6-sol"),
         ("GPT-5.6 Terra", "gpt-5.6-terra"),
         ("GPT-5.6 Luna", "gpt-5.6-luna"),
     ]
 
     for provider in (ModelProvider.OPENAI, ModelProvider.OPENAI_CHATGPT):
-        assert ui_model_options(provider.value)[:3] == expected
+        assert ui_model_options(provider.value)[:4] == expected
         assert default_model_for_provider(provider) == "gpt-5.6-sol"
+        assert ui_thinking_effort_options(provider.value, "gpt-6-astra") == [
+            ("Low", "low"),
+            ("Medium", "medium"),
+            ("High", "high"),
+            ("Extra high", "xhigh"),
+            ("Max", "max"),
+        ]
 
     assert ui_thinking_effort_options("openai", "gpt-5.6-sol") == [
         ("None", "none"),


### PR DESCRIPTION
Adds `gpt-6-astra` to the OpenAI API and ChatGPT subscription providers, making GPT-6 Astra selectable in Settings and `/model`. Both entries use Responses reasoning (`low`, `medium`, `high`, `xhigh`, `max`; default `medium`), image input, hosted web search, and the Codex apply-patch edit protocol. Existing provider defaults remain GPT-5.6 Sol.

The API entry uses the [documented 1,050,000-token context window and 128,000-token output limit](https://developers.openai.com/api/docs/models/gpt-6-astra). The subscription entry retains the existing conservative 400,000-token budget (272,000 input) until a larger Astra window is verified on the Codex backend. Documentation covers selection, reasoning, and this budget distinction.

Validation:
- GitHub CI passed on Python 3.11, 3.12, 3.13, and 3.14, including coverage. Docs, CodeQL, and dependency audit checks also passed.
- 79 focused tests passed, including request construction for every supported Astra effort on both providers and rejection of unsupported efforts.
- All pre-commit hooks passed, including Ruff and Pyright.
- Documentation build passed.
- Full fast suite with coverage: 5,371 passed, 5 skipped, 6 failed; 84.52% coverage. All failures are existing live provider checks using unchanged models: three ChatGPT checks failed because OAuth refresh returned HTTP 401, and three Together checks failed because `moonshotai/Kimi-K2.7-Code` is no longer available serverlessly. Astra request tests use mocked transports; live Astra calls were not verified.
