### PR TITLE
chore: release v0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.36.0 - 2026-09-07
+
+### Added
+
+- **GPT-6 Astra.** OpenAI's new flagship model is available on both the API
+  and ChatGPT-subscription providers: 1M-token context with 128K output,
+  vision, hosted web search, `codex_apply_patch` editing, and
+  `low`–`max` reasoning effort levels (default `medium`). The
+  ChatGPT-subscription route keeps the conservative 400K input budget until
+  Astra's larger window is verified on the Codex backend.
+- **Pre-registered OAuth credentials for remote MCP servers.** Servers that
+  don't implement Dynamic Client Registration (HubSpot, Slack, GitHub
+  Copilot, enterprise IdPs) can now be connected with a pre-registered
+  client: new `--oauth-client-id`, `--oauth-client-secret`,
+  `--oauth-client-secret-env`, and `--oauth-auth-method` flags on
+  `kolega-code mcp add`, matching OAuth controls on the MCP page in TUI
+  settings, preserved explicit redirect ports/hosts, actionable diagnostics
+  when registration fails, and PBKDF2-salted OAuth cache fingerprints with
+  refresh tokens preserved across reconnects.
+
+### Fixed
+
+- **Gateway (Telegram):** the typing indicator now stays alive for the whole
+  turn. Telegram expires typing actions after ~5 seconds, so it previously
+  vanished during exactly the stretches where feedback matters — model
+  thinking before the first chunk and long-running tool calls.
+
 ## 0.35.1 - 2026-09-03
 
 ### Fixed

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -174,4 +174,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.35.1"
+__version__ = "0.36.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.35.1"
+__version__ = "0.36.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.35.1"
+version = "0.36.0"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = "BUSL-1.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1825,7 +1825,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.35.1"
+version = "0.36.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
Release v0.36.0.

## Added
- **GPT-6 Astra** on the OpenAI API and ChatGPT-subscription providers (#678): 1M context / 128K output, vision, hosted web search, `codex_apply_patch` editing, `low`–`max` reasoning efforts.
- **Pre-registered OAuth credentials for remote MCP servers** (#677): `mcp add` flags, TUI settings controls, redirect port preservation, registration failure diagnostics, PBKDF2-salted cache fingerprints.

## Fixed
- **Gateway (Telegram):** typing indicator keep-alive for the whole turn.

Release checks: fast tests (5371 passed; 6 known environment/provider-side live failures) and pre-commit all green in `.venv-release`.