### PR TITLE
feat(llm): serve DeepSeek V4.1 Flash under its released id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,46 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
+### Changed
+
+- **DeepSeek now defaults to V4.1 Flash.** `deepseek-flash` is the default model
+  (and first entry in the picker) for the DeepSeek provider, matching DeepSeek's
+  own guidance that V4.1 Flash supersedes V4 Pro on performance, cost, speed, and
+  total time. `deepseek-v4-pro` remains selectable; DeepSeek routes it to V4.1
+  Flash from September 14, 2026.
+
+### Added
+
+- **DeepSeek V4.1 Flash (released).** The finished model is served under
+  DeepSeek's canonical `deepseek-flash` id and is available as **DeepSeek V4.1
+  Flash** in the model picker, with vision and `none`/`low`/`high`/`max`
+  reasoning effort (default `high`). Verified live: 1,048,576-token context and a
+  393,216-token API output ceiling. DeepSeek's Responses API ignores the built-in
+  `web_search` tool, so this model does not advertise hosted web search.
+
+### Fixed
+
+- **Hosted web search no longer offered where DeepSeek stopped serving it.**
+  DeepSeek silently removed server-side `web_search` with the V4.1 release, so the
+  flash models' `/web` toggle was advertising a capability that no longer exists.
+  `deepseek-v4-pro` still executes hosted search and keeps it.
+
+### Removed
+
+- **Retired DeepSeek flash ids.** DeepSeek only serves two models now — V4.1 Flash
+  and V4 Pro — so Kolega's DeepSeek catalog lists exactly those two. The retired
+  `deepseek-v4-flash` and `deepseek-v4-flash-vision-exp` entries are gone (they
+  named nothing distinct: DeepSeek routes both to V4.1 Flash). Settings, sessions,
+  and per-role overrides that still name one of them fall back to the DeepSeek
+  default (`deepseek-flash`); naming one explicitly (`--model`,
+  `KOLEGA_CODE_MODEL`) fails with a "not available for" error.
+- **DeepSeek V4.1 Flash preview id.** The expired temporary
+  `deepseek-v4.1-flash-expires-on-0910` id is no longer selectable. Settings and
+  per-role overrides that still name it fall back to the DeepSeek default
+  (`deepseek-flash`); naming it explicitly (`--model`, `KOLEGA_CODE_MODEL`) fails
+  with a "not available for" error. Switch to `deepseek-flash`, which DeepSeek
+  serves the same model under.
+
 ## 0.37.0 - 2026-09-09
 
 ### Added

--- a/benchmarks/edit_tools/matrices/validity-slice.yaml
+++ b/benchmarks/edit_tools/matrices/validity-slice.yaml
@@ -23,7 +23,7 @@ models:
     thinking_effort: high
     max_output_tokens: 16384
   - provider: deepseek
-    model: deepseek-v4-flash
+    model: deepseek-flash
     protocols: [search_replace, codex_apply_patch, claude_code, hashline_v2]
     temperature: 1.0
     thinking_effort: high

--- a/docs/src/content/docs/configuration/providers-and-models.mdx
+++ b/docs/src/content/docs/configuration/providers-and-models.mdx
@@ -329,7 +329,7 @@ Or use environment variables, named `KOLEGA_CODE_<ROLE>_PROVIDER` / `_MODEL` / `
 ```bash
 # Use a fast model for investigation; everything else uses the active model.
 export KOLEGA_CODE_INVESTIGATION_PROVIDER=deepseek
-export KOLEGA_CODE_INVESTIGATION_MODEL=deepseek-v4-flash
+export KOLEGA_CODE_INVESTIGATION_MODEL=deepseek-flash
 export KOLEGA_CODE_INVESTIGATION_EFFORT=high
 
 # Browser overrides must name a vision-capable model.
@@ -344,24 +344,45 @@ call still takes precedence over these per-role defaults.)
 
 ## Thinking effort
 
-### DeepSeek V4.1 Flash preview
+### DeepSeek V4.1 Flash
 
-The temporary model `deepseek-v4.1-flash-expires-on-0910` is available under
-**DeepSeek V4.1 Flash (Preview, expires Sep 10)** in the model picker. Its ID
-advertises expiration on **September 10, 2026**; the exact cutoff time is unknown.
-It is not the default and is not aliased to a stable model.
+The released model is served under DeepSeek's canonical `deepseek-flash` id,
+appears as **DeepSeek V4.1 Flash** in the model picker, and is DeepSeek's default
+model in Kolega. DeepSeek says V4.1 Flash surpasses V4 Pro on performance, cost,
+speed, and total time, and routes every other first-party id to it — including
+`deepseek-v4-pro` from 12:00 Beijing Time on September 14, 2026.
 
 ```bash
-kolega-code --provider deepseek --model deepseek-v4.1-flash-expires-on-0910
+kolega-code --provider deepseek --model deepseek-flash
 ```
 
-Live API checks on September 9, 2026 confirmed Responses API access, image input,
-function calls, hosted web search, and `none`/`low`/`high`/`max` reasoning effort
-(default: `high`). This unlisted preview may not appear in DeepSeek's `/models`
-response. Kolega provisionally uses the existing Flash-family 1,000,000-token
-context budget; the preview's context limit has not been independently verified.
-The configured 384,000-token output budget is accepted by the API, not a measured
-generation length. After the preview expires, select an available stable model.
+`deepseek-v4.1-flash` is not an accepted id: DeepSeek's `/models` lists exactly
+`deepseek-flash` and `deepseek-v4-pro`, which are the two models Kolega offers for
+this provider. DeepSeek still accepts the retired `deepseek-v4-flash`,
+`deepseek-v4-flash-vision-exp`, and `deepseek-v4.1-flash-expires-on-0910` ids, but
+they name nothing distinct (every one of them is served by V4.1 Flash), so Kolega no
+longer lists them; settings or sessions still naming one fall back to the DeepSeek
+default (`deepseek-flash`), and passing one explicitly fails with a "not available
+for" error.
+
+Live API checks on September 10, 2026 confirmed Responses API access, image input,
+function calls, and `none`/`low`/`high`/`max` reasoning effort (default: `high`).
+The measured context limit is 1,048,576 tokens; Kolega applies the Flash-family
+1,000,000-token budget so the input budget retains margin under that hard ceiling.
+The API rejects `max_output_tokens` above 393,216, so Kolega keeps the conservative
+384,000-token output budget.
+
+Hosted web search is **not** available on this route. DeepSeek removed it silently
+with the V4.1 release: on September 9, 2026 their Responses guide still listed
+`web_search` as *"Supported, executed on the server side"* and accepted it under
+`tool_choice`; on September 10 both entries read *Ignored*. Nothing in DeepSeek's
+release notes, news page, or FAQ mentions the change. Live probes return no
+`web_search_call` items — the model answers that it has no search tool even when
+the tool is declared. Kolega therefore does not offer the `/web` toggle for
+`deepseek-flash` or the retired flash ids. Results from searches made by older
+models still replay into context. `deepseek-v4-pro` still executes hosted search
+today, and keeps the toggle until DeepSeek routes it to V4.1 Flash on
+September 14 — expect to revisit it then.
 
 ### Supported effort values
 
@@ -374,8 +395,7 @@ models in the TUI.
 | Anthropic `claude-fable-5` | `low`, `medium`, `high`, `xhigh`, `max` | `medium` |
 | Anthropic `claude-opus-5` | `low`, `medium`, `high`, `xhigh`, `max` | `medium` |
 | Anthropic `claude-sonnet-5` | `low`, `medium`, `high`, `xhigh`, `max` | `medium` |
-| DeepSeek `deepseek-v4-pro`, `deepseek-v4-flash`, `deepseek-v4-flash-vision-exp` | `none`, `low`, `high`, `max` | `high` |
-| DeepSeek `deepseek-v4.1-flash-expires-on-0910` (temporary preview) | `none`, `low`, `high`, `max` | `high` |
+| DeepSeek `deepseek-flash`, `deepseek-v4-pro` | `none`, `low`, `high`, `max` | `high` |
 | Moonshot `kimi-k3` | `max` | `max` |
 | Moonshot `kimi-k2.7-code` | `auto` | `auto` |
 | Moonshot `kimi-k2.6` | `auto`, `none` | `auto` |

--- a/docs/src/content/docs/configuration/settings-and-api-keys.mdx
+++ b/docs/src/content/docs/configuration/settings-and-api-keys.mdx
@@ -135,7 +135,7 @@ The file looks like this:
   "agent_models": {
     "investigation": {
       "provider": "deepseek",
-      "model": "deepseek-v4-flash",
+      "model": "deepseek-flash",
       "thinking_effort": "high"
     }
   },

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -26,7 +26,7 @@ broad enough to benefit from fan-out.
 
    On first run, choose **Sign in with ChatGPT** or **Use an API key**. For the
    API-key path, pick a provider and model (for example **Moonshot — Kimi K2.7
-   Code** or **DeepSeek — DeepSeek V4 Pro**), enter the key, and finish setup.
+   Code** or **DeepSeek — DeepSeek V4.1 Flash**), enter the key, and finish setup.
    You can optionally send a tiny connection-test request before finishing.
 
    To change this later, select **Settings** in the sidebar and then **Open

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ bytes so you can verify nothing below the delimiter was touched.
 ## parallel-code-review.py
 
 The script was authored by `gpt-5.6-sol` from a two-sentence prompt. Every
-sub-agent is pinned to `deepseek-v4-flash` by the script's own `model_override`.
+sub-agent is pinned to `deepseek-flash` by the script's own `model_override`.
 This is a two-model workflow: one model wrote the orchestration, and a cheaper
 one staffed it. The workflow uses six parallel discovery specialists (API contracts,
 auth/security, Zapier actions/dataflow, SDK/runtime, tests/release, plus an

--- a/examples/parallel-code-review.py
+++ b/examples/parallel-code-review.py
@@ -5,12 +5,12 @@
 # Authoring prompt (verbatim; this was the COMPLETE prompt):
 #
 #     write a gigacode workflow for parallel code review of this repo and
-#     execute it. Use deepseek-v4-flash for all the workflow sub-agents
+#     execute it. Use deepseek-flash for all the workflow sub-agents
 #     (deepseek provider, via model_override).
 #
 # Date:            2026-07-31
 # Authoring model: openai_chatgpt/gpt-5.6-sol (thinking effort "medium")
-# Sub-agents:      deepseek/deepseek-v4-flash (effort "high"), pinned by the
+# Sub-agents:      deepseek/deepseek-flash (effort "high"), pinned by the
 #                  script itself via a complete atomic model_override on every
 #                  agent() call
 # Harness:         kolega-code
@@ -27,13 +27,13 @@
 # executed it via run_workflow(script_path=..., args={repository, head,
 # boundary}) with NO token budget — following the harness's sizing guidance
 # ("when unsure, omit it") — and verified afterwards that every workflow call
-# ran on deepseek-v4-flash.
+# ran on deepseek-flash.
 #
 # Execution record of THESE EXACT BYTES (hash-verified identical to the
 # persisted run script):
 #   run 9773faa8 — status COMPLETED. 18 agent calls, all completed: 6 parallel
 #   discovery specialists, 11 adversarial challengers (one per candidate
-#   finding), 1 synthesis gate. Every call ran on deepseek/deepseek-v4-flash
+#   finding), 1 synthesis gate. Every call ran on deepseek/deepseek-flash
 #   (effort high) as instructed; all workers were read-only investigation
 #   agents. 267,421 output tokens; 645 s workflow duration inside a 14m22s
 #   turn including authoring. Zero script-exception drops, zero duplicate
@@ -57,7 +57,7 @@ meta = {
 
 MODEL = {
     "provider": "deepseek",
-    "model": "deepseek-v4-flash",
+    "model": "deepseek-flash",
     "effort": "high",
 }
 

--- a/kolega_code/agent/compression.py
+++ b/kolega_code/agent/compression.py
@@ -157,7 +157,7 @@ class HistoryCompressor:
     # Don't bother summarizing a trivially short prefix.
     MIN_PREFIX_TO_SUMMARIZE = 3
     # Cap the summary length. The prompt targets ~600 words, but reasoning
-    # models (deepseek-v4-flash Responses, etc.) can consume the entire budget
+    # models (DeepSeek Responses models, etc.) can consume the entire budget
     # on chain-of-thought and leave no room for text output, producing an empty
     # summary. A generous ceiling gives reasoning headroom while still staying
     # well under the model's full completion budget.

--- a/kolega_code/cli/provider_registry.py
+++ b/kolega_code/cli/provider_registry.py
@@ -70,10 +70,8 @@ MODEL_LABELS: dict[str, str] = {
     "kimi-for-coding": "Kimi for Coding",
     "kimi-for-coding-highspeed": "Kimi for Coding (HighSpeed)",
     # DeepSeek
-    "deepseek-v4.1-flash-expires-on-0910": "DeepSeek V4.1 Flash (Preview, expires Sep 10)",
+    "deepseek-flash": "DeepSeek V4.1 Flash",
     "deepseek-v4-pro": "DeepSeek V4 Pro",
-    "deepseek-v4-flash": "DeepSeek V4 Flash",
-    "deepseek-v4-flash-vision-exp": "DeepSeek V4 Flash Vision (Exp)",
     # Z.AI (GLM Coding Plan)
     "glm-5.3": "GLM-5.3",
     "glm-5.3-flash": "GLM-5.3 Flash",
@@ -164,7 +162,7 @@ MODEL_LABELS: dict[str, str] = {
 # "available set is everything, default pick is curated" split.
 PROVIDER_DEFAULT_MODEL: dict[ModelProvider, str] = {
     ModelProvider.MOONSHOT: "kimi-k3",
-    ModelProvider.DEEPSEEK: "deepseek-v4-pro",
+    ModelProvider.DEEPSEEK: "deepseek-flash",
     ModelProvider.ZAI: "glm-5.3",
     ModelProvider.KIMI_CODING: "kimi-for-coding",
     ModelProvider.ANTHROPIC: "claude-opus-5",
@@ -189,7 +187,7 @@ PROVIDER_DEFAULT_MODEL: dict[ModelProvider, str] = {
 UI_DEFAULT_PROVIDER = ModelProvider.MOONSHOT.value
 UI_DEFAULT_MODEL = "kimi-k3"
 MOONSHOT_K26_MODEL = "kimi-k2.6"
-DEEPSEEK_DEFAULT_MODEL = "deepseek-v4-pro"
+DEEPSEEK_DEFAULT_MODEL = "deepseek-flash"
 
 
 @dataclass(frozen=True)

--- a/kolega_code/llm/providers/deepseek_responses.py
+++ b/kolega_code/llm/providers/deepseek_responses.py
@@ -1,6 +1,6 @@
 """DeepSeek provider that speaks the **Responses API** (``/responses``).
 
-The whole DeepSeek catalog (``deepseek-v4-pro`` and ``deepseek-v4-flash``) speaks
+The whole DeepSeek catalog (``deepseek-flash`` and ``deepseek-v4-pro``) speaks
 the Responses API, so the ``deepseek`` provider routes here wholesale from
 ``LLMClient._provider_class`` (no model-name branching). DeepSeek models hosted on
 other providers (Fireworks/OpenRouter/Ollama-Cloud) still use Chat Completions via
@@ -49,7 +49,7 @@ from .models import GenerationParams
 from .responses_common import ResponsesProviderBase
 
 DEFAULT_BASE_URL = "https://api.deepseek.com"
-DEFAULT_MODEL = "deepseek-v4-flash"
+DEFAULT_MODEL = "deepseek-flash"
 
 
 class DeepSeekResponsesProvider(ResponsesProviderBase):

--- a/kolega_code/llm/specs/accessors.py
+++ b/kolega_code/llm/specs/accessors.py
@@ -203,9 +203,7 @@ DEEPSEEK_WIRE_OUTPUT_CAP = 64000
 
 # Routes that use the catalog output budget without the legacy Pro/chat clamp.
 _UNCLAMPED_DEEPSEEK_ROUTES = {
-    ("deepseek", "deepseek-v4-flash"),
-    ("deepseek", "deepseek-v4-flash-vision-exp"),
-    ("deepseek", "deepseek-v4.1-flash-expires-on-0910"),
+    ("deepseek", "deepseek-flash"),
 }
 
 

--- a/kolega_code/llm/specs/catalog/deepseek.py
+++ b/kolega_code/llm/specs/catalog/deepseek.py
@@ -19,79 +19,75 @@ from kolega_code.llm.specs.types import ThinkingEffortSpec
 # DEEPSEEK_WIRE_OUTPUT_CAP=64000 (specs/accessors.py) so the client cap fires
 # before the server ceiling and truncation is reported honestly. flash passes
 # through.
+#
+# INSERTION ORDER IS LOAD-BEARING: the first entry is what the Settings model
+# picker shows first and what a provider switch falls back to
+# (ui_model_options(provider)[0]); it must stay in sync with
+# PROVIDER_DEFAULT_MODEL[DEEPSEEK] in cli/provider_registry.py.
 DEEPSEEK_SPECS = {
+    # Released DeepSeek Flash (V4.1), served under the canonical `deepseek-flash`, and
+    # the provider default. Verified live on /responses 2026-09-10: the retired preview
+    # ID (`deepseek-v4.1-flash-expires-on-0910`) as well as the older `deepseek-v4-flash`
+    # and `deepseek-v4-flash-vision-exp` aliases all now answer as
+    # `model="deepseek-flash"`, and `/models` lists exactly `deepseek-flash` and
+    # `deepseek-v4-pro`; a versioned `deepseek-v4.1-flash` is rejected ("The supported
+    # API model names are ..."). Vision (image input), function calls, and
+    # none/low/high/max reasoning effort all work on this route.
+    # NO hosted web search: DeepSeek removed it silently with the V4.1 release. Their
+    # Responses guide said "web_search / web_search_2025_08_26: Supported, executed on
+    # the server side" and listed {"type": "web_search"} under tool_choice on
+    # 2026-09-09; by 2026-09-10 the same rows read "web_search / file_search /
+    # code_interpreter / computer_use / mcp / other built-in tools: Ignored", with
+    # web_search dropped from tool_choice and its streaming events deleted. Nothing on
+    # /updates, /news, the docs home, or the FAQ mentions the removal. Live probes on
+    # 2026-09-10 returned zero web_search_call items while the model answered that it
+    # has no such tool (at effort=high it emitted bogus tool-call XML as text instead).
+    # Requests with the tool declared are accepted and silently do nothing, so Kolega
+    # must not advertise the /web toggle here. Replayed web_search_call items from
+    # older requests are still restored into context, per the same guide.
+    # Context measured at 1048576 tokens (oversized request -> "This model's maximum
+    # context length is 1048576 tokens"); keep the Flash-family 1000000 budget so the
+    # window_minus_output input budget retains margin under the hard ceiling.
+    # max_output_tokens above 393216 is rejected ("the valid range of max_tokens is
+    # [1, 393216]"), so the conservative 384000 output budget stands.
+    # Reasoning mechanics (inherited from the retired V4 Flash entries this id replaces,
+    # and still the shape this backend serves): effort must ride the Responses
+    # `reasoning` block, not the Chat-Completions `reasoning_effort` field the shared
+    # builder ignores, and this mode excludes flash from the flat reasoning_content
+    # replay path — reasoning comes back as Responses reasoning ITEMS instead. The
+    # endpoint returns no reasoning.encrypted_content (the include param is silently
+    # ignored) but exposes raw chain-of-thought as plain reasoning_text content, which
+    # the stream wrapper retains and resends next turn (mirroring Codex) so the context
+    # gauge counts it like any other content. The backend ALSO re-attaches prior CoT
+    # server-side keyed on its own function_call call_ids, billing it as input and
+    # deduping explicit copies (verified live 2026-08-04 on V4 Flash); reasoning-bearing
+    # replays with a foreign call_id 400 with "reasoning_text must be passed back",
+    # while minimal single-round histories with foreign ids are tolerated.
+    ("deepseek", "deepseek-flash"): {
+        "context_length": 1000000,
+        "max_completion_tokens": 384000,
+        "input_budget": "window_minus_output",
+        "default_temperature": 1.0,
+        "supports_vision": True,
+        "supports_hosted_web_search": False,
+        "preferred_edit_protocol": "claude_code",
+        "thinking_effort": ThinkingEffortSpec(
+            options=("none", "low", "high", "max"),
+            default="high",
+            mode="openai_responses_reasoning",
+        ),
+    },
     ("deepseek", "deepseek-v4-pro"): {
         "context_length": 1000000,
         "max_completion_tokens": 65536,
         "input_budget": "window_minus_output",
         "default_temperature": 1.0,
         "supports_vision": False,
-        "supports_hosted_web_search": True,
-        "preferred_edit_protocol": "claude_code",
-        "thinking_effort": ThinkingEffortSpec(
-            options=("none", "low", "high", "max"),
-            default="high",
-            mode="openai_responses_reasoning",
-        ),
-    },
-    # deepseek-v4-flash speaks the Responses API (see DeepSeekResponsesProvider), so its
-    # reasoning effort must be emitted as the Responses `reasoning` block rather than the
-    # Chat-Completions `reasoning_effort` field the shared Responses request builder ignores.
-    # This mode also correctly excludes flash from the flat reasoning_content replay path:
-    # flash's reasoning rides in Responses reasoning ITEMS instead. The endpoint returns no
-    # reasoning.encrypted_content (the include param is silently ignored) but exposes the
-    # raw chain-of-thought as plain reasoning_text content, which the stream wrapper
-    # retains and resends next turn (mirroring Codex, the client this endpoint was adapted
-    # for) — so the context gauge counts it from the history like any other content. The
-    # backend ALSO restores prior CoT server-side keyed on its own function_call call_ids,
-    # billing it as input and deduping explicit copies (verified live 2026-08-04); deep
-    # reasoning-bearing replays with a foreign call_id 400 with "reasoning_text must be
-    # passed back", minimal single-round histories with foreign ids are tolerated.
-    ("deepseek", "deepseek-v4-flash"): {
-        "context_length": 1000000,
-        "max_completion_tokens": 384000,
-        "input_budget": "window_minus_output",
-        "default_temperature": 1.0,
-        "supports_vision": False,
-        # /responses executes {"type": "web_search"} server-side (search +
-        # open_page) and restores the searched content on replay of the
-        # web_search_call items, billed as input (verified live 2026-08-04,
-        # findings/probes/hosted_web_search_probe.py).
-        "supports_hosted_web_search": True,
-        "preferred_edit_protocol": "claude_code",
-        "thinking_effort": ThinkingEffortSpec(
-            options=("none", "low", "high", "max"),
-            default="high",
-            mode="openai_responses_reasoning",
-        ),
-    },
-    ("deepseek", "deepseek-v4-flash-vision-exp"): {
-        "context_length": 1000000,
-        "max_completion_tokens": 384000,
-        "input_budget": "window_minus_output",
-        "default_temperature": 1.0,
-        "supports_vision": True,
-        "supports_hosted_web_search": True,
-        "preferred_edit_protocol": "claude_code",
-        "thinking_effort": ThinkingEffortSpec(
-            options=("none", "low", "high", "max"),
-            default="high",
-            mode="openai_responses_reasoning",
-        ),
-    },
-    # Append previews: settings uses the first catalog model as provider fallback.
-    # Unlisted preview, verified on /responses on 2026-09-09. The ID advertises
-    # expiry on September 10; do not alias it to a stable model or make it default.
-    # Vision, hosted search, tools, and all four exposed efforts work live.
-    # Retain the Flash-family 1M context budget provisionally (not independently
-    # measured for this preview). The API accepts 384000 output tokens and reports
-    # a maximum of 393216; keep the existing conservative Flash output budget.
-    ("deepseek", "deepseek-v4.1-flash-expires-on-0910"): {
-        "context_length": 1000000,
-        "max_completion_tokens": 384000,
-        "input_budget": "window_minus_output",
-        "default_temperature": 1.0,
-        "supports_vision": True,
+        # Hosted search still works on the V4 Pro model — re-verified live 2026-09-10
+        # (probe A body -> ws_calls=1, real answer), and it is the last first-party
+        # route that executes it. NOTE: from 12:00 Beijing Time 2026-09-14 DeepSeek
+        # routes deepseek-v4-pro requests to V4.1 Flash, whose architecture has no
+        # server-side web search; re-check this flag and the /web toggle after that.
         "supports_hosted_web_search": True,
         "preferred_edit_protocol": "claude_code",
         "thinking_effort": ThinkingEffortSpec(

--- a/tests/agent/llm/test_deepseek_requests.py
+++ b/tests/agent/llm/test_deepseek_requests.py
@@ -25,7 +25,7 @@ from kolega_code.llm.specs import (
     is_deepseek_model,
 )
 
-FLASH = "deepseek-v4-flash"
+FLASH = "deepseek-flash"
 OLLAMA_DEEPSEEK_MODEL = "deepseek-test-small"
 
 
@@ -179,13 +179,3 @@ def test_responses_build_request_clamps_pro_cap() -> None:
     oversized = _responses_request(GenerationParams(max_completion_tokens=384000), model=pro)
     assert oversized["max_output_tokens"] == 64000
     assert _responses_request(GenerationParams(max_completion_tokens=4096), model=pro)["max_output_tokens"] == 4096
-
-
-def test_responses_build_request_passes_vision_exp_cap_through() -> None:
-    vision = "deepseek-v4-flash-vision-exp"
-    # Flash-family: the catalog's real 384K ceiling passes through unclamped.
-    assert _responses_request(None, model=vision)["max_output_tokens"] == 384000
-    assert (
-        _responses_request(GenerationParams(max_completion_tokens=384000), model=vision)["max_output_tokens"] == 384000
-    )
-    assert _responses_request(GenerationParams(max_completion_tokens=4096), model=vision)["max_output_tokens"] == 4096

--- a/tests/agent/llm/test_deepseek_responses_live.py
+++ b/tests/agent/llm/test_deepseek_responses_live.py
@@ -1,7 +1,7 @@
 """Credential-gated live smoke for DeepSeek over the **Responses API**.
 
-The first-party ``deepseek`` provider (``deepseek-v4-flash``, ``deepseek-v4-pro``,
-and ``deepseek-v4-flash-vision-exp``) routes to the Responses API (see
+The first-party ``deepseek`` provider (``deepseek-flash`` and ``deepseek-v4-pro``,
+the only two models DeepSeek still lists) routes to the Responses API (see
 DeepSeekResponsesProvider); DeepSeek models on other providers stay on Chat
 Completions. These tests hit the real ``https://api.deepseek.com`` Responses
 endpoint, so they are marked ``slow``/``integration`` and skip when
@@ -29,8 +29,11 @@ from kolega_code.llm.providers.deepseek_responses import DeepSeekResponsesProvid
 
 pytestmark = [pytest.mark.slow, pytest.mark.integration]
 
-_MODEL = "deepseek-v4-flash"
-_VISION_MODEL = "deepseek-v4-flash-vision-exp"
+_MODEL = "deepseek-flash"
+# The released V4.1 Flash is multimodal, so the image-path tests use the same id;
+# kept as a named constant to make those sections' intent explicit.
+_VISION_MODEL = _MODEL
+_PRO_MODEL = "deepseek-v4-pro"
 
 # 64x64 solid red PNG (generated with PIL, base64-encoded).
 _RED_PNG_B64 = (
@@ -118,7 +121,7 @@ async def test_tool_call_over_responses_api(deepseek_flash_client):
     assert response.stop_reason == "tool_use"
 
 
-# --- deepseek-v4-flash-vision-exp (first multimodal DeepSeek model) ----------------
+# --- deepseek-flash (first multimodal DeepSeek model) ----------------
 
 
 @pytest.fixture
@@ -178,19 +181,43 @@ async def test_vision_image_input_identifies_color(deepseek_vision_client):
     assert "red" in response.get_text_content().strip().lower()
 
 
-@pytest.mark.asyncio
-async def test_vision_hosted_web_search(deepseek_vision_client):
-    # The /responses server-side web_search tool (bare {"type": "web_search"})
-    # must be captured as WebSearchCallBlock items on the vision model too.
-    messages = MessageHistory([Message("user", [TextBlock("What is the newest DeepSeek model? One sentence.")])])
+@pytest.fixture
+def deepseek_pro_client() -> LLMClient:
+    api_key = os.getenv("DEEPSEEK_API_KEY")
+    if not api_key:
+        pytest.skip("DEEPSEEK_API_KEY not set")
+    return LLMClient(provider="deepseek", api_key=api_key, model=_PRO_MODEL)
 
-    response = await deepseek_vision_client.generate(
+
+@pytest.mark.asyncio
+async def test_pro_hosted_web_search(deepseek_pro_client):
+    # Hosted search is gone from the flash architecture (V4.1 removed it silently: the
+    # docs' tool table moved web_search to "Ignored"), but the V4 Pro model still
+    # executes it, so this is the live coverage of the server-side path. NOTE: DeepSeek
+    # routes deepseek-v4-pro to V4.1 Flash from 12:00 Beijing Time 2026-09-14 — re-check
+    # this test and supports_hosted_web_search for pro after that date.
+    # Forcing a page open, rather than asking a question the model could answer from
+    # memory, is what makes the assertion test the tool instead of the model's recall.
+    messages = MessageHistory(
+        [
+            Message(
+                "user",
+                [
+                    TextBlock(
+                        "Use the web search tool to open https://blog.rust-lang.org/releases/ and reply with "
+                        "just the newest release version listed there."
+                    )
+                ],
+            )
+        ]
+    )
+
+    response = await deepseek_pro_client.generate(
         messages=messages,
         system=None,
-        model=_VISION_MODEL,
+        model=_PRO_MODEL,
         thinking="none",
-        temperature=0.0,
-        max_completion_tokens=512,
+        max_completion_tokens=2048,
         hosted_web_search=True,
     )
 

--- a/tests/agent/llm/test_deepseek_responses_routing.py
+++ b/tests/agent/llm/test_deepseek_responses_routing.py
@@ -1,8 +1,8 @@
 # ruff: noqa: E402
 """Provider-level API routing for DeepSeek.
 
-The whole ``deepseek`` provider (``deepseek-v4-pro``, ``deepseek-v4-flash``, and
-``deepseek-v4-flash-vision-exp``) speaks the Responses API via
+The whole ``deepseek`` provider (``deepseek-flash`` and ``deepseek-v4-pro``) speaks the
+Responses API via
 :class:`DeepSeekResponsesProvider`. DeepSeek models hosted on other providers
 (Fireworks/OpenRouter/Ollama-Cloud) still use Chat Completions. See
 ``LLMClient._provider_class``.
@@ -16,19 +16,13 @@ from kolega_code.llm.specs.thinking import build_thinking_request_params, reason
 
 class TestDeepSeekModelRouting:
     def test_flash_routes_to_responses_provider(self):
-        provider = LLMClient(provider="deepseek", api_key="sk-test", model="deepseek-v4-flash").provider
+        provider = LLMClient(provider="deepseek", api_key="sk-test", model="deepseek-flash").provider
         assert isinstance(provider, DeepSeekResponsesProvider)
         assert provider.base_url == "https://api.deepseek.com"
         assert provider.provider_name == "deepseek"
 
     def test_pro_routes_to_responses_provider(self):
         provider = LLMClient(provider="deepseek", api_key="sk-test", model="deepseek-v4-pro").provider
-        assert isinstance(provider, DeepSeekResponsesProvider)
-        assert provider.base_url == "https://api.deepseek.com"
-        assert provider.provider_name == "deepseek"
-
-    def test_flash_vision_routes_to_responses_provider(self):
-        provider = LLMClient(provider="deepseek", api_key="sk-test", model="deepseek-v4-flash-vision-exp").provider
         assert isinstance(provider, DeepSeekResponsesProvider)
         assert provider.base_url == "https://api.deepseek.com"
         assert provider.provider_name == "deepseek"
@@ -46,7 +40,7 @@ class TestDeepSeekModelRouting:
 class TestDeepSeekReasoningShape:
     def test_flash_emits_responses_reasoning_block(self):
         for effort in ("none", "low", "high", "max"):
-            params = build_thinking_request_params("deepseek", "deepseek-v4-flash", effort)
+            params = build_thinking_request_params("deepseek", "deepseek-flash", effort)
             assert params == {"reasoning": {"effort": effort, "summary": "auto"}}
 
     def test_pro_emits_responses_reasoning_block(self):
@@ -56,13 +50,5 @@ class TestDeepSeekReasoningShape:
 
     def test_flash_and_pro_excluded_from_flat_replay(self):
         # Both carry reasoning as Responses reasoning ITEMS, not a flat field.
-        assert reasoning_replay_field("deepseek", "deepseek-v4-flash") is None
+        assert reasoning_replay_field("deepseek", "deepseek-flash") is None
         assert reasoning_replay_field("deepseek", "deepseek-v4-pro") is None
-
-    def test_flash_vision_emits_responses_reasoning_block(self):
-        for effort in ("none", "low", "high", "max"):
-            params = build_thinking_request_params("deepseek", "deepseek-v4-flash-vision-exp", effort)
-            assert params == {"reasoning": {"effort": effort, "summary": "auto"}}
-
-    def test_flash_vision_excluded_from_flat_replay(self):
-        assert reasoning_replay_field("deepseek", "deepseek-v4-flash-vision-exp") is None

--- a/tests/agent/llm/test_deepseek_v41_flash.py
+++ b/tests/agent/llm/test_deepseek_v41_flash.py
@@ -1,7 +1,8 @@
-"""Preview regression tests; live checks require KOLEGA_TEST_DEEPSEEK_PREVIEW=1.
+"""DeepSeek V4.1 Flash (released) regression tests.
 
-The model ID advertises September 10 expiry. Keep live probes explicitly opt-in
-so ordinary integration runs do not depend on a retired preview endpoint.
+The released model is served under the canonical ``deepseek-flash`` id; the
+expiring preview id was retired. Live probes follow the standard integration
+gate (``DEEPSEEK_API_KEY`` set), like the rest of the DeepSeek Responses tests.
 """
 
 import base64
@@ -21,36 +22,44 @@ from kolega_code.llm.models import (
     ToolDefinition,
     ToolParameter,
     ToolResult,
-    WebSearchCallBlock,
 )
 from kolega_code.llm.providers.deepseek_responses import DeepSeekResponsesProvider
 from kolega_code.llm.providers.models import GenerationParams
+from kolega_code.llm.specs import get_model_specs
 
-MODEL = "deepseek-v4.1-flash-expires-on-0910"
+MODEL = "deepseek-flash"
 
 
 @pytest.mark.parametrize("effort", ["none", "low", "high", "max"])
 @pytest.mark.parametrize("requested,expected", [(None, 384000), (128, 128), (500000, 384000)])
-def test_preview_request(effort: str, requested: int | None, expected: int) -> None:
+def test_v41_flash_request(effort: str, requested: int | None, expected: int) -> None:
     client = LLMClient(provider="deepseek", api_key="sk-test", model=MODEL)
     assert isinstance(client.provider, DeepSeekResponsesProvider)
     request = client.provider._build_request(
         MessageHistory([Message("user", [TextBlock("Hello")])]),
         None,
-        GenerationParams(thinking=effort, max_completion_tokens=requested, hosted_web_search=True),
+        GenerationParams(thinking=effort, max_completion_tokens=requested),
         {"model": MODEL},
     )
     assert request["model"] == MODEL
     assert request["reasoning"] == {"effort": effort, "summary": "auto"}
     assert request["max_output_tokens"] == expected
     assert request["stream"] is True
-    assert {"type": "web_search"} in request["tools"]
+    # DeepSeek's Responses surface ignores the built-in web_search tool (docs tool
+    # table + live probes), so the catalog declares no hosted search. The provider
+    # builder still honors an explicit hosted_web_search=True, but the agent gate
+    # (supports_hosted_web_search) never turns it on for this model — assert the flag
+    # in test_v41_flash_spec_has_no_hosted_web_search below.
+    assert "tools" not in request or {"type": "web_search"} not in request["tools"]
+
+
+def test_v41_flash_spec_has_no_hosted_web_search() -> None:
+    specs = get_model_specs("deepseek", MODEL)
+    assert specs["supports_hosted_web_search"] is False
 
 
 @pytest.fixture
-def preview_client() -> LLMClient:
-    if os.getenv("KOLEGA_TEST_DEEPSEEK_PREVIEW") != "1":
-        pytest.skip("Expiring preview: set KOLEGA_TEST_DEEPSEEK_PREVIEW=1 to probe explicitly")
+def v41_flash_client() -> LLMClient:
     key = os.getenv("DEEPSEEK_API_KEY")
     if not key:
         pytest.skip("DEEPSEEK_API_KEY not set")
@@ -61,13 +70,13 @@ def preview_client() -> LLMClient:
 @pytest.mark.integration
 @pytest.mark.asyncio
 @pytest.mark.parametrize("effort", ["none", "low", "high", "max"])
-async def test_preview_live_vision_and_effort(preview_client: LLMClient, effort: str) -> None:
+async def test_v41_flash_live_vision_and_effort(v41_flash_client: LLMClient, effort: str) -> None:
     png = io.BytesIO()
     Image.new("RGB", (64, 64), "red").save(png, format="PNG")
     image = ImageBlock(
         image_type="base64", media_type="image/png", data=base64.b64encode(png.getvalue()).decode("ascii")
     )
-    response = await preview_client.generate(
+    response = await v41_flash_client.generate(
         messages=MessageHistory(
             [Message("user", [TextBlock("Name the color in this image. Reply with one word."), image])]
         ),
@@ -83,7 +92,7 @@ async def test_preview_live_vision_and_effort(preview_client: LLMClient, effort:
 @pytest.mark.slow
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_preview_live_tool_round_trip(preview_client: LLMClient) -> None:
+async def test_v41_flash_live_tool_round_trip(v41_flash_client: LLMClient) -> None:
     tool = ToolDefinition(
         name="get_secret",
         description="Get the secret word.",
@@ -92,7 +101,7 @@ async def test_preview_live_tool_round_trip(preview_client: LLMClient) -> None:
     history = MessageHistory(
         [Message("user", [TextBlock("Call get_secret with key demo, then reply with only the returned secret word.")])]
     )
-    response = await preview_client.generate(
+    response = await v41_flash_client.generate(
         messages=history, system=None, model=MODEL, tools=[tool], thinking="high", max_completion_tokens=1024
     )
     assert isinstance(response, Message)
@@ -108,7 +117,7 @@ async def test_preview_live_tool_round_trip(preview_client: LLMClient) -> None:
             Message("user", [ToolResult(tool_use_id=call.id, name=call.name, content="tangerine", is_error=False)]),
         ]
     )
-    answer = await preview_client.generate(
+    answer = await v41_flash_client.generate(
         messages=replay, system=None, model=MODEL, tools=[tool], thinking="high", max_completion_tokens=1024
     )
     assert isinstance(answer, Message)
@@ -118,17 +127,15 @@ async def test_preview_live_tool_round_trip(preview_client: LLMClient) -> None:
 @pytest.mark.slow
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_preview_live_search_and_full_budget(preview_client: LLMClient) -> None:
-    response = await preview_client.generate(
+async def test_v41_flash_live_full_budget(v41_flash_client: LLMClient) -> None:
+    response = await v41_flash_client.generate(
         messages=MessageHistory(
-            [Message("user", [TextBlock("Search the web for DeepSeek's official website. Reply in one sentence.")])]
+            [Message("user", [TextBlock("What is DeepSeek's official website? Reply in one sentence.")])]
         ),
         system=None,
         model=MODEL,
         thinking="none",
-        hosted_web_search=True,
         # No override: exercise the catalog's full output budget on the wire.
     )
     assert isinstance(response, Message)
-    assert any(isinstance(block, WebSearchCallBlock) for block in response.content)
     assert response.get_text_content().strip()

--- a/tests/agent/llm/test_edit_protocol_resolution.py
+++ b/tests/agent/llm/test_edit_protocol_resolution.py
@@ -84,8 +84,6 @@ def test_direct_deepseek_models_prefer_claude_code() -> None:
     }
 
     assert deepseek_models == {
+        ("deepseek", "deepseek-flash"): EditProtocol.CLAUDE_CODE.value,
         ("deepseek", "deepseek-v4-pro"): EditProtocol.CLAUDE_CODE.value,
-        ("deepseek", "deepseek-v4-flash"): EditProtocol.CLAUDE_CODE.value,
-        ("deepseek", "deepseek-v4-flash-vision-exp"): EditProtocol.CLAUDE_CODE.value,
-        ("deepseek", "deepseek-v4.1-flash-expires-on-0910"): EditProtocol.CLAUDE_CODE.value,
     }

--- a/tests/agent/llm/test_model_specs.py
+++ b/tests/agent/llm/test_model_specs.py
@@ -186,9 +186,9 @@ def test_kimi_coding_highspeed_model_specs():
     [
         # pro: the MEASURED chat ceiling — the server cuts at exactly 65536.
         ("deepseek-v4-pro", 65536),
-        # flash: no such cut; measured running to 112990 in one call.
-        ("deepseek-v4-flash", 384000),
-        ("deepseek-v4.1-flash-expires-on-0910", 384000),
+        # flash: no such cut (measured running to 112990 in one call); the released
+        # V4.1 model rejects max_output_tokens above 393216.
+        ("deepseek-flash", 384000),
     ],
 )
 def test_deepseek_model_specs(model: str, max_completion_tokens: int):

--- a/tests/agent/llm/test_normalized_usage_live.py
+++ b/tests/agent/llm/test_normalized_usage_live.py
@@ -66,9 +66,9 @@ def _provider_models() -> list[tuple[str, str]]:
         else:
             model = default_model_for_provider(ModelProvider(provider_value))
         pairs.append((provider_value, model))
-    # The one model-level dispatch split: deepseek-v4-flash speaks the Responses
+    # The one model-level dispatch split: deepseek-flash speaks the Responses
     # API while the rest of the deepseek catalog stays on Chat Completions.
-    pairs.append((ModelProvider.DEEPSEEK.value, "deepseek-v4-flash"))
+    pairs.append((ModelProvider.DEEPSEEK.value, "deepseek-flash"))
     return pairs
 
 

--- a/tests/agent/llm/test_parallel_tool_calls_live.py
+++ b/tests/agent/llm/test_parallel_tool_calls_live.py
@@ -30,7 +30,7 @@ SKIP_IN_CI = bool(os.getenv("CI")) or bool(os.getenv("GITLAB_CI"))
 PROVIDERS = [
     ("openai", "gpt-5.6-sol", "medium"),
     ("openai_chatgpt", chatgpt_constants.DEFAULT_MODEL, "medium"),
-    ("deepseek", "deepseek-v4-flash", "high"),
+    ("deepseek", "deepseek-flash", "high"),
 ]
 
 TOOLS = [

--- a/tests/agent/llm/test_supports_vision.py
+++ b/tests/agent/llm/test_supports_vision.py
@@ -49,10 +49,9 @@ def test_supports_vision_flag_present_on_every_entry():
         ("thinking_machines", "thinkingmachines/Inkling-Small", True),
         # Non-vision models
         ("deepseek", "deepseek-v4-pro", False),
-        ("deepseek", "deepseek-v4-flash", False),
-        # First multimodal DeepSeek model (launched 2026-08-21).
-        ("deepseek", "deepseek-v4-flash-vision-exp", True),
-        ("deepseek", "deepseek-v4.1-flash-expires-on-0910", True),
+        # Released Flash (V4.1), replacing the retired V4 Flash / Vision Exp ids; it is
+        # the multimodal model now (the whole flash family answers as deepseek-flash).
+        ("deepseek", "deepseek-flash", True),
         ("fireworks", "accounts/fireworks/models/deepseek-v4-pro", False),
         ("fireworks", "accounts/fireworks/models/deepseek-v4-flash", False),
         ("fireworks", "accounts/fireworks/models/glm-5p2", False),

--- a/tests/agent/test_agent_tools_inventory.py
+++ b/tests/agent/test_agent_tools_inventory.py
@@ -312,7 +312,7 @@ def test_browser_agent_type_gated_on_browser_agent_model_vision(project_path, mo
     main = agent_config.long_context_config  # claude-sonnet — vision-capable
 
     vision_browser = Mock(provider="anthropic", model="claude-sonnet-4-5-20250929")
-    blind_browser = Mock(provider="deepseek", model="deepseek-v4-flash")
+    blind_browser = Mock(provider="deepseek", model="deepseek-v4-pro")
 
     def agent_types_with_browser_model(browser_model):
         agent_config.model_config_for_agent.side_effect = lambda name: (

--- a/tests/agent/test_base_agent_prompt_context.py
+++ b/tests/agent/test_base_agent_prompt_context.py
@@ -102,7 +102,8 @@ class TestBaseAgent:
     ):
         deepseek_model = ModelConfig(
             provider=ModelProvider.DEEPSEEK,
-            model="deepseek-v4-flash",
+            # A non-vision DeepSeek model: V4.1 Flash (the current flash id) has vision.
+            model="deepseek-v4-pro",
             rate_limits=RateLimitConfig(),
         )
         config = agent_config.model_copy(
@@ -121,7 +122,7 @@ class TestBaseAgent:
 
         context = agent.build_prompt_context()
 
-        assert context.model_name == "deepseek-v4-flash"
+        assert context.model_name == "deepseek-v4-pro"
         assert context.model_supports_vision is False
 
     def test_build_prompt_context_ignores_removed_agent_memory_file(self, base_agent, tmp_path):

--- a/tests/agent/test_base_agent_role_overrides.py
+++ b/tests/agent/test_base_agent_role_overrides.py
@@ -53,7 +53,7 @@ def _role_config():
         fast_config=ModelConfig(provider=ModelProvider.ANTHROPIC, model="claude-haiku-4-5-20251001"),
         agent_models={
             "investigation": ModelConfig(
-                provider=ModelProvider.DEEPSEEK, model="deepseek-v4-flash", thinking_effort="high"
+                provider=ModelProvider.DEEPSEEK, model="deepseek-flash", thinking_effort="high"
             )
         },
     )
@@ -69,7 +69,7 @@ def test_agent_uses_role_override_for_primary_model(tmp_path, mock_connection_ma
     )
 
     assert agent.primary_model_config.provider == ModelProvider.DEEPSEEK
-    assert agent.primary_model_config.model == "deepseek-v4-flash"
+    assert agent.primary_model_config.model == "deepseek-flash"
     assert agent.primary_model_config.thinking_effort == "high"
     # Model specs and the LLM client both follow the resolved role model.
     assert agent.model_context_length == 1_000_000

--- a/tests/agent/test_model_routing.py
+++ b/tests/agent/test_model_routing.py
@@ -34,13 +34,13 @@ def test_complete_override_replaces_only_target_role() -> None:
     resolved = resolve_subagent_model(
         config,
         "investigation-agent",
-        {"provider": "deepseek", "model": "deepseek-v4-flash", "thinking_effort": "HIGH"},
+        {"provider": "deepseek", "model": "deepseek-flash", "thinking_effort": "HIGH"},
         effort_key="thinking_effort",
     )
 
     selected = resolved.config.model_config_for_agent("investigation-agent")
     assert selected.provider == ModelProvider.DEEPSEEK
-    assert selected.model == "deepseek-v4-flash"
+    assert selected.model == "deepseek-flash"
     assert selected.thinking_effort == "high"
     assert resolved.config.model_config_for_agent("general-agent") == config.long_context_config
     assert config.agent_models == {}
@@ -178,7 +178,7 @@ def test_routing_fingerprint_changes_without_including_secrets() -> None:
             "agent_models": {
                 "general": ModelConfig(
                     provider=ModelProvider.DEEPSEEK,
-                    model="deepseek-v4-flash",
+                    model="deepseek-flash",
                     thinking_effort="high",
                 )
             }

--- a/tests/agent/tool_backend/test_workflow_tool.py
+++ b/tests/agent/tool_backend/test_workflow_tool.py
@@ -498,7 +498,7 @@ def _config_with_investigation_override() -> AgentConfig:
         anthropic_api_key="anthropic-key",
         deepseek_api_key="deepseek-key",
         agent_models={
-            "investigation": ModelConfig(provider=ModelProvider.DEEPSEEK, model="deepseek-v4-flash"),
+            "investigation": ModelConfig(provider=ModelProvider.DEEPSEEK, model="deepseek-flash"),
         },
     )
 
@@ -586,10 +586,10 @@ async def test_no_override_passes_through_role_configuration(tmp_path, connectio
     assert captured[0][0] is None
     assert captured[0][1]["effective_routing"] == {
         "provider": "deepseek",
-        "model": "deepseek-v4-flash",
+        "model": "deepseek-flash",
         "effort": None,
     }
-    assert config.model_config_for_agent("investigation-agent").model == "deepseek-v4-flash"
+    assert config.model_config_for_agent("investigation-agent").model == "deepseek-flash"
 
 
 @pytest.mark.asyncio
@@ -622,7 +622,8 @@ async def test_browser_override_requires_vision_after_actual_class_selection(wor
     script = (
         'meta = {"name": "browser-route", "description": "d"}\n'
         'return await agent("browse", agent_type="browser", model_override={'
-        '"provider": "deepseek", "model": "deepseek-v4-flash", "effort": "high"})\n'
+        # Non-vision on purpose: V4.1 Flash has vision, so the gate needs a blind model.
+        '"provider": "deepseek", "model": "deepseek-v4-pro", "effort": "high"})\n'
     )
 
     summary = await tool.run_workflow(script=script)
@@ -660,7 +661,7 @@ async def test_plan_mode_resolves_override_for_forced_investigation_agent(workfl
     script = (
         'meta = {"name": "plan-route", "description": "d"}\n'
         'return await agent("route", agent_type="browser", model_override={'
-        '"provider": "deepseek", "model": "deepseek-v4-flash", "effort": "high"})\n'
+        '"provider": "deepseek", "model": "deepseek-flash", "effort": "high"})\n'
     )
     summary = await tool.run_workflow(script=script)
 
@@ -678,7 +679,7 @@ async def test_plan_mode_resolves_override_for_forced_investigation_agent(workfl
     assert journal_entry["effective_routing"]["provider"] == "deepseek"
     transcript = (run_dir / "transcript.md").read_text()
     assert "InvestigationAgent" in transcript
-    assert "deepseek-v4-flash" in transcript
+    assert "deepseek-flash" in transcript
 
 
 @pytest.mark.asyncio

--- a/tests/benchmarks/test_edit_benchmark_runner.py
+++ b/tests/benchmarks/test_edit_benchmark_runner.py
@@ -76,7 +76,7 @@ def test_plan_uses_catalog_defaults_and_stable_trial_ids() -> None:
 
 
 def test_client_routes_deepseek_flash_from_benchmark_config() -> None:
-    model = ModelConfig(provider=ModelProvider.DEEPSEEK, model="deepseek-v4-flash")
+    model = ModelConfig(provider=ModelProvider.DEEPSEEK, model="deepseek-flash")
     config = AgentConfig(
         deepseek_api_key="test",
         long_context_config=model,

--- a/tests/cli/test_app_bootstrap_settings.py
+++ b/tests/cli/test_app_bootstrap_settings.py
@@ -596,7 +596,7 @@ async def test_textual_app_saves_deepseek_settings_and_builds_agent(
         screen = await open_settings_screen(app, pilot)
         screen.query_one("#provider_select", Select).value = ModelProvider.DEEPSEEK.value
         model_select = screen.query_one("#model_select", Select)
-        model_select.set_options([("DeepSeek V4 Pro", DEEPSEEK_DEFAULT_MODEL)])
+        model_select.set_options([("DeepSeek V4.1 Flash", DEEPSEEK_DEFAULT_MODEL)])
         model_select.value = DEEPSEEK_DEFAULT_MODEL
         await stage_provider_api_key(screen, pilot, ModelProvider.DEEPSEEK.value, "deepseek-key")
         await app._save_settings_from_ui()
@@ -808,7 +808,10 @@ async def test_browser_model_settings_preserve_and_reject_nonvision_override(
     settings = CliSettings(active_provider=UI_DEFAULT_PROVIDER, active_model=UI_DEFAULT_MODEL)
     settings.set_api_key(UI_DEFAULT_PROVIDER, "moonshot-key")
     settings.set_api_key(ModelProvider.DEEPSEEK.value, "deepseek-key")
-    settings.set_agent_model("browser", ModelProvider.DEEPSEEK.value, DEEPSEEK_DEFAULT_MODEL)
+    # A saved non-vision browser override: the DeepSeek default (V4.1 Flash) has vision
+    # now, so pin a non-vision id to exercise the "does not support vision" path.
+    non_vision_model = "deepseek-v4-pro"
+    settings.set_agent_model("browser", ModelProvider.DEEPSEEK.value, non_vision_model)
     settings_store.save(settings)
     session = store.create(project, "code", {})
     app = KolegaCodeApp(
@@ -822,7 +825,7 @@ async def test_browser_model_settings_preserve_and_reject_nonvision_override(
     async with app.run_test() as pilot:
         screen = await open_settings_screen(app, pilot, "agents")
         assert screen.query_one("#am_provider_browser", Select).value == ModelProvider.DEEPSEEK.value
-        assert screen.query_one("#am_model_browser", Select).value == DEEPSEEK_DEFAULT_MODEL
+        assert screen.query_one("#am_model_browser", Select).value == non_vision_model
         assert "does not support vision" in str(screen.query_one("#am_status_browser", Static).render())
 
         await app._save_settings_from_ui()
@@ -830,7 +833,7 @@ async def test_browser_model_settings_preserve_and_reject_nonvision_override(
         saved = settings_store.load().get_agent_model("browser")
         assert saved is not None
         assert saved["provider"] == ModelProvider.DEEPSEEK.value
-        assert saved["model"] == DEEPSEEK_DEFAULT_MODEL
+        assert saved["model"] == non_vision_model
         assert "does not support vision" in str(screen.query_one("#settings_status", Static).render())
 
 
@@ -854,7 +857,10 @@ async def test_browser_model_settings_allow_nonvision_inheritance_with_warning(
     settings_store = SettingsStore(state_dir)
     settings = CliSettings(
         active_provider=ModelProvider.DEEPSEEK.value,
-        active_model=DEEPSEEK_DEFAULT_MODEL,
+        # The DeepSeek default (V4.1 Flash) is vision-capable, so the browser role would
+        # inherit a capable model and show the positive hint. Pin a non-vision DeepSeek
+        # model here to keep exercising the inheritance warning this test is about.
+        active_model="deepseek-v4-pro",
     )
     settings.set_api_key(ModelProvider.DEEPSEEK.value, "deepseek-key")
     settings_store.save(settings)

--- a/tests/cli/test_app_rendering_errors.py
+++ b/tests/cli/test_app_rendering_errors.py
@@ -116,7 +116,7 @@ async def test_textual_app_cancellation_is_visible_in_chat(tmp_path: Path, monke
             ),
             ModelProvider.DEEPSEEK,
             DEEPSEEK_DEFAULT_MODEL,
-            "DeepSeek/deepseek-v4-pro could not run this request",
+            f"DeepSeek/{DEEPSEEK_DEFAULT_MODEL} could not run this request",
             id="billing",
         ),
         pytest.param(

--- a/tests/cli/test_cli_config.py
+++ b/tests/cli/test_cli_config.py
@@ -538,13 +538,13 @@ def _anthropic_settings_with_deepseek_key() -> CliSettings:
 
 def test_build_agent_config_applies_settings_agent_model_override(tmp_path: Path) -> None:
     settings = _anthropic_settings_with_deepseek_key()
-    settings.set_agent_model("investigation", "deepseek", "deepseek-v4-flash", "high")
+    settings.set_agent_model("investigation", "deepseek", "deepseek-flash", "high")
 
     config = build_agent_config(tmp_path, settings=settings, env={})
 
     investigation = config.model_config_for_agent("investigation-agent")
     assert investigation.provider == ModelProvider.DEEPSEEK
-    assert investigation.model == "deepseek-v4-flash"
+    assert investigation.model == "deepseek-flash"
     assert investigation.thinking_effort == "high"
     # Roles with no override inherit the active (long-context) model.
     assert config.model_config_for_agent("coder").model == ANTHROPIC_DEFAULT_MODEL
@@ -552,7 +552,7 @@ def test_build_agent_config_applies_settings_agent_model_override(tmp_path: Path
 
 def test_env_overrides_settings_agent_model(tmp_path: Path) -> None:
     settings = CliSettings(active_provider="anthropic", active_model=ANTHROPIC_DEFAULT_MODEL)
-    settings.set_agent_model("investigation", "deepseek", "deepseek-v4-flash")
+    settings.set_agent_model("investigation", "deepseek", "deepseek-flash")
 
     config = build_agent_config(
         tmp_path,
@@ -576,19 +576,19 @@ def test_env_only_agent_model_override(tmp_path: Path) -> None:
             "KOLEGA_CODE_PROVIDER": "anthropic",
             "KOLEGA_CODE_MODEL": "claude-opus-5",
             "KOLEGA_CODE_INVESTIGATION_PROVIDER": "deepseek",
-            "KOLEGA_CODE_INVESTIGATION_MODEL": "deepseek-v4-flash",
+            "KOLEGA_CODE_INVESTIGATION_MODEL": "deepseek-flash",
         },
     )
 
     assert config.model_config_for_agent("investigation-agent").provider == ModelProvider.DEEPSEEK
-    assert config.model_config_for_agent("investigation-agent").model == "deepseek-v4-flash"
+    assert config.model_config_for_agent("investigation-agent").model == "deepseek-flash"
     assert config.model_config_for_agent("coder").model == ANTHROPIC_DEFAULT_MODEL
 
 
 def test_agent_model_override_requires_api_key(tmp_path: Path) -> None:
     settings = CliSettings(active_provider="anthropic", active_model=ANTHROPIC_DEFAULT_MODEL)
     settings.set_api_key("anthropic", "anthropic-key")
-    settings.set_agent_model("investigation", "deepseek", "deepseek-v4-flash")
+    settings.set_agent_model("investigation", "deepseek", "deepseek-flash")
 
     with pytest.raises(CliConfigError, match="DEEPSEEK_API_KEY"):
         build_agent_config(tmp_path, settings=settings, env={})
@@ -596,11 +596,11 @@ def test_agent_model_override_requires_api_key(tmp_path: Path) -> None:
 
 def test_config_summary_includes_agent_models(tmp_path: Path) -> None:
     settings = _anthropic_settings_with_deepseek_key()
-    settings.set_agent_model("investigation", "deepseek", "deepseek-v4-flash")
+    settings.set_agent_model("investigation", "deepseek", "deepseek-flash")
 
     summary = config_summary(build_agent_config(tmp_path, settings=settings, env={}))
 
-    assert summary["agent_models"] == {"investigation": "deepseek/deepseek-v4-flash"}
+    assert summary["agent_models"] == {"investigation": "deepseek/deepseek-flash"}
 
 
 def test_build_agent_config_no_agent_model_overrides_by_default(tmp_path: Path) -> None:
@@ -768,12 +768,12 @@ def test_openrouter_edit_protocol_defaults_to_claude_code_except_openai_models(t
 
 def test_build_agent_config_applies_saved_model_slots(tmp_path: Path) -> None:
     settings = _anthropic_settings_with_deepseek_key()
-    settings.set_model_slot("fast", "deepseek", "deepseek-v4-flash")
+    settings.set_model_slot("fast", "deepseek", "deepseek-flash")
 
     config = build_agent_config(tmp_path, settings=settings, env={})
 
     assert config.fast_config.provider == ModelProvider.DEEPSEEK
-    assert config.fast_config.model == "deepseek-v4-flash"
+    assert config.fast_config.model == "deepseek-flash"
     # The main model is untouched by a slot override.
     assert config.long_context_config.provider == ModelProvider.ANTHROPIC
     assert config.long_context_config.model == ANTHROPIC_DEFAULT_MODEL
@@ -790,7 +790,7 @@ def test_model_slots_inherit_the_active_model_when_unset(tmp_path: Path) -> None
 
 def test_env_fast_model_beats_a_saved_model_slot(tmp_path: Path) -> None:
     settings = _anthropic_settings_with_deepseek_key()
-    settings.set_model_slot("fast", "deepseek", "deepseek-v4-flash")
+    settings.set_model_slot("fast", "deepseek", "deepseek-flash")
 
     config = build_agent_config(
         tmp_path,
@@ -804,7 +804,7 @@ def test_env_fast_model_beats_a_saved_model_slot(tmp_path: Path) -> None:
 
 def test_fast_model_flag_beats_env_and_saved_model_slot(tmp_path: Path) -> None:
     settings = _anthropic_settings_with_deepseek_key()
-    settings.set_model_slot("fast", "deepseek", "deepseek-v4-flash")
+    settings.set_model_slot("fast", "deepseek", "deepseek-flash")
 
     config = build_agent_config(
         tmp_path,
@@ -831,7 +831,7 @@ def test_saved_model_slot_with_an_uncatalogued_model_falls_back_to_the_provider_
 def test_model_slot_override_requires_the_slot_providers_api_key(tmp_path: Path) -> None:
     settings = CliSettings(active_provider="anthropic", active_model=ANTHROPIC_DEFAULT_MODEL)
     settings.set_api_key("anthropic", "anthropic-key")
-    settings.set_model_slot("fast", "deepseek", "deepseek-v4-flash")
+    settings.set_model_slot("fast", "deepseek", "deepseek-flash")
 
     with pytest.raises(CliConfigError, match="DEEPSEEK_API_KEY"):
         build_agent_config(tmp_path, settings=settings, env={})

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -620,7 +620,7 @@ def test_ask_plain_handles_billing_error_without_traceback(
     captured = capsys.readouterr()
     assert exit_code == 1
     assert captured.out == ""
-    assert "DeepSeek/deepseek-v4-pro could not run this request" in captured.err
+    assert f"DeepSeek/{DEEPSEEK_DEFAULT_MODEL} could not run this request" in captured.err
     assert "Add credits to your DeepSeek account" in captured.err
     assert FakeCoderAgent.instances[0].cleaned is True
 

--- a/tests/cli/test_provider_registry.py
+++ b/tests/cli/test_provider_registry.py
@@ -1,4 +1,5 @@
 from kolega_code.cli.provider_registry import (
+    DEEPSEEK_DEFAULT_MODEL,
     UI_DEFAULT_MODEL,
     UI_DEFAULT_PROVIDER,
     default_model_for_provider,
@@ -153,18 +154,17 @@ def test_vision_only_model_options_follow_catalog_capabilities():
         "MiniMax M3": "accounts/fireworks/models/minimax-m3",
     }
     assert dict(ui_model_options("deepseek", vision_only=True)) == {
-        "DeepSeek V4 Flash Vision (Exp)": "deepseek-v4-flash-vision-exp",
-        "DeepSeek V4.1 Flash (Preview, expires Sep 10)": "deepseek-v4.1-flash-expires-on-0910",
+        "DeepSeek V4.1 Flash": "deepseek-flash",
     }
 
 
-def test_deepseek_preview_is_selectable_without_changing_default() -> None:
-    # Settings falls back to the first option when switching providers.
-    assert ui_model_options("deepseek")[0] == ("DeepSeek V4 Pro", "deepseek-v4-pro")
-    assert dict(ui_model_options("deepseek"))["DeepSeek V4.1 Flash (Preview, expires Sep 10)"] == (
-        "deepseek-v4.1-flash-expires-on-0910"
-    )
-    assert default_model_for_provider(ModelProvider.DEEPSEEK) == "deepseek-v4-pro"
+def test_deepseek_v41_flash_is_the_default() -> None:
+    # The released V4.1 Flash is the provider default now that DeepSeek routes every
+    # other first-party id to it. Settings falls back to the first option when
+    # switching providers, so catalog order and PROVIDER_DEFAULT_MODEL must agree.
+    assert ui_model_options("deepseek")[0] == ("DeepSeek V4.1 Flash", "deepseek-flash")
+    assert default_model_for_provider(ModelProvider.DEEPSEEK) == DEEPSEEK_DEFAULT_MODEL == "deepseek-flash"
+    assert dict(ui_model_options("deepseek"))["DeepSeek V4 Pro"] == "deepseek-v4-pro"
 
 
 def test_ollama_cloud_smoke_model_is_available_without_live_call():

--- a/tests/cli/test_settings.py
+++ b/tests/cli/test_settings.py
@@ -185,7 +185,7 @@ def test_settings_save_merges_nested_mappings(tmp_path: Path) -> None:
 def test_settings_store_round_trips_agent_models(tmp_path: Path) -> None:
     store = SettingsStore(tmp_path)
     settings = CliSettings(active_provider=UI_DEFAULT_PROVIDER, active_model=UI_DEFAULT_MODEL)
-    settings.set_agent_model("investigation", "deepseek", "deepseek-v4-flash", "high")
+    settings.set_agent_model("investigation", "deepseek", "deepseek-flash", "high")
     settings.set_agent_model("building", "anthropic", "claude-opus-4-8")
 
     store.save(settings)
@@ -193,7 +193,7 @@ def test_settings_store_round_trips_agent_models(tmp_path: Path) -> None:
 
     assert loaded.get_agent_model("investigation") == {
         "provider": "deepseek",
-        "model": "deepseek-v4-flash",
+        "model": "deepseek-flash",
         "thinking_effort": "high",
     }
     assert loaded.get_agent_model("building") == {"provider": "anthropic", "model": "claude-opus-4-8"}
@@ -201,7 +201,7 @@ def test_settings_store_round_trips_agent_models(tmp_path: Path) -> None:
 
 def test_clear_agent_model_makes_role_inherit() -> None:
     settings = CliSettings()
-    settings.set_agent_model("investigation", "deepseek", "deepseek-v4-flash")
+    settings.set_agent_model("investigation", "deepseek", "deepseek-flash")
     settings.clear_agent_model("investigation")
 
     assert settings.get_agent_model("investigation") is None
@@ -212,7 +212,7 @@ def test_from_dict_drops_incomplete_agent_model_entries() -> None:
     data = {
         "schema_version": SETTINGS_SCHEMA_VERSION,
         "agent_models": {
-            "investigation": {"provider": "deepseek", "model": "deepseek-v4-flash"},
+            "investigation": {"provider": "deepseek", "model": "deepseek-flash"},
             "building": {"provider": "anthropic"},  # missing model -> dropped
             "general": "not-a-dict",  # malformed -> dropped
         },
@@ -226,17 +226,17 @@ def test_from_dict_drops_incomplete_agent_model_entries() -> None:
 def test_settings_store_round_trips_model_slots(tmp_path: Path) -> None:
     store = SettingsStore(tmp_path)
     settings = CliSettings(active_provider=UI_DEFAULT_PROVIDER, active_model=UI_DEFAULT_MODEL)
-    settings.set_model_slot("fast", "deepseek", "deepseek-v4-flash")
+    settings.set_model_slot("fast", "deepseek", "deepseek-flash")
 
     store.save(settings)
     loaded = store.load()
 
-    assert loaded.get_model_slot("fast") == {"provider": "deepseek", "model": "deepseek-v4-flash"}
+    assert loaded.get_model_slot("fast") == {"provider": "deepseek", "model": "deepseek-flash"}
 
 
 def test_clear_model_slot_makes_slot_inherit() -> None:
     settings = CliSettings()
-    settings.set_model_slot("fast", "deepseek", "deepseek-v4-flash")
+    settings.set_model_slot("fast", "deepseek", "deepseek-flash")
     settings.clear_model_slot("fast")
 
     assert settings.get_model_slot("fast") is None
@@ -247,7 +247,7 @@ def test_from_dict_drops_incomplete_model_slot_entries() -> None:
     data = {
         "schema_version": SETTINGS_SCHEMA_VERSION,
         "model_slots": {
-            "fast": {"provider": "deepseek", "model": "deepseek-v4-flash"},
+            "fast": {"provider": "deepseek", "model": "deepseek-flash"},
             "fast2": {"provider": "anthropic"},  # missing model -> dropped
         },
     }
@@ -262,7 +262,7 @@ def test_from_dict_drops_legacy_thinking_slot() -> None:
     data = {
         "schema_version": SETTINGS_SCHEMA_VERSION,
         "model_slots": {
-            "fast": {"provider": "deepseek", "model": "deepseek-v4-flash"},
+            "fast": {"provider": "deepseek", "model": "deepseek-flash"},
             "thinking": {"provider": "anthropic", "model": "claude-opus-4-8"},
         },
     }

--- a/tests/cli/test_tui_settings_screens.py
+++ b/tests/cli/test_tui_settings_screens.py
@@ -207,12 +207,12 @@ async def test_settings_screen_retains_active_model_and_effort(
         # A genuine provider change still cascades: model falls back to the new
         # provider's first model, then a manual model pick is retained.
         provider.value = "deepseek"
+        await _wait_for_select_values(pilot, screen, {"model_select": "deepseek-flash"})
+        assert str(model.value) == "deepseek-flash"
+
+        model.value = "deepseek-v4-pro"
         await _wait_for_select_values(pilot, screen, {"model_select": "deepseek-v4-pro"})
         assert str(model.value) == "deepseek-v4-pro"
-
-        model.value = "deepseek-v4-flash"
-        await _wait_for_select_values(pilot, screen, {"model_select": "deepseek-v4-flash"})
-        assert str(model.value) == "deepseek-v4-flash"
 
 
 @pytest.mark.asyncio
@@ -858,22 +858,22 @@ async def test_model_slot_row_pins_a_model_on_another_provider(
         screen = app.screen
         screen.query_one("#slot_provider_fast", Select).value = "deepseek"
         await _wait_for_select_values(pilot, screen, {"slot_provider_fast": "deepseek"})
-        screen.query_one("#slot_model_fast", Select).value = "deepseek-v4-flash"
-        await _wait_for_select_values(pilot, screen, {"slot_model_fast": "deepseek-v4-flash"})
+        screen.query_one("#slot_model_fast", Select).value = "deepseek-flash"
+        await _wait_for_select_values(pilot, screen, {"slot_model_fast": "deepseek-flash"})
 
         hint = str(screen.query_one("#slot_hint_fast", Static).render())
-        assert "deepseek/deepseek-v4-flash" in hint
+        assert "deepseek/deepseek-flash" in hint
         assert "inherited" not in hint
 
         await app._save_settings_from_ui()
 
         assert settings_store.load().get_model_slot("fast") == {
             "provider": "deepseek",
-            "model": "deepseek-v4-flash",
+            "model": "deepseek-flash",
         }
         # The fast slot now diverges from the main model it used to shadow.
         assert app.config is not None
-        assert app.config.fast_config.model == "deepseek-v4-flash"
+        assert app.config.fast_config.model == "deepseek-flash"
         assert app.config.long_context_config.model == UI_DEFAULT_MODEL
 
 
@@ -891,7 +891,7 @@ async def test_model_slot_row_returning_to_inherit_clears_the_override(
     app, settings_store = _configured_app(
         tmp_path,
         monkeypatch,
-        model_slots={"fast": {"provider": "deepseek", "model": "deepseek-v4-flash"}},
+        model_slots={"fast": {"provider": "deepseek", "model": "deepseek-flash"}},
         extra_key_providers=("deepseek",),
     )
 
@@ -901,7 +901,7 @@ async def test_model_slot_row_returning_to_inherit_clears_the_override(
         screen = app.screen
         # A saved slot is restored into its row.
         await _wait_for_select_values(
-            pilot, screen, {"slot_provider_fast": "deepseek", "slot_model_fast": "deepseek-v4-flash"}
+            pilot, screen, {"slot_provider_fast": "deepseek", "slot_model_fast": "deepseek-flash"}
         )
 
         screen.query_one("#slot_provider_fast", Select).value = INHERIT_SENTINEL


### PR DESCRIPTION
## Why

DeepSeek released **V4.1 Flash** on 2026-09-10. The finished model is served under the canonical
`deepseek-flash` id:

- `/models` lists exactly `deepseek-flash` and `deepseek-v4-pro`.
- There is **no** `deepseek-v4.1-flash` — the API rejects it with `400 … "The supported API model
  names are deepseek-flash, deepseek-v4-pro, but you passed deepseek-v4.1-flash"`.
- `deepseek-v4-flash` and `deepseek-v4-flash-vision-exp` are retired and "temporarily routed" to
  V4.1 Flash; every alias answers with `"model": "deepseek-flash"`.

So the catalog now lists the two models DeepSeek actually serves, and V4.1 Flash is the default.

## What changed

- **Catalog** — the expiring preview entry is replaced by `deepseek-flash`, verified live:
  1,048,576-token context, 393,216-token API output ceiling, vision, function calls, and
  `none`/`low`/`high`/`max` effort. The retired `deepseek-v4-flash` and
  `deepseek-v4-flash-vision-exp` entries are gone (they named nothing distinct).
- **Default** — `deepseek-flash` is `PROVIDER_DEFAULT_MODEL[DEEPSEEK]`, `DEEPSEEK_DEFAULT_MODEL`,
  and first in catalog order (which the settings provider-switch fallback reads). DeepSeek's own
  guidance is that V4.1 Flash supersedes V4 Pro; `deepseek-v4-pro` stays selectable.
- **Hosted web search** — marked unsupported on the flash route. DeepSeek removed it silently with
  the release: the Responses tool table moved `web_search` from *"Supported, executed on the server
  side"* (Sep 9) to *"Ignored"* (Sep 10), dropped it from `tool_choice`, and deleted its streaming
  events — with no mention on `/updates`, `/news`, the docs home, or the FAQ. The exact 2026-08-04
  probe body that recorded `ws_calls=1` now returns `ws_calls=0`. `deepseek-v4-pro` **still
  executes** hosted search (re-verified: `ws_calls=1`, real answer), so it keeps the flag, with a
  note to re-check after DeepSeek routes pro to V4.1 Flash on **September 14, 12:00 Beijing**.
- **Tests** — the gated preview live test becomes `test_deepseek_v41_flash.py` (gated on
  `DEEPSEEK_API_KEY` like the other DeepSeek live tests); hosted-search live coverage moves to
  `deepseek-v4-pro`; exact-set/vision/spec matrices updated. Three tests that relied on the default
  being *non-vision* now pin `deepseek-v4-pro` so they still exercise their original path.
- **Callers** — examples, demo scripts, and the runnable edit-tool matrices point at surviving ids
  (`get_model_specs` raises on an unknown model, so a stale id crashes a run).

## Behaviour for saved configs

Settings, sessions, and per-role overrides still naming a retired id fall back to the DeepSeek
default (`deepseek-flash` — the same model the alias served). Naming one explicitly (`--model`,
`KOLEGA_CODE_MODEL`) fails with a clear "not available for" error.

## Verification

- Full fast suite: **5405 passed**, 3 failed — all three are pre-existing Together live failures
  (`moonshotai/Kimi-K2.7-Code` is no longer a serverless model there), unrelated to this change.
- Live DeepSeek suite (`./run_tests.sh --all tests/agent/llm/test_deepseek_*.py`): image input at
  all four efforts, tool round trip, full-budget generation, and the pro hosted-search probe.
- `ruff check`, `ruff format --check`, `pyright`, and `pre-commit run --all-files` clean.

## Follow-ups

- Re-check `supports_hosted_web_search` for `deepseek-v4-pro` after the September 14 routing switch.
- `benchmarks/edit_tools/matrices/deepseek-v4.yaml` still names the removed id on `main`; left out of
  this PR because it also carries unrelated local experiment edits.
