### PR TITLE
feat(llm): support DeepSeek V4.1 Flash preview

### DIFF
--- a/docs/src/content/docs/configuration/providers-and-models.mdx
+++ b/docs/src/content/docs/configuration/providers-and-models.mdx
@@ -344,6 +344,27 @@ call still takes precedence over these per-role defaults.)
 
 ## Thinking effort
 
+### DeepSeek V4.1 Flash preview
+
+The temporary model `deepseek-v4.1-flash-expires-on-0910` is available under
+**DeepSeek V4.1 Flash (Preview, expires Sep 10)** in the model picker. Its ID
+advertises expiration on **September 10, 2026**; the exact cutoff time is unknown.
+It is not the default and is not aliased to a stable model.
+
+```bash
+kolega-code --provider deepseek --model deepseek-v4.1-flash-expires-on-0910
+```
+
+Live API checks on September 9, 2026 confirmed Responses API access, image input,
+function calls, hosted web search, and `none`/`low`/`high`/`max` reasoning effort
+(default: `high`). This unlisted preview may not appear in DeepSeek's `/models`
+response. Kolega provisionally uses the existing Flash-family 1,000,000-token
+context budget; the preview's context limit has not been independently verified.
+The configured 384,000-token output budget is accepted by the API, not a measured
+generation length. After the preview expires, select an available stable model.
+
+### Supported effort values
+
 Thinking effort is model-specific. Kolega Code validates the selected value
 against the active model and resets it to the new model's default when you switch
 models in the TUI.
@@ -354,6 +375,7 @@ models in the TUI.
 | Anthropic `claude-opus-5` | `low`, `medium`, `high`, `xhigh`, `max` | `medium` |
 | Anthropic `claude-sonnet-5` | `low`, `medium`, `high`, `xhigh`, `max` | `medium` |
 | DeepSeek `deepseek-v4-pro`, `deepseek-v4-flash`, `deepseek-v4-flash-vision-exp` | `none`, `low`, `high`, `max` | `high` |
+| DeepSeek `deepseek-v4.1-flash-expires-on-0910` (temporary preview) | `none`, `low`, `high`, `max` | `high` |
 | Moonshot `kimi-k3` | `max` | `max` |
 | Moonshot `kimi-k2.7-code` | `auto` | `auto` |
 | Moonshot `kimi-k2.6` | `auto`, `none` | `auto` |

--- a/kolega_code/cli/provider_registry.py
+++ b/kolega_code/cli/provider_registry.py
@@ -70,6 +70,7 @@ MODEL_LABELS: dict[str, str] = {
     "kimi-for-coding": "Kimi for Coding",
     "kimi-for-coding-highspeed": "Kimi for Coding (HighSpeed)",
     # DeepSeek
+    "deepseek-v4.1-flash-expires-on-0910": "DeepSeek V4.1 Flash (Preview, expires Sep 10)",
     "deepseek-v4-pro": "DeepSeek V4 Pro",
     "deepseek-v4-flash": "DeepSeek V4 Flash",
     "deepseek-v4-flash-vision-exp": "DeepSeek V4 Flash Vision (Exp)",

--- a/kolega_code/llm/specs/accessors.py
+++ b/kolega_code/llm/specs/accessors.py
@@ -201,8 +201,12 @@ def preferred_edit_protocol(provider: str, model_name: str) -> Optional[str]:
 # takes its catalog value instead.
 DEEPSEEK_WIRE_OUTPUT_CAP = 64000
 
-# Routes whose catalog max_completion_tokens is itself the real ceiling.
-_UNCLAMPED_DEEPSEEK_ROUTES = {("deepseek", "deepseek-v4-flash"), ("deepseek", "deepseek-v4-flash-vision-exp")}
+# Routes that use the catalog output budget without the legacy Pro/chat clamp.
+_UNCLAMPED_DEEPSEEK_ROUTES = {
+    ("deepseek", "deepseek-v4-flash"),
+    ("deepseek", "deepseek-v4-flash-vision-exp"),
+    ("deepseek", "deepseek-v4.1-flash-expires-on-0910"),
+}
 
 
 def is_deepseek_model(model_name: str) -> bool:

--- a/kolega_code/llm/specs/catalog/deepseek.py
+++ b/kolega_code/llm/specs/catalog/deepseek.py
@@ -20,6 +20,26 @@ from kolega_code.llm.specs.types import ThinkingEffortSpec
 # before the server ceiling and truncation is reported honestly. flash passes
 # through.
 DEEPSEEK_SPECS = {
+    # Unlisted preview, verified on /responses on 2026-09-09. The ID advertises
+    # expiry on September 10; do not alias it to a stable model or make it default.
+    # Vision, hosted search, tools, and all four exposed efforts work live.
+    # Retain the Flash-family 1M context budget provisionally (not independently
+    # measured for this preview). The API accepts 384000 output tokens and reports
+    # a maximum of 393216; keep the existing conservative Flash output budget.
+    ("deepseek", "deepseek-v4.1-flash-expires-on-0910"): {
+        "context_length": 1000000,
+        "max_completion_tokens": 384000,
+        "input_budget": "window_minus_output",
+        "default_temperature": 1.0,
+        "supports_vision": True,
+        "supports_hosted_web_search": True,
+        "preferred_edit_protocol": "claude_code",
+        "thinking_effort": ThinkingEffortSpec(
+            options=("none", "low", "high", "max"),
+            default="high",
+            mode="openai_responses_reasoning",
+        ),
+    },
     ("deepseek", "deepseek-v4-pro"): {
         "context_length": 1000000,
         "max_completion_tokens": 65536,

--- a/kolega_code/llm/specs/catalog/deepseek.py
+++ b/kolega_code/llm/specs/catalog/deepseek.py
@@ -20,26 +20,6 @@ from kolega_code.llm.specs.types import ThinkingEffortSpec
 # before the server ceiling and truncation is reported honestly. flash passes
 # through.
 DEEPSEEK_SPECS = {
-    # Unlisted preview, verified on /responses on 2026-09-09. The ID advertises
-    # expiry on September 10; do not alias it to a stable model or make it default.
-    # Vision, hosted search, tools, and all four exposed efforts work live.
-    # Retain the Flash-family 1M context budget provisionally (not independently
-    # measured for this preview). The API accepts 384000 output tokens and reports
-    # a maximum of 393216; keep the existing conservative Flash output budget.
-    ("deepseek", "deepseek-v4.1-flash-expires-on-0910"): {
-        "context_length": 1000000,
-        "max_completion_tokens": 384000,
-        "input_budget": "window_minus_output",
-        "default_temperature": 1.0,
-        "supports_vision": True,
-        "supports_hosted_web_search": True,
-        "preferred_edit_protocol": "claude_code",
-        "thinking_effort": ThinkingEffortSpec(
-            options=("none", "low", "high", "max"),
-            default="high",
-            mode="openai_responses_reasoning",
-        ),
-    },
     ("deepseek", "deepseek-v4-pro"): {
         "context_length": 1000000,
         "max_completion_tokens": 65536,
@@ -86,6 +66,27 @@ DEEPSEEK_SPECS = {
         ),
     },
     ("deepseek", "deepseek-v4-flash-vision-exp"): {
+        "context_length": 1000000,
+        "max_completion_tokens": 384000,
+        "input_budget": "window_minus_output",
+        "default_temperature": 1.0,
+        "supports_vision": True,
+        "supports_hosted_web_search": True,
+        "preferred_edit_protocol": "claude_code",
+        "thinking_effort": ThinkingEffortSpec(
+            options=("none", "low", "high", "max"),
+            default="high",
+            mode="openai_responses_reasoning",
+        ),
+    },
+    # Append previews: settings uses the first catalog model as provider fallback.
+    # Unlisted preview, verified on /responses on 2026-09-09. The ID advertises
+    # expiry on September 10; do not alias it to a stable model or make it default.
+    # Vision, hosted search, tools, and all four exposed efforts work live.
+    # Retain the Flash-family 1M context budget provisionally (not independently
+    # measured for this preview). The API accepts 384000 output tokens and reports
+    # a maximum of 393216; keep the existing conservative Flash output budget.
+    ("deepseek", "deepseek-v4.1-flash-expires-on-0910"): {
         "context_length": 1000000,
         "max_completion_tokens": 384000,
         "input_budget": "window_minus_output",

--- a/tests/agent/llm/test_deepseek_v41_preview.py
+++ b/tests/agent/llm/test_deepseek_v41_preview.py
@@ -1,0 +1,134 @@
+"""Preview regression tests; live checks require KOLEGA_TEST_DEEPSEEK_PREVIEW=1.
+
+The model ID advertises September 10 expiry. Keep live probes explicitly opt-in
+so ordinary integration runs do not depend on a retired preview endpoint.
+"""
+
+import base64
+import io
+import os
+
+import pytest
+from PIL import Image
+
+from kolega_code.llm.client import LLMClient
+from kolega_code.llm.models import (
+    ImageBlock,
+    Message,
+    MessageHistory,
+    TextBlock,
+    ToolCall,
+    ToolDefinition,
+    ToolParameter,
+    ToolResult,
+    WebSearchCallBlock,
+)
+from kolega_code.llm.providers.deepseek_responses import DeepSeekResponsesProvider
+from kolega_code.llm.providers.models import GenerationParams
+
+MODEL = "deepseek-v4.1-flash-expires-on-0910"
+
+
+@pytest.mark.parametrize("effort", ["none", "low", "high", "max"])
+@pytest.mark.parametrize("requested,expected", [(None, 384000), (128, 128), (500000, 384000)])
+def test_preview_request(effort: str, requested: int | None, expected: int) -> None:
+    client = LLMClient(provider="deepseek", api_key="sk-test", model=MODEL)
+    assert isinstance(client.provider, DeepSeekResponsesProvider)
+    request = client.provider._build_request(
+        MessageHistory([Message("user", [TextBlock("Hello")])]),
+        None,
+        GenerationParams(thinking=effort, max_completion_tokens=requested, hosted_web_search=True),
+        {"model": MODEL},
+    )
+    assert request["model"] == MODEL
+    assert request["reasoning"] == {"effort": effort, "summary": "auto"}
+    assert request["max_output_tokens"] == expected
+    assert request["stream"] is True
+    assert {"type": "web_search"} in request["tools"]
+
+
+@pytest.fixture
+def preview_client() -> LLMClient:
+    if os.getenv("KOLEGA_TEST_DEEPSEEK_PREVIEW") != "1":
+        pytest.skip("Expiring preview: set KOLEGA_TEST_DEEPSEEK_PREVIEW=1 to probe explicitly")
+    key = os.getenv("DEEPSEEK_API_KEY")
+    if not key:
+        pytest.skip("DEEPSEEK_API_KEY not set")
+    return LLMClient(provider="deepseek", api_key=key, model=MODEL)
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.parametrize("effort", ["none", "low", "high", "max"])
+async def test_preview_live_vision_and_effort(preview_client: LLMClient, effort: str) -> None:
+    png = io.BytesIO()
+    Image.new("RGB", (64, 64), "red").save(png, format="PNG")
+    image = ImageBlock(
+        image_type="base64", media_type="image/png", data=base64.b64encode(png.getvalue()).decode("ascii")
+    )
+    response = await preview_client.generate(
+        messages=MessageHistory(
+            [Message("user", [TextBlock("Name the color in this image. Reply with one word."), image])]
+        ),
+        system=None,
+        model=MODEL,
+        thinking=effort,
+        max_completion_tokens=512,
+    )
+    assert isinstance(response, Message)
+    assert response.get_text_content().strip().lower().rstrip(".") == "red"
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_preview_live_tool_round_trip(preview_client: LLMClient) -> None:
+    tool = ToolDefinition(
+        name="get_secret",
+        description="Get the secret word.",
+        parameters=[ToolParameter(name="key", type="string", description="Lookup key", required=True)],
+    )
+    history = MessageHistory(
+        [Message("user", [TextBlock("Call get_secret with key demo, then reply with only the returned secret word.")])]
+    )
+    response = await preview_client.generate(
+        messages=history, system=None, model=MODEL, tools=[tool], thinking="high", max_completion_tokens=1024
+    )
+    assert isinstance(response, Message)
+    calls = [block for block in response.content if isinstance(block, ToolCall)]
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.name == "get_secret"
+    assert call.input == {"key": "demo"}
+    replay = MessageHistory(
+        [
+            *history,
+            response,
+            Message("user", [ToolResult(tool_use_id=call.id, name=call.name, content="tangerine", is_error=False)]),
+        ]
+    )
+    answer = await preview_client.generate(
+        messages=replay, system=None, model=MODEL, tools=[tool], thinking="high", max_completion_tokens=1024
+    )
+    assert isinstance(answer, Message)
+    assert answer.get_text_content().strip().lower().rstrip(".") == "tangerine"
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_preview_live_search_and_full_budget(preview_client: LLMClient) -> None:
+    response = await preview_client.generate(
+        messages=MessageHistory(
+            [Message("user", [TextBlock("Search the web for DeepSeek's official website. Reply in one sentence.")])]
+        ),
+        system=None,
+        model=MODEL,
+        thinking="none",
+        hosted_web_search=True,
+        # No override: exercise the catalog's full output budget on the wire.
+    )
+    assert isinstance(response, Message)
+    assert any(isinstance(block, WebSearchCallBlock) for block in response.content)
+    assert response.get_text_content().strip()

--- a/tests/agent/llm/test_edit_protocol_resolution.py
+++ b/tests/agent/llm/test_edit_protocol_resolution.py
@@ -87,4 +87,5 @@ def test_direct_deepseek_models_prefer_claude_code() -> None:
         ("deepseek", "deepseek-v4-pro"): EditProtocol.CLAUDE_CODE.value,
         ("deepseek", "deepseek-v4-flash"): EditProtocol.CLAUDE_CODE.value,
         ("deepseek", "deepseek-v4-flash-vision-exp"): EditProtocol.CLAUDE_CODE.value,
+        ("deepseek", "deepseek-v4.1-flash-expires-on-0910"): EditProtocol.CLAUDE_CODE.value,
     }

--- a/tests/agent/llm/test_model_specs.py
+++ b/tests/agent/llm/test_model_specs.py
@@ -188,6 +188,7 @@ def test_kimi_coding_highspeed_model_specs():
         ("deepseek-v4-pro", 65536),
         # flash: no such cut; measured running to 112990 in one call.
         ("deepseek-v4-flash", 384000),
+        ("deepseek-v4.1-flash-expires-on-0910", 384000),
     ],
 )
 def test_deepseek_model_specs(model: str, max_completion_tokens: int):

--- a/tests/agent/llm/test_supports_vision.py
+++ b/tests/agent/llm/test_supports_vision.py
@@ -52,6 +52,7 @@ def test_supports_vision_flag_present_on_every_entry():
         ("deepseek", "deepseek-v4-flash", False),
         # First multimodal DeepSeek model (launched 2026-08-21).
         ("deepseek", "deepseek-v4-flash-vision-exp", True),
+        ("deepseek", "deepseek-v4.1-flash-expires-on-0910", True),
         ("fireworks", "accounts/fireworks/models/deepseek-v4-pro", False),
         ("fireworks", "accounts/fireworks/models/deepseek-v4-flash", False),
         ("fireworks", "accounts/fireworks/models/glm-5p2", False),

--- a/tests/cli/test_provider_registry.py
+++ b/tests/cli/test_provider_registry.py
@@ -153,8 +153,16 @@ def test_vision_only_model_options_follow_catalog_capabilities():
         "MiniMax M3": "accounts/fireworks/models/minimax-m3",
     }
     assert dict(ui_model_options("deepseek", vision_only=True)) == {
-        "DeepSeek V4 Flash Vision (Exp)": "deepseek-v4-flash-vision-exp"
+        "DeepSeek V4 Flash Vision (Exp)": "deepseek-v4-flash-vision-exp",
+        "DeepSeek V4.1 Flash (Preview, expires Sep 10)": "deepseek-v4.1-flash-expires-on-0910",
     }
+
+
+def test_deepseek_preview_is_selectable_without_changing_default() -> None:
+    assert dict(ui_model_options("deepseek"))["DeepSeek V4.1 Flash (Preview, expires Sep 10)"] == (
+        "deepseek-v4.1-flash-expires-on-0910"
+    )
+    assert default_model_for_provider(ModelProvider.DEEPSEEK) == "deepseek-v4-pro"
 
 
 def test_ollama_cloud_smoke_model_is_available_without_live_call():

--- a/tests/cli/test_provider_registry.py
+++ b/tests/cli/test_provider_registry.py
@@ -159,6 +159,8 @@ def test_vision_only_model_options_follow_catalog_capabilities():
 
 
 def test_deepseek_preview_is_selectable_without_changing_default() -> None:
+    # Settings falls back to the first option when switching providers.
+    assert ui_model_options("deepseek")[0] == ("DeepSeek V4 Pro", "deepseek-v4-pro")
     assert dict(ui_model_options("deepseek"))["DeepSeek V4.1 Flash (Preview, expires Sep 10)"] == (
         "deepseek-v4.1-flash-expires-on-0910"
     )


### PR DESCRIPTION
## Summary
- Add the unlisted `deepseek-v4.1-flash-expires-on-0910` model through the existing DeepSeek Responses provider.
- Expose an explicitly expiring preview label in the model picker, including vision-only selection, without changing defaults.
- Enable image input, hosted web search, function calls, and `none`/`low`/`high`/`max` reasoning effort.
- Preserve the Flash-family output budget without the legacy Pro/chat clamp, and add documentation and regression tests.

## Verification
- 923 broader LLM/config/provider regression tests passed (153 slow/integration tests deselected).
- 148 focused tests passed, including six live preview checks covering vision at all four efforts, reasoning-bearing tool-result replay, and hosted search with the full configured output budget.
- Full repository pre-commit checks passed, including Ruff and Pyright.
- Live preview tests require `KOLEGA_TEST_DEEPSEEK_PREVIEW=1` so ordinary integration runs will not depend on the expiring endpoint.

## Preview caveats
- Verified live September 9, 2026. The exact ID succeeds despite being absent from `/models`; the stable-looking `deepseek-v4.1-flash` ID is rejected.
- The ID advertises expiration on September 10, 2026; the exact cutoff time is unknown.
- The 1,000,000-token context budget is provisionally inherited from the Flash family, not independently measured for this preview.
- The API accepts the configured 384,000-token output budget and reports a maximum parameter value of 393,216; this is not a measured generation length.
- No stable alias or automatic fallback is introduced.