### PR TITLE
chore(deps): exclude benchmark edit snapshots from Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,61 @@ updates:
     # Eval pins mirror shared project dependencies and must be updated together.
     # This disables version-update PRs without affecting security-update PRs.
     open-pull-requests-limit: 0
+
+  # Benchmark edit snapshots are byte-pinned copies of upstream repositories at
+  # immutable commits; tests/benchmarks/test_edit_benchmark_corpus.py verifies
+  # every file hash against its manifest. Nothing inside a snapshot may be
+  # bumped, so ignore all dependencies in these trees for both version and
+  # security updates. Add an entry when a snapshot gains a manifest in an
+  # ecosystem the dependency graph tracks.
+  - package-ecosystem: npm
+    directories:
+      - /benchmarks/edit_tools/fixtures/snapshots/express-ae6dd37680e3/tree
+      - /benchmarks/edit_tools/fixtures/snapshots/zod-912f0f51b0ce/tree/packages/zod
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
+  - package-ecosystem: gomod
+    directory: /benchmarks/edit_tools/fixtures/snapshots/bubbletea-fc707bb7ea01/tree
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
+  - package-ecosystem: cargo
+    directory: /benchmarks/edit_tools/fixtures/snapshots/clap-4a35e3bcabf7/tree/clap_builder
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
+  - package-ecosystem: pip
+    directory: /benchmarks/edit_tools/fixtures/snapshots/click-b67832c2167e/tree
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
+  - package-ecosystem: maven
+    directory: /benchmarks/edit_tools/fixtures/snapshots/gson-c9f3fd55854a/tree/gson
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
+  - package-ecosystem: nuget
+    directory: /benchmarks/edit_tools/fixtures/snapshots/spectre-console-3ba102309539/tree/src/Spectre.Console
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
+  - package-ecosystem: composer
+    directory: /benchmarks/edit_tools/fixtures/snapshots/symfony-console-9df1ce79867b/tree
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
## Why

Dependabot security update #684 tried to bump `morgan` in `benchmarks/edit_tools/fixtures/snapshots/express-ae6dd37680e3/tree/package.json`, which breaks `tests/benchmarks/test_edit_benchmark_corpus.py::test_snapshot_manifests_pin_provenance_licenses_and_file_hashes` (all four Python jobs failed). Snapshot trees are byte-pinned copies of upstream repositories at immutable commits, so nothing inside them may be bumped.

## What

Adds `dependabot.yml` entries that ignore every dependency (version **and** security updates) in the snapshot manifests the dependency graph tracks:

| Ecosystem | Snapshot |
|---|---|
| npm | `express-ae6dd37680e3`, `zod-912f0f51b0ce` |
| gomod | `bubbletea-fc707bb7ea01` |
| cargo | `clap-4a35e3bcabf7` |
| pip | `click-b67832c2167e` |
| maven | `gson-c9f3fd55854a` |
| nuget | `spectre-console-3ba102309539` |
| composer | `symfony-console-9df1ce79867b` |

`ignore` applies to security updates as well as version updates; `open-pull-requests-limit: 0` additionally disables version-update PRs for these trees. The `rake` (gemspec, no Gemfile) and `swift-argument-parser` fixtures are not tracked by the dependency graph, so they have no entry.

Docs-only change; no runtime impact.