### PR TITLE
chore: release v0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+## 0.37.0 - 2026-09-09
+
+### Added
+
+- **DeepSeek V4.1 Flash (preview).** DeepSeek's temporary
+  `deepseek-v4.1-flash-expires-on-0910` model is available under **DeepSeek V4.1
+  Flash (Preview, expires Sep 10)** in the model picker, with vision, hosted web
+  search, and `none`/`low`/`high`/`max` reasoning effort (default `high`). It is
+  not the default and is not aliased to a stable model; the ID expires on
+  September 10, 2026, after which an available stable model must be selected.
+
 ### Fixed
 
 - Pin PDFium and the Intel Python 3.11/3.12 ONNX Runtime dependency to restore

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -174,4 +174,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.36.0"
+__version__ = "0.37.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.36.0"
+__version__ = "0.37.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.36.0"
+version = "0.37.0"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = "BUSL-1.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1825,7 +1825,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.36.0"
+version = "0.37.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
Release v0.37.0.

## Added
- **DeepSeek V4.1 Flash (preview)** (#689): the temporary `deepseek-v4.1-flash-expires-on-0910` model is available in the model picker with vision, hosted web search, and `none`/`low`/`high`/`max` reasoning effort (default `high`). It is not the default and is not aliased to a stable model; the ID expires September 10, 2026.

## Fixed
- **Intel macOS Monterey installs** (#683): PDFium and the Python 3.11/3.12 ONNX Runtime dependency are pinned so compatible wheels are selected for both the installer and direct package installs.
- **Settings saves** (#690): saves are merged with concurrent writers under a cross-process lock, so a long-running instance can no longer drop a gateway token or API key another process saved after it started.
- **`kolega-code gateway status`** (#690): now reports an installed background service that is failing to start (service state, start count, last exit code, log path) instead of only printing "not running".

Release checks: fast tests (5410 passed; 3 known Together provider-side live failures plus 1 parallel-run flake that passes in isolation) and pre-commit all green in `.venv-release`.