### PR TITLE
chore: release v0.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,7 @@ This project uses GitHub Releases for detailed generated release notes. This fil
 
 ## Unreleased
 
-### Changed
-
-- **DeepSeek now defaults to V4.1 Flash.** `deepseek-flash` is the default model
-  (and first entry in the picker) for the DeepSeek provider, matching DeepSeek's
-  own guidance that V4.1 Flash supersedes V4 Pro on performance, cost, speed, and
-  total time. `deepseek-v4-pro` remains selectable; DeepSeek routes it to V4.1
-  Flash from September 14, 2026.
+## 0.38.0 - 2026-09-11
 
 ### Added
 
@@ -23,12 +17,13 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   393,216-token API output ceiling. DeepSeek's Responses API ignores the built-in
   `web_search` tool, so this model does not advertise hosted web search.
 
-### Fixed
+### Changed
 
-- **Hosted web search no longer offered where DeepSeek stopped serving it.**
-  DeepSeek silently removed server-side `web_search` with the V4.1 release, so the
-  flash models' `/web` toggle was advertising a capability that no longer exists.
-  `deepseek-v4-pro` still executes hosted search and keeps it.
+- **DeepSeek now defaults to V4.1 Flash.** `deepseek-flash` is the default model
+  (and first entry in the picker) for the DeepSeek provider, matching DeepSeek's
+  own guidance that V4.1 Flash supersedes V4 Pro on performance, cost, speed, and
+  total time. `deepseek-v4-pro` remains selectable; DeepSeek routes it to V4.1
+  Flash from September 14, 2026.
 
 ### Removed
 
@@ -45,6 +40,13 @@ This project uses GitHub Releases for detailed generated release notes. This fil
   (`deepseek-flash`); naming it explicitly (`--model`, `KOLEGA_CODE_MODEL`) fails
   with a "not available for" error. Switch to `deepseek-flash`, which DeepSeek
   serves the same model under.
+
+### Fixed
+
+- **Hosted web search no longer offered where DeepSeek stopped serving it.**
+  DeepSeek silently removed server-side `web_search` with the V4.1 release, so the
+  flash models' `/web` toggle was advertising a capability that no longer exists.
+  `deepseek-v4-pro` still executes hosted search and keeps it.
 
 ## 0.37.0 - 2026-09-09
 

--- a/kolega_code/__init__.py
+++ b/kolega_code/__init__.py
@@ -174,4 +174,4 @@ __all__ = [
     "parse_git_status_output",
 ]
 
-__version__ = "0.37.0"
+__version__ = "0.38.0"

--- a/kolega_code/agent/__init__.py
+++ b/kolega_code/agent/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "ToolExtension",
 ]
 
-__version__ = "0.37.0"
+__version__ = "0.38.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kolega-code"
-version = "0.37.0"
+version = "0.38.0"
 description = "Multi-agent coding in the terminal"
 readme = "README.md"
 license = "BUSL-1.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1825,7 +1825,7 @@ wheels = [
 
 [[package]]
 name = "kolega-code"
-version = "0.37.0"
+version = "0.38.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
Release v0.38.0.

- Bumps the version in `pyproject.toml`, `kolega_code/__init__.py`, and `kolega_code/agent/__init__.py`; `uv lock` only re-stamped the project version (no dependency churn).
- Promotes the `Unreleased` changelog entries to a `0.38.0 - 2026-09-11` section (categories reordered to Added → Changed → Removed → Fixed).

### Highlights

- **Added:** DeepSeek V4.1 Flash (released) under the canonical `deepseek-flash` id — vision, `none`/`low`/`high`/`max` effort, 1,048,576-token context, 393,216-token output ceiling, no hosted web search.
- **Changed:** DeepSeek now defaults to V4.1 Flash (`deepseek-flash`); `deepseek-v4-pro` remains selectable.
- **Removed:** retired `deepseek-v4-flash`, `deepseek-v4-flash-vision-exp`, and `deepseek-v4.1-flash-expires-on-0910` ids (settings fall back to the default; explicit `--model` fails).
- **Fixed:** hosted web search is no longer advertised where DeepSeek stopped serving it (flash models keep it off; `deepseek-v4-pro` keeps it).

### Local release checks

- `./run_tests.sh` (release env `.venv-release`, `--extra dev --extra tinker`): 5404 passed, 6 skipped. The only 3 failures are the known provider-side `together` live tests (`moonshotai/Kimi-K2.7-Code` retired serverless → 400 `model_not_available`), which CI skips.
- `uv run pre-commit run --all-files --show-diff-on-failure`: all hooks passed.