### PR TITLE
fix(cli): stop stale settings writers from reverting concurrent changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 - Pin PDFium and the Intel Python 3.11/3.12 ONNX Runtime dependency to restore
   compatible wheel selection on macOS Monterey for both the installer and direct
   package installs. Intel Monterey requires Python 3.11 or 3.12.
+- Settings saves are merged with concurrent writers instead of replacing the whole
+  file, so a long-running instance can no longer drop a gateway token or API key
+  another process saved after it started.
+- `kolega-code gateway status` now reports an installed background service that
+  is failing to start (service state, start count, last exit code, log path)
+  instead of only printing "not running".
 
 ## 0.36.0 - 2026-09-07
 

--- a/kolega_code/cli/gateway.py
+++ b/kolega_code/cli/gateway.py
@@ -33,6 +33,7 @@ from kolega_code.gateway.service import (
     install_service,
     is_service_installed,
     restart_service,
+    service_state_summary,
     uninstall_service,
 )
 
@@ -290,6 +291,7 @@ def _gateway_status(config: GatewayConfig) -> int:
     if payload is not None:
         # A heartbeat from a process that no longer exists (e.g. SIGKILLed).
         print(f"gateway: not running (stale heartbeat from pid {payload.get('pid')})")
+        _print_service_state(config)
         return 0
     lock = FileLock(str(config.state_dir / LOCK_FILE_NAME))
     try:
@@ -303,7 +305,18 @@ def _gateway_status(config: GatewayConfig) -> int:
         return 0
     lock.release()
     print(f"gateway: not running (state: {config.state_dir})")
+    _print_service_state(config)
     return 0
+
+
+def _print_service_state(config: GatewayConfig) -> None:
+    summary = service_state_summary()
+    if summary is None:
+        return
+    print(f"  service: {summary}")
+    log_path = config.state_dir / "gateway.log"
+    if log_path.exists():
+        print(f"  log: {log_path}")
 
 
 def _pid_alive(pid: Any) -> bool:

--- a/kolega_code/cli/settings.py
+++ b/kolega_code/cli/settings.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import copy
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
+
+from filelock import FileLock
+from filelock import Timeout as FileLockTimeout
 
 from kolega_code.local_state import write_private_text
 from kolega_code.llm.specs.custom_endpoints import (
@@ -31,6 +35,41 @@ WEB_SEARCH_KEY_NAMES = ("firecrawl", "tavily")
 
 class SettingsStoreError(RuntimeError):
     """Raised when CLI settings cannot be loaded or saved."""
+
+
+SETTINGS_LOCK_TIMEOUT_SECONDS = 10.0
+
+
+def _merge_settings_documents(
+    base: dict[str, Any],
+    current: dict[str, Any],
+    on_disk: dict[str, Any],
+) -> dict[str, Any]:
+    """Apply one writer's changes on top of the current document.
+
+    ``base`` is the state the writer loaded, so keys it did not touch keep the
+    on-disk value and a stale writer cannot revert another process's change.
+    Nested dicts merge key by key, and keys the writer never saw survive.
+    """
+    merged: dict[str, Any] = {}
+    for key in set(base) | set(current) | set(on_disk):
+        if key not in current:
+            if key in base:
+                continue
+            if key in on_disk:
+                merged[key] = on_disk[key]
+            continue
+        if key in base and base[key] == current[key]:
+            merged[key] = on_disk[key] if key in on_disk else current[key]
+            continue
+        if key not in base and current[key] is None and key in on_disk:
+            merged[key] = on_disk[key]
+            continue
+        if isinstance(base.get(key), dict) and isinstance(current[key], dict) and isinstance(on_disk.get(key), dict):
+            merged[key] = _merge_settings_documents(base[key], current[key], on_disk[key])
+            continue
+        merged[key] = current[key]
+    return merged
 
 
 def _coerce_model_entries(raw: object) -> dict[str, dict]:
@@ -272,6 +311,9 @@ class CliSettings:
     # Additive optional field — absent in older files -> empty mapping.
     custom_endpoints: dict[str, dict] = field(default_factory=dict)
     schema_version: int = SETTINGS_SCHEMA_VERSION
+    # The document this instance was loaded from, used as the merge base by
+    # SettingsStore.save(). Never serialized.
+    _merge_base: Optional[dict[str, Any]] = field(default=None, repr=False, compare=False)
 
     @classmethod
     def from_dict(cls, data: dict) -> "CliSettings":
@@ -452,12 +494,47 @@ class SettingsStore:
 
     def load(self) -> CliSettings:
         if not self.path.exists():
-            return CliSettings()
+            settings = CliSettings()
+            settings._merge_base = copy.deepcopy(settings.to_dict())
+            return settings
         try:
-            return CliSettings.from_dict(json.loads(self.path.read_text(encoding="utf-8")))
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+            settings = CliSettings.from_dict(data)
         except json.JSONDecodeError as exc:
             raise SettingsStoreError(f"Settings file is not valid JSON: {self.path}") from exc
+        # The merge base is what this process understood, not the raw file:
+        # a key it never saw (newer schema, hand-edit) must survive its save.
+        settings._merge_base = copy.deepcopy(settings.to_dict())
+        if isinstance(data, dict) and "schema_version" in data:
+            settings._merge_base["schema_version"] = data["schema_version"]
+        return settings
 
     def save(self, settings: CliSettings) -> None:
-        payload = json.dumps(settings.to_dict(), indent=2, sort_keys=True)
-        write_private_text(self.path, payload + "\n")
+        """Write this instance's changes, keeping concurrent writers' fields."""
+        lock = FileLock(f"{self.path}.lock")
+        try:
+            lock.acquire(timeout=SETTINGS_LOCK_TIMEOUT_SECONDS)
+        except FileLockTimeout as exc:
+            raise SettingsStoreError(f"Timed out locking the settings file: {self.path}") from exc
+        try:
+            merged = self._merged_document(settings)
+            payload = json.dumps(merged, indent=2, sort_keys=True)
+            write_private_text(self.path, payload + "\n")
+        finally:
+            lock.release()
+        settings._merge_base = copy.deepcopy(merged)
+
+    def _merged_document(self, settings: CliSettings) -> dict[str, Any]:
+        current = settings.to_dict()
+        if settings._merge_base is None:
+            return current
+        return _merge_settings_documents(settings._merge_base, current, self._read_document())
+
+    def _read_document(self) -> dict[str, Any]:
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return {}
+        except (json.JSONDecodeError, OSError) as exc:
+            raise SettingsStoreError(f"Settings file is not valid JSON: {self.path}") from exc
+        return raw if isinstance(raw, dict) else {}

--- a/kolega_code/gateway/service.py
+++ b/kolega_code/gateway/service.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import os
 import plistlib
+import re
 import shlex
 import shutil
 import subprocess
@@ -212,6 +213,41 @@ def run_service_command(argv: list[str]) -> subprocess.CompletedProcess[str] | N
     except (OSError, subprocess.SubprocessError) as exc:
         print(f"gateway: warning: {argv[0]} failed: {exc}", file=sys.stderr)
         return None
+
+
+def service_state_summary(
+    *,
+    systemd_dir: Optional[Path] = None,
+    launchd_dir: Optional[Path] = None,
+    platform: Optional[str] = None,
+) -> Optional[str]:
+    """One line of service-manager state for an installed gateway, else None.
+
+    ``gateway status`` uses this to explain a service that is installed but not
+    running, which the daemon's own status file cannot show.
+    """
+    platform = platform if platform is not None else sys.platform
+    if not is_service_installed(systemd_dir=systemd_dir, launchd_dir=launchd_dir, platform=platform):
+        return None
+    if platform == "darwin":
+        proc = run_service_command(["launchctl", "print", f"gui/{os.getuid()}/{LAUNCHD_LABEL}"])
+        if proc is None or proc.returncode != 0:
+            return "launchd agent installed but not loaded"
+        output = proc.stdout or ""
+        parts: list[str] = []
+        state = re.search(r"^\s*state = (.+)$", output, re.MULTILINE)
+        if state:
+            parts.append(f"state {state.group(1).strip()}")
+        runs = re.search(r"^\s*runs = (\d+)$", output, re.MULTILINE)
+        if runs:
+            parts.append(f"{runs.group(1)} starts")
+        last_exit = re.search(r"^\s*last exit code = (\d+)$", output, re.MULTILINE)
+        if last_exit:
+            parts.append(f"last exit code {last_exit.group(1)}")
+        return "launchd agent " + (", ".join(parts) if parts else "loaded")
+    proc = run_service_command(["systemctl", "--user", "is-active", SERVICE_NAME])
+    state_text = (proc.stdout or "").strip() if proc is not None else ""
+    return f"systemd unit {state_text or 'unknown'}"
 
 
 def restart_service(

--- a/tests/cli/test_settings.py
+++ b/tests/cli/test_settings.py
@@ -139,6 +139,49 @@ def test_settings_store_round_trips_gateway_section(tmp_path: Path) -> None:
     assert CliSettings.from_dict({"schema_version": SETTINGS_SCHEMA_VERSION, "gateway": "not-a-dict"}).gateway == {}
 
 
+def test_settings_save_keeps_fields_another_writer_changed(tmp_path: Path) -> None:
+    store = SettingsStore(tmp_path)
+    store.save(CliSettings())
+    stale = store.load()
+    other = store.load()
+    other.telegram_bot_token = "123:fake-bot-token-for-tests-only"
+    store.save(other)
+
+    stale.active_theme = "Kolega Dark"
+    store.save(stale)
+
+    loaded = store.load()
+    assert loaded.active_theme == "Kolega Dark"
+    assert loaded.telegram_bot_token == "123:fake-bot-token-for-tests-only"
+
+
+def test_settings_save_applies_an_intentional_clear(tmp_path: Path) -> None:
+    store = SettingsStore(tmp_path)
+    store.save(CliSettings(telegram_bot_token="123:fake-bot-token-for-tests-only"))
+
+    settings = store.load()
+    settings.telegram_bot_token = None
+    store.save(settings)
+
+    assert store.load().telegram_bot_token is None
+
+
+def test_settings_save_merges_nested_mappings(tmp_path: Path) -> None:
+    store = SettingsStore(tmp_path)
+    store.save(CliSettings())
+    first = store.load()
+    first.api_keys["openai"] = "sk-openai"
+    store.save(first)
+    second = store.load()
+    second.api_keys["anthropic"] = "sk-anthropic"
+    store.save(second)
+
+    first.api_keys["openai"] = "sk-openai-updated"
+    store.save(first)
+
+    assert store.load().api_keys == {"openai": "sk-openai-updated", "anthropic": "sk-anthropic"}
+
+
 def test_settings_store_round_trips_agent_models(tmp_path: Path) -> None:
     store = SettingsStore(tmp_path)
     settings = CliSettings(active_provider=UI_DEFAULT_PROVIDER, active_model=UI_DEFAULT_MODEL)

--- a/tests/gateway/test_cli_gateway.py
+++ b/tests/gateway/test_cli_gateway.py
@@ -237,16 +237,33 @@ def test_telegram_setup_verify_failure_does_not_save(
     assert SettingsStore(root=state_dir).load().telegram_bot_token is None
 
 
-def test_status_reports_not_running(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
+def test_status_reports_not_running(capsys: pytest.CaptureFixture[str], tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr("kolega_code.cli.gateway.service_state_summary", lambda: None)
     config = GatewayConfig(adapter="echo", project_path=tmp_path / "ws", state_dir=tmp_path / "state")
     assert _gateway_status(config) == 0
     assert "not running" in capsys.readouterr().out
 
 
-def test_status_via_the_full_cli_path(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
+def test_status_reports_an_installed_service_that_is_failing(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "kolega_code.cli.gateway.service_state_summary",
+        lambda: "launchd agent state spawn scheduled, 34318 starts, last exit code 2",
+    )
+    config = GatewayConfig(adapter="echo", project_path=tmp_path / "ws", state_dir=tmp_path / "state")
+    assert _gateway_status(config) == 0
+    out = capsys.readouterr().out
+    assert "not running" in out
+    assert "34318 starts" in out
+    assert "last exit code 2" in out
+
+
+def test_status_via_the_full_cli_path(capsys: pytest.CaptureFixture[str], tmp_path: Path, monkeypatch) -> None:
     # Regression: subcommands without --project must not crash on args.project.
     from kolega_code.cli.gateway import run_gateway
 
+    monkeypatch.setattr("kolega_code.cli.gateway.service_state_summary", lambda: None)
     args = parse_args(["gateway", "status", "--state-dir", str(tmp_path / "state")])
     assert run_gateway(args) == 0
     assert "not running" in capsys.readouterr().out

--- a/tests/gateway/test_service.py
+++ b/tests/gateway/test_service.py
@@ -16,6 +16,7 @@ from kolega_code.gateway.service import (
     restart_service,
     service_command,
     service_launch_command,
+    service_state_summary,
     service_unit_path,
     uninstall_service,
 )
@@ -178,6 +179,51 @@ def test_is_service_installed(tmp_path: Path) -> None:
     unit_path = systemd_dir / SYSTEMD_UNIT_NAME
     unit_path.write_text("[Unit]", encoding="utf-8")
     assert is_service_installed(systemd_dir=systemd_dir, platform="linux")
+
+
+def test_service_state_summary_is_none_without_an_installed_service(tmp_path: Path) -> None:
+    assert service_state_summary(systemd_dir=tmp_path / "systemd", platform="linux") is None
+
+
+def test_service_state_summary_parses_launchd_agent_state(tmp_path: Path, monkeypatch) -> None:
+    launchd_dir = tmp_path / "launchd"
+    launchd_dir.mkdir(parents=True)
+    (launchd_dir / LAUNCHD_PLIST_NAME).write_text("<plist/>", encoding="utf-8")
+    output = "\tstate = spawn scheduled\n\truns = 34318\n\tlast exit code = 2\n"
+
+    def fake_run(argv, **kwargs):
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout=output, stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    summary = service_state_summary(launchd_dir=launchd_dir, platform="darwin")
+    assert summary == "launchd agent state spawn scheduled, 34318 starts, last exit code 2"
+
+
+def test_service_state_summary_reports_an_unloaded_launchd_agent(tmp_path: Path, monkeypatch) -> None:
+    launchd_dir = tmp_path / "launchd"
+    launchd_dir.mkdir(parents=True)
+    (launchd_dir / LAUNCHD_PLIST_NAME).write_text("<plist/>", encoding="utf-8")
+
+    def fake_run(argv, **kwargs):
+        return subprocess.CompletedProcess(args=argv, returncode=113, stdout="", stderr="Could not find service")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert service_state_summary(launchd_dir=launchd_dir, platform="darwin") == "launchd agent installed but not loaded"
+
+
+def test_service_state_summary_reports_the_systemd_unit_state(tmp_path: Path, monkeypatch) -> None:
+    systemd_dir = tmp_path / "systemd"
+    systemd_dir.mkdir(parents=True)
+    (systemd_dir / SYSTEMD_UNIT_NAME).write_text("[Unit]", encoding="utf-8")
+
+    def fake_run(argv, **kwargs):
+        return subprocess.CompletedProcess(args=argv, returncode=3, stdout="failed\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert service_state_summary(systemd_dir=systemd_dir, platform="linux") == "systemd unit failed"
 
 
 def test_restart_service_linux_runs_daemon_reload_and_restart(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

`SettingsStore.save()` wrote the caller's entire `CliSettings` document over the file. Any long-lived process (a TUI) that loaded settings before another process saved — `kolega-code gateway telegram setup`, another TUI — silently reverted those fields on its next save. That is how a gateway bot token disappeared and left a launchd-installed gateway crash-looping for days (`last exit code 2`, ~34k spawns) while `gateway status` kept reporting only "not running".

## Changes

- `kolega_code/cli/settings.py`: `save()` takes a cross-process lock and merges this instance's changes over the current file. Untouched keys keep the on-disk value, nested mappings merge key by key, and keys the writer never saw survive; deliberate clears and removals still apply. `CliSettings` carries a private `_merge_base` snapshot (never serialized) so the store can tell "changed" from "stale". Objects built in memory still write whole documents, as before.
- `kolega_code/gateway/service.py`: new `service_state_summary()` reports launchd/systemd state for an installed service.
- `kolega_code/cli/gateway.py`: `gateway status` prints that state plus the log path when the daemon is not running.
- Tests: stale-writer regression, intentional clear, nested merge; launchd/systemd state parsing; status output.
- CHANGELOG entry.

## Verification

- `./run_tests.sh` -> 5411 passed, 3 failed. The 3 failures are live Together-API tests (`moonshotai/Kimi-K2.7-Code` is no longer serverless: 400 `model_not_available`) and are unrelated to this change.
- `uv run pyright` -> 0 errors. `uv run pre-commit run --files <changed>` -> all hooks pass.

## Not included

The launchd plist still uses `KeepAlive: true` with no backoff, so an unrecoverable config error keeps respawning — now visible via `gateway status`. Worth a follow-up, but it changes service-install behavior, so I kept this PR to the two fixes.
